### PR TITLE
refactor(web): unify the Sign with Extension button with a shared chooser

### DIFF
--- a/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
+++ b/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
@@ -6,6 +6,7 @@ import { Button } from "@ui/button";
 import { KeyInput } from "@ui/input";
 import i18next from "i18next";
 import Image from "next/image";
+import { UilArrowLeft } from "@tooni/iconscout-unicons-react";
 import { PrivateKey } from "@ecency/sdk";
 import { MetaMaskSignButton } from "../metamask-sign-button";
 import { ExtensionInstallList, useShowExtensionInstall } from "../extension-install-list";
@@ -118,7 +119,21 @@ export function AuthUpgradeDialog() {
       </ModalHeader>
       <ModalBody>
         {choosing ? (
-          <ExtensionChooser extensions={detectedExtensions} onSelect={handleChooseExtension} />
+          // The chooser replaces the body (same as login), so offer a Back to
+          // the sign options — closing the modal would cancel the whole flow.
+          <div className="flex flex-col gap-3">
+            <Button
+              iconPlacement="left"
+              appearance="gray-link"
+              size="sm"
+              noPadding={true}
+              onClick={() => setChoosing(false)}
+              icon={<UilArrowLeft />}
+            >
+              {i18next.t("g.back")}
+            </Button>
+            <ExtensionChooser extensions={detectedExtensions} onSelect={handleChooseExtension} />
+          </div>
         ) : (
           <>
             <p className="text-sm text-gray-600 mb-4">{i18next.t("trx-common.sign-sub-title")}</p>

--- a/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
+++ b/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
@@ -9,6 +9,7 @@ import Image from "next/image";
 import { PrivateKey } from "@ecency/sdk";
 import { MetaMaskSignButton } from "../metamask-sign-button";
 import { ExtensionInstallList, useShowExtensionInstall } from "../extension-install-list";
+import { ExtensionChooser } from "../extension-chooser";
 import { resolveAuthUpgrade } from "./auth-upgrade-events";
 import { shouldUseKeychainMobile } from "@/utils/client";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
@@ -30,10 +31,12 @@ export function AuthUpgradeDialog() {
   const { activeUser } = useActiveAccount();
   const showInstall = useShowExtensionInstall();
   const [request, setRequest] = useState<AuthUpgradeRequest | null>(null);
+  const [choosing, setChoosing] = useState(false);
 
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<AuthUpgradeRequest>).detail;
+      setChoosing(false);
       setRequest(detail);
     };
     window.addEventListener("ecency-auth-upgrade", handler);
@@ -41,6 +44,7 @@ export function AuthUpgradeDialog() {
   }, []);
 
   const handleClose = useCallback(() => {
+    setChoosing(false);
     setRequest(null);
     resolveAuthUpgrade(false);
   }, []);
@@ -56,30 +60,21 @@ export function AuthUpgradeDialog() {
     resolveAuthUpgrade("hivesigner");
   }, []);
 
-  const handleKeychainOrMobile = useCallback(() => {
-    setRequest(null);
-    // For keychain-mobile users, resolve as "keychain" — the adapter's
-    // broadcastWithKeychain detects keychain-mobile and opens hive:// deep link
-    resolveAuthUpgrade("keychain");
-  }, []);
-
-  // User explicitly chose a specific browser extension to sign with. Persist it
-  // as the preference so `broadcastWithExtension` targets that extension's own
-  // API (e.g. Keychain's `window.hive_keychain`) instead of auto-resolving
-  // Keeper-first. This avoids the Keeper-vs-Keychain cross-talk where Keeper
-  // stamps `extension_id` on the shared event channel and a co-installed,
-  // not-yet-protocol-aware Keychain rejects it with
-  // `ValidationError: "extension_id" is not allowed`.
-  const handleExtensionChoice = useCallback((extId: HiveExtensionId) => {
-    setRequest(null);
-    setPreferredExtensionId(extId);
-    resolveAuthUpgrade("keychain");
-  }, []);
-
   const handleMetaMask = useCallback(() => {
     setRequest(null);
     // Resolve as 'keychain' — the adapter's broadcastWithKeychain detects
     // metamask login type and routes to the Hive snap automatically
+    resolveAuthUpgrade("keychain");
+  }, []);
+
+  // User picked a specific extension in the chooser. Persist it so
+  // `broadcastWithExtension` targets that extension's own API (e.g. Keychain's
+  // `window.hive_keychain`) instead of auto-resolving Keeper-first — which is
+  // what triggers Keeper's `extension_id`-not-allowed rejection.
+  const handleChooseExtension = useCallback((extId: HiveExtensionId) => {
+    setChoosing(false);
+    setRequest(null);
+    setPreferredExtensionId(extId);
     resolveAuthUpgrade("keychain");
   }, []);
 
@@ -89,9 +84,9 @@ export function AuthUpgradeDialog() {
   const isMetaMaskUser = activeUser && getLoginType(activeUser.username) === "metamask";
   const useKcMobile = shouldUseKeychainMobile(activeUser?.username);
   const detectedExtensions = getDetectedExtensions();
-  // The generic (deep-link) fallback button only makes sense for Keychain
-  // Mobile / in-app WebViews. On desktop with no detected extension there's
-  // nothing to sign with, so don't offer a dead-end "Sign with Extension".
+  // The unified "Sign with Extension" button shows when an extension is
+  // installed, or there's a Keychain Mobile / in-app deep-link path. On desktop
+  // with no extension we show install links instead (below) — never a dead-end.
   const canUseExtensionFallback = useKcMobile || isInAppBrowser();
   const showExtensionBtn =
     !isMetaMaskUser &&
@@ -100,113 +95,119 @@ export function AuthUpgradeDialog() {
     ? i18next.t("key-or-hot.with-keychain-mobile", { defaultValue: "Sign with Keychain Mobile" })
     : i18next.t("key-or-hot.with-extension", { defaultValue: "Sign with Extension" });
 
+  // Single unified entry point. With more than one extension installed, defer to
+  // the chooser; otherwise resolve straight away (the adapter routes a lone
+  // extension, or the Keychain Mobile / in-app deep link, from there).
+  const handleExtensionSign = () => {
+    if (detectedExtensions.length > 1) {
+      setChoosing(true);
+      return;
+    }
+    setRequest(null);
+    resolveAuthUpgrade("keychain");
+  };
+
   return (
     <Modal show={true} centered={true} onHide={handleClose}>
       <ModalHeader closeButton={true}>
         <ModalTitle>
-          {i18next.t("trx-common.sign-title")}
+          {choosing
+            ? i18next.t("login.extensions-select-title")
+            : i18next.t("trx-common.sign-title")}
         </ModalTitle>
       </ModalHeader>
       <ModalBody>
-        <p className="text-sm text-gray-600 mb-4">
-          {i18next.t("trx-common.sign-sub-title")}
-        </p>
-        <div className="flex flex-col gap-3">
-          {isMetaMaskUser ? (
-            <MetaMaskSignButton onClick={handleMetaMask} />
-          ) : (
-            <>
-              <KeyInput onSign={handleKeySign} keyType={authority} />
-              <div className="flex items-center gap-2 my-1">
-                <hr className="flex-1" />
-                <span className="text-xs text-gray-400">
-                  {i18next.t("g.or", { defaultValue: "or" })}
-                </span>
-                <hr className="flex-1" />
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                <Button
-                  outline={true}
-                  appearance="hivesigner"
-                  onClick={handleHiveSigner}
-                  icon={
-                    <Image
-                      width={100}
-                      height={100}
-                      src="/assets/hive-signer.svg"
-                      className="w-4 h-4"
-                      alt="hivesigner"
-                    />
-                  }
-                >
-                  {i18next.t("key-or-hot.with-hivesigner")}
-                </Button>
-                {showExtensionBtn &&
-                  (detectedExtensions.length > 0 ? (
-                    // One button per detected extension. Picking one persists it
-                    // as the signing preference so we target that extension's own
-                    // API directly — no Keeper-first auto-pick, no cross-talk.
-                    detectedExtensions.map((ext) => (
-                      <Button
-                        key={ext.id}
-                        outline={true}
-                        appearance="secondary"
-                        onClick={() => handleExtensionChoice(ext.id)}
-                        icon={
-                          <Image
-                            width={20}
-                            height={20}
-                            src={ext.icon}
-                            alt={ext.name}
-                            className="w-4 h-4 rounded-sm"
-                          />
-                        }
-                      >
-                        {i18next.t("key-or-hot.with-extension-named", {
-                          name: ext.name,
-                          defaultValue: `Sign with ${ext.name}`
-                        })}
-                      </Button>
-                    ))
-                  ) : canUseExtensionFallback ? (
-                    // No extension detected but a Keychain Mobile / in-app
-                    // WebView deep-link path exists: keep the generic button —
-                    // the adapter resolves the deep-link from the login type.
+        {choosing ? (
+          <ExtensionChooser extensions={detectedExtensions} onSelect={handleChooseExtension} />
+        ) : (
+          <>
+            <p className="text-sm text-gray-600 mb-4">{i18next.t("trx-common.sign-sub-title")}</p>
+            <div className="flex flex-col gap-3">
+              {isMetaMaskUser ? (
+                <MetaMaskSignButton onClick={handleMetaMask} />
+              ) : (
+                <>
+                  <KeyInput onSign={handleKeySign} keyType={authority} />
+                  <div className="flex items-center gap-2 my-1">
+                    <hr className="flex-1" />
+                    <span className="text-xs text-gray-400">
+                      {i18next.t("g.or", { defaultValue: "or" })}
+                    </span>
+                    <hr className="flex-1" />
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                     <Button
                       outline={true}
-                      appearance="secondary"
-                      onClick={handleKeychainOrMobile}
+                      appearance="hivesigner"
+                      onClick={handleHiveSigner}
                       icon={
                         <Image
-                          width={20}
-                          height={20}
-                          src="/assets/keychain.png"
-                          alt="extensions"
+                          width={100}
+                          height={100}
+                          src="/assets/hive-signer.svg"
                           className="w-4 h-4"
+                          alt="hivesigner"
                         />
                       }
                     >
-                      {extensionLabel}
+                      {i18next.t("key-or-hot.with-hivesigner")}
                     </Button>
-                  ) : null)}
-              </div>
-              {!showExtensionBtn && showInstall && (
-                // Desktop with no extension and no mobile deep-link path:
-                // instead of a dead-end, point the user at the install options
-                // (same list as login), browser-appropriate. Hidden on mobile
-                // via showInstall. Key entry / HiveSigner above still work.
-                <div className="mt-1">
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                    {i18next.t("key-or-hot.no-extension-prompt", {
-                      defaultValue: "Don't have a Hive extension? Install one:"
-                    })}
-                  </p>
-                  <ExtensionInstallList />
-                </div>
+                    {showExtensionBtn && (
+                      // Unified entry point — one button regardless of how many
+                      // extensions are installed. The choice (when >1) happens in
+                      // the chooser, matching the login flow.
+                      <Button
+                        outline={true}
+                        appearance="secondary"
+                        onClick={handleExtensionSign}
+                        icon={
+                          <div className="flex items-center -space-x-1">
+                            {detectedExtensions.length > 0 ? (
+                              detectedExtensions.map((ext) => (
+                                <Image
+                                  key={ext.id}
+                                  width={20}
+                                  height={20}
+                                  src={ext.icon}
+                                  alt={ext.name}
+                                  className="w-4 h-4 rounded-sm"
+                                />
+                              ))
+                            ) : (
+                              <Image
+                                width={20}
+                                height={20}
+                                src="/assets/keychain.png"
+                                alt="extensions"
+                                className="w-4 h-4"
+                              />
+                            )}
+                          </div>
+                        }
+                      >
+                        {extensionLabel}
+                      </Button>
+                    )}
+                  </div>
+                  {!showExtensionBtn && showInstall && (
+                    // Desktop with no extension and no mobile deep-link path:
+                    // instead of a dead-end, point the user at the install
+                    // options (browser-appropriate, hidden on mobile). Key entry
+                    // / HiveSigner above still work.
+                    <div className="mt-1">
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                        {i18next.t("key-or-hot.no-extension-prompt", {
+                          defaultValue: "Don't have a Hive extension? Install one:"
+                        })}
+                      </p>
+                      <ExtensionInstallList />
+                    </div>
+                  )}
+                </>
               )}
-            </>
-          )}
-        </div>
+            </div>
+          </>
+        )}
       </ModalBody>
     </Modal>
   );

--- a/apps/web/src/features/shared/extension-chooser.tsx
+++ b/apps/web/src/features/shared/extension-chooser.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Image from "next/image";
+import i18next from "i18next";
+import { UilArrowRight } from "@tooni/iconscout-unicons-react";
+import type { DetectedExtension, HiveExtensionId } from "@/utils/hive-extensions";
+
+interface Props {
+  extensions: DetectedExtension[];
+  onSelect: (id: HiveExtensionId) => void;
+}
+
+/**
+ * The "which extension do you want to use?" selection step, shown when more than
+ * one Hive extension is installed. Shared by the login dialog and the
+ * auth-upgrade (signing) dialog so the choice is the same everywhere.
+ */
+export function ExtensionChooser({ extensions, onSelect }: Props) {
+  return (
+    <>
+      <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+        {i18next.t("login.extensions-select-description")}
+      </p>
+      <div className="flex flex-col gap-3">
+        {extensions.map((ext) => (
+          <button
+            key={ext.id}
+            type="button"
+            onClick={() => onSelect(ext.id)}
+            className="flex items-center gap-3 p-3 rounded-lg border border-[--border-color] hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-left w-full"
+          >
+            <Image
+              width={32}
+              height={32}
+              src={ext.icon}
+              alt={ext.name}
+              className="w-8 h-8 rounded"
+            />
+            <div className="flex-1 font-semibold text-sm">{ext.name}</div>
+            <UilArrowRight className="w-4 h-4 opacity-50" />
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/features/shared/extension-chooser.tsx
+++ b/apps/web/src/features/shared/extension-chooser.tsx
@@ -16,6 +16,10 @@ interface Props {
  * auth-upgrade (signing) dialog so the choice is the same everywhere.
  */
 export function ExtensionChooser({ extensions, onSelect }: Props) {
+  // Defensive: callers only open the chooser with >1 extension, but never show
+  // a blank body if that invariant is ever violated.
+  if (extensions.length === 0) return null;
+
   return (
     <>
       <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">

--- a/apps/web/src/features/shared/login/login.tsx
+++ b/apps/web/src/features/shared/login/login.tsx
@@ -13,6 +13,7 @@ import { useLoginByKeychain, useLoginByMetaMask } from "./hooks";
 import { LoginUserByKey } from "./login-user-by-key";
 import { LoginUsersList } from "./login-users-list";
 import { ExtensionInstallList, useShowExtensionInstall } from "../extension-install-list";
+import { ExtensionChooser } from "../extension-chooser";
 import { motion } from "framer-motion";
 import { TabItem } from "@/features/ui";
 import clsx from "clsx";
@@ -272,25 +273,7 @@ export default function Login() {
         </ModalHeader>
         <ModalBody>
           {detectedExtensions.length > 1 ? (
-            <>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                {i18next.t("login.extensions-select-description")}
-              </p>
-              <div className="flex flex-col gap-3">
-                {detectedExtensions.map((ext) => (
-                  <button
-                    key={ext.id}
-                    type="button"
-                    onClick={() => handleSelectExtension(ext.id)}
-                    className="flex items-center gap-3 p-3 rounded-lg border border-[--border-color] hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-left w-full"
-                  >
-                    <Image width={32} height={32} src={ext.icon} alt={ext.name} className="w-8 h-8 rounded" />
-                    <div className="flex-1 font-semibold text-sm">{ext.name}</div>
-                    <UilArrowRight className="w-4 h-4 opacity-50" />
-                  </button>
-                ))}
-              </div>
-            </>
+            <ExtensionChooser extensions={detectedExtensions} onSelect={handleSelectExtension} />
           ) : showExtensionInstall ? (
             <>
               <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">

--- a/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
+++ b/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
@@ -49,10 +49,9 @@ function openDialog() {
   });
 }
 
-// i18next is globally mocked to echo keys, so button labels are not the real
-// "Sign with X" strings. Each extension button still carries an <img alt={name}>
-// that contributes the extension name to the button's accessible name, so we
-// match on that via a regex.
+// i18next is globally mocked to echo keys, so labels are the key strings (e.g.
+// "key-or-hot.with-extension"). Buttons also carry <img alt> icons that
+// contribute to their accessible name, so we match via regex.
 const ORIGINAL_UA = navigator.userAgent;
 function setUserAgent(ua: string) {
   Object.defineProperty(window.navigator, "userAgent", { value: ua, configurable: true });
@@ -73,26 +72,32 @@ describe("AuthUpgradeDialog extension picker", () => {
     cleanup();
   });
 
-  it("renders one sign button per detected extension", () => {
+  it("shows a single unified extension button, not one per extension", () => {
     openDialog();
-    expect(screen.getByRole("button", { name: /hive keeper/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /keychain/i })).toBeInTheDocument();
+    // One "Sign with Extension" button regardless of how many are installed; the
+    // choice is deferred to the chooser (matching login), not shown inline.
+    expect(screen.getByRole("button", { name: /key-or-hot\.with-extension/i })).toBeInTheDocument();
+    expect(screen.queryByText("login.extensions-select-description")).toBeNull();
   });
 
-  it("persists the chosen extension and resolves as keychain (no Keeper auto-pick)", () => {
+  it("opens the chooser on click and persists the selected extension", () => {
     openDialog();
 
-    fireEvent.click(screen.getByRole("button", { name: /keychain/i }));
+    // Click the unified button → the body switches to the extension chooser.
+    fireEvent.click(screen.getByRole("button", { name: /key-or-hot\.with-extension/i }));
+    expect(screen.getByText("login.extensions-select-description")).toBeInTheDocument();
 
-    // The user's explicit choice is stored so broadcastWithExtension targets
-    // window.hive_keychain directly instead of falling back to Keeper-first.
+    // Picking one stores it so broadcastWithExtension targets that extension's
+    // own API instead of falling back to Keeper-first.
+    fireEvent.click(screen.getByRole("button", { name: /keychain/i }));
     expect(h.setPreferredExtensionId).toHaveBeenCalledWith("keychain");
     expect(h.resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
   });
 
-  it("persists Keeper when Keeper is explicitly chosen", () => {
+  it("persists Keeper when Keeper is chosen in the chooser", () => {
     openDialog();
 
+    fireEvent.click(screen.getByRole("button", { name: /key-or-hot\.with-extension/i }));
     fireEvent.click(screen.getByRole("button", { name: /hive keeper/i }));
 
     expect(h.setPreferredExtensionId).toHaveBeenCalledWith("hive-keeper");

--- a/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
+++ b/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
@@ -104,6 +104,19 @@ describe("AuthUpgradeDialog extension picker", () => {
     expect(h.resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
   });
 
+  it("returns from the chooser to the sign options via Back without cancelling", () => {
+    openDialog();
+    fireEvent.click(screen.getByRole("button", { name: /key-or-hot\.with-extension/i }));
+    expect(screen.getByText("login.extensions-select-description")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /g\.back/i }));
+
+    // Sign options are back, the chooser is gone, and nothing was resolved.
+    expect(screen.getByRole("button", { name: /key-or-hot\.with-extension/i })).toBeInTheDocument();
+    expect(screen.queryByText("login.extensions-select-description")).toBeNull();
+    expect(h.resolveAuthUpgrade).not.toHaveBeenCalled();
+  });
+
   it("shows install options on desktop when no extension is detected", () => {
     h.detected = [];
     openDialog();


### PR DESCRIPTION
Follow-up to #874.

## Problem

#874 rendered **one button per detected extension** ("Sign with Keychain", "Sign with Hive Keeper") inline in the auth-upgrade (signing) dialog. That diverged from the established pattern in **login**, which shows a single "Sign with Extension" button and, when more than one extension is installed, a **selection step** on click. Different signing/login experiences for the same choice.

## Fix

- Restore the single unified **"Sign with Extension"** button in the signing dialog.
- When more than one extension is installed, clicking it switches the dialog body to an **extension chooser** (then persists the chosen extension and resolves) — same UX as login.
- With one extension (or a Keychain Mobile / in-app deep-link path), it resolves straight away.
- Extract login's inline selection list into a shared **`ExtensionChooser`** component, reused by both the login dialog and the signing dialog so the choice is identical everywhere.

No behavior change to the desktop install-prompt / browser-aware links / mobile-hide added in #874 — only the multi-extension entry point is unified.

## Testing

- `auth-upgrade-dialog.spec.tsx` updated (7 tests): single unified button (not per-extension), click opens the chooser, selecting Keychain/Keeper persists the preference + resolves, plus the existing install-prompt / Firefox-only / mobile-hidden / Keychain-Mobile cases.
- `tsc` (no new errors), ESLint clean.