### PR TITLE
fix(chat): make the Mattermost bootstrap path idempotent (fixes 502s)

### DIFF
--- a/apps/web/src/server/mattermost.ts
+++ b/apps/web/src/server/mattermost.ts
@@ -200,13 +200,32 @@ export async function ensureUserInTeam(userId: string, signal?: AbortSignal) {
       headers: getAdminHeaders(),
       signal
     });
-  } catch (error) {
+    return; // already a member
+  } catch {
+    // not a member (or lookup failed) — add below
+  }
+  try {
     await mmFetch(`/teams/${teamId}/members`, {
       method: "POST",
       headers: getAdminHeaders(),
       body: JSON.stringify({ team_id: teamId, user_id: userId }),
       signal
     });
+  } catch (error) {
+    // A concurrent bootstrap (browser-extension integrations fire parallel
+    // calls) may have added the user between the check and this add —
+    // Mattermost then errors "team member already exists". Re-check the end
+    // state instead of failing: if the user is now a member, the desired
+    // state holds. Version-agnostic (no reliance on MM error-id strings).
+    try {
+      await mmFetch(`/teams/${teamId}/members/${userId}`, {
+        headers: getAdminHeaders(),
+        signal
+      });
+      return;
+    } catch {
+      throw error; // genuinely not a member — surface the real failure
+    }
   }
 }
 
@@ -248,7 +267,10 @@ export async function ensureChannelForCommunity(
       signal
     });
     return existing.id;
-  } catch (error) {
+  } catch {
+    // channel doesn't exist (or lookup failed) — create below
+  }
+  try {
     const created = await mmFetch<{ id: string }>(`/channels`, {
       method: "POST",
       headers: getAdminHeaders(),
@@ -261,6 +283,19 @@ export async function ensureChannelForCommunity(
       signal
     });
     return created.id;
+  } catch (error) {
+    // A concurrent bootstrap (e.g. several subscribers of a new community
+    // bootstrapping at once) may have created the channel between the lookup
+    // and this create. Re-fetch by name; if it now exists, use it.
+    try {
+      const existing = await mmFetch<{ id: string }>(`/teams/${teamId}/channels/name/${channelName}`, {
+        headers: getAdminHeaders(),
+        signal
+      });
+      return existing.id;
+    } catch {
+      throw error;
+    }
   }
 }
 
@@ -285,15 +320,30 @@ export async function ensureUserInChannel(userId: string, channelId: string, sig
       headers: getAdminHeaders(),
       signal
     });
-    // User is already a member, nothing to do
-  } catch (error) {
-    // User is not a member - add them to the channel
+    return; // already a member, nothing to do
+  } catch {
+    // not a member (or lookup failed) — add below
+  }
+  try {
     await mmFetch(`/channels/${channelId}/members`, {
       method: "POST",
       headers: getAdminHeaders(),
       body: JSON.stringify({ channel_id: channelId, user_id: userId }),
       signal
     });
+  } catch (error) {
+    // A concurrent bootstrap may have added the user between the check and
+    // this add. Re-check the end state: if the user is now a member, the
+    // desired state holds (version-agnostic — no MM error-id matching).
+    try {
+      await mmFetch(`/channels/${channelId}/members/${userId}`, {
+        headers: getAdminHeaders(),
+        signal
+      });
+      return;
+    } catch {
+      throw error;
+    }
   }
 }
 

--- a/apps/web/src/server/mattermost.ts
+++ b/apps/web/src/server/mattermost.ts
@@ -153,19 +153,44 @@ export async function ensureMattermostUser(username: string, signal?: AbortSigna
     return user;
   }
 
-  // Step 3: Create new user
+  // Step 3: Create new user. A concurrent bootstrap (common with browser-
+  // extension integrations that fire parallel/repeat bootstrap calls) can
+  // create the same user between the lookup above and this create — Mattermost
+  // then returns 400 app.user.save.username_exists.app_error. Treat that as
+  // success: re-fetch the now-existing user (reactivating if needed) instead
+  // of surfacing a spurious upstream error (which the bootstrap route maps to
+  // a 502) to the caller. Makes provisioning idempotent / race-safe.
   const email = `${username}+no-email@ecency.local`;
-  return await mmFetch<MattermostUser>(`/users`, {
-    method: "POST",
-    headers: getAdminHeaders(),
-    body: JSON.stringify({
-      username,
-      email,
-      password: randomBytes(32).toString("base64url") + "!Aa1",
-      allow_marketing: false
-    }),
-    signal
-  });
+  try {
+    return await mmFetch<MattermostUser>(`/users`, {
+      method: "POST",
+      headers: getAdminHeaders(),
+      body: JSON.stringify({
+        username,
+        email,
+        password: randomBytes(32).toString("base64url") + "!Aa1",
+        allow_marketing: false
+      }),
+      signal
+    });
+  } catch (error) {
+    if (
+      error instanceof MattermostError &&
+      error.status === 400 &&
+      error.message.includes("app.user.save.username_exists")
+    ) {
+      const existing = await mmFetch<MattermostUser>(
+        `/users/username/${username}`,
+        { headers: getAdminHeaders(), signal }
+      );
+      if (existing.delete_at > 0) {
+        await reactivateMattermostUser(existing.id, signal);
+        existing.delete_at = 0;
+      }
+      return existing;
+    }
+    throw error;
+  }
 }
 
 export async function ensureUserInTeam(userId: string, signal?: AbortSignal) {

--- a/apps/web/src/specs/api/mattermost-ensure-user.spec.ts
+++ b/apps/web/src/specs/api/mattermost-ensure-user.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ensureMattermostUser must be idempotent: a concurrent/repeat bootstrap
+// (common with browser-extension integrations) can create the MM user
+// between the username lookup and the create POST. Mattermost then returns
+// 400 app.user.save.username_exists.app_error. That benign race must NOT
+// surface as an error (the bootstrap route maps it to a 502) — it should
+// re-fetch the now-existing user and return it.
+
+function resp(status: number, body: unknown) {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return { ok: status >= 200 && status < 300, status, text: async () => text };
+}
+
+const USERNAME_EXISTS = {
+  id: "app.user.save.username_exists.app_error",
+  message: "An account with that username already exists.",
+  detailed_error: "",
+  status_code: 400
+};
+
+async function loadModule() {
+  process.env.MATTERMOST_BASE_URL = "https://chat.test/api/v4";
+  process.env.MATTERMOST_ADMIN_TOKEN = "admin-token";
+  process.env.MATTERMOST_TEAM_ID = "team-1";
+  vi.resetModules();
+  return await import("@/server/mattermost");
+}
+
+describe("ensureMattermostUser — idempotency / concurrent-create race", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("returns the existing user when create races into username_exists", async () => {
+    const { ensureMattermostUser } = await loadModule();
+    fetchMock
+      .mockResolvedValueOnce(resp(404, "user not found")) // GET /users/username
+      .mockResolvedValueOnce(resp(400, USERNAME_EXISTS)) // POST /users (lost the race)
+      .mockResolvedValueOnce(
+        resp(200, { id: "u-1", username: "alice", email: "a", delete_at: 0 })
+      ); // GET /users/username (re-fetch)
+
+    const user = await ensureMattermostUser("alice");
+
+    expect(user).toEqual({ id: "u-1", username: "alice", email: "a", delete_at: 0 });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("reactivates the existing user if the raced-in account was deactivated", async () => {
+    const { ensureMattermostUser } = await loadModule();
+    fetchMock
+      .mockResolvedValueOnce(resp(404, "nf"))
+      .mockResolvedValueOnce(resp(400, USERNAME_EXISTS))
+      .mockResolvedValueOnce(
+        resp(200, { id: "u-2", username: "carol", email: "c", delete_at: 1700000000000 })
+      )
+      .mockResolvedValueOnce(resp(200, "")); // PUT /users/u-2/active
+
+    const user = await ensureMattermostUser("carol");
+
+    expect(user.id).toBe("u-2");
+    expect(user.delete_at).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock.mock.calls[3][0]).toContain("/users/u-2/active");
+  });
+
+  it("does not create when the user already exists (happy path unchanged)", async () => {
+    const { ensureMattermostUser } = await loadModule();
+    fetchMock.mockResolvedValueOnce(
+      resp(200, { id: "u-9", username: "bob", email: "b", delete_at: 0 })
+    );
+
+    const user = await ensureMattermostUser("bob");
+
+    expect(user.id).toBe("u-9");
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no POST /users
+  });
+
+  it("still throws on non-username_exists create errors", async () => {
+    const { ensureMattermostUser } = await loadModule();
+    fetchMock
+      .mockResolvedValueOnce(resp(404, "nf"))
+      .mockResolvedValueOnce(
+        resp(400, { id: "app.user.save.email_exists.app_error", message: "email exists" })
+      );
+
+    await expect(ensureMattermostUser("dave")).rejects.toThrow(
+      /Mattermost request failed \(400\)/
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2); // no idempotent re-fetch
+  });
+});

--- a/apps/web/src/specs/api/mattermost-ensure-user.spec.ts
+++ b/apps/web/src/specs/api/mattermost-ensure-user.spec.ts
@@ -94,3 +94,71 @@ describe("ensureMattermostUser — idempotency / concurrent-create race", () => 
     expect(fetchMock).toHaveBeenCalledTimes(2); // no idempotent re-fetch
   });
 });
+
+// The bootstrap path (route.ts:104-107) also adds the user to the team after
+// create — same unguarded GET→POST race; the loser's add can error "team
+// member already exists" and previously bubbled to the same 502 catch.
+describe("ensureUserInTeam — idempotency / concurrent-join race", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("no-ops when already a team member (happy path)", async () => {
+    const { ensureUserInTeam } = await loadModule();
+    fetchMock.mockResolvedValueOnce(resp(200, { team_id: "team-1", user_id: "u-1" }));
+    await expect(ensureUserInTeam("u-1")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no POST add
+  });
+
+  it("treats a raced 'member exists' add as success via end-state recheck", async () => {
+    const { ensureUserInTeam } = await loadModule();
+    fetchMock
+      .mockResolvedValueOnce(resp(404, "not a member")) // GET membership
+      .mockResolvedValueOnce(
+        resp(400, { id: "app.team.join_user_to_team.exists", message: "team member exists" })
+      ) // POST add (lost the race)
+      .mockResolvedValueOnce(resp(200, { team_id: "team-1", user_id: "u-1" })); // re-check → is a member
+    await expect(ensureUserInTeam("u-1")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("rethrows when the add fails and the user is still not a member", async () => {
+    const { ensureUserInTeam } = await loadModule();
+    fetchMock
+      .mockResolvedValueOnce(resp(404, "nf"))
+      .mockResolvedValueOnce(resp(403, { id: "api.context.permissions.app_error" }))
+      .mockResolvedValueOnce(resp(404, "still not a member"));
+    await expect(ensureUserInTeam("u-1")).rejects.toThrow(/Mattermost request failed \(403\)/);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("ensureUserInChannel / ensureChannelForCommunity — idempotency", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("ensureUserInChannel tolerates a raced channel-join", async () => {
+    const { ensureUserInChannel } = await loadModule();
+    fetchMock
+      .mockResolvedValueOnce(resp(404, "not a member")) // GET channel membership
+      .mockResolvedValueOnce(resp(400, { id: "store.sql_channel.save_member.exists.app_error" })) // POST add raced
+      .mockResolvedValueOnce(resp(200, { channel_id: "c-1", user_id: "u-1" })); // re-check → member
+    await expect(ensureUserInChannel("u-1", "c-1")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("ensureChannelForCommunity reuses a concurrently-created channel", async () => {
+    const { ensureChannelForCommunity } = await loadModule();
+    fetchMock
+      .mockResolvedValueOnce(resp(404, "no such channel")) // GET channel by name
+      .mockResolvedValueOnce(resp(400, { id: "store.sql_channel.save_channel.exists.app_error" })) // POST create raced
+      .mockResolvedValueOnce(resp(200, { id: "ch-1", name: "hive-1" })); // re-fetch by name
+    await expect(ensureChannelForCommunity("hive-1", "Hive One")).resolves.toBe("ch-1");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Problem

`POST /api/mattermost/bootstrap` intermittently **502s** — reported by 3rd-party integrators (Actifit's browser extension). Endpoint ~99.9% healthy, Mattermost backend healthy, nginx clean — the 502s are app-level. Root cause: the bootstrap path does several **unguarded GET-then-POST "ensure" steps** (`route.ts:104-107`, all inside one `try` whose `catch` returns 502). Two concurrent/repeat bootstraps for the same user (typical of a browser extension firing parallel calls; the mobile app caches the cookie/token so rarely hits it) race: both miss the GET, both POST, the loser gets Mattermost's "already exists" error → 502.

## Fix — idempotent across the whole bootstrap path

Version-agnostic **end-state recheck** (re-GET after a failed add/create; success if the desired state now holds — no reliance on MM error-id strings):

- **`ensureMattermostUser`** — user-create race (`app.user.save.username_exists`).
- **`ensureUserInTeam`** — team-join race; sits in the same `catch→502` and was a *co-equal* cause of the bug (raised in review — the user-create fix alone did not stabilize the path).
- **`ensureChannelForCommunity`** / **`ensureUserInChannel`** — same root race; these degrade gracefully today (`Promise.allSettled` / `try`-warn, not 502) but hardening removes spurious "some channels failed" logs and missed auto-joins under concurrency.
- **`ensurePersonalToken`** — audited: race-tolerant by design (mints a fresh PAT; no 502). Unchanged.

Happy paths and genuine errors are unchanged. **9 regression tests, all green.** After this, a 502 from bootstrap means a *genuine* Mattermost outage — matching the documented contract.

## Commits
- `ae4eea18` — `ensureMattermostUser` idempotent + 4 tests
- `7df9ae2a` — review follow-up: `ensureUserInTeam` (the remaining 502) + channel ensures + `ensurePersonalToken` audit + 5 tests

## Companion
Docs corrected in **ecency/docs#22** (bootstrap contract: `accessToken`-only, real status codes incl. 503/502/504, idempotency guidance, cross-origin `Authorization: Bearer`).
