### PR TITLE
Leaderboard: badge for completing all daily quests

### DIFF
--- a/apps/web/src/app/discover/@leaderboard/page.tsx
+++ b/apps/web/src/app/discover/@leaderboard/page.tsx
@@ -15,7 +15,7 @@ import {
   UserTableListHeader
 } from "@/app/discover/_components";
 import { Badge } from "@ui/badge";
-import { UilInfoCircle } from "@tooni/iconscout-unicons-react";
+import { UilCheckCircle, UilInfoCircle } from "@tooni/iconscout-unicons-react";
 import { medalSvg } from "@ui/svg";
 import { classNameObject } from "@ui/util";
 import { useParams, useSearchParams } from "next/navigation";
@@ -77,6 +77,11 @@ export default function LeaderboardPage({ searchParams }: Props) {
                   i={i}
                   key={i}
                 >
+                  {r.quests_done && (
+                    <Tooltip content={i18next.t("leaderboard.quests-done")}>
+                      <UilCheckCircle className="w-4 h-4 text-green-600" />
+                    </Tooltip>
+                  )}
                   <div className="text-blue-dark-sky text-sm font-semibold">
                     {r.points !== "0.000" && `${r.points} POINTS`}
                   </div>

--- a/apps/web/src/app/discover/@leaderboard/page.tsx
+++ b/apps/web/src/app/discover/@leaderboard/page.tsx
@@ -26,10 +26,9 @@ interface Props {
 
 export default function LeaderboardPage({ searchParams }: Props) {
   const params = useSearchParams();
+  const period = (params.get("period") as LeaderBoardDuration) ?? "day";
 
-  const { data } = useQuery(
-    getDiscoverLeaderboardQueryOptions((params.get("period") as LeaderBoardDuration) ?? "day")
-  );
+  const { data } = useQuery(getDiscoverLeaderboardQueryOptions(period));
 
   return (
     <HydrationBoundary state={dehydrate(getQueryClient())}>
@@ -77,7 +76,7 @@ export default function LeaderboardPage({ searchParams }: Props) {
                   i={i}
                   key={i}
                 >
-                  {r.quests_done && (
+                  {period === "day" && r.quests_done && (
                     <Tooltip content={i18next.t("leaderboard.quests-done")}>
                       <UilCheckCircle className="w-4 h-4 text-green-600" />
                     </Tooltip>

--- a/apps/web/src/entities/private-api/leader-board.ts
+++ b/apps/web/src/entities/private-api/leader-board.ts
@@ -2,6 +2,8 @@ export interface LeaderBoardItem {
   _id: string;
   count: number;
   points: string;
+  /** true when the user completed all of today's daily quests (recognition badge) */
+  quests_done?: boolean;
 }
 
 export type LeaderBoardDuration = "day" | "week" | "month";

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1959,7 +1959,8 @@
     "header-score-tip": "Post + comments made by a user for selected period",
     "header-reward": "Reward",
     "header-votes": "Votes",
-    "header-votes-tip": "Number of votes in this period"
+    "header-votes-tip": "Number of votes in this period",
+    "quests-done": "Completed all daily quests today"
   },
   "discover": {
     "title": "Discover",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.3
+
+### Patch Changes
+
+- Leaderboard: badge for completing all daily quests (#839)
+
 ## 2.3.1
 
 ### Patch Changes

--- a/packages/sdk/dist/browser/index.d.ts
+++ b/packages/sdk/dist/browser/index.d.ts
@@ -4709,6 +4709,8 @@ interface LeaderBoardItem {
     _id: string;
     count: number;
     points: string;
+    /** true when the user completed all of today's daily quests (recognition badge) */
+    quests_done?: boolean;
 }
 type LeaderBoardDuration = "day" | "week" | "month";
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ecency/sdk",
   "private": false,
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Ecency SDK",
   "repository": {
     "type": "git",

--- a/packages/sdk/src/modules/analytics/types/leader-board.ts
+++ b/packages/sdk/src/modules/analytics/types/leader-board.ts
@@ -2,6 +2,8 @@ export interface LeaderBoardItem {
   _id: string;
   count: number;
   points: string;
+  /** true when the user completed all of today's daily quests (recognition badge) */
+  quests_done?: boolean;
 }
 
 export type LeaderBoardDuration = "day" | "week" | "month";

--- a/packages/wallets/CHANGELOG.md
+++ b/packages/wallets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ecency/wallets
 
+## 5.0.2
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @ecency/sdk@2.3.3
+
 ## 5.0.1
 
 ### Patch Changes

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ecency/wallets",
   "private": false,
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Ecency wallets",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

Shows a small green ✓ (with tooltip *"Completed all daily quests today"*) on **discover leaderboard** rows for users who finished **all** their daily quests today. Pure recognition — **no points**.

## Changes

- `LeaderBoardItem` gains `quests_done?: boolean` (SDK type + the parallel `entities` type).
- `discover/@leaderboard/page.tsx` renders the check when `quests_done` is true.
- en-US: `leaderboard.quests-done`.

The flag is computed server-side on the existing esync leaderboard query (ecency/esync-py#4) — read-only, index-driven, cached 10 min. Deploy esync first so the field is populated (until then it's simply absent → no badge). Mobile leaderboard badge follows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Leaderboard now displays a check-circle badge for users who complete all daily quests, featuring a tooltip confirming the achievement on the daily view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->