### PR TITLE
fix(post): guard react-tweet rendering with an error boundary + bump to 3.3.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -119,7 +119,7 @@
     "react-resize-detector": "^7.1.2",
     "react-sortablejs": "^6.1.4",
     "react-textarea-autosize": "^8.5.3",
-    "react-tweet": "^3.2.2",
+    "react-tweet": "^3.3.0",
     "react-twitter-embed": "^4.0.4",
     "react-use": "^17.4.2",
     "react-virtualized": "^9.22.5",

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-body-viewer.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-body-viewer.tsx
@@ -3,51 +3,12 @@
 import { Entry } from "@/entities";
 import { SelectionPopover } from "./selection-popover";
 import { EntryPageViewerManager } from "./entry-page-viewer-manager";
-import dynamic from "next/dynamic";
 import { useContext, useEffect, useState } from "react";
+import { SafeTweet } from "@/features/shared/safe-tweet";
 import TransactionSigner from "@/features/shared/transactions/transaction-signer";
 import { EntryPageContext } from "./context";
 import { EntryPageEdit } from "./entry-page-edit";
 import { makeEntryPath } from "@/utils";
-
-// Twitter embed component with error handling for ChunkLoadError
-const Tweet = dynamic(
-  () =>
-    import("react-tweet")
-      .then((m) => m.Tweet)
-      .catch((error) => {
-        // Handle ChunkLoadError gracefully (network issues, CDN problems, iOS Safari strict policies)
-        console.error("Failed to load react-tweet component:", error);
-        // Return a proper fallback component
-        return {
-          default: ({ id }: { id: string }) => (
-            <div
-              style={{
-                padding: "16px",
-                border: "1px solid #e1e8ed",
-                borderRadius: "8px",
-                backgroundColor: "#f7f9fa",
-                color: "#657786",
-                textAlign: "center",
-              }}
-            >
-              Failed to load tweet. View on Twitter:{" "}
-              <a
-                href={`https://twitter.com/i/status/${id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ color: "#1da1f2" }}
-              >
-                https://twitter.com/i/status/{id}
-              </a>
-            </div>
-          ),
-        };
-      }),
-  {
-    ssr: false,
-  }
-);
 
 interface Props {
   entry: Entry;
@@ -136,7 +97,7 @@ export function EntryPageBodyViewer({ entry }: Props) {
             onHiveOperationClick: (op) => {
               setSigningOperation(op);
             },
-            TwitterComponent: Tweet,
+            TwitterComponent: SafeTweet,
             images: entry.json_metadata?.image,
           });
         } catch (e) {

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1,4 +1,8 @@
 {
+  "tweet": {
+    "load-failed": "Couldn't load this post.",
+    "view-on-x": "View on X"
+  },
   "g": {
     "now": "Now",
     "all": "All",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1,6 +1,6 @@
 {
   "tweet": {
-    "load-failed": "Couldn't load this post.",
+    "load-failed": "Couldn't load this X post.",
     "view-on-x": "View on X"
   },
   "g": {

--- a/apps/web/src/features/shared/post-content-renderer.tsx
+++ b/apps/web/src/features/shared/post-content-renderer.tsx
@@ -3,7 +3,7 @@
 import { EcencyRenderer } from "@/features/post-renderer";
 import type { RenderOptions, SeoContext } from "@ecency/render-helper";
 import { HTMLProps, memo, useCallback, useMemo, useState } from "react";
-import { Tweet } from "react-tweet";
+import { SafeTweet } from "./safe-tweet";
 import TransactionSigner from "./transactions/transaction-signer";
 
 const MemoizedEcencyRenderer = memo(EcencyRenderer);
@@ -84,7 +84,7 @@ export function PostContentRenderer({
         {...(restProps as any)}
         onClick={handleClick}
         onHiveOperationClick={handleHiveOperationClick}
-        TwitterComponent={Tweet}
+        TwitterComponent={SafeTweet}
       />
       <TransactionSigner
         show={!!signingOperation}

--- a/apps/web/src/features/shared/safe-tweet.tsx
+++ b/apps/web/src/features/shared/safe-tweet.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Component, ReactNode } from "react";
+import dynamic from "next/dynamic";
+import i18next from "i18next";
+
+function TweetFallback({ id }: { id: string }) {
+  return (
+    <div className="er-twitter-fallback my-2 rounded-lg border border-[--border-color] p-4 text-center text-sm text-gray-600 dark:text-gray-400">
+      {i18next.t("tweet.load-failed")}{" "}
+      <a
+        className="text-blue-500 hover:underline"
+        href={`https://x.com/i/status/${id}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {i18next.t("tweet.view-on-x")}
+      </a>
+    </div>
+  );
+}
+
+// Lazy-load react-tweet's client component. The .catch only covers chunk-load
+// failures (network / CDN / iOS Safari strict policies) — render-time throws are
+// handled by the error boundary below.
+const Tweet = dynamic<{ id: string }>(
+  () =>
+    import("react-tweet")
+      .then((m) => ({ default: m.Tweet }))
+      .catch((error) => {
+        console.error("Failed to load react-tweet component:", error);
+        return { default: TweetFallback };
+      }),
+  { ssr: false }
+);
+
+interface BoundaryProps {
+  id: string;
+  children: ReactNode;
+}
+
+class TweetErrorBoundary extends Component<BoundaryProps, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    // react-tweet throws inside its own render when X's syndication data shape
+    // shifts (a field it iterates becomes undefined). Catch it so one
+    // unavailable/changed tweet degrades to a link instead of crashing the post.
+    console.error("react-tweet render failed:", error);
+  }
+
+  render() {
+    return this.state.hasError ? <TweetFallback id={this.props.id} /> : this.props.children;
+  }
+}
+
+/**
+ * Drop-in for react-tweet's `<Tweet>`: lazy-loads it (with a chunk-load
+ * fallback) and wraps it in an error boundary so a render-time throw shows a
+ * fallback link instead of breaking the surrounding post. Used as the
+ * renderer's `TwitterComponent` and in post enhancements.
+ */
+export function SafeTweet({ id }: { id: string }) {
+  return (
+    <TweetErrorBoundary key={id} id={id}>
+      <Tweet id={id} />
+    </TweetErrorBoundary>
+  );
+}

--- a/apps/web/src/features/shared/safe-tweet.tsx
+++ b/apps/web/src/features/shared/safe-tweet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Component, ReactNode } from "react";
+import { Component, ErrorInfo, ReactNode } from "react";
 import dynamic from "next/dynamic";
 import i18next from "i18next";
 
@@ -46,11 +46,11 @@ class TweetErrorBoundary extends Component<BoundaryProps, { hasError: boolean }>
     return { hasError: true };
   }
 
-  componentDidCatch(error: Error) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     // react-tweet throws inside its own render when X's syndication data shape
     // shifts (a field it iterates becomes undefined). Catch it so one
     // unavailable/changed tweet degrades to a link instead of crashing the post.
-    console.error("react-tweet render failed:", error);
+    console.error("react-tweet render failed:", error, errorInfo);
   }
 
   render() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,8 +531,8 @@ importers:
         specifier: ^8.5.3
         version: 8.5.9(@types/react@19.2.8)(react@19.2.3)
       react-tweet:
-        specifier: ^3.2.2
-        version: 3.2.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^3.3.0
+        version: 3.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-twitter-embed:
         specifier: ^4.0.4
         version: 4.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -3602,9 +3602,6 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
-
-  '@swc/helpers@0.5.17':
-    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
 
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
@@ -7577,8 +7574,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-tweet@3.2.2:
-    resolution: {integrity: sha512-hIkxAVPpN2RqWoDEbo3TTnN/pDcp9/Jb6pTgiA4EbXa9S+m2vHIvvZKHR+eS0PDIsYqe+zTmANRa5k6+/iwGog==}
+  react-tweet@3.3.0:
+    resolution: {integrity: sha512-gSIG2169ZK7UH6rBzuU+j1xnQbH3IlOTLEkuGrRiJJTMgETik+h+26yHyyVKrLkzwrOaYPk4K3OtEKycqKgNLw==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -12882,10 +12879,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@swc/helpers@0.5.17':
-    dependencies:
-      tslib: 2.8.1
-
   '@swc/helpers@0.5.18':
     dependencies:
       tslib: 2.8.1
@@ -13912,7 +13905,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(@vitest/ui@3.2.4)(jiti@1.21.7)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0)
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -17309,9 +17302,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  react-tweet@3.2.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-tweet@3.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@swc/helpers': 0.5.17
+      '@swc/helpers': 0.5.21
       clsx: 2.1.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)


### PR DESCRIPTION
## Problem

`react-tweet@3.2.2` throws inside its minified `dist/utils.js` (function `c`) when rendering an embedded tweet whose X syndication data shape changed (a field it iterates is now `undefined`). The embed wasn't wrapped in an error boundary, so one failing tweet crashed the post body.

Sentry: **~305 events / ~240 users** across two grouped issues since ~May 22:
- `122064590` — "undefined is not an object (evaluating 'r')" (Safari/WebKit)
- `121781008` — "r is not iterable" (Chrome/V8)

## Fix

- **`SafeTweet`** (`features/shared/safe-tweet.tsx`): lazy-loads react-tweet (`ssr: false`, same chunk-load fallback as before) and wraps it in an **error boundary**. A render-time throw now renders a fallback link ("View on X") instead of crashing the post.
- Wired as `TwitterComponent` in both the renderer (`post-content-renderer.tsx`) and post enhancements (`entry-page-body-viewer.tsx`). The dynamic import is **not** discarded — it's consolidated into `SafeTweet` (post-content-renderer previously imported `Tweet` statically, so it's now code-split too).
- Bumped `react-tweet` `^3.2.2` → `^3.3.0` — if upstream patched the parsing, tweets render again; the error boundary covers us either way.

## Notes

- Independent of the notification PRs.
- Fallback strings added to `en-US.json` (`tweet.load-failed`, `tweet.view-on-x`).
- Pre-existing react-dom peer warning (react-tweet lists `^16/17/18`, app is on 19) — unchanged by this bump.
