### PR TITLE
Backfill Mattermost posts since last read

### DIFF
--- a/apps/web/src/app/api/mattermost/channels/[channelId]/view/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/[channelId]/view/route.ts
@@ -5,7 +5,10 @@ import {
   mmUserFetch
 } from "@/server/mattermost";
 
-export async function POST(req: Request, { params }: { params: { channelId: string } }) {
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ channelId: string }> }
+) {
   const token = await getMattermostTokenFromCookies();
 
   if (!token) {
@@ -13,7 +16,7 @@ export async function POST(req: Request, { params }: { params: { channelId: stri
   }
 
   try {
-    const channelId = params.channelId;
+    const { channelId } = await params;
     let prevChannelId = "";
 
     try {


### PR DESCRIPTION
## Summary
- fetch the current user's channel membership before loading posts so we can request history since the last read marker
- default Mattermost post requests to use `since` when available to deliver all unread context even when many join events are present
- increase Mattermost post page size to reduce missing messages when large batches arrive

## Testing
- pnpm --filter web lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937c1e03fac832fbf595acd1b50a5d4)