### PR TITLE
Inline proposal support from the announcement banner

### DIFF
--- a/apps/web/src/features/announcement/index.tsx
+++ b/apps/web/src/features/announcement/index.tsx
@@ -11,6 +11,7 @@ import i18next from "i18next";
 import { getAnnouncementsQueryOptions } from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { ProposalVoteAction } from "./proposal-vote-action";
 
 export const Announcements = () => {
   const { activeUser } = useActiveAccount();
@@ -176,9 +177,18 @@ export const Announcements = () => {
                     <p>{x?.description}</p>
                   </div>
                   <div className="flex actions">
-                    <Link href={x?.button_link ?? "/"} onClick={dismissClick}>
-                      <Button>{x?.button_text}</Button>
-                    </Link>
+                    {x?.proposal_ids && x.proposal_ids.length > 0 ? (
+                      <ProposalVoteAction
+                        proposalId={x.proposal_ids[0]}
+                        buttonText={x?.button_text}
+                        viewLink={x?.button_link ?? "/"}
+                        onSupported={dismissClick}
+                      />
+                    ) : (
+                      <Link href={x?.button_link ?? "/"} onClick={dismissClick}>
+                        <Button>{x?.button_text}</Button>
+                      </Link>
+                    )}
                     <Button onClick={laterClick} appearance="primary" outline={true}>
                       {i18next.t("announcements.later")}
                     </Button>

--- a/apps/web/src/features/announcement/index.tsx
+++ b/apps/web/src/features/announcement/index.tsx
@@ -178,6 +178,9 @@ export const Announcements = () => {
                   </div>
                   <div className="flex actions">
                     {x?.proposal_ids && x.proposal_ids.length > 0 ? (
+                      // Ecency proposal announcements target a single proposal; we vote
+                      // on the first id. (The Hive op accepts an array, but the web
+                      // mutation is single-id and the data has never carried more.)
                       <ProposalVoteAction
                         proposalId={x.proposal_ids[0]}
                         buttonText={x?.button_text}

--- a/apps/web/src/features/announcement/proposal-vote-action.tsx
+++ b/apps/web/src/features/announcement/proposal-vote-action.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { getUserProposalVotesQueryOptions } from "@ecency/sdk";
 import { Button } from "@ui/button";
-import { success } from "@/features/shared";
+import { LoginRequired, success } from "@/features/shared";
 import { useProposalVoteMutation } from "@/api/sdk-mutations";
 import { useActiveUsername } from "@/core/hooks/use-active-username";
 
@@ -54,13 +54,29 @@ export function ProposalVoteAction({ proposalId, buttonText, viewLink, onSupport
     }
   };
 
+  if (!username) {
+    // Voting needs an account. This is only reachable if an announcement omits
+    // auth:true (ours sets it); prompt login on the primary action rather than
+    // swallowing the "no active user" error and doing nothing visible.
+    return (
+      <>
+        <LoginRequired>
+          <Button>{buttonText}</Button>
+        </LoginRequired>
+        <Link href={viewLink}>
+          <Button appearance="link">{i18next.t("announcements.view-proposal")}</Button>
+        </Link>
+      </>
+    );
+  }
+
   if (voted) {
     return (
       <>
         <Button appearance="success" outline={true} disabled={true}>
           {i18next.t("announcements.voted")}
         </Button>
-        <Link href={viewLink} onClick={onSupported}>
+        <Link href={viewLink}>
           <Button appearance="link">{i18next.t("announcements.view-proposal")}</Button>
         </Link>
       </>

--- a/apps/web/src/features/announcement/proposal-vote-action.tsx
+++ b/apps/web/src/features/announcement/proposal-vote-action.tsx
@@ -1,0 +1,80 @@
+import React, { useMemo } from "react";
+import i18next from "i18next";
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { getUserProposalVotesQueryOptions } from "@ecency/sdk";
+import { Button } from "@ui/button";
+import { success } from "@/features/shared";
+import { useProposalVoteMutation } from "@/api/sdk-mutations";
+import { useActiveUsername } from "@/core/hooks/use-active-username";
+
+interface Props {
+  proposalId: number;
+  buttonText: string;
+  viewLink: string;
+  onSupported: () => void;
+}
+
+/**
+ * Inline "support this proposal" action for proposal-type announcements.
+ *
+ * Instead of only linking to the proposal page, this casts the
+ * `update_proposal_votes` operation directly via the existing SDK mutation
+ * (active authority — the SDK surfaces the auth-upgrade dialog when the user is
+ * logged in with a posting key only). We build the operation client-side from a
+ * known proposal id rather than broadcasting any server-provided op blob.
+ *
+ * A secondary "view proposal" link is always offered so users can read the
+ * proposal first, and users who have already voted see a confirmation instead of
+ * being asked again.
+ */
+export function ProposalVoteAction({ proposalId, buttonText, viewLink, onSupported }: Props) {
+  const username = useActiveUsername();
+
+  const { data: userVotes } = useQuery({
+    ...getUserProposalVotesQueryOptions(username ?? ""),
+    enabled: !!username
+  });
+
+  const voted = useMemo(
+    () => !!userVotes?.some((vote) => vote.proposal?.proposal_id === proposalId),
+    [userVotes, proposalId]
+  );
+
+  const { mutateAsync: vote, isPending } = useProposalVoteMutation(proposalId);
+
+  const onSupport = async () => {
+    try {
+      await vote({ approve: true });
+      success(i18next.t("announcements.vote-success"));
+      onSupported();
+    } catch {
+      // Broadcast/auth errors are surfaced by the web broadcast adapter; swallow
+      // here so a declined signature doesn't bubble up as an unhandled rejection.
+    }
+  };
+
+  if (voted) {
+    return (
+      <>
+        <Button appearance="success" outline={true} disabled={true}>
+          {i18next.t("announcements.voted")}
+        </Button>
+        <Link href={viewLink} onClick={onSupported}>
+          <Button appearance="link">{i18next.t("announcements.view-proposal")}</Button>
+        </Link>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Button isLoading={isPending} disabled={isPending} onClick={onSupport}>
+        {buttonText}
+      </Button>
+      <Link href={viewLink}>
+        <Button appearance="link">{i18next.t("announcements.view-proposal")}</Button>
+      </Link>
+    </>
+  );
+}

--- a/apps/web/src/features/announcement/types/announcement.ts
+++ b/apps/web/src/features/announcement/types/announcement.ts
@@ -4,6 +4,11 @@ export interface Announcement {
   description: string;
   button_text: string;
   button_link: string;
+  // When present, the announcement is a Hive proposal-support prompt. The web client
+  // lets the user approve the proposal inline (active authority) instead of only
+  // linking to the proposal page. The server's `ops` (mobile signing URI) is not
+  // consumed on web — we construct the vote operation client-side from these ids.
+  proposal_ids?: number[];
 }
 
 export interface LaterAnnouncement {

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -128,7 +128,10 @@
   "announcements": {
     "dismiss": "Dismiss",
     "next": "Next",
-    "later": "Later"
+    "later": "Later",
+    "voted": "Voted",
+    "view-proposal": "View proposal",
+    "vote-success": "Thank you for supporting Ecency!"
   },
   "floating-faq": {
     "toggle-icon-info": "Click to expand",

--- a/apps/web/src/specs/features/announcement/proposal-vote-action.spec.tsx
+++ b/apps/web/src/specs/features/announcement/proposal-vote-action.spec.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { ProposalVoteAction } from "@/features/announcement/proposal-vote-action";
+
+const { votesRef, voteMock, successMock } = vi.hoisted(() => ({
+  votesRef: { current: [] as { proposal?: { proposal_id: number } }[] },
+  voteMock: vi.fn(),
+  successMock: vi.fn()
+}));
+
+vi.mock("@/core/hooks/use-active-username", () => ({
+  useActiveUsername: () => "alice"
+}));
+
+vi.mock("@/api/sdk-mutations", () => ({
+  useProposalVoteMutation: () => ({ mutateAsync: voteMock, isPending: false })
+}));
+
+vi.mock("@/features/shared", () => ({
+  success: successMock
+}));
+
+vi.mock("@ecency/sdk", () => ({
+  getUserProposalVotesQueryOptions: () => ({
+    queryKey: ["user-proposal-votes", "alice"],
+    queryFn: async () => votesRef.current
+  })
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-query")>()),
+  useQuery: () => ({ data: votesRef.current })
+}));
+
+describe("ProposalVoteAction", () => {
+  beforeEach(() => {
+    voteMock.mockReset().mockResolvedValue(true);
+    successMock.mockReset();
+    votesRef.current = [];
+  });
+
+  it("casts an approve vote and dismisses on success", async () => {
+    const onSupported = vi.fn();
+    render(
+      <ProposalVoteAction
+        proposalId={379}
+        buttonText="Support now"
+        viewLink="/proposals/379"
+        onSupported={onSupported}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Support now" }));
+
+    await waitFor(() => expect(voteMock).toHaveBeenCalledWith({ approve: true }));
+    await waitFor(() => expect(onSupported).toHaveBeenCalledTimes(1));
+    expect(successMock).toHaveBeenCalled();
+  });
+
+  it("swallows a rejected vote without dismissing or showing success", async () => {
+    voteMock.mockReset().mockRejectedValueOnce(new Error("Broadcast failed"));
+    const onSupported = vi.fn();
+    render(
+      <ProposalVoteAction
+        proposalId={379}
+        buttonText="Support now"
+        viewLink="/proposals/379"
+        onSupported={onSupported}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Support now" }));
+
+    await waitFor(() => expect(voteMock).toHaveBeenCalledWith({ approve: true }));
+    expect(onSupported).not.toHaveBeenCalled();
+    expect(successMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a confirmation (and no support button) when the user already voted", () => {
+    votesRef.current = [{ proposal: { proposal_id: 379 } }];
+
+    render(
+      <ProposalVoteAction
+        proposalId={379}
+        buttonText="Support now"
+        viewLink="/proposals/379"
+        onSupported={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Support now" })).toBeNull();
+    expect(screen.getByText("announcements.voted")).toBeInTheDocument();
+  });
+
+  it("ignores votes for other proposals when deciding the voted state", () => {
+    votesRef.current = [{ proposal: { proposal_id: 283 } }];
+
+    render(
+      <ProposalVoteAction
+        proposalId={379}
+        buttonText="Support now"
+        viewLink="/proposals/379"
+        onSupported={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Support now" })).toBeInTheDocument();
+  });
+
+  it("always offers a link to view the proposal", () => {
+    render(
+      <ProposalVoteAction
+        proposalId={379}
+        buttonText="Support now"
+        viewLink="/proposals/379"
+        onSupported={vi.fn()}
+      />
+    );
+
+    const link = screen.getByText("announcements.view-proposal").closest("a");
+    expect(link).toHaveAttribute("href", "/proposals/379");
+  });
+});

--- a/apps/web/src/specs/features/announcement/proposal-vote-action.spec.tsx
+++ b/apps/web/src/specs/features/announcement/proposal-vote-action.spec.tsx
@@ -4,14 +4,15 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import { ProposalVoteAction } from "@/features/announcement/proposal-vote-action";
 
-const { votesRef, voteMock, successMock } = vi.hoisted(() => ({
+const { votesRef, voteMock, successMock, usernameRef } = vi.hoisted(() => ({
   votesRef: { current: [] as { proposal?: { proposal_id: number } }[] },
   voteMock: vi.fn(),
-  successMock: vi.fn()
+  successMock: vi.fn(),
+  usernameRef: { current: "alice" as string | undefined }
 }));
 
 vi.mock("@/core/hooks/use-active-username", () => ({
-  useActiveUsername: () => "alice"
+  useActiveUsername: () => usernameRef.current
 }));
 
 vi.mock("@/api/sdk-mutations", () => ({
@@ -19,7 +20,8 @@ vi.mock("@/api/sdk-mutations", () => ({
 }));
 
 vi.mock("@/features/shared", () => ({
-  success: successMock
+  success: successMock,
+  LoginRequired: ({ children }: { children: React.ReactNode }) => <>{children}</>
 }));
 
 vi.mock("@ecency/sdk", () => ({
@@ -39,6 +41,25 @@ describe("ProposalVoteAction", () => {
     voteMock.mockReset().mockResolvedValue(true);
     successMock.mockReset();
     votesRef.current = [];
+    usernameRef.current = "alice";
+  });
+
+  it("prompts login instead of voting when there is no active user", () => {
+    usernameRef.current = undefined;
+    render(
+      <ProposalVoteAction
+        proposalId={379}
+        buttonText="Support now"
+        viewLink="/proposals/379"
+        onSupported={vi.fn()}
+      />
+    );
+
+    // The primary button is shown (wrapped in LoginRequired) and is NOT wired
+    // directly to the vote mutation — so a logged-out click can't silently fail.
+    const supportBtn = screen.getByRole("button", { name: "Support now" });
+    fireEvent.click(supportBtn);
+    expect(voteMock).not.toHaveBeenCalled();
   });
 
   it("casts an approve vote and dismisses on success", async () => {


### PR DESCRIPTION
Proposal-type announcements (those carrying `proposal_ids`) now let users approve the proposal **inline** from the banner instead of only linking to the proposal page.

### What
- New `ProposalVoteAction` renders a "Support now" button that casts `update_proposal_votes` via the existing `useProposalVoteMutation` (active authority — the SDK shows the auth-upgrade dialog when the user is signed in with a posting key only).
- The vote operation is built **client-side** from the proposal id; the server's `ops` signing URI is not consumed on web (it remains the mobile transport).
- Users who already voted see a confirmation; a "View proposal" link is always offered.
- Falls back to the previous link behaviour when `proposal_ids` is absent.

### Notes
- Depends on the API serving `proposal_ids` (companion change in ecency/vision-api). Until that ships this stays dormant (link fallback).
- 5 unit tests added (`proposal-vote-action.spec.tsx`); typecheck + lint clean.