### PR TITLE
fix: profile page dates cause Firefox hydration teardown

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -6,8 +6,9 @@ import defaults from "@/defaults";
 import { Account } from "@/entities";
 import { FollowControls, HivePosh, UserAvatar } from "@/features/shared";
 import { FavoriteBtn } from "@/features/shared/favorite-btn";
+import { TimeLabel } from "@/features/shared/time-label";
 import { Badge } from "@/features/ui";
-import { accountReputation, dateToFormatted } from "@/utils";
+import { accountReputation } from "@/utils";
 import {
   getAccountRcQueryOptions,
   getAccountSubscriptionsQueryOptions,
@@ -213,7 +214,7 @@ export function ProfileCard({ account }: Props) {
             icon={<UilCalendarAlt className="w-5 h-5" />}
             label={i18next.t("referral.created")}
           >
-            {dateToFormatted(data?.created, "LL")}
+            <TimeLabel created={data?.created} mode="absolute" format="LL" className="" />
           </ProfileCardExtraProperty>
         )}
 

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -214,7 +214,7 @@ export function ProfileCard({ account }: Props) {
             icon={<UilCalendarAlt className="w-5 h-5" />}
             label={i18next.t("referral.created")}
           >
-            <TimeLabel created={data?.created} mode="absolute" format="LL" className="" />
+            <TimeLabel created={data?.created} mode="absolute" format="LL" />
           </ProfileCardExtraProperty>
         )}
 

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/wallet/(token)/hp/_components/hp-about-card.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/wallet/(token)/hp/_components/hp-about-card.tsx
@@ -9,7 +9,8 @@ import { getDynamicPropsQueryOptions } from "@ecency/sdk";
 import { WalletOperationsDialog } from "@/features/wallet";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { Button } from "@/features/ui";
-import { dateToFullRelative, formatNumber } from "@/utils";
+import { formatNumber } from "@/utils";
+import { useFormattedDate } from "@/features/shared/time-label";
 import { getPowerDownSchedule } from "@/features/wallet/operations/get-power-down-schedule";
 
 interface Props {
@@ -27,6 +28,10 @@ export function HpAboutCard({ username }: Props) {
     () => getPowerDownSchedule(accountData, hivePerMVests),
     [accountData, hivePerMVests]
   );
+  const nextWithdrawalText = useFormattedDate(
+    powerDownSchedule?.nextWithdrawal,
+    "fullRelative"
+  );
 
   return (
     <ProfileWalletTokenHistoryCard title={i18next.t("static.about.page-title")}> 
@@ -40,7 +45,7 @@ export function HpAboutCard({ username }: Props) {
             </div>
             <div>
               {i18next.t("wallet.next-power-down", {
-                time: dateToFullRelative(powerDownSchedule.nextWithdrawal),
+                time: nextWithdrawalText,
                 amount: `${formatNumber(powerDownSchedule.weeklyHp, 3)} HP`,
                 weeks: powerDownSchedule.weeks,
               })}

--- a/apps/web/src/features/shared/time-label/index.tsx
+++ b/apps/web/src/features/shared/time-label/index.tsx
@@ -1,23 +1,86 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { dateToFormatted, dateToFormattedUtc, dateToRelative } from "@/utils";
+import {
+  dateToFormatted,
+  dateToFormattedUtc,
+  dateToFullRelative,
+  dateToRelative,
+} from "@/utils";
 
-export function TimeLabel({ created, refresh }: { created: string; refresh?: number }) {
-    const [display, setDisplay] = useState<string | null>(null);
-    const [localFormatted, setLocalFormatted] = useState<string | null>(null);
+type Mode = "relative" | "fullRelative" | "absolute";
 
-    // True UTC formatted date - identical on server and client, no hydration mismatch
-    const ssrSafe = dateToFormattedUtc(created);
+interface Props {
+  created: string | undefined;
+  refresh?: number;
+  /**
+   * Display mode after client mount:
+   * - "relative" (default): short form, e.g. "5h"
+   * - "fullRelative": long form, e.g. "5 hours ago"
+   * - "absolute": formatted date using `format`
+   *
+   * The first paint (SSR + initial client render) is always a UTC numeric
+   * string so the two sides agree and React doesn't fire hydration error
+   * #418. After mount the visible text and tooltip swap to the user's local
+   * timezone and locale.
+   */
+  mode?: Mode;
+  /** dayjs format token used when `mode` is "absolute". Defaults to "LLLL". */
+  format?: string;
+  className?: string;
+}
 
-    useEffect(() => {
-        setDisplay(dateToRelative(created));
-        setLocalFormatted(dateToFormatted(created));
-    }, [created, refresh]);
+export function TimeLabel({
+  created,
+  refresh,
+  mode = "relative",
+  format = "LLLL",
+  className = "date",
+}: Props) {
+  const [display, setDisplay] = useState<string | null>(null);
+  const [localFormatted, setLocalFormatted] = useState<string | null>(null);
 
-    return (
-        <span className="date" title={localFormatted ?? ssrSafe}>
+  // Numeric UTC — identical on server and client, no hydration mismatch.
+  const ssrSafe = dateToFormattedUtc(created);
+
+  useEffect(() => {
+    setLocalFormatted(dateToFormatted(created));
+    if (mode === "absolute") setDisplay(dateToFormatted(created, format));
+    else if (mode === "fullRelative") setDisplay(dateToFullRelative(created));
+    else setDisplay(dateToRelative(created));
+  }, [created, refresh, mode, format]);
+
+  return (
+    <span className={className} title={localFormatted ?? ssrSafe} suppressHydrationWarning>
       {display ?? ssrSafe}
     </span>
-    );
+  );
+}
+
+/**
+ * String form of {@link TimeLabel} for cases where a React node won't fit —
+ * attribute values, i18next interpolation. Returns "" before mount and the
+ * formatted value after, so SSR HTML has an empty slot that fills in on the
+ * client. Use this when SSR/client text divergence would cause a hydration
+ * mismatch (timezone-dependent dates, locale-dependent formats).
+ */
+export function useFormattedDate(
+  value: string | undefined,
+  mode: Mode = "relative",
+  format: string = "LLLL",
+  refresh?: number
+): string {
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    if (!value) {
+      setText("");
+      return;
+    }
+    if (mode === "absolute") setText(dateToFormatted(value, format));
+    else if (mode === "fullRelative") setText(dateToFullRelative(value));
+    else setText(dateToRelative(value));
+  }, [value, mode, format, refresh]);
+
+  return text;
 }


### PR DESCRIPTION
## Summary

Profile pages render `dateToFormatted(date, "LL")` inline. The helper does `dayjs.utc(...).local().format(...)` — `.local()` resolves to the server's TZ on SSR and the browser's TZ on hydration, and the `LL` token is locale-aware (server stays on en-US since locale lives in localStorage; the client switches after `initI18next` resolves). Both produce different text server vs. client → React hydration error #418 → in Firefox the downstream tree teardown trips `iframe.contentWindow is null` (the cascade documented in `apps/web/sentry.client.config.ts:63-75`).

This is the source of the long-running Sentry alert spike on `ecency-next`: ~98% Firefox, ~5,900 unique users/hour at 1% sampling, smoldering since 2026-04-02. The fix follows the convention already used by feed/entry surfaces (`<TimeLabel>`).

## Changes

- **`features/shared/time-label/index.tsx`** — extends `<TimeLabel>` with `mode` (`"relative" | "fullRelative" | "absolute"`, default `"relative"`), `format` (default `"LLLL"`), and `className` (default `"date"`); widens `created` to `string | undefined`. Exports a `useFormattedDate` hook for places a React node won't fit (attribute values, i18next interpolation). All defaults preserve the existing 7 callers' behavior. Adds `suppressHydrationWarning` belt-and-braces.
- **`profile-card/index.tsx`** — line 217 now uses `<TimeLabel created={data?.created} mode="absolute" format="LL" className="" />`. **High-leverage fix** — this date renders on every profile sub-page (wallet, blog, posts, comments, communities, …).
- **`hp-about-card.tsx`** — replaces the inline `dateToFullRelative(...)` inside `i18next.t("wallet.next-power-down", { time: ... })` with a `useFormattedDate(..., "fullRelative")` hook called at the top of the component. Lower volume but uses the same primitive.

The four other profile-page date callsites (`converts`, `open-orders-list`, `savings-withdraw`, `converts-collateralized`) live inside `<Modal>` bodies that only mount on user click — no SSR exposure → no hydration risk → left alone.

## Test plan

- [x] `pnpm test` on `time-label.spec.tsx` — 3/3 pass.
- [x] `tsc --noEmit` shows no new errors in the touched files (the two pre-existing TS errors in `profile-card/index.tsx` at lines 55 & 110 are unrelated to this PR — `account?.name` and `data.profile` typing issues already in the file).
- [ ] Visual: profile page on Firefox/Linux — confirm "Joined: May 13, 2026" still renders, briefly shows UTC numeric form on first paint then swaps to localized form. No console error #418.
- [ ] Sentry: after deploy, watch React #418 rate on `/@user/...` and Firefox `contentWindow is null` rate (issue 109327438 + sibling groups) — both should drop sharply within 24h.

Followups (not in this PR):
- Hoist locale into a cookie so the server can SSR with the user's language and dayjs locale, eliminating the locale-drift class of mismatches for `i18next.t(...)` strings as well. Expected to be small additional wins after this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced date and time formatting across profile cards and wallet information sections
  * Updated time label display with improved visual consistency
  * Refined timestamp presentation for better readability of creation dates and power-down scheduling information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/790)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->