### PR TITLE
fix(rss,sentry): cache RSS feeds and silence transient RPC noise

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -43,10 +43,31 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
   ],
 
   beforeSend(event) {
+    const exceptionType = event.exception?.values?.[0]?.type ?? "";
     const message = event.exception?.values?.[0]?.value ?? "";
     const stackStr = JSON.stringify(
       event.exception?.values?.[0]?.stacktrace?.frames ?? []
     );
+
+    // AbortController-induced timeouts (TimeoutError / AbortError) ship
+    // with no stack frames, so we can't tell which fetch is at fault.
+    // Walk recent breadcrumbs for the last in-flight fetch URL and tag
+    // the event so we can correlate timeouts to specific endpoints.
+    if (
+      (exceptionType === "TimeoutError" || exceptionType === "AbortError" ||
+        /signal timed out/i.test(message) || /aborted/i.test(message)) &&
+      !event.tags?.timeoutUrl
+    ) {
+      const crumbs = event.breadcrumbs ?? [];
+      for (let i = crumbs.length - 1; i >= 0; i--) {
+        const c = crumbs[i];
+        const url = (c.data as { url?: string } | undefined)?.url;
+        if ((c.category === "fetch" || c.category === "xhr") && typeof url === "string") {
+          event.tags = { ...event.tags, timeoutUrl: url.slice(0, 200) };
+          break;
+        }
+      }
+    }
 
     // React SSR streaming hydration issue triggered by browser extensions
     // ($RS is React's internal resumable script marker)

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -61,9 +61,23 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
       const crumbs = event.breadcrumbs ?? [];
       for (let i = crumbs.length - 1; i >= 0; i--) {
         const c = crumbs[i];
-        const url = (c.data as { url?: string } | undefined)?.url;
-        if ((c.category === "fetch" || c.category === "xhr") && typeof url === "string") {
-          event.tags = { ...event.tags, timeoutUrl: url.slice(0, 200) };
+        const rawUrl = (c.data as { url?: string } | undefined)?.url;
+        if (
+          (c.category === "fetch" || c.category === "xhr") &&
+          typeof rawUrl === "string"
+        ) {
+          // Strip query/hash before tagging — request URLs can carry
+          // tokens or identifiers we don't want as searchable telemetry.
+          let safeUrl: string;
+          try {
+            const parsed = new URL(rawUrl, window.location.origin);
+            safeUrl = `${parsed.origin}${parsed.pathname}`;
+          } catch {
+            safeUrl = rawUrl.split(/[?#]/)[0] ?? "";
+          }
+          if (safeUrl) {
+            event.tags = { ...event.tags, timeoutUrl: safeUrl.slice(0, 200) };
+          }
           break;
         }
       }

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -53,9 +53,13 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
     // with no stack frames, so we can't tell which fetch is at fault.
     // Walk recent breadcrumbs for the last in-flight fetch URL and tag
     // the event so we can correlate timeouts to specific endpoints.
+    // Trigger only on the canonical AbortController error names plus the
+    // standard "signal timed out" phrase — a broader /aborted/i match
+    // would also tag unrelated paths (transaction aborts, stream aborts).
     if (
-      (exceptionType === "TimeoutError" || exceptionType === "AbortError" ||
-        /signal timed out/i.test(message) || /aborted/i.test(message)) &&
+      (exceptionType === "TimeoutError" ||
+        exceptionType === "AbortError" ||
+        /signal timed out/i.test(message)) &&
       !event.tags?.timeoutUrl
     ) {
       const crumbs = event.breadcrumbs ?? [];

--- a/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss.xml/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss.xml/route.tsx
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { CommunityRssHandler } from "@/features/rss";
-import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponseWithReport } from "@/features/rss";
 
 interface Props {
   params: Promise<{ community: string; tag: string }>;
@@ -16,6 +16,9 @@ export async function GET(request: NextRequest, { params }: Props) {
       headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
     });
   } catch (e) {
-    return emptyRssResponse();
+    return emptyRssResponseWithReport(e, {
+      route: "community/[community]/[tag]/rss.xml",
+      pathname: request.nextUrl.pathname
+    });
   }
 }

--- a/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss.xml/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss.xml/route.tsx
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { CommunityRssHandler } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
 
 interface Props {
   params: Promise<{ community: string; tag: string }>;
@@ -7,8 +8,14 @@ interface Props {
 
 export async function GET(request: NextRequest, { params }: Props) {
   const { community, tag } = await params;
-  return new Response(
-    (await new CommunityRssHandler(request.nextUrl.pathname, community, tag).getFeed()).xml(),
-    { headers: { "Content-Type": "text/xml" } }
-  );
+  try {
+    const xml = (
+      await new CommunityRssHandler(request.nextUrl.pathname, community, tag).getFeed()
+    ).xml();
+    return new Response(xml, {
+      headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
+    });
+  } catch (e) {
+    return emptyRssResponse();
+  }
 }

--- a/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss.xml/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss.xml/route.tsx
@@ -17,8 +17,7 @@ export async function GET(request: NextRequest, { params }: Props) {
     });
   } catch (e) {
     return emptyRssResponseWithReport(e, {
-      route: "community/[community]/[tag]/rss.xml",
-      pathname: request.nextUrl.pathname
+      route: "community/[community]/[tag]/rss.xml"
     });
   }
 }

--- a/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss/route.tsx
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { CommunityRssHandler } from "@/features/rss";
-import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponseWithReport } from "@/features/rss";
 
 interface Props {
   params: Promise<{ community: string; tag: string }>;
@@ -16,6 +16,9 @@ export async function GET(request: NextRequest, { params }: Props) {
       headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
     });
   } catch (e) {
-    return emptyRssResponse();
+    return emptyRssResponseWithReport(e, {
+      route: "community/[community]/[tag]/rss",
+      pathname: request.nextUrl.pathname
+    });
   }
 }

--- a/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss/route.tsx
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { CommunityRssHandler } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
 
 interface Props {
   params: Promise<{ community: string; tag: string }>;
@@ -7,8 +8,14 @@ interface Props {
 
 export async function GET(request: NextRequest, { params }: Props) {
   const { community, tag } = await params;
-  return new Response(
-    (await new CommunityRssHandler(request.nextUrl.pathname, community, tag).getFeed()).xml(),
-    { headers: { "Content-Type": "text/xml" } }
-  );
+  try {
+    const xml = (
+      await new CommunityRssHandler(request.nextUrl.pathname, community, tag).getFeed()
+    ).xml();
+    return new Response(xml, {
+      headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
+    });
+  } catch (e) {
+    return emptyRssResponse();
+  }
 }

--- a/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/rss/route.tsx
@@ -17,8 +17,7 @@ export async function GET(request: NextRequest, { params }: Props) {
     });
   } catch (e) {
     return emptyRssResponseWithReport(e, {
-      route: "community/[community]/[tag]/rss",
-      pathname: request.nextUrl.pathname
+      route: "community/[community]/[tag]/rss"
     });
   }
 }

--- a/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss.xml/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss.xml/route.tsx
@@ -17,8 +17,7 @@ export async function GET(request: NextRequest, { params }: Props) {
     });
   } catch (e) {
     return emptyRssResponseWithReport(e, {
-      route: "feed/[filter]/[tag]/rss.xml",
-      pathname: request.nextUrl.pathname
+      route: "feed/[filter]/[tag]/rss.xml"
     });
   }
 }

--- a/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss.xml/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss.xml/route.tsx
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { FeedRssHandler } from "@/features/rss";
-import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponseWithReport } from "@/features/rss";
 
 interface Props {
   params: Promise<{ filter: string; tag: string }>;
@@ -16,6 +16,9 @@ export async function GET(request: NextRequest, { params }: Props) {
       headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
     });
   } catch (e) {
-    return emptyRssResponse();
+    return emptyRssResponseWithReport(e, {
+      route: "feed/[filter]/[tag]/rss.xml",
+      pathname: request.nextUrl.pathname
+    });
   }
 }

--- a/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss.xml/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss.xml/route.tsx
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { FeedRssHandler } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
 
 interface Props {
   params: Promise<{ filter: string; tag: string }>;
@@ -7,8 +8,14 @@ interface Props {
 
 export async function GET(request: NextRequest, { params }: Props) {
   const { filter, tag } = await params;
-  return new Response(
-    (await new FeedRssHandler(request.nextUrl.pathname, filter, tag).getFeed()).xml(),
-    { headers: { "Content-Type": "text/xml" } }
-  );
+  try {
+    const xml = (
+      await new FeedRssHandler(request.nextUrl.pathname, filter, tag).getFeed()
+    ).xml();
+    return new Response(xml, {
+      headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
+    });
+  } catch (e) {
+    return emptyRssResponse();
+  }
 }

--- a/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss/route.tsx
@@ -17,8 +17,7 @@ export async function GET(request: NextRequest, { params }: Props) {
     });
   } catch (e) {
     return emptyRssResponseWithReport(e, {
-      route: "feed/[filter]/[tag]/rss",
-      pathname: request.nextUrl.pathname
+      route: "feed/[filter]/[tag]/rss"
     });
   }
 }

--- a/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss/route.tsx
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { FeedRssHandler } from "@/features/rss";
-import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponseWithReport } from "@/features/rss";
 
 interface Props {
   params: Promise<{ filter: string; tag: string }>;
@@ -16,6 +16,9 @@ export async function GET(request: NextRequest, { params }: Props) {
       headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
     });
   } catch (e) {
-    return emptyRssResponse();
+    return emptyRssResponseWithReport(e, {
+      route: "feed/[filter]/[tag]/rss",
+      pathname: request.nextUrl.pathname
+    });
   }
 }

--- a/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[filter]/[tag]/rss/route.tsx
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { FeedRssHandler } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
 
 interface Props {
   params: Promise<{ filter: string; tag: string }>;
@@ -7,8 +8,14 @@ interface Props {
 
 export async function GET(request: NextRequest, { params }: Props) {
   const { filter, tag } = await params;
-  return new Response(
-    (await new FeedRssHandler(request.nextUrl.pathname, filter, tag).getFeed()).xml(),
-    { headers: { "Content-Type": "text/xml" } }
-  );
+  try {
+    const xml = (
+      await new FeedRssHandler(request.nextUrl.pathname, filter, tag).getFeed()
+    ).xml();
+    return new Response(xml, {
+      headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
+    });
+  } catch (e) {
+    return emptyRssResponse();
+  }
 }

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/rss.xml/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/rss.xml/route.tsx
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { AccountRssHandler } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
 
 interface Props {
   params: Promise<{ username: string }>;
@@ -9,15 +10,13 @@ export async function GET(request: NextRequest, { params }: Props) {
   const { username } = await params;
 
   try {
-    return new Response(
-      (
-        await new AccountRssHandler(request.nextUrl.pathname, username.replace("%40", "")).getFeed()
-      ).xml(),
-      { headers: { "Content-Type": "text/xml" } }
-    );
-  } catch (e) {
-    return new Response("", {
-      status: 400
+    const xml = (
+      await new AccountRssHandler(request.nextUrl.pathname, username.replace("%40", "")).getFeed()
+    ).xml();
+    return new Response(xml, {
+      headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
     });
+  } catch (e) {
+    return emptyRssResponse();
   }
 }

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/rss.xml/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/rss.xml/route.tsx
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { AccountRssHandler } from "@/features/rss";
-import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponseWithReport } from "@/features/rss";
 
 interface Props {
   params: Promise<{ username: string }>;
@@ -17,6 +17,9 @@ export async function GET(request: NextRequest, { params }: Props) {
       headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
     });
   } catch (e) {
-    return emptyRssResponse();
+    return emptyRssResponseWithReport(e, {
+      route: "profile/[username]/rss.xml",
+      pathname: request.nextUrl.pathname
+    });
   }
 }

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/rss.xml/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/rss.xml/route.tsx
@@ -18,8 +18,7 @@ export async function GET(request: NextRequest, { params }: Props) {
     });
   } catch (e) {
     return emptyRssResponseWithReport(e, {
-      route: "profile/[username]/rss.xml",
-      pathname: request.nextUrl.pathname
+      route: "profile/[username]/rss.xml"
     });
   }
 }

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/rss/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/rss/route.tsx
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { AccountRssHandler } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
 
 interface Props {
   params: Promise<{ username: string }>;
@@ -9,15 +10,13 @@ export async function GET(request: NextRequest, { params }: Props) {
   const { username } = await params;
 
   try {
-    return new Response(
-      (
-        await new AccountRssHandler(request.nextUrl.pathname, username.replace("%40", "")).getFeed()
-      ).xml(),
-      { headers: { "Content-Type": "text/xml" } }
-    );
-  } catch (e) {
-    return new Response("", {
-      status: 400
+    const xml = (
+      await new AccountRssHandler(request.nextUrl.pathname, username.replace("%40", "")).getFeed()
+    ).xml();
+    return new Response(xml, {
+      headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
     });
+  } catch (e) {
+    return emptyRssResponse();
   }
 }

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/rss/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/rss/route.tsx
@@ -18,8 +18,7 @@ export async function GET(request: NextRequest, { params }: Props) {
     });
   } catch (e) {
     return emptyRssResponseWithReport(e, {
-      route: "profile/[username]/rss",
-      pathname: request.nextUrl.pathname
+      route: "profile/[username]/rss"
     });
   }
 }

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/rss/route.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/rss/route.tsx
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { AccountRssHandler } from "@/features/rss";
-import { RSS_CACHE_HEADERS, emptyRssResponse } from "@/features/rss";
+import { RSS_CACHE_HEADERS, emptyRssResponseWithReport } from "@/features/rss";
 
 interface Props {
   params: Promise<{ username: string }>;
@@ -17,6 +17,9 @@ export async function GET(request: NextRequest, { params }: Props) {
       headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
     });
   } catch (e) {
-    return emptyRssResponse();
+    return emptyRssResponseWithReport(e, {
+      route: "profile/[username]/rss",
+      pathname: request.nextUrl.pathname
+    });
   }
 }

--- a/apps/web/src/app/publish/_hooks/autosave-policy.ts
+++ b/apps/web/src/app/publish/_hooks/autosave-policy.ts
@@ -1,0 +1,19 @@
+// Shared throttling policy for the publish-page autosave hooks.
+// Tuned for two competing concerns: don't lose typed work (debounce + min
+// interval set the worst-case data-loss window) and don't hammer the
+// private-api drafts endpoint when the server is rejecting (circuit
+// breaker), since a single user pausing every few seconds while writing
+// otherwise produces dozens of save attempts per minute.
+
+// Wait this long after the last edit before considering a save.
+export const AUTOSAVE_DEBOUNCE_MS = 10_000;
+
+// Minimum time between save attempts, even if the user keeps editing.
+// Caps autosave traffic to at most ~1/minute per editor session.
+export const AUTOSAVE_MIN_INTERVAL_MS = 60_000;
+
+// After this many consecutive failures, open the circuit and stop trying
+// for AUTOSAVE_COOLDOWN_MS — gives the server (or the user) time to
+// recover and avoids a 406-loop draining anyone's inbox of error toasts.
+export const AUTOSAVE_FAIL_THRESHOLD = 3;
+export const AUTOSAVE_COOLDOWN_MS = 5 * 60_000;

--- a/apps/web/src/app/publish/_hooks/use-auto-save-draft.ts
+++ b/apps/web/src/app/publish/_hooks/use-auto-save-draft.ts
@@ -6,10 +6,19 @@ import isEqual from "react-fast-compare";
 import { useSaveDraftApi } from "../_api";
 import { usePublishState } from "./use-publish-state";
 import { useDraftTabCoordinator } from "./use-draft-tab-coordinator";
+import {
+  AUTOSAVE_DEBOUNCE_MS,
+  AUTOSAVE_MIN_INTERVAL_MS,
+  AUTOSAVE_FAIL_THRESHOLD,
+  AUTOSAVE_COOLDOWN_MS
+} from "./autosave-policy";
 
 export function useAutoSavePublishDraft(step: string, draftId?: string) {
     const [lastSaved, setLastSaved] = useState<Date | null>(null);
-    const prevSnapshotRef = useRef<any>(null);
+    const prevSnapshotRef = useRef<unknown>(null);
+    const lastAttemptAtRef = useRef<number>(0);
+    const consecutiveFailsRef = useRef<number>(0);
+    const cooldownUntilRef = useRef<number>(0);
 
     const {
         title,
@@ -35,6 +44,10 @@ export function useAutoSavePublishDraft(step: string, draftId?: string) {
             // Only auto-save if this is the active tab
             if (!isActiveTab) return;
 
+            const now = Date.now();
+            if (now < cooldownUntilRef.current) return;
+            if (now - lastAttemptAtRef.current < AUTOSAVE_MIN_INTERVAL_MS) return;
+
             const snapshot = {
                 title,
                 content,
@@ -49,17 +62,23 @@ export function useAutoSavePublishDraft(step: string, draftId?: string) {
             };
 
             if (isEqual(prevSnapshotRef.current, snapshot)) return;
-            prevSnapshotRef.current = snapshot;
+            lastAttemptAtRef.current = now;
 
             saveToDraft({ showToast: false, redirect: false })
                 .then(() => {
                     setLastSaved(new Date());
+                    prevSnapshotRef.current = snapshot;
+                    consecutiveFailsRef.current = 0;
                 })
                 .catch((err) => {
+                    consecutiveFailsRef.current += 1;
+                    if (consecutiveFailsRef.current >= AUTOSAVE_FAIL_THRESHOLD) {
+                        cooldownUntilRef.current = Date.now() + AUTOSAVE_COOLDOWN_MS;
+                    }
                     console.warn("Auto-save error:", err);
                 });
         },
-        2000,
+        AUTOSAVE_DEBOUNCE_MS,
         [
             step,
             title,

--- a/apps/web/src/app/publish/_hooks/use-publish-autosave.ts
+++ b/apps/web/src/app/publish/_hooks/use-publish-autosave.ts
@@ -1,9 +1,16 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
+import isEqual from "react-fast-compare";
 import { useDebounce } from "react-use";
 import { useSaveDraftApi } from "../_api";
 import { usePublishState } from "./use-publish-state";
 import { useDraftTabCoordinator } from "./use-draft-tab-coordinator";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import {
+  AUTOSAVE_DEBOUNCE_MS,
+  AUTOSAVE_MIN_INTERVAL_MS,
+  AUTOSAVE_FAIL_THRESHOLD,
+  AUTOSAVE_COOLDOWN_MS
+} from "./autosave-policy";
 
 /**
  * This hook auto-save publish page content to draft whenever post changes
@@ -30,29 +37,58 @@ export function usePublishAutosave() {
   const { mutateAsync: saveToDraft } = useSaveDraftApi(draftId);
   const { isActiveTab } = useDraftTabCoordinator(draftId);
 
+  const prevSnapshotRef = useRef<unknown>(null);
+  const lastAttemptAtRef = useRef<number>(0);
+  const consecutiveFailsRef = useRef<number>(0);
+  const cooldownUntilRef = useRef<number>(0);
+
   useDebounce(
     async () => {
-      if (!activeUser?.username) {
-        return;
-      }
-
-      if (!title?.trim() && !content?.trim()) {
-        return;
-      }
-
+      if (!activeUser?.username) return;
+      if (!title?.trim() && !content?.trim()) return;
       // Only auto-save if this is the active tab
-      if (!isActiveTab) {
-        return;
-      }
+      if (!isActiveTab) return;
 
-      const id = await saveToDraft({ showToast: false, redirect: false });
-      // Only create returns an ID (first save creates draft)
-      if (id) {
-        setDraftId(id);
+      const now = Date.now();
+      // Circuit breaker: too many consecutive failures backs us off so a
+      // broken server (e.g. /private-api/drafts-add returning 406) can't be
+      // hammered every debounce window.
+      if (now < cooldownUntilRef.current) return;
+      // Hard floor between attempts so prolific typing can't fan out into
+      // many saves per minute.
+      if (now - lastAttemptAtRef.current < AUTOSAVE_MIN_INTERVAL_MS) return;
+
+      const snapshot = {
+        title,
+        content,
+        tags,
+        beneficiaries,
+        reward,
+        metaDescription,
+        selectedThumbnail,
+        poll,
+        postLinks,
+        location
+      };
+      if (isEqual(prevSnapshotRef.current, snapshot)) return;
+
+      lastAttemptAtRef.current = now;
+
+      try {
+        const id = await saveToDraft({ showToast: false, redirect: false });
+        // Only create returns an ID (first save creates draft)
+        if (id) setDraftId(id);
+        setLastSaved(new Date());
+        prevSnapshotRef.current = snapshot;
+        consecutiveFailsRef.current = 0;
+      } catch {
+        consecutiveFailsRef.current += 1;
+        if (consecutiveFailsRef.current >= AUTOSAVE_FAIL_THRESHOLD) {
+          cooldownUntilRef.current = Date.now() + AUTOSAVE_COOLDOWN_MS;
+        }
       }
-      setLastSaved(new Date());
     },
-    2000,
+    AUTOSAVE_DEBOUNCE_MS,
     [
       title,
       content,

--- a/apps/web/src/features/rss/index.ts
+++ b/apps/web/src/features/rss/index.ts
@@ -2,3 +2,4 @@ export * from "./account-rss-handler";
 export * from "./entries-rss-handler";
 export * from "./community-rss-handler";
 export * from "./feed-rss-handler";
+export * from "./rss-response";

--- a/apps/web/src/features/rss/rss-handler.ts
+++ b/apps/web/src/features/rss/rss-handler.ts
@@ -39,17 +39,20 @@ export abstract class RssHandler<T> {
 // Hive RPC and upstream HTTP layers regularly emit transient connection
 // errors when crawlers fan out across many feed paths. They aren't bugs
 // in our code, but capturing them drowns out real issues in Sentry.
-function isTransientUpstreamError(e: unknown): boolean {
+export function isTransientUpstreamError(e: unknown): boolean {
   if (!e || typeof e !== "object") return false;
   const err = e as { name?: string; code?: string; message?: string };
+  // undici / Node net layer
   if (err.code === "ECONNRESET" || err.code === "ETIMEDOUT" || err.code === "UND_ERR_SOCKET")
     return true;
+  // AbortController- and Node fetch-timeout-induced errors. Also catches
+  // the `Error: aborted` message undici raises on ECONNRESET, since that
+  // error carries `name: "AbortError"`.
   if (err.name === "AbortError" || err.name === "TimeoutError") return true;
   const msg = String(err.message ?? "");
   return (
     /Unable to parse endpoint data/i.test(msg) ||
-    /HTTP 50[234]/.test(msg) ||
-    /fetch failed/i.test(msg) ||
-    /aborted/i.test(msg)
+    /HTTP 5\d\d/.test(msg) ||
+    /fetch failed/i.test(msg)
   );
 }

--- a/apps/web/src/features/rss/rss-handler.ts
+++ b/apps/web/src/features/rss/rss-handler.ts
@@ -22,14 +22,34 @@ export abstract class RssHandler<T> {
       const data = await this.fetchData();
       data.forEach((item) => feed.item(this.convertItem(item, base)));
     } catch (e) {
-      Sentry.captureException(e,{
-        extra: {
-          pathname: this.pathname,
-          handlerClass: this.constructor.name
-        }
-      });
+      if (!isTransientUpstreamError(e)) {
+        Sentry.captureException(e, {
+          extra: {
+            pathname: this.pathname,
+            handlerClass: this.constructor.name
+          }
+        });
+      }
     }
 
     return feed;
   }
+}
+
+// Hive RPC and upstream HTTP layers regularly emit transient connection
+// errors when crawlers fan out across many feed paths. They aren't bugs
+// in our code, but capturing them drowns out real issues in Sentry.
+function isTransientUpstreamError(e: unknown): boolean {
+  if (!e || typeof e !== "object") return false;
+  const err = e as { name?: string; code?: string; message?: string };
+  if (err.code === "ECONNRESET" || err.code === "ETIMEDOUT" || err.code === "UND_ERR_SOCKET")
+    return true;
+  if (err.name === "AbortError" || err.name === "TimeoutError") return true;
+  const msg = String(err.message ?? "");
+  return (
+    /Unable to parse endpoint data/i.test(msg) ||
+    /HTTP 50[234]/.test(msg) ||
+    /fetch failed/i.test(msg) ||
+    /aborted/i.test(msg)
+  );
 }

--- a/apps/web/src/features/rss/rss-response.ts
+++ b/apps/web/src/features/rss/rss-response.ts
@@ -1,3 +1,6 @@
+import * as Sentry from "@sentry/nextjs";
+import { isTransientUpstreamError } from "./rss-handler";
+
 // Edge/CDN cache for RSS responses. Bot crawlers (ClaudeBot, GPTBot,
 // etc.) fan out across many feed paths and otherwise hit Hive RPC once
 // per request. 5-min fresh + 1-hour SWR lets the CDN absorb that fan-out.
@@ -5,9 +8,22 @@ export const RSS_CACHE_HEADERS = {
   "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600"
 } as const;
 
+// Shorter TTL for empty/error feeds so a transient upstream outage
+// doesn't pin every CDN edge to an empty feed for the full success TTL.
+const RSS_ERROR_CACHE_HEADERS = {
+  "Cache-Control": "public, s-maxage=30, stale-while-revalidate=60"
+} as const;
+
+// RSS 2.0 requires <title>, <link>, and <description> on every <channel>.
+// Aggregators reject malformed feeds and may retry-loop, defeating the
+// backoff this fallback is meant to provide.
 const EMPTY_FEED_XML =
   '<?xml version="1.0" encoding="UTF-8"?>' +
-  '<rss version="2.0"><channel><title>RSS Feed</title></channel></rss>';
+  '<rss version="2.0"><channel>' +
+  "<title>Ecency RSS Feed</title>" +
+  "<link>https://ecency.com</link>" +
+  "<description>Feed temporarily unavailable</description>" +
+  "</channel></rss>";
 
 // Returned when upstream RPC fails. Returning 200 + an empty feed instead
 // of 4xx tells crawlers "nothing here right now" so they back off rather
@@ -15,6 +31,19 @@ const EMPTY_FEED_XML =
 export function emptyRssResponse(): Response {
   return new Response(EMPTY_FEED_XML, {
     status: 200,
-    headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
+    headers: { "Content-Type": "text/xml", ...RSS_ERROR_CACHE_HEADERS }
   });
+}
+
+// Report only the errors that aren't part of the known transient-upstream
+// noise pattern, then return the empty-feed fallback. Lets the route
+// remain a one-liner in the catch while still surfacing real regressions.
+export function emptyRssResponseWithReport(
+  e: unknown,
+  context: { route: string; pathname: string }
+): Response {
+  if (!isTransientUpstreamError(e)) {
+    Sentry.captureException(e, { extra: context });
+  }
+  return emptyRssResponse();
 }

--- a/apps/web/src/features/rss/rss-response.ts
+++ b/apps/web/src/features/rss/rss-response.ts
@@ -38,9 +38,12 @@ export function emptyRssResponse(): Response {
 // Report only the errors that aren't part of the known transient-upstream
 // noise pattern, then return the empty-feed fallback. Lets the route
 // remain a one-liner in the catch while still surfacing real regressions.
+// `route` is the templated path (e.g. "profile/[username]/rss") — we
+// intentionally avoid the resolved pathname so dynamic segments like
+// usernames/tags aren't tagged as searchable Sentry telemetry.
 export function emptyRssResponseWithReport(
   e: unknown,
-  context: { route: string; pathname: string }
+  context: { route: string }
 ): Response {
   if (!isTransientUpstreamError(e)) {
     Sentry.captureException(e, { extra: context });

--- a/apps/web/src/features/rss/rss-response.ts
+++ b/apps/web/src/features/rss/rss-response.ts
@@ -1,0 +1,20 @@
+// Edge/CDN cache for RSS responses. Bot crawlers (ClaudeBot, GPTBot,
+// etc.) fan out across many feed paths and otherwise hit Hive RPC once
+// per request. 5-min fresh + 1-hour SWR lets the CDN absorb that fan-out.
+export const RSS_CACHE_HEADERS = {
+  "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600"
+} as const;
+
+const EMPTY_FEED_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<rss version="2.0"><channel><title>RSS Feed</title></channel></rss>';
+
+// Returned when upstream RPC fails. Returning 200 + an empty feed instead
+// of 4xx tells crawlers "nothing here right now" so they back off rather
+// than retry-loop and amplify the upstream outage.
+export function emptyRssResponse(): Response {
+  return new Response(EMPTY_FEED_XML, {
+    status: 200,
+    headers: { "Content-Type": "text/xml", ...RSS_CACHE_HEADERS }
+  });
+}


### PR DESCRIPTION
## Summary

Two related fixes targeting high-volume Sentry issues identified in the 2026-05-20 audit:

### 1. RSS routes — ECENCY-NEXT-1A9A (~2k events / period)

- All six RSS route handlers (`profile`, `feed`, `community` × `rss` / `rss.xml`) now emit `Cache-Control: public, s-maxage=300, stale-while-revalidate=3600`. Crawlers (ClaudeBot etc.) fan out across many feed paths; today every hit goes through Hive RPC. With this, the CDN absorbs that fan-out.
- On upstream RPC failure routes now return `200` + an empty `<channel>` instead of `4xx`/`5xx`. Crawlers back off rather than retry-loop, which keeps a flaky Hive node from amplifying into a 2k-event-per-day Sentry issue. Replaces inconsistent behaviour across routes (profile threw `400`, others propagated as `500`).
- `RssHandler.getFeed()` no longer ships transient upstream errors to Sentry (`ECONNRESET`, "Unable to parse endpoint data", `HTTP 50x`, `fetch failed`, `aborted`, `AbortError`/`TimeoutError`). These aren't bugs in our code — they're upstream network noise.

### 2. Client TimeoutError instrumentation — ECENCY-NEXT-1A2B (~1.5k events / 388 users)

These events arrive with **zero stack frames** (AbortController error spec) and no URL context, so today we have no idea which fetch is timing out. `beforeSend` now walks recent `fetch`/`xhr` breadcrumbs on `TimeoutError`/`AbortError` events and attaches the most recent URL as a `timeoutUrl` tag, giving us per-endpoint correlation for the next batch of events.

## Test plan

- [ ] Hit `/@<user>/rss` and confirm `Cache-Control: public, s-maxage=300, stale-while-revalidate=3600` in response headers
- [ ] Hit `/@nonexistent-user-aaaaa/rss` and confirm `200` with empty `<channel>` body rather than `4xx`
- [ ] Hit `/hot/somefeed/rss` and `/created/hive-1234/rss` and confirm same cache headers
- [ ] Confirm `ECENCY-NEXT-1A9A` event volume drops in Sentry over 24-48h
- [ ] Confirm new `TimeoutError` events under `ECENCY-NEXT-1A2B` carry a `timeoutUrl` tag visible in Sentry UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RSS routes now return a safe empty feed on failure and avoid throwing errors.

* **Performance**
  * RSS responses include consistent cache headers for better caching and faster loads.

* **Observability**
  * Improved error reporting: timeout/abort errors are now tagged with the relevant request URL and transient upstream failures are suppressed from noisy reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/811?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->