### PR TITLE
Run a single web replica on staging

### DIFF
--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -24,7 +24,10 @@ services:
     image: ecency/vision-next:develop
     stop_grace_period: 30s
     deploy:
-      replicas: 4
+      # Staging runs a single web replica — the staging environment serves
+      # low traffic and 4 replicas added unnecessary memory/CPU pressure.
+      # Production replica count lives in docker-compose.production.yml.
+      replicas: 1
       update_config:
         parallelism: 1
         delay: 15s


### PR DESCRIPTION
## What
Set the `web` service `replicas` to **1** in `apps/web/docker-compose.yml` (the staging compose).

## Why
The staging environment serves low traffic; running 4 web replicas added unnecessary memory and CPU pressure on the staging host for no benefit. `update_config: order: start-first` keeps deploys effectively zero-downtime even at a single replica.

## Production impact
**None.** Production replica count is defined separately in `docker-compose.production.yml`, which is unchanged (still 4).