### PR TITLE
Fix translation on `HotListItem` component

### DIFF
--- a/src/app/decks/_components/columns/deck-items/deck-hot-list-item.tsx
+++ b/src/app/decks/_components/columns/deck-items/deck-hot-list-item.tsx
@@ -24,7 +24,7 @@ export const HotListItem = ({ index, entry, onMounted, onClick }: HotListItemPro
         </a>
       </div>
       <div className="hot-item-post-count">
-        {entry.top_posts + entry.comments || 0} {i18next.t("communities.n-posts")}
+        {i18next.t("communities.n-posts", { n: entry.top_posts + entry.comments || 0 })}
       </div>
     </div>
   );


### PR DESCRIPTION
There is a bug on the "Topics" deck due to a bad translation.

<img width="406" alt="Screenshot 2024-10-20 at 09 46 54" src="https://github.com/user-attachments/assets/34f6d302-44c9-4374-9107-dc0018149ea2">

I used the string interpolation to fix the issue.