### PR TITLE
fix(web): stop SW precaching deleted source maps (persistent 500s)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -7,11 +7,19 @@ const path = require("path");
 const withPWA = require("next-pwa")({
   dest: "public",
   // Activate a new SW as soon as it finishes installing, and take control of
-  // open clients immediately. Combined with the client-side update listener
-  // in <PWAInstallPrompt>, users get fresh assets on the next navigation
-  // without needing to fully close all tabs.
+  // open clients immediately. Paired with <ServiceWorkerRecovery>, which reloads
+  // once on `controllerchange` so an open tab doesn't keep running an old webpack
+  // runtime against freshly-cached chunks.
   skipWaiting: true,
   clientsClaim: true,
+  // Never precache source maps. We upload them to Sentry and then delete them
+  // from the build output (deleteSourcemapsAfterUpload), so the .map URLs 404 in
+  // production. Workbox's precacheAndRoute fetches every precache entry during
+  // SW install and rejects the whole install on any non-OK response — so a SW
+  // that precached the (now-missing) .map files could never install/update,
+  // stranding users on a stale cache that served mismatched chunks ("Element
+  // type is invalid: undefined" → persistent 500).
+  buildExcludes: [/\.map$/],
   // Raise the max size to precache large chunks:
   maximumFileSizeToCacheInBytes: 8 * 1024 * 1024, // 8MB
   // Advanced caching strategies for better performance

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { HiringConsoleLog } from "@/app/_components";
 import { cookies } from "next/headers";
 import { Theme } from "@/enums";
 import { BannerManager } from "@/features/banners";
+import { ServiceWorkerRecovery } from "@/features/pwa-install";
 import React from "react";
 import Script from "next/script";
 import { Inter, Lora } from "next/font/google";
@@ -92,6 +93,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <Script defer data-domain="ecency.com" data-api="/pl/api/event" src="/pl/js/script.js" />
       <body className={theme === Theme.night ? "dark" : ""}>
         <BannerManager />
+        <ServiceWorkerRecovery />
         <HiringConsoleLog />
         <Providers><main id="main-content">{children}</main></Providers>
         <div id="modal-overlay-container" />

--- a/apps/web/src/features/pwa-install/index.ts
+++ b/apps/web/src/features/pwa-install/index.ts
@@ -1,3 +1,4 @@
 export { usePwaInstall } from "./use-pwa-install";
 export type { UsePwaInstallResult } from "./use-pwa-install";
 export { isIosSafari } from "./is-ios-safari";
+export { ServiceWorkerRecovery, isChunkLoadError } from "./service-worker-recovery";

--- a/apps/web/src/features/pwa-install/service-worker-recovery.tsx
+++ b/apps/web/src/features/pwa-install/service-worker-recovery.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Matches the runtime symptoms of a stale service worker handing a mismatched
+// chunk to the running webpack runtime: the dynamic import either fails outright
+// (ChunkLoadError / failed module script) or loads a module whose exports don't
+// line up. We can only auto-recover the former here; the latter is handled by
+// the React error boundaries. Keep this list aligned with what the bundlers /
+// browsers actually throw.
+export function isChunkLoadError(message?: string | null): boolean {
+  if (!message) {
+    return false;
+  }
+  return (
+    /ChunkLoadError/i.test(message) ||
+    /Loading chunk [\w-]+ failed/i.test(message) ||
+    /Loading CSS chunk/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /Importing a module script failed/i.test(message) ||
+    /Failed to fetch dynamically imported module/i.test(message)
+  );
+}
+
+// Guards against reload loops: at most one chunk-error recovery reload per tab
+// session. If the page still errors after the reload, we stop and let the error
+// boundary render its fallback rather than refreshing forever.
+const CHUNK_RELOAD_FLAG = "sw-chunk-recovery-reloaded";
+
+// Guards a controllerchange reload against firing twice within one page load.
+let controllerReloadStarted = false;
+
+function reloadAfterChunkError() {
+  try {
+    if (sessionStorage.getItem(CHUNK_RELOAD_FLAG)) {
+      return;
+    }
+    sessionStorage.setItem(CHUNK_RELOAD_FLAG, "1");
+  } catch {
+    // sessionStorage can throw (private mode / quota); a single reload without
+    // the guard is still preferable to a stuck page.
+  }
+  window.location.reload();
+}
+
+/**
+ * Recovers users stranded on a stale service worker / mismatched chunks — the
+ * cause of the persistent "Element type is invalid: undefined" 500s. Renders
+ * nothing.
+ *
+ * 1. When a NEW service worker takes control of an already-controlled page
+ *    (`controllerchange`), reload once so the in-memory webpack runtime matches
+ *    the freshly-cached chunks. Only armed when the page already had a
+ *    controller at mount — otherwise the upcoming `controllerchange` is just the
+ *    initial `clientsClaim` on a first visit and a reload would be spurious.
+ * 2. As a safety net, reload once (per session) on a ChunkLoadError / failed
+ *    dynamic import, which is what a stale-cache chunk mismatch surfaces as.
+ */
+export function ServiceWorkerRecovery() {
+  useEffect(() => {
+    const hasServiceWorker = typeof navigator !== "undefined" && "serviceWorker" in navigator;
+
+    const onControllerChange = () => {
+      if (controllerReloadStarted) {
+        return;
+      }
+      controllerReloadStarted = true;
+      window.location.reload();
+    };
+
+    const armedForController = hasServiceWorker && !!navigator.serviceWorker.controller;
+    if (armedForController) {
+      navigator.serviceWorker.addEventListener("controllerchange", onControllerChange);
+    }
+
+    const onError = (event: ErrorEvent) => {
+      if (isChunkLoadError(event.message) || isChunkLoadError(event.error?.message)) {
+        reloadAfterChunkError();
+      }
+    };
+    const onRejection = (event: PromiseRejectionEvent) => {
+      const reason = event.reason;
+      const message = typeof reason === "string" ? reason : reason?.message;
+      if (isChunkLoadError(message)) {
+        reloadAfterChunkError();
+      }
+    };
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onRejection);
+
+    return () => {
+      if (armedForController) {
+        navigator.serviceWorker.removeEventListener("controllerchange", onControllerChange);
+      }
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/features/pwa-install/service-worker-recovery.tsx
+++ b/apps/web/src/features/pwa-install/service-worker-recovery.tsx
@@ -37,8 +37,11 @@ function reloadAfterChunkError() {
     }
     sessionStorage.setItem(CHUNK_RELOAD_FLAG, "1");
   } catch {
-    // sessionStorage can throw (private mode / quota); a single reload without
-    // the guard is still preferable to a stuck page.
+    // sessionStorage unusable (private mode / quota) — without a persisted guard
+    // we can't prove we haven't already reloaded this session, so do NOT reload.
+    // A stuck page (the React error boundary renders its fallback) is far better
+    // than an infinite reload loop.
+    return;
   }
   window.location.reload();
 }
@@ -58,7 +61,12 @@ function reloadAfterChunkError() {
  */
 export function ServiceWorkerRecovery() {
   useEffect(() => {
-    const hasServiceWorker = typeof navigator !== "undefined" && "serviceWorker" in navigator;
+    // Capture the container up front so cleanup detaches from the same object,
+    // not whatever `navigator.serviceWorker` happens to be later.
+    const swContainer =
+      typeof navigator !== "undefined" && "serviceWorker" in navigator
+        ? navigator.serviceWorker
+        : null;
 
     const onControllerChange = () => {
       if (controllerReloadStarted) {
@@ -68,9 +76,12 @@ export function ServiceWorkerRecovery() {
       window.location.reload();
     };
 
-    const armedForController = hasServiceWorker && !!navigator.serviceWorker.controller;
+    // Only arm when the page already has a controller — otherwise the upcoming
+    // controllerchange is just the initial clientsClaim on a first visit and a
+    // reload would be spurious.
+    const armedForController = !!swContainer && !!swContainer.controller;
     if (armedForController) {
-      navigator.serviceWorker.addEventListener("controllerchange", onControllerChange);
+      swContainer!.addEventListener("controllerchange", onControllerChange);
     }
 
     const onError = (event: ErrorEvent) => {
@@ -89,8 +100,8 @@ export function ServiceWorkerRecovery() {
     window.addEventListener("unhandledrejection", onRejection);
 
     return () => {
-      if (armedForController) {
-        navigator.serviceWorker.removeEventListener("controllerchange", onControllerChange);
+      if (armedForController && swContainer) {
+        swContainer.removeEventListener("controllerchange", onControllerChange);
       }
       window.removeEventListener("error", onError);
       window.removeEventListener("unhandledrejection", onRejection);

--- a/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
+++ b/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
@@ -1,9 +1,8 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render } from "@testing-library/react";
-import {
-  ServiceWorkerRecovery,
-  isChunkLoadError
-} from "@/features/pwa-install/service-worker-recovery";
+// ServiceWorkerRecovery is imported dynamically per-test (see beforeEach) to reset
+// its module-level reload guards; isChunkLoadError is pure, imported statically.
+import { isChunkLoadError } from "@/features/pwa-install/service-worker-recovery";
 
 describe("isChunkLoadError", () => {
   it("matches the chunk / dynamic-import failure messages", () => {
@@ -26,23 +25,36 @@ describe("isChunkLoadError", () => {
 describe("ServiceWorkerRecovery", () => {
   let reloadMock: ReturnType<typeof vi.fn>;
   const realLocation = window.location;
+  let Recovery: (typeof import("@/features/pwa-install/service-worker-recovery"))["ServiceWorkerRecovery"];
 
-  beforeEach(() => {
+  function mockServiceWorker(controller: object | null) {
+    const target = Object.assign(new EventTarget(), { controller });
+    Object.defineProperty(navigator, "serviceWorker", { configurable: true, value: target });
+    return target;
+  }
+
+  beforeEach(async () => {
     sessionStorage.clear();
     reloadMock = vi.fn();
     Object.defineProperty(window, "location", {
       configurable: true,
       value: { ...realLocation, reload: reloadMock }
     });
+    // Re-import per test so the module-level reload guards (controllerReloadStarted)
+    // reset and can't leak between tests.
+    vi.resetModules();
+    Recovery = (await import("@/features/pwa-install/service-worker-recovery"))
+      .ServiceWorkerRecovery;
   });
 
   afterEach(() => {
     Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+    delete (navigator as unknown as { serviceWorker?: unknown }).serviceWorker;
     vi.restoreAllMocks();
   });
 
   it("reloads once on a chunk-load error, then not again in the same session", () => {
-    render(<ServiceWorkerRecovery />);
+    render(<Recovery />);
 
     window.dispatchEvent(
       new ErrorEvent("error", { message: "ChunkLoadError: Loading chunk 7 failed" })
@@ -57,14 +69,14 @@ describe("ServiceWorkerRecovery", () => {
   });
 
   it("does not reload on unrelated errors", () => {
-    render(<ServiceWorkerRecovery />);
+    render(<Recovery />);
 
     window.dispatchEvent(new ErrorEvent("error", { message: "TypeError: boom" }));
     expect(reloadMock).not.toHaveBeenCalled();
   });
 
   it("recovers from a rejected dynamic import", () => {
-    render(<ServiceWorkerRecovery />);
+    render(<Recovery />);
 
     // jsdom's PromiseRejectionEvent constructor is unreliable; dispatch a plain
     // event carrying `reason`, which is all the handler reads.
@@ -73,5 +85,32 @@ describe("ServiceWorkerRecovery", () => {
     window.dispatchEvent(event);
 
     expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload when sessionStorage is unusable (no reload loop)", () => {
+    render(<Recovery />);
+
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage denied");
+    });
+    window.dispatchEvent(new ErrorEvent("error", { message: "ChunkLoadError: x" }));
+
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it("reloads once when a new service worker takes control of an already-controlled page", () => {
+    const sw = mockServiceWorker({}); // controller present at mount → armed
+    render(<Recovery />);
+
+    sw.dispatchEvent(new Event("controllerchange"));
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload on controllerchange when the page had no controller at mount", () => {
+    const sw = mockServiceWorker(null); // no controller → not armed (initial claim)
+    render(<Recovery />);
+
+    sw.dispatchEvent(new Event("controllerchange"));
+    expect(reloadMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
+++ b/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
@@ -1,0 +1,77 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import {
+  ServiceWorkerRecovery,
+  isChunkLoadError
+} from "@/features/pwa-install/service-worker-recovery";
+
+describe("isChunkLoadError", () => {
+  it("matches the chunk / dynamic-import failure messages", () => {
+    expect(isChunkLoadError("ChunkLoadError: something")).toBe(true);
+    expect(isChunkLoadError("Loading chunk 482 failed")).toBe(true);
+    expect(isChunkLoadError("Loading CSS chunk 5 failed")).toBe(true);
+    expect(isChunkLoadError("Failed to fetch dynamically imported module: /a.js")).toBe(true);
+    expect(isChunkLoadError("error loading dynamically imported module")).toBe(true);
+    expect(isChunkLoadError("Importing a module script failed.")).toBe(true);
+  });
+
+  it("ignores unrelated errors and empty input", () => {
+    expect(isChunkLoadError("TypeError: x is not a function")).toBe(false);
+    expect(isChunkLoadError("")).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+  });
+});
+
+describe("ServiceWorkerRecovery", () => {
+  let reloadMock: ReturnType<typeof vi.fn>;
+  const realLocation = window.location;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    reloadMock = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...realLocation, reload: reloadMock }
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+    vi.restoreAllMocks();
+  });
+
+  it("reloads once on a chunk-load error, then not again in the same session", () => {
+    render(<ServiceWorkerRecovery />);
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "ChunkLoadError: Loading chunk 7 failed" })
+    );
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+
+    // Session guard: a second chunk error must NOT trigger another reload loop.
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "ChunkLoadError: Loading chunk 9 failed" })
+    );
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload on unrelated errors", () => {
+    render(<ServiceWorkerRecovery />);
+
+    window.dispatchEvent(new ErrorEvent("error", { message: "TypeError: boom" }));
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it("recovers from a rejected dynamic import", () => {
+    render(<ServiceWorkerRecovery />);
+
+    // jsdom's PromiseRejectionEvent constructor is unreliable; dispatch a plain
+    // event carrying `reason`, which is all the handler reads.
+    const event = new Event("unhandledrejection") as Event & { reason?: unknown };
+    event.reason = new Error("Failed to fetch dynamically imported module: /_next/x.js");
+    window.dispatchEvent(event);
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Root cause (confirmed against the live deploy)
The service worker precaches **256 `.js.map` files, and every one returns HTTP 404** in production — because Sentry strips source maps from the build output after upload (`deleteSourcemapsAfterUpload`). Workbox's `precacheAndRoute` fetches **every** precache entry during SW **install** and rejects the whole install on any non-OK response (`bad-precaching-response`).

Result: the SW **can never install/update**. Users who installed a working SW before this regression are **stuck on it** — it keeps serving old precached chunks. Once the site's HTML/runtime moved on, those chunks mismatch the running webpack runtime → **"Element type is invalid: undefined" → a 500 on every visit**. This is a code-clean failure (why static analysis found nothing), persistent per-user (poisoned cache, not random), produces no `ChunkLoadError` (it's precache-install failure + stale serving), and correlates in time with when source-map upload was added.

## Fix
- **`next.config.js` → `buildExcludes: [/\.map$/]`** — never precache source maps. SW install/update succeeds again, and stuck users **auto-recover on their next SW-update check** (the browser re-fetches `sw.js` within 24h).
- **`ServiceWorkerRecovery`** (mounted in root layout, renders null):
  - reloads **once** on `controllerchange` — only when the page already had a controller at mount (so the initial `clientsClaim` on a first visit doesn't trigger a spurious reload) — so a tab that gets a new SW mid-session doesn't keep running a stale runtime against fresh chunks.
  - **one-reload-per-session** safety net on `ChunkLoadError` / failed dynamic import.
  - replaces the `<PWAInstallPrompt>` update listener the old config comment referenced but which never existed.

## Testing
- `service-worker-recovery.spec.tsx`: 5/5 — `isChunkLoadError` matching, reload-once + session guard (no loop), ignores unrelated errors, recovers from a rejected dynamic import.
- `tsc` clean on touched files; prettier clean on new files (`next.config.js`/`layout.tsx` left as-is — already non-conforming on develop, edits match local style).

## Note
This is the structural fix for the persistent 500s. It complements #857 (which made the crash non-fatal + self-reporting); together they stop the bleeding and recover already-stuck users.