### PR TITLE
feat(decks): gate Decks behind auth with a guided first-run

### DIFF
--- a/apps/web/src/app/decks/_components/consts/default-layout.const.ts
+++ b/apps/web/src/app/decks/_components/consts/default-layout.const.ts
@@ -1,20 +1,15 @@
 import { DeckGridItem, DeckGrids } from "../types";
 import * as uuid from "uuid";
 
+// A brand-new deck opens straight into the "add column" picker instead of a
+// pre-filled feed. The picker (DeckAddColumn) is itself the guided empty state —
+// it lists every column type with a description and, once a user picks one,
+// replaces itself in place. Pairing this with the one-time onboarding modal
+// (DecksOnboarding) teaches what a deck is without seeding arbitrary content.
 export const DEFAULT_COLUMNS: DeckGridItem[] = [
   {
     id: uuid.v4(),
     key: 1,
-    type: "u",
-    settings: {
-      username: "ecency",
-      contentType: "posts",
-      updateIntervalMs: 60000
-    }
-  },
-  {
-    id: uuid.v4(),
-    key: 2,
     type: "ac",
     settings: {}
   }

--- a/apps/web/src/app/decks/_components/decks-intro-features.tsx
+++ b/apps/web/src/app/decks/_components/decks-intro-features.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import {
+  UilCloudComputing,
+  UilColumns,
+  UilUsersAlt,
+  UilWindow
+} from "@tooni/iconscout-unicons-react";
+
+/**
+ * Feature highlights shared by the logged-out Decks splash (DecksIntro) and the
+ * one-time onboarding modal (DecksOnboarding). Titles/descriptions resolve from
+ * i18n keys `decks.intro.features.<key>-title` / `-description`.
+ */
+export const DECKS_INTRO_FEATURES = [
+  { icon: <UilColumns className="opacity-50" />, key: "columns" },
+  { icon: <UilUsersAlt className="opacity-50" />, key: "anything" },
+  { icon: <UilWindow className="opacity-50" />, key: "arrange" },
+  { icon: <UilCloudComputing className="opacity-50" />, key: "saved" }
+] as const;

--- a/apps/web/src/app/decks/_components/decks-intro.tsx
+++ b/apps/web/src/app/decks/_components/decks-intro.tsx
@@ -3,21 +3,10 @@
 import React from "react";
 import i18next from "i18next";
 import { useRouter } from "next/navigation";
-import {
-  UilCloudComputing,
-  UilColumns,
-  UilUsersAlt,
-  UilWindow
-} from "@tooni/iconscout-unicons-react";
+import { UilColumns } from "@tooni/iconscout-unicons-react";
 import { Button } from "@ui/button";
 import { useGlobalStore } from "@/core/global-store";
-
-const FEATURES = [
-  { icon: <UilColumns className="opacity-50" />, key: "columns" },
-  { icon: <UilUsersAlt className="opacity-50" />, key: "anything" },
-  { icon: <UilWindow className="opacity-50" />, key: "arrange" },
-  { icon: <UilCloudComputing className="opacity-50" />, key: "saved" }
-];
+import { DECKS_INTRO_FEATURES } from "./decks-intro-features";
 
 /**
  * Logged-out landing for /decks. A logged-out visitor cannot save decks or use
@@ -43,7 +32,7 @@ export function DecksIntro() {
           </p>
         </div>
         <div className="w-full grid grid-cols-1 sm:grid-cols-2 gap-6 text-left">
-          {FEATURES.map(({ icon, key }) => (
+          {DECKS_INTRO_FEATURES.map(({ icon, key }) => (
             <div
               className="grid gap-4 items-start"
               key={key}

--- a/apps/web/src/app/decks/_components/decks-intro.tsx
+++ b/apps/web/src/app/decks/_components/decks-intro.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React from "react";
+import i18next from "i18next";
+import { useRouter } from "next/navigation";
+import {
+  UilCloudComputing,
+  UilColumns,
+  UilUsersAlt,
+  UilWindow
+} from "@tooni/iconscout-unicons-react";
+import { Button } from "@ui/button";
+import { useGlobalStore } from "@/core/global-store";
+
+const FEATURES = [
+  { icon: <UilColumns className="opacity-50" />, key: "columns" },
+  { icon: <UilUsersAlt className="opacity-50" />, key: "anything" },
+  { icon: <UilWindow className="opacity-50" />, key: "arrange" },
+  { icon: <UilCloudComputing className="opacity-50" />, key: "saved" }
+];
+
+/**
+ * Logged-out landing for /decks. A logged-out visitor cannot save decks or use
+ * the account-scoped columns (notifications, wallet, waves), so instead of
+ * dropping them into the raw, contextless deck surface we explain what Decks is
+ * and route them to log in or browse communities. Logged-in users never see
+ * this — `_page.tsx` renders the deck surface for them.
+ */
+export function DecksIntro() {
+  const router = useRouter();
+  const toggleUiProp = useGlobalStore((state) => state.toggleUiProp);
+
+  return (
+    <div className="flex items-center justify-center min-h-[80vh] px-4 py-12">
+      <div className="w-full max-w-[640px] flex flex-col items-center gap-8 text-center">
+        <div className="flex items-center justify-center w-16 h-16 rounded-2xl bg-blue-duck-egg text-blue-dark-sky dark:bg-dark-default">
+          <UilColumns size={32} />
+        </div>
+        <div className="flex flex-col gap-3">
+          <h1 className="text-2xl lg:text-3xl font-bold">{i18next.t("decks.intro.title")}</h1>
+          <p className="opacity-75 max-w-[480px] mx-auto">
+            {i18next.t("decks.intro.description")}
+          </p>
+        </div>
+        <div className="w-full grid grid-cols-1 sm:grid-cols-2 gap-6 text-left">
+          {FEATURES.map(({ icon, key }) => (
+            <div
+              className="grid gap-4 items-start"
+              key={key}
+              style={{ gridTemplateColumns: "max-content 1fr" }}
+            >
+              {icon}
+              <div className="-mt-1">
+                <div className="font-bold">{i18next.t(`decks.intro.features.${key}-title`)}</div>
+                <div className="opacity-75 text-sm">
+                  {i18next.t(`decks.intro.features.${key}-description`)}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-col sm:flex-row items-center gap-3 mt-2">
+          <Button size="lg" onClick={() => toggleUiProp("login", true)}>
+            {i18next.t("decks.intro.login")}
+          </Button>
+          <Button size="lg" appearance="gray-link" onClick={() => router.push("/communities")}>
+            {i18next.t("decks.intro.browse-communities")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/decks/_components/decks-onboarding.tsx
+++ b/apps/web/src/app/decks/_components/decks-onboarding.tsx
@@ -5,22 +5,13 @@ import i18next from "i18next";
 import {
   UilArrowRight,
   UilCloudComputing,
-  UilColumns,
   UilDraggabledots,
-  UilPlusCircle,
-  UilUsersAlt,
-  UilWindow
+  UilPlusCircle
 } from "@tooni/iconscout-unicons-react";
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "@/features/ui";
 import { useSynchronizedLocalStorage } from "@/utils";
 import { PREFIX } from "@/utils/local-storage";
-
-const FEATURES = [
-  { icon: <UilColumns className="opacity-50" />, key: "columns" },
-  { icon: <UilUsersAlt className="opacity-50" />, key: "anything" },
-  { icon: <UilWindow className="opacity-50" />, key: "arrange" },
-  { icon: <UilCloudComputing className="opacity-50" />, key: "saved" }
-];
+import { DECKS_INTRO_FEATURES } from "./decks-intro-features";
 
 const TIPS = [
   { icon: <UilPlusCircle className="opacity-50" />, key: "add" },
@@ -49,10 +40,7 @@ export function DecksOnboarding() {
     <Modal
       centered={true}
       show={!!show}
-      onHide={() => {
-        setShow(false);
-        setStep("intro");
-      }}
+      onHide={() => setShow(false)}
     >
       <ModalHeader closeButton={true}>
         {step === "build" && i18next.t("decks.onboarding.build-title")}
@@ -65,7 +53,7 @@ export function DecksOnboarding() {
                 {i18next.t("decks.onboarding.title")}
               </div>
               <div className="flex flex-col gap-6">
-                {FEATURES.map(({ icon, key }) => (
+                {DECKS_INTRO_FEATURES.map(({ icon, key }) => (
                   <div
                     className="grid gap-4 items-start"
                     key={key}

--- a/apps/web/src/app/decks/_components/decks-onboarding.tsx
+++ b/apps/web/src/app/decks/_components/decks-onboarding.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import React, { useCallback, useState } from "react";
+import i18next from "i18next";
+import {
+  UilArrowRight,
+  UilCloudComputing,
+  UilColumns,
+  UilDraggabledots,
+  UilPlusCircle,
+  UilUsersAlt,
+  UilWindow
+} from "@tooni/iconscout-unicons-react";
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "@/features/ui";
+import { useSynchronizedLocalStorage } from "@/utils";
+import { PREFIX } from "@/utils/local-storage";
+
+const FEATURES = [
+  { icon: <UilColumns className="opacity-50" />, key: "columns" },
+  { icon: <UilUsersAlt className="opacity-50" />, key: "anything" },
+  { icon: <UilWindow className="opacity-50" />, key: "arrange" },
+  { icon: <UilCloudComputing className="opacity-50" />, key: "saved" }
+];
+
+const TIPS = [
+  { icon: <UilPlusCircle className="opacity-50" />, key: "add" },
+  { icon: <UilDraggabledots className="opacity-50" />, key: "drag" },
+  { icon: <UilCloudComputing className="opacity-50" />, key: "save" }
+];
+
+/**
+ * One-time guided intro shown on the deck surface to first-time (logged-in)
+ * users — the Decks equivalent of the /publish onboarding. Self-gates on a
+ * localStorage flag so it appears once and never blocks returning users.
+ */
+export function DecksOnboarding() {
+  const [show, setShow] = useSynchronizedLocalStorage(PREFIX + "_decks_onboarding_passed", true);
+  const [step, setStep] = useState<"intro" | "build">("intro");
+
+  const next = useCallback(() => {
+    if (step === "intro") {
+      setStep("build");
+    } else {
+      setShow(false);
+    }
+  }, [setShow, step]);
+
+  return (
+    <Modal
+      centered={true}
+      show={!!show}
+      onHide={() => {
+        setShow(false);
+        setStep("intro");
+      }}
+    >
+      <ModalHeader closeButton={true}>
+        {step === "build" && i18next.t("decks.onboarding.build-title")}
+      </ModalHeader>
+      <ModalBody>
+        <div className="mx-auto flex flex-col gap-6 lg:gap-8 p-4">
+          {step === "intro" && (
+            <>
+              <div className="text-2xl font-bold text-center">
+                {i18next.t("decks.onboarding.title")}
+              </div>
+              <div className="flex flex-col gap-6">
+                {FEATURES.map(({ icon, key }) => (
+                  <div
+                    className="grid gap-4 items-start"
+                    key={key}
+                    style={{ gridTemplateColumns: "max-content 1fr" }}
+                  >
+                    {icon}
+                    <div className="-mt-1">
+                      <div className="font-bold">
+                        {i18next.t(`decks.intro.features.${key}-title`)}
+                      </div>
+                      <div className="opacity-75">
+                        {i18next.t(`decks.intro.features.${key}-description`)}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+          {step === "build" && (
+            <div className="flex flex-col gap-6">
+              {TIPS.map(({ icon, key }) => (
+                <div
+                  className="grid gap-4 items-start"
+                  key={key}
+                  style={{ gridTemplateColumns: "max-content 1fr" }}
+                >
+                  {icon}
+                  <div className="-mt-1">
+                    <div className="font-bold">
+                      {i18next.t(`decks.onboarding.tips.${key}-title`)}
+                    </div>
+                    <div className="opacity-75">
+                      {i18next.t(`decks.onboarding.tips.${key}-description`)}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </ModalBody>
+      <ModalFooter className="justify-center gap-4 flex p-4">
+        <Button icon={<UilArrowRight />} onClick={next}>
+          {step === "intro"
+            ? i18next.t("decks.onboarding.button")
+            : i18next.t("decks.onboarding.finish")}
+        </Button>
+        {step === "intro" && (
+          <Button appearance="gray-link" onClick={() => setShow(false)}>
+            {i18next.t("decks.onboarding.skip")}
+          </Button>
+        )}
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/apps/web/src/app/decks/_components/index.tsx
+++ b/apps/web/src/app/decks/_components/index.tsx
@@ -15,6 +15,7 @@ import { DeckFloatingToolbarActivator } from "./deck-toolbar/deck-floating-toolb
 import { useNav } from "@/utils";
 import { PollsManager } from "@/features/polls";
 import { classNameObject } from "@ui/util";
+import { DecksOnboarding } from "./decks-onboarding";
 
 export const Decks = () => {
   const { setNavShow } = useNav();
@@ -54,6 +55,7 @@ export const Decks = () => {
                     setOpen={(v) => setIsCollapsed(!v)}
                   />
                   <DeckToolbar isExpanded={isExpanded} setIsExpanded={setIsExpanded} />
+                  <DecksOnboarding />
                   <DeckThreadsForm className={showThreadsForm ? "show" : ""} persistable={true} />
                   {isDecksLoading ? (
                     <DeckLoader />

--- a/apps/web/src/app/decks/_page.tsx
+++ b/apps/web/src/app/decks/_page.tsx
@@ -4,29 +4,39 @@ import React from "react";
 import { Feedback } from "@/features/shared/feedback";
 import { Theme } from "@/features/shared/theme";
 import dynamic from "next/dynamic";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { useHydrated } from "@/api/queries";
+import { DecksIntro } from "@/app/decks/_components/decks-intro";
+
+const decksLoader = () => (
+  <div className="flex items-center justify-center min-h-screen">
+    <div className="text-center">
+      <div className="spinner mb-4" />
+      <p>Loading Decks...</p>
+    </div>
+  </div>
+);
 
 const Decks = dynamic(
   () => import("@/app/decks/_components").then((m) => ({ default: m.Decks })),
   {
     ssr: false,
-    loading: () => (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-center">
-          <div className="spinner mb-4" />
-          <p>Loading Decks...</p>
-        </div>
-      </div>
-    )
+    loading: decksLoader
   }
 );
 
 export function DecksPage() {
+  const { activeUser } = useActiveAccount();
+  const hydrated = useHydrated();
+
   return (
     <div className="mb-24 md:mb-0 p-0 m-0 mw-full">
       <Theme />
       <Feedback />
       <div id="deck-media-view-container" />
-      <Decks />
+      {/* Avoid flashing the logged-out intro to logged-in users before the
+          client store hydrates; the deck surface is client-only anyway. */}
+      {!hydrated ? decksLoader() : activeUser ? <Decks /> : <DecksIntro />}
     </div>
   );
 }

--- a/apps/web/src/app/decks/_page.tsx
+++ b/apps/web/src/app/decks/_page.tsx
@@ -8,20 +8,22 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useHydrated } from "@/api/queries";
 import { DecksIntro } from "@/app/decks/_components/decks-intro";
 
-const decksLoader = () => (
-  <div className="flex items-center justify-center min-h-screen">
-    <div className="text-center">
-      <div className="spinner mb-4" />
-      <p>Loading Decks...</p>
+function DecksLoader() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="text-center">
+        <div className="spinner mb-4" />
+        <p>Loading Decks...</p>
+      </div>
     </div>
-  </div>
-);
+  );
+}
 
 const Decks = dynamic(
   () => import("@/app/decks/_components").then((m) => ({ default: m.Decks })),
   {
     ssr: false,
-    loading: decksLoader
+    loading: DecksLoader
   }
 );
 
@@ -36,7 +38,7 @@ export function DecksPage() {
       <div id="deck-media-view-container" />
       {/* Avoid flashing the logged-out intro to logged-in users before the
           client store hydrates; the deck surface is client-only anyway. */}
-      {!hydrated ? decksLoader() : activeUser ? <Decks /> : <DecksIntro />}
+      {!hydrated ? <DecksLoader /> : activeUser ? <Decks /> : <DecksIntro />}
     </div>
   );
 }

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -646,6 +646,37 @@
     "choose-one": "Choose one",
     "user": "User",
     "search-query": "Search query",
+    "intro": {
+      "title": "Decks — your personalized dashboard",
+      "description": "Follow feeds, communities, Waves, notifications and your wallet side by side, updating in real time. Sign in to build and save your own deck.",
+      "login": "Log in to build your deck",
+      "browse-communities": "Browse communities instead",
+      "features": {
+        "columns-title": "Live columns",
+        "columns-description": "Watch multiple feeds update next to each other, in real time.",
+        "anything-title": "Anything you follow",
+        "anything-description": "Add columns for people, communities, Waves, trending, search, notifications and your wallet.",
+        "arrange-title": "Arrange your way",
+        "arrange-description": "Drag columns to reorder them and shape your own workspace.",
+        "saved-title": "Saved to your account",
+        "saved-description": "Sign in and your decks sync with you across every device."
+      }
+    },
+    "onboarding": {
+      "title": "Welcome to Decks",
+      "button": "Get started",
+      "skip": "Skip",
+      "finish": "Build my deck",
+      "build-title": "Build your deck",
+      "tips": {
+        "add-title": "Add a column",
+        "add-description": "Pick a column type to follow a feed, community, person, your notifications and more.",
+        "drag-title": "Arrange them",
+        "drag-description": "Drag columns by their header to reorder your workspace any way you like.",
+        "save-title": "Save your deck",
+        "save-description": "Save a deck to your account from its settings to keep it across devices."
+      }
+    },
     "columns": {
       "view-full-post": "View full post",
       "user": "User",

--- a/apps/web/src/features/shared/navbar/navbar-main-sidebar.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-main-sidebar.tsx
@@ -140,16 +140,20 @@ export function NavbarMainSidebar({ show, setShow, setStepOne }: Props) {
             dot={unread?.truncated ? false : Boolean(unread?.totalUnread)}
           />
         </EcencyConfigManager.Conditional>
-        <EcencyConfigManager.Conditional
-          condition={({ visionFeatures }) => visionFeatures.decks.enabled}
-        >
-          <NavbarSideMainMenuItem
-            label={i18next.t("navbar.decks")}
-            to="/decks"
-            onClick={() => setShow(false)}
-            icon={<UilColumns size={16} />}
-          />
-        </EcencyConfigManager.Conditional>
+        {/* Decks only pays off once logged in (saved decks, account columns);
+            logged-out users already have the Communities entry above. */}
+        {activeUser && hydrated && (
+          <EcencyConfigManager.Conditional
+            condition={({ visionFeatures }) => visionFeatures.decks.enabled}
+          >
+            <NavbarSideMainMenuItem
+              label={i18next.t("navbar.decks")}
+              to="/decks"
+              onClick={() => setShow(false)}
+              icon={<UilColumns size={16} />}
+            />
+          </EcencyConfigManager.Conditional>
+        )}
 
         <NavbarSideMainMenuItem
           label={i18next.t("proposals.page-title")}

--- a/apps/web/src/features/shared/navbar/navbar-text-menu.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-text-menu.tsx
@@ -7,9 +7,18 @@ import i18n from "i18next";
 import { EcencyConfigManager } from "@/config";
 import { usePathname } from "next/navigation";
 import { classNameObject } from "@ui/util";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { useHydrated } from "@/api/queries";
 
 export function NavbarTextMenu() {
   const pathname = usePathname();
+  const { activeUser } = useActiveAccount();
+  const hydrated = useHydrated();
+
+  // Decks only pays off once you can build and save one, so logged-out visitors
+  // see Communities (a content-rich discovery surface) in that slot instead.
+  // Gate on `hydrated` so server and first client render agree (no mismatch).
+  const isLoggedIn = hydrated && !!activeUser;
 
   const ITEMS = [
     {
@@ -22,16 +31,24 @@ export function NavbarTextMenu() {
       label: i18n.t("navbar.waves"),
       show: EcencyConfigManager.selector(({ visionFeatures }) => visionFeatures.waves.enabled)
     },
-    {
-      link: "/decks",
-      label: i18next.t("navbar.decks"),
-      show: EcencyConfigManager.selector(({ visionFeatures }) => visionFeatures.decks.enabled)
-    }
+    isLoggedIn
+      ? {
+          link: "/decks",
+          label: i18next.t("navbar.decks"),
+          show: EcencyConfigManager.selector(({ visionFeatures }) => visionFeatures.decks.enabled)
+        }
+      : {
+          link: "/communities",
+          label: i18next.t("navbar.communities"),
+          show: true
+        }
   ];
+
+  const visibleItems = ITEMS.filter((item) => item.show);
 
   return (
     <div className="hidden sm:flex md:hidden xl:flex text-menu items-center gap-4 justify-center h-full md:mr-2">
-      {ITEMS.map((item, i) => (
+      {visibleItems.map((item, i) => (
         <Fragment key={i}>
           <Link
             key={item.link}
@@ -47,7 +64,7 @@ export function NavbarTextMenu() {
           >
             {item.label}
           </Link>
-          {i !== ITEMS.length - 1 && (
+          {i !== visibleItems.length - 1 && (
             <i
               key={"circle" + item.label}
               className="w-2 h-2 bg-gray-200 dark:bg-dark-default rounded-full"

--- a/apps/web/src/specs/features/decks/default-layout.spec.ts
+++ b/apps/web/src/specs/features/decks/default-layout.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_COLUMNS, DEFAULT_LAYOUT } from "@/app/decks/_components/consts/default-layout.const";
+
+describe("decks default layout", () => {
+  it("opens a brand-new deck on the add-column picker with no seeded content", () => {
+    // The picker ("ac") is the guided empty state; we must NOT pre-seed an
+    // arbitrary feed (the old @ecency user column), which mis-taught new users
+    // that Decks is a single feed page rather than a dashboard they build.
+    expect(DEFAULT_COLUMNS).toHaveLength(1);
+    expect(DEFAULT_COLUMNS[0].type).toBe("ac");
+    expect(DEFAULT_COLUMNS.every((c) => c.type === "ac")).toBe(true);
+  });
+
+  it("wraps the empty columns in a single local default deck", () => {
+    expect(DEFAULT_LAYOUT.decks).toHaveLength(1);
+    expect(DEFAULT_LAYOUT.decks[0].columns).toBe(DEFAULT_COLUMNS);
+    expect(DEFAULT_LAYOUT.decks[0].storageType).toBe("local");
+  });
+});

--- a/apps/web/src/specs/features/shared/navbar-text-menu.spec.tsx
+++ b/apps/web/src/specs/features/shared/navbar-text-menu.spec.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+
+vi.mock("@/api/queries", () => ({
+  useHydrated: () => true
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/"
+}));
+
+import { NavbarTextMenu } from "@/features/shared/navbar/navbar-text-menu";
+
+const mockedUseActiveAccount = vi.mocked(useActiveAccount);
+
+function setLoggedIn(loggedIn: boolean) {
+  mockedUseActiveAccount.mockReturnValue({
+    activeUser: loggedIn ? ({ username: "alice" } as never) : null,
+    username: loggedIn ? "alice" : null,
+    account: null,
+    isLoading: false,
+    isPending: false,
+    isError: false,
+    isSuccess: loggedIn,
+    error: null,
+    refetch: vi.fn()
+  } as ReturnType<typeof useActiveAccount>);
+}
+
+describe("NavbarTextMenu — auth-aware Decks/Communities slot", () => {
+  beforeEach(() => setLoggedIn(false));
+
+  it("shows Communities (and hides Decks) for logged-out visitors", () => {
+    render(<NavbarTextMenu />);
+
+    expect(screen.getByRole("link", { name: "navbar.communities" }).getAttribute("href")).toBe(
+      "/communities"
+    );
+    expect(screen.queryByRole("link", { name: "navbar.decks" })).toBeNull();
+  });
+
+  it("shows Decks (and hides Communities) once logged in", () => {
+    setLoggedIn(true);
+    render(<NavbarTextMenu />);
+
+    expect(screen.getByRole("link", { name: "navbar.decks" }).getAttribute("href")).toBe("/decks");
+    expect(screen.queryByRole("link", { name: "navbar.communities" })).toBeNull();
+  });
+
+  it("always keeps Discover and Waves regardless of auth", () => {
+    render(<NavbarTextMenu />);
+
+    expect(screen.getByRole("link", { name: "navbar.discover" }).getAttribute("href")).toBe(
+      "/discover"
+    );
+    expect(screen.getByRole("link", { name: "navbar.waves" }).getAttribute("href")).toBe("/waves");
+  });
+});


### PR DESCRIPTION
## Why

Anonymous visitors landed on a contextless, multi-column Decks surface seeded with a single hardcoded **@ecency** column. This confused first-time users and mistaught Decks as "a feed page" rather than a dashboard they build — and Decks' real value (saved decks, notification/wallet/Waves columns) only exists once logged in.

## What changed

- **Auth-aware navigation** — the logged-out top-nav slot shows **Communities** in place of Decks and flips back to **Decks** on login. The sidebar Decks item is gated on login too (Communities is already always shown there).
- **Logged-out `/decks`** — direct hits (bookmarks, shared links, SEO) now render an **intro splash** explaining Decks, with a **log-in** CTA and a "browse communities" link, instead of the raw deck surface. Guarded by `useHydrated()` so logged-in users never flash the splash.
- **Empty, guided new decks** — a new deck opens straight on the column picker (the picker *is* the guided empty state) instead of a pre-seeded @ecency feed. Existing saved decks in `localStorage` are unaffected — only fresh visitors get the new default.
- **Onboarding modal** — a one-time, skippable modal (modeled on the `/publish` onboarding) explains what Decks is and how to add/arrange/save columns.

## Files

- `app/decks/_components/consts/default-layout.const.ts` — default deck = column picker only
- `app/decks/_components/decks-intro.tsx` (new) — logged-out splash
- `app/decks/_components/decks-onboarding.tsx` (new) — one-time intro modal
- `app/decks/_page.tsx`, `_components/index.tsx` — auth/hydration branching + modal wiring
- `features/shared/navbar/navbar-text-menu.tsx`, `navbar-main-sidebar.tsx` — auth-aware Decks/Communities
- `features/i18n/locales/en-US.json` — `decks.intro.*` / `decks.onboarding.*`

## Test plan

- `src/specs/features/shared/navbar-text-menu.spec.tsx` — Communities↔Decks swap by auth; Discover/Waves always present.
- `src/specs/features/decks/default-layout.spec.ts` — new deck opens empty (picker only), no seeded feed.
- Type check + lint clean on changed files.

## Screenshots

**Logged-out `/decks` — intro splash**

![Decks intro splash](https://raw.githubusercontent.com/ecency/vision-next/decks-anon-onboarding-assets/splash.png)

**First-run onboarding (over the guided empty deck)**

![Onboarding step 1 — Welcome to Decks](https://raw.githubusercontent.com/ecency/vision-next/decks-anon-onboarding-assets/onboarding-intro.png)
![Onboarding step 2 — Build your deck](https://raw.githubusercontent.com/ecency/vision-next/decks-anon-onboarding-assets/onboarding-build.png)

**Empty, guided deck (new default — column picker only)**

![Empty guided deck](https://raw.githubusercontent.com/ecency/vision-next/decks-anon-onboarding-assets/empty-deck.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated landing page for logged-out users showcasing key decks features and benefits.
  * Introduced a guided onboarding modal for first-time deck users with setup tips.
  * Simplified default deck initialization to start empty, guiding users through the column addition process.
  * Updated navigation to display decks only for authenticated users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-next/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->