### PR TITLE
Rename navbar Perks button label (Plus → Perks)

### DIFF
--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -261,7 +261,7 @@
     "boost": "Boost",
     "submit": "Create a post",
     "chats": "Chats",
-    "perks": "Plus"
+    "perks": "Perks"
   },
   "intro": {
     "title": "Aspire to greatness",

--- a/apps/web/src/features/shared/navbar/navbar-perks-button.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-perks-button.tsx
@@ -4,13 +4,14 @@ import { UilFire } from "@tooni/iconscout-unicons-react";
 import i18next from "i18next";
 
 export function NavbarPerksButton() {
+  const label = i18next.t("user-nav.perks");
   return (
     <Button
       href="/perks"
       icon={<UilFire />}
+      aria-label={label}
+      title={label}
       className="font-semibold flex whitespace-nowrap text-sm"
-    >
-      {i18next.t("user-nav.perks")}
-    </Button>
+    />
   );
 }


### PR DESCRIPTION
Relabels the navbar flame button from **Plus** to **Perks**. The button already uses the flame icon and links to `/perks` (now the quests + perks hub); this just makes the label match.

One-line change to `user-nav.perks` in en-US.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated UI label terminology for enhanced clarity and consistency across the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->