### PR TITLE
feat(notifications): make the notification toast clickable to open related content

### DIFF
--- a/apps/web/src/api/notifications-ws-api.ts
+++ b/apps/web/src/api/notifications-ws-api.ts
@@ -22,7 +22,7 @@ export class NotificationsWebSocket {
   private isConnecting = false;
   private socket: WebSocket | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private pendingMessages: string[] = [];
+  private pendingMessages: { body: string; link?: string }[] = [];
   private burstTimer: ReturnType<typeof setTimeout> | null = null;
 
   private static getBody(data: WsNotification) {
@@ -94,6 +94,45 @@ export class NotificationsWebSocket {
       }
       default:
         return "";
+    }
+  }
+
+  /**
+   * The in-app destination for a notification, or undefined when there's no
+   * specific target (clicking then just opens the panel). `target` is the
+   * recipient (the logged-in user), `source` is the actor.
+   */
+  private static getLink(data: WsNotification): string | undefined {
+    const toEntry = (author: string, permlink: string) => {
+      // Canonical entry URL is category-less: /@author/permlink.
+      if (!author || !permlink || permlink.trim().length === 0 || permlink === "undefined") {
+        return undefined;
+      }
+      return `/@${author}/${permlink.trim()}`;
+    };
+
+    switch (data.type) {
+      case "vote":
+      case "favorites":
+      case "bookmarks":
+      case "reblog":
+        // Action on the user's own content — author is the recipient (target).
+        return toEntry(data.target, data.extra.permlink);
+      case "mention":
+      case "reply":
+        // The mentioning/reply content is authored by the actor (source).
+        return toEntry(data.source, data.extra.permlink);
+      case "payouts":
+        return data.extra?.permlink ? toEntry(data.target, data.extra.permlink) : undefined;
+      case "follow":
+        return `/@${data.source}`;
+      case "transfer":
+      case "delegations":
+        return `/@${data.target}/wallet`;
+      default:
+        // checkins, monthly-posts, weekly_earnings, etc. have no specific
+        // destination.
+        return undefined;
     }
   }
 
@@ -288,10 +327,13 @@ export class NotificationsWebSocket {
     const messages = this.pendingMessages.splice(0);
     if (messages.length === 0) return;
 
+    const single = messages.length === 1 ? messages[0] : undefined;
     const toastBody =
-      messages.length === 1
-        ? messages[0]
-        : i18next.t("notifications.new-notifications-batch", { count: messages.length });
+      single?.body ??
+      i18next.t("notifications.new-notifications-batch", { count: messages.length });
+    // Only a single notification has an unambiguous destination; a batch has no
+    // single link, so its toast/notification just opens the panel on click.
+    const link = single?.link;
 
     const permissionGranted =
       "Notification" in window && Notification.permission === "granted";
@@ -306,8 +348,9 @@ export class NotificationsWebSocket {
     const inBackground = typeof document !== "undefined" && document.hidden;
 
     if (!inBackground) {
-      // Foreground: the in-app toast renders reliably in-page.
-      info(toastBody);
+      // Foreground: the in-app toast renders reliably in-page. Pass the link so
+      // clicking it navigates to the related content.
+      info(toastBody, link);
     } else if (permissionGranted) {
       // Backgrounded tab with OS permission: the OS notification is the only
       // thing the user can actually see right now. (An in-app toast would fire
@@ -320,7 +363,9 @@ export class NotificationsWebSocket {
       });
       notification.onclick = () => {
         window.focus();
-        if (!this.hasUiNotifications) {
+        if (link) {
+          window.location.href = link;
+        } else if (!this.hasUiNotifications) {
           this.toggleUiProp("notifications");
         }
       };
@@ -336,8 +381,8 @@ export class NotificationsWebSocket {
     }
   }
 
-  private queueNotification(msg: string) {
-    this.pendingMessages.push(msg);
+  private queueNotification(msg: string, link?: string) {
+    this.pendingMessages.push({ body: msg, link });
 
     // Start a fixed-window timer on the first message only.
     // Subsequent messages within the window are batched without resetting the timer.
@@ -384,6 +429,6 @@ export class NotificationsWebSocket {
       return;
     }
 
-    this.queueNotification(msg);
+    this.queueNotification(msg, NotificationsWebSocket.getLink(data));
   }
 }

--- a/apps/web/src/api/notifications-ws-api.ts
+++ b/apps/web/src/api/notifications-ws-api.ts
@@ -103,32 +103,36 @@ export class NotificationsWebSocket {
    * recipient (the logged-in user), `source` is the actor.
    */
   private static getLink(data: WsNotification): string | undefined {
-    const toEntry = (author: string, permlink: string) => {
-      // Canonical entry URL is category-less: /@author/permlink.
+    // Canonical entry URL is category-less: /@author/permlink. The helpers
+    // guard their inputs so a malformed/empty field never produces a bad route
+    // (e.g. "/@" or "/@/wallet"); `extra` is read with optional chaining so a
+    // malformed message can't throw and abort notification handling.
+    const toEntry = (author?: string, permlink?: string) => {
       if (!author || !permlink || permlink.trim().length === 0 || permlink === "undefined") {
         return undefined;
       }
       return `/@${author}/${permlink.trim()}`;
     };
+    const toProfile = (username?: string, suffix = "") =>
+      username ? `/@${username}${suffix}` : undefined;
 
     switch (data.type) {
       case "vote":
       case "favorites":
       case "bookmarks":
       case "reblog":
+      case "payouts":
         // Action on the user's own content — author is the recipient (target).
-        return toEntry(data.target, data.extra.permlink);
+        return toEntry(data.target, data.extra?.permlink);
       case "mention":
       case "reply":
         // The mentioning/reply content is authored by the actor (source).
-        return toEntry(data.source, data.extra.permlink);
-      case "payouts":
-        return data.extra?.permlink ? toEntry(data.target, data.extra.permlink) : undefined;
+        return toEntry(data.source, data.extra?.permlink);
       case "follow":
-        return `/@${data.source}`;
+        return toProfile(data.source);
       case "transfer":
       case "delegations":
-        return `/@${data.target}/wallet`;
+        return toProfile(data.target, "/wallet");
       default:
         // checkins, monthly-posts, weekly_earnings, etc. have no specific
         // destination.

--- a/apps/web/src/features/shared/feedback/feedback-events.ts
+++ b/apps/web/src/features/shared/feedback/feedback-events.ts
@@ -54,11 +54,12 @@ export const success = (message: string) => {
   window.dispatchEvent(ev);
 };
 
-export const info = (message: string) => {
+export const info = (message: string, link?: string) => {
   const detail: FeedbackObject = {
     id: random(),
     type: "info",
-    message
+    message,
+    link
   };
   const ev = new CustomEvent("ecency-feedback", { detail });
   window.dispatchEvent(ev);
@@ -70,6 +71,8 @@ export interface FeedbackObject {
   id: string;
   type: FeedbackType;
   message: string;
+  /** Optional in-app destination; when set, the toast message is clickable. */
+  link?: string;
 }
 
 export interface ErrorFeedbackObject extends FeedbackObject {

--- a/apps/web/src/features/shared/feedback/feedback-message.tsx
+++ b/apps/web/src/features/shared/feedback/feedback-message.tsx
@@ -13,6 +13,7 @@ import { Button } from "@ui/button";
 import clsx from "clsx";
 import i18next from "i18next";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useCallback, useRef, useState } from "react";
 import { useMount, useUnmount } from "react-use";
 import * as Sentry from "@sentry/nextjs";
@@ -29,9 +30,11 @@ export function FeedbackMessage({ feedback, onClose }: Props) {
   // Use global store directly instead of useActiveAccount() to avoid QueryClient dependency
   // We only need the username for the purchase link, not the full account data
   const activeUser = useGlobalStore((s) => s.activeUser);
+  const router = useRouter();
 
   const [showDialog, setShowDialog] = useState(false);
   const errorType = (feedback as ErrorFeedbackObject).errorType;
+  const link = feedback.link;
 
   const handleClose = useCallback(() => {
     if (timeoutRef.current) {
@@ -86,7 +89,20 @@ export function FeedbackMessage({ feedback, onClose }: Props) {
               aria-label={i18next.t("g.close", { defaultValue: "Close" })}
             />
           </div>
-          <div className="text-gray-600 dark:text-gray-400">{feedback.message}</div>
+          {link ? (
+            <button
+              type="button"
+              className="block w-full text-left text-gray-600 dark:text-gray-400 hover:underline cursor-pointer"
+              onClick={() => {
+                handleClose();
+                router.push(link);
+              }}
+            >
+              {feedback.message}
+            </button>
+          ) : (
+            <div className="text-gray-600 dark:text-gray-400">{feedback.message}</div>
+          )}
           {errorType === ErrorTypes.INSUFFICIENT_RESOURCE_CREDITS && (
             <div className="mt-2 flex flex-col gap-2">
               <Link

--- a/apps/web/src/features/shared/feedback/feedback-message.tsx
+++ b/apps/web/src/features/shared/feedback/feedback-message.tsx
@@ -93,6 +93,8 @@ export function FeedbackMessage({ feedback, onClose }: Props) {
             <button
               type="button"
               className="block w-full text-left text-gray-600 dark:text-gray-400 hover:underline cursor-pointer"
+              onFocus={() => clearTimeout(timeoutRef.current)}
+              onBlur={() => initTimeout()}
               onClick={() => {
                 handleClose();
                 router.push(link);


### PR DESCRIPTION
## What

Clicking a notification toast now opens the related content. Previously the in-app toast (and the background OS notification) did nothing useful on click.

## How

- **`NotificationsWebSocket.getLink(data)`** maps a `WsNotification` to an in-app path (`target` = recipient, `source` = actor):
  - vote / favorites / bookmarks / reblog → recipient's content (`/@{target}/{permlink}`)
  - mention / reply → actor's content (`/@{source}/{permlink}`)
  - payouts → the post (when a permlink is present)
  - follow → `/@{source}`
  - transfer / delegations → `/@{target}/wallet`
  - checkins / monthly-posts / weekly-earnings → none (click just shows the toast / opens the panel)
  - Entry paths are **category-less** (`/@author/permlink`), matching the canonical URL format.
- The link rides through the 500ms burst queue. A **single** notification uses its link; a **batch** has no single destination, so it behaves as before.
- **Foreground**: the in-app toast message is now a clickable button → `router.push(link)` + dismiss.
- **Background**: the OS notification's `onclick` navigates via `window.location` (falls back to opening the panel when there's no link).
- The shared feedback `info()` helper gains an optional `link`; `FeedbackObject` carries it and `FeedbackMessage` renders a clickable message when set. Non-link toasts are unchanged.

## Notes

- Builds on #827 (merged). Independent of #828.
- Delivery gating is unchanged — the link only affects what happens on click.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications now support deep-linking, allowing users to navigate directly to relevant content when clicking a notification.
  * Info feedback messages can now include clickable links that navigate to relevant destinations.
  * Enhanced notification handling: clicking background notifications now navigates to the linked content, with fallback to notification panel toggle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->