### PR TITLE
Stream Mattermost channels & members instead of paginating

### DIFF
--- a/apps/web/src/app/api/mattermost/channels/helpers.ts
+++ b/apps/web/src/app/api/mattermost/channels/helpers.ts
@@ -1,4 +1,4 @@
-import { mmUserFetch } from "@/server/mattermost";
+import { mmUserFetch, mmUserFetchNdjson } from "@/server/mattermost";
 
 interface MattermostChannel {
   id: string;
@@ -27,36 +27,24 @@ interface MattermostChannelMemberCounts {
   last_update_at?: number;
 }
 
-export const pageSize = 200;
-export const maxPages = 3;
-
+// `/users/me/channels` returns the user's full channel list as a single
+// streamed response when no `page`/`per_page` are supplied. This matches
+// Client4.getAllTeamsChannels in the official Mattermost webapp and avoids
+// the 3-page sequential round-trip the previous paginated form required.
 export async function fetchAllChannelPages(token: string): Promise<MattermostChannel[]> {
-  const results: MattermostChannel[] = [];
-  for (let page = 0; page < maxPages; page++) {
-    const pageItems = await mmUserFetch<MattermostChannel[]>(
-      `/users/me/channels?page=${page}&per_page=${pageSize}`,
-      token
-    );
-    const items = Array.isArray(pageItems) ? pageItems : [];
-    results.push(...items);
-    if (items.length < pageSize) return results;
-  }
-  return results;
+  const result = await mmUserFetch<MattermostChannel[]>("/users/me/channels", token);
+  return Array.isArray(result) ? result : [];
 }
 
+// `/users/me/channel_members?page=-1` switches Mattermost into NDJSON
+// streaming mode (Client4.getAllChannelsMembers uses this with userId/-1).
+// It returns every channel-member row for the user across teams in a single
+// response, removing the sequential pagination we used to do per team.
 export async function fetchAllChannelMemberPages(
-  teamId: string,
   token: string
 ): Promise<MattermostChannelMemberCounts[]> {
-  const results: MattermostChannelMemberCounts[] = [];
-  for (let page = 0; page < maxPages; page++) {
-    const pageItems = await mmUserFetch<MattermostChannelMemberCounts[]>(
-      `/users/me/teams/${teamId}/channels/members?page=${page}&per_page=${pageSize}`,
-      token
-    );
-    const items = Array.isArray(pageItems) ? pageItems : [];
-    results.push(...items);
-    if (items.length < pageSize) return results;
-  }
-  return results;
+  return await mmUserFetchNdjson<MattermostChannelMemberCounts>(
+    "/users/me/channel_members?page=-1",
+    token
+  );
 }

--- a/apps/web/src/app/api/mattermost/channels/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/route.ts
@@ -77,7 +77,7 @@ export async function GET() {
     const [channels, currentUser, channelMembers, categoriesResponse, preferences] = await Promise.all([
       fetchAllChannelPages(token),
       mmUserFetch<MattermostUser>(`/users/me`, token),
-      fetchAllChannelMemberPages(teamId, token),
+      fetchAllChannelMemberPages(token),
       mmUserFetch<{ categories: MattermostChannelCategory[]; order: string[] }>(
         `/users/me/teams/${teamId}/channels/categories`,
         token

--- a/apps/web/src/app/api/mattermost/channels/unreads/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/unreads/route.ts
@@ -6,6 +6,7 @@ import {
   mmUserFetch
 } from "@/server/mattermost";
 import * as Sentry from "@sentry/nextjs";
+import { fetchAllChannelPages, fetchAllChannelMemberPages } from "../helpers";
 
 interface MattermostChannel {
   id: string;
@@ -41,38 +42,11 @@ interface MattermostThreadsResponse {
   total: number;
 }
 
-const PAGE_SIZE = 200;
-const DEFAULT_MAX_PAGES = 2; // Safety cap to avoid long-running unread checks
-const MAX_ALLOWED_PAGES = 2;
-
-function withPagination(path: string, page: number) {
-  const [base, query] = path.split("?");
-  const params = new URLSearchParams(query ?? "");
-  params.set("page", String(page));
-  params.set("per_page", String(PAGE_SIZE));
-  return `${base}?${params.toString()}`;
-}
-
-async function fetchAllPages<T>(path: string, token: string, maxPages: number) {
-  const results: T[] = [];
-  let truncated = false;
-
-  for (let page = 0; page < maxPages; page += 1) {
-    const pageItems = await mmUserFetch<T[]>(withPagination(path, page), token);
-    if (!pageItems.length) {
-      break;
-    }
-    results.push(...pageItems);
-    if (pageItems.length < PAGE_SIZE) {
-      break;
-    }
-    if (page === maxPages - 1) {
-      truncated = true;
-    }
-  }
-
-  return { items: results, truncated };
-}
+// Threads still paginate — kept identical to prior behavior. Channels and
+// channel-member lists now come from streaming endpoints (see helpers.ts).
+const THREAD_PAGE_SIZE = 200;
+const THREAD_DEFAULT_MAX_PAGES = 2;
+const THREAD_MAX_ALLOWED_PAGES = 2;
 
 async function fetchAllThreadPages(token: string, teamId: string, maxPages: number) {
   const results: MattermostThread[] = [];
@@ -80,7 +54,7 @@ async function fetchAllThreadPages(token: string, teamId: string, maxPages: numb
 
   for (let page = 0; page < maxPages; page += 1) {
     const response = await mmUserFetch<MattermostThreadsResponse>(
-      withPagination(`/users/me/teams/${teamId}/threads`, page),
+      `/users/me/teams/${teamId}/threads?page=${page}&per_page=${THREAD_PAGE_SIZE}`,
       token
     );
     const pageItems = response.threads || [];
@@ -88,7 +62,7 @@ async function fetchAllThreadPages(token: string, teamId: string, maxPages: numb
       break;
     }
     results.push(...pageItems);
-    if (pageItems.length < PAGE_SIZE) {
+    if (pageItems.length < THREAD_PAGE_SIZE) {
       break;
     }
     if (page === maxPages - 1) {
@@ -117,28 +91,24 @@ export async function GET() {
 
     const rawMaxPages = process.env.MATTERMOST_UNREAD_MAX_PAGES;
     const parsedMaxPages = Number.isNaN(parseInt(rawMaxPages ?? "", 10))
-      ? DEFAULT_MAX_PAGES
+      ? THREAD_DEFAULT_MAX_PAGES
       : parseInt(rawMaxPages as string, 10);
-    const maxPages = Math.min(
-      MAX_ALLOWED_PAGES,
+    const threadMaxPages = Math.min(
+      THREAD_MAX_ALLOWED_PAGES,
       Math.max(1, parsedMaxPages)
     );
 
-    const [channelsResult, membersResult, threadsResult, currentUser] = await Promise.all([
-      fetchAllPages<MattermostChannel>("/users/me/channels", token, maxPages),
-      fetchAllPages<MattermostChannelMember>(
-        `/users/me/teams/${teamId}/channels/members`,
-        token,
-        maxPages
-      ),
-      fetchAllThreadPages(token, teamId, maxPages).catch(() => ({ items: [], truncated: false })),
+    const [allChannels, members, threadsResult, currentUser] = await Promise.all([
+      fetchAllChannelPages(token),
+      fetchAllChannelMemberPages(token),
+      fetchAllThreadPages(token, teamId, threadMaxPages).catch(() => ({ items: [], truncated: false })),
       mmUserFetch<{ id: string }>(`/users/me`, token)
     ]);
 
-    const allChannels = channelsResult.items;
-    const members = membersResult.items;
     const threads = threadsResult.items;
-    const truncated = channelsResult.truncated || membersResult.truncated || threadsResult.truncated;
+    // Channels & members come from streaming endpoints — they cannot truncate.
+    // Only thread pagination can still hit a cap, so `truncated` reflects only that.
+    const truncated = threadsResult.truncated;
 
     // Extract user IDs from DM channels to check for deactivated users
     const dmChannels = allChannels.filter((ch) => ch.type === "D");
@@ -267,6 +237,8 @@ export async function GET() {
       .reduce((sum, channel) => sum + channel.thread_unread, 0);
 
     if (truncated) {
+      // Only thread pagination can still hit a cap — channels and members are
+      // streamed in full now.
       Sentry.withScope((scope) => {
         scope.setTag("context", "chat");
         scope.setLevel("warning");
@@ -274,10 +246,11 @@ export async function GET() {
           userId: currentUser?.id,
           channelCount: allChannels.length,
           memberCount: members.length,
-          maxPages,
-          pageSize: PAGE_SIZE
+          threadCount: threads.length,
+          threadMaxPages,
+          threadPageSize: THREAD_PAGE_SIZE
         });
-        Sentry.captureMessage("Mattermost unreads truncated");
+        Sentry.captureMessage("Mattermost thread unreads truncated");
       });
     }
 

--- a/apps/web/src/app/api/mattermost/users/[userId]/image/route.ts
+++ b/apps/web/src/app/api/mattermost/users/[userId]/image/route.ts
@@ -14,36 +14,37 @@ export async function GET(_req: NextRequest, { params }: { params: { userId: str
     return NextResponse.json({ error: "MATTERMOST_BASE_URL not configured" }, { status: 500 });
   }
 
-  let res: Response;
   try {
-    res = await fetch(`${baseUrl}/users/${params.userId}/image`, {
+    // Avatar fetches that hang would tie up Node connection slots and
+    // contribute to the same kind of pile-up we saw on the Plausible
+    // proxy path. 8s matches the CF Worker primary timeout — anything
+    // slower has already been cut off at the edge.
+    const res = await fetch(`${baseUrl}/users/${params.userId}/image`, {
       headers: { Authorization: `Bearer ${token}` },
-      // Avatar fetches that hang would tie up Node connection slots and
-      // contribute to the same kind of pile-up we saw on the Plausible
-      // proxy path. 8s matches the CF Worker primary timeout — anything
-      // slower has already been cut off at the edge.
       signal: AbortSignal.timeout(8000)
     });
-  } catch (err) {
-    const isTimeout = err instanceof Error && err.name === "TimeoutError";
-    return NextResponse.json(
-      { error: isTimeout ? "avatar fetch timed out" : "avatar fetch failed" },
-      { status: isTimeout ? 504 : 502 }
-    );
-  }
 
-  if (!res.ok) {
-    const message = await res.text();
-    return NextResponse.json({ error: message || "unable to load avatar" }, { status: res.status });
-  }
-
-  const buffer = Buffer.from(await res.arrayBuffer());
-
-  return new NextResponse(buffer, {
-    status: res.status,
-    headers: {
-      "Content-Type": res.headers.get("Content-Type") || "image/png",
-      "Cache-Control": "public, max-age=300"
+    if (!res.ok) {
+      const message = await res.text();
+      return NextResponse.json({ error: message || "unable to load avatar" }, { status: res.status });
     }
-  });
+
+    const buffer = Buffer.from(await res.arrayBuffer());
+
+    return new NextResponse(buffer, {
+      status: res.status,
+      headers: {
+        "Content-Type": res.headers.get("Content-Type") || "image/png",
+        "Cache-Control": "public, max-age=300"
+      }
+    });
+  } catch (err) {
+    // AbortSignal.timeout fires as TimeoutError during the initial fetch;
+    // an abort during streaming body reads (res.text() / res.arrayBuffer())
+    // surfaces as AbortError. Treat both as timeout.
+    if (err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError")) {
+      return NextResponse.json({ error: "avatar fetch timed out" }, { status: 504 });
+    }
+    return NextResponse.json({ error: "avatar fetch failed" }, { status: 502 });
+  }
 }

--- a/apps/web/src/app/api/mattermost/users/[userId]/image/route.ts
+++ b/apps/web/src/app/api/mattermost/users/[userId]/image/route.ts
@@ -14,11 +14,23 @@ export async function GET(_req: NextRequest, { params }: { params: { userId: str
     return NextResponse.json({ error: "MATTERMOST_BASE_URL not configured" }, { status: 500 });
   }
 
-  const res = await fetch(`${baseUrl}/users/${params.userId}/image`, {
-    headers: {
-      Authorization: `Bearer ${token}`
-    }
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl}/users/${params.userId}/image`, {
+      headers: { Authorization: `Bearer ${token}` },
+      // Avatar fetches that hang would tie up Node connection slots and
+      // contribute to the same kind of pile-up we saw on the Plausible
+      // proxy path. 8s matches the CF Worker primary timeout — anything
+      // slower has already been cut off at the edge.
+      signal: AbortSignal.timeout(8000)
+    });
+  } catch (err) {
+    const isTimeout = err instanceof Error && err.name === "TimeoutError";
+    return NextResponse.json(
+      { error: isTimeout ? "avatar fetch timed out" : "avatar fetch failed" },
+      { status: isTimeout ? 504 : 502 }
+    );
+  }
 
   if (!res.ok) {
     const message = await res.text();

--- a/apps/web/src/app/api/stats/route.ts
+++ b/apps/web/src/app/api/stats/route.ts
@@ -53,6 +53,13 @@ export async function POST(request: NextRequest) {
   try {
     return NextResponse.json(await response.json());
   } catch (e) {
-    return NextResponse.json({}, { status: 400 });
+    // The same AbortSignal that bounds the fetch also bounds the body read,
+    // so response.json() can throw TimeoutError or AbortError if the cap fires
+    // mid-stream. Classify those as 504; treat anything else as a transport
+    // failure (502) rather than a 400 client error.
+    if (e instanceof Error && (e.name === "TimeoutError" || e.name === "AbortError")) {
+      return NextResponse.json({}, { status: 504 });
+    }
+    return NextResponse.json({}, { status: 502 });
   }
 }

--- a/apps/web/src/app/api/stats/route.ts
+++ b/apps/web/src/app/api/stats/route.ts
@@ -20,25 +20,35 @@ export async function POST(request: NextRequest) {
     ({ visionFeatures }) => visionFeatures.plausible.host
   );
 
-  const response = await fetch(`${statsHost}/api/v2/query`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${EcencyConfigManager.getConfigValue(
-        ({ visionFeatures }) => visionFeatures.plausible.apiKey
-      )}`
-    },
-    body: JSON.stringify({
-      site_id: EcencyConfigManager.getConfigValue(
-        ({ visionFeatures }) => visionFeatures.plausible.siteId
-      ),
-      metrics,
-      filters: [["contains", "event:page", [safeDecodeURIComponent(url)]]],
-      dimensions,
-      date_range: dateRange
-    }),
-    cache: "default"
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${statsHost}/api/v2/query`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${EcencyConfigManager.getConfigValue(
+          ({ visionFeatures }) => visionFeatures.plausible.apiKey
+        )}`
+      },
+      body: JSON.stringify({
+        site_id: EcencyConfigManager.getConfigValue(
+          ({ visionFeatures }) => visionFeatures.plausible.siteId
+        ),
+        metrics,
+        filters: [["contains", "event:page", [safeDecodeURIComponent(url)]]],
+        dimensions,
+        date_range: dateRange
+      }),
+      cache: "default",
+      // Plausible's /api/v2/query has historically blocked on its DB pool
+      // (DBConnection.ConnectionError); a hung fetch here would pile up Node
+      // connection slots the same way /pl/api/event used to. Bound it.
+      signal: AbortSignal.timeout(8000)
+    });
+  } catch (e) {
+    const isTimeout = e instanceof Error && e.name === "TimeoutError";
+    return NextResponse.json({}, { status: isTimeout ? 504 : 502 });
+  }
 
   try {
     return NextResponse.json(await response.json());

--- a/apps/web/src/app/api/threespeak/thumbnail/route.ts
+++ b/apps/web/src/app/api/threespeak/thumbnail/route.ts
@@ -63,6 +63,19 @@ export async function POST(req: NextRequest) {
     return Response.json(data);
   } catch (e) {
     console.error("[3Speak] Thumbnail endpoint error:", e);
+    if (e instanceof Error) {
+      // AbortSignal.timeout fires as TimeoutError; an abort during streaming
+      // body reads can surface as AbortError. Both indicate the upstream
+      // exceeded our budget.
+      if (e.name === "TimeoutError" || e.name === "AbortError") {
+        return Response.json({ error: "Thumbnail update timed out" }, { status: 504 });
+      }
+      // Node's fetch wraps DNS/TLS/connection failures as TypeError("fetch failed");
+      // surface those as a bad-gateway condition rather than an internal error.
+      if (e instanceof TypeError) {
+        return Response.json({ error: "Thumbnail update failed (upstream)" }, { status: 502 });
+      }
+    }
     return Response.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/apps/web/src/app/api/threespeak/thumbnail/route.ts
+++ b/apps/web/src/app/api/threespeak/thumbnail/route.ts
@@ -49,7 +49,8 @@ export async function POST(req: NextRequest) {
         "X-API-Key": apiKey,
         "Content-Type": "application/json"
       },
-      body: JSON.stringify({ thumbnail_url, hive_author: auth.username })
+      body: JSON.stringify({ thumbnail_url, hive_author: auth.username }),
+      signal: AbortSignal.timeout(10_000)
     });
 
     if (!res.ok) {

--- a/apps/web/src/app/api/threespeak/upload-token/route.ts
+++ b/apps/web/src/app/api/threespeak/upload-token/route.ts
@@ -62,7 +62,8 @@ export async function POST(req: NextRequest) {
         allowed_origins: isWebClient
           ? ["https://ecency.com", "https://alpha.ecency.com"]
           : []
-      })
+      }),
+      signal: AbortSignal.timeout(10_000)
     });
 
     if (!res.ok) {

--- a/apps/web/src/server/mattermost.ts
+++ b/apps/web/src/server/mattermost.ts
@@ -67,7 +67,11 @@ function getAdminHeaders() {
 // honouring a caller-supplied AbortSignal (e.g. request-scoped cancellation).
 const MM_FETCH_TIMEOUT_MS = Number(process.env.MM_FETCH_TIMEOUT_MS) || 10_000;
 
-async function mmFetch<T>(path: string, init?: RequestInit): Promise<T> {
+// Shared transport for all Mattermost calls: base URL resolution, MM_FETCH_TIMEOUT_MS
+// composed with any caller-supplied AbortSignal, fetch, non-OK → MattermostError, and
+// TimeoutError → MattermostError(504) mapping. Returns the response body as a string
+// (empty body → ""). Parsing is left to callers (mmFetch: JSON; mmFetchNdjson: NDJSON).
+async function mmFetchRaw(path: string, init?: RequestInit): Promise<string> {
   const base = requireEnv(MATTERMOST_BASE_URL, "MATTERMOST_BASE_URL");
 
   const timeoutSignal = AbortSignal.timeout(MM_FETCH_TIMEOUT_MS);
@@ -90,13 +94,7 @@ async function mmFetch<T>(path: string, init?: RequestInit): Promise<T> {
       throw new MattermostError(`Mattermost request failed (${res.status}): ${text}`, res.status);
     }
 
-    const text = await res.text();
-
-    if (!text) {
-      return undefined as T;
-    }
-
-    return JSON.parse(text) as T;
+    return await res.text();
   } catch (err) {
     // AbortSignal.timeout aborts with a DOMException whose name is "TimeoutError";
     // this can fire during either the initial fetch or the body read. Either way,
@@ -111,6 +109,14 @@ async function mmFetch<T>(path: string, init?: RequestInit): Promise<T> {
     }
     throw err;
   }
+}
+
+async function mmFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const text = await mmFetchRaw(path, init);
+  if (!text) {
+    return undefined as T;
+  }
+  return JSON.parse(text) as T;
 }
 
 export async function reactivateMattermostUser(userId: string, signal?: AbortSignal): Promise<void> {
@@ -418,53 +424,22 @@ export async function mmUserFetch<T>(path: string, token: string, init?: Request
 // NDJSON variant: Mattermost's streaming endpoints (e.g. channel_members?page=-1)
 // return one JSON object per line instead of a JSON array.
 async function mmFetchNdjson<T>(path: string, init?: RequestInit): Promise<T[]> {
-  const base = requireEnv(MATTERMOST_BASE_URL, "MATTERMOST_BASE_URL");
-
-  const timeoutSignal = AbortSignal.timeout(MM_FETCH_TIMEOUT_MS);
-  const signal = init?.signal
-    ? AbortSignal.any([init.signal, timeoutSignal])
-    : timeoutSignal;
-
-  try {
-    const res = await fetch(`${base}${path}`, {
-      ...init,
-      headers: {
-        ...(init?.headers || {}),
-        Accept: "application/json"
-      },
-      signal
-    });
-
-    if (!res.ok) {
-      const text = await res.text();
-      throw new MattermostError(`Mattermost request failed (${res.status}): ${text}`, res.status);
-    }
-
-    const text = await res.text();
-    if (!text) {
-      return [];
-    }
-
-    const results: T[] = [];
-    for (const line of text.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        results.push(JSON.parse(trimmed) as T);
-      } catch {
-        // Tolerate a malformed final line (partial chunk at EOS).
-      }
-    }
-    return results;
-  } catch (err) {
-    if (err instanceof Error && err.name === "TimeoutError") {
-      throw new MattermostError(
-        `Mattermost request timed out after ${MM_FETCH_TIMEOUT_MS}ms (${path})`,
-        504
-      );
-    }
-    throw err;
+  const text = await mmFetchRaw(path, init);
+  if (!text) {
+    return [];
   }
+
+  const results: T[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      results.push(JSON.parse(trimmed) as T);
+    } catch {
+      // Tolerate a malformed final line (partial chunk at EOS).
+    }
+  }
+  return results;
 }
 
 export async function mmUserFetchNdjson<T>(path: string, token: string, init?: RequestInit) {

--- a/apps/web/src/server/mattermost.ts
+++ b/apps/web/src/server/mattermost.ts
@@ -415,6 +415,69 @@ export async function mmUserFetch<T>(path: string, token: string, init?: Request
   });
 }
 
+// NDJSON variant: Mattermost's streaming endpoints (e.g. channel_members?page=-1)
+// return one JSON object per line instead of a JSON array.
+async function mmFetchNdjson<T>(path: string, init?: RequestInit): Promise<T[]> {
+  const base = requireEnv(MATTERMOST_BASE_URL, "MATTERMOST_BASE_URL");
+
+  const timeoutSignal = AbortSignal.timeout(MM_FETCH_TIMEOUT_MS);
+  const signal = init?.signal
+    ? AbortSignal.any([init.signal, timeoutSignal])
+    : timeoutSignal;
+
+  try {
+    const res = await fetch(`${base}${path}`, {
+      ...init,
+      headers: {
+        ...(init?.headers || {}),
+        Accept: "application/json"
+      },
+      signal
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new MattermostError(`Mattermost request failed (${res.status}): ${text}`, res.status);
+    }
+
+    const text = await res.text();
+    if (!text) {
+      return [];
+    }
+
+    const results: T[] = [];
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        results.push(JSON.parse(trimmed) as T);
+      } catch {
+        // Tolerate a malformed final line (partial chunk at EOS).
+      }
+    }
+    return results;
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      throw new MattermostError(
+        `Mattermost request timed out after ${MM_FETCH_TIMEOUT_MS}ms (${path})`,
+        504
+      );
+    }
+    throw err;
+  }
+}
+
+export async function mmUserFetchNdjson<T>(path: string, token: string, init?: RequestInit) {
+  return await mmFetchNdjson<T>(path, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...(init?.headers || {})
+    }
+  });
+}
+
 export function isMattermostUnauthorizedError(error: unknown) {
   return error instanceof MattermostError && (error.status === 401 || error.status === 403);
 }


### PR DESCRIPTION
## Summary

Switch the `/api/mattermost/channels` and `/api/mattermost/channels/unreads` route handlers from a paginated fan-out (5+ upstream calls per request, up to 3 pages each) to the streaming endpoints the official Mattermost webapp uses:

- `GET /users/me/channels` (no `page`/`per_page`) — server streams the full channel list in one response.
- `GET /users/me/channel_members?page=-1` — NDJSON streaming mode for member rows.
- Threads still paginate (no streaming form available); cap unchanged at 2 pages × 200.

A small `mmFetchNdjson` helper in `server/mattermost.ts` parses line-delimited JSON with the same timeout/abort semantics as `mmFetch`.

## Why

Under traffic spikes the prior fan-out (channels + members + categories + preferences + threads + a `/users/ids` POST, each potentially paginating) competed with SSR rendering for the Node.js event loop. The in-band `/api/healthcheck` queued behind the work and Swarm killed replicas with `dockerexec: unhealthy container`. Reducing per-request upstream calls cuts CPU pressure on the proxy path. This won't fully eliminate the kill cascade by itself — SSR-side load is still the dominant pressure — but it removes one of the contributors and fixes a latent counting bug along the way.

## Backwards compatibility

Response shapes are preserved exactly. Verified against `chat.ecency.com` 10.11 with `@good-karma`'s PAT:

- `/channels`: byte-for-byte identical (23 channels, 17,934 b, all keys preserved including `directUser` on DMs)
- `/unreads`: identical totals (`totalUnread=65`, `totalMentions=1`, `totalDMs=0`, `totalThreads=0`, `truncated=false`)

The `truncated` flag in `/unreads` narrows in meaning: it now only flips to `true` if a user has >400 active threads, never from channel/member pagination caps. The websocket optimistic-update path in `mattermost-websocket.ts` already short-circuits gracefully when channels are missing, so this is backwards compatible for the mobile app and other clients.

## Side effect (admin-only)

The previous paginated form against `/users/me/channels?page=N&per_page=200` produced cumulative duplicate rows for cross-team admin accounts, doubling `totalUnread`. The streaming form returns each membership once, so admin totals are now correct. Regular single-team users (the typical case) see no numeric change.

## Test plan

- [x] Type-check (no new errors in changed files)
- [x] Production build (`pnpm --filter @ecency/web build`) succeeds
- [x] Endpoint shape parity with current prod (admin and `@good-karma`)
- [x] Local container test against live `chat.ecency.com`
- [ ] Smoke after rollout: chat panel mount loads channels, badge count matches, mark-as-read still updates badge instantly via WS
- [ ] Sentry: no rise in `Mattermost thread unreads truncated` events
- [ ] Nginx logs: `/api/mattermost/*` p99 latency unchanged or better; no rise in 504s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster Mattermost channel/member loading via single-request and streaming fetches, improving responsiveness.

* **Reliability & Error Handling**
  * Network calls (avatars, stats, thumbnails, uploads) now have timeouts and clearer error responses to avoid hangs.

* **Bug Fixes**
  * Unread counts/truncation reporting adjusted to reflect thread-specific pagination and avoid misleading truncation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->