### PR TITLE
Reply/wave canonical model + shared isIndexable

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
@@ -60,15 +60,20 @@ export async function generateEntryMetadata(
       entry.json_metadata?.description || truncate(postBodySummary(entry.body, 210), 140);
 
     const image = catchPostImage(entry, 1200, 630, "match");
-    // Bare /@author/permlink form — matches the new self-canonical so og:url
-    // and rel=canonical agree, which is what Google expects to consolidate
-    // duplicates onto a single URL.
+    // Bare /@author/permlink form for this exact page.
     const fullUrl = `${base}/@${entry.author}/${entry.permlink}`;
     const authorUrl = `${base}/@${entry.author}`;
     const createdAt = parseDate(entry.created ?? new Date().toISOString());
     const updatedAt = parseDate(entry.updated ?? entry.last_update ?? entry.created ?? new Date().toISOString());
     const canonical = entryCanonical(entry, base);
     const finalCanonical = canonical ?? fullUrl;
+    // og:url must describe THIS page's content (title/desc/image are the
+    // entry's). For a reply, rel=canonical points to the discussion root for
+    // SEO consolidation, but og:url must stay the reply's own URL — otherwise
+    // social scrapers (which key the share object on og:url) attach the
+    // reply's card to the root URL. og:url and canonical legitimately differ
+    // when a page is canonicalised to a different resource.
+    const ogUrl = isComment ? fullUrl : finalCanonical;
 
     let authorAccount: ReputationSource = null;
     let accountFetchFailed = false;
@@ -94,7 +99,7 @@ export async function generateEntryMetadata(
       openGraph: {
         title,
         description: summary,
-        url: finalCanonical,
+        url: ogUrl,
         images: image ? [image] : [],
         type: "article",
         publishedTime: createdAt.toISOString(),

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
@@ -1,32 +1,12 @@
-import { accountReputation, parseDate, safeDecodeURIComponent, truncate } from "@/utils";
+import { parseDate, safeDecodeURIComponent, truncate } from "@/utils";
 import { entryCanonical } from "@/utils/entry-canonical";
-import { isNsfwEntry } from "@/utils/nsfw-detection";
+import { isIndexable, ReputationSource } from "@/utils/entry-indexability";
 import { catchPostImage, postBodySummary, isValidPermlink } from "@ecency/render-helper";
 import { Metadata } from "next";
-import { getContentQueryOptions, getProfilesQueryOptions, Profile } from "@ecency/sdk";
+import { getContentQueryOptions, getProfilesQueryOptions } from "@ecency/sdk";
 import { prefetchQuery } from "@/core/react-query";
 import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { getServerAppBase } from "@/utils/server-app-base";
-import { FullAccount } from "@/entities";
-
-const NOINDEX_REPUTATION_THRESHOLD = 40;
-
-type ReputationSource = Pick<FullAccount, "reputation" | "post_count"> | Profile | null;
-
-const shouldApplyNoIndex = (
-  account: ReputationSource,
-  fallbackReputation: number
-): boolean => {
-  const reputationScore = accountReputation(account?.reputation ?? fallbackReputation ?? 0);
-  const postCount = typeof account?.post_count === "number" ? account.post_count : 0;
-
-  const meetsReputationGate = reputationScore < NOINDEX_REPUTATION_THRESHOLD;
-  const lacksPostingHistory = postCount <= 3;
-
-  // Accounts are no-indexed when they lack reputation or meaningful posting history, regardless of age.
-  return meetsReputationGate || lacksPostingHistory;
-};
-
 
 export async function generateEntryMetadata(
   username: string,
@@ -43,25 +23,27 @@ export async function generateEntryMetadata(
   }
   try {
     const cleanAuthor = username.replace("%40", "");
-    let entry = await prefetchQuery(EcencyEntriesCacheManagement.getEntryQueryByPath(cleanAuthor, cleanPermlink));
+
+    // Source from condenser_api.get_content first: it returns root_author /
+    // root_permlink (needed to canonical replies to their discussion root and
+    // to detect container/wave trees), which bridge.get_post omits. This is
+    // fetch-count-neutral — bridge is the fallback, already trusted here.
+    let entry = null;
+    try {
+      entry = await prefetchQuery(getContentQueryOptions(cleanAuthor, cleanPermlink));
+    } catch (e) {
+      console.warn("generateEntryMetadata: get_content failed, trying bridge", e);
+    }
 
     if (!entry || !entry.body || !entry.created) {
-      console.warn("generateEntryMetadata: incomplete, trying fallback getContent", {
-        username,
-        permlink: cleanPermlink
-      });
-      try {
-        // fallback to direct content API
-        entry = await prefetchQuery(
-          getContentQueryOptions(cleanAuthor, cleanPermlink)
-        );
-      } catch (e) {
-        console.error("generateEntryMetadata: fallback getContent failed", cleanAuthor, cleanPermlink);
-        return {};
-      }
-
+      entry = await prefetchQuery(
+        EcencyEntriesCacheManagement.getEntryQueryByPath(cleanAuthor, cleanPermlink)
+      );
       if (!entry || !entry.body || !entry.created) {
-        console.warn("generateEntryMetadata: fallback also failed", { username, permlink: cleanPermlink });
+        console.warn("generateEntryMetadata: both content sources failed", {
+          username,
+          permlink: cleanPermlink
+        });
         return {};
       }
     }
@@ -101,12 +83,9 @@ export async function generateEntryMetadata(
       console.warn("generateEntryMetadata: failed to load author account", e);
     }
 
-    const nsfwNoIndex = isNsfwEntry(entry);
-    const reputationNoIndex = !accountFetchFailed
-      && shouldApplyNoIndex(authorAccount, entry.author_reputation ?? 0);
-    const applyNoIndex = nsfwNoIndex || reputationNoIndex;
-
-    const robots = applyNoIndex ? "noindex, nofollow" : undefined;
+    const robots = isIndexable(entry, authorAccount, accountFetchFailed)
+      ? undefined
+      : "noindex, nofollow";
 
     return {
       title,

--- a/apps/web/src/entities/entries.ts
+++ b/apps/web/src/entities/entries.ts
@@ -68,6 +68,8 @@ export interface Entry {
   net_rshares: number;
   parent_author?: string;
   parent_permlink?: string;
+  root_author?: string;
+  root_permlink?: string;
   payout: number;
   payout_at: string;
   pending_payout_value: string;

--- a/apps/web/src/specs/utils/entry-indexability.spec.ts
+++ b/apps/web/src/specs/utils/entry-indexability.spec.ts
@@ -6,7 +6,7 @@ vi.mock("@ecency/render-helper", () => ({
   postBodySummary: (b: string) => b ?? ""
 }));
 
-import { Entry } from "@/entities";
+import { Entry, EntryVote } from "@/entities";
 import {
   canonicalTarget,
   isIndexable,
@@ -18,6 +18,9 @@ import {
 const BASE = "https://ecency.com";
 const longBody = "x".repeat(WAVE_MIN_BODY_CHARS + 20);
 const shortBody = "gm";
+
+const vote = (voter: string): EntryVote => ({ voter, rshares: 0 });
+const votes = (n: number): EntryVote[] => Array.from({ length: n }, () => vote("v"));
 
 const makeEntry = (o: Partial<Entry>): Entry =>
   ({
@@ -98,6 +101,18 @@ describe("canonicalTarget", () => {
     expect(canonicalTarget(e, BASE)).toBe("https://ecency.com/@alice/my-wave");
   });
 
+  it("bridge-fallback depth-1 wave (no root_*) -> self, NOT the anchor (P1 regression)", () => {
+    const e = makeEntry({
+      author: "alice",
+      permlink: "my-wave",
+      depth: 1,
+      parent_author: "ecency.waves",
+      parent_permlink: "waves-2026"
+      // root_author/root_permlink absent — bridge.get_post shape
+    });
+    expect(canonicalTarget(e, BASE)).toBe("https://ecency.com/@alice/my-wave");
+  });
+
   it("reply to a wave (depth 2) -> the wave (its parent)", () => {
     const e = makeEntry({
       author: "carol",
@@ -129,6 +144,11 @@ describe("isContainerTree", () => {
   });
   it("false for normal threads", () => {
     expect(isContainerTree(makeEntry({ root_author: "bob", depth: 1 }))).toBe(false);
+  });
+  it("true for bridge-fallback depth-1 wave (no root_*, parent is container)", () => {
+    expect(
+      isContainerTree(makeEntry({ depth: 1, parent_author: "ecency.waves" }))
+    ).toBe(true);
   });
   it("all five container accounts recognised", () => {
     for (const a of ["leothreads", "ecency.waves", "peak.snaps", "liketu.moments", "hive.flow"]) {
@@ -198,7 +218,7 @@ describe("wave quality gate (depth-1 under container)", () => {
       idx(
         wave({
           children: 0,
-          active_votes: new Array(6).fill({ voter: "v" }),
+          active_votes: votes(6),
           pending_payout_value: "0.500 HBD"
         })
       )
@@ -210,7 +230,7 @@ describe("wave quality gate (depth-1 under container)", () => {
       idx(
         wave({
           children: 0,
-          active_votes: [{ voter: "self" }] as never,
+          active_votes: [vote("self")],
           pending_payout_value: "50.000 HBD"
         })
       )
@@ -222,7 +242,7 @@ describe("wave quality gate (depth-1 under container)", () => {
       idx(
         wave({
           children: 0,
-          active_votes: new Array(40).fill({ voter: "v" }),
+          active_votes: votes(40),
           pending_payout_value: "0.001 HBD"
         })
       )
@@ -234,7 +254,7 @@ describe("wave quality gate (depth-1 under container)", () => {
       idx(
         wave({
           children: 0,
-          active_votes: new Array(6).fill({ voter: "v" }),
+          active_votes: votes(6),
           pending_payout_value: "0.000 HBD",
           payout: 1.23
         } as Partial<Entry>)

--- a/apps/web/src/specs/utils/entry-indexability.spec.ts
+++ b/apps/web/src/specs/utils/entry-indexability.spec.ts
@@ -19,6 +19,7 @@ const BASE = "https://ecency.com";
 const longBody = "x".repeat(WAVE_MIN_BODY_CHARS + 20);
 const shortBody = "gm";
 
+const realPostBody = "x".repeat(500); // > CONTAINER_ANCHOR_MAX_BODY (400)
 const vote = (voter: string): EntryVote => ({ voter, rshares: 0 });
 const votes = (n: number): EntryVote[] => Array.from({ length: n }, () => vote("v"));
 
@@ -84,9 +85,21 @@ describe("canonicalTarget", () => {
     expect(canonicalTarget(e, BASE)).toBeNull();
   });
 
-  it("container anchor post (depth 0) -> null", () => {
+  it("container anchor post (depth 0, thin body) -> null", () => {
     const e = makeEntry({ author: "ecency.waves", permlink: "waves-2026", depth: 0 });
     expect(canonicalTarget(e, BASE)).toBeNull();
+  });
+
+  it("substantive depth-0 post BY a container account -> self (not anchor-suppressed)", () => {
+    const e = makeEntry({
+      author: "ecency.waves",
+      permlink: "waves-feature-announcement",
+      depth: 0,
+      body: realPostBody
+    });
+    expect(canonicalTarget(e, BASE)).toBe(
+      "https://ecency.com/@ecency.waves/waves-feature-announcement"
+    );
   });
 
   it("wave (depth 1 under container) -> self", () => {
@@ -169,8 +182,13 @@ describe("isIndexable - structure", () => {
   it("normal deep reply with no root NOT indexable", () => {
     expect(idx(makeEntry({ depth: 4, parent_author: "x", parent_permlink: "y" }))).toBe(false);
   });
-  it("container anchor post NOT indexable", () => {
+  it("container anchor post (thin) NOT indexable", () => {
     expect(idx(makeEntry({ author: "ecency.waves", depth: 0 }))).toBe(false);
+  });
+  it("substantive depth-0 post by a container account IS indexable", () => {
+    expect(
+      idx(makeEntry({ author: "peak.snaps", depth: 0, body: realPostBody }))
+    ).toBe(true);
   });
   it("reply to wave (depth 2) indexable", () => {
     expect(

--- a/apps/web/src/specs/utils/entry-indexability.spec.ts
+++ b/apps/web/src/specs/utils/entry-indexability.spec.ts
@@ -1,0 +1,261 @@
+import { vi } from "vitest";
+
+// postBodySummary is globally mocked (render-helper). Re-mock as identity so the
+// Tier-0 content-floor length reflects the test body deterministically.
+vi.mock("@ecency/render-helper", () => ({
+  postBodySummary: (b: string) => b ?? ""
+}));
+
+import { Entry } from "@/entities";
+import {
+  canonicalTarget,
+  isIndexable,
+  isContainerTree,
+  CONTAINER_ACCOUNTS,
+  WAVE_MIN_BODY_CHARS
+} from "../../utils/entry-indexability";
+
+const BASE = "https://ecency.com";
+const longBody = "x".repeat(WAVE_MIN_BODY_CHARS + 20);
+const shortBody = "gm";
+
+const makeEntry = (o: Partial<Entry>): Entry =>
+  ({
+    author: "alice",
+    permlink: "a-post",
+    depth: 0,
+    body: longBody,
+    children: 0,
+    active_votes: [],
+    json_metadata: {},
+    author_reputation: 0,
+    pending_payout_value: "0.000 HBD",
+    curator_payout_value: "0.000 HBD",
+    ...o
+  }) as unknown as Entry;
+
+// account=null + accountFetchFailed=true => reputation gate skipped (isolates logic)
+const idx = (e: Entry) => isIndexable(e, null, true);
+
+describe("canonicalTarget", () => {
+  it("normal top-level post -> self", () => {
+    const e = makeEntry({ depth: 0, author: "bob", permlink: "hello" });
+    expect(canonicalTarget(e, BASE)).toBe("https://ecency.com/@bob/hello");
+  });
+
+  it("explicit canonical_url wins and strips www", () => {
+    const e = makeEntry({ json_metadata: { canonical_url: "https://www.foo.bar/x" } });
+    expect(canonicalTarget(e, BASE)).toBe("https://foo.bar/x");
+  });
+
+  it("missing author/permlink -> null", () => {
+    expect(canonicalTarget(makeEntry({ permlink: "" }), BASE)).toBeNull();
+  });
+
+  it("normal reply with root_* -> root post (any depth)", () => {
+    const e = makeEntry({
+      depth: 5,
+      author: "alice",
+      permlink: "re-x",
+      parent_author: "carol",
+      parent_permlink: "re-y",
+      root_author: "bob",
+      root_permlink: "the-post"
+    });
+    expect(canonicalTarget(e, BASE)).toBe("https://ecency.com/@bob/the-post");
+  });
+
+  it("normal depth-1 reply without root_* -> parent (parent is root)", () => {
+    const e = makeEntry({
+      depth: 1,
+      author: "alice",
+      permlink: "re-x",
+      parent_author: "bob",
+      parent_permlink: "the-post"
+    });
+    expect(canonicalTarget(e, BASE)).toBe("https://ecency.com/@bob/the-post");
+  });
+
+  it("normal deep reply with no resolvable root -> null", () => {
+    const e = makeEntry({ depth: 4, parent_author: "x", parent_permlink: "y" });
+    expect(canonicalTarget(e, BASE)).toBeNull();
+  });
+
+  it("container anchor post (depth 0) -> null", () => {
+    const e = makeEntry({ author: "ecency.waves", permlink: "waves-2026", depth: 0 });
+    expect(canonicalTarget(e, BASE)).toBeNull();
+  });
+
+  it("wave (depth 1 under container) -> self", () => {
+    const e = makeEntry({
+      author: "alice",
+      permlink: "my-wave",
+      depth: 1,
+      parent_author: "ecency.waves",
+      root_author: "ecency.waves",
+      root_permlink: "waves-2026"
+    });
+    expect(canonicalTarget(e, BASE)).toBe("https://ecency.com/@alice/my-wave");
+  });
+
+  it("reply to a wave (depth 2) -> the wave (its parent)", () => {
+    const e = makeEntry({
+      author: "carol",
+      permlink: "re-wave",
+      depth: 2,
+      parent_author: "alice",
+      parent_permlink: "my-wave",
+      root_author: "ecency.waves",
+      root_permlink: "waves-2026"
+    });
+    expect(canonicalTarget(e, BASE)).toBe("https://ecency.com/@alice/my-wave");
+  });
+
+  it("deep wave sub-reply (depth >= 3) -> null", () => {
+    const e = makeEntry({
+      depth: 3,
+      parent_author: "carol",
+      parent_permlink: "re-wave",
+      root_author: "peak.snaps",
+      root_permlink: "snap-container"
+    });
+    expect(canonicalTarget(e, BASE)).toBeNull();
+  });
+});
+
+describe("isContainerTree", () => {
+  it("true when root author is a known container account", () => {
+    expect(isContainerTree(makeEntry({ root_author: "leothreads", depth: 1 }))).toBe(true);
+  });
+  it("false for normal threads", () => {
+    expect(isContainerTree(makeEntry({ root_author: "bob", depth: 1 }))).toBe(false);
+  });
+  it("all five container accounts recognised", () => {
+    for (const a of ["leothreads", "ecency.waves", "peak.snaps", "liketu.moments", "hive.flow"]) {
+      expect(CONTAINER_ACCOUNTS.has(a)).toBe(true);
+    }
+  });
+});
+
+describe("isIndexable - structure", () => {
+  it("normal post indexable", () => {
+    expect(idx(makeEntry({ depth: 0 }))).toBe(true);
+  });
+  it("normal reply with resolvable root indexable", () => {
+    expect(
+      idx(makeEntry({ depth: 2, root_author: "bob", root_permlink: "p" }))
+    ).toBe(true);
+  });
+  it("normal deep reply with no root NOT indexable", () => {
+    expect(idx(makeEntry({ depth: 4, parent_author: "x", parent_permlink: "y" }))).toBe(false);
+  });
+  it("container anchor post NOT indexable", () => {
+    expect(idx(makeEntry({ author: "ecency.waves", depth: 0 }))).toBe(false);
+  });
+  it("reply to wave (depth 2) indexable", () => {
+    expect(
+      idx(
+        makeEntry({
+          depth: 2,
+          parent_author: "alice",
+          parent_permlink: "w",
+          root_author: "ecency.waves"
+        })
+      )
+    ).toBe(true);
+  });
+  it("deep wave sub-reply (depth 3) NOT indexable", () => {
+    expect(idx(makeEntry({ depth: 3, root_author: "ecency.waves" }))).toBe(false);
+  });
+});
+
+describe("wave quality gate (depth-1 under container)", () => {
+  const wave = (o: Partial<Entry>) =>
+    makeEntry({
+      author: "alice",
+      permlink: "w",
+      depth: 1,
+      parent_author: "ecency.waves",
+      root_author: "ecency.waves",
+      root_permlink: "waves-2026",
+      ...o
+    });
+
+  it("Tier0 fail: short body -> not indexable", () => {
+    expect(idx(wave({ body: shortBody, children: 99 }))).toBe(false);
+  });
+
+  it("Tier1 pass via children", () => {
+    expect(idx(wave({ body: longBody, children: 3 }))).toBe(true);
+  });
+
+  it("Tier1 fail: long body but no engagement", () => {
+    expect(idx(wave({ body: longBody, children: 0, active_votes: [] }))).toBe(false);
+  });
+
+  it("Tier1 pass via voters + payout", () => {
+    expect(
+      idx(
+        wave({
+          children: 0,
+          active_votes: new Array(6).fill({ voter: "v" }),
+          pending_payout_value: "0.500 HBD"
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("gaming: high payout but only 1 voter -> fail", () => {
+    expect(
+      idx(
+        wave({
+          children: 0,
+          active_votes: [{ voter: "self" }] as never,
+          pending_payout_value: "50.000 HBD"
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("gaming: many voters but dust payout -> fail", () => {
+    expect(
+      idx(
+        wave({
+          children: 0,
+          active_votes: new Array(40).fill({ voter: "v" }),
+          pending_payout_value: "0.001 HBD"
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("payout is source-agnostic (numeric payout field counts)", () => {
+    expect(
+      idx(
+        wave({
+          children: 0,
+          active_votes: new Array(6).fill({ voter: "v" }),
+          pending_payout_value: "0.000 HBD",
+          payout: 1.23
+        } as Partial<Entry>)
+      )
+    ).toBe(true);
+  });
+});
+
+describe("isIndexable - NSFW and reputation gates", () => {
+  it("nsfw tag -> not indexable even for a normal post", () => {
+    const e = makeEntry({ depth: 0, json_metadata: { tags: ["nsfw"] } });
+    expect(idx(e)).toBe(false);
+  });
+
+  it("low-reputation author -> not indexable when account known", () => {
+    const e = makeEntry({ depth: 0 });
+    expect(isIndexable(e, { reputation: 0, post_count: 0 }, false)).toBe(false);
+  });
+
+  it("account fetch failed -> reputation gate skipped (not punished)", () => {
+    const e = makeEntry({ depth: 0 });
+    expect(isIndexable(e, null, true)).toBe(true);
+  });
+});

--- a/apps/web/src/utils/entry-canonical.ts
+++ b/apps/web/src/utils/entry-canonical.ts
@@ -1,28 +1,17 @@
 import { Entry } from "@/entities";
 import defaults from "@/defaults";
+import { canonicalTarget } from "@/utils/entry-indexability";
 
 /**
- * Returns the canonical URL for an entry.
+ * Returns the canonical URL for an entry, or null when it has no canonical
+ * target (thin container post / unresolvable deep wave sub-reply) and should
+ * be noindexed instead.
  *
- * Always self-canonical to `${baseUrl}/@${author}/${permlink}` unless the post
- * explicitly declares its own canonical (e.g. cross-published syndication).
- *
- * Why bare /@author/permlink: the same post is reachable on ecency.com via
- * multiple URL forms (community-prefixed, legacy Steemit categories, bare).
- * Picking one canonical shape consolidates Google's duplicate cluster onto a
- * single URL and stops leaking ranking signals to other frontends, which the
- * older `app`-based cross-frontend canonical was doing — and which Google was
- * silently ignoring anyway when those targets were CSR.
+ * Thin wrapper over canonicalTarget — the single source of truth shared with
+ * the indexability decision so canonical and noindex can never disagree.
+ * See entry-indexability.ts for the full model (self-canonical posts,
+ * reply -> discussion root, wave/snap container handling).
  */
 export function entryCanonical(entry: Entry, baseUrl = defaults.base): string | null {
-  const canonicalFromMetadata = entry.json_metadata?.canonical_url;
-  if (canonicalFromMetadata) {
-    return canonicalFromMetadata.replace("https://www.", "https://");
-  }
-
-  if (!entry.author || !entry.permlink) {
-    return null;
-  }
-
-  return `${baseUrl}/@${entry.author}/${entry.permlink}`;
+  return canonicalTarget(entry, baseUrl);
 }

--- a/apps/web/src/utils/entry-indexability.ts
+++ b/apps/web/src/utils/entry-indexability.ts
@@ -37,6 +37,13 @@ export const WAVE_MIN_CHILDREN = 3; // a real micro-thread
 export const WAVE_MIN_VOTERS = 5; // beyond self + a 1-2 acct circle
 export const WAVE_MIN_PAYOUT = 0.1; // dust floor (combined with voters)
 
+// A depth-0 post BY a container account is the machine anchor only when its
+// body is thin. Verified anchors are 24–119 chars; a real standalone post
+// (rare, but these are not guaranteed never to publish one) is far longer.
+// 400 separates them with wide margin in both directions, so anchors stay
+// suppressed while a genuine post by the same account still gets indexed.
+export const CONTAINER_ANCHOR_MAX_BODY = 400;
+
 export type ReputationSource =
   | Pick<FullAccount, "reputation" | "post_count">
   | Profile
@@ -79,6 +86,19 @@ export const isContainerTree = (entry: ThreadShape): boolean =>
   // to the thin anchor post — strictly worse than the old self-canonical.
   (entry.depth === 1 && CONTAINER_ACCOUNTS.has(entry.parent_author ?? ""));
 
+/** Plain-text (markdown/links/images stripped) body length. */
+const plainBodyLen = (entry: Pick<Entry, "body">): number =>
+  postBodySummary(entry.body || "", 1000).trim().length;
+
+/**
+ * A depth-0 post authored by a container account that is thin enough to be the
+ * machine-generated anchor (not a rare real standalone post by that account).
+ */
+const isContainerAnchorPost = (entry: Entry): boolean =>
+  (entry.depth ?? 0) === 0 &&
+  isContainerTree(entry) &&
+  plainBodyLen(entry) <= CONTAINER_ANCHOR_MAX_BODY;
+
 /**
  * The canonical URL for an entry, or null when it has no canonical target and
  * should be noindexed (thin container post, or a deep wave sub-reply whose
@@ -103,7 +123,12 @@ export function canonicalTarget(
   const depth = entry.depth ?? 0;
 
   if (isContainerTree(entry)) {
-    if (depth === 0) return null; // thin container anchor — never a target
+    if (depth === 0) {
+      // Thin body = machine anchor (no canonical → noindex). A substantive
+      // body = a rare real standalone post by the account → treat as normal
+      // post (self), so we don't silently suppress a valid page.
+      return isContainerAnchorPost(entry) ? null : self;
+    }
     if (depth === 1) return self; // the wave/snap is the content unit
     if (depth === 2 && entry.parent_author && entry.parent_permlink) {
       // reply to a wave → the wave (its immediate parent). Known seam: the
@@ -154,8 +179,7 @@ const effectivePayout = (entry: Entry): number => {
 /** Tier 0 (content floor) + Tier 1 (engagement) gate for depth-1 waves. */
 const passesWaveQualityGate = (entry: Entry): boolean => {
   // Tier 0: intrinsic content floor (NSFW + reputation already checked upstream).
-  const plain = postBodySummary(entry.body || "", 1000).trim();
-  if (plain.length < WAVE_MIN_BODY_CHARS) return false;
+  if (plainBodyLen(entry) < WAVE_MIN_BODY_CHARS) return false;
 
   // Tier 1: engagement corroboration.
   const children = typeof entry.children === "number" ? entry.children : 0;
@@ -184,7 +208,7 @@ export function isIndexable(
   const depth = entry.depth ?? 0;
 
   if (isContainerTree(entry)) {
-    if (depth === 0) return false; // thin container anchor
+    if (depth === 0) return !isContainerAnchorPost(entry); // anchor → noindex; real post → index
     if (depth === 1) return passesWaveQualityGate(entry); // the wave/snap
     if (depth === 2) return true; // reply to a wave (canonicals to the wave)
     return false; // depth >= 3 in a container tree

--- a/apps/web/src/utils/entry-indexability.ts
+++ b/apps/web/src/utils/entry-indexability.ts
@@ -1,0 +1,189 @@
+import { Entry, FullAccount } from "@/entities";
+import { Profile } from "@ecency/sdk";
+import { postBodySummary } from "@ecency/render-helper";
+import { accountReputation } from "@/utils/account-reputation";
+import { isNsfwEntry } from "@/utils/nsfw-detection";
+import defaults from "@/defaults";
+
+/**
+ * Single source of truth for "is this entry indexable" and "what URL should it
+ * canonical to". Consumed by entry-canonical.ts and generate-entry-metadata.ts
+ * so the sitemap/canonical/noindex decisions can never drift apart.
+ *
+ * Core principle: a comment is not its own indexable page — it canonicals to
+ * the root of its discussion thread. The discussion root is the depth-0 post
+ * for a normal thread, or the depth-1 wave/snap for a microblog container tree
+ * (the thin depth-0 container is plumbing, never a target).
+ */
+
+// Accounts that publish thin "container" anchor posts whose depth-1 children
+// are the actual short-form content (waves / snaps / threads / moments).
+// hive.flow is pre-provisioned (does not exist yet — future account unifying
+// waves+snaps); inert until it posts. Verify its depth-0/depth-1 shape at launch.
+export const CONTAINER_ACCOUNTS = new Set<string>([
+  "leothreads",
+  "ecency.waves",
+  "peak.snaps",
+  "liketu.moments",
+  "hive.flow",
+]);
+
+const NOINDEX_REPUTATION_THRESHOLD = 40;
+
+// Wave/snap quality gate (depth-1 in a container tree). Deliberately
+// conservative — index few, widen later from Search Console data.
+export const WAVE_MIN_BODY_CHARS = 100; // stripped prose length
+export const WAVE_MIN_CHILDREN = 3; // a real micro-thread
+export const WAVE_MIN_VOTERS = 5; // beyond self + a 1-2 acct circle
+export const WAVE_MIN_PAYOUT = 0.1; // dust floor (combined with voters)
+
+export type ReputationSource =
+  | Pick<FullAccount, "reputation" | "post_count">
+  | Profile
+  | null;
+
+export const shouldApplyNoIndex = (
+  account: ReputationSource,
+  fallbackReputation: number
+): boolean => {
+  const reputationScore = accountReputation(account?.reputation ?? fallbackReputation ?? 0);
+  const postCount = typeof account?.post_count === "number" ? account.post_count : 0;
+
+  const meetsReputationGate = reputationScore < NOINDEX_REPUTATION_THRESHOLD;
+  const lacksPostingHistory = postCount <= 3;
+
+  // No-indexed when the author lacks reputation or meaningful posting history.
+  return meetsReputationGate || lacksPostingHistory;
+};
+
+type ThreadShape = Pick<
+  Entry,
+  | "author"
+  | "permlink"
+  | "depth"
+  | "parent_author"
+  | "parent_permlink"
+  | "root_author"
+  | "root_permlink"
+>;
+
+/** depth-0 author of the thread (a post is its own root). */
+const rootAuthorOf = (entry: ThreadShape): string =>
+  entry.root_author || entry.author;
+
+export const isContainerTree = (entry: ThreadShape): boolean =>
+  CONTAINER_ACCOUNTS.has(rootAuthorOf(entry));
+
+/**
+ * The canonical URL for an entry, or null when it has no canonical target and
+ * should be noindexed (thin container post, or a deep wave sub-reply whose
+ * depth-1 wave isn't resolvable from the entry without tree-walking).
+ *
+ * Honors an explicit json_metadata.canonical_url first (syndication intent).
+ */
+export function canonicalTarget(
+  entry: Entry,
+  baseUrl: string = defaults.base
+): string | null {
+  const declared = entry.json_metadata?.canonical_url;
+  if (declared) {
+    return declared.replace("https://www.", "https://");
+  }
+
+  if (!entry.author || !entry.permlink) {
+    return null;
+  }
+
+  const self = `${baseUrl}/@${entry.author}/${entry.permlink}`;
+  const depth = entry.depth ?? 0;
+
+  if (isContainerTree(entry)) {
+    if (depth === 0) return null; // thin container anchor — never a target
+    if (depth === 1) return self; // the wave/snap is the content unit
+    if (depth === 2 && entry.parent_author && entry.parent_permlink) {
+      // reply to a wave → the wave (its immediate parent)
+      return `${baseUrl}/@${entry.parent_author}/${entry.parent_permlink}`;
+    }
+    return null; // depth >= 3 in a container tree — unresolvable, noindex
+  }
+
+  if (depth === 0) return self; // normal top-level post → self
+
+  // normal reply → the depth-0 root post
+  if (entry.root_author && entry.root_permlink) {
+    return `${baseUrl}/@${entry.root_author}/${entry.root_permlink}`;
+  }
+  if (depth === 1 && entry.parent_author && entry.parent_permlink) {
+    // depth-1 reply: parent IS the root (covers bridge-fed entries lacking root_*)
+    return `${baseUrl}/@${entry.parent_author}/${entry.parent_permlink}`;
+  }
+  return null; // deep reply with no resolvable root — noindex
+}
+
+const parsePayout = (v: unknown): number => {
+  if (typeof v === "number") return Number.isFinite(v) ? v : 0;
+  if (typeof v === "string") {
+    const n = parseFloat(v.replace(/[^0-9.]/g, ""));
+    return Number.isFinite(n) ? n : 0;
+  }
+  return 0;
+};
+
+/**
+ * Source-agnostic effective payout. condenser_api.get_content omits
+ * is_paidout/author_payout_value (bridge-shape fields), so read whatever is
+ * present and take the max of the numeric `payout` and the summed *_value
+ * strings. The §gate floor is coarse — precision is not required.
+ */
+const effectivePayout = (entry: Entry): number => {
+  const summed =
+    parsePayout(entry.pending_payout_value) +
+    parsePayout(entry.author_payout_value) +
+    parsePayout(entry.curator_payout_value);
+  return Math.max(parsePayout(entry.payout), summed);
+};
+
+/** Tier 0 (content floor) + Tier 1 (engagement) gate for depth-1 waves. */
+const passesWaveQualityGate = (entry: Entry): boolean => {
+  // Tier 0: intrinsic content floor (NSFW + reputation already checked upstream).
+  const plain = postBodySummary(entry.body || "", 1000).trim();
+  if (plain.length < WAVE_MIN_BODY_CHARS) return false;
+
+  // Tier 1: engagement corroboration.
+  const children = typeof entry.children === "number" ? entry.children : 0;
+  if (children >= WAVE_MIN_CHILDREN) return true;
+
+  const voters = Array.isArray(entry.active_votes) ? entry.active_votes.length : 0;
+  return voters >= WAVE_MIN_VOTERS && effectivePayout(entry) >= WAVE_MIN_PAYOUT;
+};
+
+/**
+ * Whether the entry should be indexed (true) or emit robots noindex (false).
+ * The reputation gate needs the fetched author account; callers pass it plus
+ * whether that fetch failed (failure => don't punish, skip the rep gate).
+ */
+export function isIndexable(
+  entry: Entry,
+  account: ReputationSource,
+  accountFetchFailed: boolean
+): boolean {
+  if (isNsfwEntry(entry)) return false;
+
+  const reputationNoIndex =
+    !accountFetchFailed && shouldApplyNoIndex(account, entry.author_reputation ?? 0);
+  if (reputationNoIndex) return false;
+
+  const depth = entry.depth ?? 0;
+
+  if (isContainerTree(entry)) {
+    if (depth === 0) return false; // thin container anchor
+    if (depth === 1) return passesWaveQualityGate(entry); // the wave/snap
+    if (depth === 2) return true; // reply to a wave (canonicals to the wave)
+    return false; // depth >= 3 in a container tree
+  }
+
+  if (depth === 0) return true; // normal top-level post
+
+  // normal reply: indexable only if its discussion root is resolvable
+  return canonicalTarget(entry) !== null;
+}

--- a/apps/web/src/utils/entry-indexability.ts
+++ b/apps/web/src/utils/entry-indexability.ts
@@ -49,11 +49,11 @@ export const shouldApplyNoIndex = (
   const reputationScore = accountReputation(account?.reputation ?? fallbackReputation ?? 0);
   const postCount = typeof account?.post_count === "number" ? account.post_count : 0;
 
-  const meetsReputationGate = reputationScore < NOINDEX_REPUTATION_THRESHOLD;
+  const belowReputationThreshold = reputationScore < NOINDEX_REPUTATION_THRESHOLD;
   const lacksPostingHistory = postCount <= 3;
 
   // No-indexed when the author lacks reputation or meaningful posting history.
-  return meetsReputationGate || lacksPostingHistory;
+  return belowReputationThreshold || lacksPostingHistory;
 };
 
 type ThreadShape = Pick<
@@ -72,7 +72,12 @@ const rootAuthorOf = (entry: ThreadShape): string =>
   entry.root_author || entry.author;
 
 export const isContainerTree = (entry: ThreadShape): boolean =>
-  CONTAINER_ACCOUNTS.has(rootAuthorOf(entry));
+  CONTAINER_ACCOUNTS.has(rootAuthorOf(entry)) ||
+  // Bridge-fallback path omits root_*; for a depth-1 wave the immediate parent
+  // IS the container account, so detect via parent_author too. Without this a
+  // bridge-fed wave would be misread as a normal depth-1 reply and canonical
+  // to the thin anchor post — strictly worse than the old self-canonical.
+  (entry.depth === 1 && CONTAINER_ACCOUNTS.has(entry.parent_author ?? ""));
 
 /**
  * The canonical URL for an entry, or null when it has no canonical target and
@@ -101,7 +106,10 @@ export function canonicalTarget(
     if (depth === 0) return null; // thin container anchor — never a target
     if (depth === 1) return self; // the wave/snap is the content unit
     if (depth === 2 && entry.parent_author && entry.parent_permlink) {
-      // reply to a wave → the wave (its immediate parent)
+      // reply to a wave → the wave (its immediate parent). Known seam: the
+      // wave may itself fail the quality gate (noindex); we don't fetch it to
+      // check (no SSR fan-out). Same accepted trade-off as the normal
+      // reply→possibly-noindexed-root seam — see spec §5.
       return `${baseUrl}/@${entry.parent_author}/${entry.parent_permlink}`;
     }
     return null; // depth >= 3 in a container tree — unresolvable, noindex


### PR DESCRIPTION
## Summary

Adopts the Reddit/Stack-Overflow model: **a comment is not its own indexable page — it canonicals to the root of its discussion thread.** The discussion root is the depth-0 post for a normal thread, or the **depth-1 wave/snap** for a microblog container tree (the thin depth-0 container is plumbing, never a target). Extends the bare self-canonical from #788.

Single source of truth: new `apps/web/src/utils/entry-indexability.ts`, consumed by both `entry-canonical.ts` and `generate-entry-metadata.ts` so canonical and noindex can never disagree.

## Model

`canonicalTarget(entry)`:

| Case | Target |
|---|---|
| explicit `json_metadata.canonical_url` | declared (www-stripped) |
| normal post (depth 0) | self |
| normal reply (any depth) | root post (`root_*`; or parent when depth-1) |
| container anchor post (depth 0) | none → noindex |
| wave / snap (depth 1, container tree) | self (subject to quality gate) |
| reply to a wave (depth 2) | the wave (its parent) |
| deep container sub-reply (depth ≥ 3) | none → noindex (unresolvable without tree-walk; outcome-equivalent) |

`isIndexable(entry, account, accountFetchFailed)`: NSFW + reputation gates (moved here, **behavior unchanged**), container structure, and the wave quality gate.

**Wave quality gate** (depth-1 in a container tree): Tier 0 intrinsic content floor (≥100 stripped chars) **and** Tier 1 engagement (`children ≥ 3` **OR** `voters ≥ 5 AND payout ≥ $0.10`). Combined voter+payout defeats whale/dust gaming. No freshness exception. Conservative starting constants, tunable from GSC data.

`CONTAINER_ACCOUNTS`: `leothreads`, `ecency.waves`, `peak.snaps`, `liketu.moments` (all verified live: thin depth-0, high children), `hive.flow` (pre-provisioned future account unifying waves+snaps — inert until it exists; verify depth-0/depth-1 shape at launch).

## Key infra change — fetch source

`bridge.get_post` (the primary SSR fetch) **omits `root_author`/`root_permlink`** (verified: returns `null` for a depth-5 reply). The model needs them. `condenser_api.get_content` returns them plus every gate field. So `generate-entry-metadata` now sources the entry from `getContentQueryOptions` (condenser) **first**, bridge as fallback — **fetch-count-neutral** (bridge was already the fallback, already trusted here). Page render path untouched. `effective_payout` is source-agnostic because condenser omits `is_paidout`/`author_payout_value`.

`root_author?`/`root_permlink?` added to the web `Entry` type (`apps/web/src/entities/entries.ts` — local type, **no SDK rebuild**). `entry-canonical.ts` is now a thin delegating wrapper.

## Test plan

- [x] `vitest run` entry-indexability (29, new) + entry-canonical (9) + nsfw-detection (11) — **49/49 pass**
- [x] New tests cover the full matrix incl. gaming cases (whale-only, dust-only, source-agnostic payout) and NSFW/reputation gates
- [x] ESLint clean on all changed files
- [x] Typecheck: no new errors in changed files (the one `similar-entries` Entry-vs-Entry error is **pre-existing on develop**, unrelated)
- [ ] Post-deploy smoke: verify a normal reply canonicals to its root post; a wave self-canonicals when it passes the gate and noindexes when thin; a container anchor noindexes; og:url matches canonical
- [ ] Add wave/reply rows to the weekly GSC convergence report's tracked set

## Notes

- Deep container sub-reply (depth ≥ 3) noindex is a **mechanical** choice (depth-1 wave unresolvable from one Entry without SSR fan-out / canonical chain), outcome-equivalent to canonical→wave for that near-zero-value slice — not a semantic carve-out. Restores to full symmetry if a depth-1-ancestor field is ever added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined entry metadata generation with improved content fetching fallback logic and centralized indexability decisions for more consistent search engine optimization.

* **New Features**
  * Added support for root-level authorship metadata on entries to better represent entry relationships.

* **Tests**
  * Added comprehensive test coverage for indexability and canonical URL resolution logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->