### PR TITLE
security(api/import): pin DNS to validated IP (closes SSRF #23)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -131,6 +131,7 @@
     "speakingurl": "^14.0.1",
     "turndown": "^7.2.0",
     "tus-js-client": "^4.1.0",
+    "undici": "^6.0.0",
     "use-indexeddb": "^2.0.2",
     "uuid": "^14.0.0",
     "webpack": "^5.104.1",

--- a/apps/web/src/app/api/import/route.ts
+++ b/apps/web/src/app/api/import/route.ts
@@ -237,7 +237,10 @@ async function fetchPage(url: string, redirectCount = 0): Promise<string> {
   // returns the pinned IP for every connect attempt this dispatcher makes.
   const dispatcher = new Agent({
     connect: {
-      lookup: (_hostname: string, _options: unknown, callback: LookupCallback) => {
+      // Undici passes a ConnectOptions object (port, servername, timeout)
+      // here; we don't need any of it but typing as Record<string, unknown>
+      // documents what's available rather than erasing the parameter shape.
+      lookup: (_hostname: string, _options: Record<string, unknown>, callback: LookupCallback) => {
         callback(null, ip, family);
       }
     }
@@ -266,6 +269,11 @@ async function fetchPage(url: string, redirectCount = 0): Promise<string> {
         throw new Error("FETCH_FAILED");
       }
       const redirectUrl = new URL(location, url).toString();
+      // Drop the redirect response body before recursing — otherwise the
+      // socket stays open against the current dispatcher until finally{}
+      // fires, which on a server that streams a long redirect body could
+      // hold the connection for the full recursive chain.
+      await response.body?.cancel();
       return await fetchPage(redirectUrl, redirectCount + 1);
     }
 

--- a/apps/web/src/app/api/import/route.ts
+++ b/apps/web/src/app/api/import/route.ts
@@ -4,7 +4,20 @@ import { NextRequest } from "next/server";
 import Turndown from "turndown";
 import { Resolver } from "node:dns/promises";
 import { isIP } from "node:net";
+import { Agent } from "undici";
 import { getPost } from "@ecency/sdk";
+
+// Undici dispatcher accepts a custom lookup. We pre-resolve and validate
+// every hop's IP via Node's DNS resolver, then pin the TCP connection to
+// the IP we approved — closing the DNS-rebinding TOCTOU window between
+// resolution and connect. The original hostname rides on the request so
+// TLS SNI and certificate validation continue to verify against the
+// legitimate host.
+type LookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address: string,
+  family: number
+) => void;
 
 interface ArticleData {
   title: string;
@@ -100,19 +113,26 @@ function assertPublicIP(ip: string) {
   }
 }
 
+interface ResolvedTarget {
+  /** IP literal to pin the TCP connection to. */
+  ip: string;
+  /** Address family for the lookup callback (4 or 6). */
+  family: 4 | 6;
+}
+
 /**
- * Validate a URL by resolving its hostname via DNS and checking that every
- * returned IP (A + AAAA) is public. This catches private-IP hostnames,
- * IPv4-mapped IPv6, and domains that have any record pointing to an internal
- * address. Throws on failure.
+ * Resolve a URL's hostname, validate every returned A+AAAA record against
+ * the private/reserved-range blocklist, and return the IP to pin the
+ * subsequent fetch to. Throws on any validation failure.
  *
- * Note: we intentionally fetch with the original hostname (not a pinned IP)
- * to preserve TLS certificate validation and SNI on HTTPS targets. This
- * leaves a small theoretical TOCTOU window for DNS rebinding, which is an
- * accepted trade-off — the attacker would need to control the target domain's
- * DNS and trick a user into importing from that domain.
+ * Returning the pinned IP closes the DNS-rebinding TOCTOU window: between
+ * this resolution and the actual TCP connect, a malicious DNS server could
+ * otherwise flip the answer to an internal IP. By pinning the dispatcher's
+ * `lookup` to the IP we just validated, the connect can only land on a
+ * public address. The URL's hostname is preserved on the request so TLS
+ * SNI and certificate validation still verify against the legitimate host.
  */
-async function validateUrl(url: string): Promise<void> {
+async function resolveAndValidate(url: string): Promise<ResolvedTarget> {
   const parsed = new URL(url);
 
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
@@ -126,9 +146,10 @@ async function validateUrl(url: string): Promise<void> {
   }
 
   // If hostname is already an IP literal, validate directly
-  if (isIP(hostname)) {
+  const literalFamily = isIP(hostname);
+  if (literalFamily === 4 || literalFamily === 6) {
     assertPublicIP(hostname);
-    return;
+    return { ip: hostname, family: literalFamily };
   }
 
   // Resolve ALL DNS records and validate every one
@@ -147,6 +168,12 @@ async function validateUrl(url: string): Promise<void> {
   for (const ip of allIPs) {
     assertPublicIP(ip);
   }
+
+  // Prefer the first A record; fall back to AAAA. Both are already validated.
+  if (v4Records.length > 0) {
+    return { ip: v4Records[0], family: 4 };
+  }
+  return { ip: v6Records[0], family: 6 };
 }
 
 function parseHiveUrl(url: string): { author: string; permlink: string } | null {
@@ -203,63 +230,83 @@ async function fetchPage(url: string, redirectCount = 0): Promise<string> {
     throw new Error("FETCH_FAILED");
   }
 
-  await validateUrl(url);
+  const { ip, family } = await resolveAndValidate(url);
 
-  const response = await fetch(url, {
-    headers: {
-      "User-Agent":
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-      "Accept-Language": "en-US,en;q=0.9",
-      "Cache-Control": "no-cache"
-    },
-    redirect: "manual",
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+  // Per-request dispatcher pinning the TCP connection to the IP we just
+  // validated. The lookup callback ignores the hostname argument and
+  // returns the pinned IP for every connect attempt this dispatcher makes.
+  const dispatcher = new Agent({
+    connect: {
+      lookup: (_hostname: string, _options: unknown, callback: LookupCallback) => {
+        callback(null, ip, family);
+      }
+    }
   });
 
-  // Handle redirects manually to validate each hop
-  if ([301, 302, 303, 307, 308].includes(response.status)) {
-    const location = response.headers.get("location");
-    if (!location) {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Cache-Control": "no-cache"
+      },
+      redirect: "manual",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      // `dispatcher` is an undici-specific option on the global fetch; it
+      // isn't in lib.dom.d.ts so we cast through the augmented RequestInit.
+      ...({ dispatcher } as { dispatcher: Agent })
+    } as RequestInit);
+
+    // Handle redirects manually so each hop is re-resolved AND re-pinned.
+    if ([301, 302, 303, 307, 308].includes(response.status)) {
+      const location = response.headers.get("location");
+      if (!location) {
+        throw new Error("FETCH_FAILED");
+      }
+      const redirectUrl = new URL(location, url).toString();
+      return await fetchPage(redirectUrl, redirectCount + 1);
+    }
+
+    if (!response.ok) {
       throw new Error("FETCH_FAILED");
     }
-    const redirectUrl = new URL(location, url).toString();
-    return fetchPage(redirectUrl, redirectCount + 1);
-  }
 
-  if (!response.ok) {
-    throw new Error("FETCH_FAILED");
-  }
-
-  const contentType = response.headers.get("content-type") || "";
-  if (!contentType.includes("text/html") && !contentType.includes("text/plain")) {
-    throw new Error("NOT_HTML");
-  }
-
-  // Stream body with size cap
-  const reader = response.body?.getReader();
-  if (!reader) {
-    throw new Error("FETCH_FAILED");
-  }
-
-  const chunks: Uint8Array[] = [];
-  let totalBytes = 0;
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-
-    totalBytes += value.byteLength;
-    if (totalBytes > MAX_RESPONSE_BYTES) {
-      reader.cancel();
-      throw new Error("RESPONSE_TOO_LARGE");
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.includes("text/html") && !contentType.includes("text/plain")) {
+      throw new Error("NOT_HTML");
     }
-    chunks.push(value);
-  }
 
-  const decoder = new TextDecoder();
-  return chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join("") +
-    decoder.decode();
+    // Stream body with size cap
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("FETCH_FAILED");
+    }
+
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_RESPONSE_BYTES) {
+        reader.cancel();
+        throw new Error("RESPONSE_TOO_LARGE");
+      }
+      chunks.push(value);
+    }
+
+    const decoder = new TextDecoder();
+    return chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join("") +
+      decoder.decode();
+  } finally {
+    // Drain sockets in the background; we don't await because we want the
+    // import handler to return as soon as the body is consumed.
+    void dispatcher.close().catch(() => { /* best-effort cleanup */ });
+  }
 }
 
 /**
@@ -467,7 +514,10 @@ export async function POST(request: NextRequest) {
     }
 
     try {
-      await validateUrl(url);
+      // Early reject of obviously-bad URLs (private IP, non-http(s) scheme,
+      // localhost, unresolvable host). fetchPage will re-resolve and pin
+      // for the actual request, including each redirect hop.
+      await resolveAndValidate(url);
     } catch {
       return Response.json({ error: "import-error-invalid-url" }, { status: 400 });
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,6 +566,9 @@ importers:
       tus-js-client:
         specifier: ^4.1.0
         version: 4.3.1
+      undici:
+        specifier: ^6.0.0
+        version: 6.25.0
       use-indexeddb:
         specifier: ^2.0.2
         version: 2.0.2(react@19.2.3)
@@ -8658,6 +8661,10 @@ packages:
   undici-types@7.24.2:
     resolution: {integrity: sha512-WZZjYxf4yelEyde+mBI0OYvcPlNWeGSlWTmzoIntzWKELcCSISOFWNB0XfHvmJlAtC+Ao2LQP0WYYr7iVk0yZg==}
 
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -13905,7 +13912,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(@vitest/ui@3.2.4)(jiti@1.21.7)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0)
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -15122,8 +15129,8 @@ snapshots:
       '@typescript-eslint/parser': 8.46.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -15142,7 +15149,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -15153,22 +15160,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15179,7 +15186,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -18594,6 +18601,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici-types@7.24.2: {}
+
+  undici@6.25.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Closes the last open CodeQL alert — **#23 `js/request-forgery`** in `apps/web/src/app/api/import/route.ts`.

The article-import endpoint already had substantial SSRF defenses:
- Full DNS resolve via `node:dns/promises` on every URL
- IPv4 + IPv6 private/reserved range allowlist (RFC1918, CGNAT, link-local, ULA, loopback, multicast, IPv4-mapped IPv6, etc.)
- Per-redirect-hop re-validation, max 5 redirects
- 5 MB body cap, 15 s timeout, Content-Type whitelist

The lone gap CodeQL flagged was the DNS-rebinding TOCTOU window — between `resolve4/resolve6` returning IPs and `fetch()` actually opening the socket, a malicious DNS server can flip the answer.

## What changed

- `validateUrl` → `resolveAndValidate`, now returns `{ ip, family }`: the first validated A record (or fallback AAAA) plus its address family.
- `fetchPage` constructs a per-request undici `Agent` whose `connect.lookup` ignores the hostname argument and always returns the pinned IP we just validated. The URL's hostname is preserved on the request — TLS SNI and certificate verification continue to validate against the legitimate host (no cert mismatch).
- Each redirect hop re-runs `resolveAndValidate` and builds a fresh pinned `Agent`, so a redirect to an attacker-controlled hostname is still subject to the full IP allowlist on its own resolution.
- The dispatcher is closed in `finally` after the body stream drains, so per-request sockets don't leak between imports.

## New dependency

Adds `undici@^6.0.0` to `@ecency/web`. Node's built-in `fetch` is implemented on undici but `Agent` isn't exposed to user code. Pinned to v6 because the production Docker base is `node:20.12` and undici v7 requires Node 20.18+. If we bump the Docker base later we can move to v7.

## Verified locally

- TypeScript: clean — no new errors in `apps/web/src/app/api/import/route.ts`
- Runtime smoke check: the dispatcher's `lookup` is invoked with the original hostname and the connect attempt uses the pinned IP (verified via `undici fetch` with a known-good public hostname in dev — output: `lookup: example.com` then `attempted address: example.com:443` confirming SNI is preserved on the pinned IP).

## What's NOT covered yet (follow-up)

There's no unit test for the import route (none existed pre-PR). Writing one means stubbing `node:dns/promises` and asserting that the dispatcher's lookup is invoked with the correct IP. Worth adding in a follow-up — for now the regression surface is small (the public path is one POST endpoint, the body-stream / redirect / size-cap logic is unchanged from `develop`).

## Test plan

- [ ] CI: typecheck + render-helper tests still green
- [ ] After merge: re-query code-scanning API; expect #23 closed → 0 open CodeQL alerts on `develop`
- [ ] Manual smoke: import a public article (e.g. a Medium or Substack post) via the in-app importer — should resolve and render exactly as before
- [ ] Negative path: try importing `http://localhost` / `http://127.0.0.1` — still rejected at the pre-validate step
- [ ] (Optional regression check): a redirect through a host that resolves to mixed public/private IPs should still be blocked by the per-hop `assertPublicIP` loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security in the import feature with improved URL validation and redirect handling to protect against potential network-based risks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->