### PR TITLE
Read post-age L2 (Redis) on the request path

### DIFF
--- a/apps/web/public/dmca/dmca-accounts.json
+++ b/apps/web/public/dmca/dmca-accounts.json
@@ -229,6 +229,7 @@
     "metamasksupport",
     "metamasksupportu",
     "metamaskus",
+    "miriam-flow",
     "mmcrypto1",
     "mmfuture",
     "mondkratzert5445",
@@ -364,6 +365,6 @@
     "zhgsildfh",
     "zkbvu0tcv2la"
   ],
-  "updated": "2026-01-28T10:00:00.123Z",
+  "updated": "2026-05-08T08:45:00.000Z",
   "version": "1.0"
 }

--- a/apps/web/src/features/next-middleware/post-age-cache.ts
+++ b/apps/web/src/features/next-middleware/post-age-cache.ts
@@ -11,13 +11,17 @@
  * amplifying RPC-node-lag false negatives across all replicas in a region.
  *
  * Design:
- *   - Best-effort. A miss falls back to a conservative entry tier in
- *     middleware — no added latency on the current request.
- *   - After a miss, middleware kicks off `event.waitUntil(refreshPostCreatedMs)`.
- *     refresh checks Redis first (cheap dedup across replicas for positive
- *     entries) and only hits RPC if Redis also missed.
- *   - The synchronous getter only consults L1; we deliberately do NOT block
- *     on Redis from the request path.
+ *   - Two getters share L1:
+ *       getCachedPostCreatedMs (sync) — L1-only, for callers that can't await.
+ *       awaitPostCreatedMs (async) — L1 fast path, then Redis with a tight
+ *         timeout. Used by middleware on the request path: Redis on the
+ *         docker overlay is sub-millisecond when healthy, and skipping it
+ *         here meant the entry-unknown response (60s) got cached at every
+ *         edge layer until L1 happened to warm — which rarely converged
+ *         for long-tail posts under load-balanced traffic + L1 FIFO eviction.
+ *   - On L1 miss, middleware also kicks off `event.waitUntil(refreshPostCreatedMs)`
+ *     so future requests find positive entries in Redis even if this one
+ *     timed out the request-path lookup.
  *   - Transient RPC failures (timeout, all nodes failed) do NOT enter the
  *     cache at all — let the next request retry.
  *   - Non-throwing misses (RPC succeeded but returned no `created` field)
@@ -44,6 +48,10 @@ const MAX_ENTRIES = 2000;
 const NEGATIVE_CACHE_TTL_MS = 5 * 60_000;
 const FETCH_TIMEOUT_MS = 2000;
 const FETCH_RETRIES = 2;
+// Tight cap on the request-path Redis lookup. Local docker overlay reads are
+// sub-ms when healthy; 50ms protects middleware from a degraded Redis without
+// regressing to today's behavior (we just fall through to entry-unknown).
+const REQUEST_PATH_REDIS_TIMEOUT_MS = 50;
 
 const REDIS_URL = process.env.REDIS_URL || "redis://redis:6379";
 const REDIS_KEY_PREFIX = "postage:";
@@ -99,29 +107,92 @@ function getRedis(): RedisClient | null {
 }
 
 /**
- * Synchronous cache lookup. Returns the post's created-timestamp in ms,
- * or null if we have a negative-cache entry, or undefined if we don't know.
- *
- * Only L1 is consulted — Redis is async and middleware can't await on the
- * request path. A miss returns undefined and the caller should kick off
- * `refreshPostCreatedMs` via `event.waitUntil(...)`.
+ * Sentinel distinct from a negative-cache hit: `null` means "we have a
+ * negative entry in L1", whereas L1_MISS means "L1 doesn't have anything
+ * for this key". Callers map L1_MISS → fall through to L2 / undefined.
  */
-export function getCachedPostCreatedMs(
-  author: string,
-  permlink: string
-): number | null | undefined {
-  const k = key(author, permlink);
+const L1_MISS = Symbol("l1-miss");
+type L1Result = number | null | typeof L1_MISS;
+
+function consultL1(k: string): L1Result {
   const entry = l1.get(k);
-  if (!entry) return undefined;
+  if (!entry) return L1_MISS;
 
   // Negative entries expire after NEGATIVE_CACHE_TTL_MS; positive entries
   // are valid indefinitely (created dates are immutable on Hive).
   if (entry.createdMs === null && Date.now() - entry.cachedAt > NEGATIVE_CACHE_TTL_MS) {
     l1.delete(k);
-    return undefined;
+    return L1_MISS;
   }
 
   return entry.createdMs;
+}
+
+/**
+ * Synchronous cache lookup. Returns the post's created-timestamp in ms,
+ * or null if we have a negative-cache entry, or undefined if we don't know.
+ *
+ * Only L1 is consulted. Use `awaitPostCreatedMs` from middleware where the
+ * Redis fallback is desired; this sync flavor is for callers that can't
+ * await (none today, but the export is preserved for stability).
+ */
+export function getCachedPostCreatedMs(
+  author: string,
+  permlink: string
+): number | null | undefined {
+  const r = consultL1(key(author, permlink));
+  return r === L1_MISS ? undefined : r;
+}
+
+/**
+ * Asynchronous cache lookup. Same return semantics as
+ * `getCachedPostCreatedMs`, but on L1 miss falls through to Redis with a
+ * tight timeout. Used by middleware on the request path so the entry-tier
+ * response carries the refined TTL even on a cold-L1 replica — without it,
+ * the entry-unknown 60s response gets cached at every edge layer until L1
+ * happens to warm, which rarely converges for long-tail posts.
+ *
+ * - L1 hit (positive or non-expired negative) → resolve immediately.
+ * - L1 miss + Redis hit → populate L1, resolve with the value.
+ * - L1 miss + Redis miss / timeout / error → resolve undefined. Caller is
+ *   expected to also schedule `event.waitUntil(refreshPostCreatedMs)` so
+ *   the next request finds a positive entry.
+ *
+ * Negatives are intentionally never read from Redis: refresh only writes
+ * positives there (RPC node lag protection — see refreshPostCreatedMs).
+ */
+export async function awaitPostCreatedMs(
+  author: string,
+  permlink: string
+): Promise<number | null | undefined> {
+  const k = key(author, permlink);
+
+  const l1Result = consultL1(k);
+  if (l1Result !== L1_MISS) return l1Result;
+
+  const redis = getRedis();
+  if (!redis) return undefined;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const TIMEOUT = Symbol("redis-timeout");
+  const timeout = new Promise<typeof TIMEOUT>((resolve) => {
+    timer = setTimeout(() => resolve(TIMEOUT), REQUEST_PATH_REDIS_TIMEOUT_MS);
+  });
+
+  try {
+    const v = await Promise.race([redis.get(REDIS_KEY_PREFIX + k), timeout]);
+    if (v === TIMEOUT) return undefined;
+    if (v === null || v === undefined) return undefined; // Redis miss
+    const n = Number(v);
+    if (!Number.isFinite(n)) return undefined; // malformed
+    setL1(k, n);
+    return n;
+  } catch {
+    // Redis hiccup — fall through to undefined; refresh path will retry.
+    return undefined;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 /**
@@ -242,4 +313,14 @@ export function __resetPostAgeCacheForTests(): void {
     }
   }
   _redis = undefined;
+}
+
+/**
+ * Test-only: inject a fake Redis client (or null to force "no Redis").
+ * Bypasses lazy init so tests can exercise `awaitPostCreatedMs`'s L2 path
+ * without opening a real socket. Pass `undefined` to clear and re-trigger
+ * normal lazy init on next call.
+ */
+export function __setRedisForTests(client: RedisClient | null | undefined): void {
+  _redis = client;
 }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
 import {
+  awaitPostCreatedMs,
   buildCacheControlHeader,
-  getCachedPostCreatedMs,
   getCachePolicyForPath,
   getEntryTierForAge,
   handleIndexRedirect,
@@ -23,7 +23,7 @@ const ENTRY_COLD_MISS_POLICY = { tier: "entry-unknown", sMaxAge: 60, staleWhileR
 
 const METHOD_NOT_ALLOWED_HEADERS = { Allow: "GET, HEAD, OPTIONS" };
 
-export function middleware(request: NextRequest, event: NextFetchEvent) {
+export async function middleware(request: NextRequest, event: NextFetchEvent) {
   const { pathname } = request.nextUrl;
   const method = request.method;
 
@@ -107,11 +107,11 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
   }
 
   const response = NextResponse.next();
-  applyCacheHeaders(request, response, path, event);
+  await applyCacheHeaders(request, response, path, event);
   return response;
 }
 
-function applyCacheHeaders(
+async function applyCacheHeaders(
   request: NextRequest,
   response: NextResponse,
   path: string,
@@ -122,26 +122,28 @@ function applyCacheHeaders(
 
   const isLoggedIn = request.cookies.has(ACTIVE_USER_COOKIE_NAME);
 
-  // For entry pages, try to refine TTL based on post age. Cache-miss here is
-  // non-blocking: we set the default entry tier immediately and populate the
-  // cache in the background for the next request.
-  // Runs for both anon and logged-in users — entry tier is cacheable in both
-  // cases (per buildCacheControlHeader), so logged-in users benefit equally
-  // from age-refined TTLs (entry-fresh through entry-ancient).
+  // For entry pages, refine TTL based on post age. The lookup hits L1 sync
+  // first; on miss it falls through to Redis with a tight timeout. Without
+  // the Redis step, the entry-unknown 60s response gets cached at every
+  // edge layer until L1 happens to warm — which rarely converges for
+  // long-tail posts under load-balanced traffic + L1 FIFO eviction.
+  // Runs for both anon and logged-in users — entry tier is cacheable in
+  // both cases (per buildCacheControlHeader).
   let policy = basePolicy;
   if (basePolicy.tier === "entry") {
     const parsed = parseEntryUrl(path);
     if (parsed) {
-      const createdMs = getCachedPostCreatedMs(parsed.author, parsed.permlink);
+      const createdMs = await awaitPostCreatedMs(parsed.author, parsed.permlink);
       if (typeof createdMs === "number") {
         policy = getEntryTierForAge(Date.now() - createdMs);
       } else {
-        // Both undefined (no cache entry) and null (cached as missing/malformed)
-        // get the conservative cold-miss TTL. Treating null as the default
-        // entry tier (1h/1d) over-caches when the RPC reports "no created"
-        // for a fresh post that simply isn't indexed yet on the node we hit.
-        // Only undefined triggers a background refresh — for null, the L1
-        // negative entry is still fresh and re-RPC'ing would just spam.
+        // Both undefined (not cached anywhere) and null (cached as missing/
+        // malformed in L1) get the conservative cold-miss TTL. Treating null
+        // as the default entry tier (1h/1d) over-caches when the RPC reports
+        // "no created" for a fresh post that simply isn't indexed yet on the
+        // node we hit. Only undefined triggers a background refresh — for
+        // null, the L1 negative entry is still fresh and re-RPC'ing would
+        // just spam.
         policy = ENTRY_COLD_MISS_POLICY;
         if (createdMs === undefined) {
           event.waitUntil(refreshPostCreatedMs(parsed.author, parsed.permlink));

--- a/apps/web/src/specs/features/next-middleware/post-age-cache.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/post-age-cache.spec.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetPostAgeCacheForTests,
+  __setRedisForTests,
+  awaitPostCreatedMs,
   getCachedPostCreatedMs,
   refreshPostCreatedMs
 } from "@/features/next-middleware";
@@ -13,6 +15,12 @@ vi.mock("@ecency/sdk", () => ({
 }));
 
 import { callRPC } from "@ecency/sdk";
+
+// Minimal stand-in for the bits of ioredis we touch on the request path.
+type FakeRedis = {
+  get: (k: string) => Promise<string | null>;
+  disconnect?: () => void;
+};
 
 describe("post-age-cache", () => {
   beforeEach(() => {
@@ -101,5 +109,90 @@ describe("post-age-cache", () => {
 
     expect(getCachedPostCreatedMs("alice", "post-a")).toBe(Date.parse("2025-01-01T00:00:00Z"));
     expect(getCachedPostCreatedMs("bob", "post-b")).toBe(Date.parse("2025-06-01T00:00:00Z"));
+  });
+});
+
+describe("awaitPostCreatedMs", () => {
+  beforeEach(() => {
+    __resetPostAgeCacheForTests();
+    vi.mocked(callRPC).mockReset();
+  });
+
+  afterEach(() => {
+    __setRedisForTests(undefined);
+    vi.restoreAllMocks();
+  });
+
+  it("returns L1 value without consulting Redis on hit", async () => {
+    vi.mocked(callRPC).mockResolvedValue({ created: "2025-01-15T12:00:00" });
+    await refreshPostCreatedMs("alice", "post"); // populate L1
+
+    const get = vi.fn();
+    __setRedisForTests({ get } as FakeRedis as never);
+
+    const v = await awaitPostCreatedMs("alice", "post");
+    expect(v).toBe(Date.parse("2025-01-15T12:00:00Z"));
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("falls through to Redis on L1 miss and populates L1", async () => {
+    const get = vi.fn().mockResolvedValue("1521633183000");
+    __setRedisForTests({ get } as FakeRedis as never);
+
+    const v = await awaitPostCreatedMs("alice", "post");
+    expect(v).toBe(1521633183000);
+    expect(get).toHaveBeenCalledWith("postage:alice/post");
+
+    // Subsequent sync read should hit L1.
+    expect(getCachedPostCreatedMs("alice", "post")).toBe(1521633183000);
+  });
+
+  it("returns undefined on Redis miss without poisoning L1", async () => {
+    const get = vi.fn().mockResolvedValue(null);
+    __setRedisForTests({ get } as FakeRedis as never);
+
+    const v = await awaitPostCreatedMs("alice", "post");
+    expect(v).toBeUndefined();
+    expect(getCachedPostCreatedMs("alice", "post")).toBeUndefined();
+  });
+
+  it("returns undefined when Redis returns malformed value", async () => {
+    const get = vi.fn().mockResolvedValue("not-a-number");
+    __setRedisForTests({ get } as FakeRedis as never);
+
+    const v = await awaitPostCreatedMs("alice", "post");
+    expect(v).toBeUndefined();
+  });
+
+  it("returns undefined on Redis error", async () => {
+    const get = vi.fn().mockRejectedValue(new Error("ECONNRESET"));
+    __setRedisForTests({ get } as FakeRedis as never);
+
+    const v = await awaitPostCreatedMs("alice", "post");
+    expect(v).toBeUndefined();
+  });
+
+  it("returns undefined when no Redis client is available", async () => {
+    __setRedisForTests(null);
+
+    const v = await awaitPostCreatedMs("alice", "post");
+    expect(v).toBeUndefined();
+  });
+
+  it("times out and returns undefined when Redis hangs past 50ms", async () => {
+    // get() never resolves — Promise.race against the internal 50ms timer
+    // must resolve to undefined.
+    const get = vi.fn().mockReturnValue(new Promise(() => {}));
+    __setRedisForTests({ get } as FakeRedis as never);
+
+    const start = Date.now();
+    const v = await awaitPostCreatedMs("alice", "post");
+    const elapsed = Date.now() - start;
+
+    expect(v).toBeUndefined();
+    // Lower bound proves we waited the timeout window; upper bound a safety
+    // margin so the test fails if the cap blows out.
+    expect(elapsed).toBeGreaterThanOrEqual(40);
+    expect(elapsed).toBeLessThan(500);
   });
 });

--- a/docs/cache/README.md
+++ b/docs/cache/README.md
@@ -105,24 +105,37 @@ Without step 2, CF serves the pre-DMCA HTML until `s-maxage` expires
 
 ## Per-post-age TTL refinement
 
-For entry (post) pages, the middleware starts with a conservative
-`entry-unknown` tier (60s / 5m) when the post's `created` date is not yet
-known, then refines it based on the post's age once available:
+For entry (post) pages, the middleware refines the cache TTL based on the
+post's age. The lookup is two-tier:
 
-1. First request for `/cat/@author/permlink` on a given replica: middleware
-   sees no cached age → emits `entry-unknown` (60s / 5m) → kicks off a
-   background lookup via `event.waitUntil(refreshPostCreatedMs(...))`.
-2. Background lookup checks Redis (L2, shared across the host's vision_web
-   replicas), then falls back to Hive RPC (`condenser_api.get_content`) if
-   Redis missed. Result is stored in both L1 (in-process Map) and Redis.
-3. Next request for the same post: L1 hit → middleware emits the refined
-   tier (`entry-fresh` through `entry-ancient`).
+1. **L1 — in-process `Map`** (per Node.js process, 4 replicas per host).
+   Sub-microsecond reads, capped at 2000 entries with FIFO eviction. Wiped
+   on replica restart.
+2. **L2 — per-host Redis** (one container per origin server, shared across
+   that host's 4 replicas via the docker overlay network). Sub-millisecond
+   local TCP. Survives replica restarts. Only positive entries — null
+   (negative-cache for missing/malformed RPC results) stays L1-only to
+   avoid amplifying RPC node lag across all replicas.
 
-L2 (Redis) lets the post-age cache survive replica restarts and amortize
-RPC fetches across all replicas on the same host. Failures during RPC
-(timeout, all nodes failed) are NOT cached — they let the next request
-retry — to avoid over-caching a fresh post to the default 1h tier across
-the whole region.
+On every entry-page request, middleware:
+
+1. Reads L1 (sync). On hit, emits the refined tier (`entry-fresh` through
+   `entry-ancient`) immediately.
+2. On L1 miss, awaits L2 with a tight 50ms cap. On hit, populates L1 and
+   emits the refined tier.
+3. On L1+L2 miss (or L2 timeout), emits `entry-unknown` (60s / 5m) and
+   kicks off `event.waitUntil(refreshPostCreatedMs(...))` which fetches
+   from Hive RPC (`condenser_api.get_content`) and writes both L1 and L2.
+
+The L2 read on the request path is what lets warm-Redis posts skip the
+`entry-unknown` window entirely. Without it, the entry-unknown 60s
+response gets cached at every edge layer until L1 happens to warm — which
+rarely converges for long-tail posts under load-balanced traffic +
+L1 FIFO eviction.
+
+Transient RPC failures (timeout, all nodes failed) are NOT cached — they
+let the next request retry — to avoid over-caching a fresh post to the
+default 1h tier across the whole region.
 
 See `apps/web/src/features/next-middleware/post-age-cache.ts`.
 

--- a/docs/cache/cloudflare-worker.md
+++ b/docs/cache/cloudflare-worker.md
@@ -83,6 +83,11 @@ The Next.js middleware refines entry-page TTL based on post age. A per-host
 Redis container (deployed alongside vision_web on each origin server) acts
 as L2 for the in-process L1 Map; it lets the post-age cache survive replica
 restarts and amortize RPC fetches across all replicas on the same host.
+Middleware reads L2 on the request path with a tight 50ms cap, so any
+replica on a host can emit the refined tier as soon as Redis is populated
+by any other replica — without that, the entry-unknown 60s response gets
+cached at every edge layer until the responding replica's L1 happens to
+warm, which rarely converges for long-tail posts.
 
 The CF worker does **not** need to fetch post metadata — it just respects
 the `Cache-Control` header emitted by middleware, which already encodes the


### PR DESCRIPTION
Middleware was checking only the in-process L1 Map for post `created` timestamps. With L1 capped at 2000 entries per replica + FIFO eviction + healthcheck-induced replica restarts, most long-tail post requests missed L1 even though Redis had the answer (1.7M entries across the 3 origins today).

Cold-L1 → middleware emits `entry-unknown` (60s s-maxage) → that response gets cached at every edge layer (worker `caches.default`, CF Smart Tiered Cache, nginx ssrcache). When the cache expires, CF re-fetches a load-balanced replica that may also be cold for that post, and the cycle repeats. Net result: post-page CF HIT% sits at 0.5–1.7% even though Redis is warm with most of these post ages.

Add `awaitPostCreatedMs` — same return semantics as the existing sync getter, but on L1 miss falls through to Redis with a 50ms `Promise.race` cap. Middleware (now `async`) uses it for the entry tier branch only; L1-hit reads stay sync-fast. On Redis timeout / error / miss, behavior is identical to today (emit entry-unknown, schedule RPC populate via `event.waitUntil`).

Sync `getCachedPostCreatedMs` is preserved for callers that can't await; both getters share the same L1 lookup helper.