### PR TITLE
SEO: communities sitemap shard; flatten posts shard name

### DIFF
--- a/apps/web/src/app/api/internal/seo/blacklist-refresh/route.ts
+++ b/apps/web/src/app/api/internal/seo/blacklist-refresh/route.ts
@@ -93,11 +93,17 @@ export async function POST(req: Request): Promise<Response> {
 
     return jsonResponse(200, { ok: true, count: newCount, oldCount });
   } catch (e) {
-    // Live key untouched (rename only runs on success). Keep last-good.
-    return jsonResponse(200, {
-      error: "refresh-failed",
-      message: e instanceof Error ? e.message : String(e)
-    });
+    // Live key untouched (rename only runs on success) — last-good preserved.
+    // But this IS a failure: return 5xx (not 200) so the caller/monitoring
+    // sees it, and record it in META. 200 is reserved for success and the
+    // intentional delta-sanity skip; 502/503 cover upstream/redis already.
+    const message = e instanceof Error ? e.message : String(e);
+    try {
+      await redis.set(META, JSON.stringify({ ok: false, reason: "refresh-failed", message, ts }));
+    } catch {
+      /* best-effort failure record */
+    }
+    return jsonResponse(500, { error: "refresh-failed", message });
   } finally {
     // Drop the temp key on every path: on success rename() already moved
     // it to LIVE (no-op del); on skip/error this clears any partial set.

--- a/apps/web/src/app/api/internal/seo/blacklist-refresh/route.ts
+++ b/apps/web/src/app/api/internal/seo/blacklist-refresh/route.ts
@@ -55,13 +55,29 @@ export async function POST(req: Request): Promise<Response> {
     try {
       const res = await fetch(SOURCE, { signal: ctrl.signal });
       if (!res.ok) return jsonResponse(502, { error: `upstream-${res.status}` });
-      parsed = JSON.parse(await res.text()); // content-type is text/plain
+      const text = await res.text(); // content-type is text/plain
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = undefined; // not JSON → unexpected-shape below
+      }
     } finally {
       clearTimeout(t);
     }
 
+    // Strict by design. The SEO blacklist is specifically the spaminator
+    // *spam* list ({"result":[...]}). Other Hive "blacklists" — e.g. the
+    // Watchmen badactors.txt *security/phishing* feed — are a different
+    // thing and must NOT be silently ingested as an SEO spam filter. A
+    // shape mismatch means SEO_BLACKLIST_URL points at the wrong feed, so
+    // fail loud (502 + META) instead of polluting noindex/sitemap data.
     const result = (parsed as ParsedResult)?.result;
     if (!Array.isArray(result)) {
+      try {
+        await redis.set(META, JSON.stringify({ ok: false, reason: "unexpected-shape", ts }));
+      } catch {
+        /* best-effort failure record */
+      }
       return jsonResponse(502, { error: "unexpected-shape" });
     }
     const accounts = Array.from(

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -21,6 +21,7 @@ import { getSeoRedis, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
 import { cronAuthorized, notFound } from "@/features/seo/cron-auth";
 import { SITEMAP_SHARDS } from "@/features/seo/sitemap-shards";
 import { isIndexable, canonicalTarget } from "@/utils/entry-indexability";
+import { isNsfwCommunity } from "@/utils/nsfw-detection";
 import { Entry } from "@/entities";
 import defaults from "@/defaults";
 // Hive-only entry: this is a server route handler — avoid pulling the
@@ -41,6 +42,11 @@ const TIME_BUDGET_MS = 50_000;
 const MAX_PAGES = 150;
 const WINDOW_MS = 48 * 60 * 60_000;
 const PAGE = 20;
+// Communities: a small, stable hub set (not a freshness walk). list_communities
+// caps at 100/page → 5 pages ≈ top ~500 by rank. Cheap, independent of the
+// post-walk time budget.
+const COMM_PAGES = 5;
+const COMM_LIMIT = 100;
 
 const esc = (s: string) =>
   s.replace(/[&<>'"]/g, (c) =>
@@ -103,6 +109,37 @@ export async function POST(req: Request): Promise<Response> {
     blacklist = new Set();
   }
 
+  // Communities hub shard — bounded, resilient, independent of the post walk.
+  // /created/hive-NNN is 200 + self-canonical (/trending|/hot canonical TO
+  // it), so it's a safe indexable target. NSFW excluded via our curated set
+  // (single source of truth); the response `is_nsfw` flag is unreliable so
+  // it's only an additive bonus signal, never relied upon.
+  const communityUrls: { loc: string }[] = [];
+  const seenComm = new Set<string>();
+  let commLast = "";
+  for (let cp = 0; cp < COMM_PAGES; cp++) {
+    let cbatch: Record<string, unknown>[];
+    try {
+      cbatch = (await callRPC("bridge.list_communities", {
+        sort: "rank",
+        limit: COMM_LIMIT,
+        last: commLast
+      })) as Record<string, unknown>[];
+    } catch {
+      break;
+    }
+    if (!Array.isArray(cbatch) || cbatch.length === 0) break;
+    for (const c of cbatch) {
+      const name = typeof c.name === "string" ? c.name : "";
+      if (!name || seenComm.has(name)) continue;
+      seenComm.add(name);
+      commLast = name;
+      if (isNsfwCommunity(name) || c.is_nsfw === true) continue;
+      communityUrls.push({ loc: `${BASE}/created/${name}` });
+    }
+    if (cbatch.length < COMM_LIMIT) break;
+  }
+
   const seen = new Set<string>();
   const postUrls: { loc: string; lastmod?: string }[] = [];
   const authors = new Set<string>();
@@ -163,8 +200,9 @@ export async function POST(req: Request): Promise<Response> {
   // allowlist the public route validates against. A name here that isn't in
   // that list is a compile error (keyof typeof), not a silent prod 404.
   const shardXml: Record<(typeof SITEMAP_SHARDS)[number], string> = {
-    "posts-1.xml": urlset(postUrls),
+    "posts.xml": urlset(postUrls),
     "authors.xml": urlset(authorUrls),
+    "communities.xml": urlset(communityUrls),
     "static.xml": urlset(staticUrls)
   };
 
@@ -182,6 +220,7 @@ export async function POST(req: Request): Promise<Response> {
         ts: new Date().toISOString(),
         posts: postUrls.length,
         authors: authorUrls.length,
+        communities: communityUrls.length,
         pages,
         ms: Date.now() - started,
         reachedCutoff
@@ -201,6 +240,7 @@ export async function POST(req: Request): Promise<Response> {
       ok: true,
       posts: postUrls.length,
       authors: authorUrls.length,
+      communities: communityUrls.length,
       pages,
       ms: Date.now() - started,
       reachedCutoff

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -47,6 +47,13 @@ const PAGE = 20;
 // post-walk time budget.
 const COMM_PAGES = 5;
 const COMM_LIMIT = 100;
+// The community *list* changes slowly → re-fetch via list_communities at most
+// weekly (names cached in Redis). The shard is still rebuilt every run from
+// the cached names + fresh post-derived lastmod, so freshness stays hourly
+// while the ~5 list_communities RPCs run only ~weekly.
+const COMM_REFRESH_MS = 7 * 24 * 60 * 60_000;
+const COMM_NAMES_KEY = `${SEO_REDIS_PREFIX}sitemap:communities:names`;
+const COMM_BUILT_KEY = `${SEO_REDIS_PREFIX}sitemap:communities:builtAt`;
 
 interface SitemapUrl {
   loc: string;
@@ -114,44 +121,78 @@ export async function POST(req: Request): Promise<Response> {
     blacklist = new Set();
   }
 
-  // Communities hub shard — bounded, resilient, independent of the post walk.
-  // /created/hive-NNN is 200 + self-canonical (/trending|/hot canonical TO
-  // it), so it's a safe indexable target. NSFW excluded via our curated set
-  // (single source of truth); the response `is_nsfw` flag is unreliable so
-  // it's only an additive bonus signal, never relied upon.
-  const communityUrls: SitemapUrl[] = [];
-  const seenComm = new Set<string>();
-  let commLast = "";
-  for (let cp = 0; cp < COMM_PAGES; cp++) {
-    let cbatch: Record<string, unknown>[];
-    try {
-      cbatch = (await callRPC("bridge.list_communities", {
-        sort: "rank",
-        limit: COMM_LIMIT,
-        last: commLast
-      })) as Record<string, unknown>[];
-    } catch {
-      break;
+  // Community name list — changes slowly, so refresh it from list_communities
+  // at most weekly and cache the names in Redis. Every run still rebuilds the
+  // communities shard (below) from these names + the post-derived lastmod, so
+  // freshness stays hourly while the ~5 list_communities RPCs run only weekly.
+  let communityNames: string[] = [];
+  try {
+    const [builtAt, cached] = await Promise.all([
+      redis.get(COMM_BUILT_KEY),
+      redis.get(COMM_NAMES_KEY)
+    ]);
+    if (cached) {
+      const arr: unknown = JSON.parse(cached);
+      if (Array.isArray(arr)) {
+        communityNames = arr.filter((x): x is string => typeof x === "string");
+      }
     }
-    if (!Array.isArray(cbatch) || cbatch.length === 0) break;
-    for (const c of cbatch) {
-      const name = typeof c.name === "string" ? c.name : "";
-      if (!name || seenComm.has(name)) continue;
-      seenComm.add(name);
-      commLast = name;
-      // Defensive: only emit the verified self-canonical /created/hive-NNN
-      // form. Hive community accounts are always hive-<digits>; the guard is
-      // after the cursor advance so a freak value can't stall pagination.
-      if (!/^hive-\d+$/.test(name)) continue;
-      if (isNsfwCommunity(name) || c.is_nsfw === true) continue;
-      communityUrls.push({ loc: `${BASE}/created/${name}` });
+    const fresh =
+      communityNames.length > 0 &&
+      !!builtAt &&
+      Date.now() - Date.parse(builtAt) < COMM_REFRESH_MS;
+    if (!fresh) {
+      const fetched: string[] = [];
+      const seenComm = new Set<string>();
+      let commLast = "";
+      for (let cp = 0; cp < COMM_PAGES; cp++) {
+        let cbatch: Record<string, unknown>[];
+        try {
+          cbatch = (await callRPC("bridge.list_communities", {
+            sort: "rank",
+            limit: COMM_LIMIT,
+            last: commLast
+          })) as Record<string, unknown>[];
+        } catch {
+          break;
+        }
+        if (!Array.isArray(cbatch) || cbatch.length === 0) break;
+        for (const c of cbatch) {
+          const name = typeof c.name === "string" ? c.name : "";
+          if (!name || seenComm.has(name)) continue;
+          seenComm.add(name);
+          commLast = name;
+          // Defensive: only the verified self-canonical /created/hive-NNN
+          // form. Hive community accounts are always hive-<digits>; guard is
+          // after the cursor advance so a freak value can't stall pagination.
+          if (!/^hive-\d+$/.test(name)) continue;
+          if (isNsfwCommunity(name) || c.is_nsfw === true) continue;
+          fetched.push(name);
+        }
+        if (cbatch.length < COMM_LIMIT) break;
+      }
+      // Only adopt/recache a non-empty fetch — a failed refresh must not wipe
+      // a good cached list (fall back to the stale names instead).
+      if (fetched.length > 0) {
+        communityNames = fetched;
+        try {
+          await redis.set(COMM_NAMES_KEY, JSON.stringify(fetched));
+          await redis.set(COMM_BUILT_KEY, new Date().toISOString());
+        } catch {
+          /* best-effort cache; in-memory names still used this run */
+        }
+      }
     }
-    if (cbatch.length < COMM_LIMIT) break;
+  } catch {
+    /* Redis read failed — communityNames stays []; shard just omits them */
   }
 
   const seen = new Set<string>();
   const postUrls: SitemapUrl[] = [];
   const authors = new Set<string>();
+  // community id -> newest post day (YYYY-MM-DD) seen in the freshness
+  // window. Free: derived from the post walk below, no extra RPC.
+  const communityLatest = new Map<string, string>();
   let startAuthor: string | undefined;
   let startPermlink: string | undefined;
   let pages = 0;
@@ -185,6 +226,15 @@ export async function POST(req: Request): Promise<Response> {
         reachedCutoff = true;
         break;
       }
+      // Community freshness (free, from this walk): newest post day per
+      // community, before the indexable filter — a new post makes the hub
+      // fresh even if that post itself is rep-gated/non-indexable.
+      const comm = typeof raw.community === "string" ? raw.community : "";
+      if (comm) {
+        const day = (e.updated || e.created || "").slice(0, 10);
+        const prev = communityLatest.get(comm);
+        if (day && (!prev || day > prev)) communityLatest.set(comm, day);
+      }
       if (!isIndexable(e, null, true, blacklist)) continue;
       const loc = canonicalTarget(e, BASE);
       if (!loc) continue;
@@ -203,6 +253,15 @@ export async function POST(req: Request): Promise<Response> {
     loc: `${BASE}/@${a}`,
     lastmod: nowDay
   }));
+  // Cached/weekly name list + free hourly post-derived lastmod. A community
+  // with no post in the freshness window simply omits lastmod (honest: it
+  // signals staleness by absence rather than a fabricated date).
+  const communityUrls: SitemapUrl[] = communityNames.map((name) => {
+    const lastmod = communityLatest.get(name);
+    return lastmod
+      ? { loc: `${BASE}/created/${name}`, lastmod }
+      : { loc: `${BASE}/created/${name}` };
+  });
 
   // Writer/index/route stay in lockstep: every shard we emit — and every
   // child the index points at — comes from the single shared SITEMAP_SHARDS

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -48,12 +48,17 @@ const PAGE = 20;
 const COMM_PAGES = 5;
 const COMM_LIMIT = 100;
 
+interface SitemapUrl {
+  loc: string;
+  lastmod?: string;
+}
+
 const esc = (s: string) =>
   s.replace(/[&<>'"]/g, (c) =>
     ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", "'": "&apos;", '"': "&quot;" })[c]!
   );
 
-const urlset = (urls: { loc: string; lastmod?: string }[]) =>
+const urlset = (urls: SitemapUrl[]) =>
   `<?xml version="1.0" encoding="UTF-8"?>\n` +
   `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
   urls
@@ -114,7 +119,7 @@ export async function POST(req: Request): Promise<Response> {
   // it), so it's a safe indexable target. NSFW excluded via our curated set
   // (single source of truth); the response `is_nsfw` flag is unreliable so
   // it's only an additive bonus signal, never relied upon.
-  const communityUrls: { loc: string }[] = [];
+  const communityUrls: SitemapUrl[] = [];
   const seenComm = new Set<string>();
   let commLast = "";
   for (let cp = 0; cp < COMM_PAGES; cp++) {
@@ -134,6 +139,10 @@ export async function POST(req: Request): Promise<Response> {
       if (!name || seenComm.has(name)) continue;
       seenComm.add(name);
       commLast = name;
+      // Defensive: only emit the verified self-canonical /created/hive-NNN
+      // form. Hive community accounts are always hive-<digits>; the guard is
+      // after the cursor advance so a freak value can't stall pagination.
+      if (!/^hive-\d+$/.test(name)) continue;
       if (isNsfwCommunity(name) || c.is_nsfw === true) continue;
       communityUrls.push({ loc: `${BASE}/created/${name}` });
     }
@@ -141,7 +150,7 @@ export async function POST(req: Request): Promise<Response> {
   }
 
   const seen = new Set<string>();
-  const postUrls: { loc: string; lastmod?: string }[] = [];
+  const postUrls: SitemapUrl[] = [];
   const authors = new Set<string>();
   let startAuthor: string | undefined;
   let startPermlink: string | undefined;

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -149,9 +149,11 @@ export async function POST(req: Request): Promise<Response> {
       !!builtAt &&
       Date.now() - Date.parse(builtAt) < COMM_REFRESH_MS;
     if (!fresh) {
+      const prevCount = communityNames.length; // screened cached baseline
       const fetched: string[] = [];
       const seenComm = new Set<string>();
       let commLast = "";
+      let aborted = false; // an RPC error mid-pagination → likely truncated
       for (let cp = 0; cp < COMM_PAGES; cp++) {
         let cbatch: Record<string, unknown>[];
         try {
@@ -161,6 +163,7 @@ export async function POST(req: Request): Promise<Response> {
             last: commLast
           })) as Record<string, unknown>[];
         } catch {
+          aborted = true;
           break;
         }
         if (!Array.isArray(cbatch) || cbatch.length === 0) break;
@@ -178,9 +181,17 @@ export async function POST(req: Request): Promise<Response> {
         }
         if (cbatch.length < COMM_LIMIT) break;
       }
-      // Only adopt/recache a non-empty fetch — a failed refresh must not wipe
-      // a good cached list (fall back to the stale names instead).
-      if (fetched.length > 0) {
+      // Stale-preserving sanity (mirrors the blacklist delta-sanity): only
+      // adopt/recache a fetch that completed without an RPC abort and isn't
+      // implausibly smaller than the baseline. A truncated/partial fetch
+      // (page-2+ RPC error) or a >50% shrink is rejected — keep the cached
+      // (time-stale but complete) names and DON'T recache, so the weekly
+      // refresh keeps retrying instead of persisting a bad list for a week.
+      const sane =
+        fetched.length > 0 &&
+        !aborted &&
+        (prevCount === 0 || fetched.length >= prevCount * 0.5);
+      if (sane) {
         communityNames = fetched;
         try {
           await redis.set(COMM_NAMES_KEY, JSON.stringify(fetched));

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -134,7 +134,14 @@ export async function POST(req: Request): Promise<Response> {
     if (cached) {
       const arr: unknown = JSON.parse(cached);
       if (Array.isArray(arr)) {
-        communityNames = arr.filter((x): x is string => typeof x === "string");
+        // Re-screen on every load: a code-side NSFW_COMMUNITIES addition
+        // must take effect on the next run, not only when the weekly cache
+        // expires. (The response `is_nsfw` bonus signal can't be re-applied
+        // here — names only — but the curated set is the source of truth.)
+        communityNames = arr.filter(
+          (x): x is string =>
+            typeof x === "string" && /^hive-\d+$/.test(x) && !isNsfwCommunity(x)
+        );
       }
     }
     const fresh =

--- a/apps/web/src/app/sitemap/[shard]/route.ts
+++ b/apps/web/src/app/sitemap/[shard]/route.ts
@@ -12,10 +12,12 @@
  * Status semantics matter for crawlers: only a shard NOT in the allowlist is
  * 404 ("this resource doesn't exist"). A known shard that's merely not in
  * Redis yet (pre-prime) or unreachable (Redis blip) returns 503 + Retry-After
- * so the engine retries instead of dropping a real, advertised resource.
+ * so the engine retries instead of dropping a real, advertised resource. A
+ * just-retired shard name (a stale cached index may still link it for one
+ * cron cycle after a rename) is likewise 503, never 404.
  */
 import { getSeoRedis, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
-import { isKnownShard } from "@/features/seo/sitemap-shards";
+import { isKnownShard, isRetiredShard } from "@/features/seo/sitemap-shards";
 
 export const dynamic = "force-dynamic";
 
@@ -26,15 +28,17 @@ export async function GET(
   { params }: { params: Promise<{ shard: string }> }
 ): Promise<Response> {
   const { shard } = await params;
-  if (!isKnownShard(shard)) {
-    return new Response("Not Found", { status: 404 });
-  }
-  // Known shard but not (yet) available → transient, not "gone".
+  // Known shard but not (yet) available, OR a just-retired name a stale
+  // cached index may still link → transient, not "gone".
   const unavailable = () =>
     new Response("Service Unavailable", {
       status: 503,
       headers: { "Retry-After": "600" }
     });
+  if (isRetiredShard(shard)) return unavailable();
+  if (!isKnownShard(shard)) {
+    return new Response("Not Found", { status: 404 });
+  }
   const redis = getSeoRedis();
   if (!redis) return unavailable();
   try {

--- a/apps/web/src/features/seo/sitemap-shards.ts
+++ b/apps/web/src/features/seo/sitemap-shards.ts
@@ -9,7 +9,12 @@
  * shard means adding it here (and emitting it from the generator) — both sides
  * stay in lockstep by construction.
  */
-export const SITEMAP_SHARDS = ["posts-1.xml", "authors.xml", "static.xml"] as const;
+export const SITEMAP_SHARDS = [
+  "posts.xml",
+  "authors.xml",
+  "communities.xml",
+  "static.xml"
+] as const;
 
 export type SitemapShard = (typeof SITEMAP_SHARDS)[number];
 

--- a/apps/web/src/features/seo/sitemap-shards.ts
+++ b/apps/web/src/features/seo/sitemap-shards.ts
@@ -23,3 +23,17 @@ const SHARD_SET: ReadonlySet<string> = new Set(SITEMAP_SHARDS);
 export function isKnownShard(name: string): name is SitemapShard {
   return SHARD_SET.has(name);
 }
+
+/**
+ * Shard names we used to emit. After a rename, a Redis-cached index written by
+ * the *previous* deploy's cron can still advertise the old name until the next
+ * generation rewrites it. Serving that as a 404 would tell crawlers the shard
+ * was permanently removed; the route returns 503 (transient) for these instead
+ * so it's retried, then disappears from the index on the next cron run. Prune
+ * an entry once every environment has regenerated past the rename.
+ */
+const RETIRED_SHARDS: ReadonlySet<string> = new Set<string>(["posts-1.xml"]);
+
+export function isRetiredShard(name: string): boolean {
+  return RETIRED_SHARDS.has(name);
+}

--- a/apps/web/src/utils/nsfw-detection.ts
+++ b/apps/web/src/utils/nsfw-detection.ts
@@ -22,6 +22,11 @@ export interface NsfwCheckableEntry {
   json_metadata?: { tags?: string[] } | null;
 }
 
+// Curated NSFW community check — the reliable source of truth. The
+// list_communities `is_nsfw` response field is unreliable/stale, so it's
+// only ever used as an additive bonus signal alongside this set.
+export const isNsfwCommunity = (name: string): boolean => NSFW_COMMUNITIES.has(name);
+
 export const isNsfwEntry = (entry: NsfwCheckableEntry): boolean => {
   const candidates: string[] = [];
   if (entry.category) candidates.push(entry.category);


### PR DESCRIPTION
Follow-up to #799.

- **New `communities.xml` shard** — top ~500 communities by rank (`bridge.list_communities`, paginated via `last`, deduped), emitting the self-canonical `/created/hive-NNN` form (`/trending|/hot` canonical to it; bare `/hive-NNN` 404s). NSFW excluded via the curated `NSFW_COMMUNITIES` set; the response `is_nsfw` field is only an additive bonus signal.
- **Rename `posts-1.xml` -> `posts.xml`** — the post shard is a single rolling freshness set (regenerated hourly, well under the 50k-URL/file limit), never accumulated/paginated, so the `-1` suffix was misleading and inconsistent with the other flat shard names.
- Uses the existing shared closed-allowlist mechanism (writer/route stay in lockstep by construction). Touched files type-clean; existing specs pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Communities are now indexed in search engine sitemaps, significantly improving community discoverability, visibility, and engagement opportunities for users across the platform.

* **Improvements**
  * NSFW-tagged communities are automatically filtered and excluded from search engine indexing to maintain appropriate content standards and ensure only suitable content appears in search results.

* **Chores**
  * Sitemap infrastructure updated with community data integration, improved metadata organization, and enhanced search engine compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->