### PR TITLE
Add chat link to sidebar and drop center button

### DIFF
--- a/src/app/client-providers.tsx
+++ b/src/app/client-providers.tsx
@@ -4,7 +4,6 @@ import { ClientInit } from "@/app/client-init";
 import { EcencyConfigManager } from "@/config";
 import { getQueryClient } from "@/core/react-query";
 import { Announcements } from "@/features/announcement";
-import { EcencyCenter } from "@/features/ecency-center";
 import { Tracker } from "@/features/monitoring";
 import { PushNotificationsProvider } from "@/features/push-notifications";
 import { UserActivityRecorder } from "@/features/user-activity";
@@ -28,11 +27,6 @@ export function ClientProviders(props: PropsWithChildren) {
         <PushNotificationsProvider>
           <ConditionalChatProvider>
             {props.children}
-            <EcencyConfigManager.Conditional
-              condition={({ visionFeatures }) => visionFeatures.center.enabled}
-            >
-              <EcencyCenter />
-            </EcencyConfigManager.Conditional>
           </ConditionalChatProvider>
         </PushNotificationsProvider>
         <Announcements />

--- a/src/features/i18n/locales/en-US.json
+++ b/src/features/i18n/locales/en-US.json
@@ -168,7 +168,8 @@
     "address-placeholder": "enter url or search query",
     "home": "Home",
     "waves": "Waves",
-    "communities": "Communities"
+    "communities": "Communities",
+    "chats": "Chats"
   },
   "search": {
     "placeholder": "Search",

--- a/src/features/shared/navbar/navbar-main-sidebar.tsx
+++ b/src/features/shared/navbar/navbar-main-sidebar.tsx
@@ -1,8 +1,8 @@
 import {
   UilCloudComputing,
   UilColumns,
+  UilCommentDots,
   UilCommentPlus,
-  UilEdit,
   UilEditAlt,
   UilHome,
   UilListUl,
@@ -108,6 +108,16 @@ export function NavbarMainSidebar({ show, setShow, setStepOne }: Props) {
           onClick={() => setShow(false)}
           icon={<UilUserSquare size={16} />}
         />
+        <EcencyConfigManager.Conditional
+          condition={({ visionFeatures }) => visionFeatures.center.enabled}
+        >
+          <NavbarSideMainMenuItem
+            label={i18next.t("navbar.chats")}
+            to="/chats"
+            onClick={() => setShow(false)}
+            icon={<UilCommentDots size={16} />}
+          />
+        </EcencyConfigManager.Conditional>
         <EcencyConfigManager.Conditional
           condition={({ visionFeatures }) => visionFeatures.decks.enabled}
         >


### PR DESCRIPTION
## Summary
- expose chats in main sidebar above decks
- remove floating ecency center button
- add i18n key for chats

## Testing
- `yarn lint`
- `yarn test` *(fails: TypeError: _i18next.default.init is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689b02028c14832f9e610a916edb928f