### PR TITLE
Mobile nav: expanding search, pen FAB icon, scroll-to-top placement

### DIFF
--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -9,9 +9,10 @@ import { NavbarNotificationsButton } from "@/features/shared/navbar/navbar-notif
 import { NavbarSide } from "@/features/shared/navbar/sidebar/navbar-side";
 import { useHideOnScroll } from "@/features/shared/navbar/use-hide-on-scroll";
 import { searchIconSvg } from "@ui/icons";
+import { closeSvg } from "@ui/svg";
 import { isInAppBrowser } from "@/utils";
 import { useMattermostUnread } from "@/features/chat/mattermost-api";
-import { UilBars, UilComment, UilHomeAlt, UilLock, UilPlus, UilWater } from "@tooni/iconscout-unicons-react";
+import { UilBars, UilComment, UilHomeAlt, UilLock, UilPen, UilWater } from "@tooni/iconscout-unicons-react";
 import { Button } from "@ui/button";
 import clsx from "clsx";
 import i18next from "i18next";
@@ -20,6 +21,14 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import defaults from "@/defaults";
+import dynamic from "next/dynamic";
+
+// The full search experience (input + suggester); loaded only when the user
+// opens the in-navbar quick search.
+const MobileSearch = dynamic(
+  () => import("@/features/shared/navbar/search").then((m) => ({ default: m.Search })),
+  { ssr: false }
+);
 
 interface Props {
   step?: number;
@@ -44,6 +53,11 @@ export function NavbarMobile({
   const { data: unread } = useMattermostUnread(Boolean(activeUser && hydrated));
   const pathname = usePathname();
   const hidden = useHideOnScroll();
+  const [searchOpen, setSearchOpen] = useState(false);
+  // Collapse the in-navbar search when navigating away.
+  useEffect(() => {
+    setSearchOpen(false);
+  }, [pathname]);
 
   const [isInRn, setIsInRn] = useState(false);
   useEffect(() => {
@@ -75,34 +89,52 @@ export function NavbarMobile({
           scroll-up, like a mobile browser's own toolbar. */}
       <div
         className={clsx(
-          "fixed top-0 left-0 right-0 z-20 md:hidden flex items-center justify-between gap-2 px-3 h-14",
+          "fixed top-0 left-0 right-0 z-20 md:hidden flex items-center gap-2 px-3 h-14",
           "bg-white/90 dark:bg-dark-200/90 backdrop-blur-sm border-b border-[--border-color]",
           "transition-transform duration-300 will-change-transform",
           hidden ? "-translate-y-full" : "translate-y-0",
           step === 1 && "transparent"
         )}
       >
-        <div className="flex items-center gap-1">
-          <Button
-            appearance="gray-link"
-            noPadding={true}
-            icon={<UilBars width={22} height={22} />}
-            onClick={() => setMainBarExpanded(true)}
-            aria-label={i18next.t("navbar.toggle-menu")}
-            aria-expanded={mainBarExpanded}
-          />
-          <Link href="/" className="flex items-center">
-            {/* The image alt provides the link's accessible name (brand/home),
-                distinct from the "Home" feed tab below. */}
-            <Image src={defaults.logo} alt="Ecency" width={30} height={30} className="rounded" />
-          </Link>
-        </div>
-        <Button
-          href="/search"
-          appearance="gray-link"
-          icon={searchIconSvg}
-          aria-label={i18next.t("navbar.search", { defaultValue: "Search" })}
-        />
+        {searchOpen ? (
+          <>
+            <Button
+              appearance="gray-link"
+              noPadding={true}
+              icon={closeSvg}
+              onClick={() => setSearchOpen(false)}
+              aria-label={i18next.t("g.close", { defaultValue: "Close search" })}
+            />
+            <div className="flex-1 min-w-0">
+              <MobileSearch containerClassName="w-full" />
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex items-center gap-1">
+              <Button
+                appearance="gray-link"
+                noPadding={true}
+                icon={<UilBars width={22} height={22} />}
+                onClick={() => setMainBarExpanded(true)}
+                aria-label={i18next.t("navbar.toggle-menu")}
+                aria-expanded={mainBarExpanded}
+              />
+              <Link href="/" className="flex items-center">
+                {/* The image alt provides the link's accessible name (brand/home),
+                    distinct from the "Home" feed tab below. */}
+                <Image src={defaults.logo} alt="Ecency" width={30} height={30} className="rounded" />
+              </Link>
+            </div>
+            <Button
+              className="ml-auto"
+              appearance="gray-link"
+              icon={searchIconSvg}
+              onClick={() => setSearchOpen(true)}
+              aria-label={i18next.t("navbar.search", { defaultValue: "Search" })}
+            />
+          </>
+        )}
       </div>
 
       {/* Bottom primary tabs */}
@@ -182,7 +214,7 @@ export function NavbarMobile({
         href="/publish"
         appearance="primary"
         noPadding={true}
-        icon={<UilPlus width={26} height={26} />}
+        icon={<UilPen width={26} height={26} />}
         aria-label={i18next.t("navbar.post")}
         aria-current={isActive("/publish") ? "page" : undefined}
         className={clsx(

--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -18,8 +18,8 @@ import clsx from "clsx";
 import i18next from "i18next";
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import defaults from "@/defaults";
 import dynamic from "next/dynamic";
 
@@ -52,12 +52,38 @@ export function NavbarMobile({
   const toggleUIProp = useGlobalStore((s) => s.toggleUiProp);
   const { data: unread } = useMattermostUnread(Boolean(activeUser && hydrated));
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  // Use the string form (stable identity) so the effect only fires on a real
+  // query change, not on every render where useSearchParams returns a new object.
+  const searchKey = searchParams?.toString();
   const hidden = useHideOnScroll();
   const [searchOpen, setSearchOpen] = useState(false);
-  // Collapse the in-navbar search when navigating away.
+  const searchWrapRef = useRef<HTMLDivElement>(null);
+
+  // Collapse the in-navbar search after any navigation — including a query-only
+  // change (e.g. submitting a new search while already on /search).
   useEffect(() => {
     setSearchOpen(false);
-  }, [pathname]);
+  }, [pathname, searchKey]);
+
+  // Focus the input once the (lazily-loaded) search mounts, so it's ready to type.
+  useEffect(() => {
+    if (!searchOpen) {
+      return;
+    }
+    let raf = 0;
+    let tries = 0;
+    const focusInput = () => {
+      const input = searchWrapRef.current?.querySelector("input");
+      if (input) {
+        input.focus();
+      } else if (tries++ < 30) {
+        raf = requestAnimationFrame(focusInput);
+      }
+    };
+    raf = requestAnimationFrame(focusInput);
+    return () => cancelAnimationFrame(raf);
+  }, [searchOpen]);
 
   const [isInRn, setIsInRn] = useState(false);
   useEffect(() => {
@@ -105,7 +131,7 @@ export function NavbarMobile({
               onClick={() => setSearchOpen(false)}
               aria-label={i18next.t("g.close", { defaultValue: "Close search" })}
             />
-            <div className="flex-1 min-w-0">
+            <div ref={searchWrapRef} className="flex-1 min-w-0">
               <MobileSearch containerClassName="w-full" />
             </div>
           </>

--- a/apps/web/src/features/shared/scroll-to-top/_index.scss
+++ b/apps/web/src/features/shared/scroll-to-top/_index.scss
@@ -14,6 +14,14 @@
   display: none;
   cursor: pointer;
 
+  // On mobile, sit above the bottom tab bar and clear of the bottom-right
+  // compose FAB (which lives on the right).
+  @media (max-width: 767px) {
+    left: 16px;
+    right: auto;
+    bottom: calc(env(safe-area-inset-bottom) + 5.5rem);
+  }
+
   &.visible {
     display: flex;
     align-items: center;

--- a/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
+++ b/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
@@ -7,7 +7,10 @@ let pathname = "/";
 const toggleUiProp = vi.fn();
 const useActiveAccount = vi.fn(() => ({ activeUser: { username: "tester" } as { username: string } | null }));
 
-vi.mock("next/navigation", () => ({ usePathname: () => pathname }));
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+  useSearchParams: () => new URLSearchParams()
+}));
 vi.mock("next/image", () => ({
   // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
   default: ({ src, alt, ...rest }: any) => <img src={typeof src === "string" ? src : ""} alt={alt} {...rest} />

--- a/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
+++ b/apps/web/src/specs/features/shared/navbar-mobile.spec.tsx
@@ -12,6 +12,12 @@ vi.mock("next/image", () => ({
   // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
   default: ({ src, alt, ...rest }: any) => <img src={typeof src === "string" ? src : ""} alt={alt} {...rest} />
 }));
+vi.mock("next/dynamic", () => ({
+  // Render the dynamically-imported in-navbar search as a lightweight stub.
+  default: () => function MobileSearchStub() {
+    return <input data-testid="mobile-search" aria-label="search input" />;
+  }
+}));
 vi.mock("@/api/queries", () => ({ useHydrated: () => true }));
 vi.mock("@/core/global-store", () => ({ useGlobalStore: (s: any) => s({ toggleUiProp }) }));
 vi.mock("@/core/hooks/use-active-account", () => ({ useActiveAccount: () => useActiveAccount() }));
@@ -76,6 +82,18 @@ describe("NavbarMobile", () => {
     renderNav();
     expect(screen.getByLabelText("navbar.home")).toHaveAttribute("aria-current", "page");
     expect(screen.getByLabelText("navbar.chats")).not.toHaveAttribute("aria-current", "page");
+  });
+
+  test("tapping search expands an in-navbar search input and can be closed", () => {
+    renderNav();
+    fireEvent.click(screen.getByLabelText("navbar.search"));
+    // search mode: brand/menu replaced by a close control + the search input
+    expect(screen.getByLabelText("g.close")).toBeInTheDocument();
+    expect(screen.getByTestId("mobile-search")).toBeInTheDocument();
+    expect(screen.queryByLabelText("navbar.toggle-menu")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("g.close"));
+    expect(screen.getByLabelText("navbar.toggle-menu")).toBeInTheDocument();
   });
 
   test("keeps Home active across other feed sorts (e.g. /trending)", () => {


### PR DESCRIPTION
Follow-up to #867 — three mobile top-nav refinements from alpha testing.

## Changes
1. **In-navbar quick search.** The search icon used to open `/search` with no query. It now **expands an inline search input** in the top bar (reuses the existing `Search` component, so you get suggestions/quick-actions; Enter navigates to `/search?q=…`). A close control collapses it, and it auto-collapses on navigation.
2. **Compose FAB icon: `+` → pen** — matches the post/write action.
3. **Scroll-to-top placement.** On mobile it sat bottom-right and collided with the bottom tab bar and the bottom-right compose FAB. Moved it **above the bottom bar and to the left**, clear of both.

## Testing
- `navbar-mobile` spec +1 (search expand/collapse toggle); 7 tests pass. 0 new tsc/lint.

## QA (mobile)
- Tap search → input expands, type + Enter → results; close/collapse works.
- FAB shows a pen icon.
- Scroll a long post: scroll-to-top no longer overlaps the FAB or bottom bar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile navigation bar now features in-navbar quick search functionality

* **Style**
  * Updated compose button icon appearance

* **Bug Fixes**
  * Improved scroll-to-top button positioning on mobile to better account for device safe areas

* **Tests**
  * Added tests for mobile search mode interaction and close functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->