### PR TITLE
seo: canonical author URLs in sitemap + raise post-walk time budget to 90s

### DIFF
--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -39,7 +39,13 @@ export const dynamic = "force-dynamic";
 const BASE = defaults.base;
 const LIVE_BL = `${SEO_REDIS_PREFIX}blacklist:authors`;
 const K = (s: string) => `${SEO_REDIS_PREFIX}sitemap:${s}`;
-const TIME_BUDGET_MS = 50_000;
+// Wall-clock backstop on the post walk, checked each page. 90s (was 50s): on
+// slower upstream RPC nodes the 50s budget could truncate the walk before the
+// 48h cutoff (reachedCutoff:false → only a partial freshness window published).
+// 90s lets the walk reach the cutoff while staying inside the scheduler's
+// curl --max-time even with a worst-case retrying trailing page
+// (RPC_TIMEOUT_MS × (RPC_RETRY+1)).
+const TIME_BUDGET_MS = 90_000;
 // bridge.get_ranked_posts hard-caps `limit` at 20 — the RPC *rejects*
 // anything higher with "limit = N outside valid range [1:20]" (confirmed
 // against api.hive.blog; see packages/render-helper/scan-post-corpus.mjs).
@@ -333,8 +339,14 @@ export async function POST(req: Request): Promise<Response> {
     ...hubPaths.map((p) => ({ loc: p ? `${BASE}/${p}` : `${BASE}/`, lastmod: nowDay })),
     ...infoPaths.map((p) => ({ loc: `${BASE}/${p}` }))
   ];
+  // Emit the CANONICAL profile URL. Profile pages canonicalize /@a → /@a/posts,
+  // so listing the bare /@a made Google report every author entry as "Alternate
+  // page with proper canonical tag" — the canonical /@a/posts indexes fine, but
+  // the sitemap'd URL itself doesn't, and a crawl is spent resolving the
+  // canonical. A sitemap must list canonical URLs — the same rule posts.xml
+  // already follows via canonicalTarget.
   const authorUrls = Array.from(authors).map((a) => ({
-    loc: `${BASE}/@${a}`,
+    loc: `${BASE}/@${a}/posts`,
     lastmod: nowDay
   }));
   // Cached/weekly name list + free hourly post-derived lastmod. A community


### PR DESCRIPTION
## What

Two SEO fixes to the sitemap generator (`/api/internal/seo/sitemap-generate`).

### 1. `authors.xml` now lists the canonical profile URL (`/@a/posts`)

Profile pages canonicalize `/@a` → `/@a/posts`, but the sitemap was emitting the bare `/@a`. As a result Google marks every author entry as **"Alternate page with proper canonical tag"** — the canonical `/@a/posts` indexes fine, but the URL we actually submit doesn't, and a crawl is spent resolving the canonical each time.

This emits the canonical form directly, so the submitted author URLs are the ones Google indexes — the same canonical-only rule `posts.xml` already follows via `canonicalTarget` (and `communities.xml` via its self-canonical `/created/hive-NNN`). No canonical direction is changed, so there is no de-index/re-index churn: the `/@a/posts` URLs are already indexed.

### 2. Post-walk time budget raised 50s → 90s

The walk is bounded by whichever hits first: the 48h cutoff, `MAX_PAGES`, or the wall-clock budget. On slower upstream RPC nodes the 50s budget was binding *before* the 48h cutoff (`reachedCutoff:false`), publishing only a partial freshness window. 90s lets the walk reach the cutoff. It stays within the scheduler's `curl --max-time` even with a worst-case retrying trailing page; `MAX_PAGES` (150) and the 48h window are unchanged.

## Notes

- Code-only change → the `seocron` service spec is unchanged, so the new output appears at the next hourly regeneration after deploy (or a manual `sitemap-generate` trigger).
- No test changes needed — no spec asserts the author URL format or the budget value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sitemap generation with improved performance and author profile URL formatting for better search engine indexing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->