### PR TITLE
fix(ui/modal): only call onHide on a real open→close transition

### DIFF
--- a/apps/web/src/features/ui/modal/index.tsx
+++ b/apps/web/src/features/ui/modal/index.tsx
@@ -42,6 +42,10 @@ export function Modal(props: Omit<HTMLProps<HTMLDivElement>, "size"> & Props) {
   const showRef = useRef(show);
   showRef.current = show;
 
+  // Holds the previous internal `show` so onHide() fires only on a genuine
+  // open→close transition (see the effect below). Updated inside that effect.
+  const prevShowRef = useRef(show);
+
   useEffect(() => {
     const onKeyUp = (e: KeyboardEvent) => {
       if (e.key === "Escape" && showRef.current === true) {
@@ -59,10 +63,18 @@ export function Modal(props: Omit<HTMLProps<HTMLDivElement>, "size"> & Props) {
   }, [props.show]);
 
   useEffect(() => {
-    if (typeof show === "boolean") {
-      if (!show) {
-        props.onHide();
-      }
+    const prevShow = prevShowRef.current;
+    prevShowRef.current = show;
+
+    // Notify the parent only when the modal actually transitions from open to
+    // closed (backdrop click, ESC, or the parent clearing `show`). Previously
+    // this fired whenever `show` was false — including the initial
+    // undefined→false settle — so onHide() ran on mount for every closed modal,
+    // resetting state in parents whose onHide has side effects (e.g. the
+    // notifications dialog toggling its global store flag, which made the
+    // navbar bell need a second click).
+    if (prevShow === true && show === false) {
+      props.onHide();
     }
   }, [show]);
 


### PR DESCRIPTION
## Problem

The base `Modal` notified its parent from an effect whenever its internal `show` was falsy:

```js
useEffect(() => {
  if (typeof show === "boolean") {
    if (!show) props.onHide();
  }
}, [show]);
```

`show` starts `undefined` and settles to `props.show` via another effect. For a modal that mounts closed, that's an `undefined → false` transition — which trips this effect and calls `props.onHide()` **on mount**. Every closed modal in the app therefore fires `onHide()` once at mount, which resets state in any parent whose `onHide` has side effects.

The visible symptom: the navbar notifications bell intermittently needed a second click. The notifications dialog's `onHide` toggles the global `uiNotifications` flag; the freshly-mounted Modal's spurious `onHide` reset that flag right after the bell set it, so the click appeared to do nothing.

## Fix

Track the previous internal `show` and call `onHide()` only on a genuine **open → close** transition (`true → false`) — backdrop click, ESC, or the parent clearing `show`. The `undefined → false` mount settle (and any `false → false`) no longer fires it.

Real closes are unchanged; only the spurious mount-time call is removed.

## Scope / blast radius

This is the shared base `Modal`, used across the app. The change only *removes* a spurious `onHide()` call on mount — it doesn't change behavior for actual closes, so consumers that rely on `onHide` firing when the modal closes are unaffected. Consumers that were quietly receiving a no-op `onHide()` at mount simply stop receiving it.

## Relationship to #825

Independent of #825 (the notification-websocket + bell-dialog fixes). #825 already works around this from the dialog side (single source of truth); this addresses the root cause in `Modal` so the whole class of bug can't recur for other modals. Either can merge on its own.
