### PR TITLE
Fix React #418 hydration mismatch on /@user/wallet

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/wallet/_components/profile-wallet-external-banner.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/wallet/_components/profile-wallet-external-banner.tsx
@@ -13,7 +13,7 @@ import { UilArrowRight } from "@tooni/iconscout-unicons-react";
 import i18next from "i18next";
 import Image from "next/image";
 import { useParams } from "next/navigation";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import useLocalStorage from "react-use/lib/useLocalStorage";
 
 const EXTERNAL_BANNER_STORAGE_KEY_PREFIX = "externalWalletSetupBannerDismissed";
@@ -30,14 +30,22 @@ export function ProfileWalletExternalBanner() {
     null
   );
 
+  // Avoid hydration mismatch: SSR has no localStorage so `dismissedAt` is the
+  // default (null) and the banner renders; but a returning user may have
+  // dismissed it, which would make the first client render skip the banner
+  // entirely — a different DOM tree than SSR, triggering React error #418.
+  // Treat as "not dismissed" until after mount.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+
   const isDismissed = useMemo(() => {
-    if (!dismissedAt) {
+    if (!hydrated || !dismissedAt) {
       return false;
     }
 
     const diff = Date.now() - dismissedAt;
     return diff < THIRTY_DAYS_IN_MS;
-  }, [dismissedAt]);
+  }, [hydrated, dismissedAt]);
 
   useEffect(() => {
     if (!dismissedAt) {

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/wallet/_components/profile-wallet-summary.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/wallet/_components/profile-wallet-summary.tsx
@@ -9,7 +9,7 @@ import {
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { motion } from "framer-motion";
 import { useParams } from "next/navigation";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import i18next from "i18next";
 import useLocalStorage from "react-use/lib/useLocalStorage";
 
@@ -24,6 +24,14 @@ export function ProfileWalletSummary() {
   const { username } = useParams();
   const currency = useGlobalStore((state) => state.currency);
   const [showDetails, setShowDetails] = useLocalStorage(PREFIX + "_wallet_details", true);
+  // Avoid hydration mismatch: SSR has no localStorage so the hook returns the
+  // default (true), but a returning user may have toggled details off — that
+  // would render a different DOM client-side and trigger React error #418.
+  // Use the SSR default during the first render, switch to the stored value
+  // after mount.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  const detailsVisible = hydrated ? !!showDetails : true;
   const { data } = useQuery(
     getAccountWalletListQueryOptions((username as string).replace("%40", ""), currency || "usd")
   );
@@ -114,17 +122,17 @@ export function ProfileWalletSummary() {
       </div>
       <ProfileWalletPendingEarnings />
       <button
-        onClick={() => setShowDetails(!showDetails)}
+        onClick={() => setShowDetails(!detailsVisible)}
         className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors cursor-pointer self-start"
-        aria-expanded={showDetails}
+        aria-expanded={detailsVisible}
         aria-controls="wallet-details"
       >
-        {showDetails
+        {detailsVisible
           ? i18next.t("wallet.hide-details", { defaultValue: "Hide details" })
           : i18next.t("wallet.show-details", { defaultValue: "Show details" })
         }
       </button>
-      {showDetails && (
+      {detailsVisible && (
         <div id="wallet-details">
           <div className="flex w-full text-sm text-gray-400 dark:text-white rounded-lg overflow-hidden gap-0.5">
             {assetsParts.length === 0 && (


### PR DESCRIPTION
Two wallet components read localStorage during render and let it gate which DOM tree gets produced. SSR has no localStorage, so it always uses the hook's default value; the first client render reads the stored value and may produce a different tree, which React aborts as error #418 in production.

profile-wallet-summary.tsx — `_wallet_details` defaults to true on the server, but a returning user who toggled it off would skip the DetailsSection on first client render.

profile-wallet-external-banner.tsx — `dismissedAt` defaults to null on the server (banner renders), but a returning user who dismissed it would early-return on first client render.

Both now gate the localStorage value behind a `hydrated` flag set inside useEffect, so SSR and the first client render produce identical DOM and the stored preference applies on the next paint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering stability issues in the profile wallet banner and summary components to ensure consistent display across different loading states.
  * Improved reliability of wallet information visibility toggle and banner dismissal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->