### PR TITLE
Guard floating-ui autoUpdate against null elements

### DIFF
--- a/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/selection-popover/index.tsx
+++ b/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/selection-popover/index.tsx
@@ -5,7 +5,8 @@ import { useCallback, useContext, useState } from "react";
 import { useGlobalStore } from "@/core/global-store";
 import { Button } from "@/features/ui";
 import { flip, shift } from "@floating-ui/dom";
-import { autoUpdate, useFloating } from "@floating-ui/react-dom";
+import { useFloating } from "@floating-ui/react-dom";
+import { safeAutoUpdate } from "@ui/util";
 import { UilClipboardAlt, UilComment, UilTwitter } from "@tooni/iconscout-unicons-react";
 import { motion } from "framer-motion";
 import Link from "next/link";
@@ -47,7 +48,7 @@ export const SelectionPopover = ({ children, postUrl }: any) => {
   const [selectedText, setSelectedText] = useState("");
 
   const { refs, floatingStyles } = useFloating({
-    whileElementsMounted: autoUpdate,
+    whileElementsMounted: safeAutoUpdate,
     middleware: [flip(), shift()],
     placement: "top",
     transform: true

--- a/src/features/shared/available-credits/index.tsx
+++ b/src/features/shared/available-credits/index.tsx
@@ -5,7 +5,8 @@ import { RcOperation } from "@/entities";
 import { rcFormatter } from "@/utils";
 import { useMounted } from "@/utils/use-mounted";
 import { getAccountRcQueryOptions, getRcStatsQueryOptions } from "@ecency/sdk";
-import { autoUpdate, flip, shift, useFloating } from "@floating-ui/react-dom";
+import { flip, shift, useFloating } from "@floating-ui/react-dom";
+import { safeAutoUpdate } from "@ui/util";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@ui/button";
 import i18next from "i18next";
@@ -38,7 +39,7 @@ export const AvailableCredits = ({ username, className }: Props) => {
   const { data: rcStats } = useQuery(getRcStatsQueryOptions());
 
   const { refs, floatingStyles, update } = useFloating({
-    whileElementsMounted: autoUpdate,
+    whileElementsMounted: safeAutoUpdate,
     middleware: [flip(), shift()],
     placement: "top",
     transform: true

--- a/src/features/shared/discussion/discussion-bots.tsx
+++ b/src/features/shared/discussion/discussion-bots.tsx
@@ -2,7 +2,8 @@ import { Entry } from "@/entities";
 import { ProfileLink } from "@/features/shared";
 import { dateToRelative } from "@/utils";
 import {renderPostBody, setProxyBase} from "@ecency/render-helper";
-import { autoUpdate, flip, shift, useFloating } from "@floating-ui/react-dom";
+import { flip, shift, useFloating } from "@floating-ui/react-dom";
+import { safeAutoUpdate } from "@ui/util";
 import { AnimatePresence, motion } from "framer-motion";
 import { useMemo, useRef, useState, useEffect } from "react";
 import { createPortal } from "react-dom";
@@ -23,7 +24,7 @@ export function DiscussionBots({ entries }: Props) {
 
 
   const { refs, floatingStyles } = useFloating({
-    whileElementsMounted: autoUpdate,
+    whileElementsMounted: safeAutoUpdate,
     middleware: [flip(), shift()],
     placement: "top",
     transform: true

--- a/src/features/tiptap-editor/extensions/bubble-menu-extension.tsx
+++ b/src/features/tiptap-editor/extensions/bubble-menu-extension.tsx
@@ -1,5 +1,6 @@
 import { Button, StyledTooltip } from "@/features/ui";
-import { autoUpdate, flip, shift, useFloating } from "@floating-ui/react-dom";
+import { flip, shift, useFloating } from "@floating-ui/react-dom";
+import { safeAutoUpdate } from "@ui/util";
 import { Editor, posToDOMRect } from "@tiptap/core";
 import {
   UilArrow,
@@ -34,7 +35,7 @@ export function BubbleMenu({ editor }: Props) {
   const [editingLink, setEditingLink] = useState<string>();
 
   const { refs, floatingStyles } = useFloating({
-    whileElementsMounted: autoUpdate,
+    whileElementsMounted: safeAutoUpdate,
     middleware: [flip(), shift()],
     placement: "top",
     transform: true

--- a/src/features/ui/popover/index.tsx
+++ b/src/features/ui/popover/index.tsx
@@ -13,8 +13,9 @@ import { createPortal } from "react-dom";
 import { useFilteredProps } from "../util";
 import { useClickAway, useMountedState, useWindowSize } from "react-use";
 import { PopoverSheet } from "@ui/popover/popover-sheet";
-import { autoUpdate, flip, Placement, shift } from "@floating-ui/dom";
+import { flip, Placement, shift } from "@floating-ui/dom";
 import { useFloating } from "@floating-ui/react-dom";
+import { safeAutoUpdate } from "@ui/util";
 import { AnimatePresence, motion } from "framer-motion";
 import clsx from "clsx";
 
@@ -49,7 +50,7 @@ export function Popover(
   ]);
 
   const { refs, floatingStyles } = useFloating({
-    whileElementsMounted: autoUpdate,
+    whileElementsMounted: safeAutoUpdate,
     middleware: [flip(), shift()],
     placement: props.placement,
     transform: true

--- a/src/features/ui/tooltip.tsx
+++ b/src/features/ui/tooltip.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { autoUpdate, offset } from "@floating-ui/dom";
+import { offset } from "@floating-ui/dom";
 import { flip, useFloating } from "@floating-ui/react-dom";
+import { safeAutoUpdate } from "@ui/util";
 import clsx from "clsx";
 import { AnimatePresence, motion } from "framer-motion";
 import React, { ReactNode, useState } from "react";
@@ -28,7 +29,7 @@ export function StyledTooltip({ children, content, className, onHide }: StyledPr
   const [show, setShow] = useState(false);
 
   const { refs, floatingStyles } = useFloating({
-    whileElementsMounted: autoUpdate,
+    whileElementsMounted: safeAutoUpdate,
     placement: "bottom",
     middleware: [flip(), offset({ mainAxis: 4 })]
   });

--- a/src/features/ui/util/index.ts
+++ b/src/features/ui/util/index.ts
@@ -1,2 +1,3 @@
 export * from "./props-filter";
 export * from "./class-name-object";
+export * from "./safe-auto-update";

--- a/src/features/ui/util/safe-auto-update.ts
+++ b/src/features/ui/util/safe-auto-update.ts
@@ -1,0 +1,13 @@
+import { autoUpdate, type AutoUpdateOptions, type FloatingElement, type ReferenceElement } from "@floating-ui/dom";
+
+export function safeAutoUpdate(
+  reference: ReferenceElement | null,
+  floating: FloatingElement | null,
+  update: () => void,
+  options?: AutoUpdateOptions
+) {
+  if (!reference || !floating) {
+    return () => {};
+  }
+  return autoUpdate(reference, floating, update, options);
+}


### PR DESCRIPTION
## Summary
- add `safeAutoUpdate` helper to validate elements before invoking floating-ui's `autoUpdate`
- use the safe wrapper in popover, tooltip and other components to avoid null `parentNode` errors

