### PR TITLE
Noindex NSFW posts via tag, community, and title detection

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
@@ -1,5 +1,6 @@
 import { accountReputation, parseDate, safeDecodeURIComponent, truncate } from "@/utils";
 import { entryCanonical } from "@/utils/entry-canonical";
+import { isNsfwEntry } from "@/utils/nsfw-detection";
 import { catchPostImage, postBodySummary, isValidPermlink } from "@ecency/render-helper";
 import { Metadata } from "next";
 import { getContentQueryOptions, getProfilesQueryOptions, Profile } from "@ecency/sdk";
@@ -98,9 +99,10 @@ export async function generateEntryMetadata(
       console.warn("generateEntryMetadata: failed to load author account", e);
     }
 
-    const applyNoIndex = accountFetchFailed
-      ? false
-      : shouldApplyNoIndex(authorAccount, entry.author_reputation ?? 0);
+    const nsfwNoIndex = isNsfwEntry(entry);
+    const reputationNoIndex = !accountFetchFailed
+      && shouldApplyNoIndex(authorAccount, entry.author_reputation ?? 0);
+    const applyNoIndex = nsfwNoIndex || reputationNoIndex;
 
     const robots = applyNoIndex ? "noindex, nofollow" : undefined;
 

--- a/apps/web/src/specs/utils/nsfw-detection.spec.ts
+++ b/apps/web/src/specs/utils/nsfw-detection.spec.ts
@@ -1,0 +1,68 @@
+import { isNsfwEntry } from "../../utils/nsfw-detection";
+
+describe("isNsfwEntry", () => {
+  it("returns false for a typical post with safe tags", () => {
+    expect(isNsfwEntry({ category: "hive-100000", json_metadata: { tags: ["photography", "travel"] } })).toBe(false);
+  });
+
+  it("returns true when nsfw is in json_metadata.tags", () => {
+    expect(isNsfwEntry({ category: "hive-100000", json_metadata: { tags: ["art", "nsfw"] } })).toBe(true);
+  });
+
+  it("returns true when nsfw is the category (legacy Steemit posts)", () => {
+    expect(isNsfwEntry({ category: "nsfw", json_metadata: { tags: ["misc"] } })).toBe(true);
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    expect(isNsfwEntry({ category: "hive-100000", json_metadata: { tags: ["  NSFW  "] } })).toBe(true);
+    expect(isNsfwEntry({ category: "  NSFW  ", json_metadata: null })).toBe(true);
+  });
+
+  it("handles missing json_metadata gracefully", () => {
+    expect(isNsfwEntry({ category: "blog", json_metadata: null })).toBe(false);
+    expect(isNsfwEntry({ category: null, json_metadata: null })).toBe(false);
+  });
+
+  it("ignores non-string tag entries", () => {
+    // Some legacy posts have malformed tags arrays; the function must not throw.
+    expect(isNsfwEntry({ category: "blog", json_metadata: { tags: [null as unknown as string, 42 as unknown as string, "nsfw"] } })).toBe(true);
+    expect(isNsfwEntry({ category: "blog", json_metadata: { tags: [null as unknown as string, 42 as unknown as string] } })).toBe(false);
+  });
+
+  it("returns false when tags array is missing", () => {
+    expect(isNsfwEntry({ category: "blog", json_metadata: {} })).toBe(false);
+  });
+
+  it("returns true for posts in known NSFW communities", () => {
+    expect(isNsfwEntry({ category: "hive-109634", json_metadata: { tags: ["art"] } })).toBe(true);
+    expect(isNsfwEntry({ category: "hive-189000", json_metadata: null })).toBe(true);
+    expect(isNsfwEntry({ category: "blog", json_metadata: { tags: ["hive-196493"] } })).toBe(true);
+  });
+
+  describe("title keyword detection", () => {
+    it("catches legacy untagged NSFW by title keywords", () => {
+      // Real top-traffic URL on ecency.com that deliberately omits the nsfw tag.
+      expect(isNsfwEntry({
+        category: "history",
+        title: "Top 10 Most Beautiful Porn Stars (No Nude thats why no NSFW tag thanks)",
+        json_metadata: { tags: ["history", "top10"] },
+      })).toBe(true);
+      expect(isNsfwEntry({ category: "blog", title: "10 Free Safe Porn Sites" })).toBe(true);
+      expect(isNsfwEntry({ category: "blog", title: "Ten Female Masturbation Methods" })).toBe(true);
+      expect(isNsfwEntry({ category: "blog", title: "Photos of Nude Living 13" })).toBe(true);
+      expect(isNsfwEntry({ category: "blog", title: "Tiwa Savage leak XXX tape" })).toBe(true);
+    });
+
+    it("does not flag innocent titles containing safe stems", () => {
+      expect(isNsfwEntry({ category: "blog", title: "Nuclear power plant explained" })).toBe(false);
+      expect(isNsfwEntry({ category: "blog", title: "Popcorn movie night reviews" })).toBe(false);
+      expect(isNsfwEntry({ category: "blog", title: "Hornets nest near my window" })).toBe(false);
+      expect(isNsfwEntry({ category: "blog", title: "Capricorn personality traits" })).toBe(false);
+    });
+
+    it("ignores missing title", () => {
+      expect(isNsfwEntry({ category: "blog" })).toBe(false);
+      expect(isNsfwEntry({ category: "blog", title: null })).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/utils/nsfw-detection.ts
+++ b/apps/web/src/utils/nsfw-detection.ts
@@ -1,0 +1,41 @@
+const NSFW_TAGS = new Set<string>(["nsfw"]);
+
+// Hive community IDs (e.g. "hive-123456") whose posts should always be treated as NSFW.
+// Extend as adult-content communities are identified.
+const NSFW_COMMUNITIES = new Set<string>([
+  "hive-109634", // DPorn
+  "hive-125278", // Boudoir photography
+  "hive-135681", // Adult AI Artwork
+  "hive-189000", // xxx
+  "hive-195331", // Porn
+  "hive-196493", // NSFW
+]);
+
+// Catches legacy posts that deliberately omit the nsfw tag (common Steemit-era pattern).
+// Word-boundary match on a conservative stem list; trailing letters allowed so "porn"
+// catches "pornstar", "masturbat" catches "masturbation/masturbating", etc.
+const NSFW_TITLE_REGEX = /\b(porn|pornstar|nude|xxx|masturbat|erotica?|sextape|fetish)\w*/i;
+
+export interface NsfwCheckableEntry {
+  category?: string | null;
+  title?: string | null;
+  json_metadata?: { tags?: string[] } | null;
+}
+
+export const isNsfwEntry = (entry: NsfwCheckableEntry): boolean => {
+  const candidates: string[] = [];
+  if (entry.category) candidates.push(entry.category);
+  const metaTags = entry.json_metadata?.tags;
+  if (Array.isArray(metaTags)) {
+    for (const t of metaTags) {
+      if (typeof t === "string") candidates.push(t);
+    }
+  }
+  for (const raw of candidates) {
+    const tag = raw.toLowerCase().trim();
+    if (NSFW_TAGS.has(tag)) return true;
+    if (NSFW_COMMUNITIES.has(tag)) return true;
+  }
+  if (entry.title && NSFW_TITLE_REGEX.test(entry.title)) return true;
+  return false;
+};


### PR DESCRIPTION
## Summary

Adds three-layer NSFW detection to the entry metadata pipeline and emits `<meta name="robots" content="noindex, nofollow">` for matched posts. Extends the existing reputation-gated noindex without changing its behavior for non-NSFW content.

Detection layers in `apps/web/src/utils/nsfw-detection.ts`:

- **Tag**: `nsfw` in `entry.category` or `entry.json_metadata.tags`
- **Community**: 6 known adult Hive communities — `hive-109634` (DPorn), `hive-125278` (Boudoir photography), `hive-135681` (Adult AI Artwork), `hive-189000` (xxx), `hive-195331` (Porn), `hive-196493` (NSFW)
- **Title keyword**: conservative word-boundary regex matching `porn`, `nude`, `xxx`, `masturbat`, `erotic`, `sextape`, `fetish` (with stems). Catches legacy Steemit-era posts that deliberately omit the `nsfw` tag

## Why

Search Console data shows that NSFW + piracy content from old Steemit-era posts dominates ecency.com's top-clicked search URLs. The visible search surface skewing toward adult content hurts:

- **Brand**: ecency.com SERPs read as a porn/piracy aggregator to anyone evaluating the platform
- **Algorithmic**: Google's quality models penalize sites whose ranked surface area concentrates in adult/low-quality content; this is a plausible contributor to the ~78% YoY decline in organic clicks since the June 2025 core update

`noindex` removes these pages from search results without removing them from the chain or the site UX. Authors and readers see no change; search engines do.

## Files

- `apps/web/src/utils/nsfw-detection.ts` — new, pure detection helper
- `apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts` — wires the helper into `applyNoIndex`; NSFW match fires independently of profile-fetch state
- `apps/web/src/specs/utils/nsfw-detection.spec.ts` — 11 unit tests

## Test plan

- [x] `pnpm --filter @ecency/web test -- nsfw-detection` — 11/11 passing
- [x] ESLint clean on all three files
- [x] Verified false-positive guards: "nuclear", "popcorn", "hornets nest", "capricorn" do **not** match
- [x] Verified the real top-traffic NSFW URL title triggers detection
- [x] All 6 community IDs verified via `bridge.get_community` on api.hive.blog
- [ ] Manual smoke after deploy: inspect a few NSFW URLs in Search Console; confirm `noindex` is present in HTML head

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added improved NSFW content detection that automatically applies appropriate search engine indexing rules to ensure content is handled consistently across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/787)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->