### PR TITLE
perf(web): lazy-load emoji picker; stop barrelling it into shared bundles (−508KB post first-load)

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-edit.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-edit.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Comment } from "@/features/shared";
+import { Comment } from "@/features/shared/comment";
 import i18next from "i18next";
 import { Entry } from "@/entities";
 import { useRouter } from "next/navigation";

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-reply-section.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-reply-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Comment } from "@/features/shared";
+import { Comment } from "@/features/shared/comment";
 import i18next from "i18next";
 import { Entry } from "@/entities";
 import { createReplyPermlink, makeJsonMetaDataReply } from "@/utils";

--- a/apps/web/src/app/decks/_components/columns/content-viewer/deck-post-viewer-comment-box.tsx
+++ b/apps/web/src/app/decks/_components/columns/content-viewer/deck-post-viewer-comment-box.tsx
@@ -5,7 +5,7 @@ import { useCreateReply } from "@/api/mutations";
 import { createReplyPermlink, makeJsonMetaDataReply } from "@/utils";
 import appPackage from "../../../../../../package.json";
 import i18next from "i18next";
-import { Comment } from "@/features/shared";
+import { Comment } from "@/features/shared/comment";
 import { useActiveAccount } from "@/core/hooks";
 
 interface Props {

--- a/apps/web/src/app/decks/_components/deck-settings/decks-settings.tsx
+++ b/apps/web/src/app/decks/_components/deck-settings/decks-settings.tsx
@@ -10,7 +10,7 @@ import { Button } from "@ui/button";
 import { Form } from "@ui/form";
 import { Alert } from "@ui/alert";
 import { deleteForeverSvg, emoticonHappyOutlineSvg } from "@ui/svg";
-import { EmojiPicker } from "@/features/ui";
+import { EmojiPicker } from "@ui/emoji-picker/lazy-emoji-picker";
 import i18next from "i18next";
 import { ClickAwayListener } from "@/features/shared";
 

--- a/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
+++ b/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
@@ -26,7 +26,8 @@ const GalleryDialog = dynamic(
   { ssr: false }
 );
 import { VideoUpload } from "@/features/shared/video-upload-threespeak";
-import { EmojiPicker, StyledTooltip } from "@/features/ui";
+import { StyledTooltip } from "@/features/ui";
+import { EmojiPicker } from "@ui/emoji-picker/lazy-emoji-picker";
 import { useEditorState } from "@tiptap/react";
 import { YOUTUBE_REGEX } from "@/features/tiptap-editor";
 import {

--- a/apps/web/src/app/submit/_functions/handle-shortcuts.ts
+++ b/apps/web/src/app/submit/_functions/handle-shortcuts.ts
@@ -1,5 +1,5 @@
 import { KeyboardEvent } from "react";
-import { detectEvent } from "@/features/shared";
+import { detectEvent } from "@/features/shared/editor-toolbar";
 
 export function handleShortcuts(e: KeyboardEvent<HTMLDivElement>) {
   if (!e.altKey) {

--- a/apps/web/src/features/shared/editor-toolbar/index.tsx
+++ b/apps/web/src/features/shared/editor-toolbar/index.tsx
@@ -29,7 +29,7 @@ import { insertOrReplace, replace } from "@/utils";
 import { convertHeicToJpeg } from "@/utils/convert-heic";
 import { Tooltip } from "@ui/tooltip";
 import i18next from "i18next";
-import { EmojiPicker } from "@/features/ui";
+import { EmojiPicker } from "@ui/emoji-picker/lazy-emoji-picker";
 import { GifPicker } from "@ui/gif-picker";
 import { classNameObject } from "@ui/util";
 import { GalleryDialog } from "@/features/shared/gallery";

--- a/apps/web/src/features/shared/index.ts
+++ b/apps/web/src/features/shared/index.ts
@@ -40,7 +40,11 @@ export * from "./entry-info";
 export * from "./bookmark-btn";
 export * from "./discussion";
 export * from "./entry-delete-btn";
-export * from "./comment";
+// NOTE: ./comment (the reply/edit composer) is intentionally NOT re-exported from
+// this barrel. It pulls the markdown editor toolbar, emoji/GIF pickers, textarea
+// autocomplete, polls and video upload (~80KB) — importing any unrelated symbol
+// from this barrel dragged all of that into pages that never render a composer.
+// Import it directly: `import { Comment } from "@/features/shared/comment"`.
 export * from "./transactions";
 export * from "./click-away-listener";
 export * from "./available-credits";
@@ -56,7 +60,8 @@ export * from "./gallery";
 export * from "./boost";
 export * from "./static-navbar";
 export * from "./edit-history";
-export * from "./editor-toolbar";
+// NOTE: ./editor-toolbar is intentionally NOT re-exported here — see the ./comment
+// note above. Import directly from "@/features/shared/editor-toolbar".
 export * from "./redirect";
 export * from "./entry-stats";
 export * from "./post-content-renderer";

--- a/apps/web/src/features/ui/emoji-picker/lazy-emoji-picker.tsx
+++ b/apps/web/src/features/ui/emoji-picker/lazy-emoji-picker.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import dynamic from "next/dynamic";
 
 export const EmojiPicker = dynamic(

--- a/apps/web/src/features/ui/index.ts
+++ b/apps/web/src/features/ui/index.ts
@@ -9,7 +9,11 @@ export * from "./alert";
 export * from "./badge";
 export * from "./pagination";
 export * from "./tooltip";
-export * from "./emoji-picker";
+// NOTE: the eager emoji picker (which statically pulls @emoji-mart/data, ~460KB)
+// is intentionally NOT re-exported here. Importing it through this barrel dragged
+// the emoji dataset into the shared/layout bundle for every route. Import the
+// lazy (dynamic, ssr:false) wrapper directly from
+// "@ui/emoji-picker/lazy-emoji-picker" in client components instead.
 export * from "./full-height";
 export * from "./modal-confirm";
 export * from "./page-menu";


### PR DESCRIPTION
## Problem

Two heavy interaction modules were being pulled into the **first-load bundle of every page** (including logged-out / crawler views of post pages) via `export *` barrels, even on routes that never render them:

- **Emoji picker** — the eager `EmojiPicker` statically imports `@emoji-mart/data` (~460KB). It was re-exported from the `@/features/ui` barrel, so importing *any* UI primitive (e.g. a `Button` in the navbar) dragged the whole emoji dataset into the shared/layout bundle for **100+ routes**.
- **Comment composer** (`./comment`, `./editor-toolbar`) — re-exported from the `@/features/shared` barrel, so unrelated imports pulled the markdown editor toolbar in too.

## Fix

- Point the emoji picker's consumers at the existing lazy (`dynamic`, `ssr:false`) wrapper `@ui/emoji-picker/lazy-emoji-picker`, and **drop the eager re-export** from the `@/features/ui` barrel.
- **Remove `./comment` and `./editor-toolbar` from the `@/features/shared` barrel** and switch their (few) consumers to direct imports. Moving away from mega-barrel `export *` toward direct imports keeps unrelated junk out of pages and prevents this class of regression.

## Result (verified via `@next/bundle-analyzer` + `app-build-manifest.json`)

Post page (`/[category]/@author/permlink`) first-load JS:

| | Before | After |
|---|---|---|
| Parsed JS | 4071 KB | **3563 KB** (−508 KB) |
| Chunks | 15 | 13 |
| `@emoji-mart` in first-load | ~460 KB | **0 KB** (post route **and** shared layout) |

The picker still works — its dataset now loads on demand when the picker opens. `tsc --noEmit` unchanged from baseline.

## Notes / deferred

- The comment **composer (~84KB)** still rides in first-load because `discussion-item.tsx` statically imports it for each comment's inline reply/edit form, and the comment list is SSR'd for SEO. Deferring it is a follow-up (load the per-comment composer on “Reply” click).
- Further barrel/bundle follow-ups identified for separate PRs: SVG icon barrels (`features/ui/svg.tsx` + `assets/img/svg.tsx`, ~59KB), `en-US.json` i18n splitting (~180KB in first-load), and `chat/mattermost-api` on the post page (~15KB).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated module imports to use more specific paths instead of barrel exports for better code organization.
  * Switched emoji picker to lazy loading, reducing initial bundle size and improving page load performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->