### PR TITLE
fix(web): use callRPCBroadcast for MetaMask snap broadcasts

### DIFF
--- a/apps/web/src/providers/sdk/web-broadcast-adapter.ts
+++ b/apps/web/src/providers/sdk/web-broadcast-adapter.ts
@@ -6,6 +6,7 @@ import {
   getAccountFullQueryOptions,
   broadcastOperations,
   callRPC,
+  callRPCBroadcast,
   buildGrantPostingPermissionOp,
   usrActivity,
 } from '@ecency/sdk';
@@ -179,7 +180,10 @@ async function broadcastWithMetaMaskSnap(
     signatures: result.signatures
   };
 
-  const broadcastResult = await callRPC("condenser_api.broadcast_transaction_synchronous", [signedTx]) as TransactionConfirmation;
+  // Use callRPCBroadcast (15s timeout, broadcast-safe failover) instead of callRPC
+  // (5s timeout, read-path retry) so a slow node doesn't get cut off mid-flight and
+  // the request isn't ping-pong-cancelled across nodes on every 4.9s abort.
+  const broadcastResult = await callRPCBroadcast("condenser_api.broadcast_transaction_synchronous", [signedTx]) as TransactionConfirmation;
   return broadcastResult;
 }
 


### PR DESCRIPTION
## Summary

- The MetaMask snap broadcast in `web-broadcast-adapter.ts` was using the SDK's **read-path** `callRPC` (5s timeout, broad failover that retries on any transport error — including timeouts) to send `broadcast_transaction_synchronous`.
- `broadcast_transaction_synchronous` waits for block inclusion, so it legitimately takes ~3–9s. With a 5s timeout, the browser aborted the fetch at the 4.9s mark and the SDK replayed it across 3–4 nodes before finally throwing **"Signal timed out"** — visible in DevTools as a string of cancelled requests for any transfer/active op signed via MetaMask.
- Switched to `callRPCBroadcast`, which is what every other broadcast path uses (`broadcastOperations`, `Transaction.broadcast`). It has a **15s timeout** and **broadcast-safe failover** (only pre-connection / browser network errors trigger failover; timeouts do not). One clean attempt instead of a cancel-cascade, while keeping `broadcast_transaction_synchronous` so transfers still surface `block_num`/`trx_num` on success.

## Why recent SDK fixes didn't help here

The MetaMask path was the only broadcast that wasn't already routed through `callRPCBroadcast`, so the recent failover/retry work (timeout-no-failover regression guard, broadened browser-error detection, widened retry budget) never reached it.

## Test plan

- [ ] Sign a HIVE/HBD transfer with MetaMask snap → expect a single in-flight `broadcast_transaction_synchronous` request (no cancellations) and a normal success result with `block_num`/`trx_num`.
- [ ] Sign a posting op via MetaMask snap → unchanged behavior (still routes through the snap path).
- [ ] Sign a transfer with a private posting/active key → unchanged (already used `broadcastOperations` → `callRPCBroadcast`).
- [ ] Sign a transfer via Keychain browser extension → unchanged (extension handles its own broadcast).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction broadcasting reliability via MetaMask Hive snap by updating the broadcast mechanism and timeout/retry behavior for signed transactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->