### PR TITLE
SEO: enrich BlogPosting JSON-LD + tune post SERP snippet

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
@@ -57,8 +57,10 @@ export async function generateEntryMetadata(
       title = `@${entry.author}: ${rawCommentTitle}`;
     }
 
+    // Cap at 160 chars to use Google's full desktop snippet width (~155-160);
+    // it truncates responsively on narrower viewports.
     const summary =
-      entry.json_metadata?.description || truncate(postBodySummary(entry.body, 210), 140);
+      entry.json_metadata?.description || truncate(postBodySummary(entry.body, 210), 160);
 
     const image = catchPostImage(entry, 1200, 630, "match");
     // Bare /@author/permlink form for this exact page.
@@ -100,7 +102,10 @@ export async function generateEntryMetadata(
 
     return {
       title,
-      description: `${summary} by @${entry.author}`,
+      // Authorship is conveyed via the Article JSON-LD author + og/article:author;
+      // a bare "@handle" in the SERP snippet spends characters without earning
+      // clicks, so the description is the post summary alone (matches og/twitter).
+      description: summary,
       robots,
       openGraph: {
         title,

--- a/apps/web/src/features/structured-data/index.tsx
+++ b/apps/web/src/features/structured-data/index.tsx
@@ -107,12 +107,19 @@ export function buildArticleJsonLd({
   const authorName = account?.profile?.name?.trim() || entry.author;
   const headline = (entry.title ?? "").slice(0, HEADLINE_MAX);
   const image = catchPostImage(entry, 1200, 630, "match") || undefined;
+  // Post tags → keywords; the community/category is the section the post sits
+  // in. Both are optional Article properties that strengthen topical/section
+  // signals. Filter to non-empty strings so a malformed json_metadata can't
+  // emit null/empty keyword entries.
+  const keywords = (entry.json_metadata?.tags ?? []).filter(
+    (t): t is string => typeof t === "string" && t.length > 0
+  );
 
   return {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     headline,
-    description: entry.json_metadata?.description || postBodySummary(entry.body, 140),
+    description: entry.json_metadata?.description || postBodySummary(entry.body, 160),
     image: image ? [image] : undefined,
     datePublished: toUtcIso(entry.created),
     dateModified: toUtcIso(entry.updated ?? entry.created),
@@ -125,6 +132,8 @@ export function buildArticleJsonLd({
     publisher: { "@id": ORG_ID },
     mainEntityOfPage: { "@type": "WebPage", "@id": url },
     url,
+    articleSection: entry.community_title || entry.category || undefined,
+    keywords: keywords.length ? keywords : undefined,
     commentCount: entry.children,
     interactionStatistic: entry.children
       ? {

--- a/apps/web/src/features/structured-data/index.tsx
+++ b/apps/web/src/features/structured-data/index.tsx
@@ -107,13 +107,22 @@ export function buildArticleJsonLd({
   const authorName = account?.profile?.name?.trim() || entry.author;
   const headline = (entry.title ?? "").slice(0, HEADLINE_MAX);
   const image = catchPostImage(entry, 1200, 630, "match") || undefined;
-  // Post tags → keywords; the community/category is the section the post sits
-  // in. Both are optional Article properties that strengthen topical/section
-  // signals. Filter to non-empty strings so a malformed json_metadata can't
-  // emit null/empty keyword entries.
-  const keywords = (entry.json_metadata?.tags ?? []).filter(
+  // json_metadata is untrusted on-chain data: guard that `tags` is actually an
+  // array before filtering to non-empty strings — a truthy non-array value
+  // would otherwise throw here, on the entry-page SSR path. (Matches the
+  // Array.isArray(tags) guard used elsewhere in the entry components.)
+  const rawTags = entry.json_metadata?.tags;
+  const keywords = (Array.isArray(rawTags) ? rawTags : []).filter(
     (t): t is string => typeof t === "string" && t.length > 0
   );
+  // The community/category is the post's section. `community_title` is a
+  // bridge-only field; when it's absent for a community post, `category` is a
+  // raw machine id ("hive-12345") that's meaningless as a section signal, so
+  // omit it in that case rather than leak the id.
+  const articleSection =
+    entry.community_title ||
+    (/^hive-\d+$/.test(entry.category ?? "") ? undefined : entry.category) ||
+    undefined;
 
   return {
     "@context": "https://schema.org",
@@ -132,8 +141,9 @@ export function buildArticleJsonLd({
     publisher: { "@id": ORG_ID },
     mainEntityOfPage: { "@type": "WebPage", "@id": url },
     url,
-    articleSection: entry.community_title || entry.category || undefined,
-    keywords: keywords.length ? keywords : undefined,
+    articleSection,
+    // schema.org `keywords` is Text — emit the conventional comma-separated form.
+    keywords: keywords.length ? keywords.join(", ") : undefined,
     commentCount: entry.children,
     interactionStatistic: entry.children
       ? {


### PR DESCRIPTION
The site-wide structured data added in the home rework (`Organization`, `WebSite`+`SearchAction`, `BreadcrumbList`, `BlogPosting`, `ProfilePage`, `FAQPage`) already covers the safe, automatable rich-result types. So this PR is **incremental enrichment + snippet tuning**, not new schema.

### `structured-data` — `buildArticleJsonLd`
- Add **`articleSection`** (community title / category) and **`keywords`** (post tags) — both valid, previously-unused `Article` properties that strengthen topical & section signals. `keywords` is filtered to non-empty strings so malformed `json_metadata` can't emit empty entries.
- Widen the fallback description to 160 chars.

### `generate-entry-metadata` — post meta description
- **Drop the trailing `" by @author"`.** Authorship is already carried by the `Article` JSON-LD `author` + `og`/`article:author`; a bare handle spends description characters without adding value. The description now matches the `og`/`twitter` descriptions, which already omit it.
- **Widen the description cap 140 → 160** to use the full desktop snippet width (it truncates responsively on narrower viewports).

### Deliberately out of scope: Recipe/Review schema
Hive `json_metadata` carries no structured recipe/review fields, and inferring them from freeform markdown would emit **incomplete** structured data — which earns Google manual actions rather than rich results. Those types need author-supplied structured input (an editor feature), not auto-detection.

### Validation
- `tsc --noEmit` clean for both changed files.
- No snapshot/spec tests cover the metadata or JSON-LD output, so nothing to update.
- Changes are SSR-rendered (server components, unchanged render path).
