### PR TITLE
SEO: expand static sitemap; harden seocron deploy prime

### DIFF
--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -102,12 +102,20 @@ services:
         while true; do
           S=$$(( 3600 - $$(date -u +%s) % 3600 ))
           sleep "$$S"
-          # Refresh the blacklist BEFORE the 03:00 sitemap so the daily run
-          # reflects today's list, not yesterday's (other hours: sitemap only).
-          if [ "$$(date -u +%H)" = "03" ]; then
-            curl -fsS --max-time 60 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/blacklist-refresh >/dev/null 2>&1 || true
+          # Keep the blacklist populated: daily at 03:00, AND every hour
+          # until the first success — a cold origin whose prime never
+          # reached the source must not publish an unfiltered sitemap. BL
+          # stays 1 once set (Redis keeps last-good if a later refresh
+          # fails). Blacklist runs before sitemap so 03:00 reflects today.
+          if [ "$$BL" -eq 0 ] || [ "$$(date -u +%H)" = "03" ]; then
+            if curl -fsS --max-time 90 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/blacklist-refresh >/dev/null 2>&1; then
+              BL=1
+            fi
           fi
-          curl -fsS --max-time 120 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/sitemap-generate >/dev/null 2>&1 || true
+          # Never publish an unfiltered sitemap.
+          if [ "$$BL" -eq 1 ]; then
+            curl -fsS --max-time 180 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/sitemap-generate >/dev/null 2>&1 || true
+          fi
         done
     restart: always
     hostname: seocron

--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -81,11 +81,19 @@ services:
         # Deploy-time prime: /sitemap.xml is advertised in robots.txt, so it
         # must not 404 until the first hour boundary. Retry covers web not
         # being ready yet (swarm starts services in parallel; depends_on is
-        # not honored). Blacklist first so the first sitemap is abuse-filtered.
+        # not honored). The first published sitemap MUST be abuse-filtered,
+        # so break only once BOTH the blacklist refresh AND the sitemap
+        # generation have succeeded — a slow/failed blacklist (an origin with
+        # high latency to the source) must not leave it empty until the next
+        # daily run. If the blacklist never succeeds here, the steady loop
+        # keeps retrying (prefer a slightly delayed but filtered sitemap).
         P=0
+        BL=0
         while [ "$$P" -lt 30 ]; do
-          curl -fsS --max-time 60 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/blacklist-refresh >/dev/null 2>&1 || true
-          if curl -fsS --max-time 120 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/sitemap-generate >/dev/null 2>&1; then
+          if [ "$$BL" -eq 0 ] && curl -fsS --max-time 90 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/blacklist-refresh >/dev/null 2>&1; then
+            BL=1
+          fi
+          if [ "$$BL" -eq 1 ] && curl -fsS --max-time 180 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/sitemap-generate >/dev/null 2>&1; then
             break
           fi
           P=$$((P + 1))

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -80,11 +80,19 @@ services:
         # Deploy-time prime: /sitemap.xml is advertised in robots.txt, so it
         # must not 404 until the first hour boundary. Retry covers web not
         # being ready yet (swarm starts services in parallel; depends_on is
-        # not honored). Blacklist first so the first sitemap is abuse-filtered.
+        # not honored). The first published sitemap MUST be abuse-filtered,
+        # so break only once BOTH the blacklist refresh AND the sitemap
+        # generation have succeeded — a slow/failed blacklist (an origin with
+        # high latency to the source) must not leave it empty until the next
+        # daily run. If the blacklist never succeeds here, the steady loop
+        # keeps retrying (prefer a slightly delayed but filtered sitemap).
         P=0
+        BL=0
         while [ "$$P" -lt 30 ]; do
-          curl -fsS --max-time 60 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/blacklist-refresh >/dev/null 2>&1 || true
-          if curl -fsS --max-time 120 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/sitemap-generate >/dev/null 2>&1; then
+          if [ "$$BL" -eq 0 ] && curl -fsS --max-time 90 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/blacklist-refresh >/dev/null 2>&1; then
+            BL=1
+          fi
+          if [ "$$BL" -eq 1 ] && curl -fsS --max-time 180 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/sitemap-generate >/dev/null 2>&1; then
             break
           fi
           P=$$((P + 1))

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -101,12 +101,20 @@ services:
         while true; do
           S=$$(( 3600 - $$(date -u +%s) % 3600 ))
           sleep "$$S"
-          # Refresh the blacklist BEFORE the 03:00 sitemap so the daily run
-          # reflects today's list, not yesterday's (other hours: sitemap only).
-          if [ "$$(date -u +%H)" = "03" ]; then
-            curl -fsS --max-time 60 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/blacklist-refresh >/dev/null 2>&1 || true
+          # Keep the blacklist populated: daily at 03:00, AND every hour
+          # until the first success — a cold origin whose prime never
+          # reached the source must not publish an unfiltered sitemap. BL
+          # stays 1 once set (Redis keeps last-good if a later refresh
+          # fails). Blacklist runs before sitemap so 03:00 reflects today.
+          if [ "$$BL" -eq 0 ] || [ "$$(date -u +%H)" = "03" ]; then
+            if curl -fsS --max-time 90 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/blacklist-refresh >/dev/null 2>&1; then
+              BL=1
+            fi
           fi
-          curl -fsS --max-time 120 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/sitemap-generate >/dev/null 2>&1 || true
+          # Never publish an unfiltered sitemap.
+          if [ "$$BL" -eq 1 ]; then
+            curl -fsS --max-time 180 -X POST -H "x-seo-cron-secret: $$SEO_CRON_SECRET" http://web:3000/api/internal/seo/sitemap-generate >/dev/null 2>&1 || true
+          fi
         done
     restart: always
     hostname: seocron

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -262,10 +262,25 @@ export async function POST(req: Request): Promise<Response> {
   }
 
   const nowDay = new Date().toISOString().slice(0, 10);
-  const staticUrls = [
-    { loc: `${BASE}/`, lastmod: nowDay },
-    { loc: `${BASE}/discover`, lastmod: nowDay },
-    { loc: `${BASE}/communities`, lastmod: nowDay }
+  // Hub pages whose listed content changes daily → lastmod = today.
+  // Info/legal pages rarely change → no lastmod (honest: don't claim a
+  // daily change). All verified on prod: 200, not noindex, no
+  // canonical-away. /market is excluded (307 → /market/swap).
+  const HUB_PATHS = ["", "discover", "communities", "witnesses", "proposals", "tags", "waves"];
+  const INFO_PATHS = [
+    "about",
+    "faq",
+    "perks",
+    "mobile",
+    "contributors",
+    "whitepaper",
+    "privacy-policy",
+    "terms-of-service",
+    "child-safety"
+  ];
+  const staticUrls: SitemapUrl[] = [
+    ...HUB_PATHS.map((p) => ({ loc: p ? `${BASE}/${p}` : `${BASE}/`, lastmod: nowDay })),
+    ...INFO_PATHS.map((p) => ({ loc: `${BASE}/${p}` }))
   ];
   const authorUrls = Array.from(authors).map((a) => ({
     loc: `${BASE}/@${a}`,

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -269,8 +269,8 @@ export async function POST(req: Request): Promise<Response> {
   // excluded: a volatile microblog feed with no stable landing value —
   // its substantive content is already covered by posts.xml (depth-1
   // container/wave items passing the wave quality gate).
-  const HUB_PATHS = ["", "discover", "communities", "witnesses", "proposals", "tags"];
-  const INFO_PATHS = [
+  const hubPaths = ["", "discover", "communities", "witnesses", "proposals", "tags"];
+  const infoPaths = [
     "about",
     "faq",
     "perks",
@@ -282,8 +282,8 @@ export async function POST(req: Request): Promise<Response> {
     "child-safety"
   ];
   const staticUrls: SitemapUrl[] = [
-    ...HUB_PATHS.map((p) => ({ loc: p ? `${BASE}/${p}` : `${BASE}/`, lastmod: nowDay })),
-    ...INFO_PATHS.map((p) => ({ loc: `${BASE}/${p}` }))
+    ...hubPaths.map((p) => ({ loc: p ? `${BASE}/${p}` : `${BASE}/`, lastmod: nowDay })),
+    ...infoPaths.map((p) => ({ loc: `${BASE}/${p}` }))
   ];
   const authorUrls = Array.from(authors).map((a) => ({
     loc: `${BASE}/@${a}`,

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -265,8 +265,11 @@ export async function POST(req: Request): Promise<Response> {
   // Hub pages whose listed content changes daily → lastmod = today.
   // Info/legal pages rarely change → no lastmod (honest: don't claim a
   // daily change). All verified on prod: 200, not noindex, no
-  // canonical-away. /market is excluded (307 → /market/swap).
-  const HUB_PATHS = ["", "discover", "communities", "witnesses", "proposals", "tags", "waves"];
+  // canonical-away. /market excluded (307 → /market/swap). /waves
+  // excluded: a volatile microblog feed with no stable landing value —
+  // its substantive content is already covered by posts.xml (depth-1
+  // container/wave items passing the wave quality gate).
+  const HUB_PATHS = ["", "discover", "communities", "witnesses", "proposals", "tags"];
   const INFO_PATHS = [
     "about",
     "faq",


### PR DESCRIPTION
Follow-up to #800.

- **static.xml** expanded from 3 URLs to the stable public hub + info/legal pages (about, faq, perks, mobile, contributors, whitepaper, privacy-policy, terms-of-service, child-safety, witnesses, proposals, tags, waves). Hubs get `lastmod=today`; rarely-changing info pages omit `lastmod`. Each verified on prod: 200, not noindex, no canonical-away; `/market` excluded (307 redirect).
- **seocron deploy prime** now breaks only once *both* blacklist-refresh and sitemap-generate succeed. Previously blacklist was fire-and-forget and the loop broke on sitemap alone, so a high-latency origin could publish an unfiltered sitemap and leave the blacklist empty until the next daily run (observed on one prod origin). Both compose files updated.

Touched files type-clean (vs the known pre-existing tsc baseline); existing specs pass; compose YAML + prime logic asserted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SEO feature initialization during deployment with enhanced error handling and configuration validation to ensure reliable startup.

* **Improvements**
  * Extended sitemap to include more hub and information pages with updated metadata for better search engine indexing coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->