### PR TITLE
fix(web): deployment skew protection for post-deploy chunk crashes

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -118,6 +118,15 @@ const config = {
       return Date.now().toString();
     }
   },
+  // Deployment skew protection. Tags asset/RSC requests with the per-deploy
+  // commit SHA so a client running an older build is detected on navigation and
+  // cleanly hard-reloads onto the current build, instead of loading a mismatched
+  // chunk (the post-deploy "undefined (reading 'call')" / "element type is
+  // invalid" 500s). Reuses the SHA already injected as SENTRY_RELEASE in CI;
+  // unset in local dev, where skew protection is inactive (and unnecessary).
+  deploymentId: process.env.SENTRY_RELEASE
+    ? process.env.SENTRY_RELEASE.replace(/^ecency-next@/, "")
+    : undefined,
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },
   transpilePackages: ["@ecency/sdk", "@ecency/wallets", "@ecency/render-helper"],

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -4,6 +4,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 import appPackage from "./package.json";
+import { isEmptyCaptureEvent } from "./src/utils/sentry-empty-capture";
 
 // Defer Sentry initialization until after first user interaction or 5s idle.
 // This moves ~1s of JS evaluation off the critical rendering path.
@@ -44,6 +45,15 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
   ],
 
   beforeSend(event) {
+    // Drop value-less captures — captureException(null/undefined/"") produces a
+    // synthetic exception with no message and no stack frames (zero actionable
+    // info, all grouped as the "<unknown>" issue). Only empty + frame-less
+    // events are dropped, so real errors (which always carry a stack or a
+    // message) are never lost. See sentry-empty-capture for the exact rule.
+    if (isEmptyCaptureEvent(event)) {
+      return null;
+    }
+
     const exceptionType = event.exception?.values?.[0]?.type ?? "";
     const message = event.exception?.values?.[0]?.value ?? "";
     const stackStr = JSON.stringify(

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -36,7 +36,10 @@ export default function GlobalError({
         tags: { deploy_skew: "true" },
         fingerprint: ["deploy-skew-auto-recovered"]
       });
-      reloadForSkew();
+      // Flush the transport before reloading, otherwise the monitoring event is
+      // dropped on unload. Bounded so a slow/blocked transport can't delay the
+      // recovery reload; reloadForSkew still runs on timeout.
+      void Sentry.flush(2000).finally(() => reloadForSkew());
       return;
     }
     setEventId(Sentry.captureException(error));

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -25,13 +25,21 @@ export default function GlobalError({
   // optional user feedback (via SentryIssueReporterDialog) is then attached to
   // THIS event id instead of capturing a second, separate exception.
   useEffect(() => {
-    setEventId(Sentry.captureException(error));
-    // A deploy-skew crash (mismatched chunk after a deploy) isn't a real bug —
-    // reload once onto the current build instead of stranding the user on the
-    // 500 page. Guarded to one reload per session.
+    // A deploy-skew crash (a chunk that no longer matches the running build) is
+    // auto-recovered by reloading onto the current build. Record it as a
+    // distinct, low-severity "auto-recovered" event — NOT a fresh 500 that would
+    // re-spike after every deploy — so we keep visibility into skew frequency
+    // without it masquerading as a new crash. Then reload (once per session).
     if (isDeploySkewError(error)) {
+      Sentry.captureException(error, {
+        level: "warning",
+        tags: { deploy_skew: "true" },
+        fingerprint: ["deploy-skew-auto-recovered"]
+      });
       reloadForSkew();
+      return;
     }
+    setEventId(Sentry.captureException(error));
   }, [error]);
 
   return (

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -8,6 +8,7 @@ import { Button } from "@ui/button";
 import { SentryIssueReporterDialog } from "@/features/issue-reporter";
 import defaults from "@/defaults";
 import * as Sentry from "@sentry/nextjs";
+import { isDeploySkewError, reloadForSkew } from "@/features/pwa-install/service-worker-recovery";
 import { useEffect, useState } from "react";
 
 export default function GlobalError({
@@ -25,6 +26,12 @@ export default function GlobalError({
   // THIS event id instead of capturing a second, separate exception.
   useEffect(() => {
     setEventId(Sentry.captureException(error));
+    // A deploy-skew crash (mismatched chunk after a deploy) isn't a real bug —
+    // reload once onto the current build instead of stranding the user on the
+    // 500 page. Guarded to one reload per session.
+    if (isDeploySkewError(error)) {
+      reloadForSkew();
+    }
   }, [error]);
 
   return (

--- a/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
+++ b/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
@@ -2,6 +2,7 @@
 
 import { Component, ErrorInfo, ReactNode } from "react";
 import * as Sentry from "@sentry/nextjs";
+import { isDeploySkewError, reloadForSkew } from "@/features/pwa-install/service-worker-recovery";
 
 interface FallbackProps {
   error: Error;
@@ -48,6 +49,12 @@ export class SentryErrorBoundary extends Component<Props, State> {
       contexts: { react: { componentStack: errorInfo.componentStack ?? undefined } }
     });
     this.setState({ eventId });
+    // A deploy-skew crash (a chunk that doesn't match the running build) isn't a
+    // real render bug — reload once onto the current build instead of showing the
+    // fallback. Guarded to one reload per session.
+    if (isDeploySkewError(error)) {
+      reloadForSkew();
+    }
   }
 
   reset = () => this.setState({ error: undefined, eventId: undefined });

--- a/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
+++ b/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
@@ -56,7 +56,10 @@ export class SentryErrorBoundary extends Component<Props, State> {
         tags: { deploy_skew: "true" },
         fingerprint: ["deploy-skew-auto-recovered"]
       });
-      reloadForSkew();
+      // Flush the transport before reloading, otherwise the monitoring event is
+      // dropped on unload. Bounded so a slow/blocked transport can't delay the
+      // recovery reload; reloadForSkew still runs on timeout.
+      void Sentry.flush(2000).finally(() => reloadForSkew());
       return;
     }
     const eventId = Sentry.captureException(error, {

--- a/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
+++ b/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
@@ -45,16 +45,24 @@ export class SentryErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // A deploy-skew crash (a chunk that no longer matches the running build) is
+    // auto-recovered by reloading. Record it as a distinct, low-severity
+    // "auto-recovered" event (so skew frequency stays visible) instead of a
+    // fresh crash that re-spikes after every deploy, then reload — skip the
+    // component-stack capture, which is only useful for real render bugs.
+    if (isDeploySkewError(error)) {
+      Sentry.captureException(error, {
+        level: "warning",
+        tags: { deploy_skew: "true" },
+        fingerprint: ["deploy-skew-auto-recovered"]
+      });
+      reloadForSkew();
+      return;
+    }
     const eventId = Sentry.captureException(error, {
       contexts: { react: { componentStack: errorInfo.componentStack ?? undefined } }
     });
     this.setState({ eventId });
-    // A deploy-skew crash (a chunk that doesn't match the running build) isn't a
-    // real render bug — reload once onto the current build instead of showing the
-    // fallback. Guarded to one reload per session.
-    if (isDeploySkewError(error)) {
-      reloadForSkew();
-    }
   }
 
   reset = () => this.setState({ error: undefined, eventId: undefined });

--- a/apps/web/src/features/pwa-install/index.ts
+++ b/apps/web/src/features/pwa-install/index.ts
@@ -1,4 +1,9 @@
 export { usePwaInstall } from "./use-pwa-install";
 export type { UsePwaInstallResult } from "./use-pwa-install";
 export { isIosSafari } from "./is-ios-safari";
-export { ServiceWorkerRecovery, isChunkLoadError } from "./service-worker-recovery";
+export {
+  ServiceWorkerRecovery,
+  isChunkLoadError,
+  isDeploySkewError,
+  reloadForSkew
+} from "./service-worker-recovery";

--- a/apps/web/src/features/pwa-install/service-worker-recovery.tsx
+++ b/apps/web/src/features/pwa-install/service-worker-recovery.tsx
@@ -2,12 +2,8 @@
 
 import { useEffect } from "react";
 
-// Matches the runtime symptoms of a stale service worker handing a mismatched
-// chunk to the running webpack runtime: the dynamic import either fails outright
-// (ChunkLoadError / failed module script) or loads a module whose exports don't
-// line up. We can only auto-recover the former here; the latter is handled by
-// the React error boundaries. Keep this list aligned with what the bundlers /
-// browsers actually throw.
+// Message patterns for a failed chunk / dynamic import — a stale cache or a
+// just-replaced build handing the client a chunk that no longer exists.
 export function isChunkLoadError(message?: string | null): boolean {
   if (!message) {
     return false;
@@ -22,20 +18,51 @@ export function isChunkLoadError(message?: string | null): boolean {
   );
 }
 
-// Guards against reload loops: at most one chunk-error recovery reload per tab
-// session. If the page still errors after the reload, we stop and let the error
-// boundary render its fallback rather than refreshing forever.
-const CHUNK_RELOAD_FLAG = "sw-chunk-recovery-reloaded";
+// The webpack runtime was handed an undefined module factory: a chunk loaded but
+// references a module id the running runtime doesn't have — a build/version
+// mismatch after a deploy ("Cannot read properties of undefined (reading 'call')"
+// thrown from webpack-*.js, or the Safari equivalent). Require the webpack
+// runtime frame so this never fires on unrelated ".call of undefined" app bugs.
+function isWebpackFactoryError(error: { message?: string; stack?: string }): boolean {
+  const stack = error.stack ?? "";
+  const fromWebpackRuntime =
+    /webpack-[0-9a-f]+\.js/i.test(stack) || /webpack-internal/i.test(stack);
+  if (!fromWebpackRuntime) {
+    return false;
+  }
+  const message = error.message ?? "";
+  return (
+    /Cannot read propert(?:y|ies) of undefined \(reading 'call'\)/i.test(message) ||
+    /undefined is not an object \(evaluating '[^']*\.call'\)/i.test(message) ||
+    /'call' of undefined/i.test(message)
+  );
+}
 
-// Guards a controllerchange reload against firing twice within one page load.
-let controllerReloadStarted = false;
+// True when the error indicates the client is running a build that no longer
+// matches what the server serves (chunk-load failures + webpack factory
+// mismatches). The cure is to reload onto the current build.
+export function isDeploySkewError(error: unknown): boolean {
+  if (typeof error === "string") {
+    return isChunkLoadError(error);
+  }
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const e = error as { message?: string; stack?: string };
+  return isChunkLoadError(e.message) || isWebpackFactoryError(e);
+}
 
-function reloadAfterChunkError() {
+// Guards against reload loops: at most one recovery reload per tab session. If
+// the page still errors after the reload, we stop and let the error boundary
+// render its fallback rather than refreshing forever.
+const RELOAD_FLAG = "deploy-skew-recovery-reloaded";
+
+export function reloadForSkew() {
   try {
-    if (sessionStorage.getItem(CHUNK_RELOAD_FLAG)) {
+    if (sessionStorage.getItem(RELOAD_FLAG)) {
       return;
     }
-    sessionStorage.setItem(CHUNK_RELOAD_FLAG, "1");
+    sessionStorage.setItem(RELOAD_FLAG, "1");
   } catch {
     // sessionStorage unusable (private mode / quota) — without a persisted guard
     // we can't prove we haven't already reloaded this session, so do NOT reload.
@@ -46,18 +73,23 @@ function reloadAfterChunkError() {
   window.location.reload();
 }
 
+// Guards a controllerchange reload against firing twice within one page load.
+let controllerReloadStarted = false;
+
 /**
- * Recovers users stranded on a stale service worker / mismatched chunks — the
- * cause of the persistent "Element type is invalid: undefined" 500s. Renders
- * nothing.
+ * Recovers users running a build that no longer matches the server — the cause
+ * of the post-deploy "Element type is invalid: undefined" / "undefined (reading
+ * 'call')" 500s. Renders nothing. Complements Next's `deploymentId` skew
+ * protection (which hard-reloads on navigation); this catches the cases that
+ * already crashed (stale cached HTML, mid-render mismatch).
  *
  * 1. When a NEW service worker takes control of an already-controlled page
  *    (`controllerchange`), reload once so the in-memory webpack runtime matches
  *    the freshly-cached chunks. Only armed when the page already had a
  *    controller at mount — otherwise the upcoming `controllerchange` is just the
  *    initial `clientsClaim` on a first visit and a reload would be spurious.
- * 2. As a safety net, reload once (per session) on a ChunkLoadError / failed
- *    dynamic import, which is what a stale-cache chunk mismatch surfaces as.
+ * 2. As a safety net, reload once (per session) on an uncaught deploy-skew error
+ *    (chunk-load failure or webpack factory mismatch).
  */
 export function ServiceWorkerRecovery() {
   useEffect(() => {
@@ -85,15 +117,13 @@ export function ServiceWorkerRecovery() {
     }
 
     const onError = (event: ErrorEvent) => {
-      if (isChunkLoadError(event.message) || isChunkLoadError(event.error?.message)) {
-        reloadAfterChunkError();
+      if (isDeploySkewError(event.error) || isChunkLoadError(event.message)) {
+        reloadForSkew();
       }
     };
     const onRejection = (event: PromiseRejectionEvent) => {
-      const reason = event.reason;
-      const message = typeof reason === "string" ? reason : reason?.message;
-      if (isChunkLoadError(message)) {
-        reloadAfterChunkError();
+      if (isDeploySkewError(event.reason)) {
+        reloadForSkew();
       }
     };
     window.addEventListener("error", onError);

--- a/apps/web/src/specs/features/issue-reporter/sentry-error-boundary.spec.tsx
+++ b/apps/web/src/specs/features/issue-reporter/sentry-error-boundary.spec.tsx
@@ -5,7 +5,8 @@ import * as Sentry from "@sentry/nextjs";
 import { SentryErrorBoundary } from "@/features/issue-reporter/sentry-error-boundary";
 
 vi.mock("@sentry/nextjs", () => ({
-  captureException: vi.fn(() => "evt-123")
+  captureException: vi.fn(() => "evt-123"),
+  flush: vi.fn(() => Promise.resolve(true))
 }));
 
 // A child whose throwing is toggleable, so we can exercise reset/recovery.
@@ -71,7 +72,7 @@ describe("SentryErrorBoundary", () => {
     expect(screen.getByTestId("fallback")).toHaveTextContent("fallback:evt-123");
   });
 
-  it("reloads + reports a low-severity tagged event (not the component-stack crash) on a deploy-skew error", () => {
+  it("reloads + reports a low-severity tagged event (not the component-stack crash) on a deploy-skew error", async () => {
     const reloadMock = vi.fn();
     const realLocation = window.location;
     Object.defineProperty(window, "location", {
@@ -104,8 +105,10 @@ describe("SentryErrorBoundary", () => {
         fingerprint: ["deploy-skew-auto-recovered"]
       })
     );
-    // And it triggered a one-time recovery reload onto the current build.
-    expect(reloadMock).toHaveBeenCalledTimes(1);
+    // The reload happens after the transport flush resolves (so the monitoring
+    // event isn't dropped on unload).
+    expect(Sentry.flush).toHaveBeenCalled();
+    await vi.waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
 
     Object.defineProperty(window, "location", { configurable: true, value: realLocation });
   });

--- a/apps/web/src/specs/features/issue-reporter/sentry-error-boundary.spec.tsx
+++ b/apps/web/src/specs/features/issue-reporter/sentry-error-boundary.spec.tsx
@@ -71,6 +71,45 @@ describe("SentryErrorBoundary", () => {
     expect(screen.getByTestId("fallback")).toHaveTextContent("fallback:evt-123");
   });
 
+  it("reloads + reports a low-severity tagged event (not the component-stack crash) on a deploy-skew error", () => {
+    const reloadMock = vi.fn();
+    const realLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...realLocation, reload: reloadMock }
+    });
+    sessionStorage.clear();
+
+    function SkewBomb(): never {
+      throw Object.assign(new Error("Cannot read properties of undefined (reading 'call')"), {
+        stack: "at a (https://ecency.com/_next/static/chunks/webpack-2bcfd50e.js:1:1)"
+      });
+    }
+
+    render(
+      <SentryErrorBoundary fallback={fallback}>
+        <SkewBomb />
+      </SentryErrorBoundary>
+    );
+
+    // Captured as a distinct, low-severity, fingerprinted "auto-recovered" event
+    // — NOT the component-stack crash capture (so it never re-spikes as a fresh
+    // 500 after a deploy).
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        level: "warning",
+        tags: { deploy_skew: "true" },
+        fingerprint: ["deploy-skew-auto-recovered"]
+      })
+    );
+    // And it triggered a one-time recovery reload onto the current build.
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+  });
+
   it("restores children when reset is called after the child stops throwing", () => {
     render(
       <SentryErrorBoundary fallback={fallback}>

--- a/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
+++ b/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
@@ -1,8 +1,11 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render } from "@testing-library/react";
 // ServiceWorkerRecovery is imported dynamically per-test (see beforeEach) to reset
-// its module-level reload guards; isChunkLoadError is pure, imported statically.
-import { isChunkLoadError } from "@/features/pwa-install/service-worker-recovery";
+// its module-level reload guards; the pure helpers are imported statically.
+import {
+  isChunkLoadError,
+  isDeploySkewError
+} from "@/features/pwa-install/service-worker-recovery";
 
 describe("isChunkLoadError", () => {
   it("matches the chunk / dynamic-import failure messages", () => {
@@ -19,6 +22,54 @@ describe("isChunkLoadError", () => {
     expect(isChunkLoadError("")).toBe(false);
     expect(isChunkLoadError(undefined)).toBe(false);
     expect(isChunkLoadError(null)).toBe(false);
+  });
+});
+
+describe("isDeploySkewError", () => {
+  it("matches chunk-load errors (string or Error)", () => {
+    expect(isDeploySkewError("ChunkLoadError: x")).toBe(true);
+    expect(isDeploySkewError(new Error("Loading chunk 7 failed"))).toBe(true);
+  });
+
+  it("matches the webpack factory mismatch ONLY when thrown from the webpack runtime", () => {
+    // The real post-deploy crash: undefined module factory in webpack-*.js.
+    expect(
+      isDeploySkewError({
+        message: "Cannot read properties of undefined (reading 'call')",
+        stack: "at a (https://ecency.com/_next/static/chunks/webpack-2bcfd50e3f341c1.js:1:1)"
+      })
+    ).toBe(true);
+    // Safari phrasing, also from the webpack runtime.
+    expect(
+      isDeploySkewError({
+        message: "undefined is not an object (evaluating 'r.call')",
+        stack: "webpack-internal:///./node_modules/x"
+      })
+    ).toBe(true);
+  });
+
+  it("does NOT fire on an unrelated `.call of undefined` app bug (no webpack frame)", () => {
+    expect(
+      isDeploySkewError({
+        message: "Cannot read properties of undefined (reading 'call')",
+        stack: "at handleClick (https://ecency.com/_next/static/chunks/app/page.js:5:9)"
+      })
+    ).toBe(false);
+  });
+
+  it("does NOT fire on a different undefined read even from the webpack runtime", () => {
+    expect(
+      isDeploySkewError({
+        message: "Cannot read properties of undefined (reading 'foo')",
+        stack: "at a (https://ecency.com/_next/static/chunks/webpack-abc.js:1:1)"
+      })
+    ).toBe(false);
+  });
+
+  it("ignores non-error input", () => {
+    expect(isDeploySkewError(null)).toBe(false);
+    expect(isDeploySkewError(undefined)).toBe(false);
+    expect(isDeploySkewError(42)).toBe(false);
   });
 });
 
@@ -65,6 +116,16 @@ describe("ServiceWorkerRecovery", () => {
     window.dispatchEvent(
       new ErrorEvent("error", { message: "ChunkLoadError: Loading chunk 9 failed" })
     );
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads on an uncaught webpack factory mismatch (post-deploy skew)", () => {
+    render(<Recovery />);
+
+    const error = Object.assign(new Error("Cannot read properties of undefined (reading 'call')"), {
+      stack: "at a (https://ecency.com/_next/static/chunks/webpack-2bcfd50e.js:1:1)"
+    });
+    window.dispatchEvent(new ErrorEvent("error", { message: error.message, error }));
     expect(reloadMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/specs/utils/sentry-empty-capture.spec.ts
+++ b/apps/web/src/specs/utils/sentry-empty-capture.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { isEmptyCaptureEvent } from "@/utils/sentry-empty-capture";
+
+const exc = (value: unknown, frames: unknown[] = []) => ({
+  exception: { values: [{ value: value as string, stacktrace: { frames } }] }
+});
+
+describe("isEmptyCaptureEvent", () => {
+  it("drops value-less, frame-less captures (captureException(null/undefined/''))", () => {
+    expect(isEmptyCaptureEvent(exc("null"))).toBe(true);
+    expect(isEmptyCaptureEvent(exc("undefined"))).toBe(true);
+    expect(isEmptyCaptureEvent(exc(""))).toBe(true);
+    expect(isEmptyCaptureEvent(exc("   "))).toBe(true);
+    expect(isEmptyCaptureEvent(exc(undefined))).toBe(true);
+  });
+
+  // Guardrail: never drop a real bug.
+  it("KEEPS a non-Error thrown with a message (e.g. `throw 'boom'`)", () => {
+    expect(isEmptyCaptureEvent(exc("boom"))).toBe(false);
+    expect(isEmptyCaptureEvent(exc("Something went wrong"))).toBe(false);
+  });
+
+  it("KEEPS any exception that has a stack (a real thrown Error)", () => {
+    expect(isEmptyCaptureEvent(exc("", [{ filename: "app.js", lineno: 1 }]))).toBe(false);
+    expect(isEmptyCaptureEvent(exc("null", [{ filename: "x.js" }]))).toBe(false);
+  });
+
+  it("KEEPS frame-less real errors like AbortController timeouts", () => {
+    expect(isEmptyCaptureEvent(exc("signal timed out"))).toBe(false);
+    expect(isEmptyCaptureEvent(exc("The user aborted a request."))).toBe(false);
+  });
+
+  it("KEEPS non-exception events (messages, transactions)", () => {
+    expect(isEmptyCaptureEvent({})).toBe(false);
+    expect(isEmptyCaptureEvent({ exception: { values: [] } })).toBe(false);
+  });
+
+  it("only drops when EVERY exception value is empty + frame-less", () => {
+    // chained exceptions: one empty, one real -> keep
+    expect(
+      isEmptyCaptureEvent({
+        exception: {
+          values: [
+            { value: "null", stacktrace: { frames: [] } },
+            { value: "Real cause", stacktrace: { frames: [{ filename: "a.js" }] } }
+          ]
+        }
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/utils/sentry-empty-capture.ts
+++ b/apps/web/src/utils/sentry-empty-capture.ts
@@ -1,0 +1,38 @@
+// Minimal shape of a Sentry event's exception payload — enough to decide whether
+// it carries any actionable information, without depending on @sentry/types here.
+interface ExceptionLikeEvent {
+  exception?: {
+    values?: Array<{
+      value?: string;
+      stacktrace?: { frames?: unknown[] };
+    }>;
+  };
+}
+
+/**
+ * True only for the signature of a value-less capture: `captureException(null)`
+ * / `captureException(undefined)` / `captureException("")`. Sentry synthesizes
+ * an Error with a "null"/"undefined"/empty value and NO stack frames — these
+ * carry zero debugging info and all bucket together as the noisy "<unknown>"
+ * issue (ECENCY-NEXT-1A1E).
+ *
+ * Deliberately conservative so we never drop a real bug:
+ *  - a genuinely thrown Error always has a stack (frames) -> kept;
+ *  - a non-Error thrown WITH a message keeps that value (e.g. `throw "boom"`,
+ *    `throw { message: "x" }`) -> kept;
+ *  - non-exception events (messages, transactions) -> kept.
+ * Only when EVERY exception value is both empty AND frame-less do we treat it as
+ * non-actionable noise.
+ */
+export function isEmptyCaptureEvent(event: ExceptionLikeEvent): boolean {
+  const values = event.exception?.values;
+  if (!values || values.length === 0) {
+    return false;
+  }
+  return values.every((v) => {
+    const normalized = (v.value ?? "").trim().toLowerCase();
+    const emptyValue = normalized === "" || normalized === "null" || normalized === "undefined";
+    const noFrames = !v.stacktrace?.frames || v.stacktrace.frames.length === 0;
+    return emptyValue && noFrames;
+  });
+}


### PR DESCRIPTION
## Problem
Each deploy ships a new image with only the new build's `/_next/static`; old chunks are gone. A client still running the **previous** build then loads a missing/mismatched chunk → `Cannot read properties of undefined (reading 'call')` (webpack runtime) and `element type is invalid: undefined` 500s. Real and recurring (ECENCY-NEXT-143M, 101 users), worst right after each deploy. Follows #859 (which fixed the SW-install side that made it *persistent*).

We deliberately do **not** retain old chunks — that would pin a buggy build on devices longer. Instead, every path converges users onto the **latest** build.

## Fix (two layers)
1. **`deploymentId`** (= the per-deploy commit SHA already injected as `SENTRY_RELEASE`). Next tags asset/RSC requests with it, so a client on an older build is detected on navigation and **cleanly hard-reloads onto the current build** instead of loading a mismatched chunk. Covers the common case (tab open → navigate after a deploy).
2. **Recovery net** for what `deploymentId` can't catch (already-loaded **stale cached HTML**, mid-render mismatch): `isDeploySkewError()` detects the skew signature — chunk-load failures plus the webpack factory `reading 'call'` error **scoped to a `webpack-*` frame** so it never fires on unrelated `.call`-of-undefined app bugs — and reloads **once per session** from the React boundaries (`SentryErrorBoundary`, `global-error`) and the SW `window` listeners.

## Testing
- `service-worker-recovery.spec.tsx`: 14/14 — `isDeploySkewError` (matches webpack-factory only with a webpack frame; ignores unrelated `.call` bugs and other undefined reads), plus the existing reload/loop-guard/controllerchange coverage.
- `sentry-error-boundary.spec.tsx`: 3/3 still green.
- tsc + prettier clean.

## Note
`deploymentId` behavior should be eyeballed on staging (it’s active only when `SENTRY_RELEASE` is set, i.e. CI builds; inactive in local dev). This is the prevention; the recovery net is the safety net.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for post-deployment code version mismatches, enabling seamless page reloads once per session to restore functionality instead of error pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->