### PR TITLE
Show Ecency source badge on post page

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-footer-info.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-footer-info.tsx
@@ -3,6 +3,7 @@ import i18next from "i18next";
 import { Tsx } from "@/features/i18n/helper";
 import { Entry } from "@/entities";
 import { accountReputation, appName, parseDate } from "@/utils";
+import Image from "next/image";
 import React from "react";
 
 interface Props {
@@ -12,6 +13,7 @@ interface Props {
 export function EntryFooterInfo({ entry }: Props) {
   const app = appName(entry.json_metadata?.app);
   const appShort = app.split("/")[0].split(" ")[0];
+  const isEcency = app.toLowerCase().includes("ecency");
   const reputation = accountReputation(entry.author_reputation ?? 0);
 
   return (
@@ -36,6 +38,15 @@ export function EntryFooterInfo({ entry }: Props) {
             <Tsx k="entry.via-app" args={{ app: appShort }}>
               <a href="/faq#source-label" />
             </Tsx>
+            {isEcency && (
+              <Image
+                className="ecency-source-badge inline-block align-text-bottom ml-1"
+                src="/assets/logo-circle.svg"
+                alt="Ecency"
+                width={14}
+                height={14}
+              />
+            )}
           </div>
         </>
       )}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-footer-info.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-footer-info.tsx
@@ -42,7 +42,7 @@ export function EntryFooterInfo({ entry }: Props) {
               <Image
                 className="ecency-source-badge inline-block align-text-bottom ml-1"
                 src="/assets/logo-circle.svg"
-                alt="Ecency"
+                alt=""
                 width={14}
                 height={14}
               />
@@ -50,7 +50,7 @@ export function EntryFooterInfo({ entry }: Props) {
           </div>
         </>
       )}
-        {app && app.indexOf('ecency')==-1 && (
+        {app && !isEcency && (
             <div className="post-disclaimer-print">
                 <Tsx k="entry.disclaimer" args={{ appName: appShort }}>
                     <a href="/faq#source-label" />


### PR DESCRIPTION
## What

Appends the circular Ecency logo right after the existing "via Ecency" source label in the entry footer, shown **only when the post was published via Ecency**. Posts from other apps are unchanged — their existing text source label stays as-is.

## Why

The post page already shows the source app in text, but a small brand mark makes Ecency-native content recognizable at a glance and gives our publishers a subtle "this is ours" signal.

## Details

- Single file: `entry-footer-info.tsx`.
- Reuses the existing `appName()` parse + the existing `/assets/logo-circle.svg`.
- Ecency check: `appName(...).toLowerCase().includes("ecency")`.
- Styled with Tailwind (`inline-block align-text-bottom ml-1`) at a fixed 14×14 so it flows inline with the text — no layout shift, no effect on wrapping at any breakpoint.

## Scope

- Post page only. Feed list items are intentionally left for a follow-up.

## Testing

- Verify on alpha after merge: open an Ecency-published post and a post from another app; the badge should appear only on the former, inline after "via Ecency", at both desktop and mobile widths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ecency app badge display next to the "via app" label for entries shared through the Ecency application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->