### PR TITLE
seo: sitemap never emits third-party canonical URLs (fix GSC "URL not allowed")

### DIFF
--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -285,8 +285,20 @@ export async function POST(req: Request): Promise<Response> {
         if (day && (!prev || day > prev)) communityLatest.set(comm, day);
       }
       if (!isIndexable(e, null, true, blacklist)) continue;
-      const loc = canonicalTarget(e, BASE);
-      if (!loc) continue;
+      // Sitemap mode (3rd arg = true): canonicalTarget NEVER consults the
+      // declared json_metadata.canonical_url here — resolution is purely
+      // structural and can only yield `${BASE}/…` or null. inLeo/PeakD/
+      // hive.blog are just other frontends over the same on-chain post we also
+      // render on ecency.com; the Sitemaps protocol permits only same-host
+      // URLs, and sitemap membership is a discovery hint, NOT a canonical claim
+      // (the entry page still rel-canonicals to the declared URL; Google
+      // decides attribution). This is what fixed GSC's "URL not allowed"
+      // (cross-host <loc> in an ecency.com sitemap) and forecloses any future
+      // 3rdparty.tld/xyz leak by construction.
+      const loc = canonicalTarget(e, BASE, true);
+      // Defensive protocol-boundary guard: even if a future canonicalTarget
+      // edit regressed, no cross-host URL may enter any shard.
+      if (!loc || !loc.startsWith(`${BASE}/`)) continue;
       postUrls.push({ loc, lastmod: (e.updated || e.created || "").slice(0, 10) });
       if (e.author) authors.add(e.author);
     }

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -284,7 +284,12 @@ export async function POST(req: Request): Promise<Response> {
         const prev = communityLatest.get(comm);
         if (day && (!prev || day > prev)) communityLatest.set(comm, day);
       }
-      if (!isIndexable(e, null, true, blacklist)) continue;
+      // 5th arg = true: keep isIndexable in lockstep with the sitemap-mode
+      // canonicalTarget call below, so the indexable count can't drift from
+      // the emitted posts.xml (a reply with only an off-host declared
+      // canonical and no resolvable on-domain root is rejected here, not
+      // silently dropped by the same-host guard a few lines down).
+      if (!isIndexable(e, null, true, blacklist, true)) continue;
       // Sitemap mode (3rd arg = true): canonicalTarget NEVER consults the
       // declared json_metadata.canonical_url here — resolution is purely
       // structural and can only yield `${BASE}/…` or null. inLeo/PeakD/

--- a/apps/web/src/specs/utils/entry-indexability.spec.ts
+++ b/apps/web/src/specs/utils/entry-indexability.spec.ts
@@ -287,6 +287,21 @@ describe("isIndexable - structure", () => {
   it("deep wave sub-reply (depth 3) NOT indexable", () => {
     expect(idx(makeEntry({ depth: 3, root_author: "ecency.waves" }))).toBe(false);
   });
+
+  // Symmetry with the sitemap writer: a depth>=2 reply whose ONLY canonical is
+  // an external declared one (no resolvable on-domain root) is indexable for
+  // the page (flag off) but must be rejected here in sitemap mode (flag on),
+  // so the indexable count can't drift from the emitted posts.xml.
+  it("reply with only an external declared canonical: page-indexable, sitemap-rejected", () => {
+    const e = makeEntry({
+      depth: 2,
+      parent_author: "x",
+      parent_permlink: "y",
+      json_metadata: { canonical_url: "https://inleo.io/@a/b" }
+    });
+    expect(isIndexable(e, null, true)).toBe(true); // page path (flag off)
+    expect(isIndexable(e, null, true, undefined, true)).toBe(false); // sitemap mode
+  });
 });
 
 describe("wave quality gate (depth-1 under container)", () => {

--- a/apps/web/src/specs/utils/entry-indexability.spec.ts
+++ b/apps/web/src/specs/utils/entry-indexability.spec.ts
@@ -53,6 +53,87 @@ describe("canonicalTarget", () => {
     expect(canonicalTarget(e, BASE)).toBe("https://foo.bar/x");
   });
 
+  // Sitemap mode (3rd arg) — regression for GSC "URL not allowed". The
+  // sitemap NEVER consults the declared canonical: any declared value (inLeo/
+  // PeakD/hive.blog mirror of the same on-chain post, with or without a
+  // category prefix) is ignored and resolution is purely structural, so a
+  // <loc> can only ever be on ecency.com.
+  describe("ignoreDeclaredCanonical (sitemap mode)", () => {
+    it("inLeo declared canonical is ignored -> on-domain self", () => {
+      const e = makeEntry({
+        author: "julie100",
+        permlink: "movie-review-karate-kid--jxy",
+        json_metadata: {
+          canonical_url: "https://inleo.io/@julie100/movie-review-karate-kid--jxy"
+        }
+      });
+      expect(canonicalTarget(e, BASE, true)).toBe(
+        "https://ecency.com/@julie100/movie-review-karate-kid--jxy"
+      );
+    });
+
+    it("PeakD declared canonical WITH category prefix is ignored -> on-domain self", () => {
+      const e = makeEntry({
+        author: "linkievichgabrie",
+        permlink: "fakie-over-crooked-fakie-360-flip-out-skatepark-ezeiza-linkievich",
+        category: "hive-106687",
+        json_metadata: {
+          canonical_url:
+            "https://peakd.com/hive-106687/@linkievichgabrie/fakie-over-crooked-fakie-360-flip-out-skatepark-ezeiza-linkievich"
+        }
+      });
+      expect(canonicalTarget(e, BASE, true)).toBe(
+        "https://ecency.com/@linkievichgabrie/fakie-over-crooked-fakie-360-flip-out-skatepark-ezeiza-linkievich"
+      );
+    });
+
+    it("page path (flag off) still returns the external declared canonical", () => {
+      const e = makeEntry({
+        author: "julie100",
+        permlink: "movie-review-karate-kid--jxy",
+        json_metadata: {
+          canonical_url: "https://inleo.io/@julie100/movie-review-karate-kid--jxy"
+        }
+      });
+      expect(canonicalTarget(e, BASE)).toBe(
+        "https://inleo.io/@julie100/movie-review-karate-kid--jxy"
+      );
+    });
+
+    it("declared canonical is ignored even when same-origin (purely structural)", () => {
+      // Declared points at a *different* ecency path; sitemap must use the
+      // structural self, proving it never reads canonical_url at all.
+      const e = makeEntry({
+        author: "bob",
+        permlink: "hello",
+        json_metadata: { canonical_url: "https://ecency.com/@bob/some-other-post" }
+      });
+      expect(canonicalTarget(e, BASE, true)).toBe("https://ecency.com/@bob/hello");
+    });
+
+    it("off-host declared canonical on a reply -> on-domain root, not external", () => {
+      const e = makeEntry({
+        depth: 1,
+        author: "alice",
+        permlink: "re-x",
+        parent_author: "bob",
+        parent_permlink: "the-post",
+        json_metadata: { canonical_url: "https://peakd.com/@alice/re-x" }
+      });
+      expect(canonicalTarget(e, BASE, true)).toBe("https://ecency.com/@bob/the-post");
+    });
+
+    it("thin container anchor still -> null in sitemap mode (declared ignored)", () => {
+      const e = makeEntry({
+        author: "ecency.waves",
+        permlink: "waves-2026",
+        depth: 0,
+        json_metadata: { canonical_url: "https://inleo.io/@ecency.waves/waves-2026" }
+      });
+      expect(canonicalTarget(e, BASE, true)).toBeNull();
+    });
+  });
+
   it("missing author/permlink -> null", () => {
     expect(canonicalTarget(makeEntry({ permlink: "" }), BASE)).toBeNull();
   });

--- a/apps/web/src/utils/entry-indexability.ts
+++ b/apps/web/src/utils/entry-indexability.ts
@@ -138,12 +138,28 @@ const isEffectivelyEmpty = (entry: Entry): boolean =>
  * depth-1 wave isn't resolvable from the entry without tree-walking).
  *
  * Honors an explicit json_metadata.canonical_url first (syndication intent).
+ *
+ * `ignoreDeclaredCanonical` (sitemap-only): the sitemap must NEVER consult the
+ * declared canonical at all — it may list only URLs on its own host, and it is
+ * purely a *discovery* hint (Google decides canonicalization from the page's
+ * rel=canonical, not from sitemap membership). inLeo/PeakD/hive.blog are just
+ * other frontends over the same on-chain post we also render at
+ * `${baseUrl}/@author/permlink`. With this flag set the declared-canonical
+ * branch is skipped entirely, so resolution is purely structural and can only
+ * ever yield `${baseUrl}/…` or null — no third-party URL can reach a sitemap
+ * by any path, now or from future cross-frontend canonical conventions. The
+ * entry *page* still calls this with the flag off, so it keeps emitting
+ * rel=canonical to the declared URL and Google attributes the content itself.
  */
 export function canonicalTarget(
   entry: Entry,
-  baseUrl: string = defaults.base
+  baseUrl: string = defaults.base,
+  ignoreDeclaredCanonical = false
 ): string | null {
-  const declared = entry.json_metadata?.canonical_url;
+  // Sitemap mode never looks at json_metadata.canonical_url — see doc above.
+  const declared = ignoreDeclaredCanonical
+    ? undefined
+    : entry.json_metadata?.canonical_url;
   if (declared) {
     return declared.replace("https://www.", "https://");
   }

--- a/apps/web/src/utils/entry-indexability.ts
+++ b/apps/web/src/utils/entry-indexability.ts
@@ -247,7 +247,10 @@ export function isIndexable(
   entry: Entry,
   account: ReputationSource,
   accountFetchFailed: boolean,
-  blacklist: ReadonlySet<string> = EMPTY_BLACKLIST
+  blacklist: ReadonlySet<string> = EMPTY_BLACKLIST,
+  // Forwarded to the internal canonicalTarget so this filter and the sitemap
+  // writer's canonicalTarget(e, BASE, true) never disagree (see below).
+  ignoreDeclaredCanonical = false
 ): boolean {
   // Community anti-abuse consensus (plagiarism/spam). Clear negative, first.
   if (blacklist.has(entry.author)) return false;
@@ -268,6 +271,10 @@ export function isIndexable(
 
   if (depth === 0) return !isEffectivelyEmpty(entry); // normal top-level post
 
-  // normal reply: indexable only if its discussion root is resolvable
-  return canonicalTarget(entry) !== null;
+  // normal reply: indexable only if its discussion root is resolvable. Forward
+  // ignoreDeclaredCanonical so this matches the sitemap writer exactly — else a
+  // depth>=2 reply carrying only an external declared canonical and no
+  // resolvable on-domain root would pass here yet be discarded by the writer's
+  // same-host guard, drifting the indexable count from posts.xml silently.
+  return canonicalTarget(entry, defaults.base, ignoreDeclaredCanonical) !== null;
 }


### PR DESCRIPTION
## Problem

Google Search Console flags **236 "URL not allowed"** errors on `https://ecency.com/sitemap/posts.xml`:

> This url is not allowed for a Sitemap at this location.
> `https://inleo.io/@julie100/movie-review-karate-kid--jxy`
> `https://peakd.com/hive-106687/@linkievichgabrie/fakie-...`

## Root cause

Posts authored through other Hive frontends (inLeo / PeakD / hive.blog) carry a `json_metadata.canonical_url` pointing at *that* frontend. `canonicalTarget()` honors the declared canonical first — correct for the **entry page's** `rel=canonical` (syndication intent) — but the sitemap generator pushed that returned value straight into `posts.xml`, emitting **cross-host `<loc>` entries**. The Sitemaps protocol permits only same-host URLs, so GSC rejects them.

`isIndexable()` never consults the canonical for a depth-0 post, so these cross-posts pass the indexable filter and then leak the foreign URL.

## Fix

A sitemap may list only same-host URLs and is **purely a discovery hint** — Google decides canonicalization from the page's `rel=canonical`, not from sitemap membership. Ecency renders the same on-chain post at `ecency.com/@author/permlink` regardless of which frontend authored it.

- `canonicalTarget()` gains an opt-in `ignoreDeclaredCanonical` arg. When set, the declared-canonical branch is **skipped entirely** — resolution is purely structural and can only ever yield `${baseUrl}/…` or `null`. No third-party URL can reach a sitemap by any path, including future cross-frontend canonical conventions.
- The **entry page is unchanged** (calls with the flag off): it still emits `rel=canonical → inleo.io`, so Googlebot crawls our copy and decides attribution itself.
- `sitemap-generate` passes the flag and adds a defensive same-host `startsWith` guard at the writer boundary as protection against future `canonicalTarget` regressions.

## Tests

6 new regression cases in `entry-indexability.spec.ts` (inLeo; PeakD **with category prefix**; reply→root; same-origin declared still ignored; thin container anchor still `null`; page path still returns the external declared canonical). Full suite: **58/58 pass**; typecheck clean for touched files.

## Rollout

Effect appears on the next hourly `seocron` `sitemap-generate` run; resubmit `posts.xml` in GSC after deploy to clear the 236 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sitemap generation now validates and filters URLs to exclude any malformed or cross-host links, ensuring published sitemaps contain only valid, same-origin entries with proper canonical URL resolution.

* **Tests**
  * Added comprehensive test coverage to verify sitemap URL validation, filtering behavior, and canonical URL resolution across various entry types and different configuration modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->