### PR TITLE
SEO: make bare-canonical post redirect permanent (307 → 308)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -272,12 +272,13 @@ const config = {
       // of /@x/@y/z matching. Edit URLs (/:cat/@a/p/edit) and sub-path URLs
       // (/:cat/@a/p/:sub) are 4 segments and don't match this 3-segment rule —
       // their existing rewrites in rewrites() handle them.
-      // Starts as 302 (temporary) so the change is reversible while we
-      // verify in production; can flip to permanent: true once confident.
+      // 308 (permanent): consolidation verified — community-prefixed URLs
+      // converge onto the bare canonical with no traffic regression, so the
+      // redirect is now permanent for full SEO signal transfer.
       {
         source: "/:category((?!@)[^/]+)/:author(@[^/]+)/:permlink",
         destination: "/:author/:permlink",
-        permanent: false
+        permanent: true
       }
     ];
   },


### PR DESCRIPTION
The post-URL consolidation redirect — `/:category/@:author/:permlink` → `/@author/:permlink` — was intentionally a temporary **307** while we verified it in production.

Weekly Search Console convergence checks now confirm it is working as intended:
- Community-prefixed post URLs drop to **"Duplicate"** with the bare URL as Google's chosen canonical.
- No traffic regression attributable to the redirect.

This flips it to a permanent **308** (`permanent: true`) so the full SEO signal transfers to the canonical URL.

### Change
- `apps/web/next.config.js`: `permanent: false` → `permanent: true` on the bare-canonical redirect (one line + comment update).

### Note
308 is cached aggressively by browsers and search engines, so reverting is slower than a 307 — the temporary phase was the safeguard, and convergence is now confirmed.