### PR TITLE
Consolidate post URLs onto bare /@author/permlink (canonical + redirect)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -254,6 +254,19 @@ const config = {
         source: "/:author(@[^/]+)/engine",
         destination: "/:author/wallet",
         permanent: false
+      },
+      // SEO: consolidate post URLs onto bare /@author/permlink form.
+      // Matches /:category/@:author/:permlink (community-prefixed or any legacy
+      // category prefix). The (?!@) on :category prevents the wild edge case
+      // of /@x/@y/z matching. Edit URLs (/:cat/@a/p/edit) and sub-path URLs
+      // (/:cat/@a/p/:sub) are 4 segments and don't match this 3-segment rule —
+      // their existing rewrites in rewrites() handle them.
+      // Starts as 302 (temporary) so the change is reversible while we
+      // verify in production; can flip to permanent: true once confident.
+      {
+        source: "/:category((?!@)[^/]+)/:author(@[^/]+)/:permlink",
+        destination: "/:author/:permlink",
+        permanent: false
       }
     ];
   },

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
@@ -115,7 +115,7 @@ export async function generateEntryMetadata(
       openGraph: {
         title,
         description: summary,
-        url: fullUrl,
+        url: finalCanonical,
         images: image ? [image] : [],
         type: "article",
         publishedTime: createdAt.toISOString(),

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
@@ -78,12 +78,14 @@ export async function generateEntryMetadata(
       entry.json_metadata?.description || truncate(postBodySummary(entry.body, 210), 140);
 
     const image = catchPostImage(entry, 1200, 630, "match");
-    const urlParts = entry.url.split("#");
-    const fullUrl = isComment && urlParts[1] ? `${base}/${urlParts[1]}` : `${base}${entry.url}`;
+    // Bare /@author/permlink form — matches the new self-canonical so og:url
+    // and rel=canonical agree, which is what Google expects to consolidate
+    // duplicates onto a single URL.
+    const fullUrl = `${base}/@${entry.author}/${entry.permlink}`;
     const authorUrl = `${base}/@${entry.author}`;
     const createdAt = parseDate(entry.created ?? new Date().toISOString());
     const updatedAt = parseDate(entry.updated ?? entry.last_update ?? entry.created ?? new Date().toISOString());
-    const canonical = entryCanonical(entry, false, base);
+    const canonical = entryCanonical(entry, base);
     const finalCanonical = canonical ?? fullUrl;
 
     let authorAccount: ReputationSource = null;

--- a/apps/web/src/specs/utils/entry-canonical.spec.ts
+++ b/apps/web/src/specs/utils/entry-canonical.spec.ts
@@ -53,4 +53,13 @@ describe("Entry canonical", () => {
     const entry = { ...entryInstance1, permlink: "", json_metadata: {} };
     expect(entryCanonical(entry)).toBeNull();
   });
+
+  it("(9) Honors explicit canonical_url even when author/permlink are missing", () => {
+    const entry = {
+      ...entryInstance1,
+      permlink: "",
+      json_metadata: { canonical_url: "https://elsewhere.example/post" }
+    };
+    expect(entryCanonical(entry)).toBe("https://elsewhere.example/post");
+  });
 });

--- a/apps/web/src/specs/utils/entry-canonical.spec.ts
+++ b/apps/web/src/specs/utils/entry-canonical.spec.ts
@@ -2,35 +2,55 @@ import { entryInstance1 } from "../test-helper";
 import { entryCanonical } from "../../utils/entry-canonical";
 
 describe("Entry canonical", () => {
-  it("(1) No app definition in json", () => {
+  it("(1) No app definition in json — bare /@author/permlink", () => {
     const entry = { ...entryInstance1, ...{ json_metadata: {} } };
     const result = entryCanonical(entry);
-    expect(result).toBe("https://ecency.com/hive/@good-karma/awesome-hive");
+    expect(result).toBe("https://ecency.com/@good-karma/awesome-hive");
   });
 
-  it("(2) Not valid/registered app", () => {
+  it("(2) Ecency app — bare /@author/permlink", () => {
     const entry = { ...entryInstance1, ...{ json_metadata: { app: "ecency/0.1" } } };
     const result = entryCanonical(entry);
-    expect(result).toBe("https://ecency.com/hive/@good-karma/awesome-hive");
+    expect(result).toBe("https://ecency.com/@good-karma/awesome-hive");
   });
 
-  it("(3) Esteem", () => {
+  it("(3) Esteem app (legacy) — bare /@author/permlink", () => {
     const result = entryCanonical(entryInstance1);
-    expect(result).toBe("https://ecency.com/hive/@good-karma/awesome-hive");
+    expect(result).toBe("https://ecency.com/@good-karma/awesome-hive");
   });
 
-  it("(4) Hive", () => {
+  it("(4) Hive.blog app — still self-canonical (no cross-frontend canonical)", () => {
     const entry = { ...entryInstance1, ...{ json_metadata: { app: "hiveblog/0.1" } } };
     const result = entryCanonical(entry);
-    expect(result).toBe("https://hive.blog/hive/@good-karma/awesome-hive");
+    expect(result).toBe("https://ecency.com/@good-karma/awesome-hive");
   });
 
-  it("(5) From canonical field", () => {
+  it("(5) Explicit canonical_url in metadata wins", () => {
     const entry = {
       ...entryInstance1,
       ...{ json_metadata: { canonical_url: "http://foo.bar/baz" } }
     };
     const result = entryCanonical(entry);
     expect(result).toBe("http://foo.bar/baz");
+  });
+
+  it("(6) Strips https://www. prefix from explicit canonical_url", () => {
+    const entry = {
+      ...entryInstance1,
+      ...{ json_metadata: { canonical_url: "https://www.foo.bar/baz" } }
+    };
+    const result = entryCanonical(entry);
+    expect(result).toBe("https://foo.bar/baz");
+  });
+
+  it("(7) Ignores category — same canonical regardless of which community", () => {
+    const entry = { ...entryInstance1, category: "hive-120026", json_metadata: {} };
+    const result = entryCanonical(entry);
+    expect(result).toBe("https://ecency.com/@good-karma/awesome-hive");
+  });
+
+  it("(8) Returns null for entries missing author or permlink", () => {
+    const entry = { ...entryInstance1, permlink: "", json_metadata: {} };
+    expect(entryCanonical(entry)).toBeNull();
   });
 });

--- a/apps/web/src/utils/entry-canonical.ts
+++ b/apps/web/src/utils/entry-canonical.ts
@@ -15,13 +15,13 @@ import defaults from "@/defaults";
  * silently ignoring anyway when those targets were CSR.
  */
 export function entryCanonical(entry: Entry, baseUrl = defaults.base): string | null {
-  if (!entry.author || !entry.permlink) {
-    return null;
-  }
-
   const canonicalFromMetadata = entry.json_metadata?.canonical_url;
   if (canonicalFromMetadata) {
     return canonicalFromMetadata.replace("https://www.", "https://");
+  }
+
+  if (!entry.author || !entry.permlink) {
+    return null;
   }
 
   return `${baseUrl}/@${entry.author}/${entry.permlink}`;

--- a/apps/web/src/utils/entry-canonical.ts
+++ b/apps/web/src/utils/entry-canonical.ts
@@ -1,26 +1,22 @@
 import { Entry } from "@/entities";
-import rawApps from "@hiveio/hivescript/apps.json";
 import defaults from "@/defaults";
-import { appName } from "./app-name";
-import { makeEntryPath } from "./make-path";
 
-type AppInfo = {
-  name: string;
-  homepage: string;
-  url_scheme?: string;
-};
-
-type AppsMap = Record<string, AppInfo>;
-
-const apps = rawApps as AppsMap;
-
-export function entryCanonical(entry: Entry, isAmp = false, baseUrl = defaults.base): string | null {
-  const path = makeEntryPath(entry.category, entry.author, entry.permlink);
-  if (path === "#") {
+/**
+ * Returns the canonical URL for an entry.
+ *
+ * Always self-canonical to `${baseUrl}/@${author}/${permlink}` unless the post
+ * explicitly declares its own canonical (e.g. cross-published syndication).
+ *
+ * Why bare /@author/permlink: the same post is reachable on ecency.com via
+ * multiple URL forms (community-prefixed, legacy Steemit categories, bare).
+ * Picking one canonical shape consolidates Google's duplicate cluster onto a
+ * single URL and stops leaking ranking signals to other frontends, which the
+ * older `app`-based cross-frontend canonical was doing — and which Google was
+ * silently ignoring anyway when those targets were CSR.
+ */
+export function entryCanonical(entry: Entry, baseUrl = defaults.base): string | null {
+  if (!entry.author || !entry.permlink) {
     return null;
-  }
-  if (isAmp) {
-    return `${baseUrl}${path}`;
   }
 
   const canonicalFromMetadata = entry.json_metadata?.canonical_url;
@@ -28,21 +24,5 @@ export function entryCanonical(entry: Entry, isAmp = false, baseUrl = defaults.b
     return canonicalFromMetadata.replace("https://www.", "https://");
   }
 
-  const app = appName(entry.json_metadata?.app);
-  const identifier = app?.split("/")[0];
-
-  if (!identifier || ["ecency", "esteem"].includes(identifier)) {
-    return `${baseUrl}${path}`;
-  }
-
-  const appInfo = apps[identifier] as { url_scheme?: string };
-  if (!appInfo?.url_scheme) {
-    return `${baseUrl}${path}`;
-  }
-
-  return appInfo.url_scheme
-    .replace("{category}", entry.category)
-    .replace("{username}", entry.author)
-    .replace("{permlink}", entry.permlink);
+  return `${baseUrl}/@${entry.author}/${entry.permlink}`;
 }
-


### PR DESCRIPTION
## Summary

Two-layer URL consolidation for ecency.com posts:

**Layer A (commits 60a277a, 64947dd):** every entry page self-canonicals to `${base}/@${author}/${permlink}`. `rel=canonical` and `og:url` agree on a single URL form. Drops the older `app`-based cross-frontend canonical (peakd, hive.blog, etc.) which Google was ignoring anyway.

**Layer B (commit 0af1c23):** 302 redirect from any `/:category/@:author/:permlink` URL to the bare form. Forces consolidation — external linkers, internal navigation, and bot crawlers all land on the canonical shape.

## Why

1. **Cross-frontend canonical was being ignored.** URL Inspection on real ecency.com post pages shows no `userCanonical` in the API response — Google discards the cross-domain canonical to peakd/hive.blog. The page falls back to "Duplicate without user-selected canonical" or Google picks its own, losing crawl budget and ranking signal.
2. **Multiple URL shapes for the same post on ecency.com.** Community-prefixed (`/hive-XXX/@a/p`), bare (`/@a/p`), and legacy Steemit category prefixes (`/history/@a/p`, `/photo/@a/p`, `/steemit/@a/p`, `/captain-america/@a/p`, etc.) all serve identical content. Without a single canonical shape, Google has to pick one per duplicate cluster, fragmenting ranking signals across siblings.

The bare `/@author/permlink` form is the cleanest target: doesn't depend on which community / legacy category the URL was accessed through, matches how replies are already addressed by convention.

## What changes

- **`entry-canonical.ts`**: simplified — drops `app` detection, drops the AMP branch, drops the unused `isAmp` parameter. Honors explicit `json_metadata.canonical_url` first (for syndication), falls through to bare self-canonical.
- **`generate-entry-metadata.ts`**: `og:url` uses `finalCanonical` (matches `rel=canonical`, including any explicit canonical_url override).
- **`next.config.js`**: new redirect at the top of `redirects()` matching `/:category((?!@)[^/]+)/:author(@[^/]+)/:permlink` → `/:author/:permlink`. Starts as `permanent: false` (302) for safe reversibility; can flip to 301 once verified in production. 4-segment URLs (edit, sub paths) do NOT match and remain handled by existing rewrites.
- **Tests**: `entry-canonical.spec.ts` updated and extended (9 cases, all passing).

## What doesn't change (intentionally)

- **Internal navigation links**: `makeEntryPath` still produces community-prefixed hrefs (Layer C). Those will simply 302 to the bare form on first click. Updating ~15 call sites is a separate, larger patch.
- **Sitemap**: still untouched. Worth revisiting once the redirect-cluster has been seen in Search Console.

## Why 302, not 301?

Layer B starts with `permanent: false` (302). Reasoning:
- The Layer A canonical signal already tells Google the bare form is canonical, so consolidation strength is high even with 302.
- Browsers cache 301s aggressively (often 6+ months without explicit Cache-Control). Reversing a 301 in case of unforeseen breakage is painful; reversing a 302 is immediate.
- Once production smoke confirms nothing odd is happening (no broken internal flows, no 404 loops, expected redirect behavior in browser/curl), flipping to 301 in a follow-up is a one-line change for full SEO benefit.

## Test plan

- [x] `vitest run src/specs/utils/entry-canonical.spec.ts` — 9/9 passing
- [x] `vitest run src/specs/utils/nsfw-detection.spec.ts` — 11/11 (regression check after merge)
- [x] ESLint clean
- [x] Redirect pattern verified against 19 representative URLs via `path-to-regexp`:
  - post URLs with `hive-NNNNNN`, `/history/`, `/photo/`, `/captain-america/`, `/ecency/`, `/steemit/` all match
  - bare `/@author/permlink` does **not** match (already canonical)
  - `/@author/wallet`, `/@author`, `/@author/post/edit` do **not** match
  - 4-segment `/hive-NNNNNN/@a/p/comments` does **not** match
  - `/decks`, `/hot/tag`, `/trending/x/sub` do **not** match
  - `/_next/`, `/api/`, `/communities`, `/discover/communities` do **not** match
- [ ] After deploy: visit `https://ecency.com/hive-120026/@author/permlink` and confirm 302 → `/@author/permlink`
- [ ] After deploy: confirm `<link rel="canonical" href="https://ecency.com/@author/permlink">` in HTML head and `og:url` matches
- [ ] Search Console: re-inspect a sample of post URLs after a few days to confirm `userCanonical` is now populated and matches our declared URL
- [ ] After 1-2 weeks of clean operation: consider flipping the redirect to `permanent: true` for full Layer B SEO benefit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized canonical URL generation and normalization (removes legacy app-based variants).

* **Tests**
  * Expanded coverage for canonical URL behavior, explicit canonical URLs, and edge cases.

* **Bug Fixes / UX**
  * Consolidated post URLs and added redirects to the simplified author/permlink form; canonical URL now drives page metadata and social preview URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/788)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->