### PR TITLE
fix(web): auto-capture entry render crashes to Sentry with component stack

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-render-boundary.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-render-boundary.tsx
@@ -20,6 +20,10 @@ const SentryIssueReporterDialog = dynamic(
   { ssr: false }
 );
 
+interface EntryRenderBoundaryProps {
+  children: ReactNode;
+}
+
 /**
  * Wraps the entry (post / reply) content so a render-time crash in the body,
  * client content or discussion subtree degrades to an inline retry card instead
@@ -28,7 +32,7 @@ const SentryIssueReporterDialog = dynamic(
  * named. Lives as a client component because `fallback` is a function, which
  * can't cross the server→client (RSC) boundary from the server page.
  */
-export function EntryRenderBoundary({ children }: { children: ReactNode }) {
+export function EntryRenderBoundary({ children }: EntryRenderBoundaryProps) {
   return (
     <SentryErrorBoundary
       fallback={({ error, eventId, reset }) => (

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-render-boundary.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-render-boundary.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { ReactNode } from "react";
+import dynamic from "next/dynamic";
+import i18next from "i18next";
+import { Button } from "@ui/button";
+// Import the boundary from its direct path (not the barrel) so the eager path
+// can't pull the report dialog in transitively.
+import { SentryErrorBoundary } from "@/features/issue-reporter/sentry-error-boundary";
+
+// The report dialog (modal + form + react-query provider) is only needed once a
+// crash has happened, so lazy-load it from the fallback. This keeps it out of
+// the entry page's first-load bundle on the happy path — zero added cost unless
+// the boundary actually catches.
+const SentryIssueReporterDialog = dynamic(
+  () =>
+    import("@/features/issue-reporter/sentry-issue-reporter-dialog").then((m) => ({
+      default: m.SentryIssueReporterDialog
+    })),
+  { ssr: false }
+);
+
+/**
+ * Wraps the entry (post / reply) content so a render-time crash in the body,
+ * client content or discussion subtree degrades to an inline retry card instead
+ * of bubbling to the full-page 500 (global-error) — and, crucially, reports the
+ * error to Sentry WITH the React component stack so the failing component is
+ * named. Lives as a client component because `fallback` is a function, which
+ * can't cross the server→client (RSC) boundary from the server page.
+ */
+export function EntryRenderBoundary({ children }: { children: ReactNode }) {
+  return (
+    <SentryErrorBoundary
+      fallback={({ error, eventId, reset }) => (
+        <div className="my-6 rounded-2xl border border-[--border-color] p-6 text-center">
+          <p className="mb-4 text-gray-600 dark:text-gray-400">
+            {i18next.t("entry.unable-to-load")}
+          </p>
+          <div className="flex items-center justify-center gap-4">
+            <Button onClick={reset}>{i18next.t("g.try-again")}</Button>
+            <SentryIssueReporterDialog error={error} eventId={eventId} />
+          </div>
+        </div>
+      )}
+    >
+      {children}
+    </SentryErrorBoundary>
+  );
+}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/index.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/index.ts
@@ -18,3 +18,4 @@ export * from "./entry-page-discussions";
 export * from "./entry-page-edit-history";
 export * from "./context";
 export * from "./entry-reply-section";
+export * from "./entry-render-boundary";

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
@@ -16,6 +16,7 @@ import {
   EntryPageContextProvider,
   EntryPageCrossPostHeader,
   EntryPageEditHistory,
+  EntryRenderBoundary,
   MdHandler
 } from "./_components";
 import { EntryNotFoundFallback } from "./_components/entry-not-found-fallback";
@@ -79,10 +80,7 @@ export default async function EntryPage({ params, searchParams }: Props) {
       <EntryPageContextProvider>
         <div className="app-content entry-page">
           <div className="the-entry">
-            <EntryNotFoundFallback
-              username={author}
-              permlink={permlink}
-            />
+            <EntryNotFoundFallback username={author} permlink={permlink} />
           </div>
         </div>
       </EntryPageContextProvider>
@@ -152,9 +150,11 @@ export default async function EntryPage({ params, searchParams }: Props) {
           <div className="the-entry">
             <EntryPageCrossPostHeader entry={entry} />
             {structuredData && <JsonLd data={structuredData} />}
-            <EntryPageContentSSR entry={entry} isRawContent={isRawContent} />
-            <EntryPageContentClient entry={entry} />
-            <EntryPageDiscussionsWrapper entry={entry} category={category} />
+            <EntryRenderBoundary>
+              <EntryPageContentSSR entry={entry} isRawContent={isRawContent} />
+              <EntryPageContentClient entry={entry} />
+              <EntryPageDiscussionsWrapper entry={entry} category={category} />
+            </EntryRenderBoundary>
           </div>
         </div>
         <EntryPageEditHistory entry={entry} />

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -7,6 +7,8 @@ import Link from "next/link";
 import { Button } from "@ui/button";
 import { SentryIssueReporterDialog } from "@/features/issue-reporter";
 import defaults from "@/defaults";
+import * as Sentry from "@sentry/nextjs";
+import { useEffect, useState } from "react";
 
 export default function GlobalError({
   error,
@@ -15,6 +17,16 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const [eventId, setEventId] = useState<string>();
+
+  // Report the crash to Sentry as soon as the fallback renders, so we always
+  // get an event — even when the user never opens the report dialog. The
+  // optional user feedback (via SentryIssueReporterDialog) is then attached to
+  // THIS event id instead of capturing a second, separate exception.
+  useEffect(() => {
+    setEventId(Sentry.captureException(error));
+  }, [error]);
+
   return (
     // global-error must include html and body tags
     <html>
@@ -38,7 +50,7 @@ export default function GlobalError({
                 <Link href="/">
                   <Button>{i18next.t("not-found.back-home")}</Button>
                 </Link>
-                <SentryIssueReporterDialog error={error} />
+                <SentryIssueReporterDialog error={error} eventId={eventId} />
               </div>
             </div>
             <Image src="/assets/illustration-open-source.png" alt="logo" width={571} height={460} />

--- a/apps/web/src/features/issue-reporter/index.ts
+++ b/apps/web/src/features/issue-reporter/index.ts
@@ -1,2 +1,3 @@
 export * from "./sentry-issue-reporter";
 export * from "./sentry-issue-reporter-dialog";
+export * from "./sentry-error-boundary";

--- a/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
+++ b/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Component, ErrorInfo, ReactNode } from "react";
+import * as Sentry from "@sentry/nextjs";
+
+interface FallbackProps {
+  error: Error;
+  // Sentry event id of the captured exception, so the fallback can attach user
+  // feedback to the SAME event (see SentryIssueReporterDialog).
+  eventId?: string;
+  reset: () => void;
+}
+
+interface Props {
+  children: ReactNode;
+  fallback: (props: FallbackProps) => ReactNode;
+}
+
+interface State {
+  error?: Error;
+  eventId?: string;
+}
+
+/**
+ * Client error boundary that reports render-time throws to Sentry WITH the React
+ * component stack attached. For "Element type is invalid" / undefined-component
+ * errors the framework JS stack is entirely react-dom internals (0 app frames),
+ * so the component stack is the only thing that names the component at fault —
+ * `captureException` alone (e.g. from global-error, which only receives
+ * `{ error }`) cannot. Pair with the uploaded source maps to pinpoint the file.
+ */
+export class SentryErrorBoundary extends Component<Props, State> {
+  state: State = {};
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    const eventId = Sentry.captureException(error, {
+      contexts: { react: { componentStack: errorInfo.componentStack ?? undefined } }
+    });
+    this.setState({ eventId });
+  }
+
+  reset = () => this.setState({ error: undefined, eventId: undefined });
+
+  render() {
+    const { error, eventId } = this.state;
+    if (error) {
+      return this.props.fallback({ error, eventId, reset: this.reset });
+    }
+    return this.props.children;
+  }
+}

--- a/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
+++ b/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
@@ -28,6 +28,13 @@ interface State {
  * so the component stack is the only thing that names the component at fault —
  * `captureException` alone (e.g. from global-error, which only receives
  * `{ error }`) cannot. Pair with the uploaded source maps to pinpoint the file.
+ *
+ * Lifecycle note: `getDerivedStateFromError` renders the fallback first with
+ * `eventId` still undefined, then `componentDidCatch` captures the exception and
+ * sets `eventId` on a second render. A fallback that auto-opens the report
+ * dialog must therefore guard on `eventId` to avoid capturing a duplicate
+ * exception; the current entry fallback only reports on explicit click, so it
+ * is unaffected.
  */
 export class SentryErrorBoundary extends Component<Props, State> {
   state: State = {};

--- a/apps/web/src/features/issue-reporter/sentry-issue-reporter-dialog.tsx
+++ b/apps/web/src/features/issue-reporter/sentry-issue-reporter-dialog.tsx
@@ -10,9 +10,13 @@ import { getQueryClient } from "@/core/react-query";
 
 interface Props {
   error?: any;
+  // Event id of an exception already captured by the caller (e.g. global-error
+  // auto-capture). When provided, the feedback is attached to it instead of
+  // capturing the exception again.
+  eventId?: string;
 }
 
-export function SentryIssueReporterDialog({ error }: Props) {
+export function SentryIssueReporterDialog({ error, eventId }: Props) {
   const [show, setShow] = useState(false);
 
   const onHide = useCallback(() => setShow(false), []);
@@ -25,7 +29,7 @@ export function SentryIssueReporterDialog({ error }: Props) {
       <Modal centered={true} show={show} onHide={() => setShow(false)}>
         <ModalHeader closeButton={true}>{i18next.t("issue-reporter.report-issue")}</ModalHeader>
         <ModalBody>
-          <SentryIssueReporter error={error} onHide={onHide} />
+          <SentryIssueReporter error={error} eventId={eventId} onHide={onHide} />
         </ModalBody>
       </Modal>
     </QueryClientProvider>

--- a/apps/web/src/features/issue-reporter/sentry-issue-reporter.tsx
+++ b/apps/web/src/features/issue-reporter/sentry-issue-reporter.tsx
@@ -13,10 +13,13 @@ import { success } from "@/features/shared";
 
 interface Props {
   error?: any;
+  // Event id of an exception already captured upstream (global-error
+  // auto-capture). When set, feedback attaches to it instead of re-capturing.
+  eventId?: string;
   onHide: () => void;
 }
 
-export function SentryIssueReporter({ error, onHide }: Props) {
+export function SentryIssueReporter({ error, eventId, onHide }: Props) {
   const { activeUser } = useActiveAccount();
 
   const pathname = usePathname();
@@ -34,20 +37,23 @@ export function SentryIssueReporter({ error, onHide }: Props) {
       });
     }
 
-    const eventId = Sentry.captureException(error);
+    // Prefer the event already captured by the error boundary so the feedback
+    // enriches that event rather than creating a duplicate; fall back to
+    // capturing here when the dialog is used without a pre-captured event.
+    const associatedEventId = eventId ?? Sentry.captureException(error);
 
     Sentry.captureFeedback({
       message,
       name,
       email,
       url: pathname ?? undefined,
-      associatedEventId: eventId
+      associatedEventId
     });
 
     setIsLoading(false);
     success(i18next.t("issue-reporter.issue-reported"));
     onHide();
-  }, [activeUser, email, error, message, name, onHide, pathname]);
+  }, [activeUser, email, error, eventId, message, name, onHide, pathname]);
 
   return (
     <Form className="flex flex-col gap-4">

--- a/apps/web/src/specs/features/entry/entry-render-boundary.spec.tsx
+++ b/apps/web/src/specs/features/entry/entry-render-boundary.spec.tsx
@@ -1,0 +1,52 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { EntryRenderBoundary } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-render-boundary";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(() => "evt-456")
+}));
+
+// The report dialog is lazy-loaded (next/dynamic, ssr:false) and only matters
+// once the user clicks Report. Stub next/dynamic to a no-op so the test doesn't
+// pull the modal/form/react-query chain into the happy/error path.
+vi.mock("next/dynamic", () => ({
+  default: () => () => null
+}));
+
+function Boom(): never {
+  throw new Error("kaboom");
+}
+
+describe("EntryRenderBoundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children when nothing throws", () => {
+    render(
+      <EntryRenderBoundary>
+        <div>post body</div>
+      </EntryRenderBoundary>
+    );
+
+    expect(screen.getByText("post body")).toBeInTheDocument();
+  });
+
+  it("shows the inline retry card when a child throws", () => {
+    render(
+      <EntryRenderBoundary>
+        <Boom />
+      </EntryRenderBoundary>
+    );
+
+    // i18next is mocked to echo the key (see setup-any-spec.ts).
+    expect(screen.getByText("entry.unable-to-load")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "g.try-again" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/specs/features/issue-reporter/sentry-error-boundary.spec.tsx
+++ b/apps/web/src/specs/features/issue-reporter/sentry-error-boundary.spec.tsx
@@ -1,0 +1,89 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import * as Sentry from "@sentry/nextjs";
+import { SentryErrorBoundary } from "@/features/issue-reporter/sentry-error-boundary";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(() => "evt-123")
+}));
+
+// A child whose throwing is toggleable, so we can exercise reset/recovery.
+let shouldThrow = true;
+function Maybe() {
+  if (shouldThrow) {
+    throw new Error("boom");
+  }
+  return <div>recovered child</div>;
+}
+
+const fallback = ({ eventId, reset }: { error: Error; eventId?: string; reset: () => void }) => (
+  <div>
+    <span data-testid="fallback">fallback:{eventId ?? "none"}</span>
+    <button onClick={reset}>retry</button>
+  </div>
+);
+
+describe("SentryErrorBoundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shouldThrow = true;
+    // React logs caught boundary errors to console.error; silence the noise.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children when nothing throws", () => {
+    render(
+      <SentryErrorBoundary fallback={fallback}>
+        <div>safe child</div>
+      </SentryErrorBoundary>
+    );
+
+    expect(screen.getByText("safe child")).toBeInTheDocument();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("renders the fallback and reports with the React component stack on throw", () => {
+    render(
+      <SentryErrorBoundary fallback={fallback}>
+        <Maybe />
+      </SentryErrorBoundary>
+    );
+
+    // Fallback is shown instead of the crashed subtree.
+    expect(screen.getByTestId("fallback")).toBeInTheDocument();
+
+    // Reported once, WITH the component stack attached (the part source maps
+    // alone can't provide for undefined-component crashes).
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        contexts: { react: { componentStack: expect.any(String) } }
+      })
+    );
+
+    // The captured event id is threaded into the fallback (for feedback assoc).
+    expect(screen.getByTestId("fallback")).toHaveTextContent("fallback:evt-123");
+  });
+
+  it("restores children when reset is called after the child stops throwing", () => {
+    render(
+      <SentryErrorBoundary fallback={fallback}>
+        <Maybe />
+      </SentryErrorBoundary>
+    );
+
+    expect(screen.getByTestId("fallback")).toBeInTheDocument();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole("button", { name: "retry" }));
+
+    expect(screen.getByText("recovered child")).toBeInTheDocument();
+    expect(screen.queryByTestId("fallback")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem
The 500 page (`global-error.tsx`) only created a Sentry event when a user clicked **Report** — so render crashes that nobody reported were invisible in Sentry. On top of that, "Element type is invalid (undefined component)" crashes throw deep inside react-dom internals: the JS stack has **zero app frames**, so the source maps we already upload can't name the component at fault.

## Changes
- **Auto-capture in `global-error`** — captures the exception on mount (`useEffect`) so every crash reports automatically, not just reported ones. The returned event id is threaded into the report dialog so user feedback attaches to the **same** event (`associatedEventId`) instead of creating a duplicate. The dialog still self-captures when used without a pre-captured id (backward compatible).
- **`SentryErrorBoundary`** (reusable, in `features/issue-reporter`) — a client error boundary that reports with the **React component stack** (`contexts.react.componentStack`). That stack — unlike the framework-internal JS stack — names the component that rendered the undefined element, and pairs with our existing source-map upload to pinpoint the file.
- **`EntryRenderBoundary`** wraps the entry (post/reply) content subtree on the entry page. A render crash there now degrades to an inline retry card (+ report button) instead of the full-page 500.

## SSR
The boundary receives the SSR'd content as **children** — server components are rendered by the server page and passed through, never imported into the client module — so server rendering is unchanged. The boundary renders `children` directly (no wrapper element) when there's no error, so the SSR HTML is byte-identical and there's no hydration mismatch.

## Testing
- `tsc --noEmit`: no new errors in touched files
- `entry-page-discussions-wrapper` spec: 3/3 pass
- prettier clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful error recovery for entry content—rendering failures now display an inline retry option instead of a full-page error
  * Enhanced error tracking to associate user feedback with specific error events during reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->