### PR TITLE
fix(nav): align mobile compose FAB and scroll-to-top as a 48px circle pair

### DIFF
--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -224,7 +224,10 @@ export function NavbarMobile({
         aria-label={i18next.t("navbar.post")}
         aria-current={isActive("/publish") ? "page" : undefined}
         className={clsx(
-          "md:hidden fixed right-4 z-20 h-14 w-14 !rounded-full flex items-center justify-center shadow-lg",
+          // `!h-12 !w-12` (48px) overrides the Button's injected `h-[2.125rem]`
+          // size class so this renders as a true circle, level with the
+          // scroll-to-top control on the opposite corner (same size + bottom).
+          "md:hidden fixed right-4 z-20 !h-12 !w-12 !rounded-full flex items-center justify-center shadow-lg",
           "transition-transform duration-300",
           hidden && "translate-y-[200%]",
           step === 1 && "transparent"

--- a/apps/web/src/features/shared/scroll-to-top/_index.scss
+++ b/apps/web/src/features/shared/scroll-to-top/_index.scss
@@ -14,12 +14,20 @@
   display: none;
   cursor: pointer;
 
-  // On mobile, sit above the bottom tab bar and clear of the bottom-right
-  // compose FAB (which lives on the right).
+  // On mobile, sit above the bottom tab bar on the left, mirroring the
+  // bottom-right compose FAB as a matched pair: same 48px circle, same level.
   @media (max-width: 767px) {
     left: 16px;
     right: auto;
-    bottom: calc(env(safe-area-inset-bottom) + 5.5rem);
+    width: 48px;
+    height: 48px;
+    bottom: calc(env(safe-area-inset-bottom) + 4.75rem);
+
+    // In the in-app (RN) browser the bottom bar uses a fixed offset, so match
+    // the FAB's RN bottom (see the FAB style in navbar-mobile.tsx).
+    body.is-inapp-browser & {
+      bottom: 7rem;
+    }
   }
 
   &.visible {


### PR DESCRIPTION
## What & why

Follow-up polish to the recent mobile nav changes. On mobile the bottom-right **compose FAB** rendered as a horizontal **pill** instead of a circle, and it did not line up with the bottom-left **scroll-to-top** button (different size and different bottom offset).

### Root cause of the pill shape
The FAB is a `<Button>`. The Button component injects its `md` size class `h-[2.125rem]` (34px), which won over the FAB's `h-14` (56px): height was clamped while `w-14` (56px) stuck. `!rounded-full` on a 56x34 box renders as a stadium/pill, which is exactly what showed on the device.

## Changes
- **Compose FAB** (`navbar-mobile.tsx`): force a true circle with `!h-12 !w-12` (48px) so the height beats the Button's injected size class. Bottom offset unchanged (it was already nicely placed).
- **Scroll-to-top** (`scroll-to-top/_index.scss`, mobile only): match the FAB at a **48px circle** and the same `safe-area-inset-bottom + 4.75rem` bottom (was 40px @ `+5.5rem`). Desktop is untouched (stays 40px). Also matches the FAB's in-app (RN) bottom so the pair stays level in the native webview too.

## Result
Two identical **48px** circles, **level** on opposite bottom corners: a clean matched pair, with the same blue and the same icon size (20px).

## Verification
- `navbar-mobile.spec.tsx`: 7/7 pass
- ESLint on changed file: clean
- Typecheck: no new errors introduced by these files (only pre-existing repo-wide errors, unrelated)

CSS-only / positioning change, no logic touched. Best reviewed on a mobile viewport (< 768px).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted mobile compose button sizing for improved visual balance.
  * Repositioned scroll-to-top button on mobile to better align with bottom navigation layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->