### PR TITLE
feat(i18n): enable Thai & Turkish in the language picker

### DIFF
--- a/apps/web/src/app/client-init.tsx
+++ b/apps/web/src/app/client-init.tsx
@@ -4,7 +4,7 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useGlobalStore } from "@/core/global-store";
 import { useQuery } from "@tanstack/react-query";
 import { getAccountFullQueryOptions } from "@ecency/sdk";
-import { initI18next } from "@/features/i18n";
+import { initI18next, detectBrowserLang } from "@/features/i18n";
 import * as ls from "@/utils/local-storage";
 import Cookies from "js-cookie";
 import { ConfigManager } from "@ecency/sdk";
@@ -25,6 +25,7 @@ export function ClientInit() {
   const loadUsers = useGlobalStore((state) => state.loadUsers);
   const setCurrency = useGlobalStore((state) => state.setCurrency);
   const currency = useGlobalStore((state) => state.currency);
+  const setLang = useGlobalStore((state) => state.setLang);
 
   const queryClient = useQueryClient();
 
@@ -37,7 +38,19 @@ export function ClientInit() {
     ConfigManager.setQueryClient(queryClient as any);
 
     initKeychain();
-    initI18next();
+    // Initialize i18n, then auto-detect the visitor's locale on their first
+    // visit (no saved preference). This runs post-mount, so the initial render
+    // still matches the server's en-US output — no hydration mismatch. The
+    // detected language persists via setLang and is overridable from settings.
+    initI18next().then(() => {
+      const savedLang = ls.get("lang") || ls.get("current-language");
+      if (!savedLang) {
+        const detected = detectBrowserLang();
+        if (detected && detected !== "en-US") {
+          setLang(detected);
+        }
+      }
+    });
     loadUsers();
 
     const activeUsername = ls.get("active_user") ?? Cookies.get("active_user");

--- a/apps/web/src/features/i18n/index.ts
+++ b/apps/web/src/features/i18n/index.ts
@@ -71,6 +71,14 @@ export const langOptions = [
   {
     code: "zh-CN",
     name: "简体字"
+  },
+  {
+    code: "th-TH",
+    name: "ไทย"
+  },
+  {
+    code: "tr-TR",
+    name: "Türkçe"
   }
 ];
 
@@ -93,7 +101,9 @@ const localeLoaders: Record<string, () => Promise<any>> = {
   "bg-BG": () => import("./locales/bg-BG.json"),
   "ru-RU": () => import("./locales/ru-RU.json"),
   "uz-UZ": () => import("./locales/uz-UZ.json"),
-  "zh-CN": () => import("./locales/zh-CN.json")
+  "zh-CN": () => import("./locales/zh-CN.json"),
+  "th-TH": () => import("./locales/th-TH.json"),
+  "tr-TR": () => import("./locales/tr-TR.json")
 };
 
 export async function loadLocale(lang: string) {

--- a/apps/web/src/features/i18n/index.ts
+++ b/apps/web/src/features/i18n/index.ts
@@ -116,6 +116,32 @@ export async function loadLocale(lang: string) {
 
 const supportedCodes = new Set(langOptions.map((l) => l.code));
 
+/**
+ * Best-effort detection of the visitor's preferred UI language from the browser.
+ * Returns a supported langOptions code, or null when nothing matches.
+ * SSR-safe: returns null when `navigator` is unavailable, so it must only be
+ * relied upon on the client (call after mount to avoid hydration mismatches).
+ */
+export function detectBrowserLang(): string | null {
+  if (typeof navigator === "undefined") return null;
+  const navLangs =
+    navigator.languages && navigator.languages.length
+      ? navigator.languages
+      : [navigator.language];
+  for (const nav of navLangs) {
+    if (!nav) continue;
+    const lower = nav.toLowerCase();
+    // exact match (e.g. "pt-PT")
+    const exact = langOptions.find((o) => o.code.toLowerCase() === lower);
+    if (exact) return exact.code;
+    // base-language match (e.g. "de", "de-AT" -> "de-DE")
+    const base = lower.split("-")[0];
+    const baseMatch = langOptions.find((o) => o.code.split("-")[0].toLowerCase() === base);
+    if (baseMatch) return baseMatch.code;
+  }
+  return null;
+}
+
 let initI18nextPromise: Promise<void> | null = null;
 
 export function initI18next(): Promise<void> {

--- a/apps/web/src/utils/dayjs.ts
+++ b/apps/web/src/utils/dayjs.ts
@@ -20,6 +20,8 @@ import "dayjs/locale/sr";
 import "dayjs/locale/uk";
 import "dayjs/locale/uz";
 import "dayjs/locale/zh-cn";
+import "dayjs/locale/th";
+import "dayjs/locale/tr";
 
 // Extend dayjs with commonly used plugins
 // These are needed for replacing moment.js features across the codebase


### PR DESCRIPTION
Enables **Thai (th-TH)** and **Turkish (tr-TR)** in the web language selector — both are now ~99% translated. Adds them to `langOptions` (which drives the picker and `supportedCodes`) and `localeLoaders` (lazy import). Their translated content arrives via the Crowdin sync in #884, so merge that first/together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Thai and Turkish language options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->