### PR TITLE
fix(notifications): show in-app toast in foreground (OS notification was suppressed)

### DIFF
--- a/apps/web/src/api/notifications-ws-api.ts
+++ b/apps/web/src/api/notifications-ws-api.ts
@@ -305,8 +305,14 @@ export class NotificationsWebSocket {
     // — the in-app toast doesn't need OS permission, it's in-page feedback.
     const inBackground = typeof document !== "undefined" && document.hidden;
 
-    if (permissionGranted && inBackground) {
-      // `new Notification` can throw on some mobile browsers (requires a service
+    if (!inBackground) {
+      // Foreground: the in-app toast renders reliably in-page.
+      info(toastBody);
+    } else if (permissionGranted) {
+      // Backgrounded tab with OS permission: the OS notification is the only
+      // thing the user can actually see right now. (An in-app toast would fire
+      // into the hidden tab and auto-dismiss before they return.) `new
+      // Notification` can throw on some mobile browsers (requires a service
       // worker); the caller's `.catch` handles that gracefully.
       const notification = new Notification(i18next.t("notification.popup-title"), {
         body: toastBody,
@@ -318,9 +324,10 @@ export class NotificationsWebSocket {
           this.toggleUiProp("notifications");
         }
       };
-    } else {
-      info(toastBody);
     }
+    // Backgrounded tab without OS permission: nothing useful to show now — an
+    // in-app toast would expire unseen. The unread-count badge already
+    // refreshed, so the count is correct when the user returns.
 
     // Play the sound only when OS permission was granted, so we don't add sound
     // for users who declined notifications at the browser level.

--- a/apps/web/src/api/notifications-ws-api.ts
+++ b/apps/web/src/api/notifications-ws-api.ts
@@ -3,6 +3,7 @@ import { ActiveUser, WsNotification } from "@/entities";
 import { NotifyTypes } from "@/enums";
 import i18next from "i18next";
 import { playNotificationSound, requestNotificationPermission } from "@/utils";
+import { info } from "@/features/shared/feedback/feedback-events";
 import logo from "@/assets/img/logo-circle.svg";
 
 declare var window: Window & {
@@ -287,38 +288,45 @@ export class NotificationsWebSocket {
     const messages = this.pendingMessages.splice(0);
     if (messages.length === 0) return;
 
-    // Respect the browser notification permission. If the user hasn't granted
-    // it, stay completely silent — no popup, no sound, no auto-opening the
-    // notifications panel. The unread-count badge already refreshed in the
-    // background via the on-message callback. Forcing in-app toasts or sounds
-    // on people who declined notifications would annoy exactly the users who
-    // opted out. We read the current permission here (set once at connect time)
-    // rather than re-requesting it, so a message never triggers a prompt.
-    if (!("Notification" in window) || Notification.permission !== "granted") {
-      return;
-    }
-
     const toastBody =
       messages.length === 1
         ? messages[0]
         : i18next.t("notifications.new-notifications-batch", { count: messages.length });
 
-    // `new Notification` can throw on some mobile browsers (requires a service
-    // worker); the caller's `.catch` handles that gracefully. Construct it
-    // before playing the sound so we never play a sound without a visible
-    // notification.
-    const notification = new Notification(i18next.t("notification.popup-title"), {
-      body: toastBody,
-      icon: logo
-    });
+    const permissionGranted =
+      "Notification" in window && Notification.permission === "granted";
 
-    notification.onclick = () => {
-      if (!this.hasUiNotifications) {
-        this.toggleUiProp("notifications");
-      }
-    };
+    // The websocket only fires while the tab is open, and desktop browsers/OSes
+    // routinely suppress page-created OS notifications for a focused tab — so an
+    // OS notification here would fire into the void. Use it only when the tab is
+    // actually backgrounded; in the foreground show the in-app toast, which
+    // renders reliably. Delivery is already gated upstream by the user's
+    // settings (allows_notify + per-type), so reaching here means they opted in
+    // — the in-app toast doesn't need OS permission, it's in-page feedback.
+    const inBackground = typeof document !== "undefined" && document.hidden;
 
-    playNotificationSound();
+    if (permissionGranted && inBackground) {
+      // `new Notification` can throw on some mobile browsers (requires a service
+      // worker); the caller's `.catch` handles that gracefully.
+      const notification = new Notification(i18next.t("notification.popup-title"), {
+        body: toastBody,
+        icon: logo
+      });
+      notification.onclick = () => {
+        window.focus();
+        if (!this.hasUiNotifications) {
+          this.toggleUiProp("notifications");
+        }
+      };
+    } else {
+      info(toastBody);
+    }
+
+    // Play the sound only when OS permission was granted, so we don't add sound
+    // for users who declined notifications at the browser level.
+    if (permissionGranted) {
+      playNotificationSound();
+    }
   }
 
   private queueNotification(msg: string) {


### PR DESCRIPTION
## Problem

After #825, the websocket flush displayed an OS `new Notification()` only when permission was granted and dropped the in-app toast fallback. But the websocket `onmessage` fires while the tab is open, and desktop browsers/OSes routinely suppress page-created OS notifications for a focused tab. Result in production: the unread badge updates and the sound plays, but **no visible toast**.

## Fix

In `flushPendingNotifications`:
- **Foreground** (`!document.hidden`): show the in-app `info()` toast — it renders reliably in-page.
- **Background** (`document.hidden`) **+ permission granted**: use the OS `Notification` so it's seen outside the tab; no in-app toast (avoids duplicates). Click focuses the window and opens the panel.
- **Sound** plays only when OS permission was granted.

Delivery remains gated upstream by `allows_notify` + per-type, so users who opted out in settings still get nothing. The in-app toast is in-page feedback and intentionally does **not** require OS permission — the user opted in via settings; OS permission only governs the OS-level popup and sound.

## Notes

- Addresses the **websocket** path (Brave / no-FCM, or any granted-but-focused tab). The FCM foreground path (`handleMessage`) has the same characteristic; if toasts are also missing on Chrome/FCM, aligning that is a small follow-up.
- The in-app toast renders via the `<Feedback>` component, which is mounted on the major route layouts (home, entry, feed, community, profile, waves, chats, etc.) but not globally — a pre-existing limitation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification behavior to better respect browser permissions. OS notifications now only display when the tab is backgrounded and permission is granted. In-app notifications appear as fallback. Notification sounds only play when OS notification permission is enabled, preventing unwanted audio.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->