### PR TITLE
Point the streak/quests reminder notification to perks (web)

### DIFF
--- a/apps/web/public/firebase-messaging-sw.js
+++ b/apps/web/public/firebase-messaging-sw.js
@@ -37,14 +37,19 @@ self.addEventListener('notificationclick', function (event) {
   const data = event.notification.data;
   let url = 'https://ecency.com';
   const fullPermlink = data.permlink1 + data.permlink2 + data.permlink3;
-  if (['vote', 'unvote', 'spin', 'inactive'].includes(data.type)) {
-    url += '/@' + data.target;
+  if (data.target_page) {
+    // e.g. the perks/quests reminder -> open the perks page directly
+    url += '/' + data.target_page;
   } else {
-    // delegation, mention, transfer, follow, unfollow, ignore, blacklist, reblog
-    url += '/@' + data.source;
-  }
-  if (fullPermlink) {
-    url += '/' + fullPermlink;
+    if (['vote', 'unvote', 'spin', 'inactive'].includes(data.type)) {
+      url += '/@' + data.target;
+    } else {
+      // delegation, mention, transfer, follow, unfollow, ignore, blacklist, reblog
+      url += '/@' + data.source;
+    }
+    if (fullPermlink) {
+      url += '/' + fullPermlink;
+    }
   }
 
   clients.openWindow(url, '_blank');

--- a/apps/web/public/firebase-messaging-sw.js
+++ b/apps/web/public/firebase-messaging-sw.js
@@ -37,7 +37,10 @@ self.addEventListener('notificationclick', function (event) {
   const data = event.notification.data;
   let url = 'https://ecency.com';
   const fullPermlink = data.permlink1 + data.permlink2 + data.permlink3;
-  if (data.target_page) {
+  // Allowlist target pages so a forged/misconfigured push can't route to an arbitrary
+  // ecency.com path. Add new deep-link targets here as they're introduced.
+  const ALLOWED_TARGET_PAGES = ['perks'];
+  if (data.target_page && ALLOWED_TARGET_PAGES.includes(data.target_page)) {
     // e.g. the perks/quests reminder -> open the perks page directly
     url += '/' + data.target_page;
   } else {

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1924,7 +1924,7 @@
     "checkins-title": "Great streak on @{{username}}",
     "payouts-title": "You received a payout on @{{username}}",
     "monthly-posts-title": "Finishing the month strong, @{{username}}",
-    "spin-str": "Time to earn more Points, Play Spin!",
+    "spin-str": "Keep your streak alive, your daily quests are waiting!",
     "inactive-str": "Be active! Write a post, continue earning",
     "referral-str": "joined with referral, welcome them",
     "account-update-str": "Your account or profile were updated",


### PR DESCRIPTION
## What

The spin reminder has been repurposed (in enotify) into a daily **streak-at-risk / quests reminder**. This aligns the web side:

- **In-app notification:** already links to `/perks`; reworded its copy (`notifications.spin-str`) from *"Time to earn more Points, Play Spin!"* to *"Keep your streak alive, your daily quests are waiting!"*.
- **Push click (service worker):** `firebase-messaging-sw.js` now honors `custom_data.target_page` — the reminder sets `target_page: 'perks'`, so a push tap opens `/perks` instead of the user's profile (the old `spin` routing). Other notification types are unaffected.

Pairs with ecency/enotify-py#13 (the repurposed reminder, already deployed). Mobile deep-link follows separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification click handling with enhanced routing options for navigation
  * Updated daily quest notification message for clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->