### PR TITLE
Staleness and parallel fix

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/page.tsx
@@ -32,11 +32,12 @@ function pageToEntries(p: Page): Entry[] {
 export default async function CommunityPostsPage({ params }: Props) {
   const { community, tag } = await params;
 
-  const communityData = await prefetchQuery(getCommunityCache(community));
-  if (!communityData) return notFound();
+  const [communityData, data] = await Promise.all([
+    prefetchQuery(getCommunityCache(community)),
+    prefetchGetPostsFeedQuery(tag, community)
+  ]);
 
-  // no cast needed if prefetchGetPostsFeedQuery is typed
-  const data = await prefetchGetPostsFeedQuery(tag, community); // InfiniteData<Page, unknown> | undefined
+  if (!communityData) return notFound();
 
   if (!data || !Array.isArray(data.pages) || data.pages.length === 0) {
     return null;

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-discussions-wrapper.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-discussions-wrapper.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { useState } from "react";
 import { Entry } from "@/entities";
 import { EntryPageDiscussions } from "./entry-page-discussions";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { getDiscussionsQueryOptions, SortOrder } from "@ecency/sdk";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import i18next from "i18next";
@@ -18,7 +18,21 @@ interface Props {
 function DiscussionsLoader({ entry, category }: Props) {
   const { username: activeUsername } = useActiveAccount();
 
-  useSuspenseQuery(getDiscussionsQueryOptions(entry, SortOrder.created, true, activeUsername ?? undefined));
+  const { isLoading, isError, refetch } = useQuery(getDiscussionsQueryOptions(entry, SortOrder.created, true, activeUsername ?? undefined));
+
+  if (isLoading) {
+    return <DiscussionsSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <div className="bg-white/80 dark:bg-dark-200/90 rounded-xl p-4 my-4 flex justify-center">
+        <Button icon={<UilComment />} onClick={() => refetch()}>
+          {i18next.t("discussion.load-error", { defaultValue: "Failed to load comments. Tap to retry" })}
+        </Button>
+      </div>
+    );
+  }
 
   return <EntryPageDiscussions entry={entry} category={category} />;
 }
@@ -53,9 +67,5 @@ export function EntryPageDiscussionsWrapper({ entry, category }: Props) {
     ) : null;
   }
 
-  return (
-    <Suspense fallback={<DiscussionsSkeleton />}>
-      <DiscussionsLoader entry={entry} category={category} />
-    </Suspense>
-  );
+  return <DiscussionsLoader entry={entry} category={category} />;
 }

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
@@ -45,18 +45,18 @@ export default async function EntryPage({ params, searchParams }: Props) {
   const isRawContent = sParams.raw !== undefined;
 
   const author = username.replace("%40", "");
-  const entry = await prefetchQuery(EcencyEntriesCacheManagement.getEntryQueryByPath(author, permlink));
+  const [entry] = await Promise.all([
+    prefetchQuery(EcencyEntriesCacheManagement.getEntryQueryByPath(author, permlink)),
+    // Warm the query cache for child components that read account data.
+    // Use author from URL params so this runs in parallel with the entry fetch.
+    prefetchQuery(getAccountFullQueryOptions(author))
+  ]);
 
   if (
     permlink.startsWith("wave-") ||
     (permlink.startsWith("re-ecencywaves-") && entry?.parent_author === "ecency.waves")
   ) {
     return redirect(`/waves/${author}/${permlink}`);
-  }
-
-  if (entry?.author) {
-    // Warm the query cache for child components that read account data
-    await prefetchQuery(getAccountFullQueryOptions(entry.author));
   }
 
   if (!entry) {

--- a/apps/web/src/features/chat/mattermost-api.ts
+++ b/apps/web/src/features/chat/mattermost-api.ts
@@ -515,7 +515,7 @@ export function useMattermostUnread(enabled: boolean) {
     enabled: enabled && Boolean(username),
     refetchInterval: 60000,
     refetchOnWindowFocus: false,
-    staleTime: 30000,
+    staleTime: 60000,
     queryFn: async () => {
       const res = await fetch("/api/mattermost/channels/unreads");
 

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -963,7 +963,8 @@
     "start-conversation": "Start conversation",
     "join-hint": "Join the conversation and earn for your contributions",
     "new-comment": "{{n}} new comment - tap to load",
-    "new-comments": "{{n}} new comments - tap to load"
+    "new-comments": "{{n}} new comments - tap to load",
+    "load-error": "Failed to load comments. Tap to retry"
   },
   "community": {
     "page-description": "{{f}} topics",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Community posts and entry pages now prefetch related data in parallel for faster page load.
  * Chat unread count refresh delay increased to reduce unnecessary background updates.

* **Bug Fixes**
  * Discussions now show a loading skeleton and a clear error panel with a retry button when comments fail to load.

* **Localization**
  * Added a user-facing message for comment load failures: “Failed to load comments. Tap to retry”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->