### PR TITLE
Cache logged-in users on auth-class-equivalent routes

### DIFF
--- a/apps/web/src/features/next-middleware/cache-policy.ts
+++ b/apps/web/src/features/next-middleware/cache-policy.ts
@@ -41,8 +41,21 @@ const NO_CACHE_PREFIXES = [
   "/wallet"
 ];
 
-/** Profile subsections that must never be edge-cached. */
-const NO_CACHE_PROFILE_SECTIONS = new Set(["wallet", "settings", "permissions", "referrals"]);
+/**
+ * Profile subsections that must never be edge-cached.
+ *
+ * `insights` is here because the route handler reads `active_user` to render
+ * owner-only stats (see profile/[username]/insights/page.tsx), so the SSR
+ * differs for the profile owner vs everyone else. Sharing the cache entry
+ * across logged-in users would leak the owner-only sections to other viewers.
+ */
+const NO_CACHE_PROFILE_SECTIONS = new Set([
+  "wallet",
+  "settings",
+  "permissions",
+  "referrals",
+  "insights"
+]);
 
 /**
  * Profile subsections that aggregate content from OTHER users (not the
@@ -71,6 +84,30 @@ const STATIC_PAGES = new Set([
 ]);
 
 const FEED_FILTERS = new Set(["hot", "created", "trending", "payout", "muted", "promoted"]);
+
+/**
+ * Cache tiers whose SSR is filtered by the logged-in user's mute list (via
+ * `observer` in feed/[...sections]/page.tsx). Different logged-in users see
+ * different filtered feeds, so these tiers must stay private when isLoggedIn.
+ *
+ * All other tiers are auth-class-equivalent (anon vs any-logged-in-user) per
+ * empirical sweep across 26 page types — they can share an edge cache entry
+ * across logged-in users.
+ */
+const USER_SPECIFIC_TIERS_WHEN_LOGGED_IN = new Set([
+  "feed", // /:filter (hot, trending, payout, muted, promoted)
+  "feed-created", // /:filter where filter is "created", and tag feeds
+  "profile-feed" // /@author/feed and /@author/trail
+]);
+
+/**
+ * True when this policy's SSR depends on the logged-in user's identity (today
+ * only the mute-filter feed tiers). Exposed for middleware observability and
+ * potential reuse in the CF worker / nginx layers.
+ */
+export function isUserSpecificForLoggedIn(policy: CachePolicy, isLoggedIn: boolean): boolean {
+  return isLoggedIn && USER_SPECIFIC_TIERS_WHEN_LOGGED_IN.has(policy.tier);
+}
 
 export function getCachePolicyForPath(pathname: string): CachePolicy | null {
   // Strip trailing slash (except root) for consistent matching.
@@ -178,7 +215,7 @@ export function getCachePolicyForPath(pathname: string): CachePolicy | null {
 
 /** Build a Cache-Control header value from a policy. */
 export function buildCacheControlHeader(policy: CachePolicy, isLoggedIn: boolean): string {
-  if (isLoggedIn || policy.tier === NO_CACHE_TIER) {
+  if (policy.tier === NO_CACHE_TIER || isUserSpecificForLoggedIn(policy, isLoggedIn)) {
     return "private, no-store";
   }
   return `public, max-age=0, s-maxage=${policy.sMaxAge}, stale-while-revalidate=${policy.staleWhileRevalidate}`;

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -6,6 +6,7 @@ import {
   getEntryTierForAge,
   handleIndexRedirect,
   isIndexRedirect,
+  isUserSpecificForLoggedIn,
   parseEntryUrl,
   refreshPostCreatedMs
 } from "@/features/next-middleware";
@@ -112,8 +113,11 @@ function applyCacheHeaders(
   // For entry pages, try to refine TTL based on post age. Cache-miss here is
   // non-blocking: we set the default entry tier immediately and populate the
   // cache in the background for the next request.
+  // Runs for both anon and logged-in users — entry tier is cacheable in both
+  // cases (per buildCacheControlHeader), so logged-in users benefit equally
+  // from age-refined TTLs (entry-fresh through entry-ancient).
   let policy = basePolicy;
-  if (basePolicy.tier === "entry" && !isLoggedIn) {
+  if (basePolicy.tier === "entry") {
     const parsed = parseEntryUrl(path);
     if (parsed) {
       const createdMs = getCachedPostCreatedMs(parsed.author, parsed.permlink);
@@ -135,11 +139,15 @@ function applyCacheHeaders(
   }
 
   response.headers.set("Cache-Control", buildCacheControlHeader(policy, isLoggedIn));
-  response.headers.set("x-cache-tier", isLoggedIn ? "logged-in" : policy.tier);
+  // x-cache-tier is observability-only. Reflect actual gating so cached-vs-private
+  // is distinguishable in nginx logs and CF analytics.
+  const userSpecific = isUserSpecificForLoggedIn(policy, isLoggedIn);
+  response.headers.set("x-cache-tier", userSpecific ? `${policy.tier}-loggedin` : policy.tier);
   // NOTE: we deliberately do NOT emit `Vary: Cookie`. That would fragment the
   // edge cache on every cookie (analytics, locale, experiments) and cripple
-  // hit ratio. Auth bifurcation happens at the infra layer:
-  //   - Nginx: cache key includes $cookie_active_user
-  //   - CF worker: explicitly bypasses cache when active_user cookie present
-  // See docs/cache/nginx.md and docs/cache/cloudflare-worker.md.
+  // hit ratio. Auth bifurcation happens via cache-key suffix in the worker:
+  //   - CF worker: cache key encodes auth-class (anon|loggedin) so anon and
+  //     logged-in get separate cache entries (2 per URL) without Vary
+  //   - Origin Cache-Control still gates writes: `private, no-store` for
+  //     no-cache routes and (only when isLoggedIn) feed/profile-feed tiers
 }

--- a/apps/web/src/specs/features/next-middleware/cache-policy.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/cache-policy.spec.ts
@@ -3,6 +3,7 @@ import {
   buildCacheControlHeader,
   getCachePolicyForPath,
   getEntryTierForAge,
+  isUserSpecificForLoggedIn,
   parseEntryUrl
 } from "@/features/next-middleware";
 
@@ -34,13 +35,16 @@ describe("getCachePolicyForPath", () => {
       expect(policy).toEqual({ tier: "no-cache", sMaxAge: 0, staleWhileRevalidate: 0 });
     });
 
-    it.each(["/@alice/wallet", "/@alice/settings", "/@alice/permissions", "/@alice/referrals"])(
-      "returns no-cache for sensitive profile section %s",
-      (path) => {
-        const policy = getCachePolicyForPath(path);
-        expect(policy?.tier).toBe("no-cache");
-      }
-    );
+    it.each([
+      "/@alice/wallet",
+      "/@alice/settings",
+      "/@alice/permissions",
+      "/@alice/referrals",
+      "/@alice/insights"
+    ])("returns no-cache for sensitive profile section %s", (path) => {
+      const policy = getCachePolicyForPath(path);
+      expect(policy?.tier).toBe("no-cache");
+    });
   });
 
   describe("static pages", () => {
@@ -133,7 +137,7 @@ describe("getCachePolicyForPath", () => {
       expect(policy).toEqual({ tier: "profile", sMaxAge: 300, staleWhileRevalidate: 3600 });
     });
 
-    it.each(["posts", "blog", "comments", "replies", "communities", "insights"])(
+    it.each(["posts", "blog", "comments", "replies", "communities"])(
       "returns profile tier for /@alice/%s",
       (section) => {
         const policy = getCachePolicyForPath(`/@alice/${section}`);
@@ -201,13 +205,38 @@ describe("buildCacheControlHeader", () => {
     expect(header).toBe("public, max-age=0, s-maxage=300, stale-while-revalidate=3600");
   });
 
-  it("emits private no-store for logged-in users", () => {
+  it("emits public s-maxage + swr for logged-in users on auth-class-equivalent tiers", () => {
+    // profile, list, entry, community, static, home — SSR is the same for
+    // anon and any-logged-in user, so logged-in shares the cache (worker
+    // keys it under #auth=loggedin separately from #auth=anon).
     const header = buildCacheControlHeader(
       { tier: "list", sMaxAge: 300, staleWhileRevalidate: 3600 },
       true
     );
-    expect(header).toBe("private, no-store");
+    expect(header).toBe("public, max-age=0, s-maxage=300, stale-while-revalidate=3600");
   });
+
+  it.each(["feed", "feed-created", "profile-feed"])(
+    "emits private no-store for logged-in users on %s tier (mute filter)",
+    (tier) => {
+      const header = buildCacheControlHeader(
+        { tier, sMaxAge: 60, staleWhileRevalidate: 300 },
+        true
+      );
+      expect(header).toBe("private, no-store");
+    }
+  );
+
+  it.each(["feed", "feed-created", "profile-feed"])(
+    "still emits public for anonymous users on %s tier",
+    (tier) => {
+      const header = buildCacheControlHeader(
+        { tier, sMaxAge: 60, staleWhileRevalidate: 300 },
+        false
+      );
+      expect(header).toBe("public, max-age=0, s-maxage=60, stale-while-revalidate=300");
+    }
+  );
 
   it("emits private no-store for no-cache tier even anonymous", () => {
     const header = buildCacheControlHeader(
@@ -216,6 +245,43 @@ describe("buildCacheControlHeader", () => {
     );
     expect(header).toBe("private, no-store");
   });
+
+  it("emits private no-store for no-cache tier when logged-in", () => {
+    const header = buildCacheControlHeader(
+      { tier: "no-cache", sMaxAge: 0, staleWhileRevalidate: 0 },
+      true
+    );
+    expect(header).toBe("private, no-store");
+  });
+});
+
+describe("isUserSpecificForLoggedIn", () => {
+  it.each(["feed", "feed-created", "profile-feed"])(
+    "returns true for %s tier when logged-in",
+    (tier) => {
+      expect(
+        isUserSpecificForLoggedIn({ tier, sMaxAge: 60, staleWhileRevalidate: 300 }, true)
+      ).toBe(true);
+    }
+  );
+
+  it.each(["feed", "feed-created", "profile-feed"])(
+    "returns false for %s tier when anonymous",
+    (tier) => {
+      expect(
+        isUserSpecificForLoggedIn({ tier, sMaxAge: 60, staleWhileRevalidate: 300 }, false)
+      ).toBe(false);
+    }
+  );
+
+  it.each(["profile", "entry", "list", "community", "static", "home", "no-cache"])(
+    "returns false for %s tier even when logged-in (auth-class-equivalent)",
+    (tier) => {
+      expect(
+        isUserSpecificForLoggedIn({ tier, sMaxAge: 60, staleWhileRevalidate: 300 }, true)
+      ).toBe(false);
+    }
+  );
 });
 
 describe("getEntryTierForAge", () => {

--- a/docs/cache/README.md
+++ b/docs/cache/README.md
@@ -6,70 +6,89 @@ This directory documents the edge caching system for ecency.com.
 
 ```
 ┌─────────────────┐
-│   Cloudflare    │ ← respects origin Cache-Control, skips cache on active_user cookie
+│   Cloudflare    │ ← cf.cacheKey on subfetches; Smart-Tiered-Cache eligible
 │   (edge cache)  │
 └────────┬────────┘
          ↓
 ┌─────────────────┐
-│     Nginx       │ ← respects origin Cache-Control, cookie-aware cache key
-│  (proxy cache)  │
+│  CF Worker      │ ← cache key = URL + auth-class (anon | loggedin)
+│  (geo-router)   │   2 cache entries per URL; respects origin Cache-Control
+└────────┬────────┘
+         ↓
+┌─────────────────┐
+│     Nginx       │ ← URL-keyed proxy cache, respects origin Cache-Control
+│  (proxy cache)  │   (32G LRU, 2h inactive, per-host)
 └────────┬────────┘
          ↓
 ┌─────────────────┐
 │    Next.js      │ ← single source of truth; middleware emits Cache-Control
-│  (3 regions ×   │   per route pattern
+│  (3 regions ×   │   per route pattern, with auth-aware policy
 │   4 replicas)   │
 └─────────────────┘
 ```
 
 **Principle:** Next.js decides the cache policy. Nginx and Cloudflare respect
-that policy.
+that policy. The CF worker keys cache entries by auth-class so logged-in
+users get separate cached responses from anonymous users (one entry each)
+without needing a `Vary: Cookie` header.
 
 ## Where the policy is defined
 
 - **Route-pattern TTLs**: `apps/web/src/features/next-middleware/cache-policy.ts`
 - **Header injection**: `apps/web/src/middleware.ts`
-- Cache headers are always emitted by `apps/web/src/middleware.ts`
+- **User-specific gate**: `isUserSpecificForLoggedIn(policy, isLoggedIn)`
+  exported from `cache-policy.ts` — true only when SSR genuinely depends on
+  the logged-in user's identity (today: feed tiers via mute filter)
 
-## TTL tiers (anonymous users only)
+## TTL tiers
 
-Logged-in users (requests with `active_user` cookie) always get
-`Cache-Control: private, no-store`.
+Both anonymous and logged-in users share these s-maxage values, EXCEPT for
+`feed`, `feed-created`, and `profile-feed` tiers which emit
+`private, no-store` for logged-in users (mute filter applied server-side
+to feed content; sharing the cache entry across users would leak filtered
+content).
 
-| Tier | `s-maxage` | `stale-while-revalidate` | Routes |
-|---|---|---|---|
-| `static` | 24h | 7d | `/faq`, `/about`, `/child-safety`, `/contributors`, `/privacy-policy`, `/terms-of-service`, `/whitepaper`, `/mobile` |
-| `home` | 5m | 1h | `/` |
-| `list` | 5m | 1h | `/discover`, `/communities`, `/witnesses`, `/tags` |
-| `list-proposals` | 10m | 1h | `/proposals` |
-| `feed` | 1m | 5m | `/hot`, `/trending`, `/payout`, `/muted`, `/promoted` + tags |
-| `feed-created` | 30s | 2m | `/created`, `/tags/:tag` |
-| `community` | 1m | 5m | `/:tag/hive-xxxxx` |
-| `profile` | 5m | 1h | `/@author`, `/@author/posts`, `/blog`, `/comments`, `/replies`, `/communities`, `/insights` |
-| `profile-feed` | 1m | 5m | `/@author/feed`, `/@author/trail` (aggregates other users' content) |
-| `entry` | 1h | 1d | post pages (default — used until post age is known) |
-| `entry-fresh` | 1m | 5m | posts < 1 day old |
-| `entry-week` | 1h | 1d | posts 1-7 days old |
-| `entry-month` | 1d | 7d | posts 7-30 days old |
-| `entry-archive` | 30d | 7d | posts 30-60 days old |
-| `entry-ancient` | 30d | 60d | posts > 60 days old |
-| `no-cache` | 0 | 0 | `/publish`, `/chats`, `/auth/*`, `/wallet`, `/@author/settings`, etc. |
+| Tier | `s-maxage` | `stale-while-revalidate` | Routes | Cacheable for logged-in? |
+|---|---|---|---|---|
+| `static` | 24h | 7d | `/faq`, `/about`, `/child-safety`, `/contributors`, `/privacy-policy`, `/terms-of-service`, `/whitepaper`, `/mobile` | yes |
+| `home` | 5m | 1h | `/` | n/a (logged-in `/` rewrites to `/@user/feed`) |
+| `list` | 5m | 1h | `/discover`, `/communities`, `/witnesses`, `/tags` | yes |
+| `list-proposals` | 10m | 1h | `/proposals` | yes |
+| `feed` | 1m | 5m | `/hot`, `/trending`, `/payout`, `/muted`, `/promoted` + tags | **no** (mute filter) |
+| `feed-created` | 30s | 2m | `/created`, `/tags/:tag` | **no** (mute filter) |
+| `community` | 1m | 5m | `/:tag/hive-xxxxx` | yes |
+| `profile` | 5m | 1h | `/@author`, `/@author/posts`, `/blog`, `/comments`, `/replies`, `/communities` | yes |
+| `profile-feed` | 1m | 5m | `/@author/feed`, `/@author/trail` (aggregates other users' content) | **no** (mute filter) |
+| `entry` | 1h | 1d | post pages (default — used until post age is known) | yes |
+| `entry-fresh` | 1m | 5m | posts < 1 day old | yes |
+| `entry-week` | 1h | 1d | posts 1-7 days old | yes |
+| `entry-month` | 1d | 7d | posts 7-30 days old | yes |
+| `entry-archive` | 30d | 7d | posts 30-60 days old | yes |
+| `entry-ancient` | 30d | 60d | posts > 60 days old | yes |
+| `no-cache` | 0 | 0 | `/publish`, `/chats`, `/auth/*`, `/wallet`, `/@author/settings`, `/@author/insights`, etc. | no |
 
-**Observability header:** Every response carries `x-cache-tier: <tier>` (or
-`logged-in`) so CF analytics, Nginx logs, and browser DevTools all reveal
-which policy was applied.
+**Empirical basis (2026-05-08):** SSR was tested across 26 page types with
+multiple user identities. Routes flagged as cacheable for logged-in produce
+byte-equivalent SSR (modulo timestamps in dehydrated React Query state)
+across all logged-in users. Routes flagged as not-cacheable read
+`active_user` server-side (`feed/[...sections]/page.tsx` for mute filter,
+`profile/[username]/insights/page.tsx` for owner-only stats).
 
-**No `Vary: Cookie`.** Auth bifurcation is done at the infra layer (Nginx
-includes `$cookie_active_user` in the cache key; CF worker bypasses cache
-when the cookie is present). Emitting `Vary: Cookie` would fragment the
-edge cache on every unrelated cookie (analytics, locale, experiments) and
-destroy hit ratio.
+**Observability header:** Every response carries `x-cache-tier: <tier>`,
+or `<tier>-loggedin` for tiers that are user-specific when logged-in (e.g.
+`feed-created-loggedin`). CF analytics, Nginx logs, and browser DevTools
+all reveal which policy was applied.
+
+**No `Vary: Cookie`.** Auth bifurcation happens via the CF worker's cache
+key, which encodes auth-class (`anon` or `loggedin`) as a synthetic URL
+prefix. Two cache entries per URL — one per auth class — without
+fragmenting on every cookie (analytics, locale, theme, experiments).
 
 ## Layer-specific configuration
 
-- [Nginx](./nginx.md) — proxy cache alignment, cookie-aware cache key
-- [Cloudflare Worker](./cloudflare-worker.md) — edge cache alignment,
-  per-post-age TTL refinement
+- [Nginx](./nginx.md) — proxy cache (32G LRU, 2h inactive)
+- [Cloudflare Worker](./cloudflare-worker.md) — auth-class cache key,
+  Smart-Tiered-Cache subfetches, per-post-age TTL via origin
 
 ## DMCA / moderation invalidation
 
@@ -85,21 +104,24 @@ Without step 2, CF serves the pre-DMCA HTML until `s-maxage` expires
 
 ## Per-post-age TTL refinement
 
-For entry (post) pages, the middleware starts with the conservative `entry`
-tier (1h / 1d), then refines it based on the post's age once known:
+For entry (post) pages, the middleware starts with a conservative
+`entry-unknown` tier (60s / 5m) when the post's `created` date is not yet
+known, then refines it based on the post's age once available:
 
-1. First request for `/cat/@author/permlink`: middleware sees no cached
-   age → emits `entry` tier → kicks off a background fetch of the post's
-   `created` date via `event.waitUntil(...)`.
-2. Background fetch hits `https://api.hive.blog` (condenser_api.get_content),
-   parses the `created` timestamp, stores in a module-level LRU cache
-   (capped at 2000 entries per edge isolate).
-3. Next request for the same post: middleware looks up the cached age
-   → emits the refined tier (`entry-fresh` through `entry-ancient`).
+1. First request for `/cat/@author/permlink` on a given replica: middleware
+   sees no cached age → emits `entry-unknown` (60s / 5m) → kicks off a
+   background lookup via `event.waitUntil(refreshPostCreatedMs(...))`.
+2. Background lookup checks Redis (L2, shared across the host's vision_web
+   replicas), then falls back to Hive RPC (`condenser_api.get_content`) if
+   Redis missed. Result is stored in both L1 (in-process Map) and Redis.
+3. Next request for the same post: L1 hit → middleware emits the refined
+   tier (`entry-fresh` through `entry-ancient`).
 
-The in-memory cache is per edge isolate — different isolates warm up
-independently. Failures (timeout, malformed response, missing fields) are
-negative-cached for 5 minutes to avoid hammering the upstream on retries.
+L2 (Redis) lets the post-age cache survive replica restarts and amortize
+RPC fetches across all replicas on the same host. Failures during RPC
+(timeout, all nodes failed) are NOT cached — they let the next request
+retry — to avoid over-caching a fresh post to the default 1h tier across
+the whole region.
 
 See `apps/web/src/features/next-middleware/post-age-cache.ts`.
 
@@ -108,14 +130,17 @@ See `apps/web/src/features/next-middleware/post-age-cache.ts`.
 Implemented in this repo:
 
 - Middleware emits `Cache-Control` and `x-cache-tier` for cacheable HTML routes
-- Entry-page TTL is refined by post age via the in-memory post-age cache
+- Logged-in users share cache on auth-class-equivalent routes
+- Feed tiers + insights stay private when logged-in (server-side
+  `active_user` reads detected and excluded)
+- Entry-page TTL refined by post age via L1 Map + per-host Redis L2
 - `scripts/purge-cache.sh` supports manual DMCA / moderation invalidation
 
-Still required outside this repo:
+Operated outside this repo:
 
-- Nginx must respect origin `Cache-Control`, vary cache by `active_user`, and expose cache status headers
-- The Cloudflare worker must respect origin cache headers for HTML, bypass logged-in traffic, and preserve `x-cache-tier`
+- Nginx (`ssrcache` zone) on each origin host — see [nginx.md](./nginx.md)
+- Cloudflare worker `ecency-geo-router` — see [cloudflare-worker.md](./cloudflare-worker.md)
 
-Before production rollout, verify `x-cache-tier` values across route types in
-staging and confirm the Nginx / Cloudflare layers are aligned with the origin
-policy.
+Before production rollout of changes here, verify `x-cache-tier` values
+across route types in staging and confirm the Nginx / Cloudflare layers
+are aligned with the origin policy.

--- a/docs/cache/cloudflare-worker.md
+++ b/docs/cache/cloudflare-worker.md
@@ -1,81 +1,94 @@
 # Cloudflare Worker Cache Alignment
 
-Changes required in the production CF worker to respect origin Cache-Control
-headers for HTML and enable aggressive edge caching.
+The `ecency-geo-router` worker sits in front of nginx and is the primary edge
+cache layer for ecency.com. It implements:
 
-## Required changes
+1. Bot management gating
+2. Geo-routing across 3 origins (eu/us/asia.ecency.com)
+3. WebSocket pass-through to the closest origin
+4. Edge cache for cacheable HTML responses, keyed by URL + auth-class
+5. Smart-Tiered-Cache-eligible subfetches via `cf.cacheKey`
 
-### 1. Respect origin Cache-Control for HTML
+## Cache key strategy
 
-Currently the worker caches non-HTML (static assets) and passes HTML through.
-After this change, HTML is cached per origin's `Cache-Control` header.
+The cache key encodes both the URL and the auth class so anonymous and
+logged-in users get separate cache entries — 2 entries per URL — without
+needing a `Vary: Cookie` header (which would fragment cache on every cookie).
 
 ```js
-export default {
-  async fetch(request, env, ctx) {
-    // Bypass cache entirely for logged-in users
-    const cookieHeader = request.headers.get("Cookie") || "";
-    const isLoggedIn = /(^|;\s*)active_user=/.test(cookieHeader);
-    if (isLoggedIn) {
-      return fetch(request);
-    }
+const authClass = hasActiveUser ? "loggedin" : "anon";
+// Synthetic URL prefixed with auth class. Real URL is unchanged for the
+// actual fetch; this is only for the cache lookup/store key.
+const cacheKeyUrl =
+  `https://cache.internal/${authClass}${reqUrl.pathname}${reqUrl.search}`;
+```
 
-    // Skip cache for non-GET
-    if (request.method !== "GET") {
-      return fetch(request);
-    }
+`active_user` cookie presence determines auth-class. Neither the cookie's
+value nor any other cookie is part of the key — empirical analysis confirmed
+that SSR is auth-class-equivalent (same for any logged-in user) on every
+route except feed and profile-feed tiers, which are user-specific via mute
+filter and stay private (see "Trust origin Cache-Control" below).
 
-    // Normalize cache key — strip query params we don't want to split cache on
-    // (optional: preserves pagination params, drops analytics noise)
-    const cacheKey = new Request(request.url, request);
+## Trust origin Cache-Control
 
-    const cache = caches.default;
-    let response = await cache.match(cacheKey);
+The worker does not decide cacheability — origin's middleware
+(`apps/web/src/features/next-middleware/cache-policy.ts`) does, via
+`buildCacheControlHeader`. The worker's job is to honor the result.
 
-    if (!response) {
-      response = await fetch(request);
+Origin emits `private, no-store` for:
+- `NO_CACHE_PREFIXES` (publish, chats, wallet, search, market, etc.)
+- Profile sub-sections in `NO_CACHE_PROFILE_SECTIONS`
+  (wallet, settings, permissions, referrals, **insights**)
+- `feed`, `feed-created`, `profile-feed` tiers — but only when `isLoggedIn`,
+  because these routes filter SSR by the user's mute list
 
-      // Only cache successful responses with a cacheable Cache-Control
-      if (response.status === 200 && isCacheable(response)) {
-        // Clone so we can stash it while still returning to client
-        ctx.waitUntil(cache.put(cacheKey, response.clone()));
-      }
-    }
+For everything else (post pages, profile main + most sub-sections, community,
+list, static), origin emits `public, max-age=0, s-maxage=N, stale-while-
+revalidate=M` for both anon and logged-in.
 
-    return response;
-  }
-};
+The worker then:
 
-function isCacheable(response) {
-  const cc = response.headers.get("Cache-Control") || "";
-  // Honor private/no-store/no-cache from origin
-  if (/\b(private|no-store|no-cache)\b/i.test(cc)) return false;
-  // Only cache when origin explicitly asks us to
-  return /\bs-maxage=\d+/i.test(cc) || /\bmax-age=\d+/i.test(cc);
+```js
+const originCC = upstream.headers.get("cache-control") || "";
+const hasNoStore = /\bno-store\b/i.test(originCC);
+const isPrivate = /\bprivate\b/i.test(originCC);
+const sMaxMatch = originCC.match(/s-maxage=(\d+)/);
+const cacheable = !hasNoStore && !isPrivate && sMaxMatch && parseInt(sMaxMatch[1], 10) > 0;
+if (cacheable) {
+  await caches.default.put(cacheKey, response.clone());
 }
 ```
 
-### 2. Enable Tiered Cache / Argo
+## Subfetch with cf.cacheKey
 
-With 3 origins (EU/US/SG), enable **Tiered Cache** so regional edges
-consolidate misses before hitting origin. This dramatically reduces origin
-load during viral traffic bursts.
+For cacheable requests, the origin subfetch is annotated with the same
+synthetic cache-key URL. This engages CF's standard cache (eligible for
+Smart Tiered Cache when enabled at the zone level), giving cross-colo
+consolidation in addition to the worker's per-colo `caches.default`.
 
-Dashboard: Caching → Tiered Cache → Enable
+```js
+const subfetchInit = canEdgeCache
+  ? { cf: { cacheKey: cacheKeyUrl } }
+  : {};
+const upstream = await fetch(target, { ...subfetchInit, /* ... */ });
+```
 
-### 3. Per-post-age TTL refinement — already implemented in middleware
+Note: `cacheEverything` is intentionally NOT set — origin Cache-Control
+still gates whether CF's standard cache stores the subfetch response, so
+no-store/private routes remain bypassed even at this layer.
 
-The Next.js middleware now refines entry-page TTL based on post age via a
-background-populated in-memory cache
-(`apps/web/src/features/next-middleware/post-age-cache.ts`). First request
-for a post gets the default `entry` tier; subsequent requests get the
-refined tier based on the post's `created` date.
+## Per-post-age TTL refinement — owned by middleware + Redis
+
+The Next.js middleware refines entry-page TTL based on post age. A per-host
+Redis container (deployed alongside vision_web on each origin server) acts
+as L2 for the in-process L1 Map; it lets the post-age cache survive replica
+restarts and amortize RPC fetches across all replicas on the same host.
 
 The CF worker does **not** need to fetch post metadata — it just respects
-the `Cache-Control` header emitted by middleware, which already encodes
-the age-based TTL.
+the `Cache-Control` header emitted by middleware, which already encodes the
+age-based TTL.
 
-**Tier table (for reference / CF-side refinement if ever needed):**
+**Tier table (origin-emitted, for reference):**
 
 | Post age | `s-maxage` | `stale-while-revalidate` |
 |---|---|---|
@@ -85,92 +98,66 @@ the age-based TTL.
 | 30-60d | 30d | 7d |
 | > 60d | 30d | 60d |
 
-**Implementation sketch:**
+The worker caps stored TTL at 7 days as a safety bound:
 
 ```js
-// On cache miss for entry page URLs, fetch post metadata from Hive API
-// and compute a tighter or looser TTL than what origin sent.
-
-async function refineEntryPageTTL(request, response, env) {
-  const url = new URL(request.url);
-  const match = url.pathname.match(/^\/(?:[^/]+\/)?@([^/]+)\/([^/]+)/);
-  if (!match) return response;
-
-  const [, author, permlink] = match;
-  const post = await getPostMetadata(author, permlink, env); // long-cached in KV
-  if (!post?.created) return response;
-
-  const ageMs = Date.now() - new Date(post.created + "Z").getTime();
-  const ageDays = ageMs / 86400000;
-
-  let sMaxAge, swr;
-  if (ageDays < 1)      { sMaxAge = 60;       swr = 300; }
-  else if (ageDays < 7) { sMaxAge = 3600;     swr = 86400; }
-  else if (ageDays < 30){ sMaxAge = 86400;    swr = 604800; }
-  else if (ageDays < 60){ sMaxAge = 2592000;  swr = 604800; }
-  else                  { sMaxAge = 2592000;  swr = 5184000; }
-
-  const cloned = new Response(response.body, response);
-  cloned.headers.set(
-    "Cache-Control",
-    `public, max-age=0, s-maxage=${sMaxAge}, stale-while-revalidate=${swr}`
-  );
-  return cloned;
-}
-
-async function getPostMetadata(author, permlink, env) {
-  const key = `post:${author}/${permlink}`;
-  const cached = await env.POST_META_KV.get(key, "json");
-  if (cached) return cached;
-
-  // Fetch minimal metadata from Hive condenser API
-  const res = await fetch("https://api.hive.blog", {
-    method: "POST",
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      method: "condenser_api.get_content",
-      params: [author, permlink],
-      id: 1
-    })
-  });
-  const data = await res.json();
-  const post = { created: data.result?.created };
-
-  // Created date is immutable — cache aggressively
-  await env.POST_META_KV.put(key, JSON.stringify(post), {
-    expirationTtl: 604800
-  });
-  return post;
-}
+const cappedTtl = Math.min(edgeTtl, 604800);
 ```
 
-Requires KV binding `POST_META_KV`.
+## Observability
 
-### 4. Observability
+The worker sets `X-Edge-Cache: HIT|MISS` on every response. The origin's
+`x-cache-tier` header passes through unchanged (e.g. `entry-ancient`,
+`profile`, `feed-loggedin`). CF's own `cf-cache-status` reflects the
+standard-cache outcome on the subfetch path — not the worker's
+`caches.default` HIT, which appears as `dynamic` to CF's metrics.
 
-Add cache status to response headers:
-
-```js
-response.headers.set("CF-Cache-Status", hit ? "HIT" : "MISS");
-// Preserve x-cache-tier from origin — lets us analyze hit ratio per tier
-```
+To accurately measure worker effectiveness, parse `X-Edge-Cache` from
+response headers, not `cf-cache-status`.
 
 ## Verification
 
+Verify against the origin (port 3000) with a `Host: ecency.com` header to
+bypass CF entirely — this isolates the middleware/SSR layer from worker
+behavior. For end-to-end edge tests, a browser session works best because
+it satisfies CF's bot management without relying on operational allowlists.
+
 ```bash
-# First request — MISS
-curl -sI https://ecency.com/discover | grep -iE 'cf-cache|tier|cache-control'
+# Anonymous post page — second request should HIT in worker's caches.default
+# (visible via X-Edge-Cache: HIT response header)
+curl -sI -H "Host: ecency.com" \
+  "http://127.0.0.1:3000/<community>/<author>/<permlink>" | \
+  grep -iE 'cache-control|x-cache-tier'
+# expect: cache-control: public, max-age=0, s-maxage=N, stale-while-revalidate=M
 
-# Second request — HIT (from CF)
-curl -sI https://ecency.com/discover | grep -iE 'cf-cache|tier'
+# Logged-in (auth-class-equivalent route) — origin emits cacheable header
+curl -sI --cookie "active_user=alice" -H "Host: ecency.com" \
+  "http://127.0.0.1:3000/@<author>" | grep -iE 'cache-control|x-cache-tier'
+# expect: cache-control: public ... s-maxage=300
 
-# Logged-in bypass
-curl -sI --cookie "active_user=alice" https://ecency.com/discover | grep -iE 'cf-cache|cache-control'
+# Logged-in (feed) — stays private regardless
+curl -sI --cookie "active_user=alice" -H "Host: ecency.com" \
+  "http://127.0.0.1:3000/created" | grep -iE 'cache-control|x-cache-tier'
+# expect: cache-control: private, no-store
+# expect: x-cache-tier: feed-created-loggedin
+
+# Logged-in (insights) — stays private (owner-stats SSR)
+curl -sI --cookie "active_user=alice" -H "Host: ecency.com" \
+  "http://127.0.0.1:3000/@<author>/insights" | grep -iE 'cache-control'
+# expect: cache-control: private, no-store
 ```
 
-## Rollout
+## Deploy
 
-1. Deploy worker with HTML caching + cookie bypass but without per-post-age
-   refinement. Verify hit ratio climbs on entry pages.
-2. Add KV binding and deploy per-post-age refinement.
-3. Monitor origin RPS — expect 70-90% reduction on anonymous traffic.
+Worker source is maintained outside this repo (operations infrastructure).
+Deploy via the Cloudflare Workers Scripts API:
+
+```bash
+curl -X PUT -H "Authorization: Bearer $CF_API_TOKEN" \
+  -F 'metadata={"main_module":"worker.js","compatibility_date":"2024-01-01"};type=application/json' \
+  -F "worker.js=@${WORKER_SOURCE};filename=worker.js;type=application/javascript+module" \
+  "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/workers/scripts/ecency-geo-router"
+```
+
+Provide `CF_API_TOKEN`, `WORKER_SOURCE`, and `CF_ACCOUNT_ID` from your
+deployment environment. Keep prior versions as backups for one-line revert.

--- a/docs/cache/nginx.md
+++ b/docs/cache/nginx.md
@@ -1,116 +1,107 @@
 # Nginx Cache Alignment
 
-Changes required in the production Nginx config to respect the Cache-Control
-headers emitted by the Next.js middleware.
+Nginx (`ssrcache` zone) sits between the CF worker and vision_web. It runs
+on each origin server (eu/us/asia.ecency.com). Because the worker has
+already keyed on auth-class and only forwards cacheable requests, **nginx
+does NOT need to gate on `active_user` cookie itself** — origin's
+`Cache-Control` is the source of truth.
 
-## Required changes
-
-### 1. Respect origin Cache-Control for HTML
-
-**Remove** any `proxy_ignore_headers Cache-Control;` directive that applies to
-HTML responses. Next.js is the source of truth.
-
-**Set** `proxy_cache_valid` to defer to origin:
+## Cache zone
 
 ```nginx
-# Respect Cache-Control from origin (Next.js middleware)
-proxy_cache_valid 200 0;
-# Keep short fallback for responses without Cache-Control
-proxy_cache_valid any 30s;
+proxy_cache_path /var/cache/nginx/ssr levels=1:2
+                 keys_zone=ssrcache:200m
+                 max_size=32g
+                 inactive=2h;
 ```
 
-### 2. Cookie-aware cache key and bypass
+- `keys_zone=200m` — supports ~1.6M keys (~125 bytes each)
+- `max_size=32g` — total disk; LRU evicts beyond this
+- `inactive=2h` — entries not accessed in 2 hours are evicted regardless of
+  s-maxage. Picked as a compromise between honoring the policy intent (some
+  tiers want 30d) and bounding edit-staleness for long-tail content. A
+  separate `last_update`-based invalidation system would be required to
+  honor full s-maxage safely.
 
-Logged-in users must never see cached anonymous HTML, and vice versa.
-
-```nginx
-# Vary cache by auth state
-proxy_cache_key "$scheme$request_method$host$request_uri$cookie_active_user";
-
-# Skip cache entirely when user is logged in
-proxy_cache_bypass $cookie_active_user;
-proxy_no_cache     $cookie_active_user;
-```
-
-### 3. Respect `stale-while-revalidate`
-
-Nginx supports serving stale content via `proxy_cache_use_stale`:
+## Per-host config
 
 ```nginx
-proxy_cache_use_stale updating error timeout http_500 http_502 http_503 http_504;
-proxy_cache_background_update on;
-proxy_cache_lock on;
-```
-
-`proxy_cache_background_update on` is the Nginx equivalent of
-`stale-while-revalidate` — it serves stale content to the client while
-fetching a fresh copy in the background.
-
-### 4. Expose cache status for observability
-
-```nginx
-add_header X-Cache-Status $upstream_cache_status always;
-# Preserve the tier header set by middleware
-add_header X-Cache-Tier $upstream_http_x_cache_tier always;
-```
-
-## Example block
-
-```nginx
-proxy_cache_path /var/cache/nginx/ssr levels=1:2 keys_zone=ssr_cache:50m
-                 max_size=5g inactive=7d use_temp_path=off;
-
 server {
   listen 80;
-  server_name ecency.com;
+  server_name eu.ecency.com;  # or us / asia per host
 
   location / {
-    proxy_cache                  ssr_cache;
-    proxy_cache_key              "$scheme$request_method$host$request_uri$cookie_active_user";
-    proxy_cache_valid            200 0;    # defer to origin
-    proxy_cache_valid            any 30s;  # fallback
-    proxy_cache_bypass           $cookie_active_user;
-    proxy_no_cache               $cookie_active_user;
+    proxy_cache                  ssrcache;
+    proxy_cache_key              "$request_uri";
+    # Defer to origin Cache-Control. Fallback for responses without it.
+    proxy_cache_valid            200 0;
+    proxy_cache_valid            any 30s;
+    # Stale-while-revalidate semantics
     proxy_cache_use_stale        updating error timeout http_500 http_502 http_503 http_504;
     proxy_cache_background_update on;
     proxy_cache_lock             on;
+    proxy_cache_lock_timeout     5s;
 
+    # Observability
     add_header X-Cache-Status $upstream_cache_status always;
     add_header X-Cache-Tier   $upstream_http_x_cache_tier always;
 
-    proxy_pass http://vision_next_upstream;
+    proxy_pass http://127.0.0.1:3000;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_connect_timeout 5s;
+    proxy_send_timeout    20s;
+    proxy_read_timeout    20s;
   }
 }
 ```
 
+## Why no cookie in cache key
+
+The CF worker keys on `https://cache.internal/<authClass><path><query>`
+where `authClass` ∈ `{anon, loggedin}`. Nginx is downstream of the worker
+and never sees both auth classes — the worker has already split traffic.
+Including `$cookie_active_user` in the nginx cache key would just create a
+3rd-level fragmentation that doesn't help.
+
+For the rare case of nginx being hit directly (e.g. internal monitoring,
+direct origin access bypassing CF), the response is still safe because
+origin's middleware emits the right Cache-Control regardless of how the
+request arrived.
+
 ## Verification
 
-After applying these changes, verify with:
+Hit nginx directly (its listen port, with the right `Host:` header) to
+isolate the nginx + middleware layers from CF. Going through port 3000
+would bypass nginx and exercise only the upstream Next.js process —
+useful for middleware-only checks but won't show `X-Cache-Status`.
+Browser sessions remain the right way to verify the full edge stack
+end-to-end.
 
 ```bash
-# First request — MISS
-curl -sI https://ecency.com/discover | grep -iE 'cache|tier'
-# X-Cache-Status: MISS
-# X-Cache-Tier: list
-# Cache-Control: public, max-age=0, s-maxage=300, stale-while-revalidate=3600
+# Anon post page — second request should HIT in nginx ssrcache
+curl -sI -H "Host: ecency.com" \
+  "http://127.0.0.1/<community>/<author>/<permlink>" | grep -iE 'cache|tier'
+# expect X-Cache-Status: MISS first, HIT on replay
 
-# Second request — HIT
-curl -sI https://ecency.com/discover | grep -iE 'cache|tier'
-# X-Cache-Status: HIT
+# Logged-in (cacheable route) — origin emits public/s-maxage; nginx caches
+curl -sI --cookie "active_user=alice" -H "Host: ecency.com" \
+  "http://127.0.0.1/@<author>" | grep -iE 'cache|tier'
+# expect Cache-Control: public ... s-maxage=300
+# expect X-Cache-Status: MISS first, HIT on replay
 
-# Logged-in bypass
-curl -sI --cookie "active_user=alice" https://ecency.com/discover | grep -iE 'cache|tier'
-# X-Cache-Status: BYPASS
-# X-Cache-Tier: logged-in
-# Cache-Control: private, no-store
+# Logged-in (feed) — never cached, X-Cache-Status: BYPASS or MISS each time
+curl -sI --cookie "active_user=alice" -H "Host: ecency.com" \
+  "http://127.0.0.1/created" | grep -iE 'cache|tier'
+# expect Cache-Control: private, no-store
+# expect X-Cache-Tier: feed-created-loggedin
 ```
 
 ## Rollout
 
-1. Apply in staging, verify headers
-2. Watch origin RPS — should drop sharply
-3. Roll to production region-by-region
+1. Apply config in staging, verify config test (`nginx -t`).
+2. Reload via `systemctl reload nginx` (zero downtime).
+3. Watch `$upstream_cache_status` distribution in access logs — HIT% should
+   climb on cacheable routes within a few hours of warmup under normal load.


### PR DESCRIPTION
Empirical analysis across 26 page types (post, profile, community, lists, static, feeds, etc.) confirmed SSR is auth-class-equivalent on every route except ones that read active_user server-side. The previous blanket isLoggedIn -> private, no-store was over-conservative and threw away cache hits for ~70-80% of post-page traffic that's safely shareable.

Changes:

- cache-policy.ts: introduce USER_SPECIFIC_TIERS_WHEN_LOGGED_IN (feed, feed-created, profile-feed) which read active_user as observer for mute filtering and must stay private when logged-in. All other tiers emit the same s-maxage for anon and logged-in.
- cache-policy.ts: add insights to NO_CACHE_PROFILE_SECTIONS - the route handler reads active_user for owner-only stats, so SSR differs for the profile owner vs other viewers.
- cache-policy.ts: export isUserSpecificForLoggedIn(policy, isLoggedIn).
- middleware.ts: x-cache-tier reflects actual gating (feed-loggedin) instead of a generic "logged-in" label, for log/analytics observability.
- docs/cache: rewrite worker + nginx docs to describe the auth-class cache-key strategy. Cookie-keyed nginx cache and worker bypass are removed; auth bifurcation now lives in the worker via the cache key.

Worker side (out of repo): cacheKey encodes auth-class as a synthetic URL prefix, allowing 2 cache entries per URL (anon vs logged-in) without a Vary: Cookie header that would fragment cache on every cookie.

Tests updated. Roll out alpha first, watch Sentry for hydration mismatches and CF analytics for post-page HIT% lift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cache control logic that intelligently respects user authentication status, particularly for feed and profile pages.

* **Documentation**
  * Updated cache architecture documentation for Cloudflare Worker and nginx integration.

* **Tests**
  * Expanded test coverage for cache policy behavior across authenticated and anonymous user scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->