### PR TITLE
security: close residual CodeQL alerts (18 → 3)

### DIFF
--- a/.github/workflows/PR-branch.yml
+++ b/.github/workflows/PR-branch.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - 'bugfix/*'
       - 'feature/*'
+# Build/test only — no writes back to GitHub.
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -3,6 +3,12 @@ on:
   push:
     branches:
       - main
+# Default to read-only access for GITHUB_TOKEN. Deploy jobs use SSH and
+# don't need any GitHub API access; the build job pushes only to Docker
+# Hub (external). Per-job overrides can be added if a step ever needs
+# write access on GitHub itself.
+permissions:
+  contents: read
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -12,6 +12,11 @@ on:
       - 'packages/wallets/**'
       - 'packages/ui/**'
 
+# Default to read-only GITHUB_TOKEN. Build pushes to Docker Hub (external);
+# deploy jobs SCP/SSH to servers — neither path needs GitHub write access.
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -6,6 +6,10 @@ on:
     paths-ignore:
       - 'apps/self-hosted/hosting/**'
       - '.github/workflows/self-hosted.yml'
+# Default to read-only GITHUB_TOKEN. Build pushes to Docker Hub (external);
+# deploy uses SSH; neither needs write access to the GitHub repo.
+permissions:
+  contents: read
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - 'develop'
+# Build-only smoke test — no writes back to GitHub.
+permissions:
+  contents: read
 jobs:
   build:
     if: github.ref_name != 'main'

--- a/apps/self-hosted/src/features/floating-menu/utils.ts
+++ b/apps/self-hosted/src/features/floating-menu/utils.ts
@@ -10,6 +10,10 @@ export function deepClone<T>(obj: T): T {
   return JSON.parse(JSON.stringify(obj));
 }
 
+function isForbiddenKey(key: string): boolean {
+  return key === '__proto__' || key === 'constructor' || key === 'prototype';
+}
+
 /**
  * Update a nested object path with a new value
  */
@@ -18,16 +22,25 @@ export function updateNestedPath(
   path: string,
   value: ConfigValue,
 ): Record<string, ConfigValue> {
-  const newObj = deepClone(obj);
   const keys = path.split('.');
+  // Upfront whole-path rejection: an adversarial path like
+  // `network.__proto__.polluted` must NOT create the intermediate
+  // `network = {}` node before the guard fires later in the loop —
+  // doing so silently overwrites legitimate config under "rejected"
+  // input. So bail out before we touch the clone at all.
+  if (keys.some(isForbiddenKey)) {
+    return deepClone(obj);
+  }
+
+  const newObj = deepClone(obj);
   let current: Record<string, ConfigValue> = newObj;
 
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];
-    // In-loop prototype-pollution guard. Each write key is checked
-    // explicitly against the dangerous identifiers so CodeQL's data-flow
-    // analysis sees the sanitiser on the exact assignment line.
-    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    // Inline guard at each sink line so CodeQL's data-flow analysis sees
+    // a sanitiser on the exact assignment (the upfront check above is
+    // for correctness; this is what closes the prototype-pollution alert).
+    if (isForbiddenKey(key)) {
       return newObj;
     }
     if (
@@ -41,7 +54,7 @@ export function updateNestedPath(
   }
 
   const finalKey = keys[keys.length - 1]!;
-  if (finalKey === '__proto__' || finalKey === 'constructor' || finalKey === 'prototype') {
+  if (isForbiddenKey(finalKey)) {
     return newObj;
   }
   current[finalKey] = value;

--- a/apps/self-hosted/src/features/floating-menu/utils.ts
+++ b/apps/self-hosted/src/features/floating-menu/utils.ts
@@ -10,10 +10,6 @@ export function deepClone<T>(obj: T): T {
   return JSON.parse(JSON.stringify(obj));
 }
 
-// Reject keys that would mutate the prototype chain. Without this guard,
-// a path like "__proto__.polluted" would assign onto Object.prototype.
-const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-
 /**
  * Update a nested object path with a new value
  */
@@ -24,13 +20,16 @@ export function updateNestedPath(
 ): Record<string, ConfigValue> {
   const newObj = deepClone(obj);
   const keys = path.split('.');
-  if (keys.some((k) => FORBIDDEN_KEYS.has(k))) {
-    return newObj;
-  }
   let current: Record<string, ConfigValue> = newObj;
 
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];
+    // In-loop prototype-pollution guard. Each write key is checked
+    // explicitly against the dangerous identifiers so CodeQL's data-flow
+    // analysis sees the sanitiser on the exact assignment line.
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      return newObj;
+    }
     if (
       !current[key] ||
       typeof current[key] !== 'object' ||
@@ -41,7 +40,11 @@ export function updateNestedPath(
     current = current[key] as Record<string, ConfigValue>;
   }
 
-  current[keys[keys.length - 1]!] = value;
+  const finalKey = keys[keys.length - 1]!;
+  if (finalKey === '__proto__' || finalKey === 'constructor' || finalKey === 'prototype') {
+    return newObj;
+  }
+  current[finalKey] = value;
   return newObj;
 }
 

--- a/apps/web/src/app/_components/top-communities-widget/index.tsx
+++ b/apps/web/src/app/_components/top-communities-widget/index.tsx
@@ -20,10 +20,14 @@ export const TopCommunitiesWidget = () => {
     }
 
     // CSPRNG pick — the picked community flows into URLs and CodeQL treats
-    // it as taint when sourced from Math.random.
+    // it as taint when sourced from Math.random. Rejection-sample to drop
+    // any draw that would introduce modulo bias.
     const pickIndex = (n: number) => {
+      const limit = Math.floor(0x1_0000_0000 / n) * n;
       const buf = new Uint32Array(1);
-      crypto.getRandomValues(buf);
+      do {
+        crypto.getRandomValues(buf);
+      } while (buf[0] >= limit);
       return buf[0] % n;
     };
 

--- a/apps/web/src/app/_components/top-communities-widget/index.tsx
+++ b/apps/web/src/app/_components/top-communities-widget/index.tsx
@@ -19,9 +19,17 @@ export const TopCommunitiesWidget = () => {
       return [];
     }
 
+    // CSPRNG pick — the picked community flows into URLs and CodeQL treats
+    // it as taint when sourced from Math.random.
+    const pickIndex = (n: number) => {
+      const buf = new Uint32Array(1);
+      crypto.getRandomValues(buf);
+      return buf[0] % n;
+    };
+
     const result: Community[] = [];
-    while (result.length < 5) {
-      const index = Math.floor(Math.random() * (data.length - 1));
+    while (result.length < 5 && result.length < data.length) {
+      const index = pickIndex(data.length);
       if (result.every((item) => data[index].id !== item.id)) {
         result.push(data[index]);
       }


### PR DESCRIPTION
## Summary

Follow-up to #813. Closes 18 of the remaining 21 open CodeQL alerts on `develop`.

### Code-level fixes (3 alerts)

- **`top-communities-widget`** (#131, #132): the `Math.random()` index pick at `index.tsx:24` was the upstream taint source feeding `CommunityListItem`'s avatar URL and admin `ProfileLink`. Switched to `crypto.getRandomValues`-based `pickIndex`, mirroring the wave-follows-card fix from #813. Also fixes a pre-existing off-by-one (`data.length - 1` excluded the last item) and adds a `result.length < data.length` guard so the while-loop can't spin forever when the dataset has fewer than 5 items.
- **`floating-menu/utils`** (#22): the upfront `keys.some(k => FORBIDDEN_KEYS.has(k))` guard from #813 was correct but CodeQL didn't recognise it as a sanitiser on the recursive write. Moved to inline string-equality checks (`key === '__proto__' || key === 'constructor' || key === 'prototype'`) at each assignment line so the data-flow analysis sees the guard on the exact sink.

### Workflow permissions (15 alerts)

Every workflow gets a top-level `permissions: contents: read`. Jobs inherit it; no job currently needs write access on GitHub itself (build jobs push only to Docker Hub via `DOCKERHUB_TOKEN`; deploy jobs SCP/SSH to servers; CI jobs only test/build). Future steps that need write access can be granted per-job.

| Workflow | Alerts closed |
|---|---|
| `master.yml` | #2, #3, #6, #11, #13 |
| `staging.yml` | #5, #7, #9 |
| `self-hosted.yml` | #4, #8, #10, #12, #15 |
| `web-build.yml` | #14 |
| `PR-branch.yml` | #1 |

### Remaining 3 alerts after this merge

- **#23 (critical)** SSRF in `api/import/route.ts:208` — DNS-IP allowlist already in place, residual TOCTOU window between resolve and connect. Needs a custom undici dispatcher pinning fetch to the pre-resolved IP. Separate PR.
- **#21 (high)** `video-upload-threespeak` `<source src={URL.createObjectURL(file)}>` — same-origin blob URL, false positive. Dismiss in CodeQL UI.
- **#100 (high)** `youtubeVideosEnhancer.spec.ts:15` URL match in test mock — false positive (CodeQL has already auto-classified it `test`). Dismiss in CodeQL UI.

## Test plan

- [ ] CI: workflows still parse & run with the new `permissions` block (auto-tested by the build itself running)
- [ ] After merge: re-query code-scanning API; expect open alert count to drop from 21 → 3
- [ ] Manual smoke: top-communities widget on home page still renders 5 unique communities (no infinite loop on smaller datasets)
- [ ] Self-hosted floating-menu config edits still work (path-write sanitiser doesn't reject legitimate keys)