### PR TITLE
fix(web): run Next directly in prod image; fail deploys on Swarm rollback

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -136,28 +136,37 @@ jobs:
           cd apps/web
           docker network create --driver overlay vision || true
           docker pull ecency/api:latest
-          docker pull ecency/vision-next:latest
+          web_pull="$(docker pull ecency/vision-next:latest)"; printf '%s\n' "$web_pull"
           docker stack deploy -c <(docker-compose -f docker-compose.production.yml config) vision
-          # Fail the job if vision_web does not converge — e.g. the new image
-          # crashes on start and Swarm rolls back to the previous image. Without
-          # this, `docker stack deploy` returns 0 immediately, so a rolled-back
-          # rollout still reports a green deploy while prod serves the old build.
-          state=""
-          for i in $(seq 1 36); do
-            state=$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")
-            case "$state" in
-              ""|completed) break ;;
-              rollback_*|paused) break ;;
-            esac
-            sleep 5
-          done
-          case "$state" in
-            rollback_*|paused)
-              echo "::error::vision_web did not converge (UpdateStatus=$state); prod still on previous image"
-              exit 1 ;;
-          esac
+          # Don't report a green deploy unless the new image actually rolled out.
+          # `docker stack deploy` returns as soon as the spec is committed to Raft
+          # (before Swarm populates UpdateStatus), so a crash-on-start (-> rollback)
+          # or a stuck/slow rollout would otherwise pass silently. When a new image
+          # was pulled, wait for vision_web to reach `completed`: never accept an
+          # empty/`updating` reading as success, fail immediately on rollback/pause,
+          # and fail on timeout in any non-`completed` state. Skip the wait only
+          # when the image was unchanged (genuine no-op, nothing to roll out).
+          if printf '%s' "$web_pull" | grep -q 'Image is up to date'; then
+            echo "vision_web image unchanged; no rollout expected"
+          else
+            state=""
+            for i in $(seq 1 60); do
+              state="$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")"
+              case "$state" in
+                completed) break ;;
+                rollback_*|paused)
+                  echo "::error::vision_web rolled back (UpdateStatus=$state); prod still on the previous image"
+                  exit 1 ;;
+              esac
+              sleep 5
+            done
+            if [ "$state" != "completed" ]; then
+              echo "::error::vision_web did not converge within ~5m (UpdateStatus=${state:-empty}); prod may still be on the previous image"
+              exit 1
+            fi
+            echo "vision_web converged (UpdateStatus=completed)"
+          fi
           docker system prune -f
-          echo "vision_web converged (UpdateStatus=${state:-none})"
 
   deploy-US:
     needs: build
@@ -210,28 +219,37 @@ jobs:
           cd apps/web
           docker network create --driver overlay vision || true
           docker pull ecency/api:latest
-          docker pull ecency/vision-next:latest
+          web_pull="$(docker pull ecency/vision-next:latest)"; printf '%s\n' "$web_pull"
           docker stack deploy -c <(docker-compose -f docker-compose.production.yml config) vision
-          # Fail the job if vision_web does not converge — e.g. the new image
-          # crashes on start and Swarm rolls back to the previous image. Without
-          # this, `docker stack deploy` returns 0 immediately, so a rolled-back
-          # rollout still reports a green deploy while prod serves the old build.
-          state=""
-          for i in $(seq 1 36); do
-            state=$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")
-            case "$state" in
-              ""|completed) break ;;
-              rollback_*|paused) break ;;
-            esac
-            sleep 5
-          done
-          case "$state" in
-            rollback_*|paused)
-              echo "::error::vision_web did not converge (UpdateStatus=$state); prod still on previous image"
-              exit 1 ;;
-          esac
+          # Don't report a green deploy unless the new image actually rolled out.
+          # `docker stack deploy` returns as soon as the spec is committed to Raft
+          # (before Swarm populates UpdateStatus), so a crash-on-start (-> rollback)
+          # or a stuck/slow rollout would otherwise pass silently. When a new image
+          # was pulled, wait for vision_web to reach `completed`: never accept an
+          # empty/`updating` reading as success, fail immediately on rollback/pause,
+          # and fail on timeout in any non-`completed` state. Skip the wait only
+          # when the image was unchanged (genuine no-op, nothing to roll out).
+          if printf '%s' "$web_pull" | grep -q 'Image is up to date'; then
+            echo "vision_web image unchanged; no rollout expected"
+          else
+            state=""
+            for i in $(seq 1 60); do
+              state="$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")"
+              case "$state" in
+                completed) break ;;
+                rollback_*|paused)
+                  echo "::error::vision_web rolled back (UpdateStatus=$state); prod still on the previous image"
+                  exit 1 ;;
+              esac
+              sleep 5
+            done
+            if [ "$state" != "completed" ]; then
+              echo "::error::vision_web did not converge within ~5m (UpdateStatus=${state:-empty}); prod may still be on the previous image"
+              exit 1
+            fi
+            echo "vision_web converged (UpdateStatus=completed)"
+          fi
           docker system prune -f
-          echo "vision_web converged (UpdateStatus=${state:-none})"
 
   deploy-SG:
     needs: build
@@ -284,25 +302,34 @@ jobs:
           cd apps/web
           docker network create --driver overlay vision || true
           docker pull ecency/api:latest
-          docker pull ecency/vision-next:latest
+          web_pull="$(docker pull ecency/vision-next:latest)"; printf '%s\n' "$web_pull"
           docker stack deploy -c <(docker-compose -f docker-compose.production.yml config) vision
-          # Fail the job if vision_web does not converge — e.g. the new image
-          # crashes on start and Swarm rolls back to the previous image. Without
-          # this, `docker stack deploy` returns 0 immediately, so a rolled-back
-          # rollout still reports a green deploy while prod serves the old build.
-          state=""
-          for i in $(seq 1 36); do
-            state=$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")
-            case "$state" in
-              ""|completed) break ;;
-              rollback_*|paused) break ;;
-            esac
-            sleep 5
-          done
-          case "$state" in
-            rollback_*|paused)
-              echo "::error::vision_web did not converge (UpdateStatus=$state); prod still on previous image"
-              exit 1 ;;
-          esac
+          # Don't report a green deploy unless the new image actually rolled out.
+          # `docker stack deploy` returns as soon as the spec is committed to Raft
+          # (before Swarm populates UpdateStatus), so a crash-on-start (-> rollback)
+          # or a stuck/slow rollout would otherwise pass silently. When a new image
+          # was pulled, wait for vision_web to reach `completed`: never accept an
+          # empty/`updating` reading as success, fail immediately on rollback/pause,
+          # and fail on timeout in any non-`completed` state. Skip the wait only
+          # when the image was unchanged (genuine no-op, nothing to roll out).
+          if printf '%s' "$web_pull" | grep -q 'Image is up to date'; then
+            echo "vision_web image unchanged; no rollout expected"
+          else
+            state=""
+            for i in $(seq 1 60); do
+              state="$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")"
+              case "$state" in
+                completed) break ;;
+                rollback_*|paused)
+                  echo "::error::vision_web rolled back (UpdateStatus=$state); prod still on the previous image"
+                  exit 1 ;;
+              esac
+              sleep 5
+            done
+            if [ "$state" != "completed" ]; then
+              echo "::error::vision_web did not converge within ~5m (UpdateStatus=${state:-empty}); prod may still be on the previous image"
+              exit 1
+            fi
+            echo "vision_web converged (UpdateStatus=completed)"
+          fi
           docker system prune -f
-          echo "vision_web converged (UpdateStatus=${state:-none})"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -138,8 +138,26 @@ jobs:
           docker pull ecency/api:latest
           docker pull ecency/vision-next:latest
           docker stack deploy -c <(docker-compose -f docker-compose.production.yml config) vision
-          sleep 60
+          # Fail the job if vision_web does not converge — e.g. the new image
+          # crashes on start and Swarm rolls back to the previous image. Without
+          # this, `docker stack deploy` returns 0 immediately, so a rolled-back
+          # rollout still reports a green deploy while prod serves the old build.
+          state=""
+          for i in $(seq 1 36); do
+            state=$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")
+            case "$state" in
+              ""|completed) break ;;
+              rollback_*|paused) break ;;
+            esac
+            sleep 5
+          done
+          case "$state" in
+            rollback_*|paused)
+              echo "::error::vision_web did not converge (UpdateStatus=$state); prod still on previous image"
+              exit 1 ;;
+          esac
           docker system prune -f
+          echo "vision_web converged (UpdateStatus=${state:-none})"
 
   deploy-US:
     needs: build
@@ -194,8 +212,26 @@ jobs:
           docker pull ecency/api:latest
           docker pull ecency/vision-next:latest
           docker stack deploy -c <(docker-compose -f docker-compose.production.yml config) vision
-          sleep 60
+          # Fail the job if vision_web does not converge — e.g. the new image
+          # crashes on start and Swarm rolls back to the previous image. Without
+          # this, `docker stack deploy` returns 0 immediately, so a rolled-back
+          # rollout still reports a green deploy while prod serves the old build.
+          state=""
+          for i in $(seq 1 36); do
+            state=$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")
+            case "$state" in
+              ""|completed) break ;;
+              rollback_*|paused) break ;;
+            esac
+            sleep 5
+          done
+          case "$state" in
+            rollback_*|paused)
+              echo "::error::vision_web did not converge (UpdateStatus=$state); prod still on previous image"
+              exit 1 ;;
+          esac
           docker system prune -f
+          echo "vision_web converged (UpdateStatus=${state:-none})"
 
   deploy-SG:
     needs: build
@@ -250,5 +286,23 @@ jobs:
           docker pull ecency/api:latest
           docker pull ecency/vision-next:latest
           docker stack deploy -c <(docker-compose -f docker-compose.production.yml config) vision
-          sleep 60
+          # Fail the job if vision_web does not converge — e.g. the new image
+          # crashes on start and Swarm rolls back to the previous image. Without
+          # this, `docker stack deploy` returns 0 immediately, so a rolled-back
+          # rollout still reports a green deploy while prod serves the old build.
+          state=""
+          for i in $(seq 1 36); do
+            state=$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")
+            case "$state" in
+              ""|completed) break ;;
+              rollback_*|paused) break ;;
+            esac
+            sleep 5
+          done
+          case "$state" in
+            rollback_*|paused)
+              echo "::error::vision_web did not converge (UpdateStatus=$state); prod still on previous image"
+              exit 1 ;;
+          esac
           docker system prune -f
+          echo "vision_web converged (UpdateStatus=${state:-none})"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -133,24 +133,33 @@ jobs:
           git pull origin develop
           cd apps/web
           docker network create --driver overlay vision || true
-          docker pull ecency/vision-next:develop
+          web_pull="$(docker pull ecency/vision-next:develop)"; printf '%s\n' "$web_pull"
           docker stack deploy -c <(docker-compose config) vision
-          # Fail the job if vision_web does not converge — e.g. the new image
-          # crashes on start and Swarm rolls back to the previous image. Without
-          # this, `docker stack deploy` returns 0 immediately, so a rolled-back
-          # rollout still reports a green deploy while staging serves the old build.
-          state=""
-          for i in $(seq 1 36); do
-            state=$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")
-            case "$state" in
-              ""|completed) break ;;
-              rollback_*|paused) break ;;
-            esac
-            sleep 5
-          done
-          case "$state" in
-            rollback_*|paused)
-              echo "::error::vision_web did not converge (UpdateStatus=$state); staging still on previous image"
-              exit 1 ;;
-          esac
-          echo "vision_web converged (UpdateStatus=${state:-none})"
+          # Don't report a green deploy unless the new image actually rolled out.
+          # `docker stack deploy` returns as soon as the spec is committed to Raft
+          # (before Swarm populates UpdateStatus), so a crash-on-start (-> rollback)
+          # or a stuck/slow rollout would otherwise pass silently. When a new image
+          # was pulled, wait for vision_web to reach `completed`: never accept an
+          # empty/`updating` reading as success, fail immediately on rollback/pause,
+          # and fail on timeout in any non-`completed` state. Skip the wait only
+          # when the image was unchanged (genuine no-op, nothing to roll out).
+          if printf '%s' "$web_pull" | grep -q 'Image is up to date'; then
+            echo "vision_web image unchanged; no rollout expected"
+          else
+            state=""
+            for i in $(seq 1 60); do
+              state="$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")"
+              case "$state" in
+                completed) break ;;
+                rollback_*|paused)
+                  echo "::error::vision_web rolled back (UpdateStatus=$state); staging still on the previous image"
+                  exit 1 ;;
+              esac
+              sleep 5
+            done
+            if [ "$state" != "completed" ]; then
+              echo "::error::vision_web did not converge within ~5m (UpdateStatus=${state:-empty}); staging may still be on the previous image"
+              exit 1
+            fi
+            echo "vision_web converged (UpdateStatus=completed)"
+          fi

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -135,3 +135,22 @@ jobs:
           docker network create --driver overlay vision || true
           docker pull ecency/vision-next:develop
           docker stack deploy -c <(docker-compose config) vision
+          # Fail the job if vision_web does not converge — e.g. the new image
+          # crashes on start and Swarm rolls back to the previous image. Without
+          # this, `docker stack deploy` returns 0 immediately, so a rolled-back
+          # rollout still reports a green deploy while staging serves the old build.
+          state=""
+          for i in $(seq 1 36); do
+            state=$(docker service inspect vision_web --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")
+            case "$state" in
+              ""|completed) break ;;
+              rollback_*|paused) break ;;
+            esac
+            sleep 5
+          done
+          case "$state" in
+            rollback_*|paused)
+              echo "::error::vision_web did not converge (UpdateStatus=$state); staging still on previous image"
+              exit 1 ;;
+          esac
+          echo "vision_web converged (UpdateStatus=${state:-none})"

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -89,4 +89,15 @@ COPY --from=base /var/app/node_modules ./node_modules
 COPY --from=base /var/app/apps/web/node_modules ./apps/web/node_modules
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 CMD node /var/app/apps/web/healthCheck.js
-CMD ["pnpm", "start"]
+
+# Start Next.js directly rather than via `pnpm start`. The production image is
+# already built; it needs no package manager at runtime. pnpm 11 runs a
+# "verify deps before run" check before the start script, decides the pruned
+# (`pnpm deploy --prod`) node_modules is stale, tries to purge + reinstall, and
+# aborts in a TTY-less container (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY ->
+# exit 1). That made every Swarm rollout crash on start and silently roll back
+# to the previous image, so deploys went green while prod kept serving the old
+# build. Invoking next directly skips that check (and a per-start corepack
+# download of pnpm).
+WORKDIR /var/app/apps/web
+CMD ["node", "./node_modules/next/dist/bin/next", "start"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -74,9 +74,6 @@ ENV NODE_ENV=production
 ARG SENTRY_RELEASE
 ENV SENTRY_RELEASE=${SENTRY_RELEASE}
 
-ARG PNPM_VERSION=11.5.0
-RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
-
 # Copy runtime artifacts from the single build
 COPY --from=base /var/app/package.json ./package.json
 COPY --from=base /var/app/pnpm-lock.yaml ./pnpm-lock.yaml


### PR DESCRIPTION
TL;DR: every web release since the pnpm 11 bump has silently not shipped — CI is green but the running containers roll back to the previous image, so prod keeps serving an older build.

## Root cause
The production container starts with `CMD ["pnpm","start"]`. pnpm 11 runs a `verify-deps-before-run` check before the start script, decides the pruned production `node_modules` (created by `pnpm deploy --prod`) is stale, tries to **purge + reinstall**, and in a TTY-less container aborts:

```
[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
[ERROR] Command failed with exit code 1: ... pnpm install --production
    at runDepsStatusCheck (.../pnpm.mjs)
```

The process exits 1. With Swarm `order: start-first` + `rollback_config`, the new task fails on start and Swarm **rolls back** to the previous image. But `docker stack deploy` has already returned 0, so the deploy job is **green** — a silent no-ship. (Reproduced by running the freshly-built image directly; the rolled-back task shows `task: non-zero exit (1)` and the service `UpdateStatus` is `rollback_completed`.)

## Fix
1. **`apps/web/Dockerfile`** — start Next.js directly (`node ./node_modules/next/dist/bin/next start`) instead of `pnpm start`. The image is already built; it needs no package manager at runtime, which sidesteps the deps check entirely (and removes a per-start corepack pnpm download). Validated by running the built image: it reaches `✓ Ready` and passes the healthcheck.
2. **`master.yml` + `staging.yml`** — after `docker stack deploy`, poll `vision_web` `UpdateStatus` and **fail the job if it rolls back / does not converge**, so a crash-on-start is a red deploy instead of a green no-op. Replaces the prior fixed `sleep 60`.

## Why this is safe to land
The deploy that ships this change builds the image from the fixed Dockerfile, so its own rollout converges instead of rolling back. Recommend merging here (→ staging) to confirm the new guard reports a converged staging deploy, then promoting to `main` for prod — which will finally ship the backlog of merged-but-undeployed changes.

## Notes
- `CI=true` (pnpm’s suggested remedy) "works" but triggers a slow runtime `pnpm install` on every container start — intentionally not used.
- Guard is scoped to `vision_web` (the service this fixes); can be extended to other services later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deployment verification to detect and fail on service convergence issues, preventing faulty rollouts across all environments
  * Added convergence checks to staging deployments to catch failures earlier
  * Improved container startup reliability to prevent unintended rollback scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->