### PR TITLE
Engagement: easier commenting, navigation & login-on-action (desktop + mobile)

### DIFF
--- a/apps/web/src/api/mutations/create-reply.ts
+++ b/apps/web/src/api/mutations/create-reply.ts
@@ -11,6 +11,7 @@ import i18next from "i18next";
 import { getAccountRcQueryOptions, addOptimisticDiscussionEntry, removeOptimisticDiscussionEntry } from "@ecency/sdk";
 import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { scheduleQuestsRefresh } from "@/utils/refresh-quests";
 import { useCommentMutation } from "@/api/sdk-mutations";
 import type { CommentPayload } from "@ecency/sdk";
 
@@ -130,6 +131,7 @@ export function useCreateReply(
           // via custom merge logic in the query options
 
           success(i18next.t("comment.success"));
+          scheduleQuestsRefresh(queryClient, activeUser?.username);
         })
         .catch((err) => {
         // Blockchain failed - remove optimistic entry from web + SDK caches

--- a/apps/web/src/api/mutations/entry-reblog-sdk.ts
+++ b/apps/web/src/api/mutations/entry-reblog-sdk.ts
@@ -8,6 +8,7 @@ import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { QueryKeys } from "@ecency/sdk";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useReblogMutation } from "@/api/sdk-mutations";
+import { scheduleQuestsRefresh } from "@/utils/refresh-quests";
 
 /**
  * Entry-specific reblog mutation hook that wraps SDK reblog with web app cache management.
@@ -54,6 +55,11 @@ export function useEntryReblog(entry: Entry) {
       // Update reblogs count in entry cache (clamped to prevent negative values)
       const newReblogsCount = Math.max(0, (entry.reblogs ?? 0) + (isDelete ? -1 : 1));
       updateReblogsCount(newReblogsCount);
+
+      // Reblogging earns points — refresh the ambient quests indicator.
+      if (!isDelete) {
+        scheduleQuestsRefresh(queryClient, activeUser?.username);
+      }
 
       // Update reblogs list cache (optimistic UI)
       queryClient.setQueryData<BlogEntry[]>(

--- a/apps/web/src/app/market/advanced/_advanced-mode/advanced-mode-toolbar.tsx
+++ b/apps/web/src/app/market/advanced/_advanced-mode/advanced-mode-toolbar.tsx
@@ -5,7 +5,7 @@ import { MARKET_MODE_LS_TOKEN, MarketMode } from "../../_enums/market-mode";
 import { ModeSelector } from "../../_components/mode-selector";
 import { AdvancedModeSettings } from "./advanced-mode-settings";
 import { MarketAsset } from "@/api/market-pair";
-import { useGlobalStore } from "@/core/global-store";
+import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import { formattedNumber } from "@/utils";
 
 interface Props {
@@ -31,7 +31,7 @@ export const AdvancedModeToolbar = ({
   updateRate,
   setUpdateRate
 }: Props) => {
-  const isMobile = useGlobalStore((s) => s.isMobile);
+  const isMobile = useIsMobile();
 
   const getPercent = () => {
     if (dayChange.percent > 0) {

--- a/apps/web/src/app/market/advanced/_components/stake-widget.tsx
+++ b/apps/web/src/app/market/advanced/_components/stake-widget.tsx
@@ -7,7 +7,7 @@ import { MarketAsset } from "@/api/market-pair";
 import { Widget } from "@/app/market/advanced/_advanced-mode/types/layout.type";
 import { PREFIX } from "@/utils/local-storage";
 import { formattedNumber } from "@/utils";
-import { useGlobalStore } from "@/core/global-store";
+import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import i18next from "i18next";
 
 interface Props {
@@ -37,7 +37,7 @@ export const StakeWidget = ({
   price,
   usdPrice
 }: Props) => {
-  const isMobile = useGlobalStore((s) => s.isMobile);
+  const isMobile = useIsMobile();
   const [storedFraction, setStoredFraction] = useLocalStorage<number>(PREFIX + "_amml_st_fr");
   const [storedViewType, setStoredViewType] = useLocalStorage<StakeWidgetViewType>(
     PREFIX + "_amml_st_vt"

--- a/apps/web/src/app/market/advanced/_components/trading-form-widget.tsx
+++ b/apps/web/src/app/market/advanced/_components/trading-form-widget.tsx
@@ -4,6 +4,7 @@ import { Button } from "@ui/button";
 import { DayChange } from "@/app/market/advanced/_advanced-mode/types/day-change.type";
 import { Widget } from "@/app/market/advanced/_advanced-mode/types/layout.type";
 import { useGlobalStore } from "@/core/global-store";
+import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import i18next from "i18next";
 import Link from "next/link";
 import { HiveBarter } from "@/app/market/_components/hive-barter";
@@ -29,7 +30,7 @@ export const TradingFormWidget = ({
   onSuccessTrade
 }: Props) => {
   const { username: activeUsername } = useActiveAccount();
-  const isMobile = useGlobalStore((s) => s.isMobile);
+  const isMobile = useIsMobile();
   const toggleUIProp = useGlobalStore((s) => s.toggleUiProp);
 
   const [loading, setLoading] = useState(false);

--- a/apps/web/src/app/perks/_page.tsx
+++ b/apps/web/src/app/perks/_page.tsx
@@ -8,7 +8,9 @@ import { motion } from "framer-motion";
 import i18next from "i18next";
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import * as ls from "@/utils/local-storage";
+import { PERKS_SEEN_KEY } from "@/features/shared/navbar/navbar-perks-button";
 import {
   PerksBasicCard,
   PerksPointsCard,
@@ -20,6 +22,11 @@ import {
 export function PerksPage() {
   const [showBoost, setShowBoost] = useState(false);
   const [showQrDialog, setShowQrDialog] = useState(false);
+
+  // Opening the hub clears the one-time discovery dot on the navbar perks button.
+  useEffect(() => {
+    ls.set(PERKS_SEEN_KEY, true);
+  }, []);
 
   return (
     <div className="flex flex-col gap-4">

--- a/apps/web/src/app/publish/_components/publish-action-bar.tsx
+++ b/apps/web/src/app/publish/_components/publish-action-bar.tsx
@@ -106,7 +106,7 @@ export function PublishActionBar({
     >
       <PublishActionBarCommunity />
       <div className="w-full sm:w-auto flex justify-end sm:justify-normal items-center gap-2 sm:gap-4">
-        <LoginRequired>
+        <LoginRequired promptOnAnon>
           <Button
             size="sm"
             appearance={scheduleDate ? "primary" : "success"}
@@ -125,7 +125,7 @@ export function PublishActionBar({
           </div>
         )}
 
-        <LoginRequired>
+        <LoginRequired promptOnAnon>
           <Button
             size="sm"
             disabled={isDraftPending || !title?.trim()}

--- a/apps/web/src/core/global-store/modules/global-module.ts
+++ b/apps/web/src/core/global-store/modules/global-module.ts
@@ -46,7 +46,6 @@ export function createGlobalState() {
     newVersion: null,
     globalNotifications: true,
     nsfw: false,
-    isMobile: false,
     imageProxy: initialImageProxy
   };
 }
@@ -56,7 +55,7 @@ type State = ReturnType<typeof createGlobalState>;
 export function createGlobalActions(set: (state: Partial<State>) => void, getState: () => State) {
   return {
     toggleTheme: (theme_key?: Theme) => {
-      const { theme, isMobile } = getState();
+      const { theme } = getState();
       let newTheme: any = theme === Theme.day ? Theme.night : Theme.day;
 
       if (!!theme_key) {

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -992,7 +992,9 @@
   },
   "comment": {
     "body-placeholder": "Write your reply here",
+    "write": "Write",
     "preview": "Preview",
+    "submit-shortcut": "Ctrl/⌘ + Enter to post",
     "success": "Your reply created successfully!",
     "delete-success": "Comment deleted successfully",
     "delete-error-hint": "Could not delete comment. Please try again",

--- a/apps/web/src/features/shared/comment/_index.scss
+++ b/apps/web/src/features/shared/comment/_index.scss
@@ -56,9 +56,36 @@
     }
   }
 
+  .comment-view-toggle {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+
   .comment-buttons {
     display: flex;
+    align-items: center;
     justify-content: flex-end;
+  }
+
+  // On phones, keep the submit row pinned above the on-screen keyboard. The
+  // keyboard height is supplied at runtime via `--comment-kb-inset` (visual
+  // viewport), and the safe-area inset clears the iOS home indicator.
+  @media (max-width: 569px) {
+    .comment-buttons {
+      position: sticky;
+      bottom: calc(env(safe-area-inset-bottom, 0px) + var(--comment-kb-inset, 0px));
+      z-index: 5;
+      padding: 8px 0;
+
+      @include themify(day) {
+        @apply bg-light-200;
+      }
+
+      @include themify(night) {
+        @apply bg-dark-200;
+      }
+    }
   }
 }
 

--- a/apps/web/src/features/shared/comment/index.tsx
+++ b/apps/web/src/features/shared/comment/index.tsx
@@ -24,6 +24,7 @@ import useLocalStorage from "react-use/lib/useLocalStorage";
 import useUnmount from "react-use/lib/useUnmount";
 import "./_index.scss";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import { useQuery } from "@tanstack/react-query";
 import {
   getCommunityContextQueryOptions,
@@ -71,10 +72,11 @@ export function Comment({
     PREFIX + `_reply_text_${entry.author}_${entry.permlink}`,
     initialText ?? ""
   );
+  const isMobile = useIsMobile();
+  const boxRef = useRef<HTMLDivElement>(null);
   const [inputHeight, setInputHeight] = useState(0);
   const [preview, setPreview] = useState("");
-  const [showEmoji, setShowEmoji] = useState(false);
-  const [showGif, setShowGif] = useState(false);
+  const [mobileView, setMobileView] = useState<"write" | "preview">("write");
 
   const { data: userContext } = useQuery({
     ...getCommunityContextQueryOptions(activeUser?.username, entry.category),
@@ -131,6 +133,26 @@ export function Comment({
     50,
     [text]
   );
+
+  // Keep the action row above the on-screen keyboard on mobile by tracking the
+  // visual viewport and exposing the keyboard height as a CSS variable.
+  useEffect(() => {
+    if (!isMobile || typeof window === "undefined" || !window.visualViewport) {
+      return;
+    }
+    const vv = window.visualViewport;
+    const update = () => {
+      const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+      boxRef.current?.style.setProperty("--comment-kb-inset", `${inset}px`);
+    };
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+    };
+  }, [isMobile]);
 
   // Restore failed text when blockchain submission fails
   useEffect(() => {
@@ -190,6 +212,16 @@ export function Comment({
 
   const handleDrop = (event: Event): void => toolbarEventListener(event, "drop");
   const handleShortcuts = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      // Submit on Cmd/Ctrl+Enter — unless the mention autocomplete dropdown is
+      // open (Enter picks a suggestion) or there is nothing to submit yet.
+      const autocompleteOpen = !!commentBodyRef.current?.querySelector(".rta__autocomplete");
+      if (!autocompleteOpen && !inProgress && text?.trim()) {
+        e.preventDefault();
+        submit();
+      }
+      return;
+    }
     if (e.altKey && e.key === "b") {
       detectEvent("bold");
     }
@@ -221,51 +253,82 @@ export function Comment({
     return <></>;
   }
 
+  const showEditor = !isMobile || mobileView === "write";
+  const showPreview = !isMobile || mobileView === "preview";
+
   return (
     <>
-      <div
-        className="comment-box"
-        role="presentation"
-        onMouseEnter={() => {
-          if (!showEmoji && !showGif) {
-            setShowEmoji(true);
-            setShowGif(true);
-          }
-        }}
-      >
-        <EditorToolbar comment={true} sm={true} />
-        <div className="comment-body" role="presentation" onKeyDown={handleShortcuts} ref={commentBodyRef}>
-          <TextareaAutocomplete
-            className={`the-editor accepts-emoji ${text!.length > 20 ? "expanded" : ""}`}
-            as="textarea"
-            placeholder={i18next.t("comment.body-placeholder")}
-            containerStyle={{ height: !text ? "80px" : inputHeight }}
-            value={text}
-            onChange={textChanged}
-            disabled={inProgress}
-            autoFocus={autoFocus}
-            minrows={10}
-            rows={rows}
-            maxrows={100}
-            ref={inputRef}
-            acceptCharset="UTF-8"
-            id="the-editor"
-            spellCheck={true}
-            isComment={true}
-          />
-          <div className="editor-toolbar bottom">
-            {activeUser ? (
-              <AvailableCredits
-                className="p-2 w-full"
-                operation="comment_operation"
-                username={activeUser.username}
-              />
-            ) : (
-              <></>
-            )}
+      <div className="comment-box" role="presentation" ref={boxRef}>
+        {isMobile && (
+          <div className="comment-view-toggle" role="tablist">
+            <Button
+              size="sm"
+              outline={mobileView !== "write"}
+              onClick={() => setMobileView("write")}
+              role="tab"
+              aria-selected={mobileView === "write"}
+            >
+              {i18next.t("comment.write")}
+            </Button>
+            <Button
+              size="sm"
+              outline={mobileView !== "preview"}
+              disabled={!text?.trim()}
+              onClick={() => setMobileView("preview")}
+              role="tab"
+              aria-selected={mobileView === "preview"}
+            >
+              {i18next.t("comment.preview")}
+            </Button>
+          </div>
+        )}
+        {/* Hide (don't unmount) the editor pane so the paste/drag/drop listeners
+            attached to `commentBodyRef` survive a Write/Preview toggle. */}
+        <div className={showEditor ? undefined : "hidden"}>
+          <EditorToolbar comment={true} sm={true} />
+          <div
+            className="comment-body"
+            role="presentation"
+            onKeyDown={handleShortcuts}
+            ref={commentBodyRef}
+          >
+            <TextareaAutocomplete
+              className={`the-editor accepts-emoji ${text!.length > 20 ? "expanded" : ""}`}
+              as="textarea"
+              placeholder={i18next.t("comment.body-placeholder")}
+              containerStyle={{ height: !text ? "80px" : inputHeight }}
+              value={text}
+              onChange={textChanged}
+              disabled={inProgress}
+              autoFocus={autoFocus}
+              minrows={3}
+              rows={rows}
+              maxrows={100}
+              ref={inputRef}
+              acceptCharset="UTF-8"
+              id="the-editor"
+              spellCheck={true}
+              isComment={true}
+            />
+            <div className="editor-toolbar bottom">
+              {activeUser ? (
+                <AvailableCredits
+                  className="p-2 w-full"
+                  operation="comment_operation"
+                  username={activeUser.username}
+                />
+              ) : (
+                <></>
+              )}
+            </div>
           </div>
         </div>
         <div className="comment-buttons flex items-center mt-3">
+          {!isMobile && (
+            <span className="comment-submit-hint mr-auto text-xs opacity-60">
+              {i18next.t("comment.submit-shortcut")}
+            </span>
+          )}
           {cancellable && (
             <Button
               className="mr-2"
@@ -277,13 +340,13 @@ export function Comment({
               {i18next.t("g.cancel")}
             </Button>
           )}
-          <LoginRequired>
+          <LoginRequired promptOnAnon>
             <Button size="sm" onClick={submit} isLoading={inProgress} iconPlacement="left">
               {submitText}
             </Button>
           </LoginRequired>
         </div>
-        <CommentPreview text={preview} />
+        {showPreview && <CommentPreview text={preview} />}
       </div>
     </>
   );

--- a/apps/web/src/features/shared/discussion/index.tsx
+++ b/apps/web/src/features/shared/discussion/index.tsx
@@ -178,7 +178,7 @@ export function Discussion({ parent, community, isRawContent, hideControls, onTo
                   <div className="text-sm">{i18next.t("discussion.join-hint")}</div>
                 </div>
               </div>
-              <LoginRequired>
+              <LoginRequired promptOnAnon>
                 <Button appearance="white" icon="🔥" size="lg">
                   {i18next.t("discussion.btn-join")}
                 </Button>

--- a/apps/web/src/features/shared/editor-toolbar/index.tsx
+++ b/apps/web/src/features/shared/editor-toolbar/index.tsx
@@ -22,7 +22,7 @@ import {
 import "./_index.scss";
 import { UilPanelAdd } from "@tooni/iconscout-unicons-react";
 import { PollsCreation, PollSnapshot } from "@/features/polls";
-import { useGlobalStore } from "@/core/global-store";
+import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import { useUploadImageMutation } from "@/api/sdk-mutations";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { insertOrReplace, replace } from "@/utils";
@@ -74,7 +74,7 @@ export function EditorToolbar({
   const { activeUser } = useActiveAccount();
   const activeUserRef = useRef(activeUser);
 
-  const isMobile = useGlobalStore((s) => s.isMobile);
+  const isMobile = useIsMobile();
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);

--- a/apps/web/src/features/shared/entry-reblog-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-reblog-btn/index.tsx
@@ -54,7 +54,7 @@ export function EntryReblogBtn({ entry }: Props) {
     );
 
     if (!activeUser) {
-        return <LoginRequired>{content}</LoginRequired>;
+        return <LoginRequired promptOnAnon>{content}</LoginRequired>;
     }
 
     return (

--- a/apps/web/src/features/shared/entry-tip-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-tip-btn/index.tsx
@@ -102,7 +102,7 @@ export function EntryTipBtn({
 
   return (
     <>
-      <LoginRequired>
+      <LoginRequired promptOnAnon>
         {inlineTipButton ? (
           inlineTipBtn
         ) : tipCount > 0 ? (

--- a/apps/web/src/features/shared/entry-vote-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/index.tsx
@@ -137,7 +137,7 @@ export function EntryVoteBtn({ entry: originalEntry, isPostSlider, account }: Pr
   }, [dialog, getPreviousVote]);
 
   return (
-    <LoginRequired>
+    <LoginRequired promptOnAnon>
       <div ref={rootRef}>
         <div
           className="entry-vote-btn"

--- a/apps/web/src/features/shared/favorite-btn/index.tsx
+++ b/apps/web/src/features/shared/favorite-btn/index.tsx
@@ -63,7 +63,7 @@ export function FavoriteBtn({ targetUsername }: Props) {
   return (
     <>
       {!activeUser && (
-        <LoginRequired>
+        <LoginRequired promptOnAnon>
           <span className="favorite-btn">
             <Tooltip content={i18next.t("favorite-btn.add")}>
               <Button

--- a/apps/web/src/features/shared/follow-controls/index.tsx
+++ b/apps/web/src/features/shared/follow-controls/index.tsx
@@ -6,7 +6,8 @@ import { error, LoginRequired, success } from "@/features/shared";
 import { getRelationshipBetweenAccountsQueryOptions, useAccountRelationsUpdate } from "@ecency/sdk";
 import { getSdkAuthContext } from "@/utils";
 import { getUser } from "@/utils/user-token";
-import { useQuery } from "@tanstack/react-query";
+import { scheduleQuestsRefresh } from "@/utils/refresh-quests";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@ui/button";
 import i18next from "i18next";
 
@@ -68,20 +69,22 @@ function FollowButton({ disabled, following }: ButtonProps) {
     getRelationshipBetweenAccountsQueryOptions(activeUser?.username, following)
   );
 
+  const queryClient = useQueryClient();
   const { mutateAsync: updateRelation, isPending } = useAccountRelationsUpdate(
     activeUser?.username,
     following,
     getSdkAuthContext(getUser(activeUser?.username ?? "")),
-    (data) => {},
+    () => scheduleQuestsRefresh(queryClient, activeUser?.username),
     (err) => error(...formatError(err))
   );
 
   return (
-    <LoginRequired>
+    <LoginRequired promptOnAnon>
       <Button
         size="sm"
         style={{ marginRight: "5px" }}
         disabled={disabled}
+        isLoading={isPending}
         onClick={() => updateRelation("toggle-follow")}
       >
         {data?.follows

--- a/apps/web/src/features/shared/login-required.tsx
+++ b/apps/web/src/features/shared/login-required.tsx
@@ -1,9 +1,23 @@
-import { cloneElement, PropsWithChildren, ReactElement } from "react";
+import { KeyboardEvent, MouseEvent, PropsWithChildren } from "react";
 import { useGlobalStore } from "@/core/global-store";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { Button } from "@ui/button";
 
-export function LoginRequired({ children }: PropsWithChildren) {
+interface Props {
+  /**
+   * When true, a logged-out user still SEES the gated child, but activating it
+   * (click / Enter / Space) opens the login modal instead of running the real
+   * action — converting intent into a login prompt rather than silently hiding
+   * the control. Use for high-intent actions (vote, reply, reblog, tip, follow,
+   * publish) where hiding the control loses the conversion.
+   *
+   * Without this prop the legacy behavior is preserved: gated children are not
+   * rendered for logged-out users.
+   */
+  promptOnAnon?: boolean;
+}
+
+export function LoginRequired({ children, promptOnAnon = false }: PropsWithChildren<Props>) {
   const { activeUser } = useActiveAccount();
   const toggleUiProp = useGlobalStore((state) => state.toggleUiProp);
 
@@ -15,8 +29,31 @@ export function LoginRequired({ children }: PropsWithChildren) {
   // User is not logged in
   if (!children) {
     // No children provided - show default login button
+    return <Button onClick={() => toggleUiProp("login")}>Login to continue</Button>;
+  }
+
+  if (promptOnAnon) {
+    // Keep the control visible, but intercept activation in the CAPTURE phase so
+    // the real (protected) handler never runs — even when the click/keypress
+    // lands on a nested element — and open the login modal instead. The wrapper
+    // uses `display: contents` so it does not affect layout.
+    const openLogin = (e: MouseEvent | KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      toggleUiProp("login");
+    };
     return (
-      <Button onClick={() => toggleUiProp("login")}>Login to continue</Button>
+      <span
+        className="contents"
+        onClickCapture={openLogin}
+        onKeyDownCapture={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            openLogin(e);
+          }
+        }}
+      >
+        {children}
+      </span>
     );
   }
 

--- a/apps/web/src/features/shared/login-required.tsx
+++ b/apps/web/src/features/shared/login-required.tsx
@@ -37,7 +37,18 @@ export function LoginRequired({ children, promptOnAnon = false }: PropsWithChild
     // the real (protected) handler never runs — even when the click/keypress
     // lands on a nested element — and open the login modal instead. The wrapper
     // uses `display: contents` so it does not affect layout.
+    // Skip editable targets so a nested input/textarea keeps typing (including
+    // Space) working instead of opening the login modal.
+    const isEditableTarget = (target: EventTarget | null) => {
+      const el = target as HTMLElement | null;
+      if (!el) return false;
+      const tag = el.tagName;
+      return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable;
+    };
     const openLogin = (e: MouseEvent | KeyboardEvent) => {
+      if (isEditableTarget(e.target)) {
+        return;
+      }
       e.preventDefault();
       e.stopPropagation();
       toggleUiProp("login");

--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -58,8 +58,12 @@ export function NavbarMobile({
   }, []);
 
   const isActive = (prefix: string) => !!pathname && pathname.startsWith(prefix);
-  const activeClass = (prefix: string) =>
-    isActive(prefix) ? "!bg-blue-duck-egg dark:!bg-gray-800 rounded-lg" : "rounded-lg";
+  // The Home tab links to /hot but represents the whole feed area, so it stays
+  // active across the feed sorts and the root.
+  const homeActive =
+    pathname === "/" || isActive("/hot") || isActive("/trending") || isActive("/created");
+  const activeClass = (active: boolean) =>
+    active ? "!bg-blue-duck-egg dark:!bg-gray-800 rounded-lg" : "rounded-lg";
 
   return (
     <>
@@ -102,8 +106,8 @@ export function NavbarMobile({
           appearance="gray-link"
           icon={<UilHomeAlt width={20} height={20} />}
           aria-label={i18next.t("navbar.home")}
-          aria-current={isActive("/hot") ? "page" : undefined}
-          className={activeClass("/hot")}
+          aria-current={homeActive ? "page" : undefined}
+          className={activeClass(homeActive)}
         />
         <div key={`mobile-chat-${activeUser?.username || "anon"}`} className="relative">
           <Button
@@ -112,7 +116,7 @@ export function NavbarMobile({
             icon={<UilComment width={20} height={20} />}
             aria-label={i18next.t("navbar.chats")}
             aria-current={isActive("/chats") ? "page" : undefined}
-            className={activeClass("/chats")}
+            className={activeClass(isActive("/chats"))}
           />
           {!unread?.truncated && unread?.totalUnread ? (
             <span className="absolute -top-1 -right-1 inline-flex min-w-[18px] justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold text-black dark:text-white shadow">

--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -5,15 +5,19 @@ import { useGlobalStore } from "@/core/global-store";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { UserAvatar, preloadLoginDialog } from "@/features/shared";
 import { NavbarMainSidebar } from "@/features/shared/navbar/navbar-main-sidebar";
-import { NavbarMainSidebarToggle } from "@/features/shared/navbar/navbar-main-sidebar-toggle";
+import { NavbarNotificationsButton } from "@/features/shared/navbar/navbar-notifications-button";
 import { NavbarSide } from "@/features/shared/navbar/sidebar/navbar-side";
 import { isInAppBrowser } from "@/utils";
 import { useMattermostUnread } from "@/features/chat/mattermost-api";
-import { UilComment, UilEditAlt, UilHomeAlt, UilLock, UilWallet, UilWater } from "@tooni/iconscout-unicons-react";
+import { UilBars, UilComment, UilHomeAlt, UilLock, UilPlusCircle } from "@tooni/iconscout-unicons-react";
 import { Button } from "@ui/button";
 import clsx from "clsx";
 import i18next from "i18next";
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import defaults from "@/defaults";
 
 interface Props {
   step?: number;
@@ -36,6 +40,7 @@ export function NavbarMobile({
   const hydrated = useHydrated();
   const toggleUIProp = useGlobalStore((s) => s.toggleUiProp);
   const { data: unread } = useMattermostUnread(Boolean(activeUser && hydrated));
+  const pathname = usePathname();
 
   const [isInRn, setIsInRn] = useState(false);
   useEffect(() => {
@@ -52,67 +57,108 @@ export function NavbarMobile({
     }
   }, []);
 
-  return (
-    <div
-      className={clsx(
-        "flex items-center justify-between bg-white/80 dark:bg-dark-200/80 backdrop-blur-sm md:hidden m-2 rounded-xl p-3",
-        "shadow-sm border border-[--border-color]",
-        step === 1 && "transparent",
-        isInRn && "mb-20"
-      )}
-    >
-      <Button
-        appearance="gray-link"
-        icon={<UilHomeAlt width={20} height={20} />}
-        onClick={() => setMainBarExpanded(true)}
-        aria-label={i18next.t("g.menu", { defaultValue: "Menu" })}
-      />
-      <Button href="/waves" appearance="gray-link" icon={<UilWater width={20} height={20} />} aria-label={i18next.t("navbar.waves")} />
-      <div key={`mobile-chat-${activeUser?.username || "anon"}`} className="relative">
-        <Button href="/chats" appearance="gray-link" icon={<UilComment width={20} height={20} />} aria-label={i18next.t("navbar.chats")} />
-        {!unread?.truncated && unread?.totalUnread ? (
-          <span className="absolute -top-1 -right-1 inline-flex min-w-[18px] justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold text-black dark:text-white shadow">
-            {unread.totalUnread}
-          </span>
-        ) : null}
-      </div>
-      <Button href="/publish" appearance="gray-link" icon={<UilEditAlt width={20} height={20} />} aria-label={i18next.t("navbar.post")} />
+  const isActive = (prefix: string) => !!pathname && pathname.startsWith(prefix);
+  const activeClass = (prefix: string) =>
+    isActive(prefix) ? "!bg-blue-duck-egg dark:!bg-gray-800 rounded-lg" : "rounded-lg";
 
-      {activeUser ? (
-        <>
-          <Button
-            href={`/@${activeUser.username}/wallet`}
-            appearance="gray-link"
-            icon={<UilWallet width={20} height={20} />}
-            aria-label={i18next.t("navbar.wallet")}
-          />
-          <button
-            key={`mobile-avatar-${activeUser.username}`}
-            type="button"
-            onClick={() => setExpanded(true)}
-            aria-label={i18next.t("user-menu.title", { defaultValue: "Open user menu" })}
-            aria-expanded={expanded}
-            className="cursor-pointer"
-          >
-            <UserAvatar size="medium" username={activeUser.username} />
-          </button>
-        </>
-      ) : (
+  return (
+    <>
+      {/* Floating brand + browse/governance menu — compact, top-left only so it
+          never costs a full row of vertical space on small screens. */}
+      <div
+        className={clsx(
+          "fixed top-2 left-2 z-20 md:hidden flex items-center gap-1 rounded-xl p-1.5",
+          "bg-white/80 dark:bg-dark-200/80 backdrop-blur-sm shadow-sm border border-[--border-color]",
+          step === 1 && "transparent"
+        )}
+      >
         <Button
-          className="btn-login"
-          onClick={() => toggleUIProp("login")}
-          onMouseEnter={preloadLoginDialog}
-          onFocus={preloadLoginDialog}
-          onPointerDown={preloadLoginDialog}
-          size="sm"
-          icon={<UilLock />}
-        >
-          {i18next.t("g.login")}
-        </Button>
-      )}
+          appearance="gray-link"
+          noPadding={true}
+          icon={<UilBars width={20} height={20} />}
+          onClick={() => setMainBarExpanded(true)}
+          aria-label={i18next.t("navbar.toggle-menu")}
+          aria-expanded={mainBarExpanded}
+        />
+        <Link href="/" className="flex items-center">
+          {/* The image alt provides the link's accessible name (brand/home),
+              distinct from the "Home" feed tab below. */}
+          <Image src={defaults.logo} alt="Ecency" width={28} height={28} className="rounded" />
+        </Link>
+      </div>
+
+      {/* Bottom primary tabs */}
+      <div
+        className={clsx(
+          "flex items-center justify-around bg-white/80 dark:bg-dark-200/80 backdrop-blur-sm md:hidden mx-2 mt-2 rounded-xl p-3",
+          "shadow-sm border border-[--border-color]",
+          step === 1 && "transparent",
+          isInRn && "mb-20"
+        )}
+        style={isInRn ? undefined : { marginBottom: "calc(env(safe-area-inset-bottom) + 0.5rem)" }}
+      >
+        <Button
+          href="/hot"
+          appearance="gray-link"
+          icon={<UilHomeAlt width={20} height={20} />}
+          aria-label={i18next.t("navbar.home")}
+          aria-current={isActive("/hot") ? "page" : undefined}
+          className={activeClass("/hot")}
+        />
+        <div key={`mobile-chat-${activeUser?.username || "anon"}`} className="relative">
+          <Button
+            href="/chats"
+            appearance="gray-link"
+            icon={<UilComment width={20} height={20} />}
+            aria-label={i18next.t("navbar.chats")}
+            aria-current={isActive("/chats") ? "page" : undefined}
+            className={activeClass("/chats")}
+          />
+          {!unread?.truncated && unread?.totalUnread ? (
+            <span className="absolute -top-1 -right-1 inline-flex min-w-[18px] justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold text-black dark:text-white shadow">
+              {unread.totalUnread}
+            </span>
+          ) : null}
+        </div>
+        <Button
+          href="/publish"
+          appearance="primary"
+          icon={<UilPlusCircle width={22} height={22} />}
+          aria-label={i18next.t("navbar.post")}
+          aria-current={isActive("/publish") ? "page" : undefined}
+        />
+
+        {activeUser ? (
+          <>
+            <NavbarNotificationsButton />
+            <button
+              key={`mobile-avatar-${activeUser.username}`}
+              type="button"
+              onClick={() => setExpanded(true)}
+              aria-label={i18next.t("user-menu.title", { defaultValue: "Open user menu" })}
+              aria-expanded={expanded}
+              className="cursor-pointer"
+            >
+              <UserAvatar size="medium" username={activeUser.username} />
+            </button>
+          </>
+        ) : (
+          <Button
+            className="btn-login"
+            onClick={() => toggleUIProp("login")}
+            onMouseEnter={preloadLoginDialog}
+            onFocus={preloadLoginDialog}
+            onPointerDown={preloadLoginDialog}
+            size="sm"
+            icon={<UilLock />}
+          >
+            {i18next.t("g.login")}
+          </Button>
+        )}
+      </div>
 
       {activeUser && <NavbarSide key={`mobile-${activeUser.username}`} show={expanded} setShow={setExpanded} />}
       <NavbarMainSidebar setShow={setMainBarExpanded} show={mainBarExpanded} setStepOne={setStepOne} />
-    </div>
+    </>
   );
 }

--- a/apps/web/src/features/shared/navbar/navbar-perks-button.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-perks-button.tsx
@@ -35,25 +35,25 @@ export function NavbarPerksButton() {
   // streak about to break, or a never-opened perks hub. No "new day" nag.
   const showDot = !!activeUser && ((streak?.at_risk ?? false) || !everSeenPerks);
 
+  const streakLabel =
+    streak && streak.current > 0
+      ? i18next.t("perks.quests.streak", { n: streak.current })
+      : undefined;
+
   const button =
     streak && streak.current > 0 ? (
-      (() => {
-        const streakLabel = i18next.t("perks.quests.streak", { n: streak.current });
-        return (
-          <Button
-            href="/perks"
-            aria-label={streakLabel}
-            title={streak.at_risk ? i18next.t("perks.quests.streak-at-risk") : streakLabel}
-            className={clsx(
-              "font-semibold flex items-center gap-1 whitespace-nowrap text-sm",
-              streak.at_risk && "text-orange-500"
-            )}
-          >
-            <span aria-hidden>🔥</span>
-            <span>{streak.current}</span>
-          </Button>
-        );
-      })()
+      <Button
+        href="/perks"
+        aria-label={streakLabel}
+        title={streak.at_risk ? i18next.t("perks.quests.streak-at-risk") : streakLabel}
+        className={clsx(
+          "font-semibold flex items-center gap-1 whitespace-nowrap text-sm",
+          streak.at_risk && "text-orange-500"
+        )}
+      >
+        <span aria-hidden>🔥</span>
+        <span>{streak.current}</span>
+      </Button>
     ) : (
       <Button
         href="/perks"

--- a/apps/web/src/features/shared/navbar/navbar-perks-button.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-perks-button.tsx
@@ -1,17 +1,80 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useState } from "react";
 import { Button } from "@ui/button";
 import { UilFire } from "@tooni/iconscout-unicons-react";
 import i18next from "i18next";
+import clsx from "clsx";
+import { useQuery } from "@tanstack/react-query";
+import { getQuestsQueryOptions } from "@ecency/sdk";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import * as ls from "@/utils/local-storage";
+
+/** Set once the user opens /perks — clears the one-time discovery dot. */
+export const PERKS_SEEN_KEY = "perks_seen";
 
 export function NavbarPerksButton() {
   const label = i18next.t("user-nav.perks");
+  const { activeUser } = useActiveAccount();
+
+  // Ambient streak indicator — the only place in the app that subscribes to the
+  // quests query outside the /perks page. `getQuestsQueryOptions` is disabled
+  // when there's no username, so logged-out users just get the plain button.
+  const { data: quests } = useQuery(getQuestsQueryOptions(activeUser?.username));
+  const streak = quests?.streak;
+
+  // One-time discovery dot: shown until the user opens /perks for the first
+  // time. Defaults to "seen" so SSR / the first client render show no dot
+  // (avoids a hydration mismatch); the real value is read after mount.
+  const [everSeenPerks, setEverSeenPerks] = useState(true);
+  useEffect(() => {
+    setEverSeenPerks(ls.get(PERKS_SEEN_KEY, false) === true);
+  }, []);
+
+  // Reward / at-risk only: a real, self-clearing reason to look — an active
+  // streak about to break, or a never-opened perks hub. No "new day" nag.
+  const showDot = !!activeUser && ((streak?.at_risk ?? false) || !everSeenPerks);
+
+  const button =
+    streak && streak.current > 0 ? (
+      (() => {
+        const streakLabel = i18next.t("perks.quests.streak", { n: streak.current });
+        return (
+          <Button
+            href="/perks"
+            aria-label={streakLabel}
+            title={streak.at_risk ? i18next.t("perks.quests.streak-at-risk") : streakLabel}
+            className={clsx(
+              "font-semibold flex items-center gap-1 whitespace-nowrap text-sm",
+              streak.at_risk && "text-orange-500"
+            )}
+          >
+            <span aria-hidden>🔥</span>
+            <span>{streak.current}</span>
+          </Button>
+        );
+      })()
+    ) : (
+      <Button
+        href="/perks"
+        icon={<UilFire />}
+        aria-label={label}
+        title={label}
+        className="font-semibold flex whitespace-nowrap text-sm"
+      />
+    );
+
+  if (!showDot) {
+    return button;
+  }
+
   return (
-    <Button
-      href="/perks"
-      icon={<UilFire />}
-      aria-label={label}
-      title={label}
-      className="font-semibold flex whitespace-nowrap text-sm"
-    />
+    <span className="relative inline-flex">
+      {button}
+      <span
+        aria-hidden
+        className="perks-badge-dot pointer-events-none absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-600 ring-2 ring-white dark:ring-dark-200"
+      />
+    </span>
   );
 }

--- a/apps/web/src/features/shared/notifications/notifications-actions.tsx
+++ b/apps/web/src/features/shared/notifications/notifications-actions.tsx
@@ -1,7 +1,7 @@
 import { useUpdateNotificationsSettings } from "@/api/mutations";
 import { useMarkNotificationsMutation, useSetLastReadMutation } from "@/api/sdk-mutations";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
-import { useGlobalStore } from "@/core/global-store";
+import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import { NotificationFilter, NotifyTypes } from "@/enums";
 import { FormControl, Tooltip } from "@/features/ui";
 import {
@@ -31,7 +31,7 @@ interface Props {
 
 export function NotificationsActions({ filter }: Props) {
   const { activeUser } = useActiveAccount();
-  const isMobile = useGlobalStore((state) => state.isMobile);
+  const isMobile = useIsMobile();
 
   const [settings, { set: setSettingItem }] = useMap<Record<NotifyTypes, boolean>>({
     [NotifyTypes.COMMENT]: false,

--- a/apps/web/src/features/shared/theme.tsx
+++ b/apps/web/src/features/shared/theme.tsx
@@ -4,20 +4,17 @@ import { useEffect } from "react";
 import { useGlobalStore } from "@/core/global-store";
 
 export function Theme() {
-  const isMobile = useGlobalStore((state) => state.isMobile);
   const theme = useGlobalStore((state) => state.theme);
 
   useEffect(() => {
     if (["day", "night"].includes(theme)) {
-      if (!isMobile) {
-        if (theme === "day") {
-          document.body.classList.remove("dark");
-        } else {
-          document.body.classList.add("dark");
-        }
+      if (theme === "day") {
+        document.body.classList.remove("dark");
+      } else {
+        document.body.classList.add("dark");
       }
     }
-  }, [isMobile, theme]);
+  }, [theme]);
 
   return <></>;
 }

--- a/apps/web/src/features/ui/util/use-is-mobile.tsx
+++ b/apps/web/src/features/ui/util/use-is-mobile.tsx
@@ -1,18 +1,40 @@
-import { useEffect, useState } from "react";
+"use client";
 
+import { useSyncExternalStore } from "react";
+
+/** Viewport width (px) below which the app is treated as a mobile browser. */
+export const MOBILE_BREAKPOINT = 570;
+
+function subscribe(onStoreChange: () => void) {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+  window.addEventListener("resize", onStoreChange);
+  return () => window.removeEventListener("resize", onStoreChange);
+}
+
+function getSnapshot() {
+  return window.innerWidth < MOBILE_BREAKPOINT;
+}
+
+// Render desktop on the server and the first client commit so SSR and hydration
+// always agree; the real viewport value is applied right after mount.
+function getServerSnapshot() {
+  return false;
+}
+
+/**
+ * SSR-safe viewport check — `true` below {@link MOBILE_BREAKPOINT}px.
+ *
+ * This is the single, canonical mobile-detection hook for the app. It returns
+ * `false` during SSR and the first client render (so hydration never
+ * mismatches), then reflects the real viewport width and updates on resize —
+ * with no leaked listeners.
+ *
+ * It replaces the former global `isMobile` Zustand flag, which had no writer and
+ * was therefore permanently `false`, silently disabling every mobile-only UI
+ * branch that depended on it.
+ */
 export function useIsMobile() {
-  const [screenWidth, setScreenWidth] = useState(
-    typeof window !== "undefined" ? window.innerWidth : 0
-  );
-
-  useEffect(() => {
-    function handleResize() {
-      setScreenWidth(window.innerWidth);
-    }
-
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
-  return screenWidth < 570;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/apps/web/src/specs/features/shared/comment.spec.tsx
+++ b/apps/web/src/specs/features/shared/comment.spec.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { fireEvent, render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Entry } from "@/entities";
 
 // --- Mock the heavy children so we can exercise the composer logic in isolation ---
 vi.mock("@/features/shared/editor-toolbar", () => ({
@@ -15,8 +16,15 @@ vi.mock("@/features/shared/textarea-autocomplete", () => ({
   // A plain textarea that forwards value/onChange/ref — onKeyDown bubbles to the
   // `.comment-body` handler exactly like the real component.
   // eslint-disable-next-line react/display-name
-  TextareaAutocomplete: React.forwardRef<HTMLTextAreaElement, any>(
-    ({ value, onChange, placeholder, id }, ref) => (
+  TextareaAutocomplete: React.forwardRef<
+    HTMLTextAreaElement,
+    {
+      value?: string;
+      onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+      placeholder?: string;
+      id?: string;
+    }
+  >(({ value, onChange, placeholder, id }, ref) => (
       <textarea
         ref={ref}
         id={id}
@@ -72,7 +80,7 @@ const entry = {
   category: "ecency",
   body: "",
   json_metadata: {}
-} as any;
+} as unknown as Entry;
 
 function renderComment(onSubmit = vi.fn().mockResolvedValue(undefined)) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -84,7 +92,7 @@ function renderComment(onSubmit = vi.fn().mockResolvedValue(undefined)) {
   return { onSubmit, ...utils };
 }
 
-function type(getByTestId: any, value: string) {
+function type(getByTestId: (testId: string) => HTMLElement, value: string) {
   fireEvent.change(getByTestId("comment-textarea"), { target: { value } });
 }
 

--- a/apps/web/src/specs/features/shared/comment.spec.tsx
+++ b/apps/web/src/specs/features/shared/comment.spec.tsx
@@ -1,0 +1,136 @@
+import { vi } from "vitest";
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// --- Mock the heavy children so we can exercise the composer logic in isolation ---
+vi.mock("@/features/shared/editor-toolbar", () => ({
+  EditorToolbar: () => null,
+  detectEvent: vi.fn(),
+  toolbarEventListener: vi.fn()
+}));
+
+vi.mock("@/features/shared/textarea-autocomplete", () => ({
+  // A plain textarea that forwards value/onChange/ref — onKeyDown bubbles to the
+  // `.comment-body` handler exactly like the real component.
+  // eslint-disable-next-line react/display-name
+  TextareaAutocomplete: React.forwardRef<HTMLTextAreaElement, any>(
+    ({ value, onChange, placeholder, id }, ref) => (
+      <textarea
+        ref={ref}
+        id={id}
+        placeholder={placeholder}
+        value={value ?? ""}
+        onChange={onChange}
+        data-testid="comment-textarea"
+      />
+    )
+  )
+}));
+
+vi.mock("@/features/shared/comment/comment-preview", () => ({
+  CommentPreview: ({ text }: { text: string }) => <div data-testid="comment-preview">{text}</div>
+}));
+
+vi.mock("@/features/shared", () => ({
+  AvailableCredits: () => null,
+  LoginRequired: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  handleAndReportError: vi.fn(() => true)
+}));
+
+vi.mock("@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/context", () => ({
+  EntryPageContext: React.createContext({ selection: "", setSelection: vi.fn() })
+}));
+
+vi.mock("@/core/hooks/use-active-account", () => ({
+  useActiveAccount: () => ({ activeUser: { username: "tester" } })
+}));
+
+vi.mock("@ecency/sdk", () => ({
+  getCommunityContextQueryOptions: vi.fn(() => ({
+    queryKey: ["community-context"],
+    queryFn: async () => ({})
+  })),
+  getCommunityPermissions: vi.fn(() => ({ canComment: true })),
+  getCommunityType: vi.fn(() => -1)
+}));
+
+// Inline mock (no importActual) so we don't pull the real utils → consts → sdk
+// chain. Comment only uses `isCommunity` from this module.
+vi.mock("@/utils", () => ({
+  isCommunity: (category?: string) => !!category && category.startsWith("hive-"),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+
+import { Comment } from "@/features/shared/comment";
+
+const entry = {
+  author: "alice",
+  permlink: "post-1",
+  category: "ecency",
+  body: "",
+  json_metadata: {}
+} as any;
+
+function renderComment(onSubmit = vi.fn().mockResolvedValue(undefined)) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <Comment entry={entry} onSubmit={onSubmit} submitText="Reply" />
+    </QueryClientProvider>
+  );
+  return { onSubmit, ...utils };
+}
+
+function type(getByTestId: any, value: string) {
+  fireEvent.change(getByTestId("comment-textarea"), { target: { value } });
+}
+
+describe("Comment composer", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  test("Cmd/Ctrl+Enter submits the typed comment", async () => {
+    const { onSubmit, getByTestId, container } = renderComment();
+
+    type(getByTestId, "hello world");
+    const body = container.querySelector(".comment-body")!;
+    fireEvent.keyDown(body, { key: "Enter", ctrlKey: true });
+
+    expect(onSubmit).toHaveBeenCalledWith("hello world");
+  });
+
+  test("plain Enter does NOT submit (newline behavior preserved)", () => {
+    const { onSubmit, getByTestId, container } = renderComment();
+
+    type(getByTestId, "hello");
+    fireEvent.keyDown(container.querySelector(".comment-body")!, { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("Cmd/Ctrl+Enter does NOT submit when the text is empty", () => {
+    const { onSubmit, container } = renderComment();
+
+    fireEvent.keyDown(container.querySelector(".comment-body")!, { key: "Enter", metaKey: true });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("Cmd/Ctrl+Enter is suppressed while the mention dropdown is open", () => {
+    const { onSubmit, getByTestId, container } = renderComment();
+
+    type(getByTestId, "hey @al");
+    // Simulate the react-textarea-autocomplete dropdown being open.
+    const body = container.querySelector(".comment-body")!;
+    body.insertAdjacentHTML("beforeend", '<div class="rta__autocomplete"></div>');
+
+    fireEvent.keyDown(body, { key: "Enter", metaKey: true });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/specs/features/shared/login-required.spec.tsx
+++ b/apps/web/src/specs/features/shared/login-required.spec.tsx
@@ -296,5 +296,17 @@ describe("LoginRequired", () => {
       expect(originalOnClick).toHaveBeenCalled();
       expect(mockToggleUiProp).not.toHaveBeenCalled();
     });
+
+    test("does not intercept Space typing inside a wrapped editable field", () => {
+      render(
+        <LoginRequired promptOnAnon>
+          <input type="text" aria-label="field" defaultValue="" />
+        </LoginRequired>
+      );
+
+      fireEvent.keyDown(screen.getByLabelText("field"), { key: " " });
+
+      expect(mockToggleUiProp).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/specs/features/shared/login-required.spec.tsx
+++ b/apps/web/src/specs/features/shared/login-required.spec.tsx
@@ -215,4 +215,86 @@ describe("LoginRequired", () => {
     // Protected content should not be visible when not logged in
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
+
+  describe("promptOnAnon mode", () => {
+    beforeEach(() => {
+      (useActiveAccount as any).mockReturnValue({ activeUser: null });
+    });
+
+    test("renders the gated child for logged-out users", () => {
+      render(
+        <LoginRequired promptOnAnon>
+          <button>Vote</button>
+        </LoginRequired>
+      );
+
+      expect(screen.getByText("Vote")).toBeInTheDocument();
+    });
+
+    test("clicking the child opens login instead of firing its handler", () => {
+      const originalOnClick = vi.fn();
+
+      render(
+        <LoginRequired promptOnAnon>
+          <button onClick={originalOnClick}>Vote</button>
+        </LoginRequired>
+      );
+
+      fireEvent.click(screen.getByText("Vote"));
+
+      expect(mockToggleUiProp).toHaveBeenCalledWith("login");
+      expect(originalOnClick).not.toHaveBeenCalled();
+    });
+
+    test("clicking a nested element inside the child still opens login, not the inner handler", () => {
+      const innerOnClick = vi.fn();
+
+      render(
+        <LoginRequired promptOnAnon>
+          <div onClick={innerOnClick} role="button">
+            <span>chevron</span>
+          </div>
+        </LoginRequired>
+      );
+
+      // Capture-phase interception must beat the nested target's own handler.
+      fireEvent.click(screen.getByText("chevron"));
+
+      expect(mockToggleUiProp).toHaveBeenCalledWith("login");
+      expect(innerOnClick).not.toHaveBeenCalled();
+    });
+
+    test("pressing Enter on the child opens login", () => {
+      const originalOnClick = vi.fn();
+
+      render(
+        <LoginRequired promptOnAnon>
+          <button onClick={originalOnClick}>Vote</button>
+        </LoginRequired>
+      );
+
+      fireEvent.keyDown(screen.getByText("Vote"), { key: "Enter" });
+
+      expect(mockToggleUiProp).toHaveBeenCalledWith("login");
+      expect(originalOnClick).not.toHaveBeenCalled();
+    });
+
+    test("ignores promptOnAnon when logged in and runs the real handler", () => {
+      (useActiveAccount as any).mockReturnValue({
+        activeUser: { username: "testuser" }
+      });
+      const originalOnClick = vi.fn();
+
+      render(
+        <LoginRequired promptOnAnon>
+          <button onClick={originalOnClick}>Vote</button>
+        </LoginRequired>
+      );
+
+      fireEvent.click(screen.getByText("Vote"));
+
+      expect(originalOnClick).toHaveBeenCalled();
+      expect(mockToggleUiProp).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
+++ b/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
@@ -1,0 +1,102 @@
+import { vi } from "vitest";
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+let pathname = "/";
+const toggleUiProp = vi.fn();
+const useActiveAccount = vi.fn(() => ({ activeUser: { username: "tester" } as { username: string } | null }));
+
+vi.mock("next/navigation", () => ({ usePathname: () => pathname }));
+vi.mock("next/image", () => ({
+  // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+  default: ({ src, alt, ...rest }: any) => <img src={typeof src === "string" ? src : ""} alt={alt} {...rest} />
+}));
+vi.mock("@/api/queries", () => ({ useHydrated: () => true }));
+vi.mock("@/core/global-store", () => ({ useGlobalStore: (s: any) => s({ toggleUiProp }) }));
+vi.mock("@/core/hooks/use-active-account", () => ({ useActiveAccount: () => useActiveAccount() }));
+vi.mock("@/features/chat/mattermost-api", () => ({ useMattermostUnread: () => ({ data: undefined }) }));
+vi.mock("@/utils", () => ({
+  isInAppBrowser: () => false,
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+vi.mock("@/defaults", () => ({ default: { logo: "/logo.png" } }));
+vi.mock("@/features/shared", () => ({
+  UserAvatar: ({ username }: any) => <span data-testid="avatar">{username}</span>,
+  preloadLoginDialog: vi.fn()
+}));
+vi.mock("@/features/shared/navbar/navbar-notifications-button", () => ({
+  NavbarNotificationsButton: () => <button data-testid="notifications">notifs</button>
+}));
+vi.mock("@/features/shared/navbar/navbar-main-sidebar", () => ({ NavbarMainSidebar: () => null }));
+vi.mock("@/features/shared/navbar/sidebar/navbar-side", () => ({ NavbarSide: () => null }));
+
+import { NavbarMobile } from "@/features/shared/navbar/navbar-mobile";
+
+function renderNav(over: Partial<React.ComponentProps<typeof NavbarMobile>> = {}) {
+  const setMainBarExpanded = vi.fn();
+  const setExpanded = vi.fn();
+  const utils = render(
+    <NavbarMobile
+      step={2}
+      setStepOne={vi.fn()}
+      expanded={false}
+      setExpanded={setExpanded}
+      mainBarExpanded={false}
+      setMainBarExpanded={setMainBarExpanded}
+      {...over}
+    />
+  );
+  return { setMainBarExpanded, setExpanded, ...utils };
+}
+
+describe("NavbarMobile", () => {
+  beforeEach(() => {
+    pathname = "/";
+    vi.clearAllMocks();
+    useActiveAccount.mockReturnValue({ activeUser: { username: "tester" } });
+  });
+
+  test("renders the brand cluster (menu + logo) and the primary tabs", () => {
+    renderNav();
+    expect(screen.getByAltText("Ecency")).toBeInTheDocument(); // logo
+    expect(screen.getByLabelText("navbar.toggle-menu")).toBeInTheDocument(); // ☰
+    expect(screen.getByLabelText("navbar.home")).toBeInTheDocument();
+    expect(screen.getByLabelText("navbar.chats")).toBeInTheDocument();
+    expect(screen.getByLabelText("navbar.post")).toBeInTheDocument();
+    expect(screen.getByTestId("notifications")).toBeInTheDocument();
+    expect(screen.getByTestId("avatar")).toBeInTheDocument();
+  });
+
+  test("marks Home active via aria-current on the hot feed", () => {
+    pathname = "/hot";
+    renderNav();
+    expect(screen.getByLabelText("navbar.home")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByLabelText("navbar.chats")).not.toHaveAttribute("aria-current", "page");
+  });
+
+  test("marks Chats active via aria-current on the chats route", () => {
+    pathname = "/chats";
+    renderNav();
+    expect(screen.getByLabelText("navbar.chats")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByLabelText("navbar.home")).not.toHaveAttribute("aria-current", "page");
+  });
+
+  test("the menu button opens the browse/governance drawer", () => {
+    const { setMainBarExpanded } = renderNav();
+    fireEvent.click(screen.getByLabelText("navbar.toggle-menu"));
+    expect(setMainBarExpanded).toHaveBeenCalledWith(true);
+  });
+
+  test("shows Login (not notifications/avatar) for logged-out users", () => {
+    useActiveAccount.mockReturnValue({ activeUser: null });
+    renderNav();
+    expect(screen.getByText("g.login")).toBeInTheDocument();
+    expect(screen.queryByTestId("avatar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("notifications")).not.toBeInTheDocument();
+    // Home / Chats / brand stay available to anonymous users
+    expect(screen.getByLabelText("navbar.home")).toBeInTheDocument();
+    expect(screen.getByAltText("Ecency")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
+++ b/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
@@ -76,6 +76,12 @@ describe("NavbarMobile", () => {
     expect(screen.getByLabelText("navbar.chats")).not.toHaveAttribute("aria-current", "page");
   });
 
+  test("keeps Home active across other feed sorts (e.g. /trending)", () => {
+    pathname = "/trending";
+    renderNav();
+    expect(screen.getByLabelText("navbar.home")).toHaveAttribute("aria-current", "page");
+  });
+
   test("marks Chats active via aria-current on the chats route", () => {
     pathname = "/chats";
     renderNav();

--- a/apps/web/src/specs/features/shared/navbar-perks-button.spec.tsx
+++ b/apps/web/src/specs/features/shared/navbar-perks-button.spec.tsx
@@ -1,0 +1,92 @@
+import { vi } from "vitest";
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const useActiveAccount = vi.fn(() => ({ activeUser: { username: "tester" } as { username: string } | null }));
+vi.mock("@/core/hooks/use-active-account", () => ({
+  useActiveAccount: () => useActiveAccount()
+}));
+
+vi.mock("@ecency/sdk", () => ({
+  getQuestsQueryOptions: (username?: string) => ({
+    queryKey: ["quests", "status", username],
+    queryFn: async () => ({}),
+    enabled: !!username,
+    staleTime: Infinity
+  })
+}));
+
+import { NavbarPerksButton } from "@/features/shared/navbar/navbar-perks-button";
+
+type Streak = { current: number; best: number; at_risk: boolean };
+
+function renderWith(streak?: Streak) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  if (streak) {
+    queryClient.setQueryData(["quests", "status", "tester"], { streak });
+  }
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NavbarPerksButton />
+    </QueryClientProvider>
+  );
+}
+
+const markPerksSeen = () => localStorage.setItem("ecency_perks_seen", "true");
+const dot = (container: HTMLElement) => container.querySelector(".perks-badge-dot");
+const control = (container: HTMLElement) => container.querySelector("a, button")!;
+
+describe("NavbarPerksButton", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useActiveAccount.mockReturnValue({ activeUser: { username: "tester" } });
+  });
+
+  test("shows the 🔥 streak count when an active streak exists", () => {
+    markPerksSeen();
+    const { container } = renderWith({ current: 7, best: 12, at_risk: false });
+    expect(container.textContent).toContain("🔥");
+    expect(container.textContent).toContain("7");
+  });
+
+  test("uses the at-risk (orange) styling when the streak is at risk", () => {
+    markPerksSeen();
+    const { container } = renderWith({ current: 3, best: 8, at_risk: true });
+    expect(control(container).className).toContain("text-orange-500");
+  });
+
+  test("renders the plain perks button (no dot) when seen and no active streak", () => {
+    markPerksSeen();
+    const { container } = renderWith({ current: 0, best: 5, at_risk: false });
+    expect(container.textContent).not.toContain("🔥");
+    expect(control(container).getAttribute("aria-label")).toBe("user-nav.perks");
+    expect(dot(container)).toBeNull();
+  });
+
+  test("renders the plain perks button for logged-out users with no dot", () => {
+    useActiveAccount.mockReturnValue({ activeUser: null });
+    const { container } = renderWith();
+    expect(control(container).getAttribute("aria-label")).toBe("user-nav.perks");
+    expect(dot(container)).toBeNull();
+  });
+
+  test("shows the dot when the streak is at risk", () => {
+    markPerksSeen(); // isolate at-risk as the only trigger
+    const { container } = renderWith({ current: 4, best: 9, at_risk: true });
+    expect(dot(container)).not.toBeNull();
+  });
+
+  test("shows a one-time discovery dot for users who have never opened /perks", () => {
+    // localStorage cleared in beforeEach → never seen
+    const { container } = renderWith({ current: 6, best: 6, at_risk: false });
+    expect(dot(container)).not.toBeNull();
+  });
+
+  test("hides the dot once /perks has been opened and the streak is not at risk", () => {
+    markPerksSeen();
+    const { container } = renderWith({ current: 6, best: 6, at_risk: false });
+    expect(dot(container)).toBeNull();
+  });
+});

--- a/apps/web/src/specs/test-helper.ts
+++ b/apps/web/src/specs/test-helper.ts
@@ -146,7 +146,6 @@ export const globalInstance: Partial<GlobalStore> = {
   searchIndexCount: 10000000,
   canUseWebp: true,
   hasKeyChain: false,
-  isMobile: false,
   globalNotifications: true,
   nsfw: false,
   newVersion: null

--- a/apps/web/src/utils/is-mobile.tsx
+++ b/apps/web/src/utils/is-mobile.tsx
@@ -1,20 +1,4 @@
-"use client";
-
-import { useEffect, useState } from "react";
-
-export function useIsMobile() {
-  const [screenWidth, setScreenWidth] = useState(
-    typeof window !== "undefined" && window.innerWidth
-  );
-
-  useEffect(() => {
-    function handleResize() {
-      setScreenWidth(window.innerWidth);
-    }
-
-    window.addEventListener("resize", handleResize);
-  });
-
-  // @ts-ignore
-  return screenWidth < 570;
-}
+// Re-export of the canonical, SSR-safe mobile-detection hook so existing
+// `@/utils` consumers keep working. The implementation lives in
+// `@/features/ui/util/use-is-mobile`.
+export { MOBILE_BREAKPOINT, useIsMobile } from "@/features/ui/util/use-is-mobile";

--- a/apps/web/src/utils/refresh-quests.ts
+++ b/apps/web/src/utils/refresh-quests.ts
@@ -1,0 +1,31 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { QueryKeys } from "@ecency/sdk";
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Debounced refresh of the quests/streak query so the ambient navbar streak pill
+ * and the /perks tiles update shortly after a points-earning action.
+ *
+ * The debounce coalesces a burst of actions into a single `/private-api/quests`
+ * request (instead of one per action), and the invalidation only triggers a
+ * network refetch when something is actually observing the query (e.g. the
+ * navbar pill or the /perks page is mounted).
+ *
+ * Intentionally NOT wired into the high-frequency vote path — votes already get
+ * rich inline feedback (count, payout, animation) and would otherwise fan out
+ * requests during fast feed voting.
+ */
+export function scheduleQuestsRefresh(queryClient: QueryClient, username?: string | null) {
+  const name = username?.replace("@", "");
+  if (!name) {
+    return;
+  }
+  if (timer) {
+    clearTimeout(timer);
+  }
+  timer = setTimeout(() => {
+    timer = null;
+    queryClient.invalidateQueries({ queryKey: QueryKeys.quests.status(name) });
+  }, 4000);
+}


### PR DESCRIPTION
## Summary

Make consuming, navigating and commenting feel lighter and more encouraging on **desktop and mobile web**, and remove some long-standing friction (login walls that hide actions, a dead mobile-detection flag, a heavy comment composer, a misleading mobile nav).

> ⚠️ **Needs browser/device QA before merge** — several changes are mobile/viewport-specific (see the QA checklist below). All automated suites pass.

---

## What changed

### 1. `LoginRequired` converts instead of hiding
`login-required.tsx` previously returned `null` for logged-out users, so upvote, reply, reblog, tip, follow and Publish/Save-draft silently vanished for anonymous readers. Added an opt-in `promptOnAnon` mode (capture-phase interception, works even when the click lands on a nested element) that keeps the control visible and opens the login modal on activation. Opted in across vote/reply/reblog/tip/follow/publish + the "Join discussion" CTA. Mute stays hidden (moderation, not engagement).

### 2. `isMobile` modernized and unified
The global `isMobile` store flag was read by 6 components but **never written**, so it was permanently `false` and those mobile branches were dead code. Replaced both ad-hoc hooks with one SSR-safe `useIsMobile` (`useSyncExternalStore` over `matchMedia`/resize) — fixes a resize-listener leak and a hydration mismatch — exported `MOBILE_BREAKPOINT`, made `utils/is-mobile.tsx` a thin re-export, deleted the dead flag, and migrated consumers. `theme.tsx`'s dead `!isMobile` guard was removed (it would otherwise have disabled dark mode on mobile).

### 3. Lighter, keyboard-aware comment composer
`features/shared/comment`: Cmd/Ctrl+Enter to submit (guarded so plain Enter still newlines and the mention dropdown isn't hijacked), `minrows` 10→3 with auto-grow, a mobile Write/Preview toggle (editor pane is hidden rather than unmounted so paste/drag-drop listeners survive), a `visualViewport`-aware sticky submit row above the on-screen keyboard, and removal of dead `showEmoji`/`showGif` state.

### 4. Engagement feedback
- Ambient **streak pill** in the navbar (`🔥 N`, amber when at-risk) — the only quests subscriber outside `/perks`.
- A **reward/at-risk perks dot**: shows only when a streak is at-risk or the user has never opened `/perks` (one-time), self-clearing — no "new day" nag, no extra network call.
- **Follow** button now shows a loading state.
- Debounced **quest refresh** on reply/reblog/follow (coalesced; deliberately not wired into the high-frequency vote path).
- Vote count / payout / animation were already optimistic — verified and left as-is.

### 5. Mobile navigation
`navbar-mobile.tsx`: a compact **floating brand + browse/governance cluster** top-left (logo → home, hamburger → the drawer that holds Discover/Communities/Proposals/Witnesses/Decks/Search), so governance is reachable behind a real menu affordance instead of a house icon. The bottom bar becomes clean primary tabs — **Home / Chats / Create / Notifications / You** — with `usePathname` active states and `env(safe-area-inset-bottom)`. Desktop is unchanged.

---

## Testing

- New specs: `login-required` (promptOnAnon incl. nested-target), `comment` (Cmd/Ctrl+Enter + guards), `navbar-perks-button` (streak pill + dot), `navbar-mobile` (brand cluster, active state, anon branch); `use-is-mobile` passes unchanged.
- `tsc --noEmit` introduces no new errors; ESLint clean on changed files.

## QA before merge (mobile/device — not coverable headless)

- [ ] Mobile branches re-enabled by the `isMobile` fix at ≤570px: comment editor's mobile image attach, notifications mobile layout, the 3 market-advanced widgets
- [ ] Comment composer sticky submit above the iOS keyboard
- [ ] New floating nav cluster doesn't obscure important top-left page content; confirm `fixed` positioning (no ancestor `transform`)
- [ ] Streak pill + perks dot + Follow loading state on a logged-in account

## Notes
- Comment thread load gating (anonymous deferral) is intentionally **unchanged** to preserve page-speed.
- Emoji/GIF hover→tap is a small shared-toolbar CSS follow-up, bundled with the editor-toolbar mobile QA above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mobile-optimized reply composer with write/preview toggle mode
  * Introduced quest and streak tracking with visual discovery indicators
  * Restructured mobile navigation with bottom tab bar for improved navigation

* **Improvements**
  * Enabled keyboard shortcut (Ctrl/Cmd+Enter) for faster submissions
  * Enhanced responsive design across all components
  * Improved anonymous user prompts for protected actions
  * Better mobile-aware perks hub notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->