### PR TITLE
Engagement alpha fixes: publish header, mobile perks placement & badge

### DIFF
--- a/apps/web/src/app/publish/_components/publish-action-bar.tsx
+++ b/apps/web/src/app/publish/_components/publish-action-bar.tsx
@@ -69,6 +69,7 @@ interface Props {
   onBackToClassic: () => void;
   onImport?: (result: ImportResult) => void;
   draftId?: string;
+  lastSaved?: Date | null;
 }
 
 export function PublishActionBar({
@@ -76,7 +77,8 @@ export function PublishActionBar({
   children,
   onBackToClassic,
   onImport,
-  draftId
+  draftId,
+  lastSaved
 }: PropsWithChildren<Props>) {
   const { schedule: scheduleDate, clearAll, title, content } = usePublishState();
 
@@ -104,7 +106,17 @@ export function PublishActionBar({
       transition={{ delay: 0.4 }}
       className="container relative z-[11] justify-between gap-4 px-2 md:px-4 flex flex-col-reverse sm:flex-row sm:items-center max-w-[1024px] py-4 mx-auto publish-action-bar"
     >
-      <PublishActionBarCommunity />
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <span className="text-xs text-gray-600 dark:text-gray-400 whitespace-nowrap">
+          {i18next.t("publish.new-content")}
+        </span>
+        {lastSaved && draftId && (
+          <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+            {i18next.t("publish.auto-save")}: {lastSaved.toLocaleTimeString()}
+          </span>
+        )}
+        <PublishActionBarCommunity />
+      </div>
       <div className="w-full sm:w-auto flex justify-end sm:justify-normal items-center gap-2 sm:gap-4">
         <LoginRequired promptOnAnon>
           <Button

--- a/apps/web/src/app/publish/_page.tsx
+++ b/apps/web/src/app/publish/_page.tsx
@@ -88,21 +88,12 @@ export default function Publish() {
       <PublishMultiTabWarning isActiveTab={isActiveTab} />
       {step === "edit" && (
         <>
-          <div className="container max-w-[1024px] mx-auto text-xs text-gray-600 dark:text-gray-400 p-2 md:p-0">
-            <div className="flex flex-wrap justify-between items-center">
-              <span>{i18next.t("publish.new-content")}</span>
-              {lastSaved && draftId && (
-                <span className="text-gray-500 dark:text-gray-400">
-                  {i18next.t("publish.auto-save")}: {lastSaved.toLocaleTimeString()}
-                </span>
-              )}
-            </div>
-          </div>
           <PublishActionBar
             onPublish={() => setStep("validation")}
             onBackToClassic={() => router.push(routes.SUBMIT)}
             onImport={handleImport}
             draftId={draftId}
+            lastSaved={lastSaved}
           />
           <PublishEditor editor={editor} />
         </>

--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -6,11 +6,10 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { UserAvatar, preloadLoginDialog } from "@/features/shared";
 import { NavbarMainSidebar } from "@/features/shared/navbar/navbar-main-sidebar";
 import { NavbarNotificationsButton } from "@/features/shared/navbar/navbar-notifications-button";
-import { NavbarPerksButton } from "@/features/shared/navbar/navbar-perks-button";
 import { NavbarSide } from "@/features/shared/navbar/sidebar/navbar-side";
 import { isInAppBrowser } from "@/utils";
 import { useMattermostUnread } from "@/features/chat/mattermost-api";
-import { UilBars, UilComment, UilHomeAlt, UilLock, UilPlusCircle } from "@tooni/iconscout-unicons-react";
+import { UilBars, UilComment, UilHomeAlt, UilLock, UilPlus, UilWater } from "@tooni/iconscout-unicons-react";
 import { Button } from "@ui/button";
 import clsx from "clsx";
 import i18next from "i18next";
@@ -110,6 +109,14 @@ export function NavbarMobile({
           aria-current={homeActive ? "page" : undefined}
           className={activeClass(homeActive)}
         />
+        <Button
+          href="/waves"
+          appearance="gray-link"
+          icon={<UilWater width={20} height={20} />}
+          aria-label={i18next.t("navbar.waves")}
+          aria-current={isActive("/waves") ? "page" : undefined}
+          className={activeClass(isActive("/waves"))}
+        />
         <div key={`mobile-chat-${activeUser?.username || "anon"}`} className="relative">
           <Button
             href="/chats"
@@ -125,17 +132,8 @@ export function NavbarMobile({
             </span>
           ) : null}
         </div>
-        <Button
-          href="/publish"
-          appearance="primary"
-          icon={<UilPlusCircle width={22} height={22} />}
-          aria-label={i18next.t("navbar.post")}
-          aria-current={isActive("/publish") ? "page" : undefined}
-        />
-
         {activeUser ? (
           <>
-            <NavbarPerksButton />
             <NavbarNotificationsButton />
             <button
               key={`mobile-avatar-${activeUser.username}`}
@@ -162,6 +160,21 @@ export function NavbarMobile({
           </Button>
         )}
       </div>
+
+      {/* Floating compose button (FAB), mirroring the native app's create action. */}
+      <Button
+        href="/publish"
+        appearance="primary"
+        noPadding={true}
+        icon={<UilPlus width={26} height={26} />}
+        aria-label={i18next.t("navbar.post")}
+        aria-current={isActive("/publish") ? "page" : undefined}
+        className={clsx(
+          "md:hidden fixed right-4 z-20 h-14 w-14 !rounded-full flex items-center justify-center shadow-lg",
+          step === 1 && "transparent"
+        )}
+        style={{ bottom: isInRn ? "7rem" : "calc(env(safe-area-inset-bottom) + 4.75rem)" }}
+      />
 
       {activeUser && <NavbarSide key={`mobile-${activeUser.username}`} show={expanded} setShow={setExpanded} />}
       <NavbarMainSidebar setShow={setMainBarExpanded} show={mainBarExpanded} setStepOne={setStepOne} />

--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -6,6 +6,7 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { UserAvatar, preloadLoginDialog } from "@/features/shared";
 import { NavbarMainSidebar } from "@/features/shared/navbar/navbar-main-sidebar";
 import { NavbarNotificationsButton } from "@/features/shared/navbar/navbar-notifications-button";
+import { NavbarPerksButton } from "@/features/shared/navbar/navbar-perks-button";
 import { NavbarSide } from "@/features/shared/navbar/sidebar/navbar-side";
 import { isInAppBrowser } from "@/utils";
 import { useMattermostUnread } from "@/features/chat/mattermost-api";
@@ -134,6 +135,7 @@ export function NavbarMobile({
 
         {activeUser ? (
           <>
+            <NavbarPerksButton />
             <NavbarNotificationsButton />
             <button
               key={`mobile-avatar-${activeUser.username}`}

--- a/apps/web/src/features/shared/navbar/navbar-perks-button.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-perks-button.tsx
@@ -52,7 +52,7 @@ export function NavbarPerksButton() {
         )}
       >
         <span aria-hidden>🔥</span>
-        <span>{streak.current}</span>
+        <span>{streak.current > 99 ? "99+" : streak.current}</span>
       </Button>
     ) : (
       <Button
@@ -73,7 +73,7 @@ export function NavbarPerksButton() {
       {button}
       <span
         aria-hidden
-        className="perks-badge-dot pointer-events-none absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-600 ring-2 ring-white dark:ring-dark-200"
+        className="perks-badge-dot pointer-events-none absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full bg-red-500"
       />
     </span>
   );

--- a/apps/web/src/features/shared/navbar/sidebar/navbar-side.tsx
+++ b/apps/web/src/features/shared/navbar/sidebar/navbar-side.tsx
@@ -48,7 +48,8 @@ export function NavbarSide({ show, setShow, placement = "right" }: Props) {
           aria-label={i18next.t("navbar.wallet")}
         />
       </div>
-      <div className="px-4 pb-3">
+      {/* On mobile this lives in the bottom tab bar instead. */}
+      <div className="hidden md:block px-4 pb-3">
         <NavbarPerksButton />
       </div>
       <NavbarSideMainMenu onHide={() => setShow(false)} />

--- a/apps/web/src/features/shared/navbar/sidebar/navbar-side.tsx
+++ b/apps/web/src/features/shared/navbar/sidebar/navbar-side.tsx
@@ -3,7 +3,6 @@ import { NavbarSideUserInfo } from "./navbar-side-user-info";
 import { NavbarSideMainMenu } from "./navbar-side-main-menu";
 import { Button } from "@ui/button";
 import { NavbarPerksButton } from "../navbar-perks-button";
-import { NavbarNotificationsButton } from "../navbar-notifications-button";
 import { UilEditAlt } from "@tooni/iconscout-unicons-react";
 import { closeSvg } from "@ui/svg";
 import { walletIconSvg } from "@ui/icons";
@@ -39,7 +38,7 @@ export function NavbarSide({ show, setShow, placement = "right" }: Props) {
           icon={<UilEditAlt width={20} height={20} />}
           aria-label={i18next.t("navbar.post")}
         />
-        <NavbarNotificationsButton onClick={() => setShow(false)} />
+        <NavbarPerksButton />
         <Button
           icon={walletIconSvg}
           size="sm"
@@ -47,10 +46,6 @@ export function NavbarSide({ show, setShow, placement = "right" }: Props) {
           href={`/@${activeUser?.username}/wallet`}
           aria-label={i18next.t("navbar.wallet")}
         />
-      </div>
-      {/* On mobile this lives in the bottom tab bar instead. */}
-      <div className="hidden md:block px-4 pb-3">
-        <NavbarPerksButton />
       </div>
       <NavbarSideMainMenu onHide={() => setShow(false)} />
     </ModalSidebar>

--- a/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
+++ b/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
@@ -29,9 +29,6 @@ vi.mock("@/features/shared", () => ({
 vi.mock("@/features/shared/navbar/navbar-notifications-button", () => ({
   NavbarNotificationsButton: () => <button data-testid="notifications">notifs</button>
 }));
-vi.mock("@/features/shared/navbar/navbar-perks-button", () => ({
-  NavbarPerksButton: () => <button data-testid="perks">perks</button>
-}));
 vi.mock("@/features/shared/navbar/navbar-main-sidebar", () => ({ NavbarMainSidebar: () => null }));
 vi.mock("@/features/shared/navbar/sidebar/navbar-side", () => ({ NavbarSide: () => null }));
 
@@ -66,10 +63,10 @@ describe("NavbarMobile", () => {
     expect(screen.getByAltText("Ecency")).toBeInTheDocument(); // logo
     expect(screen.getByLabelText("navbar.toggle-menu")).toBeInTheDocument(); // ☰
     expect(screen.getByLabelText("navbar.home")).toBeInTheDocument();
+    expect(screen.getByLabelText("navbar.waves")).toBeInTheDocument();
     expect(screen.getByLabelText("navbar.chats")).toBeInTheDocument();
-    expect(screen.getByLabelText("navbar.post")).toBeInTheDocument();
+    expect(screen.getByLabelText("navbar.post")).toBeInTheDocument(); // compose FAB
     expect(screen.getByTestId("notifications")).toBeInTheDocument();
-    expect(screen.getByTestId("perks")).toBeInTheDocument();
     expect(screen.getByTestId("avatar")).toBeInTheDocument();
   });
 
@@ -105,7 +102,6 @@ describe("NavbarMobile", () => {
     expect(screen.getByText("g.login")).toBeInTheDocument();
     expect(screen.queryByTestId("avatar")).not.toBeInTheDocument();
     expect(screen.queryByTestId("notifications")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("perks")).not.toBeInTheDocument();
     // Home / Chats / brand stay available to anonymous users
     expect(screen.getByLabelText("navbar.home")).toBeInTheDocument();
     expect(screen.getByAltText("Ecency")).toBeInTheDocument();

--- a/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
+++ b/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
@@ -29,6 +29,9 @@ vi.mock("@/features/shared", () => ({
 vi.mock("@/features/shared/navbar/navbar-notifications-button", () => ({
   NavbarNotificationsButton: () => <button data-testid="notifications">notifs</button>
 }));
+vi.mock("@/features/shared/navbar/navbar-perks-button", () => ({
+  NavbarPerksButton: () => <button data-testid="perks">perks</button>
+}));
 vi.mock("@/features/shared/navbar/navbar-main-sidebar", () => ({ NavbarMainSidebar: () => null }));
 vi.mock("@/features/shared/navbar/sidebar/navbar-side", () => ({ NavbarSide: () => null }));
 
@@ -66,6 +69,7 @@ describe("NavbarMobile", () => {
     expect(screen.getByLabelText("navbar.chats")).toBeInTheDocument();
     expect(screen.getByLabelText("navbar.post")).toBeInTheDocument();
     expect(screen.getByTestId("notifications")).toBeInTheDocument();
+    expect(screen.getByTestId("perks")).toBeInTheDocument();
     expect(screen.getByTestId("avatar")).toBeInTheDocument();
   });
 
@@ -101,6 +105,7 @@ describe("NavbarMobile", () => {
     expect(screen.getByText("g.login")).toBeInTheDocument();
     expect(screen.queryByTestId("avatar")).not.toBeInTheDocument();
     expect(screen.queryByTestId("notifications")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("perks")).not.toBeInTheDocument();
     // Home / Chats / brand stay available to anonymous users
     expect(screen.getByLabelText("navbar.home")).toBeInTheDocument();
     expect(screen.getByAltText("Ecency")).toBeInTheDocument();

--- a/apps/web/src/specs/features/shared/navbar-perks-button.spec.tsx
+++ b/apps/web/src/specs/features/shared/navbar-perks-button.spec.tsx
@@ -51,6 +51,13 @@ describe("NavbarPerksButton", () => {
     expect(container.textContent).toContain("7");
   });
 
+  test("caps the streak display at 99+ for large streaks", () => {
+    markPerksSeen();
+    const { container } = renderWith({ current: 150, best: 200, at_risk: false });
+    expect(container.textContent).toContain("99+");
+    expect(container.textContent).not.toContain("150");
+  });
+
   test("uses the at-risk (orange) styling when the streak is at risk", () => {
     markPerksSeen();
     const { container } = renderWith({ current: 3, best: 8, at_risk: true });


### PR DESCRIPTION
Follow-up to #865 — addresses feedback from alpha testing.

## Changes

1. **`/publish` "New content" label was hidden behind the floating mobile nav cluster.**
   Moved the "New content" / auto-save text into the action-bar row (same line as Continue / Save draft), so it no longer sits under the top-left logo+menu cluster.

2. **Perks/streak indicator moved into the mobile bottom tab bar.**
   It previously lived only in the user menu. Now that notifications are in the bottom bar, the perks button sits there too (between Create and Notifications); the duplicate in the user menu is hidden on mobile (kept on desktop).

3. **Perks badge styling + number cap.**
   The dot was a ringed circle floating outside the button — replaced with a small red dot sitting on the button, just above the flame/number. The streak number now caps at `99+` (like the notifications badge) so a long streak can't overflow the small control.

## Notes
- Bottom bar is now 6 items for logged-in users: `Home · Chats · Create · Perks · Notifications · You`. Happy to rearrange the perks position if you'd prefer it elsewhere.
- Needs a quick mobile visual check (publish header placement, bottom-bar spacing at 6 items, dot position).

## Testing
- `navbar-perks-button` spec +1 (99+ cap), `navbar-mobile` spec updated (perks present logged-in, absent logged-out). All affected suites pass; no new tsc/lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added perks button to mobile navigation
  * Quest streak display now capped at 99+
  * Auto-save timestamp relocated to publish action bar

* **Style**
  * Updated perks discovery indicator styling and positioning
  * Enhanced responsive layout for mobile devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->