### PR TITLE
ci(i18n): fix Crowdin sync — set the project branch (download was failing)

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -49,6 +49,9 @@ jobs:
           upload_sources: false
           upload_translations: false
           download_translations: true
+          # Strings live under a Crowdin branch (created by the old GitHub
+          # integration); without this the CLI can't match files to crowdin.yml.
+          crowdin_branch_name: '[ecency.vision-next] develop'
           # Use the develop checkout above as the base for l10n/crowdin. Without
           # this the action checks out the trigger PR's head ref, which fails (or
           # bases the translations PR on unrelated feature changes).

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -23,6 +23,9 @@ jobs:
           upload_sources: true
           upload_translations: false
           download_translations: false
+          # Upload into the same Crowdin branch the translations live under, so
+          # sources don't fork off into a separate branchless copy.
+          crowdin_branch_name: '[ecency.vision-next] develop'
         env:
           CROWDIN_PROJECT_ID: "340923"
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
Follow-up to #880. The manual download run failed with `Couldn't find any file to download` because the strings live under a Crowdin **branch** (`[ecency.vision-next] develop`, created by the old GitHub integration) and the workflows specified no branch, so the CLI couldn't match the downloaded archive to `crowdin.yml`.

**Fix:** set `crowdin_branch_name` on both the download and upload workflows.

Verified locally with `@crowdin/cli`: with the branch set and the repo's source files present (as in CI), the download writes all 23 locale files cleanly. Upload now also targets the same branch so source updates don't fork into a branchless copy.