### PR TITLE
Parallel 3Speak uploads (TUS Concatenation)

### DIFF
--- a/apps/web/src/api/threespeak-embed/api.ts
+++ b/apps/web/src/api/threespeak-embed/api.ts
@@ -100,7 +100,7 @@ const MB = 1024 * 1024;
  * throughput gain and it avoids zero-length parts. Chunk size is kept modest
  * so peak in-flight memory stays around chunkSize × parallelUploads.
  */
-function getUploadTuning(size: number): { chunkSize: number; parallelUploads: number } {
+export function getUploadTuning(size: number): { chunkSize: number; parallelUploads: number } {
   if (size <= 10 * MB) return { chunkSize: 5 * MB, parallelUploads: 1 };
   if (size <= 500 * MB) return { chunkSize: 10 * MB, parallelUploads: 3 };
   return { chunkSize: 20 * MB, parallelUploads: 3 };
@@ -153,6 +153,16 @@ export async function uploadVideoEmbed(
       },
       onSuccess() {
         const resolvedUrl = finalEmbedUrl || embedUrl;
+        // In parallel mode we expect the canonical URL on the final concat
+        // response. If it never arrived we fall back to a partial-response URL,
+        // whose permlink may be wrong — surface it so the failure is observable.
+        if (parallelUploads > 1 && !finalEmbedUrl && resolvedUrl) {
+          console.warn(
+            "[3Speak Embed] Parallel upload completed without an X-Embed-URL on the final " +
+              "concatenation response; falling back to a partial-response URL. The resulting " +
+              "permlink may be incorrect — verify the concat response carries X-Embed-URL."
+          );
+        }
         if (resolvedUrl) {
           const permlink = extractPermlink(resolvedUrl);
           if (!permlink) {

--- a/apps/web/src/api/threespeak-embed/api.ts
+++ b/apps/web/src/api/threespeak-embed/api.ts
@@ -152,17 +152,22 @@ export async function uploadVideoEmbed(
         progressCallback(percentage);
       },
       onSuccess() {
-        const resolvedUrl = finalEmbedUrl || embedUrl;
-        // In parallel mode we expect the canonical URL on the final concat
-        // response. If it never arrived we fall back to a partial-response URL,
-        // whose permlink may be wrong — surface it so the failure is observable.
-        if (parallelUploads > 1 && !finalEmbedUrl && resolvedUrl) {
-          console.warn(
-            "[3Speak Embed] Parallel upload completed without an X-Embed-URL on the final " +
-              "concatenation response; falling back to a partial-response URL. The resulting " +
-              "permlink may be incorrect — verify the concat response carries X-Embed-URL."
+        // The canonical embed URL is the one returned by the final
+        // concatenation request (Upload-Concat: final). In parallel mode we
+        // REQUIRE it: partial creation responses carry their own non-canonical
+        // URLs, so falling back to one would link the post to a transient
+        // partial resource. The sequential path has no concat step, so the
+        // last-seen URL (the final PATCH) is canonical and used as the fallback.
+        if (parallelUploads > 1 && !finalEmbedUrl) {
+          reject(
+            new Error(
+              "[3Speak Embed] Parallel upload finished without an X-Embed-URL on the final " +
+                "concatenation response; refusing to fall back to a partial-upload URL."
+            )
           );
+          return;
         }
+        const resolvedUrl = finalEmbedUrl || embedUrl;
         if (resolvedUrl) {
           const permlink = extractPermlink(resolvedUrl);
           if (!permlink) {

--- a/apps/web/src/api/threespeak-embed/api.ts
+++ b/apps/web/src/api/threespeak-embed/api.ts
@@ -89,6 +89,23 @@ export function extractPermlink(embedUrl: string): string {
   return lastSegment.split("?")[0].split("#")[0];
 }
 
+const MB = 1024 * 1024;
+
+/**
+ * Choose chunk size and parallelism based on the file size.
+ *
+ * Parallel uploads use the TUS Concatenation extension (supported by the
+ * 3Speak tusd backend): the file is split into N parts uploaded concurrently,
+ * then stitched server-side. Small files skip parallelism — there is no
+ * throughput gain and it avoids zero-length parts. Chunk size is kept modest
+ * so peak in-flight memory stays around chunkSize × parallelUploads.
+ */
+function getUploadTuning(size: number): { chunkSize: number; parallelUploads: number } {
+  if (size <= 10 * MB) return { chunkSize: 5 * MB, parallelUploads: 1 };
+  if (size <= 500 * MB) return { chunkSize: 10 * MB, parallelUploads: 3 };
+  return { chunkSize: 20 * MB, parallelUploads: 3 };
+}
+
 /**
  * Upload a video file via the TUS resumable upload protocol.
  * Obtains a short-lived upload token from the backend, then uploads directly to 3Speak.
@@ -105,12 +122,21 @@ export async function uploadVideoEmbed(
   // Fall back to config endpoint if upload_url not provided
   const endpoint = upload_url || `${getEmbedEndpoint()}/uploads`;
 
+  // Adaptive chunking + parallelism (TUS Concatenation extension)
+  const { chunkSize, parallelUploads } = getUploadTuning(file.size);
+
   return new Promise<VideoUploadResult>((resolve, reject) => {
+    // With parallelUploads the partial creation responses each carry their own
+    // X-Embed-URL; the canonical one is on the final concatenation request
+    // (Upload-Concat: final). Prefer it, falling back to the last-seen URL so
+    // the sequential path (parallelUploads = 1) keeps its previous behaviour.
     let embedUrl = "";
+    let finalEmbedUrl = "";
 
     const upload = new tus.Upload(file, {
       endpoint,
-      chunkSize: 50 * 1024 * 1024, // 50MB — each PATCH completes quickly; retries resume from last chunk
+      chunkSize,
+      parallelUploads,
       retryDelays: [0, 3000, 5000, 10000, 20000],
       headers: {
         Authorization: `Bearer ${token}`
@@ -126,8 +152,9 @@ export async function uploadVideoEmbed(
         progressCallback(percentage);
       },
       onSuccess() {
-        if (embedUrl) {
-          const permlink = extractPermlink(embedUrl);
+        const resolvedUrl = finalEmbedUrl || embedUrl;
+        if (resolvedUrl) {
+          const permlink = extractPermlink(resolvedUrl);
           if (!permlink) {
             reject(
               new Error("[3Speak Embed] Upload succeeded but the permlink could not be extracted")
@@ -135,18 +162,25 @@ export async function uploadVideoEmbed(
             return;
           }
           resolve({
-            embedUrl,
+            embedUrl: resolvedUrl,
             permlink
           });
         } else {
           reject(new Error("[3Speak Embed] Upload succeeded but no embed URL was returned"));
         }
       },
-      onAfterResponse(_req: any, res: any) {
+      onAfterResponse(req: any, res: any) {
         const headerUrl = res.getHeader?.("x-embed-url") || res.getHeader?.("X-Embed-URL");
-        if (headerUrl) {
-          embedUrl = headerUrl;
+        if (!headerUrl) {
+          return;
         }
+        // Prefer the embed URL from the final concatenation request; partial
+        // creation responses (Upload-Concat: partial) may carry their own.
+        const concat = String(req.getHeader?.("Upload-Concat") ?? "");
+        if (concat.startsWith("final")) {
+          finalEmbedUrl = headerUrl;
+        }
+        embedUrl = headerUrl;
       }
     });
 

--- a/apps/web/src/specs/utils/threespeak-embed-api.spec.ts
+++ b/apps/web/src/specs/utils/threespeak-embed-api.spec.ts
@@ -11,6 +11,33 @@ vi.mock("@/utils/user-token", () => ({
   getAccessToken: vi.fn(() => "valid-hs-token")
 }));
 
+// Drive tus-js-client's upload callbacks deterministically. `runUpload` is set
+// per-test to simulate the sequence of onAfterResponse / onSuccess calls.
+const tusMock = vi.hoisted(() => ({
+  runUpload: (_options: any) => {}
+}));
+
+vi.mock("tus-js-client", () => ({
+  Upload: class {
+    options: any;
+    constructor(_file: unknown, options: any) {
+      this.options = options;
+    }
+    start() {
+      tusMock.runUpload(this.options);
+    }
+  }
+}));
+
+// A tus response whose getHeader returns `embedUrl` for the X-Embed-URL header.
+function mockRes(embedUrl: string | null) {
+  return { getHeader: (h: string) => (/^x-embed-url$/i.test(h) ? embedUrl : null) };
+}
+// A tus request whose getHeader returns `uploadConcat` for Upload-Concat.
+function mockReq(uploadConcat?: string) {
+  return { getHeader: (h: string) => (h === "Upload-Concat" ? uploadConcat : undefined) };
+}
+
 describe("extractPermlink", () => {
   it("extracts permlink from ?v=user/permlink format", () => {
     expect(extractPermlink("https://play.3speak.tv/embed?v=alice/abcd1234")).toBe("abcd1234");
@@ -97,5 +124,71 @@ describe("getUploadTuning", () => {
   it("uses 20 MB x 3 parallel above 500 MB", () => {
     expect(getUploadTuning(500 * MB + 1)).toEqual({ chunkSize: 20 * MB, parallelUploads: 3 });
     expect(getUploadTuning(2 * 1024 * MB)).toEqual({ chunkSize: 20 * MB, parallelUploads: 3 });
+  });
+});
+
+describe("uploadVideoEmbed embed-url resolution", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ token: "tok", upload_url: "https://embed.example/uploads" })
+      })
+    );
+  });
+
+  // > 10 MB so getUploadTuning selects parallelUploads = 3.
+  const bigFile = () =>
+    new File([new Uint8Array(11 * 1024 * 1024)], "big.mp4", { type: "video/mp4" });
+  // <= 10 MB so getUploadTuning selects parallelUploads = 1 (sequential).
+  const smallFile = () => new File(["x"], "small.mp4", { type: "video/mp4" });
+
+  it("rejects a parallel upload that never returns a final-concat embed URL", async () => {
+    tusMock.runUpload = (options) => {
+      // Only a partial-creation response carries an embed URL — no final concat.
+      options.onAfterResponse(
+        mockReq("partial"),
+        mockRes("https://play.3speak.tv/embed?v=a/PART01")
+      );
+      options.onSuccess();
+    };
+    const { uploadVideoEmbed } = await import("@/api/threespeak-embed/api");
+    await expect(uploadVideoEmbed(bigFile(), "a", false, () => {})).rejects.toThrow(
+      /concatenation/i
+    );
+  });
+
+  it("resolves a parallel upload to the final-concat embed URL", async () => {
+    tusMock.runUpload = (options) => {
+      options.onAfterResponse(
+        mockReq("partial"),
+        mockRes("https://play.3speak.tv/embed?v=a/PART01")
+      );
+      options.onAfterResponse(
+        mockReq("final;https://embed.example/a https://embed.example/b"),
+        mockRes("https://play.3speak.tv/embed?v=a/FINAL567")
+      );
+      options.onSuccess();
+    };
+    const { uploadVideoEmbed } = await import("@/api/threespeak-embed/api");
+    await expect(uploadVideoEmbed(bigFile(), "a", false, () => {})).resolves.toEqual({
+      embedUrl: "https://play.3speak.tv/embed?v=a/FINAL567",
+      permlink: "FINAL567"
+    });
+  });
+
+  it("uses the last-seen embed URL for a sequential upload (no concat step)", async () => {
+    tusMock.runUpload = (options) => {
+      // Sequential path: requests carry no Upload-Concat header.
+      options.onAfterResponse(mockReq(), mockRes("https://play.3speak.tv/embed?v=a/SEQ12345"));
+      options.onSuccess();
+    };
+    const { uploadVideoEmbed } = await import("@/api/threespeak-embed/api");
+    await expect(uploadVideoEmbed(smallFile(), "a", false, () => {})).resolves.toEqual({
+      embedUrl: "https://play.3speak.tv/embed?v=a/SEQ12345",
+      permlink: "SEQ12345"
+    });
   });
 });

--- a/apps/web/src/specs/utils/threespeak-embed-api.spec.ts
+++ b/apps/web/src/specs/utils/threespeak-embed-api.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { extractPermlink } from "@/api/threespeak-embed/api";
+import { extractPermlink, getUploadTuning } from "@/api/threespeak-embed/api";
 
 // The 3Speak proxy now requires a HiveSigner OAuth token resolved from
 // localStorage + user-token. These tests exercise fetch error propagation,
@@ -76,5 +76,26 @@ describe("requestUploadToken error handling", () => {
     } catch (e: any) {
       expect(e.status).toBe(401);
     }
+  });
+});
+
+describe("getUploadTuning", () => {
+  const MB = 1024 * 1024;
+
+  it("keeps small files (<= 10 MB) sequential", () => {
+    expect(getUploadTuning(0)).toEqual({ chunkSize: 5 * MB, parallelUploads: 1 });
+    expect(getUploadTuning(1024)).toEqual({ chunkSize: 5 * MB, parallelUploads: 1 });
+    expect(getUploadTuning(10 * MB)).toEqual({ chunkSize: 5 * MB, parallelUploads: 1 });
+  });
+
+  it("uses 10 MB x 3 parallel above 10 MB up to 500 MB", () => {
+    expect(getUploadTuning(10 * MB + 1)).toEqual({ chunkSize: 10 * MB, parallelUploads: 3 });
+    expect(getUploadTuning(100 * MB)).toEqual({ chunkSize: 10 * MB, parallelUploads: 3 });
+    expect(getUploadTuning(500 * MB)).toEqual({ chunkSize: 10 * MB, parallelUploads: 3 });
+  });
+
+  it("uses 20 MB x 3 parallel above 500 MB", () => {
+    expect(getUploadTuning(500 * MB + 1)).toEqual({ chunkSize: 20 * MB, parallelUploads: 3 });
+    expect(getUploadTuning(2 * 1024 * MB)).toEqual({ chunkSize: 20 * MB, parallelUploads: 3 });
   });
 });


### PR DESCRIPTION
## What

3Speak migrated their upload backend to `tusd`, which now advertises the TUS **Concatenation** extension. This lets the client split a video into parts, upload them in parallel, and have the server stitch them back together — meaningfully higher throughput on fast connections for larger files.

## Changes

`apps/web/src/api/threespeak-embed/api.ts`:

- Add adaptive chunk size + `parallelUploads` to the embed upload. `tus-js-client` 4.3.1 already supports Concatenation, so there is **no dependency change**:
  - ≤ 10 MB → 5 MB chunks, sequential (no gain + avoids zero-length parts)
  - ≤ 500 MB → 10 MB × 3 parallel
  - larger → 20 MB × 3 parallel
- Prefer the `X-Embed-URL` from the final concatenation request when resolving the permlink. In parallel mode each *partial* creation response also carries an `X-Embed-URL`; the canonical one is on the final `Upload-Concat: final` request. The sequential path is unchanged (falls back to the last-seen URL).

The backend's async-IPFS-pin change (faster upload "done" response) needs no client change — it already applies.

## Testing

- [ ] Upload a > 10 MB video: confirm multiple simultaneous `PATCH` requests, then a final `Upload-Concat: final`; `X-Embed-URL` resolves and the video embeds.
- [ ] Upload a ≤ 10 MB clip: confirm the sequential path still works.

Typecheck + prettier + eslint pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added adaptive upload tuning that picks chunk size and parallelism based on file size.
* **Bug Fixes**
  * Improved embed URL handling at upload completion to ensure correct permlink extraction and stricter failure handling for incomplete parallel uploads.
* **Tests**
  * Added tests covering tuning across sizes and embed URL resolution/rejection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->