### PR TITLE
fix(web): let users pick which Hive extension signs

### DIFF
--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -314,6 +314,7 @@
     "extensions": "Extensions",
     "extensions-info-title": "Browser Extensions",
     "extensions-info-description": "Sign in securely using a Hive browser extension. Install one of the following extensions to get started:",
+    "extensions-mobile-note": "Hive browser extensions are only available on desktop browsers. On mobile, use Keychain Mobile or sign in with your key or HiveSigner.",
     "extensions-select-title": "Choose Extension",
     "extensions-select-description": "Multiple Hive extensions detected. Select which one to use for signing:",
     "extension-keeper-name": "Hive Keeper",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1696,6 +1696,7 @@
     "with-keychain": "Sign with Keychain",
     "with-extension": "Sign with Extension",
     "with-extension-named": "Sign with {{name}}",
+    "no-extension-prompt": "Don't have a Hive extension? Install one:",
     "with-hiveauth": "Sign with HiveAuth",
     "invalid-key": "Invalid key format. Please check for invalid characters.",
     "key-error": "Failed to process the key. Please verify it is correct.",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1695,6 +1695,7 @@
     "with-hivesigner": "Sign with Hivesigner",
     "with-keychain": "Sign with Keychain",
     "with-extension": "Sign with Extension",
+    "with-extension-named": "Sign with {{name}}",
     "with-hiveauth": "Sign with HiveAuth",
     "invalid-key": "Invalid key format. Please check for invalid characters.",
     "key-error": "Failed to process the key. Please verify it is correct.",

--- a/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
+++ b/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
@@ -13,7 +13,12 @@ import { shouldUseKeychainMobile } from "@/utils/client";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useIsMobile } from "@/utils";
 import { getLoginType } from "@/utils/user-token";
-import { getDetectedExtensions, hasAnyHiveExtension } from "@/utils/hive-extensions";
+import {
+  getDetectedExtensions,
+  hasAnyHiveExtension,
+  setPreferredExtensionId,
+  type HiveExtensionId
+} from "@/utils/hive-extensions";
 import { isInAppBrowser } from "@/utils/keychain";
 
 interface AuthUpgradeRequest {
@@ -55,6 +60,19 @@ export function AuthUpgradeDialog() {
     setRequest(null);
     // For keychain-mobile users, resolve as "keychain" — the adapter's
     // broadcastWithKeychain detects keychain-mobile and opens hive:// deep link
+    resolveAuthUpgrade("keychain");
+  }, []);
+
+  // User explicitly chose a specific browser extension to sign with. Persist it
+  // as the preference so `broadcastWithExtension` targets that extension's own
+  // API (e.g. Keychain's `window.hive_keychain`) instead of auto-resolving
+  // Keeper-first. This avoids the Keeper-vs-Keychain cross-talk where Keeper
+  // stamps `extension_id` on the shared event channel and a co-installed,
+  // not-yet-protocol-aware Keychain rejects it with
+  // `ValidationError: "extension_id" is not allowed`.
+  const handleExtensionChoice = useCallback((extId: HiveExtensionId) => {
+    setRequest(null);
+    setPreferredExtensionId(extId);
     resolveAuthUpgrade("keychain");
   }, []);
 
@@ -117,39 +135,54 @@ export function AuthUpgradeDialog() {
                 >
                   {i18next.t("key-or-hot.with-hivesigner")}
                 </Button>
-                {showExtensionBtn && (
-                  <Button
-                    outline={true}
-                    appearance="secondary"
-                    onClick={handleKeychainOrMobile}
-                    icon={
-                      <div className="flex items-center -space-x-1">
-                        {detectedExtensions.length > 0 ? (
-                          detectedExtensions.map((ext) => (
-                            <Image
-                              key={ext.id}
-                              width={20}
-                              height={20}
-                              src={ext.icon}
-                              alt={ext.name}
-                              className="w-4 h-4 rounded-sm"
-                            />
-                          ))
-                        ) : (
+                {showExtensionBtn &&
+                  (detectedExtensions.length > 0 ? (
+                    // One button per detected extension. Picking one persists it
+                    // as the signing preference so we target that extension's own
+                    // API directly — no Keeper-first auto-pick, no cross-talk.
+                    detectedExtensions.map((ext) => (
+                      <Button
+                        key={ext.id}
+                        outline={true}
+                        appearance="secondary"
+                        onClick={() => handleExtensionChoice(ext.id)}
+                        icon={
                           <Image
                             width={20}
                             height={20}
-                            src="/assets/keychain.png"
-                            alt="extensions"
-                            className="w-4 h-4"
+                            src={ext.icon}
+                            alt={ext.name}
+                            className="w-4 h-4 rounded-sm"
                           />
-                        )}
-                      </div>
-                    }
-                  >
-                    {extensionLabel}
-                  </Button>
-                )}
+                        }
+                      >
+                        {i18next.t("key-or-hot.with-extension-named", {
+                          name: ext.name,
+                          defaultValue: `Sign with ${ext.name}`
+                        })}
+                      </Button>
+                    ))
+                  ) : (
+                    // No extension detected (e.g. Keychain Mobile / in-app
+                    // WebView): keep the generic button — the adapter resolves
+                    // the deep-link path from the login type.
+                    <Button
+                      outline={true}
+                      appearance="secondary"
+                      onClick={handleKeychainOrMobile}
+                      icon={
+                        <Image
+                          width={20}
+                          height={20}
+                          src="/assets/keychain.png"
+                          alt="extensions"
+                          className="w-4 h-4"
+                        />
+                      }
+                    >
+                      {extensionLabel}
+                    </Button>
+                  ))}
               </div>
             </>
           )}

--- a/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
+++ b/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
@@ -11,7 +11,6 @@ import { MetaMaskSignButton } from "../metamask-sign-button";
 import { resolveAuthUpgrade } from "./auth-upgrade-events";
 import { shouldUseKeychainMobile } from "@/utils/client";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
-import { useIsMobile } from "@/utils";
 import { getLoginType } from "@/utils/user-token";
 import {
   getDetectedExtensions,
@@ -28,7 +27,6 @@ interface AuthUpgradeRequest {
 
 export function AuthUpgradeDialog() {
   const { activeUser } = useActiveAccount();
-  const isMobileBrowser = useIsMobile();
   const [request, setRequest] = useState<AuthUpgradeRequest | null>(null);
 
   useEffect(() => {
@@ -89,7 +87,13 @@ export function AuthUpgradeDialog() {
   const isMetaMaskUser = activeUser && getLoginType(activeUser.username) === "metamask";
   const useKcMobile = shouldUseKeychainMobile(activeUser?.username);
   const detectedExtensions = getDetectedExtensions();
-  const showExtensionBtn = !isMetaMaskUser && (!isMobileBrowser || useKcMobile || isInAppBrowser() || hasAnyHiveExtension());
+  // The generic (deep-link) fallback button only makes sense for Keychain
+  // Mobile / in-app WebViews. On desktop with no detected extension there's
+  // nothing to sign with, so don't offer a dead-end "Sign with Extension".
+  const canUseExtensionFallback = useKcMobile || isInAppBrowser();
+  const showExtensionBtn =
+    !isMetaMaskUser &&
+    (detectedExtensions.length > 0 || hasAnyHiveExtension() || canUseExtensionFallback);
   const extensionLabel = useKcMobile
     ? i18next.t("key-or-hot.with-keychain-mobile", { defaultValue: "Sign with Keychain Mobile" })
     : i18next.t("key-or-hot.with-extension", { defaultValue: "Sign with Extension" });
@@ -162,10 +166,10 @@ export function AuthUpgradeDialog() {
                         })}
                       </Button>
                     ))
-                  ) : (
-                    // No extension detected (e.g. Keychain Mobile / in-app
-                    // WebView): keep the generic button — the adapter resolves
-                    // the deep-link path from the login type.
+                  ) : canUseExtensionFallback ? (
+                    // No extension detected but a Keychain Mobile / in-app
+                    // WebView deep-link path exists: keep the generic button —
+                    // the adapter resolves the deep-link from the login type.
                     <Button
                       outline={true}
                       appearance="secondary"
@@ -182,7 +186,7 @@ export function AuthUpgradeDialog() {
                     >
                       {extensionLabel}
                     </Button>
-                  ))}
+                  ) : null)}
               </div>
             </>
           )}

--- a/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
+++ b/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
@@ -8,7 +8,7 @@ import i18next from "i18next";
 import Image from "next/image";
 import { PrivateKey } from "@ecency/sdk";
 import { MetaMaskSignButton } from "../metamask-sign-button";
-import { ExtensionInstallList } from "../extension-install-list";
+import { ExtensionInstallList, useShowExtensionInstall } from "../extension-install-list";
 import { resolveAuthUpgrade } from "./auth-upgrade-events";
 import { shouldUseKeychainMobile } from "@/utils/client";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
@@ -28,6 +28,7 @@ interface AuthUpgradeRequest {
 
 export function AuthUpgradeDialog() {
   const { activeUser } = useActiveAccount();
+  const showInstall = useShowExtensionInstall();
   const [request, setRequest] = useState<AuthUpgradeRequest | null>(null);
 
   useEffect(() => {
@@ -189,10 +190,11 @@ export function AuthUpgradeDialog() {
                     </Button>
                   ) : null)}
               </div>
-              {!showExtensionBtn && (
-                // No extension and no mobile deep-link path: instead of a
-                // dead-end, point the user at the install options (same list as
-                // the login dialog). Key entry / HiveSigner above still work.
+              {!showExtensionBtn && showInstall && (
+                // Desktop with no extension and no mobile deep-link path:
+                // instead of a dead-end, point the user at the install options
+                // (same list as login), browser-appropriate. Hidden on mobile
+                // via showInstall. Key entry / HiveSigner above still work.
                 <div className="mt-1">
                   <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
                     {i18next.t("key-or-hot.no-extension-prompt", {

--- a/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
+++ b/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
@@ -8,6 +8,7 @@ import i18next from "i18next";
 import Image from "next/image";
 import { PrivateKey } from "@ecency/sdk";
 import { MetaMaskSignButton } from "../metamask-sign-button";
+import { ExtensionInstallList } from "../extension-install-list";
 import { resolveAuthUpgrade } from "./auth-upgrade-events";
 import { shouldUseKeychainMobile } from "@/utils/client";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
@@ -188,6 +189,19 @@ export function AuthUpgradeDialog() {
                     </Button>
                   ) : null)}
               </div>
+              {!showExtensionBtn && (
+                // No extension and no mobile deep-link path: instead of a
+                // dead-end, point the user at the install options (same list as
+                // the login dialog). Key entry / HiveSigner above still work.
+                <div className="mt-1">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                    {i18next.t("key-or-hot.no-extension-prompt", {
+                      defaultValue: "Don't have a Hive extension? Install one:"
+                    })}
+                  </p>
+                  <ExtensionInstallList />
+                </div>
+              )}
             </>
           )}
         </div>

--- a/apps/web/src/features/shared/extension-install-list.tsx
+++ b/apps/web/src/features/shared/extension-install-list.tsx
@@ -2,48 +2,120 @@
 
 import Image from "next/image";
 import i18next from "i18next";
+import { useEffect, useState } from "react";
 import { UilArrowRight } from "@tooni/iconscout-unicons-react";
 
-/**
- * The set of supported Hive browser extensions with their Chrome Web Store
- * install links. Shared by the login dialog and the auth-upgrade (signing)
- * dialog so the "you don't have an extension — install one" guidance stays in
- * one place. Keeper is highlighted as the recommended (Ecency) option.
- */
-const EXTENSIONS = [
-  {
-    href: "https://chromewebstore.google.com/detail/hive-keeper/eehlplhgiofbbanbjiodipefljadfehe",
-    icon: "/assets/keeper.svg",
-    alt: "Hive Keeper",
-    nameKey: "login.extension-keeper-name",
-    descKey: "login.extension-keeper-desc",
-    highlight: true
-  },
-  {
-    href: "https://chromewebstore.google.com/detail/hive-keychain/jcacnejopjdphbnjgfaaobbfafkihpep",
-    icon: "/assets/keychain.png",
-    alt: "Keychain",
-    nameKey: "login.extension-keychain-name",
-    descKey: "login.extension-keychain-desc",
-    highlight: false
-  },
-  {
-    href: "https://chromewebstore.google.com/detail/peak-vault/mcocapccicdidkhhghnopbddglkpjcoi",
-    icon: "/assets/peakvault.svg",
-    alt: "Peak Vault",
-    nameKey: "login.extension-peakvault-name",
-    descKey: "login.extension-peakvault-desc",
-    highlight: false
-  }
-] as const;
+type BrowserFamily = "chrome" | "firefox";
+
+interface InstallableExtension {
+  alt: string;
+  icon: string;
+  nameKey: string;
+  descKey: string;
+  highlight: boolean;
+  /**
+   * Store URL per browser family. A family is omitted when there's no listing
+   * yet: Hive Keeper is still in Firefox (AMO) review, and Peak Vault ships for
+   * Chromium only. Add Keeper's `firefox` URL here once it's approved.
+   */
+  urls: Partial<Record<BrowserFamily, string>>;
+}
 
 /**
- * Renders the list of installable Hive browser extensions as store links.
+ * Supported Hive browser extensions with their store links. Shared by the login
+ * dialog and the auth-upgrade (signing) dialog. Keeper is the recommended
+ * (Ecency) option and is highlighted.
+ */
+const EXTENSIONS: InstallableExtension[] = [
+  {
+    alt: "Hive Keeper",
+    icon: "/assets/keeper.svg",
+    nameKey: "login.extension-keeper-name",
+    descKey: "login.extension-keeper-desc",
+    highlight: true,
+    urls: {
+      chrome:
+        "https://chromewebstore.google.com/detail/hive-keeper/eehlplhgiofbbanbjiodipefljadfehe"
+      // firefox: pending AMO review — add the listing URL once approved.
+    }
+  },
+  {
+    alt: "Keychain",
+    icon: "/assets/keychain.png",
+    nameKey: "login.extension-keychain-name",
+    descKey: "login.extension-keychain-desc",
+    highlight: false,
+    urls: {
+      chrome:
+        "https://chromewebstore.google.com/detail/hive-keychain/jcacnejopjdphbnjgfaaobbfafkihpep",
+      firefox: "https://addons.mozilla.org/en-US/firefox/addon/hive-keychain/"
+    }
+  },
+  {
+    alt: "Peak Vault",
+    icon: "/assets/peakvault.svg",
+    nameKey: "login.extension-peakvault-name",
+    descKey: "login.extension-peakvault-desc",
+    highlight: false,
+    urls: {
+      chrome: "https://chromewebstore.google.com/detail/peak-vault/mcocapccicdidkhhghnopbddglkpjcoi"
+    }
+  }
+];
+
+// UA-based mobile check — intentionally not the viewport-width heuristic from
+// client.ts: a narrow desktop window can still install extensions, a phone can't.
+const MOBILE_UA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
+
+interface ResolvedExtension extends InstallableExtension {
+  href: string;
+}
+
+/**
+ * Install links for the current browser, or null when nothing should render:
+ * during SSR / before mount, or on mobile (desktop extensions don't apply).
+ */
+function useInstallableExtensions(): ResolvedExtension[] | null {
+  const [resolved, setResolved] = useState<ResolvedExtension[] | null>(null);
+
+  useEffect(() => {
+    const ua = navigator.userAgent ?? "";
+    if (MOBILE_UA.test(ua)) {
+      setResolved(null);
+      return;
+    }
+    const family: BrowserFamily = /firefox/i.test(ua) ? "firefox" : "chrome";
+    const items = EXTENSIONS.flatMap((ext) => {
+      const href = ext.urls[family];
+      return href ? [{ ...ext, href }] : [];
+    });
+    setResolved(items.length ? items : null);
+  }, []);
+
+  return resolved;
+}
+
+/**
+ * True once the install list has something to render (desktop browser with at
+ * least one store link). Lets callers hide surrounding chrome — e.g. a heading —
+ * on mobile or before mount.
+ */
+export function useShowExtensionInstall(): boolean {
+  return useInstallableExtensions() !== null;
+}
+
+/**
+ * Renders installable Hive browser extensions as store links, picking the right
+ * store for the current browser (Chrome Web Store vs Firefox Add-ons). Renders
+ * nothing on mobile.
  */
 export function ExtensionInstallList() {
+  const extensions = useInstallableExtensions();
+  if (!extensions) return null;
+
   return (
     <div className="flex flex-col gap-3">
-      {EXTENSIONS.map((ext) => (
+      {extensions.map((ext) => (
         <a
           key={ext.alt}
           href={ext.href}

--- a/apps/web/src/features/shared/extension-install-list.tsx
+++ b/apps/web/src/features/shared/extension-install-list.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Image from "next/image";
+import i18next from "i18next";
+import { UilArrowRight } from "@tooni/iconscout-unicons-react";
+
+/**
+ * The set of supported Hive browser extensions with their Chrome Web Store
+ * install links. Shared by the login dialog and the auth-upgrade (signing)
+ * dialog so the "you don't have an extension — install one" guidance stays in
+ * one place. Keeper is highlighted as the recommended (Ecency) option.
+ */
+const EXTENSIONS = [
+  {
+    href: "https://chromewebstore.google.com/detail/hive-keeper/eehlplhgiofbbanbjiodipefljadfehe",
+    icon: "/assets/keeper.svg",
+    alt: "Hive Keeper",
+    nameKey: "login.extension-keeper-name",
+    descKey: "login.extension-keeper-desc",
+    highlight: true
+  },
+  {
+    href: "https://chromewebstore.google.com/detail/hive-keychain/jcacnejopjdphbnjgfaaobbfafkihpep",
+    icon: "/assets/keychain.png",
+    alt: "Keychain",
+    nameKey: "login.extension-keychain-name",
+    descKey: "login.extension-keychain-desc",
+    highlight: false
+  },
+  {
+    href: "https://chromewebstore.google.com/detail/peak-vault/mcocapccicdidkhhghnopbddglkpjcoi",
+    icon: "/assets/peakvault.svg",
+    alt: "Peak Vault",
+    nameKey: "login.extension-peakvault-name",
+    descKey: "login.extension-peakvault-desc",
+    highlight: false
+  }
+] as const;
+
+/**
+ * Renders the list of installable Hive browser extensions as store links.
+ */
+export function ExtensionInstallList() {
+  return (
+    <div className="flex flex-col gap-3">
+      {EXTENSIONS.map((ext) => (
+        <a
+          key={ext.alt}
+          href={ext.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={
+            ext.highlight
+              ? "flex items-center gap-3 p-3 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors"
+              : "flex items-center gap-3 p-3 rounded-lg border border-[--border-color] hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          }
+        >
+          <Image width={32} height={32} src={ext.icon} alt={ext.alt} className="w-8 h-8" />
+          <div className="flex-1">
+            <div className="font-semibold text-sm">{i18next.t(ext.nameKey)}</div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">{i18next.t(ext.descKey)}</div>
+          </div>
+          <UilArrowRight
+            className={ext.highlight ? "w-4 h-4 text-blue-500" : "w-4 h-4 opacity-50"}
+          />
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/shared/login/login.tsx
+++ b/apps/web/src/features/shared/login/login.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from "react";
 import { useLoginByKeychain, useLoginByMetaMask } from "./hooks";
 import { LoginUserByKey } from "./login-user-by-key";
 import { LoginUsersList } from "./login-users-list";
+import { ExtensionInstallList } from "../extension-install-list";
 import { motion } from "framer-motion";
 import { TabItem } from "@/features/ui";
 import clsx from "clsx";
@@ -294,47 +295,7 @@ export default function Login() {
               <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                 {i18next.t("login.extensions-info-description")}
               </p>
-              <div className="flex flex-col gap-3">
-                <a
-                  href="https://chromewebstore.google.com/detail/hive-keeper/eehlplhgiofbbanbjiodipefljadfehe"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-3 p-3 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors"
-                >
-                  <Image width={32} height={32} src="/assets/keeper.svg" alt="Hive Keeper" className="w-8 h-8" />
-                  <div className="flex-1">
-                    <div className="font-semibold text-sm">{i18next.t("login.extension-keeper-name")}</div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400">{i18next.t("login.extension-keeper-desc")}</div>
-                  </div>
-                  <UilArrowRight className="w-4 h-4 text-blue-500" />
-                </a>
-                <a
-                  href="https://chromewebstore.google.com/detail/hive-keychain/jcacnejopjdphbnjgfaaobbfafkihpep"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-3 p-3 rounded-lg border border-[--border-color] hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-                >
-                  <Image width={32} height={32} src="/assets/keychain.png" alt="Keychain" className="w-8 h-8" />
-                  <div className="flex-1">
-                    <div className="font-semibold text-sm">{i18next.t("login.extension-keychain-name")}</div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400">{i18next.t("login.extension-keychain-desc")}</div>
-                  </div>
-                  <UilArrowRight className="w-4 h-4 opacity-50" />
-                </a>
-                <a
-                  href="https://chromewebstore.google.com/detail/peak-vault/mcocapccicdidkhhghnopbddglkpjcoi"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-3 p-3 rounded-lg border border-[--border-color] hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-                >
-                  <Image width={32} height={32} src="/assets/peakvault.svg" alt="Peak Vault" className="w-8 h-8" />
-                  <div className="flex-1">
-                    <div className="font-semibold text-sm">{i18next.t("login.extension-peakvault-name")}</div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400">{i18next.t("login.extension-peakvault-desc")}</div>
-                  </div>
-                  <UilArrowRight className="w-4 h-4 opacity-50" />
-                </a>
-              </div>
+              <ExtensionInstallList />
             </>
           )}
         </ModalBody>

--- a/apps/web/src/features/shared/login/login.tsx
+++ b/apps/web/src/features/shared/login/login.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from "react";
 import { useLoginByKeychain, useLoginByMetaMask } from "./hooks";
 import { LoginUserByKey } from "./login-user-by-key";
 import { LoginUsersList } from "./login-users-list";
-import { ExtensionInstallList } from "../extension-install-list";
+import { ExtensionInstallList, useShowExtensionInstall } from "../extension-install-list";
 import { motion } from "framer-motion";
 import { TabItem } from "@/features/ui";
 import clsx from "clsx";
@@ -54,6 +54,7 @@ export default function Login() {
   const [detectedExtensions, setDetectedExtensions] = useState<DetectedExtension[]>([]);
   const [useKeychainMobile, setUseKeychainMobile] = useState(false);
   const [showExtensionsInfo, setShowExtensionsInfo] = useState(false);
+  const showExtensionInstall = useShowExtensionInstall();
 
   useEffect(() => {
     setDetectedExtensions(getDetectedExtensions());
@@ -290,13 +291,19 @@ export default function Login() {
                 ))}
               </div>
             </>
-          ) : (
+          ) : showExtensionInstall ? (
             <>
               <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                 {i18next.t("login.extensions-info-description")}
               </p>
               <ExtensionInstallList />
             </>
+          ) : (
+            // Mobile (or unsupported browser): desktop extensions don't apply,
+            // so guide users to the mobile sign-in options instead of links.
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {i18next.t("login.extensions-mobile-note")}
+            </p>
           )}
         </ModalBody>
       </Modal>

--- a/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
+++ b/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
@@ -1,0 +1,77 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act, render, screen, fireEvent, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// useIsMobile pulls window.matchMedia (absent in jsdom); stub it to desktop.
+vi.mock("@/utils", async () => {
+  const actual = await vi.importActual<any>("@/utils");
+  return { ...actual, useIsMobile: () => false };
+});
+
+const detected = [
+  { id: "hive-keeper", name: "Hive Keeper", icon: "/assets/keeper.svg" },
+  { id: "keychain", name: "Keychain", icon: "/assets/keychain.png" },
+];
+
+const setPreferredExtensionId = vi.fn();
+vi.mock("@/utils/hive-extensions", () => ({
+  getDetectedExtensions: () => detected,
+  hasAnyHiveExtension: () => true,
+  setPreferredExtensionId: (id: string | null) => setPreferredExtensionId(id),
+}));
+
+const resolveAuthUpgrade = vi.fn();
+vi.mock("@/features/shared/auth-upgrade/auth-upgrade-events", () => ({
+  resolveAuthUpgrade: (...args: unknown[]) => resolveAuthUpgrade(...args),
+}));
+
+import { AuthUpgradeDialog } from "@/features/shared/auth-upgrade";
+
+function openDialog() {
+  render(<AuthUpgradeDialog />);
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent("ecency-auth-upgrade", {
+        detail: { authority: "active", operation: "transfer" },
+      })
+    );
+  });
+}
+
+describe("AuthUpgradeDialog extension picker", () => {
+  beforeEach(() => {
+    setPreferredExtensionId.mockClear();
+    resolveAuthUpgrade.mockClear();
+  });
+  afterEach(cleanup);
+
+  it("renders one sign button per detected extension", () => {
+    openDialog();
+    // Each extension button carries an <img> whose alt is the extension name.
+    expect(screen.getByAltText("Hive Keeper")).toBeInTheDocument();
+    expect(screen.getByAltText("Keychain")).toBeInTheDocument();
+  });
+
+  it("persists the chosen extension and resolves as keychain (no Keeper auto-pick)", () => {
+    openDialog();
+
+    const keychainBtn = screen.getByAltText("Keychain").closest("button");
+    expect(keychainBtn).not.toBeNull();
+    fireEvent.click(keychainBtn!);
+
+    // The user's explicit choice is stored so broadcastWithExtension targets
+    // window.hive_keychain directly instead of falling back to Keeper-first.
+    expect(setPreferredExtensionId).toHaveBeenCalledWith("keychain");
+    expect(resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
+  });
+
+  it("persists Keeper when Keeper is explicitly chosen", () => {
+    openDialog();
+
+    const keeperBtn = screen.getByAltText("Hive Keeper").closest("button");
+    fireEvent.click(keeperBtn!);
+
+    expect(setPreferredExtensionId).toHaveBeenCalledWith("hive-keeper");
+    expect(resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
+  });
+});

--- a/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
+++ b/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
@@ -2,27 +2,38 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { act, render, screen, fireEvent, cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-// useIsMobile pulls window.matchMedia (absent in jsdom); stub it to desktop.
-vi.mock("@/utils", async () => {
-  const actual = await vi.importActual<any>("@/utils");
-  return { ...actual, useIsMobile: () => false };
-});
-
-const detected = [
-  { id: "hive-keeper", name: "Hive Keeper", icon: "/assets/keeper.svg" },
-  { id: "keychain", name: "Keychain", icon: "/assets/keychain.png" },
-];
-
-const setPreferredExtensionId = vi.fn();
-vi.mock("@/utils/hive-extensions", () => ({
-  getDetectedExtensions: () => detected,
-  hasAnyHiveExtension: () => true,
-  setPreferredExtensionId: (id: string | null) => setPreferredExtensionId(id),
+// Controllable state shared with the hoisted vi.mock factories. Tests mutate
+// `detected` / `kcMobile` to exercise the multi-extension, desktop-no-extension
+// and Keychain-Mobile-fallback paths.
+const h = vi.hoisted(() => ({
+  detected: [
+    { id: "hive-keeper", name: "Hive Keeper", icon: "/assets/keeper.svg" },
+    { id: "keychain", name: "Keychain", icon: "/assets/keychain.png" }
+  ] as { id: string; name: string; icon: string }[],
+  kcMobile: false,
+  setPreferredExtensionId: vi.fn(),
+  resolveAuthUpgrade: vi.fn()
 }));
 
-const resolveAuthUpgrade = vi.fn();
+// The global test setup stubs @/utils down to a couple of exports; restore the
+// real module so UI components in the render tree (Modal/Button/KeyInput) work.
+vi.mock("@/utils", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>())
+}));
+
+vi.mock("@/utils/client", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  shouldUseKeychainMobile: () => h.kcMobile
+}));
+
+vi.mock("@/utils/hive-extensions", () => ({
+  getDetectedExtensions: () => h.detected,
+  hasAnyHiveExtension: () => h.detected.length > 0,
+  setPreferredExtensionId: (id: string | null) => h.setPreferredExtensionId(id)
+}));
+
 vi.mock("@/features/shared/auth-upgrade/auth-upgrade-events", () => ({
-  resolveAuthUpgrade: (...args: unknown[]) => resolveAuthUpgrade(...args),
+  resolveAuthUpgrade: (...args: unknown[]) => h.resolveAuthUpgrade(...args)
 }));
 
 import { AuthUpgradeDialog } from "@/features/shared/auth-upgrade";
@@ -32,46 +43,77 @@ function openDialog() {
   act(() => {
     window.dispatchEvent(
       new CustomEvent("ecency-auth-upgrade", {
-        detail: { authority: "active", operation: "transfer" },
+        detail: { authority: "active", operation: "transfer" }
       })
     );
   });
 }
 
+// i18next is globally mocked to echo keys, so button labels are not the real
+// "Sign with X" strings. Each extension button still carries an <img alt={name}>
+// that contributes the extension name to the button's accessible name, so we
+// match on that via a regex.
 describe("AuthUpgradeDialog extension picker", () => {
   beforeEach(() => {
-    setPreferredExtensionId.mockClear();
-    resolveAuthUpgrade.mockClear();
+    h.detected = [
+      { id: "hive-keeper", name: "Hive Keeper", icon: "/assets/keeper.svg" },
+      { id: "keychain", name: "Keychain", icon: "/assets/keychain.png" }
+    ];
+    h.kcMobile = false;
+    h.setPreferredExtensionId.mockClear();
+    h.resolveAuthUpgrade.mockClear();
   });
   afterEach(cleanup);
 
   it("renders one sign button per detected extension", () => {
     openDialog();
-    // Each extension button carries an <img> whose alt is the extension name.
-    expect(screen.getByAltText("Hive Keeper")).toBeInTheDocument();
-    expect(screen.getByAltText("Keychain")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /hive keeper/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /keychain/i })).toBeInTheDocument();
   });
 
   it("persists the chosen extension and resolves as keychain (no Keeper auto-pick)", () => {
     openDialog();
 
-    const keychainBtn = screen.getByAltText("Keychain").closest("button");
-    expect(keychainBtn).not.toBeNull();
-    fireEvent.click(keychainBtn!);
+    fireEvent.click(screen.getByRole("button", { name: /keychain/i }));
 
     // The user's explicit choice is stored so broadcastWithExtension targets
     // window.hive_keychain directly instead of falling back to Keeper-first.
-    expect(setPreferredExtensionId).toHaveBeenCalledWith("keychain");
-    expect(resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
+    expect(h.setPreferredExtensionId).toHaveBeenCalledWith("keychain");
+    expect(h.resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
   });
 
   it("persists Keeper when Keeper is explicitly chosen", () => {
     openDialog();
 
-    const keeperBtn = screen.getByAltText("Hive Keeper").closest("button");
-    fireEvent.click(keeperBtn!);
+    fireEvent.click(screen.getByRole("button", { name: /hive keeper/i }));
 
-    expect(setPreferredExtensionId).toHaveBeenCalledWith("hive-keeper");
-    expect(resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
+    expect(h.setPreferredExtensionId).toHaveBeenCalledWith("hive-keeper");
+    expect(h.resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
+  });
+
+  it("offers no extension action on desktop when none is detected", () => {
+    h.detected = [];
+    openDialog();
+
+    // HiveSigner is always available; the extension path must not render a
+    // dead-end button when there's no extension and no mobile deep-link target.
+    expect(screen.getByRole("button", { name: /hivesigner/i })).toBeInTheDocument();
+    expect(screen.queryByAltText("extensions")).toBeNull();
+    expect(screen.queryByRole("button", { name: /keeper|keychain/i })).toBeNull();
+    expect(h.setPreferredExtensionId).not.toHaveBeenCalled();
+  });
+
+  it("keeps the generic deep-link button for Keychain Mobile with no extension", () => {
+    h.detected = [];
+    h.kcMobile = true;
+    openDialog();
+
+    const fallback = screen.getByRole("button", { name: /extensions/i });
+    fireEvent.click(fallback);
+
+    // Deep-link path resolves generically; it must NOT pin an extension
+    // preference (there's no detected extension to pin).
+    expect(h.resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
+    expect(h.setPreferredExtensionId).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
+++ b/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
@@ -53,6 +53,11 @@ function openDialog() {
 // "Sign with X" strings. Each extension button still carries an <img alt={name}>
 // that contributes the extension name to the button's accessible name, so we
 // match on that via a regex.
+const ORIGINAL_UA = navigator.userAgent;
+function setUserAgent(ua: string) {
+  Object.defineProperty(window.navigator, "userAgent", { value: ua, configurable: true });
+}
+
 describe("AuthUpgradeDialog extension picker", () => {
   beforeEach(() => {
     h.detected = [
@@ -63,7 +68,10 @@ describe("AuthUpgradeDialog extension picker", () => {
     h.setPreferredExtensionId.mockClear();
     h.resolveAuthUpgrade.mockClear();
   });
-  afterEach(cleanup);
+  afterEach(() => {
+    setUserAgent(ORIGINAL_UA);
+    cleanup();
+  });
 
   it("renders one sign button per detected extension", () => {
     openDialog();
@@ -104,6 +112,31 @@ describe("AuthUpgradeDialog extension picker", () => {
     expect(keeperLink.getAttribute("href")).toContain("chromewebstore");
     expect(screen.getByRole("link", { name: /peak vault/i })).toBeInTheDocument();
     expect(h.setPreferredExtensionId).not.toHaveBeenCalled();
+  });
+
+  it("shows only the Firefox listing (Keychain) on Firefox", () => {
+    h.detected = [];
+    setUserAgent("Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0");
+    openDialog();
+
+    const keychainLink = screen.getByRole("link", { name: /keychain/i });
+    expect(keychainLink.getAttribute("href")).toContain("addons.mozilla.org");
+    // Keeper (in AMO review) and Peak Vault (Chromium-only) have no Firefox link.
+    expect(screen.queryByRole("link", { name: /hive keeper/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /peak vault/i })).toBeNull();
+  });
+
+  it("hides the install list entirely on mobile", () => {
+    h.detected = [];
+    setUserAgent(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+    );
+    openDialog();
+
+    // Desktop extensions don't apply on mobile — no install links, key entry
+    // and HiveSigner remain.
+    expect(screen.getByRole("button", { name: /hivesigner/i })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /keeper|keychain|peak vault/i })).toBeNull();
   });
 
   it("keeps the generic deep-link button for Keychain Mobile with no extension", () => {

--- a/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
+++ b/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
@@ -91,15 +91,18 @@ describe("AuthUpgradeDialog extension picker", () => {
     expect(h.resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
   });
 
-  it("offers no extension action on desktop when none is detected", () => {
+  it("shows install options on desktop when no extension is detected", () => {
     h.detected = [];
     openDialog();
 
-    // HiveSigner is always available; the extension path must not render a
-    // dead-end button when there's no extension and no mobile deep-link target.
+    // No dead-end extension button; instead guide the user to install one
+    // (key entry / HiveSigner above still work).
     expect(screen.getByRole("button", { name: /hivesigner/i })).toBeInTheDocument();
-    expect(screen.queryByAltText("extensions")).toBeNull();
     expect(screen.queryByRole("button", { name: /keeper|keychain/i })).toBeNull();
+
+    const keeperLink = screen.getByRole("link", { name: /hive keeper/i });
+    expect(keeperLink.getAttribute("href")).toContain("chromewebstore");
+    expect(screen.getByRole("link", { name: /peak vault/i })).toBeInTheDocument();
     expect(h.setPreferredExtensionId).not.toHaveBeenCalled();
   });
 
@@ -108,8 +111,10 @@ describe("AuthUpgradeDialog extension picker", () => {
     h.kcMobile = true;
     openDialog();
 
-    const fallback = screen.getByRole("button", { name: /extensions/i });
-    fireEvent.click(fallback);
+    // A deep-link path exists, so show the generic button, not install links.
+    expect(screen.queryByRole("link", { name: /hive keeper/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /extensions/i }));
 
     // Deep-link path resolves generically; it must NOT pin an extension
     // preference (there's no detected extension to pin).


### PR DESCRIPTION
## Problem

Signing an active-authority operation (e.g. **Transfer HIVE**) via the auth-upgrade dialog can fail with:

```
ValidationError: "extension_id" is not allowed
```

The dialog never let the user choose **which** installed extension signs — it resolved a generic keychain broadcast that auto-picks the first detected extension (`getKeychainLikeInstance()` is Keeper-first). So a user with Hive Keeper gets routed to Keeper, and current Keeper builds reject their own Hive Wallet Discovery `extension_id` field on every request (root-caused and fixed in ecency/browser-extension#1) — so signing fails, even when the user also has Keychain and would rather sign with it.

## Fix

- When more than one extension is detected, the dialog renders **one "Sign with {name}" button per extension**.
- Choosing one persists it via `setPreferredExtensionId`, so `broadcastWithExtension` targets that extension's own API directly (e.g. `window.hive_keychain`, which emits no `extension_id`) instead of falling back to Keeper.
- The 0-detected path (Keychain Mobile / in-app WebView) keeps the existing generic deep-link button.

This is both better UX (an explicit choice in the **signing** flow, not just at login) and an immediate mitigation: users can route around a broken/old Keeper build until ecency/browser-extension#1 ships and propagates to installs. Both the old transfer wizard and the new wallet-operations flow route active-authority signing through this dialog, so both are covered.

## Testing

- New `auth-upgrade-dialog.spec.tsx` (3 tests): renders one button per extension; choosing Keychain/Keeper persists the right preference and resolves signing.
- `tsc` (no new errors), ESLint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication upgrade dialog now displays individual "Sign with [extension]" buttons for each detected Hive extension
  * Extension installation options shown when no extensions are detected
  * Added new translation for extension-specific sign-in messaging

* **Tests**
  * Expanded test coverage for extension picker behavior across multiple scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->