### PR TITLE
fix(web): restore classic editor input width after barrel de-export

### DIFF
--- a/apps/web/src/features/shared/comment/_index.scss
+++ b/apps/web/src/features/shared/comment/_index.scss
@@ -62,21 +62,8 @@
   }
 }
 
-.the-editor {
-  @include themify(night) {
-    @apply text-silver;
-    @apply bg-dark-200;
-  }
-  @include themify(day) {
-    @apply bg-light-200;
-  }
-  border-width: 0px;
-  resize: none;
-  outline: none;
-  min-height: 80px;
-  padding: 4px;
-  line-height: 1.5;
-  font-size: 1rem;
-  font-weight: 400;
-  width: 100%;
-}
+// NOTE: `.the-editor` styles moved to textarea-autocomplete/_index.scss — the
+// stylesheet that ships with the component that actually renders the textarea.
+// Keeping them here coupled the /submit editor's width to this composer's CSS
+// being bundled, which broke when the @/features/shared barrel stopped
+// re-exporting the comment composer (#850/#852).

--- a/apps/web/src/features/shared/textarea-autocomplete/_index.scss
+++ b/apps/web/src/features/shared/textarea-autocomplete/_index.scss
@@ -1,5 +1,31 @@
 @import "src/styles/vars_mixins";
 
+// The `.the-editor` textarea (classic /submit editor and the reply/edit comment
+// composer) is rendered exclusively through this component, so its styles live
+// here — the one stylesheet guaranteed to ship wherever the editor renders.
+// Previously these rules lived in comment/_index.scss and only reached /submit
+// because the @/features/shared barrel side-effect-imported the comment composer.
+// That re-export was dropped (#850/#852), which stripped the styles (notably
+// `width: 100%`) from /submit and squashed the input column.
+.the-editor {
+  @include themify(night) {
+    @apply text-silver;
+    @apply bg-dark-200;
+  }
+  @include themify(day) {
+    @apply bg-light-200;
+  }
+  border-width: 0px;
+  resize: none;
+  outline: none;
+  min-height: 80px;
+  padding: 4px;
+  line-height: 1.5;
+  font-size: 1rem;
+  font-weight: 400;
+  width: 100%;
+}
+
 .rta {
   width: 100%;
   & > textarea {


### PR DESCRIPTION
## Problem

The classic post editor (`/submit`) renders with its markdown **input column squashed into a narrow strip** while the preview keeps its full half. Reported after yesterday's bundle/lazy-load cleanup.

![narrow input](https://cdn.discordapp.com/attachments/385448634197737484/1510388019281137794/image.png)

## Root cause

The editor textarea carries `className="the-editor"`, and `.the-editor { width: 100% }` (plus its bg/padding/font) was defined **only** in `features/shared/comment/_index.scss`. The `/submit` page never imports that file directly — it was pulled in transitively because `TextareaAutocomplete` imports `UserAvatar` from the `@/features/shared` barrel, and that barrel used to `export * from "./comment"` (side-effect-importing the comment composer's stylesheet).

PR #850/#852 removed `./comment` and `./editor-toolbar` from the `@/features/shared` barrel (to stop dragging the markdown composer into unrelated pages' first-load). That correctly trimmed the bundle, but it also stopped shipping `comment/_index.scss` to `/submit`, so `.the-editor` lost `width: 100%` and collapsed to the default textarea `cols` width. The preview column is unaffected because it doesn't use `.the-editor` — matching the screenshot.

## Fix

`.the-editor` is rendered **exclusively** through `TextareaAutocomplete` (on both `/submit` and the reply/edit comment composer). Move the whole `.the-editor` ruleset out of `comment/_index.scss` and into `textarea-autocomplete/_index.scss` — the stylesheet that always ships with the component that actually renders the textarea. This removes the cross-feature CSS coupling entirely rather than re-adding a fragile barrel dependency.

- `textarea-autocomplete/_index.scss`: add the `.the-editor` ruleset (width, bg, padding, font, etc.)
- `comment/_index.scss`: remove the `.the-editor` ruleset (left a pointer comment)

No behavior change for the comment composer (it renders the same component, which still imports this stylesheet); `/submit` regains the full-width input and the rest of the editor styling.

## Testing

- Verified `.the-editor` is now defined in exactly one SCSS file.
- Verified `textarea-autocomplete/index.tsx` imports `./_index.scss` unconditionally, so the rule ships wherever the editor renders.
- Manual: `/submit` input column returns to its half-width; reply/edit composer unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized editor styling to improve code organization and prevent CSS coupling issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->