### PR TITLE
Mobile search: native autoFocus (review follow-up)

### DIFF
--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -19,7 +19,7 @@ import i18next from "i18next";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import defaults from "@/defaults";
 import dynamic from "next/dynamic";
 
@@ -58,32 +58,12 @@ export function NavbarMobile({
   const searchKey = searchParams?.toString();
   const hidden = useHideOnScroll();
   const [searchOpen, setSearchOpen] = useState(false);
-  const searchWrapRef = useRef<HTMLDivElement>(null);
 
   // Collapse the in-navbar search after any navigation — including a query-only
   // change (e.g. submitting a new search while already on /search).
   useEffect(() => {
     setSearchOpen(false);
   }, [pathname, searchKey]);
-
-  // Focus the input once the (lazily-loaded) search mounts, so it's ready to type.
-  useEffect(() => {
-    if (!searchOpen) {
-      return;
-    }
-    let raf = 0;
-    let tries = 0;
-    const focusInput = () => {
-      const input = searchWrapRef.current?.querySelector("input");
-      if (input) {
-        input.focus();
-      } else if (tries++ < 30) {
-        raf = requestAnimationFrame(focusInput);
-      }
-    };
-    raf = requestAnimationFrame(focusInput);
-    return () => cancelAnimationFrame(raf);
-  }, [searchOpen]);
 
   const [isInRn, setIsInRn] = useState(false);
   useEffect(() => {
@@ -131,8 +111,8 @@ export function NavbarMobile({
               onClick={() => setSearchOpen(false)}
               aria-label={i18next.t("g.close", { defaultValue: "Close search" })}
             />
-            <div ref={searchWrapRef} className="flex-1 min-w-0">
-              <MobileSearch containerClassName="w-full" />
+            <div className="flex-1 min-w-0">
+              <MobileSearch containerClassName="w-full" autoFocus />
             </div>
           </>
         ) : (

--- a/apps/web/src/features/shared/navbar/search/index.tsx
+++ b/apps/web/src/features/shared/navbar/search/index.tsx
@@ -22,9 +22,10 @@ import { EcencyConfigManager } from "@/config";
 
 interface Props {
   containerClassName?: string;
+  autoFocus?: boolean;
 }
 
-export function Search({ containerClassName }: Props) {
+export function Search({ containerClassName, autoFocus }: Props) {
   const router = useRouter();
   const pathname = usePathname();
   const previousPathname = usePrevious(pathname);
@@ -514,6 +515,7 @@ export function Search({ containerClassName }: Props) {
           autoComplete="non-autocomplete-field"
           name="non-autocomplete-field"
           id="non-autocomplete-field"
+          autoFocus={autoFocus}
         />
       </SearchSuggester>
 


### PR DESCRIPTION
Tiny follow-up to #869 addressing the remaining CodeRabbit review note.

The expanding mobile search input now autofocuses via a **native `autoFocus`** prop threaded `MobileSearch → Search → SearchBox → input` (FormControl already forwards native input props), replacing the earlier `requestAnimationFrame`-based `.focus()` workaround. Cleaner and idiomatic; same one-tap open-and-type behavior. `autoFocus` is optional, so other `Search` usages (drawer, desktop) are unaffected.

navbar-mobile spec still 7/7; 0 new tsc/lint.

QA: tap the top-bar search on mobile → input is focused (cursor ready).
