### PR TITLE
fix(web): ignore browser-extension window[eFuncName] error in Sentry

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -33,6 +33,7 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
     "Cannot set property tron of #<Window> which has only a getter",
     "Cannot set property ethereum of #<Window> which has only a getter",
     "window.ethereum._handleChainChanged is not a function",
+    "window[eFuncName] is not a function",
     "Cannot destructure property 'register' of 'undefined' as it is undefined.",
     "CopyDataProperties is not a function"
   ],


### PR DESCRIPTION
## Summary
- Adds `window[eFuncName] is not a function` to the Sentry client `ignoreErrors` list.
- This error is **browser-extension noise, not our code**: `eFuncName` and dynamic `window[...]` access exist nowhere in the app, `node_modules`, or the `.next` build; the `app:///src/helpers.ts:116` frame is a bogus source-map mapping (our only `helpers.ts` is a server-side Mattermost file). The real origin is `app.js:17`, an injected content script. Events are 100% Windows, only Chrome 118 & 112, across random post pages — a per-page extension content-script signature.
- It spiked on 2026-05-28 (~13:00-15:00 UTC) and tripped the "Critical errors" alert 3x. Filtering it at `ignoreErrors` stops the false alerts while leaving real errors untouched.

Placed alongside the existing sibling extension entries (`window.ethereum._handleChainChanged is not a function`, `CopyDataProperties is not a function`). Literal string (not regex) so the brackets match literally.

## Test plan
- [ ] After deploy, confirm issue `window[eFuncName] is not a function` (ECENCY-NEXT-1A8M) stops receiving new events.
- [ ] Confirm the "Critical errors" alert no longer fires from this issue.
- [ ] Note: SW-cached bundles mean existing clients on stale JS will keep emitting briefly — expect decay, not an instant drop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error tracking configuration to better handle specific error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->