### PR TITLE
Add SVG favicon (Yandex recommendation + modern browsers)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -23,6 +23,7 @@ export const metadata: Metadata = {
   },
   icons: {
     icon: [
+      { url: "/assets/logo-512x512.svg", type: "image/svg+xml", sizes: "any" },
       { url: "/assets/logo-192x192.png", sizes: "192x192", type: "image/png" },
       { url: "/assets/logo-384x384.png", sizes: "384x384", type: "image/png" },
       { url: "/assets/logo-512x512.png", sizes: "512x512", type: "image/png" }


### PR DESCRIPTION
## What

Adds `/assets/logo-512x512.svg` as the preferred `rel="icon"` in the root metadata, ahead of the existing PNG icons.

```ts
icon: [
  { url: "/assets/logo-512x512.svg", type: "image/svg+xml", sizes: "any" }, // new
  { url: "/assets/logo-192x192.png", sizes: "192x192", type: "image/png" },
  { url: "/assets/logo-384x384.png", sizes: "384x384", type: "image/png" },
  { url: "/assets/logo-512x512.png", sizes: "512x512", type: "image/png" }
]
```

## Why

Yandex Webmaster recommends a favicon that is **SVG or at least 120×120 px**. The current icon set declares a non-square **107×104** `favicon.ico` as the smallest icon, which fails that rule — and there was no SVG favicon at all. Modern browsers also prefer a scalable SVG favicon when one is offered.

The square SVG logo was already shipped in `public/assets/` — this just wires it up. The PNG icons (192/384/512) remain as fallbacks for clients that don't render SVG favicons. No new asset added.

## Testing

- Metadata-only change; existing PNG/apple-touch icons untouched.
- After deploy, the head will expose `<link rel="icon" href="/assets/logo-512x512.svg" type="image/svg+xml" sizes="any">` as the first icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added SVG logo support to app icon assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->