### PR TITLE
docs(cache): worker no longer performs bot gating

### DIFF
--- a/docs/cache/cloudflare-worker.md
+++ b/docs/cache/cloudflare-worker.md
@@ -3,11 +3,14 @@
 The `ecency-geo-router` worker sits in front of nginx and is the primary edge
 cache layer for ecency.com. It implements:
 
-1. Bot management gating
-2. Geo-routing across 3 origins (eu/us/asia.ecency.com)
-3. WebSocket pass-through to the closest origin
-4. Edge cache for cacheable HTML responses, keyed by URL + auth-class
-5. Smart-Tiered-Cache-eligible subfetches via `cf.cacheKey`
+1. Geo-routing across 3 origins (eu/us/asia.ecency.com)
+2. WebSocket pass-through to the closest origin
+3. Edge cache for cacheable HTML responses, keyed by URL + auth-class
+4. Smart-Tiered-Cache-eligible subfetches via `cf.cacheKey`
+
+> Bot/abuse filtering is **not** done in the worker — it is handled upstream at
+> the Cloudflare edge (firewall rules + bot management). The worker only reads
+> the verified-bot flag to tune origin timeouts.
 
 ## Cache key strategy
 


### PR DESCRIPTION
Updates `docs/cache/cloudflare-worker.md` to reflect that bot/abuse filtering is handled at the Cloudflare edge (firewall rules + bot management), not inside the geo-router worker. The worker only reads the verified-bot flag to tune origin timeouts.

- Removes "Bot management gating" from the worker's responsibility list
- Adds a short clarifying note pointing to the edge layer

Docs-only; no code or behavior change.