### PR TITLE
Move /chats /decks /waves /perks /search to a 60s cacheable tier

### DIFF
--- a/apps/web/src/features/next-middleware/cache-policy.ts
+++ b/apps/web/src/features/next-middleware/cache-policy.ts
@@ -23,23 +23,49 @@ export interface CachePolicy {
 
 const NO_CACHE_TIER = "no-cache";
 
-/** Routes that must never be edge-cached (user-specific or interactive). */
+/**
+ * Routes that must never be edge-cached.
+ *
+ * These either render user-specific content server-side (drafts, wallet
+ * balances) or are inherently interactive/transactional (auth flows, market
+ * trading) where stale HTML could mislead the user.
+ *
+ * Routes that look interactive but actually render an auth-class-equivalent
+ * scaffold (with dynamic content hydrated client-side) are NOT here — they
+ * use the `dynamic-page` tier instead. See DYNAMIC_PAGE_PREFIXES below.
+ */
 const NO_CACHE_PREFIXES = [
-  "/publish",
-  "/chats",
-  "/auth",
-  "/signup",
-  "/submit",
-  "/draft",
-  "/onboard-friend",
-  "/purchase",
-  "/perks",
-  "/decks",
-  "/waves",
-  "/market",
-  "/search",
-  "/wallet"
+  "/publish", // user's drafts, in-progress content
+  "/auth", // authentication redirect flows
+  "/signup", // signup form state
+  "/submit", // post-submission form state
+  "/draft", // user-specific drafts
+  "/onboard-friend", // referral flow
+  "/purchase", // payment flow
+  "/market", // trading interactive UI
+  "/wallet" // user-specific balances
 ];
+
+/**
+ * Routes that render an anonymous-equivalent scaffold server-side and
+ * hydrate dynamic content client-side. Empirically verified that SSR HTML
+ * is byte-identical across anon, user1, user2 (route handlers don't read
+ * cookies; data fetched via React Query after hydration).
+ *
+ * Cached at 60s shared TTL — addresses the bulk of 504s historically caused
+ * by these routes saturating origin SSR (they were ~50% of post-deploy 504s
+ * because every request hit origin).
+ *
+ * - `/chats`  — Mattermost-backed messaging shell; channel/message data
+ *               loads client-side per user
+ * - `/decks`  — TweetDeck-style multi-feed UI; column content loads
+ *               client-side
+ * - `/waves`  — Hive waves (short-form posts) feed
+ * - `/perks`  — Subscription perks page; mostly static
+ * - `/search` — Search results; query is in the URL so different queries
+ *               get different cache entries automatically
+ */
+const DYNAMIC_PAGE_PREFIXES = ["/chats", "/decks", "/waves", "/perks", "/search"];
 
 /**
  * Profile subsections that must never be edge-cached.
@@ -110,8 +136,13 @@ export function isUserSpecificForLoggedIn(policy: CachePolicy, isLoggedIn: boole
 }
 
 export function getCachePolicyForPath(pathname: string): CachePolicy | null {
-  // Strip trailing slash (except root) for consistent matching.
-  const path = pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  // Normalize for consistent matching:
+  //   - Strip query string (callers usually pass `nextUrl.pathname` which has none,
+  //     but be defensive — `/search?q=...` should still match the `/search` prefix).
+  //   - Strip trailing slash (except for root).
+  const queryIdx = pathname.indexOf("?");
+  const noQuery = queryIdx >= 0 ? pathname.slice(0, queryIdx) : pathname;
+  const path = noQuery.length > 1 && noQuery.endsWith("/") ? noQuery.slice(0, -1) : noQuery;
 
   // Never cache API routes, Next internals, or assets (those are handled in next.config.js).
   if (
@@ -127,6 +158,16 @@ export function getCachePolicyForPath(pathname: string): CachePolicy | null {
   for (const prefix of NO_CACHE_PREFIXES) {
     if (path === prefix || path.startsWith(prefix + "/")) {
       return { tier: NO_CACHE_TIER, sMaxAge: 0, staleWhileRevalidate: 0 };
+    }
+  }
+
+  // Dynamic pages: anonymous-equivalent SSR with client-hydrated content.
+  // 60s/300s lets us absorb thundering-herd spikes on these routes (which
+  // historically saturated origin and produced ~50% of 504s) while still
+  // refreshing dynamic content frequently.
+  for (const prefix of DYNAMIC_PAGE_PREFIXES) {
+    if (path === prefix || path.startsWith(prefix + "/")) {
+      return { tier: "dynamic-page", sMaxAge: 60, staleWhileRevalidate: 300 };
     }
   }
 

--- a/apps/web/src/specs/features/next-middleware/cache-policy.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/cache-policy.spec.ts
@@ -14,8 +14,6 @@ describe("getCachePolicyForPath", () => {
     it.each([
       "/publish",
       "/publish/entry/@alice/hello",
-      "/chats",
-      "/chats/general",
       "/auth",
       "/auth/keychain-sign",
       "/signup",
@@ -24,10 +22,6 @@ describe("getCachePolicyForPath", () => {
       "/wallet",
       "/wallet/hive",
       "/market",
-      "/search",
-      "/decks",
-      "/waves",
-      "/perks",
       "/purchase",
       "/onboard-friend"
     ])("returns no-cache tier for %s", (path) => {
@@ -44,6 +38,24 @@ describe("getCachePolicyForPath", () => {
     ])("returns no-cache for sensitive profile section %s", (path) => {
       const policy = getCachePolicyForPath(path);
       expect(policy?.tier).toBe("no-cache");
+    });
+  });
+
+  describe("dynamic-page tier (anonymous-equivalent SSR, 60s)", () => {
+    it.each([
+      "/chats",
+      "/chats/general",
+      "/decks",
+      "/decks/main",
+      "/waves",
+      "/waves/@alice/wave-1",
+      "/perks",
+      "/perks/promote-post",
+      "/search",
+      "/search?q=hive"
+    ])("returns dynamic-page tier for %s", (path) => {
+      const policy = getCachePolicyForPath(path);
+      expect(policy).toEqual({ tier: "dynamic-page", sMaxAge: 60, staleWhileRevalidate: 300 });
     });
   });
 
@@ -192,6 +204,26 @@ describe("getCachePolicyForPath", () => {
 
     it("does not collapse root /", () => {
       expect(getCachePolicyForPath("/")?.tier).toBe("home");
+    });
+  });
+
+  describe("query string normalization", () => {
+    it("strips query string before matching (e.g. /search?q=hive)", () => {
+      expect(getCachePolicyForPath("/search?q=hive")).toEqual(
+        getCachePolicyForPath("/search")
+      );
+    });
+
+    it("strips query string for no-cache prefixes too", () => {
+      expect(getCachePolicyForPath("/publish?ref=foo")).toEqual(
+        getCachePolicyForPath("/publish")
+      );
+    });
+
+    it("strips query string for entry pages", () => {
+      expect(getCachePolicyForPath("/photography/@alice/my-post?utm=x")).toEqual(
+        getCachePolicyForPath("/photography/@alice/my-post")
+      );
     });
   });
 });

--- a/docs/cache/README.md
+++ b/docs/cache/README.md
@@ -56,6 +56,7 @@ content).
 | `list-proposals` | 10m | 1h | `/proposals` | yes |
 | `feed` | 1m | 5m | `/hot`, `/trending`, `/payout`, `/muted`, `/promoted` + tags | **no** (mute filter) |
 | `feed-created` | 30s | 2m | `/created`, `/tags/:tag` | **no** (mute filter) |
+| `dynamic-page` | 1m | 5m | `/chats`, `/decks`, `/waves`, `/perks`, `/search` | yes (anon-equivalent SSR + client hydration) |
 | `community` | 1m | 5m | `/:tag/hive-xxxxx` | yes |
 | `profile` | 5m | 1h | `/@author`, `/@author/posts`, `/blog`, `/comments`, `/replies`, `/communities` | yes |
 | `profile-feed` | 1m | 5m | `/@author/feed`, `/@author/trail` (aggregates other users' content) | **no** (mute filter) |
@@ -65,7 +66,7 @@ content).
 | `entry-month` | 1d | 7d | posts 7-30 days old | yes |
 | `entry-archive` | 30d | 7d | posts 30-60 days old | yes |
 | `entry-ancient` | 30d | 60d | posts > 60 days old | yes |
-| `no-cache` | 0 | 0 | `/publish`, `/chats`, `/auth/*`, `/wallet`, `/@author/settings`, `/@author/insights`, etc. | no |
+| `no-cache` | 0 | 0 | `/publish`, `/auth/*`, `/signup`, `/submit`, `/draft`, `/onboard-friend`, `/purchase`, `/market`, `/wallet`, `/@author/{wallet,settings,permissions,referrals,insights}` | no |
 
 **Empirical basis (2026-05-08):** SSR was tested across 26 page types with
 multiple user identities. Routes flagged as cacheable for logged-in produce


### PR DESCRIPTION
These routes were in NO_CACHE_PREFIXES along with truly-interactive routes (/publish, /auth, /signup, /market, /wallet, etc.), but their SSR is empirically auth-class-equivalent — route handlers don't read cookies, and dynamic content (chat messages, deck columns, wave feed entries, search results) is hydrated client-side via React Query.

Production 504 analysis showed they were responsible for ~50% of post-deploy 504s, because every request bypassed cache and saturated origin SSR under spikes. Caching them at 60s shared TTL absorbs thundering-herd spikes without losing the dynamic-content freshness.

Changes:
- Split NO_CACHE_PREFIXES into truly-no-cache routes only (publish, auth, signup, submit, draft, onboard-friend, purchase, market, wallet).
- Add DYNAMIC_PAGE_PREFIXES (chats, decks, waves, perks, search) with new `dynamic-page` tier at s-maxage=60, swr=300.
- /search query string is part of the cache key, so different queries get different entries automatically.
- Auth-class cache key separation (added in feat/loggedin-cache) means these still get separate entries for anon vs logged-in.
- Tests updated to assert the new tier for each affected path.
- docs/cache/README.md tier table updated.

Empirical validation across all 5 routes: SSR md5 byte-identical for anon, user1, user2 across multiple sample requests. Route handlers grep'd for cookies()/active_user/observer — all 0 reads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized cache behavior for dynamic pages including chats, decks, waves, perks, and search to improve response times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->