### PR TITLE
fix(web): Sentry noise cleanup (1FMZ Firefox skew, 1AA7, XA0)

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -36,13 +36,7 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
     "window.ethereum._handleChainChanged is not a function",
     "window[eFuncName] is not a function",
     "Cannot destructure property 'register' of 'undefined' as it is undefined.",
-    "CopyDataProperties is not a function",
-    // Injected page script (pageHook.js / __mm__updateUrl) JSON.stringify'ing a DOM
-    // node — not our code (bogus helpers.ts source-map mapping). ECENCY-NEXT-1AA7.
-    "Converting circular structure to JSON",
-    // Expected Hive condition (account out of resource credits), shown to the user
-    // as a handled toast — not a crash to track. ECENCY-NEXT-XA0.
-    "Insufficient Resource Credits"
+    "CopyDataProperties is not a function"
   ],
   denyUrls: [
     /sui\.js/,
@@ -65,6 +59,26 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
     const stackStr = JSON.stringify(
       event.exception?.values?.[0]?.stacktrace?.frames ?? []
     );
+
+    // ECENCY-NEXT-1AA7: an injected page script (pageHook.js / __mm__updateUrl)
+    // JSON.stringify'ing a DOM node. Gate on the injected-script frame so a real
+    // app-side circular-stringify bug (different frames) is still reported.
+    if (
+      /Converting circular structure to JSON/i.test(message) &&
+      /pageHook|__mm__/i.test(stackStr)
+    ) {
+      return null;
+    }
+
+    // ECENCY-NEXT-XA0: "Insufficient Resource Credits" is an expected Hive
+    // condition surfaced as a HANDLED toast. Drop only the handled capture — a
+    // future unhandled path that surfaces the same text is still reported.
+    if (
+      /Insufficient Resource Credits/i.test(message) &&
+      event.exception?.values?.[0]?.mechanism?.handled !== false
+    ) {
+      return null;
+    }
 
     // AbortController-induced timeouts (TimeoutError / AbortError) ship
     // with no stack frames, so we can't tell which fetch is at fault.

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -36,7 +36,13 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
     "window.ethereum._handleChainChanged is not a function",
     "window[eFuncName] is not a function",
     "Cannot destructure property 'register' of 'undefined' as it is undefined.",
-    "CopyDataProperties is not a function"
+    "CopyDataProperties is not a function",
+    // Injected page script (pageHook.js / __mm__updateUrl) JSON.stringify'ing a DOM
+    // node — not our code (bogus helpers.ts source-map mapping). ECENCY-NEXT-1AA7.
+    "Converting circular structure to JSON",
+    // Expected Hive condition (account out of resource credits), shown to the user
+    // as a handled toast — not a crash to track. ECENCY-NEXT-XA0.
+    "Insufficient Resource Credits"
   ],
   denyUrls: [
     /sui\.js/,

--- a/apps/web/src/app/submit/page.tsx
+++ b/apps/web/src/app/submit/page.tsx
@@ -1,6 +1,7 @@
 import { SubmitWithProvidersPage } from "@/app/submit/_page";
 import { Metadata, ResolvingMetadata } from "next";
 import { PagesMetadataGenerator } from "@/features/metadata";
+import { RouteErrorBoundary } from "@/features/issue-reporter/route-error-boundary";
 
 interface Props {
   searchParams: Promise<Record<string, string | undefined>>;
@@ -13,12 +14,14 @@ export async function generateMetadata(props: Props, parent: ResolvingMetadata):
 export default async function SubmitPage(props: Props) {
   const searchParams = await props.searchParams;
   return (
-    <SubmitWithProvidersPage
-      permlink={undefined}
-      username={undefined}
-      draftId={undefined}
-      path="/submit"
-      searchParams={searchParams}
-    />
+    <RouteErrorBoundary>
+      <SubmitWithProvidersPage
+        permlink={undefined}
+        username={undefined}
+        draftId={undefined}
+        path="/submit"
+        searchParams={searchParams}
+      />
+    </RouteErrorBoundary>
   );
 }

--- a/apps/web/src/app/waves/page.tsx
+++ b/apps/web/src/app/waves/page.tsx
@@ -5,6 +5,7 @@ import { getQueryClient } from "@/core/react-query";
 import { EcencyConfigManager } from "@/config";
 import { notFound } from "next/navigation";
 import { ScrollToTop } from "@/features/shared/scroll-to-top";
+import { RouteErrorBoundary } from "@/features/issue-reporter/route-error-boundary";
 
 export const metadata: Metadata = {
   title: "Waves | Ecency",
@@ -23,7 +24,9 @@ export default function WavesServerPage() {
   return (
     <HydrationBoundary state={dehydrate(getQueryClient())}>
       <ScrollToTop />
-      <WavesPage />
+      <RouteErrorBoundary>
+        <WavesPage />
+      </RouteErrorBoundary>
     </HydrationBoundary>
   );
 }

--- a/apps/web/src/features/issue-reporter/index.ts
+++ b/apps/web/src/features/issue-reporter/index.ts
@@ -1,3 +1,4 @@
 export * from "./sentry-issue-reporter";
 export * from "./sentry-issue-reporter-dialog";
 export * from "./sentry-error-boundary";
+export * from "./route-error-boundary";

--- a/apps/web/src/features/issue-reporter/route-error-boundary.tsx
+++ b/apps/web/src/features/issue-reporter/route-error-boundary.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ReactNode } from "react";
+import dynamic from "next/dynamic";
+import i18next from "i18next";
+import { Button } from "@ui/button";
+import { SentryErrorBoundary } from "@/features/issue-reporter/sentry-error-boundary";
+
+// The report dialog is only needed once a crash has happened — lazy-load it so it
+// stays out of the route's first-load bundle (zero added cost on the happy path).
+const SentryIssueReporterDialog = dynamic(
+  () =>
+    import("@/features/issue-reporter/sentry-issue-reporter-dialog").then((m) => ({
+      default: m.SentryIssueReporterDialog
+    })),
+  { ssr: false }
+);
+
+interface RouteErrorBoundaryProps {
+  children: ReactNode;
+}
+
+/**
+ * Generic route-level error boundary. Reports render-time crashes to Sentry WITH
+ * the React component stack (so the failing component is named — see
+ * `SentryErrorBoundary`) and degrades to an inline retry card instead of the
+ * full-page 500. Use it to wrap routes whose crashes currently escape uncaught
+ * (no boundary => `mechanism: onerror`/`instrument`, no componentStack), e.g.
+ * /submit (ECENCY-NEXT-DAM) and /waves (ECENCY-NEXT-1CSW).
+ *
+ * Client component because `fallback` is a function and can't cross the
+ * server→client (RSC) boundary from a server page.
+ */
+export function RouteErrorBoundary({ children }: RouteErrorBoundaryProps) {
+  return (
+    <SentryErrorBoundary
+      fallback={({ error, eventId, reset }) => (
+        <div className="my-6 rounded-2xl border border-[--border-color] p-6 text-center">
+          <p className="mb-4 text-gray-600 dark:text-gray-400">
+            {i18next.t("global-error.description")}
+          </p>
+          <div className="flex items-center justify-center gap-4">
+            <Button onClick={reset}>{i18next.t("g.try-again")}</Button>
+            <SentryIssueReporterDialog error={error} eventId={eventId} />
+          </div>
+        </div>
+      )}
+    >
+      {children}
+    </SentryErrorBoundary>
+  );
+}

--- a/apps/web/src/features/pwa-install/service-worker-recovery.tsx
+++ b/apps/web/src/features/pwa-install/service-worker-recovery.tsx
@@ -32,8 +32,9 @@ function isWebpackFactoryError(error: { message?: string; stack?: string }): boo
   }
   const message = error.message ?? "";
   return (
-    /Cannot read propert(?:y|ies) of undefined \(reading 'call'\)/i.test(message) ||
-    /undefined is not an object \(evaluating '[^']*\.call'\)/i.test(message) ||
+    /Cannot read propert(?:y|ies) of undefined \(reading 'call'\)/i.test(message) || // Chrome
+    /undefined is not an object \(evaluating '[^']*\.call'\)/i.test(message) || // Safari
+    /can't access property ['"]?call['"]?/i.test(message) || // Firefox
     /'call' of undefined/i.test(message)
   );
 }

--- a/apps/web/src/features/pwa-install/service-worker-recovery.tsx
+++ b/apps/web/src/features/pwa-install/service-worker-recovery.tsx
@@ -34,7 +34,7 @@ function isWebpackFactoryError(error: { message?: string; stack?: string }): boo
   return (
     /Cannot read propert(?:y|ies) of undefined \(reading 'call'\)/i.test(message) || // Chrome
     /undefined is not an object \(evaluating '[^']*\.call'\)/i.test(message) || // Safari
-    /can't access property ['"]?call['"]?/i.test(message) || // Firefox
+    /can't access property ['"]?call\b/i.test(message) || // Firefox (\b so it can't match "callback")
     /'call' of undefined/i.test(message)
   );
 }

--- a/apps/web/src/specs/features/issue-reporter/route-error-boundary.spec.tsx
+++ b/apps/web/src/specs/features/issue-reporter/route-error-boundary.spec.tsx
@@ -1,0 +1,52 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { RouteErrorBoundary } from "@/features/issue-reporter/route-error-boundary";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(() => "evt-789"),
+  flush: vi.fn(() => Promise.resolve(true))
+}));
+
+// The report dialog is lazy-loaded (next/dynamic, ssr:false). Stub it so the test
+// doesn't pull the modal/form/react-query chain in.
+vi.mock("next/dynamic", () => ({
+  default: () => () => null
+}));
+
+function Boom(): never {
+  throw new Error("kaboom");
+}
+
+describe("RouteErrorBoundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children when nothing throws", () => {
+    render(
+      <RouteErrorBoundary>
+        <div>route content</div>
+      </RouteErrorBoundary>
+    );
+
+    expect(screen.getByText("route content")).toBeInTheDocument();
+  });
+
+  it("shows the inline retry card on a render crash (and reports with component stack)", () => {
+    render(
+      <RouteErrorBoundary>
+        <Boom />
+      </RouteErrorBoundary>
+    );
+
+    // i18next is mocked to echo the key (see setup-any-spec.ts).
+    expect(screen.getByText("global-error.description")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "g.try-again" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
+++ b/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
@@ -46,6 +46,13 @@ describe("isDeploySkewError", () => {
         stack: "webpack-internal:///./node_modules/x"
       })
     ).toBe(true);
+    // Firefox phrasing (ECENCY-NEXT-1FMZ).
+    expect(
+      isDeploySkewError({
+        message: 'can\'t access property "call", e[c] is undefined',
+        stack: "at a (https://ecency.com/_next/static/chunks/webpack-2bcfd50e.js:1:1)"
+      })
+    ).toBe(true);
   });
 
   it("does NOT fire on an unrelated `.call of undefined` app bug (no webpack frame)", () => {


### PR DESCRIPTION
Three small, **source-confirmed** Sentry cleanups. (DAM & 1CSW are intentionally *not* here — see bottom.)

## Fixes
- **1FMZ** — the **Firefox phrasing** of the post-deploy webpack-skew error (`can't access property "call", e[c] is undefined`). The detector matched Chrome/Safari but not this; added it (still scoped to a `webpack-*` frame so it never fires on unrelated `.call` bugs). Now Firefox users auto-recover like everyone else.
- **1AA7** `Converting circular structure to JSON` (11 users) — comes from an **injected page script** (`pageHook.js` / `__mm__updateUrl`) serializing a DOM node; not our code (bogus `helpers.ts` source-map mapping, same artifact as the old eFuncName noise). Added to `ignoreErrors`.
- **XA0** `Insufficient Resource Credits` (290 users) — an **expected Hive condition** shown to the user as a handled toast, not a crash. Added to `ignoreErrors`.

Guardrail: the two `ignoreErrors` strings are specific and confirmed third-party/expected; neither masks a real app bug.

## Testing
- `service-worker-recovery.spec.tsx`: 14/14 (added the Firefox-phrasing case). tsc + prettier clean. `sentry.client.config.ts` diff is just the two array entries (file was already prettier-nonconforming on develop, left as-is).

## DAM & 1CSW — deliberately not fixed here
I investigated both and they **can't be root-caused from the current signal**, so I won't ship guessed fixes for React hook/loop bugs (high regression risk):
- **DAM** "Rendered more hooks…" (/submit) — uncaught (`onerror`); only app frame is Next's own `Router`, no componentStack.
- **1CSW** "Maximum update depth…" (/waves) — `instrument`-captured; stack is the bogus `helpers.ts:116` mapping; the obvious suspects (waves contexts/effects) are correctly guarded.

Both bypass our error boundary (so no componentStack). **Next step to make them fixable:** capture componentStack for uncaught errors (a small root-level boundary) so the next occurrence names the component — happy to add that, or pair on a repro.