### PR TITLE
Fix redirect loop on paths with brackets ([object Object])

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -59,14 +59,26 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
     return handleIndexRedirect(request);
   }
 
-  // Decode URL and redirect if needed
+  // Decode URL and redirect if needed.
+  //
+  // Guard against redirect loops: when the path contains characters that the
+  // URL pathname setter does NOT re-encode (e.g. brackets in `[object Object]`),
+  // assigning the decoded form back produces the same encoded string we
+  // received. Without this check we'd 307 to the same URL forever — see the
+  // ERR_TOO_MANY_REDIRECTS reports on `/@user/[object Object]` paths produced
+  // when a non-string value gets templated into a URL elsewhere in the app.
   const path = request.nextUrl.pathname;
   try {
     const decodedPath = decodeURIComponent(path);
     if (decodedPath !== path) {
       const url = request.nextUrl.clone();
       url.pathname = decodedPath;
-      return NextResponse.redirect(url);
+      // After the URL setter, url.pathname is the re-encoded canonical form.
+      // If that already matches the request's path, redirecting is a no-op
+      // and would loop.
+      if (url.pathname !== path) {
+        return NextResponse.redirect(url);
+      }
     }
   } catch (e) {
     if (e instanceof URIError) {


### PR DESCRIPTION
Some users encounter ERR_TOO_MANY_REDIRECTS when a JS object accidentally gets templated into a URL — typically `/@user/[object Object]` after a non-string value is interpolated somewhere in the app.

The decode-redirect block in middleware.ts re-canonicalizes percent-encoded paths back to their decoded form. The URL pathname setter, however, does NOT re-encode brackets (`[`, `]`) because they're not in the URL "path-percent-encode set" per the WHATWG spec — only space, control chars, and a few punctuation marks get encoded. Result: setting `url.pathname` to the decoded form produces the same encoded string we received, and we 307 to the same URL forever.

Fix: after the assignment, compare `url.pathname` (the re-encoded canonical form) with the original `path`. If they match, the redirect is a no-op and we skip it. Legitimate decoded-redirect cases (e.g. accented characters where the URL setter does re-encode to %XX) still redirect normally.

Also reduces 1100+ noisy 307s/day from a single client whose JS state was stuck looping on a `/@user/[object Object]` URL, and is suspected to be an upstream cause of the `TypeError: contentWindow is null` Sentry events (client side-effects firing during the rapid redirect storm before iframes mount).