### PR TITLE
fix(notifications): keep notification websocket alive and respect permission

### DIFF
--- a/apps/web/src/api/notifications-ws-api.ts
+++ b/apps/web/src/api/notifications-ws-api.ts
@@ -113,7 +113,14 @@ export class NotificationsWebSocket {
     this.isConnecting = true;
 
     if ("Notification" in window) {
-      await requestNotificationPermission();
+      try {
+        await requestNotificationPermission();
+      } catch {
+        // The permission prompt can throw in some environments (sandboxed
+        // iframe, extension conflicts). Permission isn't required for the
+        // socket, and swallowing here keeps the rejection from leaving
+        // isConnecting stuck true — which would block every future connect().
+      }
     }
 
     // Re-check after the async permission prompt: the user may have logged out,
@@ -286,10 +293,10 @@ export class NotificationsWebSocket {
         ? messages[0]
         : i18next.t("notifications.new-notifications-batch", { count: messages.length });
 
-    playNotificationSound();
-
     // `new Notification` can throw on some mobile browsers (requires a service
-    // worker); the caller's `.catch` handles that gracefully.
+    // worker); the caller's `.catch` handles that gracefully. Construct it
+    // before playing the sound so we never play a sound without a visible
+    // notification.
     const notification = new Notification(i18next.t("notification.popup-title"), {
       body: toastBody,
       icon: logo
@@ -300,6 +307,8 @@ export class NotificationsWebSocket {
         this.toggleUiProp("notifications");
       }
     };
+
+    playNotificationSound();
   }
 
   private queueNotification(msg: string) {

--- a/apps/web/src/api/notifications-ws-api.ts
+++ b/apps/web/src/api/notifications-ws-api.ts
@@ -19,6 +19,8 @@ export class NotificationsWebSocket {
   private enabledNotifyTypes: NotifyTypes[] = [];
   private isConnected = false;
   private isConnecting = false;
+  private socket: WebSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingMessages: string[] = [];
   private burstTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -123,6 +125,9 @@ export class NotificationsWebSocket {
     }
 
     const socket = new WebSocket(`${defaults.nwsServer}/ws?user=${user.username}`);
+    // Track the socket this instance created so disconnect() only ever tears
+    // down its own connection — never another wrapper's (e.g. NotificationHandler).
+    this.socket = socket;
     window.nws = socket;
     socket.onopen = () => {
       console.log("nws connected");
@@ -130,25 +135,37 @@ export class NotificationsWebSocket {
       this.isConnected = true;
     };
     socket.onmessage = (e) => this.onMessageReceive(e);
-    socket.onclose = (evt: CloseEvent) => {
+    socket.onclose = () => {
       console.log("nws disconnected");
 
       this.isConnected = false;
       this.isConnecting = false;
+      if (this.socket === socket) {
+        this.socket = null;
+      }
       if (window.nws === socket) {
         window.nws = undefined;
       }
 
-      // A deliberate disconnect() detaches these handlers first, so reaching
-      // here always means an unexpected close (network drop) — try to reconnect.
-      if (!evt.wasClean) {
-        console.log("nws trying to reconnect");
-
-        setTimeout(() => {
-          this.connect();
-        }, 2000);
+      // A deliberate disconnect() detaches this handler, so reaching here always
+      // means an unintended close — a network drop or a server-side close,
+      // including a clean close frame on server restart. Reconnect while we
+      // still have an active user; logout/switch clears it so this won't fire.
+      if (this.activeUser) {
+        this.scheduleReconnect();
       }
     };
+  }
+
+  private scheduleReconnect() {
+    if (this.reconnectTimer) {
+      return;
+    }
+    console.log("nws trying to reconnect");
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, 2000);
   }
 
   public disconnect() {
@@ -156,16 +173,22 @@ export class NotificationsWebSocket {
       clearTimeout(this.burstTimer);
       this.burstTimer = null;
     }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     this.pendingMessages.length = 0;
     this.isConnecting = false;
 
-    const socket = window.nws;
-    if (socket !== undefined) {
-      // Detach handlers first so this deliberate close does not trigger the
-      // reconnect path in onclose, and clear the global ref unconditionally so
-      // a socket caught mid-CONNECTING can't be orphaned — an orphaned ref
-      // would block every future connect() via the `window.nws !== undefined`
-      // guard.
+    const socket = this.socket;
+    if (socket) {
+      // Only tear down the socket THIS instance created. A secondary wrapper
+      // (e.g. NotificationHandler) never owns `this.socket`, so it can no longer
+      // close the global provider's live connection. Detaching the handlers
+      // first stops this deliberate close from triggering the reconnect path,
+      // and clearing the shared ref keeps a socket caught mid-CONNECTING from
+      // being orphaned (an orphaned `window.nws` would block every future
+      // connect()).
       socket.onopen = null;
       socket.onmessage = null;
       socket.onclose = null;
@@ -175,7 +198,10 @@ export class NotificationsWebSocket {
       } catch {
         // ignore — socket may already be closing/closed
       }
-      window.nws = undefined;
+      if (window.nws === socket) {
+        window.nws = undefined;
+      }
+      this.socket = null;
     }
     this.isConnected = false;
   }
@@ -226,7 +252,14 @@ export class NotificationsWebSocket {
         return NotifyTypes.RE_BLOG;
       case "transfer":
         return NotifyTypes.TRANSFERS;
+      case "favorites":
+        return NotifyTypes.FAVORITES;
+      case "bookmarks":
+        return NotifyTypes.BOOKMARKS;
       default:
+        // Types without a user-facing settings toggle (delegations, checkins,
+        // payouts, monthly-posts, weekly-earnings) have no per-type opt-out, so
+        // they're treated as always-allowed — still gated by the global toggle.
         return null;
     }
   }
@@ -303,8 +336,11 @@ export class NotificationsWebSocket {
 
     const msg = NotificationsWebSocket.getBody(data);
     const messageNotifyType = this.getNotificationType(data.type);
+    // For a type the user can toggle, notify only if it's in their enabled set
+    // — so an empty set means "none", not "all". Types without a toggle
+    // (messageNotifyType === null) have no per-type opt-out and are allowed.
     const allowedToNotify =
-      messageNotifyType && this.enabledNotifyTypes.length > 0
+      messageNotifyType !== null
         ? this.enabledNotifyTypes.includes(messageNotifyType)
         : true;
 

--- a/apps/web/src/api/notifications-ws-api.ts
+++ b/apps/web/src/api/notifications-ws-api.ts
@@ -131,7 +131,17 @@ export class NotificationsWebSocket {
       return;
     }
 
-    const socket = new WebSocket(`${defaults.nwsServer}/ws?user=${user.username}`);
+    let socket: WebSocket;
+    try {
+      socket = new WebSocket(`${defaults.nwsServer}/ws?user=${user.username}`);
+    } catch (error) {
+      // The constructor can throw synchronously (e.g. a malformed URL). Reset
+      // the flag so a later attempt can still reconnect instead of being
+      // short-circuited by the isConnecting guard.
+      this.isConnecting = false;
+      console.error("nws failed to connect", error);
+      return;
+    }
     // Track the socket this instance created so disconnect() only ever tears
     // down its own connection — never another wrapper's (e.g. NotificationHandler).
     this.socket = socket;
@@ -345,11 +355,13 @@ export class NotificationsWebSocket {
 
     const msg = NotificationsWebSocket.getBody(data);
     const messageNotifyType = this.getNotificationType(data.type);
-    // For a type the user can toggle, notify only if it's in their enabled set
-    // — so an empty set means "none", not "all". Types without a toggle
-    // (messageNotifyType === null) have no per-type opt-out and are allowed.
+    // For a toggle-able type, notify only when it's in the user's enabled set.
+    // An empty/unset list means "not configured" → allow all (a full opt-out is
+    // handled by the global toggle via hasNotifications), so existing users
+    // whose saved notify_types is still [] aren't silenced. Types without a
+    // toggle (messageNotifyType === null) have no per-type opt-out and pass.
     const allowedToNotify =
-      messageNotifyType !== null
+      messageNotifyType !== null && this.enabledNotifyTypes.length > 0
         ? this.enabledNotifyTypes.includes(messageNotifyType)
         : true;
 

--- a/apps/web/src/api/notifications-ws-api.ts
+++ b/apps/web/src/api/notifications-ws-api.ts
@@ -3,7 +3,6 @@ import { ActiveUser, WsNotification } from "@/entities";
 import { NotifyTypes } from "@/enums";
 import i18next from "i18next";
 import { playNotificationSound, requestNotificationPermission } from "@/utils";
-import { info } from "@/features/shared/feedback/feedback-events";
 import logo from "@/assets/img/logo-circle.svg";
 
 declare var window: Window & {
@@ -19,6 +18,7 @@ export class NotificationsWebSocket {
   private onMessageCallback: (() => void) | null = null;
   private enabledNotifyTypes: NotifyTypes[] = [];
   private isConnected = false;
+  private isConnecting = false;
   private pendingMessages: string[] = [];
   private burstTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -95,7 +95,7 @@ export class NotificationsWebSocket {
   }
 
   public async connect() {
-    if (this.isConnected) {
+    if (this.isConnected || this.isConnecting) {
       return;
     }
 
@@ -108,23 +108,40 @@ export class NotificationsWebSocket {
       return;
     }
 
+    this.isConnecting = true;
+
     if ("Notification" in window) {
       await requestNotificationPermission();
     }
 
-    window.nws = new WebSocket(`${defaults.nwsServer}/ws?user=${this.activeUser.username}`);
-    window.nws.onopen = () => {
+    // Re-check after the async permission prompt: the user may have logged out,
+    // or another connect() call may have already created the socket.
+    const user = this.activeUser;
+    if (!user || window.nws !== undefined) {
+      this.isConnecting = false;
+      return;
+    }
+
+    const socket = new WebSocket(`${defaults.nwsServer}/ws?user=${user.username}`);
+    window.nws = socket;
+    socket.onopen = () => {
       console.log("nws connected");
+      this.isConnecting = false;
       this.isConnected = true;
     };
-    window.nws.onmessage = (e) => this.onMessageReceive(e);
-    window.nws.onclose = (evt: CloseEvent) => {
+    socket.onmessage = (e) => this.onMessageReceive(e);
+    socket.onclose = (evt: CloseEvent) => {
       console.log("nws disconnected");
 
-      window.nws = undefined;
+      this.isConnected = false;
+      this.isConnecting = false;
+      if (window.nws === socket) {
+        window.nws = undefined;
+      }
 
+      // A deliberate disconnect() detaches these handlers first, so reaching
+      // here always means an unexpected close (network drop) — try to reconnect.
       if (!evt.wasClean) {
-        // Disconnected due connection error
         console.log("nws trying to reconnect");
 
         setTimeout(() => {
@@ -140,12 +157,27 @@ export class NotificationsWebSocket {
       this.burstTimer = null;
     }
     this.pendingMessages.length = 0;
+    this.isConnecting = false;
 
-    if (window.nws !== undefined && this.isConnected) {
-      window.nws.close();
+    const socket = window.nws;
+    if (socket !== undefined) {
+      // Detach handlers first so this deliberate close does not trigger the
+      // reconnect path in onclose, and clear the global ref unconditionally so
+      // a socket caught mid-CONNECTING can't be orphaned — an orphaned ref
+      // would block every future connect() via the `window.nws !== undefined`
+      // guard.
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onclose = null;
+      socket.onerror = null;
+      try {
+        socket.close();
+      } catch {
+        // ignore — socket may already be closing/closed
+      }
       window.nws = undefined;
-      this.isConnected = false;
     }
+    this.isConnected = false;
   }
 
   public withActiveUser(activeUser: ActiveUser | null) {
@@ -201,49 +233,40 @@ export class NotificationsWebSocket {
 
   private toggleUiProp: (type: "login" | "notifications", value?: boolean) => void = () => {};
 
-  private async requestPermissionAndPlaySound(): Promise<NotificationPermission | "unsupported"> {
-    if (!("Notification" in window)) {
-      // Still play sound even without Notification API support
-      playNotificationSound();
-      return "unsupported";
-    }
-    const permission = await requestNotificationPermission();
-    if (permission === "granted") {
-      playNotificationSound();
-    }
-    return permission;
-  }
-
   private async flushPendingNotifications() {
     const messages = this.pendingMessages.splice(0);
     if (messages.length === 0) return;
 
-    const toastBody = messages.length === 1
-      ? messages[0]
-      : i18next.t("notifications.new-notifications-batch", { count: messages.length });
+    // Respect the browser notification permission. If the user hasn't granted
+    // it, stay completely silent — no popup, no sound, no auto-opening the
+    // notifications panel. The unread-count badge already refreshed in the
+    // background via the on-message callback. Forcing in-app toasts or sounds
+    // on people who declined notifications would annoy exactly the users who
+    // opted out. We read the current permission here (set once at connect time)
+    // rather than re-requesting it, so a message never triggers a prompt.
+    if (!("Notification" in window) || Notification.permission !== "granted") {
+      return;
+    }
 
-    const permission = await this.requestPermissionAndPlaySound();
-    if (permission === "granted") {
-      // Browser Notification API - no in-app toast to avoid duplication
-      const notification = new Notification(i18next.t("notification.popup-title"), {
-        body: toastBody,
-        icon: logo,
-      });
+    const toastBody =
+      messages.length === 1
+        ? messages[0]
+        : i18next.t("notifications.new-notifications-batch", { count: messages.length });
 
-      notification.onclick = () => {
-        if (!this.hasUiNotifications) {
-          this.toggleUiProp("notifications");
-        }
-      };
-    } else {
-      // No browser permission - show in-app toast instead
-      info(toastBody);
+    playNotificationSound();
 
-      // Open the notifications panel if it's not already visible
+    // `new Notification` can throw on some mobile browsers (requires a service
+    // worker); the caller's `.catch` handles that gracefully.
+    const notification = new Notification(i18next.t("notification.popup-title"), {
+      body: toastBody,
+      icon: logo
+    });
+
+    notification.onclick = () => {
       if (!this.hasUiNotifications) {
         this.toggleUiProp("notifications");
       }
-    }
+    };
   }
 
   private queueNotification(msg: string) {

--- a/apps/web/src/features/push-notifications/index.tsx
+++ b/apps/web/src/features/push-notifications/index.tsx
@@ -32,6 +32,12 @@ export function PushNotificationsProvider({ children }: PropsWithChildren) {
       wasMutedPreviously
     )
   );
+  // Latest settings snapshot for the FCM callback, which is registered once
+  // inside init() and would otherwise read a stale closure (ignoring later type
+  // toggles or the global allows_notify switch).
+  const notificationSettingsRef = useRef(notificationsSettingsQuery.data);
+  notificationSettingsRef.current = notificationsSettingsQuery.data;
+
   const notificationUnreadCountQuery = useQuery(
     getNotificationsUnreadCountQueryOptions(
       activeUser?.username,
@@ -92,12 +98,17 @@ export function PushNotificationsProvider({ children }: PropsWithChildren) {
 
       if (isFbMessagingSupported && permission === "granted") {
         listenFCM((payload: MessagePayload) => {
+          const settings = notificationSettingsRef.current;
           const notifyType = wsRef.current.getNotificationType(payload.data?.type ?? "");
-          const allowed =
-            typeof notifyType === "number" && notificationsSettingsQuery.data?.notify_types
-              ? notificationsSettingsQuery.data.notify_types.includes(notifyType)
+          const typeAllowed =
+            typeof notifyType === "number" &&
+            settings?.notify_types &&
+            settings.notify_types.length > 0
+              ? settings.notify_types.includes(notifyType)
               : true;
-          if (allowed) {
+          // Mirror the websocket gating: respect the global switch and the
+          // latest per-type set (empty/unset → allow all).
+          if (Boolean(settings?.allows_notify) && typeAllowed) {
             playNotificationSound();
           }
           notificationUnreadCountQuery.refetch();

--- a/apps/web/src/features/push-notifications/index.tsx
+++ b/apps/web/src/features/push-notifications/index.tsx
@@ -15,11 +15,9 @@ import {
 import { isSupported, MessagePayload } from "@firebase/messaging";
 import { useQuery } from "@tanstack/react-query";
 import { PropsWithChildren, useCallback, useEffect, useRef } from "react";
-import usePrevious from "react-use/lib/usePrevious";
 
 export function PushNotificationsProvider({ children }: PropsWithChildren) {
   const { activeUser } = useActiveAccount();
-  const previousActiveUsr = usePrevious(activeUser);
   const wsRef = useRef(new NotificationsWebSocket());
   const setFbSupport = useGlobalStore((state) => state.setFbSupport);
 
@@ -125,23 +123,33 @@ export function PushNotificationsProvider({ children }: PropsWithChildren) {
     ]
   );
 
+  // Keep the latest `init` in a ref so the connection lifecycle effect below
+  // does NOT depend on `init`'s identity. `init` is recreated on every
+  // react-query refetch (its deps include the query result objects), so if the
+  // effect depended on it, the 60s unread-count poll — and even the socket's
+  // own on-message refetch — would re-run the effect, fire its cleanup, and
+  // tear the socket down with no reconnect for the same user. Browsers without
+  // FCM (e.g. Brave) rely on this socket staying alive, so this keeps it up.
+  const initRef = useRef(init);
+  initRef.current = init;
+
   useEffect(() => {
     const ws = wsRef.current;
-    if (!activeUser?.username && previousActiveUsr?.username) {
-      ws.disconnect();
-    }
-    if (activeUser && activeUser.username !== previousActiveUsr?.username) {
-      ws.disconnect();
+    const username = activeUser?.username;
 
+    // Runs only when the username actually changes (login / logout / switch).
+    // The cleanup disconnects the previous user's socket before we connect the
+    // next one, and on unmount.
+    if (username) {
       (async () => {
-        await init(activeUser.username);
+        await initRef.current(username);
       })();
     }
 
     return () => {
       ws.disconnect();
     };
-  }, [activeUser?.username, previousActiveUsr?.username, init]);
+  }, [activeUser?.username]);
 
   return children;
 }

--- a/apps/web/src/features/push-notifications/index.tsx
+++ b/apps/web/src/features/push-notifications/index.tsx
@@ -20,6 +20,8 @@ export function PushNotificationsProvider({ children }: PropsWithChildren) {
   const { activeUser } = useActiveAccount();
   const wsRef = useRef(new NotificationsWebSocket());
   const setFbSupport = useGlobalStore((state) => state.setFbSupport);
+  const toggleUiProp = useGlobalStore((state) => state.toggleUiProp);
+  const uiNotifications = useGlobalStore((state) => state.uiNotifications);
 
   // Safely check if notifications were muted previously
   // Returns true if muted, false if not muted or if localStorage is unavailable
@@ -114,12 +116,10 @@ export function PushNotificationsProvider({ children }: PropsWithChildren) {
           notificationUnreadCountQuery.refetch();
         });
       } else {
-        const hasUi = permission !== "granted";
         await wsRef.current
           .withActiveUser(activeUser)
           .setEnabledNotificationsTypes(settingsData?.notify_types ?? [])
           .setHasNotifications(Boolean(settingsData?.allows_notify))
-          .setHasUiNotifications(hasUi)
           .withCallbackOnMessage(() => notificationUnreadCountQuery.refetch())
           .connect();
       }
@@ -178,6 +178,14 @@ export function PushNotificationsProvider({ children }: PropsWithChildren) {
       )
       .setHasNotifications(Boolean(notificationsSettingsQuery.data?.allows_notify));
   }, [notificationsSettingsQuery.data]);
+
+  // Keep the panel-toggle wiring and the live panel-open state on the socket
+  // instance. This provider's instance owns the live socket on the websocket
+  // path, so without this an OS notification's onclick would be a no-op — and a
+  // stale open-state would close the panel instead of opening it.
+  useEffect(() => {
+    wsRef.current.withToggleUi(toggleUiProp).setHasUiNotifications(uiNotifications);
+  }, [toggleUiProp, uiNotifications]);
 
   return children;
 }

--- a/apps/web/src/features/push-notifications/index.tsx
+++ b/apps/web/src/features/push-notifications/index.tsx
@@ -19,6 +19,10 @@ import { PropsWithChildren, useCallback, useEffect, useRef } from "react";
 export function PushNotificationsProvider({ children }: PropsWithChildren) {
   const { activeUser } = useActiveAccount();
   const wsRef = useRef(new NotificationsWebSocket());
+  // Always-current active user, read inside init()'s async continuation to
+  // detect a logout/switch that happened while its awaits were in flight.
+  const activeUserRef = useRef(activeUser);
+  activeUserRef.current = activeUser;
   const setFbSupport = useGlobalStore((state) => state.setFbSupport);
   const toggleUiProp = useGlobalStore((state) => state.toggleUiProp);
   const uiNotifications = useGlobalStore((state) => state.uiNotifications);
@@ -98,6 +102,15 @@ export function PushNotificationsProvider({ children }: PropsWithChildren) {
         });
       }
 
+      // If the user logged out or switched accounts during the awaits above,
+      // bail instead of wiring up notifications for a stale user. The logout/
+      // switch effect has already disconnected; resuming here would otherwise
+      // re-set the stale user and reconnect as them.
+      const currentUser = activeUserRef.current;
+      if (!currentUser || currentUser.username !== username) {
+        return;
+      }
+
       if (isFbMessagingSupported && permission === "granted") {
         listenFCM((payload: MessagePayload) => {
           const settings = notificationSettingsRef.current;
@@ -117,7 +130,7 @@ export function PushNotificationsProvider({ children }: PropsWithChildren) {
         });
       } else {
         await wsRef.current
-          .withActiveUser(activeUser)
+          .withActiveUser(currentUser)
           .setEnabledNotificationsTypes(settingsData?.notify_types ?? [])
           .setHasNotifications(Boolean(settingsData?.allows_notify))
           .withCallbackOnMessage(() => notificationUnreadCountQuery.refetch())

--- a/apps/web/src/features/push-notifications/index.tsx
+++ b/apps/web/src/features/push-notifications/index.tsx
@@ -5,7 +5,7 @@ import { useUpdateNotificationsSettings } from "@/api/mutations";
 import { NotificationsWebSocket } from "@/api/notifications-ws-api";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useGlobalStore } from "@/core/global-store";
-import { ALL_NOTIFY_TYPES } from "@/enums";
+import { ALL_NOTIFY_TYPES, NotifyTypes } from "@/enums";
 import { getAccessToken, playNotificationSound } from "@/utils";
 import * as ls from "@/utils/local-storage";
 import {
@@ -107,7 +107,7 @@ export function PushNotificationsProvider({ children }: PropsWithChildren) {
         await wsRef.current
           .withActiveUser(activeUser)
           .setEnabledNotificationsTypes(settingsData?.notify_types ?? [])
-          .setHasNotifications(true)
+          .setHasNotifications(Boolean(settingsData?.allows_notify))
           .setHasUiNotifications(hasUi)
           .withCallbackOnMessage(() => notificationUnreadCountQuery.refetch())
           .connect();
@@ -144,12 +144,29 @@ export function PushNotificationsProvider({ children }: PropsWithChildren) {
       (async () => {
         await initRef.current(username);
       })();
+    } else {
+      // Logged out: clear the active user so a pending reconnect timer can't
+      // revive the socket, then close it.
+      ws.withActiveUser(null).disconnect();
     }
 
     return () => {
       ws.disconnect();
     };
   }, [activeUser?.username]);
+
+  // Keep the live socket's gating in sync when the user changes notification
+  // settings WITHOUT reconnecting. The lifecycle effect above only runs on
+  // username change, so without this a toggled type — or the global on/off —
+  // wouldn't take effect until reload/account switch. onMessageReceive reads
+  // these fields on each incoming message, so updating them in place is enough.
+  useEffect(() => {
+    wsRef.current
+      .setEnabledNotificationsTypes(
+        (notificationsSettingsQuery.data?.notify_types as NotifyTypes[]) ?? []
+      )
+      .setHasNotifications(Boolean(notificationsSettingsQuery.data?.allows_notify));
+  }, [notificationsSettingsQuery.data]);
 
   return children;
 }

--- a/apps/web/src/features/shared/notification-handler.tsx
+++ b/apps/web/src/features/shared/notification-handler.tsx
@@ -20,7 +20,6 @@ export function NotificationHandler() {
 
   const { activeUser } = useActiveAccount();
   const uiNotifications = useGlobalStore((state) => state.uiNotifications);
-  const globalNotifications = useGlobalStore((state) => state.globalNotifications);
   const toggleUIProp = useGlobalStore((state) => state.toggleUiProp);
   const fbSupport = useGlobalStore((state) => state.fbSupport);
 
@@ -54,8 +53,8 @@ export function NotificationHandler() {
       .withCallbackOnMessage(() => refetchAllRef.current())
       .withToggleUi(toggleUIProp)
       .setHasUiNotifications(uiNotifications)
-      .setHasNotifications(globalNotifications);
-  }, [activeUser, globalNotifications, toggleUIProp, uiNotifications]);
+      .setHasNotifications(Boolean(notificationsSettingsQuery.data?.allows_notify));
+  }, [activeUser, notificationsSettingsQuery.data, toggleUIProp, uiNotifications]);
 
   useEffect(() => {
     nws.current.setEnabledNotificationsTypes(

--- a/apps/web/src/features/shared/notifications/index.tsx
+++ b/apps/web/src/features/shared/notifications/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
 import { NotificationsContent } from "@/features/shared/notifications/notifications-content";
 import "./_index.scss";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
@@ -19,11 +18,12 @@ export function NotificationsDialog({ openLinksInNewTab = false }: Props) {
   const showNotifications = useGlobalStore((state) => state.uiNotifications);
   const toggleUIProp = useGlobalStore((state) => state.toggleUiProp);
 
-  const [show, setShow] = useState(false);
-
-  useEffect(() => {
-    setShow(showNotifications && !!activeUser);
-  }, [showNotifications, activeUser]);
+  // Drive the modal directly from the global store — the single source of
+  // truth. A mirrored local `show` (synced via effect) leaves a one-render
+  // window where it's still stale `false`; the base Modal then fires its
+  // `onHide` effect and resets `uiNotifications` right after the bell set it,
+  // so the click appears to do nothing and a second click is needed.
+  const show = showNotifications && !!activeUser;
 
   return (
     <EcencyConfigManager.Conditional
@@ -32,10 +32,7 @@ export function NotificationsDialog({ openLinksInNewTab = false }: Props) {
       <ModalSidebar
         className={`notifications-modal min-w-[90%] md:min-w-[32rem] [&_.ecency-sidebar]:overflow-hidden ${openLinksInNewTab ? "in-decks-page" : ""}`}
         show={show}
-        setShow={(v) => {
-          setShow(v);
-          toggleUIProp("notifications", v);
-        }}
+        setShow={(v) => toggleUIProp("notifications", v)}
         placement="right"
       >
         <NotificationsContent openLinksInNewTab={openLinksInNewTab} />


### PR DESCRIPTION
## Problem

On browsers without FCM (e.g. Brave), the app falls back to the notification WebSocket. The socket connects, but notifications silently stop arriving after a few seconds — the connection is closed by the client and never comes back for the same logged-in user.

## Root cause

The connect/disconnect effect in `PushNotificationsProvider` depended on `init`, and `init`'s `useCallback` deps include the react-query result objects. Those objects get a new identity on every refetch — the 60s unread-count poll, window-focus refetch, and the socket's own on-message refetch. Each refetch ⇒ new `init` ⇒ the effect re-runs ⇒ its cleanup calls `disconnect()`. For the same user the effect never calls `connect()` again, and a deliberate close doesn't hit the reconnect path, so the socket stays dead.

Because the connection is kept alive on the server side, the client should only ever close it intentionally — so this churn was the sole reason it dropped.

## Changes

- **`push-notifications/index.tsx`** — hold `init` in a ref so the lifecycle effect no longer depends on its identity. The effect now runs only on login / logout / account switch (and unmount). Refetches no longer tear the socket down. Removed the now-unused `usePrevious`.
- **`notifications-ws-api.ts`**
  - `disconnect()` detaches the socket handlers before closing (so a deliberate close can't trigger the reconnect path) and clears the global socket ref unconditionally. Previously a socket closed while still `CONNECTING` was left dangling and permanently blocked future `connect()` calls via the `window.nws !== undefined` guard.
  - Added an `isConnecting` guard to prevent duplicate sockets across the async permission prompt.
  - `onclose` reconnects only on genuinely unexpected closes (network drops).
  - **Permission is now respected for display:** a popup/sound only fires when `Notification.permission === "granted"`; otherwise the client stays silent and just lets the unread badge update. The old fallback fired an in-app toast + sound + auto-opened the panel even when permission was *not* granted, which annoyed users who had opted out. Notifications stay controllable via settings and the browser permission.

## How to test

In Brave (or Chrome with notifications **denied** so it takes the WebSocket path): log in, open DevTools → Network → WS, and confirm the notification WebSocket **stays open past 60+ seconds** (across the unread-count poll) instead of closing shortly after connecting. With permission **granted**, incoming notifications should produce a single OS notification + sound; with permission not granted, no popup/sound, but the unread badge still updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents overlapping WebSocket connect attempts during permission prompts and ensures clean disconnects on user changes.
  * More reliable reconnect/cleanup behavior when switching accounts or logging out.

* **New Features**
  * Notifications now batch pending messages into a single system notification and play sound when allowed; clicking opens the in-app notifications panel if UI toasts are disabled.
  * Notification preferences now respect per-type toggles (including favorites and bookmarks).

* **Refactor**
  * Simplified notification UI state handling to rely on settings and global store directly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->