### PR TITLE
fix(hosting-api): build native deps on node:24-alpine (better-sqlite3)

### DIFF
--- a/apps/self-hosted/hosting/api/Dockerfile
+++ b/apps/self-hosted/hosting/api/Dockerfile
@@ -3,6 +3,12 @@ FROM node:24-alpine AS builder
 
 WORKDIR /app
 
+# Toolchain for node-gyp: a transitive native dep (better-sqlite3) ships no
+# Node 24 musl prebuild, so npm compiles it from source and alpine needs
+# python3 + make + g++. Only the builder needs these; the runtime stage copies
+# the already-compiled node_modules.
+RUN apk add --no-cache python3 make g++
+
 # Install dependencies
 COPY package.json ./
 RUN npm install


### PR DESCRIPTION
**Hotfix** for the `Self-Hosted CI/CD` → `build-api` failure on develop after the pnpm 11 merge (#877). The cause is actually the **Node 20 → 24 base bump (#875)**, not pnpm 11.

## Root cause
The hosting-api image runs `npm install`, which pulls a transitive native dep — **`better-sqlite3@11.10.0`** (hosting-api itself uses `pg`). It has no Node-24 **musl** prebuild, so npm compiles it from source via node-gyp. `node:24-alpine` ships no `python3`/`make`/`g++`, so the build died with:
```
gyp ERR! find Python — Could not find any Python installation to use
… process "/bin/sh -c npm install" did not complete successfully: exit code: 1
```
On the old `node:20-alpine` better-sqlite3 used a prebuilt binary and never compiled, which is why this only appeared after the Node 24 bump.

## Fix
Add `python3 make g++` to the **builder** stage so node-gyp can compile. The runtime stage is unchanged (it copies the already-compiled `node_modules`), so the final image isn't bloated, and `node:24-alpine` already ships `libstdc++` for the node binary.

## Verified locally with Docker (29.1.3)
- `docker build apps/self-hosted/hosting/api` → **succeeds** (better-sqlite3 compiles).
- Production image **loads + runs** the compiled module: `new (require('better-sqlite3'))(':memory:')` → create/insert/select returns `1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker builder stage to include build toolchain packages necessary for native dependency compilation, enhancing build reliability and compatibility across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->