### PR TITLE
Mobile top navbar: full-width sticky bar + hide-on-scroll

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/deleted-post-screen.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/deleted-post-screen.tsx
@@ -30,7 +30,7 @@ export const DeletedPostScreen = ({ username, permlink, staticNav }: Props) => {
   return (
     <div>
       {staticNav ? <StaticNavbar fullVersionUrl="" /> : <Navbar />}
-      <div className="container overflow-x-hidden">
+      <div className="container overflow-x-hidden pt-14 md:pt-24 pb-24 md:pb-0">
         <ScrollToTop />
         <Theme />
         {isLoading && (

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-pending-index-view.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-pending-index-view.tsx
@@ -29,7 +29,7 @@ export function EntryPendingIndexView({ entry, isTimedOut }: Props) {
   return (
     <div>
       <Navbar />
-      <div className="container overflow-x-hidden">
+      <div className="container overflow-x-hidden pt-14 md:pt-24 pb-24 md:pb-0">
         <ScrollToTop />
         <Theme />
         <div className="grid grid-cols-12">

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/layout.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/layout.tsx
@@ -28,7 +28,7 @@ export default async function ProfileLayout({ children, params }: Props) {
       <Navbar experimental={true} />
       <div className="fixed top-0 left-0 w-full h-full bg-gradient-to-br from-blue-dark-sky to-blue-duck-egg backdrop-blur-lg -z-[1]" />
       <div className="fixed top-0 left-0 w-full h-full bg-white/80 dark:bg-black/90 backdrop-blur-lg -z-[1]" />
-      <div className="pb-20 md:pb-0 profile-page pt-0 sm:pt-4 md:pt-[128px] max-w-[1600px] sm:px-2 md:px-2 mx-auto flex flex-col lg:flex-row gap-0 sm:gap-4 min-h-[100vh] items-start w-full">
+      <div className="pb-20 md:pb-0 profile-page pt-16 sm:pt-16 md:pt-[128px] max-w-[1600px] sm:px-2 md:px-2 mx-auto flex flex-col lg:flex-row gap-0 sm:gap-4 min-h-[100vh] items-start w-full">
         <div
           className="bg-white/80 dark:bg-dark-200/90 glass-box rounded-none sm:rounded-xl lg:min-w-[280px] lg:max-w-[280px] w-full overflow-hidden"
         >

--- a/apps/web/src/app/chats/layout.tsx
+++ b/apps/web/src/app/chats/layout.tsx
@@ -8,7 +8,7 @@ export default function Layout(props: PropsWithChildren) {
     <>
       <Feedback />
       <Navbar />
-      <div className="bg-blue-duck-egg dark:bg-transparent box-border h-[100dvh] pb-24 pt-4 md:overflow-hidden md:pb-0 md:pt-[69px]">
+      <div className="bg-blue-duck-egg dark:bg-transparent box-border h-[100dvh] pb-24 pt-16 md:overflow-hidden md:pb-0 md:pt-[69px]">
         <div className="mx-auto flex h-full min-h-0 px-4 py-4 md:px-6 md:py-6">
           <div className="grid h-full min-h-0 w-full grid-cols-1 overflow-hidden rounded-2xl border border-[--border-color] bg-white md:grid-cols-[320px_1fr]">
             <div className="hidden min-h-[300px] border-b border-[--border-color] bg-[--surface-color] md:flex md:min-h-0 md:flex-col md:border-b-0 md:border-r md:overflow-hidden">

--- a/apps/web/src/app/communities/layout.tsx
+++ b/apps/web/src/app/communities/layout.tsx
@@ -18,7 +18,7 @@ export default function Layout(props: PropsWithChildren) {
       <ScrollToTop />
       <Theme />
       <Navbar experimental={true} />
-      <div className="bg-blue-duck-egg dark:bg-black pt-[63px] md:pt-[69px] min-h-[100vh] pb-16">
+      <div className="bg-blue-duck-egg dark:bg-black pt-[63px] md:pt-[69px] min-h-[100vh] pb-24 md:pb-16">
         <div className="container mx-auto px-2 sm:p-0 relative mt-4 md:mt-0">
           <div className="grid grid-cols-12 my-4 md:mb-10 items-center gap-4 md:gap-6 lg:gap-8 xl:gap-10 p-2 sm:p-0 md:mt-16">
             <div className="col-span-12 md:col-span-6">

--- a/apps/web/src/app/discover/layout.tsx
+++ b/apps/web/src/app/discover/layout.tsx
@@ -21,7 +21,7 @@ export default function Layout(
       <FullHeight />
       <Theme />
       <Navbar experimental={true} />
-      <div className="bg-blue-duck-egg dark:bg-black pt-[63px] md:pt-[69px] min-h-[100vh] pb-16">
+      <div className="bg-blue-duck-egg dark:bg-black pt-[63px] md:pt-[69px] min-h-[100vh] pb-24 md:pb-16">
         <div className="absolute hidden lg:block top-16 left-0 right-0 h-[280px]">
           <Image
             width={1920}

--- a/apps/web/src/app/perks/layout.tsx
+++ b/apps/web/src/app/perks/layout.tsx
@@ -5,7 +5,7 @@ import { PerksHeader } from "./components";
 
 export default function Layout({ children }: PropsWithChildren) {
   return (
-    <div className="bg-blue-duck-egg dark:bg-transparent pt-[63px] md:pt-[69px] min-h-[100vh] pb-16">
+    <div className="bg-blue-duck-egg dark:bg-transparent pt-[63px] md:pt-[69px] min-h-[100vh] pb-24 md:pb-16">
       <Feedback />
       <Navbar experimental={true} />
       <div className="container mx-auto">

--- a/apps/web/src/app/publish/layout.tsx
+++ b/apps/web/src/app/publish/layout.tsx
@@ -16,7 +16,7 @@ export default function Layout({ children }: PropsWithChildren) {
         <Feedback />
         <Navbar experimental={true} />
         <div className="bg-blue-duck-egg dark:bg-dark-700 pb-4 md:pb-8 xl:pb-12">
-          <div className="md:pt-24 min-h-[100vh] mb-24 md:mb-0">{children}</div>
+          <div className="pt-16 md:pt-24 min-h-[100vh] mb-24 md:mb-0">{children}</div>
         </div>
         <PublishOnboarding />
       </UploadTrackerProvider>

--- a/apps/web/src/app/wallet/setup-external/page.tsx
+++ b/apps/web/src/app/wallet/setup-external/page.tsx
@@ -54,7 +54,7 @@ export default function WalletSetupExternalPage() {
       <Navbar experimental={true} />
       <div className="fixed top-0 left-0 w-full h-full bg-gradient-to-br from-blue-dark-sky to-blue-duck-egg backdrop-blur-lg -z-[1]" />
       <div className="fixed top-0 left-0 w-full h-full bg-white/80 dark:bg-black/90 backdrop-blur-lg -z-[1]" />
-      <div className="container mx-auto px-2 pt-[63px] md:pt-[69px] min-h-[100vh] pb-16">
+      <div className="container mx-auto px-2 pt-[63px] md:pt-[69px] min-h-[100vh] pb-24 md:pb-16">
         <SetupExternalHeader />
         <div className="grid grid-cols-2 gap-4">
           {options.map(({ title, description, buttonText, onClick }, i) => (

--- a/apps/web/src/app/waves/layout.tsx
+++ b/apps/web/src/app/waves/layout.tsx
@@ -74,7 +74,7 @@ export default function WavesLayout(props: PropsWithChildren<Props>) {
           <Feedback />
           <ScrollToTop />
           <Navbar experimental={true} />
-          <div className="pt-4 md:pt-[108px] max-w-[1600px] md:px-6 lg:px-8 mx-auto grid grid-cols-12 gap-4 md:gap-6 xl:gap-8">
+          <div className="pt-16 pb-24 md:pt-[108px] md:pb-0 max-w-[1600px] md:px-6 lg:px-8 mx-auto grid grid-cols-12 gap-4 md:gap-6 xl:gap-8">
             <div className="hidden md:col-span-4 xl:col-span-3 md:flex flex-col gap-4 xl:gap-8">
               {isWaveDetails && waveAuthor ? (
                 <WaveAuthorCard username={waveAuthor} />

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -187,6 +187,7 @@
     "waves": "Waves",
     "communities": "Communities",
     "chats": "Chats",
+    "search": "Search",
     "toggle-menu": "Toggle navigation menu"
   },
   "search": {

--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -7,6 +7,8 @@ import { UserAvatar, preloadLoginDialog } from "@/features/shared";
 import { NavbarMainSidebar } from "@/features/shared/navbar/navbar-main-sidebar";
 import { NavbarNotificationsButton } from "@/features/shared/navbar/navbar-notifications-button";
 import { NavbarSide } from "@/features/shared/navbar/sidebar/navbar-side";
+import { useHideOnScroll } from "@/features/shared/navbar/use-hide-on-scroll";
+import { searchIconSvg } from "@ui/icons";
 import { isInAppBrowser } from "@/utils";
 import { useMattermostUnread } from "@/features/chat/mattermost-api";
 import { UilBars, UilComment, UilHomeAlt, UilLock, UilPlus, UilWater } from "@tooni/iconscout-unicons-react";
@@ -41,6 +43,7 @@ export function NavbarMobile({
   const toggleUIProp = useGlobalStore((s) => s.toggleUiProp);
   const { data: unread } = useMattermostUnread(Boolean(activeUser && hydrated));
   const pathname = usePathname();
+  const hidden = useHideOnScroll();
 
   const [isInRn, setIsInRn] = useState(false);
   useEffect(() => {
@@ -67,28 +70,39 @@ export function NavbarMobile({
 
   return (
     <>
-      {/* Floating brand + browse/governance menu — compact, top-left only so it
-          never costs a full row of vertical space on small screens. */}
+      {/* Full-width sticky top bar — brand + browse/governance menu (left) and
+          search (right). Slides up out of view on scroll-down, reveals on
+          scroll-up, like a mobile browser's own toolbar. */}
       <div
         className={clsx(
-          "fixed top-2 left-2 z-20 md:hidden flex items-center gap-1 rounded-xl p-1.5",
-          "bg-white/80 dark:bg-dark-200/80 backdrop-blur-sm shadow-sm border border-[--border-color]",
+          "fixed top-0 left-0 right-0 z-20 md:hidden flex items-center justify-between gap-2 px-3 h-14",
+          "bg-white/90 dark:bg-dark-200/90 backdrop-blur-sm border-b border-[--border-color]",
+          "transition-transform duration-300 will-change-transform",
+          hidden ? "-translate-y-full" : "translate-y-0",
           step === 1 && "transparent"
         )}
       >
+        <div className="flex items-center gap-1">
+          <Button
+            appearance="gray-link"
+            noPadding={true}
+            icon={<UilBars width={22} height={22} />}
+            onClick={() => setMainBarExpanded(true)}
+            aria-label={i18next.t("navbar.toggle-menu")}
+            aria-expanded={mainBarExpanded}
+          />
+          <Link href="/" className="flex items-center">
+            {/* The image alt provides the link's accessible name (brand/home),
+                distinct from the "Home" feed tab below. */}
+            <Image src={defaults.logo} alt="Ecency" width={30} height={30} className="rounded" />
+          </Link>
+        </div>
         <Button
+          href="/search"
           appearance="gray-link"
-          noPadding={true}
-          icon={<UilBars width={20} height={20} />}
-          onClick={() => setMainBarExpanded(true)}
-          aria-label={i18next.t("navbar.toggle-menu")}
-          aria-expanded={mainBarExpanded}
+          icon={searchIconSvg}
+          aria-label={i18next.t("navbar.search", { defaultValue: "Search" })}
         />
-        <Link href="/" className="flex items-center">
-          {/* The image alt provides the link's accessible name (brand/home),
-              distinct from the "Home" feed tab below. */}
-          <Image src={defaults.logo} alt="Ecency" width={28} height={28} className="rounded" />
-        </Link>
       </div>
 
       {/* Bottom primary tabs */}
@@ -96,6 +110,8 @@ export function NavbarMobile({
         className={clsx(
           "flex items-center justify-around bg-white/80 dark:bg-dark-200/80 backdrop-blur-sm md:hidden mx-2 mt-2 rounded-xl p-3",
           "shadow-sm border border-[--border-color]",
+          "transition-transform duration-300 will-change-transform",
+          hidden && "translate-y-[200%]",
           step === 1 && "transparent",
           isInRn && "mb-20"
         )}
@@ -171,6 +187,8 @@ export function NavbarMobile({
         aria-current={isActive("/publish") ? "page" : undefined}
         className={clsx(
           "md:hidden fixed right-4 z-20 h-14 w-14 !rounded-full flex items-center justify-center shadow-lg",
+          "transition-transform duration-300",
+          hidden && "translate-y-[200%]",
           step === 1 && "transparent"
         )}
         style={{ bottom: isInRn ? "7rem" : "calc(env(safe-area-inset-bottom) + 4.75rem)" }}

--- a/apps/web/src/features/shared/navbar/use-hide-on-scroll.ts
+++ b/apps/web/src/features/shared/navbar/use-hide-on-scroll.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Returns `true` while the user is scrolling DOWN (so sticky bars can slide away)
+ * and `false` when scrolling up or near the top — the same behaviour mobile
+ * browsers use for their own toolbars. rAF-throttled, passive listener.
+ *
+ * @param threshold  minimum px delta before toggling (debounces jitter)
+ * @param topOffset  always reveal while within this many px of the top
+ */
+export function useHideOnScroll(threshold = 8, topOffset = 56) {
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    let lastY = window.scrollY;
+    let ticking = false;
+
+    const update = () => {
+      const y = window.scrollY;
+      if (y < topOffset) {
+        setHidden(false);
+      } else {
+        const delta = y - lastY;
+        if (delta > threshold) {
+          setHidden(true);
+        } else if (delta < -threshold) {
+          setHidden(false);
+        }
+      }
+      lastY = y;
+      ticking = false;
+    };
+
+    const onScroll = () => {
+      if (!ticking) {
+        ticking = true;
+        window.requestAnimationFrame(update);
+      }
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [threshold, topOffset]);
+
+  return hidden;
+}

--- a/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
+++ b/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
@@ -62,6 +62,7 @@ describe("NavbarMobile", () => {
     renderNav();
     expect(screen.getByAltText("Ecency")).toBeInTheDocument(); // logo
     expect(screen.getByLabelText("navbar.toggle-menu")).toBeInTheDocument(); // ☰
+    expect(screen.getByLabelText("navbar.search")).toBeInTheDocument();
     expect(screen.getByLabelText("navbar.home")).toBeInTheDocument();
     expect(screen.getByLabelText("navbar.waves")).toBeInTheDocument();
     expect(screen.getByLabelText("navbar.chats")).toBeInTheDocument();

--- a/apps/web/src/styles/_base.scss
+++ b/apps/web/src/styles/_base.scss
@@ -98,7 +98,10 @@ a[target="_blank"] {
   max-width: 1600px;
   min-height: 100vh;
 
-  @apply pt-4 mb-24 px-2 md:px-4 md:pt-[6rem] mx-auto;
+  // Mobile reserves room for the floating top-left brand/menu cluster (~48px)
+  // so page content (e.g. a post title) isn't covered by it. Desktop keeps its
+  // own offset for the fixed top navbar.
+  @apply pt-14 mb-24 px-2 md:px-4 md:pt-[6rem] mx-auto;
 }
 
 // markdown styles

--- a/apps/web/src/styles/_base.scss
+++ b/apps/web/src/styles/_base.scss
@@ -101,7 +101,7 @@ a[target="_blank"] {
   // Mobile reserves room for the fixed full-width top bar (h-14 / 56px) so page
   // content isn't covered by it. Desktop keeps its own offset for the fixed top
   // navbar.
-  @apply pt-14 mb-24 px-2 md:px-4 md:pt-[6rem] mx-auto;
+  @apply pt-16 mb-24 px-2 md:px-4 md:pt-[6rem] mx-auto;
 }
 
 // markdown styles

--- a/apps/web/src/styles/_base.scss
+++ b/apps/web/src/styles/_base.scss
@@ -98,9 +98,9 @@ a[target="_blank"] {
   max-width: 1600px;
   min-height: 100vh;
 
-  // Mobile reserves room for the floating top-left brand/menu cluster (~48px)
-  // so page content (e.g. a post title) isn't covered by it. Desktop keeps its
-  // own offset for the fixed top navbar.
+  // Mobile reserves room for the fixed full-width top bar (h-14 / 56px) so page
+  // content isn't covered by it. Desktop keeps its own offset for the fixed top
+  // navbar.
   @apply pt-14 mb-24 px-2 md:px-4 md:pt-[6rem] mx-auto;
 }
 

--- a/apps/web/src/styles/static-pages.scss
+++ b/apps/web/src/styles/static-pages.scss
@@ -5,6 +5,7 @@
     display: block;
     width: 100% !important;
     max-width: 100% !important;
+
     // Mobile reserves room for the fixed top bar; desktop keeps the full-bleed look.
     padding: 4rem 0 0 !important;
 

--- a/apps/web/src/styles/static-pages.scss
+++ b/apps/web/src/styles/static-pages.scss
@@ -5,7 +5,12 @@
     display: block;
     width: 100% !important;
     max-width: 100% !important;
-    padding: 0 !important;
+    // Mobile reserves room for the fixed top bar; desktop keeps the full-bleed look.
+    padding: 4rem 0 0 !important;
+
+    @media (min-width: 768px) {
+      padding: 0 !important;
+    }
 
     .about-cloud {
       .about-inner {


### PR DESCRIPTION
Reworks the mobile top navigation from a floating corner cluster into a **predictable full-width sticky top bar**, and makes both bars hide on scroll — addressing the recurring "cluster covers content" issues (e.g. the post title).

## Why
The floating top-left cluster kept overlapping page content (publish header, post title). Avoiding that required reserving top space anyway (`pt-14`), which removes the floating approach's only advantage. A full-width bar costs the same vertical space but is predictable, more usable, and conventional.

## Changes
- **Full-width sticky top bar** (mobile): `[☰ menu] [logo]` left, `[search]` right. Replaces the floating cluster. (Search was previously buried in the drawer.)
- **Hide-on-scroll**: the top bar, the bottom tab bar, and the compose FAB slide away on scroll-down and reveal on scroll-up — like a mobile browser's own toolbars (`useHideOnScroll`, rAF-throttled, passive listener).
- **Content offset**: `.app-content` mobile top inset (`pt-14`) becomes this bar's offset, so content always clears it. Desktop offset unchanged.

## Notes
- Search reuses the existing `searchIconSvg` (no new `@tooni` icon, avoids the curated-unicons crash class).
- Bottom bar contents unchanged: `Home · Waves · Chat · Notif · Avatar` + FAB.

## QA (mobile/device)
- Top bar: menu/logo/search; doesn't cover the post title; sits above content.
- Scroll down hides top + bottom + FAB; scroll up reveals; near-top always shows.
- Smoothness of the slide; no jank; works where the page scrolls (window scroll).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fixed mobile navigation bar that intelligently shows and hides based on scroll direction
  * Introduced search functionality in the navigation bar

* **Style**
  * Adjusted spacing and padding across the app to properly accommodate the new navigation bar
  * Enhanced responsive layout behavior for improved mobile viewing experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->