### PR TITLE
fix(web): pin number-format locale to stop hydration removeChild crash (1DRM)

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/insights/_page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/insights/_page.tsx
@@ -38,7 +38,8 @@ function InsightsRange({ username, dateRange, label }: InsightsRangeProps) {
     )
   );
 
-  const formatter = useMemo(() => new Intl.NumberFormat(), []);
+  // Pinned locale so SSR == client (avoids React #418 hydration mismatch).
+  const formatter = useMemo(() => new Intl.NumberFormat("en-US"), []);
 
   const rows = useMemo<InsightsRow[]>(() => {
     const pages = statsQuery.data?.results ?? [];

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/wallet/(token)/hp/_components/hp-delegations-card.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/wallet/(token)/hp/_components/hp-delegations-card.tsx
@@ -30,7 +30,9 @@ interface Props {
   username: string;
 }
 
-const format = new Intl.NumberFormat();
+// Pinned locale so SSR and client render identically (avoids the React #418
+// hydration mismatch -> removeChild crash; see format-asset-balance).
+const format = new Intl.NumberFormat("en-US");
 
 export function HpDelegationsCard({ username }: Props) {
   const { data } = useQuery(getAccountWalletAssetInfoQueryOptions(username, "HP"));

--- a/apps/web/src/app/tags/_page.tsx
+++ b/apps/web/src/app/tags/_page.tsx
@@ -74,10 +74,10 @@ export function TagsPage() {
                         </Link>
                       </Td>
                       <Td className="border p-2">
-                        <span className="tag-metric">{tag.comments.toLocaleString()}</span>
+                        <span className="tag-metric">{tag.comments.toLocaleString("en-US")}</span>
                       </Td>
                       <Td className="border p-2">
-                        <span className="tag-metric">{tag.top_posts.toLocaleString()}</span>
+                        <span className="tag-metric">{tag.top_posts.toLocaleString("en-US")}</span>
                       </Td>
                       <Td className="border p-2">
                         <span className="tag-metric">{tag.total_payouts}</span>

--- a/apps/web/src/app/waves/_components/waves-trending-tags-card.tsx
+++ b/apps/web/src/app/waves/_components/waves-trending-tags-card.tsx
@@ -18,7 +18,8 @@ export function WavesTrendingTagsCard() {
 
   const { data, isLoading, isError } = useQuery(getWavesTrendingTagsQueryOptions(host, TRENDING_TAGS_HOURS));
 
-  const numberFormatter = useMemo(() => new Intl.NumberFormat(), []);
+  // Pinned locale so SSR == client (avoids React #418 hydration mismatch).
+  const numberFormatter = useMemo(() => new Intl.NumberFormat("en-US"), []);
   const tags = useMemo(() => data?.slice(0, TRENDING_TAGS_LIMIT) ?? [], [data]);
 
   return (

--- a/apps/web/src/app/witnesses/_components/witness-card.tsx
+++ b/apps/web/src/app/witnesses/_components/witness-card.tsx
@@ -62,7 +62,7 @@ export const WitnessCard = ({ row, witness, onVotersClick }: Props) => {
             onClick={() => onVotersClick?.(row.name)}
             aria-label={i18next.t("witnesses.voters-aria-label", { name: row.name })}
           >
-            {row.votersNum.toLocaleString()}
+            {row.votersNum.toLocaleString("en-US")}
           </button>
         </div>
       )}

--- a/apps/web/src/features/wallet/utils/format-asset-balance.ts
+++ b/apps/web/src/features/wallet/utils/format-asset-balance.ts
@@ -9,7 +9,11 @@ export function formatAssetBalance(balance: number) {
   const absolute = Math.abs(balance);
   const isSmall = absolute > 0 && absolute < 1;
 
-  const formatter = new Intl.NumberFormat(undefined, {
+  // Pin the locale: an `undefined` locale formats with the server's locale on
+  // SSR and the browser's on the client, so the rendered text differs for any
+  // user whose locale isn't the server default — a hydration mismatch (React
+  // #418) that, during recovery, throws "removeChild" (ECENCY-NEXT-1DRM).
+  const formatter = new Intl.NumberFormat("en-US", {
     minimumFractionDigits: isSmall ? DEFAULT_FRACTION_DIGITS : DEFAULT_FRACTION_DIGITS,
     maximumFractionDigits: isSmall ? SMALL_BALANCE_FRACTION_DIGITS : DEFAULT_FRACTION_DIGITS,
   });

--- a/apps/web/src/specs/features/wallet/format-asset-balance.spec.ts
+++ b/apps/web/src/specs/features/wallet/format-asset-balance.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { formatAssetBalance } from "@/features/wallet/utils/format-asset-balance";
+
+describe("formatAssetBalance", () => {
+  // Pinned "en-US" => deterministic comma grouping + period decimal regardless of
+  // the runtime locale, so SSR and client hydration produce identical text
+  // (no React #418 -> removeChild crash).
+  it("formats with a fixed en-US locale", () => {
+    expect(formatAssetBalance(1234.5)).toBe("1,234.500");
+    expect(formatAssetBalance(1_000_000)).toBe("1,000,000.000");
+  });
+
+  it("shows up to 8 fraction digits for sub-1 balances", () => {
+    expect(formatAssetBalance(0.00001234)).toBe("0.00001234");
+    expect(formatAssetBalance(0.5)).toBe("0.500");
+  });
+
+  it("returns '0' for non-finite input", () => {
+    expect(formatAssetBalance(Number.NaN)).toBe("0");
+    expect(formatAssetBalance(Number.POSITIVE_INFINITY)).toBe("0");
+  });
+});


### PR DESCRIPTION
## Root cause
`ECENCY-NEXT-1DRM` (`NotFoundError: Failed to execute 'removeChild'`) is **not** new — it's been firing across releases since 2026-04-26; the recent spike is just #857's auto-capture finally surfacing a pre-existing *handled* error (same as 143M).

The breadcrumbs show **React error #418 ("text content does not match server-rendered HTML") immediately before the removeChild**. The cause: SSR-rendered numbers formatted with an **implicit locale** — `new Intl.NumberFormat(undefined/…)` / `.toLocaleString()`. The server formats with its locale, the client re-formats with the **browser's** locale; for any user whose locale differs, the balance/count text differs → #418 → React regenerates the subtree → `removeChild` throws. Every 1DRM URL is a wallet/profile balance page, which fits exactly.

## Fix
Pin `"en-US"` so SSR and client produce identical text:
- `format-asset-balance.ts` — wallet balances (the primary driver)
- HP delegations, profile insights, witness voters, tag metrics, waves trending tags

## Not touched (and why)
Time / relative-time displays stay on the user's own clock:
- Chat timestamps use `toLocaleString()` but chat is `ssr: false` (client-only) → no hydration mismatch.
- Relative time is `dayjs().fromNow()` ("2 hours ago") — computed client-side.
- Publish auto-save time is client state.

## Testing
- `format-asset-balance.spec.ts` locks the deterministic en-US output (3/3).
- tsc clean on touched files; the 5 page files were already prettier-nonconforming on develop, so I left their style and kept edits minimal.

Independent of #860 — lands on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent number formatting across multiple pages and components. Numeric displays (comments, votes, voter counts, asset balances) now render consistently in all environments, including profile insights, wallet sections, tags, witnesses, and trending content listings.

* **Tests**
  * Added test coverage for number formatting to verify consistent behavior and prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->