### PR TITLE
perf(web): keep the post editor off the entry read page; reserve cover image box

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-body-viewer.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-body-viewer.tsx
@@ -7,8 +7,16 @@ import { useContext, useEffect, useState } from "react";
 import { SafeTweet } from "@/features/shared/safe-tweet";
 import TransactionSigner from "@/features/shared/transactions/transaction-signer";
 import { EntryPageContext } from "./context";
-import { EntryPageEdit } from "./entry-page-edit";
+import dynamic from "next/dynamic";
 import { makeEntryPath } from "@/utils";
+
+// The edit composer pulls the Comment editor (toolbar, image/video upload,
+// polls, gif picker). It only renders in edit mode, so keep it out of the
+// read-path bundle and load it on demand when the user enters editing.
+const EntryPageEdit = dynamic(
+  () => import("./entry-page-edit").then((m) => m.EntryPageEdit),
+  { ssr: false }
+);
 
 interface Props {
   entry: Entry;

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-body-viewer.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-body-viewer.tsx
@@ -9,13 +9,22 @@ import TransactionSigner from "@/features/shared/transactions/transaction-signer
 import { EntryPageContext } from "./context";
 import dynamic from "next/dynamic";
 import { makeEntryPath } from "@/utils";
+import i18next from "i18next";
 
 // The edit composer pulls the Comment editor (toolbar, image/video upload,
 // polls, gif picker). It only renders in edit mode, so keep it out of the
-// read-path bundle and load it on demand when the user enters editing.
+// read-path bundle and load it on demand when the user enters editing. The
+// loading fallback avoids a blank slot during the first chunk download.
 const EntryPageEdit = dynamic(
   () => import("./entry-page-edit").then((m) => m.EntryPageEdit),
-  { ssr: false }
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex items-center justify-center min-h-40 opacity-60">
+        {i18next.t("g.loading")}
+      </div>
+    )
+  }
 );
 
 interface Props {

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-static-body.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-static-body.tsx
@@ -3,6 +3,7 @@ import { renderPostBody, setProxyBase } from "@ecency/render-helper";
 import type { SeoContext } from "@ecency/render-helper";
 import { accountReputation } from "@/utils";
 import defaults from "@/defaults";
+import type { CSSProperties } from "react";
 
 interface Props {
   entry: Entry;
@@ -14,11 +15,28 @@ export function EntryPageStaticBody({ entry }: Props) {
     postPayout: entry.payout
   };
 
+  // Reserve the cover (LCP) image's box to prevent the body reflowing when it
+  // loads (CLS). The editor records the cover's aspect ratio at publish time in
+  // json_metadata.image_ratios[0] (aligned with the cover image[0]). We expose
+  // it as a CSS custom property on #post-body; an entry.scss rule applies it to
+  // the cover via its fetchpriority="high" hint. This deliberately stays out of
+  // the sanitized body HTML — the renderer's attribute whitelist is unchanged.
+  // Posts without a recorded ratio leave the property unset → the rule no-ops.
+  const meta = entry.json_metadata as { image_ratios?: (string | number)[] } | undefined;
+  const coverRatio = Number(meta?.image_ratios?.[0]);
+  const coverStyle =
+    Number.isFinite(coverRatio) && coverRatio > 0
+      ? ({ "--cover-ar": String(coverRatio), "--cover-w": "100%" } as CSSProperties)
+      : undefined;
+
   return (
     <div
       id="post-body"
       className="entry-body markdown-view user-selectable client"
-      dangerouslySetInnerHTML={{ __html: renderPostBody(entry.body, false, false, 'ecency.com', seoContext) }}
+      style={coverStyle}
+      dangerouslySetInnerHTML={{
+        __html: renderPostBody(entry.body, false, false, "ecency.com", seoContext)
+      }}
     />
   );
 }

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-static-body.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-static-body.tsx
@@ -22,10 +22,17 @@ export function EntryPageStaticBody({ entry }: Props) {
   // the cover via its fetchpriority="high" hint. This deliberately stays out of
   // the sanitized body HTML — the renderer's attribute whitelist is unchanged.
   // Posts without a recorded ratio leave the property unset → the rule no-ops.
+  // image_ratios lives in json_metadata — arbitrary, user-controlled data on the
+  // blockchain that any client or direct broadcast can set to any value. Clamp
+  // to a sane range so a hostile/buggy ratio (e.g. 0.001 → a ~800000px-tall box)
+  // can't break the page layout. object-fit:contain (entry.scss) letterboxes any
+  // residual mismatch from clamping.
   const meta = entry.json_metadata as { image_ratios?: (string | number)[] } | undefined;
-  const coverRatio = Number(meta?.image_ratios?.[0]);
+  const rawRatio = Number(meta?.image_ratios?.[0]);
+  const coverRatio =
+    Number.isFinite(rawRatio) && rawRatio > 0 ? Math.min(Math.max(rawRatio, 0.1), 10) : 0;
   const coverStyle =
-    Number.isFinite(coverRatio) && coverRatio > 0
+    coverRatio > 0
       ? ({ "--cover-ar": String(coverRatio), "--cover-w": "100%" } as CSSProperties)
       : undefined;
 

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/entry.scss
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/entry.scss
@@ -292,6 +292,18 @@
   height: auto;
 }
 
+// Reserve the cover (LCP) image's box from the aspect ratio the editor recorded
+// at publish time (passed as --cover-ar on #post-body) so the body can't reflow
+// when the image loads — the single layout shift GTmetrix/Lighthouse flags on
+// post pages. Targets the cover via the fetchpriority="high" hint the renderer
+// already sets on the first image. When the ratio is unknown the custom
+// properties are absent, so this falls back to `auto` and is a no-op.
+#post-body img[fetchpriority="high"] {
+  aspect-ratio: var(--cover-ar, auto);
+  width: var(--cover-w, auto);
+  height: auto;
+}
+
 .visible {
   .avatar-fixed {
     opacity: 1 !important;

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/entry.scss
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/entry.scss
@@ -302,6 +302,10 @@
   aspect-ratio: var(--cover-ar, auto);
   width: var(--cover-w, auto);
   height: auto;
+  // Safety net: if the recorded cover ratio ever maps to a different first
+  // body image (e.g. a custom thumbnail that isn't the first image), letterbox
+  // instead of stretching. A no-op when the ratio matches (the common case).
+  object-fit: contain;
 }
 
 .visible {

--- a/apps/web/src/features/shared/editor-toolbar/index.tsx
+++ b/apps/web/src/features/shared/editor-toolbar/index.tsx
@@ -40,7 +40,12 @@ import { AddLink } from "@/features/shared/editor-toolbar/add-link";
 import { AddImageMobile } from "@/features/shared/editor-toolbar/add-image-mobile";
 import useMount from "react-use/lib/useMount";
 import { EcencyConfigManager } from "@/config";
-import { useOptionalUploadTracker } from "@/app/publish/_hooks";
+// Import directly from the file, NOT the "@/app/publish/_hooks" barrel:
+// the barrel re-exports use-publish-editor (the full TipTap/ProseMirror graph,
+// ~400KB), so importing the tracker through it drags the entire editor into
+// every editor-toolbar consumer — including the read-only entry page. The
+// tracker itself only depends on React.
+import { useOptionalUploadTracker } from "@/app/publish/_hooks/use-upload-tracker";
 
 interface Props {
   sm?: boolean;


### PR DESCRIPTION
## What

The entry (read) page shipped the full TipTap/ProseMirror editor (~400KB, 4 chunks) in its first-load JS for **every** reader — including logged-out visitors who can never use it. Two static import paths caused it:

1. `EntryPageBodyViewer` statically imports `EntryPageEdit` → `Comment` → `EditorToolbar` → editor. `EntryPageEdit` only renders in edit mode, but a static import bundles it regardless.
2. `editor-toolbar` imported `useOptionalUploadTracker` from the `@/app/publish/_hooks` **barrel**, which re-exports `use-publish-editor` (the whole TipTap graph).

## Changes

- **editor-toolbar**: import `useOptionalUploadTracker` from its own file (`use-upload-tracker`) instead of the publish `_hooks` barrel — the tracker only depends on React.
- **entry-page-body-viewer**: load `EntryPageEdit` via `next/dynamic` (it only renders when editing).
- **Cover image CLS**: reserve the cover (LCP) image's box so the body can't reflow when it loads. The editor already records the cover aspect ratio in `json_metadata.image_ratios`; it's exposed as a CSS custom property (`--cover-ar`) on `#post-body` and applied by an `entry.scss` rule via the cover's existing `fetchpriority="high"` hint. **No change to the renderer's HTML sanitizer / attribute whitelist** — the reservation stays out of the sanitized body. Posts without a recorded ratio are left unreserved (no-op).

## Measured impact (production build)

Entry read route first-load JS:

| | develop | this PR |
|---|---|---|
| First Load JS | 1.23 MB | **1.09 MB** |
| chunks | 21 | 16 |
| TipTap/ProseMirror chunks | 4 present | **0** |

The editor still loads on demand when a logged-in user opens the reply composer or edits a post. The 4 editor chunks remain on `/publish` (the editor route), as expected.

## Notes

- The editor's `tus`/gif/poll bits still reach first load via the `_components` `export *` barrel (no `sideEffects` flag); clearing those is a follow-up.
- CLS reduction and field LCP/TBT are best confirmed on the preview/after deploy.
