### PR TITLE
perf(chat): parallelize bootstrap MM provisioning + Hive subscriptions

### DIFF
--- a/apps/web/src/app/api/mattermost/bootstrap/route.ts
+++ b/apps/web/src/app/api/mattermost/bootstrap/route.ts
@@ -8,7 +8,6 @@ import {
   ensurePersonalToken,
   ensureUserInTeam,
   getMattermostOutageStatus,
-  getMattermostUserWithProps,
   getUserLeftChannels,
   removeUserLeftChannel,
   withMattermostTokenCookie
@@ -99,14 +98,70 @@ async function handleBootstrap(req: Request, signal: AbortSignal): Promise<NextR
         return NextResponse.json({ error: "unauthorized" }, { status: 401 });
     }
 
-    // 3) Mattermost user / team / personal token
+    // 4) Kick off the Hive subscriptions fetch in parallel with Mattermost
+    //    provisioning below. Subscriptions only need the username, and the
+    //    rest of the bootstrap doesn't need the result until step 5.
+    //    Stacking the two sequentially can push long-tail bootstraps past
+    //    the upstream timeout for users with many community subscriptions.
+    //
+    //    A per-request QueryClient is required: the shared getQueryClient()
+    //    is scoped to Server Components, not Route Handlers, so it persists
+    //    across requests in a long-lived container and serves stale
+    //    subscription data — which would auto-join the user to communities
+    //    they unsubscribed from. Subscriptions failure is non-fatal (logged,
+    //    treated as empty list — same as before).
+    const qc = new QueryClient();
+    const subscriptionsQuery = getAccountSubscriptionsQueryOptions(username);
+    const abortSubscriptions = () => {
+        qc.cancelQueries({ queryKey: subscriptionsQuery.queryKey });
+    };
+    signal.addEventListener("abort", abortSubscriptions, { once: true });
+    // Track our own teardown so the .catch below can distinguish a real
+    // subscription failure from a cancellation we caused ourselves via the
+    // qc.clear() in this function's finally — otherwise an unrelated
+    // failure upstream would log a misleading "Unable to load subscriptions".
+    let subscriptionsTornDown = false;
+    const subscriptionsPromise: Promise<Subscription[]> = qc
+        .fetchQuery(subscriptionsQuery)
+        .then((s) => (s ?? []) as Subscription[])
+        .catch((error) => {
+            // Always settle as []. Signal aborts surface elsewhere via
+            // signal.throwIfAborted(); making this promise always-resolve
+            // means an early return in step 3 can't leave a dangling
+            // unhandled rejection. Skip the log on both abort AND teardown.
+            if (!signal.aborted && !subscriptionsTornDown) {
+                console.error("MM bootstrap: Unable to load Hive/Ecency subscriptions", error);
+            }
+            return [] as Subscription[];
+        });
+
+    try {
+    // 3) Mattermost user / team / personal token.
+    //    ensureMattermostUser must come first (it gives us user.id). After
+    //    that, ensureUserInTeam and ensurePersonalToken are independent and
+    //    fan out via Promise.all. ensurePersonalToken now returns the user
+    //    record it already fetched internally, so we get user.props (for
+    //    left-channels) without an extra round-trip.
+    //
+    //    A per-step AbortController lets us tear down the still-running
+    //    parallel call if its sibling rejects — otherwise the survivor
+    //    would fire-and-forget (the ensure-* helpers are idempotent so the
+    //    work is benign, but the upstream round-trips are avoidable).
     let user;
     let personalToken: string;
+    let userWithProps;
+    const stepAc = new AbortController();
+    const stepSignal = AbortSignal.any([signal, stepAc.signal]);
     try {
         user = await ensureMattermostUser(username, signal);
-        await ensureUserInTeam(user.id, signal);
-        personalToken = await ensurePersonalToken(user.id, signal);
+        const [, tokenResult] = await Promise.all([
+            ensureUserInTeam(user.id, stepSignal),
+            ensurePersonalToken(user.id, stepSignal)
+        ]);
+        personalToken = tokenResult.token;
+        userWithProps = tokenResult.user;
     } catch (e) {
+        stepAc.abort();
         // A caller/timeout abort must propagate to the top-level handler so it
         // can distinguish 504 (our 30s hard cap) from 499 (client disconnect).
         // Burying it under a generic outage status here would lose that.
@@ -137,29 +192,9 @@ async function handleBootstrap(req: Request, signal: AbortSignal): Promise<NextR
 
     signal.throwIfAborted();
 
-    // 4) Hive subscriptions — use a per-request QueryClient.
-    //    Do NOT use the shared getQueryClient() here: React's cache() is
-    //    scoped to Server Components, not Route Handlers. In a long-lived
-    //    container the shared QueryClient persists across requests, serving
-    //    stale subscription data that causes auto-joining to unsubscribed communities.
-    let subscriptions: Subscription[] = [];
-    const qc = new QueryClient();
-    const subscriptionsQuery = getAccountSubscriptionsQueryOptions(username);
-    try {
-        const abortSubscriptions = () => {
-          qc.cancelQueries({ queryKey: subscriptionsQuery.queryKey });
-        };
-        signal.addEventListener("abort", abortSubscriptions, { once: true });
-        try {
-          subscriptions = (await qc.fetchQuery(subscriptionsQuery)) || [];
-        } finally {
-          signal.removeEventListener("abort", abortSubscriptions);
-        }
-    } catch (error) {
-        console.error("MM bootstrap: Unable to load Hive/Ecency subscriptions", error);
-    } finally {
-        qc.clear();
-    }
+    // Wait for the in-flight subscriptions fetch (almost always already
+    // resolved by the time we get here for typical bootstraps).
+    const subscriptions = await subscriptionsPromise;
 
     const communityIds = subscriptions
         .map((sub: Subscription) => ({ id: sub?.[0], title: sub?.[1] }))
@@ -181,14 +216,7 @@ async function handleBootstrap(req: Request, signal: AbortSignal): Promise<NextR
     //    Skip channels the user has manually left (respect user choice)
     const BATCH_SIZE = 5;
 
-    let leftChannels = new Set<string>();
-    try {
-      const userWithProps = await getMattermostUserWithProps(user.id, signal);
-      leftChannels = getUserLeftChannels(userWithProps);
-    } catch (e) {
-      if (signal.aborted) throw e;
-      console.warn("MM bootstrap: failed to load left channels", { username, error: e });
-    }
+    const leftChannels = getUserLeftChannels(userWithProps);
 
     signal.throwIfAborted();
 
@@ -258,4 +286,16 @@ async function handleBootstrap(req: Request, signal: AbortSignal): Promise<NextR
         token: personalToken
     });
     return withMattermostTokenCookie(response, personalToken);
+    } finally {
+        // Mark teardown BEFORE clearing the QueryClient so the in-flight
+        // subscriptions .catch can tell our own cancellation apart from a
+        // real fetch failure.
+        subscriptionsTornDown = true;
+        signal.removeEventListener("abort", abortSubscriptions);
+        qc.clear();
+        // Belt-and-braces: attach a no-op consumer so qc.clear()'s
+        // cancellation never surfaces as an unhandled rejection on early-
+        // return paths.
+        subscriptionsPromise.catch(() => {});
+    }
 }

--- a/apps/web/src/server/mattermost.ts
+++ b/apps/web/src/server/mattermost.ts
@@ -442,20 +442,31 @@ async function createToken(userId: string, signal?: AbortSignal): Promise<string
   return result.token;
 }
 
-export async function ensurePersonalToken(userId: string, signal?: AbortSignal): Promise<string> {
+export async function ensurePersonalToken(
+  userId: string,
+  signal?: AbortSignal
+): Promise<{ token: string; user: MattermostUserWithProps }> {
   // Try to retrieve a previously stored PAT from user props.
   // Only fall through to createToken on auth errors (401/403).
   // Rethrow other errors (5xx, network) so they surface upstream.
+  //
+  // Returns the user alongside the token because the bootstrap caller also
+  // needs the user's props (for getUserLeftChannels). Folding it in here
+  // saves one extra GET /users/{id} on the hot path that used to run
+  // sequentially after this call.
   const user = await getMattermostUserWithProps(userId, signal);
   const storedToken = user.props?.[CHAT_PAT_PROP];
   if (storedToken) {
     // isTokenValid rethrows non-auth errors
     if (await isTokenValid(storedToken, signal)) {
-      return storedToken;
+      return { token: storedToken, user };
     }
-    // Token exists but is invalid (revoked/expired) — fall through to create
+    // Token exists but is invalid (revoked/expired) — fall through to create.
+    // The user.props we return here predates createToken's PUT to merge in
+    // the new PAT, but the only consumer (left-channels) doesn't care.
   }
-  return await createToken(userId, signal);
+  const token = await createToken(userId, signal);
+  return { token, user };
 }
 
 export function withMattermostTokenCookie(response: NextResponse, token: string) {

--- a/apps/web/src/specs/api/mattermost-ensure-personal-token.spec.ts
+++ b/apps/web/src/specs/api/mattermost-ensure-personal-token.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ensurePersonalToken now returns BOTH the PAT and the user record it
+// already fetched internally. The bootstrap route reads user.props for
+// left-channels — folding the read in here saves an extra MM round-trip
+// on the hot path, where stacked sequential calls used to push past the
+// upstream timeout for users with many community subscriptions.
+
+function resp(status: number, body: unknown) {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return { ok: status >= 200 && status < 300, status, text: async () => text };
+}
+
+async function loadModule() {
+  process.env.MATTERMOST_BASE_URL = "https://chat.test/api/v4";
+  process.env.MATTERMOST_ADMIN_TOKEN = "admin-token";
+  process.env.MATTERMOST_TEAM_ID = "team-1";
+  vi.resetModules();
+  return await import("@/server/mattermost");
+}
+
+describe("ensurePersonalToken — returns token + user (parallelization contract)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("returns the stored token alongside the user when the PAT is still valid", async () => {
+    const { ensurePersonalToken } = await loadModule();
+    const userWithPat = {
+      id: "u-1",
+      username: "alice",
+      email: "a",
+      delete_at: 0,
+      props: {
+        ecency_pat: "stored-pat",
+        ecency_left_channels: JSON.stringify(["hive-old"])
+      }
+    };
+    fetchMock
+      .mockResolvedValueOnce(resp(200, userWithPat)) // GET /users/u-1
+      .mockResolvedValueOnce(resp(200, { id: "u-1" })); // GET /users/me (isTokenValid)
+
+    const result = await ensurePersonalToken("u-1");
+
+    expect(result.token).toBe("stored-pat");
+    expect(result.user).toEqual(userWithPat);
+    // Caller relies on this user to feed getUserLeftChannels without a
+    // separate GET /users/{id} — regression-guard the shape.
+    expect(result.user.props?.ecency_left_channels).toBe(JSON.stringify(["hive-old"]));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates a new token and still returns the user when no PAT is stored", async () => {
+    const { ensurePersonalToken } = await loadModule();
+    const userWithoutPat = {
+      id: "u-2",
+      username: "bob",
+      email: "b",
+      delete_at: 0,
+      props: { ecency_left_channels: JSON.stringify(["hive-x"]) }
+    };
+    fetchMock
+      .mockResolvedValueOnce(resp(200, userWithoutPat)) // initial GET in ensurePersonalToken
+      .mockResolvedValueOnce(resp(200, { token: "new-pat" })) // POST /users/u-2/tokens
+      .mockResolvedValueOnce(resp(200, userWithoutPat)) // GET again (createToken re-reads for prop merge)
+      .mockResolvedValueOnce(resp(200, "")); // PUT /users/u-2/patch
+
+    const result = await ensurePersonalToken("u-2");
+
+    expect(result.token).toBe("new-pat");
+    // The returned user predates the prop merge, which is intentional: the
+    // only consumer (getUserLeftChannels) doesn't read the PAT prop.
+    expect(result.user.id).toBe("u-2");
+    expect(result.user.props?.ecency_left_channels).toBe(JSON.stringify(["hive-x"]));
+  });
+
+  it("creates a new token when the stored PAT is rejected as 401", async () => {
+    const { ensurePersonalToken } = await loadModule();
+    const userWithStalePat = {
+      id: "u-3",
+      username: "carol",
+      email: "c",
+      delete_at: 0,
+      props: { ecency_pat: "stale" }
+    };
+    fetchMock
+      .mockResolvedValueOnce(resp(200, userWithStalePat)) // GET /users/u-3
+      .mockResolvedValueOnce(resp(401, { id: "api.auth" })) // isTokenValid → 401
+      .mockResolvedValueOnce(resp(200, { token: "fresh-pat" })) // POST tokens
+      .mockResolvedValueOnce(resp(200, userWithStalePat)) // createToken re-read
+      .mockResolvedValueOnce(resp(200, "")); // PUT patch
+
+    const result = await ensurePersonalToken("u-3");
+
+    expect(result.token).toBe("fresh-pat");
+    expect(result.user.id).toBe("u-3");
+  });
+
+  it("surfaces non-auth errors from token validation (5xx must not silently re-create)", async () => {
+    const { ensurePersonalToken } = await loadModule();
+    fetchMock
+      .mockResolvedValueOnce(resp(200, {
+        id: "u-4",
+        username: "dave",
+        email: "d",
+        delete_at: 0,
+        props: { ecency_pat: "some-pat" }
+      }))
+      .mockResolvedValueOnce(resp(500, "mm exploded"));
+
+    await expect(ensurePersonalToken("u-4")).rejects.toThrow(/500|mm exploded/);
+    // No POST /users/u-4/tokens should fire — a 5xx on isTokenValid is NOT
+    // grounds to mint a duplicate token.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Why

`/api/mattermost/bootstrap` chains its work strictly sequentially:

```
ensureMattermostUser
 → ensureUserInTeam
   → ensurePersonalToken
     → (step 4) fetch Hive subscriptions
       → (step 5 preflight) getMattermostUserWithProps for leftChannels
         → (step 5) batches of 5 ensureCommunityChannelMembership
```

Each MM call here is a cross-region hop for users whose nearest origin isn't co-located with the chat backend. Six sequential round-trips + a Hive bridge fetch + N channel batches stack up, and users with many community subscriptions blow past the edge proxy's primary timeout. When that aborts a POST, the user sees a generic gateway error from the edge in the chat UI ("Chat server error (502)" + Retry).

## What

Two changes that overlap independent waits without changing observable behaviour:

1. **`ensurePersonalToken` returns `{ token, user }`**. It already fetches the user record via `getMattermostUserWithProps` internally (to merge the new PAT into props). The bootstrap caller used to make that same request *again* after step 4 for `leftChannels`. Folding it in eliminates one redundant round-trip.

2. **Bootstrap kicks off the Hive subscriptions fetch immediately** after auth verification, in parallel with MM provisioning. Once `ensureMattermostUser` returns `user.id`, `ensureUserInTeam` and `ensurePersonalToken` fan out via `Promise.all`. The QueryClient / abort listener lifecycle moved into a `try/finally` so all early-return paths still clean up.

### What didn't change

- Error mapping (`getMattermostOutageStatus` still classifies user/team/token failures into 503/504/502).
- Caller-driven aborts (504 / 499) still propagate cleanly.
- Subscriptions fetch failure → logged + empty list, same as before.
- Channel-join loop, BATCH_SIZE=5, `Promise.allSettled` semantics, explicit-community join path — all untouched.
- Idempotency from #792: `ensureUserInTeam`, `ensureChannelForCommunity`, `ensureUserInChannel`, `ensureMattermostUser` still do their end-state recheck.

### Effect on the hot path

For step 3 (user/team/PAT), serial round-trips drop from ~6 to ~2 (one for `ensureMattermostUser`, then `max(team, token)` parallel). Step 4 sub-fetch + step 5 preflight now overlap with step 3 instead of waiting their turn. Proportionally larger win for users with many communities.

## Tests

New: `apps/web/src/specs/api/mattermost-ensure-personal-token.spec.ts` — 4 specs covering the new `{ token, user }` contract (happy stored-PAT path, fresh-create path, stale-PAT-401 path, non-auth 5xx rethrow). Regression-guards the shape callers now depend on.

All mattermost specs green (32 total: 28 existing + 4 new):
```
✓ mattermost-bootstrap-subscriptions.spec.ts (2)
✓ mattermost-channels.spec.ts (3)
✓ mattermost-default-channels-filter.spec.ts (8)
✓ mattermost-ensure-personal-token.spec.ts (4)  ← new
✓ mattermost-ensure-user.spec.ts (9)
✓ mattermost-outage-status.spec.ts (6)
```

Typecheck: 0 net-new TS errors in touched files. The two errors flagged at `route.ts:123` and `route.ts:186` are pre-existing on develop (SDK `Subscriptions = string[]` vs app `Subscription = string[]`; lines shifted but baseline unchanged).

## Test plan

- [ ] CI green
- [ ] Eyeball the route diff — confirm cleanup runs on every exit path (try/finally around step 3-5)
- [ ] Monitor bootstrap response-time p95 post-deploy