### PR TITLE
perf(post-renderer): chunk medium-zoom out of SSR-critical client bundle

### DIFF
--- a/apps/web/src/features/post-renderer/components/extensions/hive-operation-extension.tsx
+++ b/apps/web/src/features/post-renderer/components/extensions/hive-operation-extension.tsx
@@ -37,10 +37,10 @@ export function HiveOperationRenderer({ op }: Props) {
                         <div className="er-hive-op-type">
                             {decodedOpType}
                         </div>
-                        {decodedOpType === "transfer" && (
+                        {decodedOp[0] === "transfer" && (
                             <div className="er-hive-op-transfer">
                 <span className="er-hive-op-transfer-highlight">
-                  {decodedOp[1].amount}
+                  {String(decodedOp[1].amount)}
                 </span>
                                 <span> to</span>
                                 <img

--- a/apps/web/src/features/post-renderer/components/extensions/image-zoom-extension.tsx
+++ b/apps/web/src/features/post-renderer/components/extensions/image-zoom-extension.tsx
@@ -12,6 +12,7 @@ export function ImageZoomExtension({
 
   useEffect(() => {
     let isMounted = true; // Track mount state to prevent post-unmount zoom attachment
+    let rafId = 0;
 
     const elements = Array.from(
         containerRef.current?.querySelectorAll<HTMLElement>(
@@ -162,7 +163,8 @@ export function ImageZoomExtension({
           }
 
           // Small delay to ensure layout is stable after image load
-          requestAnimationFrame(() => {
+          rafId = requestAnimationFrame(() => {
+            rafId = 0;
             // Final check before creating zoom instance
             if (!isMounted) {
               return;
@@ -204,6 +206,10 @@ export function ImageZoomExtension({
 
     return () => {
       isMounted = false; // Mark as unmounted to prevent async operations
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+        rafId = 0;
+      }
       zoomRef.current?.detach();
     };
   }, [containerRef]);

--- a/apps/web/src/features/post-renderer/components/extensions/image-zoom-extension.tsx
+++ b/apps/web/src/features/post-renderer/components/extensions/image-zoom-extension.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import mediumZoom, { Zoom } from "medium-zoom";
+import type { Zoom } from "medium-zoom";
 import React, { RefObject, useEffect, useRef } from "react";
 
 export function ImageZoomExtension({
@@ -128,7 +128,7 @@ export function ImageZoomExtension({
           });
         });
 
-        Promise.all(imageLoadPromises).then(() => {
+        Promise.all(imageLoadPromises).then(async () => {
           // Bail if component unmounted while waiting for images
           if (!isMounted) {
             return;
@@ -143,20 +143,36 @@ export function ImageZoomExtension({
             }
           });
 
-          if (connectedImages.length > 0) {
-            // Small delay to ensure layout is stable after image load
-            requestAnimationFrame(() => {
-              // Final check before creating zoom instance
-              if (!isMounted) {
-                return;
-              }
-
-              zoomRef.current = mediumZoom(connectedImages, {
-                background: "#131111",
-                margin: 24, // Add margin for better centering
-              });
-            });
+          if (connectedImages.length === 0) {
+            return;
           }
+
+          // Dynamic-import medium-zoom so its bundle is split out of any
+          // SSR-critical client chunk that pulls EcencyRenderer in.
+          let mediumZoom: typeof import("medium-zoom").default;
+          try {
+            ({ default: mediumZoom } = await import("medium-zoom"));
+          } catch (error) {
+            console.warn("Failed to load medium-zoom:", error);
+            return;
+          }
+
+          if (!isMounted) {
+            return;
+          }
+
+          // Small delay to ensure layout is stable after image load
+          requestAnimationFrame(() => {
+            // Final check before creating zoom instance
+            if (!isMounted) {
+              return;
+            }
+
+            zoomRef.current = mediumZoom(connectedImages, {
+              background: "#131111",
+              margin: 24, // Add margin for better centering
+            });
+          });
         }).catch((error) => {
           console.warn("Failed to wait for images to load:", error);
         });

--- a/apps/web/src/features/post-renderer/components/extensions/image-zoom-extension.tsx
+++ b/apps/web/src/features/post-renderer/components/extensions/image-zoom-extension.tsx
@@ -168,10 +168,30 @@ export function ImageZoomExtension({
               return;
             }
 
-            zoomRef.current = mediumZoom(connectedImages, {
-              background: "#131111",
-              margin: 24, // Add margin for better centering
+            // Re-filter after the dynamic-import gap — the parent can re-render
+            // (EcencyRenderer uses dangerouslySetInnerHTML) and disconnect these
+            // nodes while isMounted stays true. medium-zoom walks parentNode on
+            // every input, so a stale snapshot would throw or attach partially.
+            const stillConnected = connectedImages.filter((img) => {
+              try {
+                return img.isConnected && img.parentNode !== null;
+              } catch {
+                return false;
+              }
             });
+
+            if (stillConnected.length === 0) {
+              return;
+            }
+
+            try {
+              zoomRef.current = mediumZoom(stillConnected, {
+                background: "#131111",
+                margin: 24, // Add margin for better centering
+              });
+            } catch (error) {
+              console.warn("Failed to initialize medium-zoom:", error);
+            }
           });
         }).catch((error) => {
           console.warn("Failed to wait for images to load:", error);

--- a/apps/web/src/features/post-renderer/components/index.ts
+++ b/apps/web/src/features/post-renderer/components/index.ts
@@ -1,4 +1,3 @@
 export * from "./ecency-renderer";
-export * from "./utils/setupPostEnhancements";
 export * from "./extensions";
 export * from "./functions";

--- a/apps/web/src/features/post-renderer/components/utils/imageZoomEnhancer.ts
+++ b/apps/web/src/features/post-renderer/components/utils/imageZoomEnhancer.ts
@@ -1,4 +1,4 @@
-import mediumZoom, { Zoom } from "medium-zoom";
+import type { Zoom } from "medium-zoom";
 
 /**
  * Apply medium-zoom to images in a container.
@@ -147,7 +147,7 @@ export function applyImageZoom(container: HTMLElement): Promise<Zoom | null> {
                 });
             });
 
-            Promise.all(imageLoadPromises).then(() => {
+            Promise.all(imageLoadPromises).then(async () => {
                 // Double-check images are still in DOM after loading
                 const connectedImages = zoomableImages.filter((img) => {
                     try {
@@ -157,18 +157,30 @@ export function applyImageZoom(container: HTMLElement): Promise<Zoom | null> {
                     }
                 });
 
-                if (connectedImages.length > 0) {
-                    // Small delay to ensure layout is stable after image load
-                    requestAnimationFrame(() => {
-                        const zoom = mediumZoom(connectedImages, {
-                            background: "#131111",
-                            margin: 24, // Add margin for better centering
-                        });
-                        resolveZoom(zoom);
-                    });
-                } else {
+                if (connectedImages.length === 0) {
                     resolveZoom(null);
+                    return;
                 }
+
+                // Dynamic-import medium-zoom so its bundle is not part of any
+                // SSR-critical chunk that reaches this enhancer transitively.
+                let mediumZoom: typeof import("medium-zoom").default;
+                try {
+                    ({ default: mediumZoom } = await import("medium-zoom"));
+                } catch (error) {
+                    console.warn("Failed to load medium-zoom:", error);
+                    resolveZoom(null);
+                    return;
+                }
+
+                // Small delay to ensure layout is stable after image load
+                requestAnimationFrame(() => {
+                    const zoom = mediumZoom(connectedImages, {
+                        background: "#131111",
+                        margin: 24, // Add margin for better centering
+                    });
+                    resolveZoom(zoom);
+                });
             }).catch((error) => {
                 console.warn("Failed to wait for images to load:", error);
                 resolveZoom(null);

--- a/apps/web/src/features/post-renderer/components/utils/imageZoomEnhancer.ts
+++ b/apps/web/src/features/post-renderer/components/utils/imageZoomEnhancer.ts
@@ -175,11 +175,33 @@ export function applyImageZoom(container: HTMLElement): Promise<Zoom | null> {
 
                 // Small delay to ensure layout is stable after image load
                 requestAnimationFrame(() => {
-                    const zoom = mediumZoom(connectedImages, {
-                        background: "#131111",
-                        margin: 24, // Add margin for better centering
+                    // Re-filter after the dynamic-import gap — nodes can be
+                    // disconnected during the async chunk fetch. medium-zoom
+                    // walks parentNode on every input, so a stale snapshot
+                    // would throw or attach partially.
+                    const stillConnected = connectedImages.filter((img) => {
+                        try {
+                            return img.isConnected && img.parentNode !== null;
+                        } catch {
+                            return false;
+                        }
                     });
-                    resolveZoom(zoom);
+
+                    if (stillConnected.length === 0) {
+                        resolveZoom(null);
+                        return;
+                    }
+
+                    try {
+                        const zoom = mediumZoom(stillConnected, {
+                            background: "#131111",
+                            margin: 24, // Add margin for better centering
+                        });
+                        resolveZoom(zoom);
+                    } catch (error) {
+                        console.warn("Failed to initialize medium-zoom:", error);
+                        resolveZoom(null);
+                    }
                 });
             }).catch((error) => {
                 console.warn("Failed to wait for images to load:", error);


### PR DESCRIPTION
## Summary

`EcencyRenderer` (via `<ImageZoomExtension>`) and the post-renderer `components` barrel both eager-imported `medium-zoom`, dragging ~30 KB of pure-UX zoom JS into the post page's shared client chunk on every render. Zoom is a client-side enhancement that only matters after hydration — it has no place in the SSR-critical bundle.

Two parallel leaks fixed:

1. **Barrel leak.** `apps/web/src/features/post-renderer/components/index.ts` re-exported `setupPostEnhancements`. The call site at `entry-page-body-viewer.tsx:126` dynamic-imports it via the deep path, but the barrel re-export defeats that boundary for any consumer of `@/features/post-renderer`. Dropping the re-export lets the dynamic import actually emit a separate async chunk.

2. **Static `medium-zoom` imports.** Both `imageZoomEnhancer.ts` (used via `setupPostEnhancements`) and `extensions/image-zoom-extension.tsx` (mounted by `EcencyRenderer`) had top-level `import mediumZoom from "medium-zoom"`. Converted to `await import("medium-zoom")` at the point of binding (after image-load-complete). The `Zoom` type is now imported via `import type` so it's erased at runtime and doesn't pull the module back in.

Server-rendered HTML is byte-identical. `medium-zoom` now loads as its own async chunk after hydration + image-load — same UX path as before, click still zooms.

## Why this matters

PSI mobile shows ~649 KB of unused JS on home + post pages, with `medium-zoom` being the most easily-isolated heavy module in shared chunk `3795-*.js` (28 references). CrUX p75 mobile LCP on `ecency.com/` is 5.94s (45% Poor). This is the lowest-risk wedge that removes a known offender from the SSR-critical bundle without changing rendering behavior.

Follow-up to #795 — that PR added the dynamic-import boundary at the call site, but the barrel re-export and the parallel React-extension path kept medium-zoom in the shared chunk anyway. This PR closes both holes.

## Test plan

- [x] All 1057 unit tests pass (`pnpm --filter @ecency/web test`)
- [x] Typecheck: no new errors from these files
- [ ] After deploy: load a post, confirm a separate `medium-zoom` chunk appears in the Network panel (not embedded in the page chunk)
- [ ] After deploy: click an image, confirm zoom still works
- [ ] `grep -l medium-zoom apps/web/.next/static/chunks/*.js` after build should match only an async chunk, not the page chunks for `/` or `/[author]/[permlink]`
- [ ] CrUX p75 mobile LCP recheck in ~28 days (rolling window lag)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and recovery when the image-zoom library fails to load; prevents broken zoom and skips initialization when no images remain.
  * Fixed transfer rendering so transfer operations and amounts display reliably.

* **Refactor**
  * Deferred loading of the image-zoom implementation and added a safe initialization delay to improve reliability and performance.
  * Simplified component re-exports for clearer module surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->