### PR TITLE
fix(web): enhance bare /@author/permlink post links

### DIFF
--- a/apps/web/src/features/post-renderer/components/extensions/hive-post-link-extension.tsx
+++ b/apps/web/src/features/post-renderer/components/extensions/hive-post-link-extension.tsx
@@ -10,7 +10,11 @@ import React, {
 } from "react";
 import { createRoot } from "react-dom/client";
 import "./hive-post-link-extension.scss";
-import { findPostLinkElements, isWaveLikePost } from "../functions";
+import {
+  findPostLinkElements,
+  isInvalidPermlinkLink,
+  isWaveLikePost,
+} from "../functions";
 
 // In-memory session cache
 const simpleCache = new Map<
@@ -21,21 +25,6 @@ const simpleCache = new Map<
     image: string | undefined;
   }
 >();
-
-function isInvalidPermlinkLink(path: string): boolean {
-  try {
-    const parts = new URL(`https://ecency.com${path}`).pathname.split("/");
-    const permlink = decodeURIComponent(parts[3] || "");
-
-    const isImage = /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(permlink);
-    const hasBadChars = /[?#]/.test(permlink);
-    const isClean = /^[a-z0-9-]+$/.test(permlink); // Hive-style
-
-    return !isClean || isImage || hasBadChars;
-  } catch {
-    return true;
-  }
-}
 
 export function HivePostLinkRenderer({ link }: { link: string }) {
   const [data, setData] = useState<{

--- a/apps/web/src/features/post-renderer/components/functions/index.ts
+++ b/apps/web/src/features/post-renderer/components/functions/index.ts
@@ -1,3 +1,3 @@
 export * from "./is-wave-like-post";
 export * from "./find-post-link-elements";
-export * from "./find-post-link-elements";
+export * from "./is-invalid-permlink-link";

--- a/apps/web/src/features/post-renderer/components/functions/is-invalid-permlink-link.ts
+++ b/apps/web/src/features/post-renderer/components/functions/is-invalid-permlink-link.ts
@@ -1,0 +1,35 @@
+import { SECTION_LIST } from "@ecency/render-helper";
+
+/**
+ * Returns true when a Hive post path does NOT point at a valid, enhanceable
+ * permlink — i.e. it is an image, a profile section (/@author/posts,
+ * /@author/wallet, …), or otherwise malformed.
+ *
+ * Post links may arrive in either the canonical bare form
+ * "/@author/permlink" or the legacy category-prefixed form
+ * "/category/@author/permlink", so the permlink is located relative to the
+ * "@author" segment rather than at a fixed path index.
+ */
+export function isInvalidPermlinkLink(path: string): boolean {
+  try {
+    const segments = new URL(`https://ecency.com${path}`).pathname
+      .split("/")
+      .filter(Boolean);
+
+    // The permlink is the segment immediately following "@author".
+    const authorIndex = segments.findIndex((seg) => seg.startsWith("@"));
+    const permlink = decodeURIComponent(
+      authorIndex !== -1 ? segments[authorIndex + 1] ?? "" : "",
+    );
+
+    const isImage = /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(permlink);
+    const hasBadChars = /[?#]/.test(permlink);
+    const isClean = /^[a-z0-9-]+$/.test(permlink); // Hive-style
+    // A profile section (e.g. /@author/posts) is not an enhanceable post.
+    const isProfileSection = SECTION_LIST.includes(permlink);
+
+    return !isClean || isImage || hasBadChars || isProfileSection;
+  } catch {
+    return true;
+  }
+}

--- a/apps/web/src/specs/features/post-renderer/components/functions/isInvalidPermlinkLink.spec.ts
+++ b/apps/web/src/specs/features/post-renderer/components/functions/isInvalidPermlinkLink.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { isInvalidPermlinkLink } from "@/features/post-renderer/components/functions/is-invalid-permlink-link";
+
+describe("isInvalidPermlinkLink", () => {
+  describe("valid, enhanceable post links", () => {
+    // Regression: bare "/@author/permlink" links must be treated as valid.
+    // The legacy implementation read a fixed parts[3], which is undefined for
+    // the bare form, so every bare post link was wrongly rejected and stopped
+    // enhancing after the canonical-link migration.
+    it("accepts the bare /@author/permlink form", () => {
+      expect(isInvalidPermlinkLink("/@alice/my-post")).toBe(false);
+    });
+
+    it("accepts the legacy /category/@author/permlink form", () => {
+      expect(isInvalidPermlinkLink("/hive-167922/@alice/my-post")).toBe(false);
+    });
+
+    it("accepts the legacy /ccc/@author/permlink form", () => {
+      expect(isInvalidPermlinkLink("/ccc/@alice/my-post")).toBe(false);
+    });
+
+    it("ignores a referral query string", () => {
+      expect(isInvalidPermlinkLink("/@alice/my-post?referral=bob")).toBe(false);
+    });
+
+    it("accepts a wave-style permlink", () => {
+      expect(isInvalidPermlinkLink("/@alice/re-ecencywaves-abc")).toBe(false);
+    });
+  });
+
+  describe("invalid links", () => {
+    it("rejects profile sections (bare form)", () => {
+      expect(isInvalidPermlinkLink("/@alice/posts")).toBe(true);
+      expect(isInvalidPermlinkLink("/@alice/wallet")).toBe(true);
+      expect(isInvalidPermlinkLink("/@alice/comments")).toBe(true);
+      expect(isInvalidPermlinkLink("/@alice/followers")).toBe(true);
+      expect(isInvalidPermlinkLink("/@alice/following")).toBe(true);
+    });
+
+    it("rejects image permlinks", () => {
+      expect(isInvalidPermlinkLink("/@alice/photo.jpg")).toBe(true);
+    });
+
+    it("rejects a bare author with no permlink", () => {
+      expect(isInvalidPermlinkLink("/@alice")).toBe(true);
+    });
+
+    it("rejects non-post paths without an author segment", () => {
+      expect(isInvalidPermlinkLink("/trending")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Problem
After the canonical-link migration (#886) switched in-content post links to the bare `/@author/permlink` form, in-content post links stopped enhancing (no preview card).

## Root cause
The post-link enhancer was not updated for the new shape. `isInvalidPermlinkLink` (in `hive-post-link-extension.tsx`) read the permlink at a hardcoded `parts[3]`, which only exists in the legacy `/category/@author/permlink` layout:

```js
const parts = new URL(`https://ecency.com${path}`).pathname.split("/");
const permlink = decodeURIComponent(parts[3] || "");
```

For a bare `/@author/permlink`, `parts[3]` is `undefined` → `permlink = ""` → `isClean = false` → the link is classified **invalid**. Both consumers then drop it: the `HivePostLinkExtension` pre-filter removes the anchor from the enhance list, and the `HivePostLinkRenderer` fetch gate returns before fetching og:meta. `render-helper` still sets `class="markdown-post-link"` and `data-is-inline`, so the link is detected but rejected.

## Fix
- Extract `isInvalidPermlinkLink` into a shared helper that locates the permlink relative to the `@author` segment, so it handles **both** the bare and legacy category forms (old post bodies still contain legacy links).
- Explicitly reject **profile sections** (`/@author/posts`, `/wallet`, …) via render-helper's exported `SECTION_LIST`, so a section link is never enhanced as a post in any path. The post-body path previously relied on render-helper tagging sections as `markdown-profile-link`; the chat renderer had no such guard, and the old `parts[3]` bug only rejected them by accident.
- Drops a duplicate barrel export.

Sibling enhancers (author, tag, hive-operation, wave) and the chat link gate were audited and are already shape-agnostic — no changes needed there.

## Tests
Adds `isInvalidPermlinkLink.spec.ts` covering bare/legacy/ccc/referral/wave (valid) and image/no-permlink/non-post/profile-section (invalid). All post-renderer + chat specs pass.
