### PR TITLE
fix(entry-stats): show visit duration directly instead of dividing it

### DIFF
--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -935,7 +935,6 @@
       "update-info": "Updating every minute",
       "visitors": "Visitors",
       "views": "Views",
-      "reads": "Read time",
       "avg-visit-duration": "Avg. visit",
       "countries": "Countries",
       "devices": "Devices",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -936,6 +936,7 @@
       "visitors": "Visitors",
       "views": "Views",
       "reads": "Read time",
+      "avg-visit-duration": "Avg. visit",
       "countries": "Countries",
       "devices": "Devices",
       "referrers": "Referrers",

--- a/apps/web/src/features/shared/entry-stats/index.tsx
+++ b/apps/web/src/features/shared/entry-stats/index.tsx
@@ -43,7 +43,8 @@ export function EntryStats({ entry }: Props) {
   const avgVisitDuration = useMemo(() => {
     const seconds = Math.round(stats?.results?.[0]?.metrics?.[2] ?? 0);
     const minutes = Math.floor(seconds / 60);
-    return `${minutes}m ${String(seconds % 60).padStart(2, "0")}s`;
+    const secs = seconds % 60;
+    return minutes > 0 ? `${minutes}m ${String(secs).padStart(2, "0")}s` : `${secs}s`;
   }, [stats?.results]);
 
   if (!activeUser) return null;

--- a/apps/web/src/features/shared/entry-stats/index.tsx
+++ b/apps/web/src/features/shared/entry-stats/index.tsx
@@ -36,10 +36,15 @@ export function EntryStats({ entry }: Props) {
   );
   const totalViews = useMemo(() => stats?.results?.[0].metrics[1] || 1, [stats?.results]);
   const totalVisitors = useMemo(() => stats?.results?.[0].metrics[0] || 0, [stats?.results]);
-  const averageReadTime = useMemo(
-    () => ((stats?.results?.[0].metrics[2] ?? 0) / totalViews).toFixed(1),
-    [stats?.results, totalViews]
-  );
+  // Plausible's `visit_duration` is already an average (in seconds), so it must
+  // be displayed as-is — dividing it by pageviews/visitors collapses it to a
+  // meaningless sub-second value. Note this is session-level visit duration, not
+  // per-page time (Plausible CE does not expose a `time_on_page` metric).
+  const avgVisitDuration = useMemo(() => {
+    const seconds = Math.round(stats?.results?.[0]?.metrics?.[2] ?? 0);
+    const minutes = Math.floor(seconds / 60);
+    return `${minutes}m ${String(seconds % 60).padStart(2, "0")}s`;
+  }, [stats?.results]);
 
   if (!activeUser) return null;
 
@@ -69,8 +74,8 @@ export function EntryStats({ entry }: Props) {
             <EntryPageStatsItem count={totalViews} label={i18next.t("entry.stats.views")} />
             <EntryPageStatsItem count={totalVisitors} label={i18next.t("entry.stats.visitors")} />
             <EntryPageStatsItem
-              count={`${averageReadTime}s`}
-              label={i18next.t("entry.stats.reads")}
+              count={avgVisitDuration}
+              label={i18next.t("entry.stats.avg-visit-duration")}
             />
           </div>
 


### PR DESCRIPTION
## Problem
The post stats modal (`EntryStats`) displayed its engagement figure as `visit_duration / pageviews`. Plausible's `visit_duration` is already an **average in seconds**, so dividing it by pageviews collapsed the value to a meaningless sub-second number (e.g. `0.1s`).

## Fix
- Show `visit_duration` directly, formatted as `Xm YYs`.
- Relabel **"Read time" → "Avg. visit"**, since this is session-level visit duration, not per-page reading time. (A true per-page read time would require a `time_on_page` metric, which the current Plausible CE does not expose.)

## Notes
- The stats query filters with `contains` on `author/permlink`, so it already aggregates both `/category/@user/permlink` and the newer `/@user/permlink` canonical forms — no change needed there.