### PR TITLE
fix(web): tame post-deploy Sentry noise — deploy-skew reclassification + RC-exhaustion handling

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -4,7 +4,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 import appPackage from "./package.json";
-import { isEmptyCaptureEvent } from "./src/utils/sentry-empty-capture";
+import { beforeSend } from "./src/utils/sentry-before-send";
 
 // Defer Sentry initialization until after first user interaction or 5s idle.
 // This moves ~1s of JS evaluation off the critical rendering path.
@@ -44,142 +44,10 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
     /chrome-extension:\/\//
   ],
 
-  beforeSend(event) {
-    // Drop value-less captures — captureException(null/undefined/"") produces a
-    // synthetic exception with no message and no stack frames (zero actionable
-    // info, all grouped as the "<unknown>" issue). Only empty + frame-less
-    // events are dropped, so real errors (which always carry a stack or a
-    // message) are never lost. See sentry-empty-capture for the exact rule.
-    if (isEmptyCaptureEvent(event)) {
-      return null;
-    }
-
-    const exceptionType = event.exception?.values?.[0]?.type ?? "";
-    const message = event.exception?.values?.[0]?.value ?? "";
-    const stackStr = JSON.stringify(
-      event.exception?.values?.[0]?.stacktrace?.frames ?? []
-    );
-
-    // ECENCY-NEXT-1AA7: an injected page script (pageHook.js / __mm__updateUrl)
-    // JSON.stringify'ing a DOM node. Gate on the injected-script frame so a real
-    // app-side circular-stringify bug (different frames) is still reported.
-    if (
-      /Converting circular structure to JSON/i.test(message) &&
-      /pageHook|__mm__/i.test(stackStr)
-    ) {
-      return null;
-    }
-
-    // ECENCY-NEXT-XA0: "Insufficient Resource Credits" is an expected Hive
-    // condition surfaced as a HANDLED toast. Drop only the handled capture — a
-    // future unhandled path that surfaces the same text is still reported.
-    if (
-      /Insufficient Resource Credits/i.test(message) &&
-      event.exception?.values?.[0]?.mechanism?.handled !== false
-    ) {
-      return null;
-    }
-
-    // AbortController-induced timeouts (TimeoutError / AbortError) ship
-    // with no stack frames, so we can't tell which fetch is at fault.
-    // Walk recent breadcrumbs for the last in-flight fetch URL and tag
-    // the event so we can correlate timeouts to specific endpoints.
-    // Trigger only on the canonical AbortController error names plus the
-    // standard "signal timed out" phrase — a broader /aborted/i match
-    // would also tag unrelated paths (transaction aborts, stream aborts).
-    if (
-      (exceptionType === "TimeoutError" ||
-        exceptionType === "AbortError" ||
-        /signal timed out/i.test(message)) &&
-      !event.tags?.timeoutUrl
-    ) {
-      const crumbs = event.breadcrumbs ?? [];
-      for (let i = crumbs.length - 1; i >= 0; i--) {
-        const c = crumbs[i];
-        const rawUrl = (c.data as { url?: string } | undefined)?.url;
-        if (
-          (c.category === "fetch" || c.category === "xhr") &&
-          typeof rawUrl === "string"
-        ) {
-          // Strip query/hash before tagging — request URLs can carry
-          // tokens or identifiers we don't want as searchable telemetry.
-          let safeUrl: string;
-          try {
-            const parsed = new URL(rawUrl, window.location.origin);
-            safeUrl = `${parsed.origin}${parsed.pathname}`;
-          } catch {
-            safeUrl = rawUrl.split(/[?#]/)[0] ?? "";
-          }
-          if (safeUrl) {
-            event.tags = { ...event.tags, timeoutUrl: safeUrl.slice(0, 200) };
-          }
-          break;
-        }
-      }
-    }
-
-    // React SSR streaming hydration issue triggered by browser extensions
-    // ($RS is React's internal resumable script marker)
-    // Covers old Chrome ≤116 ("Cannot read property 'parentNode' of null"),
-    // new Chrome 117+ ("Cannot read properties of null (reading 'parentNode')"),
-    // Firefox ("can't access property \"parentNode\", a is null"), and
-    // Safari ("null is not an object (evaluating 'a.parentNode')") phrasings.
-    const isParentNodeNull =
-      message.includes("reading 'parentNode'") ||
-      message.includes("property 'parentNode'") ||
-      message.includes('"parentNode"') ||
-      /null is not an object \(evaluating '[a-z]\.parentNode'\)/.test(message);
-    if (isParentNodeNull && stackStr.includes("$RS")) {
-      return null;
-    }
-
-    // Firefox-specific iframe teardown error following a React hydration
-    // mismatch (#418) on profile pages. Symptom — when hydration fails,
-    // React tears down the tree and an iframe's contentWindow becomes null
-    // while some downstream code still tries to access .document on it.
-    // V8-based engines produce a different message for the same access
-    // (`Cannot read properties of null (reading 'document')`) so matching
-    // on the Firefox phrasing alone is engine-specific, but we *also*
-    // require browser=Firefox and a profile-page URL so unrelated iframe
-    // bugs in other surfaces aren't silently dropped. Sample 1% to keep
-    // trend visibility.
-    // TODO(hydration): investigate Firefox-only hydration drift on profile
-    // pages (`/@user/...`) — likely a locale/Date/Intl mismatch or a value
-    // that differs between SSR and the first client render.
-    // event.contexts is loosely typed by @sentry/types; coerce to string.
-    const browserName = String(event.contexts?.browser?.name ?? "");
-    const url = String(event.request?.url ?? "");
-    if (
-      message.includes("can't access property \"document\"") &&
-      message.includes("contentWindow is null") &&
-      /Firefox/i.test(browserName) &&
-      /\/@/.test(url) &&
-      Math.random() > 0.01
-    ) {
-      return null;
-    }
-
-    // Chrome botnet traffic - null/undefined document access from synthetic handler
-    if (
-      /Cannot read properties of (null|undefined) \(reading 'document'\)/.test(
-        message
-      ) &&
-      stackStr.includes("HTMLDocument.c")
-    ) {
-      return null;
-    }
-
-    // Network issues corrupting JS chunk downloads
-    if (
-      /^SyntaxError/.test(event.exception?.values?.[0]?.type ?? "") &&
-      /Unexpected (end of input|token)/.test(message) &&
-      /chunks?[/\\-]/.test(stackStr)
-    ) {
-      return null;
-    }
-
-    return event;
-  }
+  // The single source of truth for client-side event filtering and
+  // reclassification (deploy-skew, RC exhaustion, extension noise, timeouts).
+  // Extracted to src/utils/sentry-before-send so it stays unit-testable.
+  beforeSend
 };
 
 if (typeof window !== "undefined" && process.env.NODE_ENV === "production") {

--- a/apps/web/src/features/pwa-install/service-worker-recovery.tsx
+++ b/apps/web/src/features/pwa-install/service-worker-recovery.tsx
@@ -1,57 +1,12 @@
 "use client";
 
 import { useEffect } from "react";
+import { isChunkLoadError, isDeploySkewError } from "@/utils/deploy-skew";
 
-// Message patterns for a failed chunk / dynamic import — a stale cache or a
-// just-replaced build handing the client a chunk that no longer exists.
-export function isChunkLoadError(message?: string | null): boolean {
-  if (!message) {
-    return false;
-  }
-  return (
-    /ChunkLoadError/i.test(message) ||
-    /Loading chunk [\w-]+ failed/i.test(message) ||
-    /Loading CSS chunk/i.test(message) ||
-    /error loading dynamically imported module/i.test(message) ||
-    /Importing a module script failed/i.test(message) ||
-    /Failed to fetch dynamically imported module/i.test(message)
-  );
-}
-
-// The webpack runtime was handed an undefined module factory: a chunk loaded but
-// references a module id the running runtime doesn't have — a build/version
-// mismatch after a deploy ("Cannot read properties of undefined (reading 'call')"
-// thrown from webpack-*.js, or the Safari equivalent). Require the webpack
-// runtime frame so this never fires on unrelated ".call of undefined" app bugs.
-function isWebpackFactoryError(error: { message?: string; stack?: string }): boolean {
-  const stack = error.stack ?? "";
-  const fromWebpackRuntime =
-    /webpack-[0-9a-f]+\.js/i.test(stack) || /webpack-internal/i.test(stack);
-  if (!fromWebpackRuntime) {
-    return false;
-  }
-  const message = error.message ?? "";
-  return (
-    /Cannot read propert(?:y|ies) of undefined \(reading 'call'\)/i.test(message) || // Chrome
-    /undefined is not an object \(evaluating '[^']*\.call'\)/i.test(message) || // Safari
-    /can't access property ['"]?call\b/i.test(message) || // Firefox (\b so it can't match "callback")
-    /'call' of undefined/i.test(message)
-  );
-}
-
-// True when the error indicates the client is running a build that no longer
-// matches what the server serves (chunk-load failures + webpack factory
-// mismatches). The cure is to reload onto the current build.
-export function isDeploySkewError(error: unknown): boolean {
-  if (typeof error === "string") {
-    return isChunkLoadError(error);
-  }
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-  const e = error as { message?: string; stack?: string };
-  return isChunkLoadError(e.message) || isWebpackFactoryError(e);
-}
+// Re-exported so existing consumers (global-error.tsx, SentryErrorBoundary) keep
+// importing the skew matchers from here; the implementations now live in the
+// React-free @/utils/deploy-skew so the Sentry client config can share them too.
+export { isChunkLoadError, isDeploySkewError } from "@/utils/deploy-skew";
 
 // Guards against reload loops: at most one recovery reload per tab session. If
 // the page still errors after the reload, we stop and let the error boundary

--- a/apps/web/src/features/shared/entry-vote-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/index.tsx
@@ -16,6 +16,8 @@ import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { AnimatePresence, motion } from "framer-motion";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { error } from "@/features/shared/feedback";
+import { formatError } from "@/api/format-error";
 import i18next from "i18next";
 
 // The vote slider dialog only mounts on interaction (dialog && entry &&
@@ -84,9 +86,18 @@ export function EntryVoteBtn({ entry: originalEntry, isPostSlider, account }: Pr
     async (percent: number, estimated: number) => {
       const weight = Math.ceil(percent * 100);
 
-      await voteInAPI({ weight, estimated });
-
-      setDialog(false);
+      try {
+        await voteInAPI({ weight, estimated });
+      } catch (e) {
+        // The broadcast was rejected (commonly the account is out of Resource
+        // Credits, or an identical/duplicate vote). Surface the friendly,
+        // classified toast via the standard error()/formatError path instead of
+        // letting the rejection escape as an unhandled promise — which Sentry's
+        // global handler would otherwise capture as a fresh client crash.
+        error(...formatError(e));
+      } finally {
+        setDialog(false);
+      }
     },
     [voteInAPI]
   );

--- a/apps/web/src/features/shared/entry-vote-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/index.tsx
@@ -88,6 +88,9 @@ export function EntryVoteBtn({ entry: originalEntry, isPostSlider, account }: Pr
 
       try {
         await voteInAPI({ weight, estimated });
+        // Close only on success — on failure keep the slider open so the user
+        // can adjust and retry in place (matches the pre-existing behavior).
+        setDialog(false);
       } catch (e) {
         // The broadcast was rejected (commonly the account is out of Resource
         // Credits, or an identical/duplicate vote). Surface the friendly,
@@ -95,8 +98,6 @@ export function EntryVoteBtn({ entry: originalEntry, isPostSlider, account }: Pr
         // letting the rejection escape as an unhandled promise — which Sentry's
         // global handler would otherwise capture as a fresh client crash.
         error(...formatError(e));
-      } finally {
-        setDialog(false);
       }
     },
     [voteInAPI]

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { beforeSend } from "@/utils/sentry-before-send";
+
+type Ev = Parameters<typeof beforeSend>[0];
+
+function makeEvent(
+  value: string,
+  frames: { filename?: string }[] = [],
+  opts: { type?: string; handled?: boolean } = {}
+): Ev {
+  return {
+    exception: {
+      values: [
+        {
+          type: opts.type ?? "TypeError",
+          value,
+          stacktrace: { frames },
+          ...(opts.handled !== undefined
+            ? { mechanism: { type: "onunhandledrejection", handled: opts.handled } }
+            : {})
+        }
+      ]
+    }
+  } as unknown as Ev;
+}
+
+const WEBPACK_FRAME = {
+  filename: "app:///_next/static/chunks/webpack-9732e1c31d36b1a3.js"
+};
+const APP_FRAME = { filename: "app:///_next/static/chunks/app/page.js" };
+
+describe("beforeSend — deploy-skew reclassification", () => {
+  // The post-deploy cluster (ECENCY-NEXT-1FPK/1FPM/1FPN/1FPJ): a stale tab's
+  // async chunk import rejects, surfacing as onunhandledrejection that bypasses
+  // the React render boundaries. beforeSend must fold these into the single
+  // low-severity skew issue instead of letting them spawn fresh error issues.
+  it("reclassifies the Firefox webpack-factory rejection (e[c] is undefined)", () => {
+    const ev = makeEvent('can\'t access property "call", e[c] is undefined', [APP_FRAME, WEBPACK_FRAME], {
+      handled: false
+    });
+    const out = beforeSend(ev);
+    expect(out).not.toBeNull();
+    expect(out!.level).toBe("warning");
+    expect(out!.tags?.deploy_skew).toBe("true");
+    expect(out!.fingerprint).toEqual(["deploy-skew-auto-recovered"]);
+  });
+
+  it("reclassifies the Chrome webpack-factory rejection (reading 'call')", () => {
+    const ev = makeEvent("Cannot read properties of undefined (reading 'call')", [WEBPACK_FRAME], {
+      handled: false
+    });
+    const out = beforeSend(ev);
+    expect(out!.level).toBe("warning");
+    expect(out!.fingerprint).toEqual(["deploy-skew-auto-recovered"]);
+  });
+
+  it("reclassifies the Safari webpack-factory rejection (evaluating 'x.call')", () => {
+    const ev = makeEvent("undefined is not an object (evaluating 'e.call')", [WEBPACK_FRAME], {
+      handled: false
+    });
+    const out = beforeSend(ev);
+    expect(out!.level).toBe("warning");
+    expect(out!.fingerprint).toEqual(["deploy-skew-auto-recovered"]);
+  });
+
+  it("reclassifies chunk-load failures even with no stack frames", () => {
+    const ev = makeEvent("ChunkLoadError: Loading chunk 482 failed", [], { type: "ChunkLoadError" });
+    expect(beforeSend(ev)!.fingerprint).toEqual(["deploy-skew-auto-recovered"]);
+  });
+
+  it("does NOT reclassify a real `.call of undefined` app bug with no webpack frame", () => {
+    const ev = makeEvent("Cannot read properties of undefined (reading 'call')", [APP_FRAME]);
+    const out = beforeSend(ev);
+    expect(out).not.toBeNull();
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+});
+
+describe("beforeSend — RC exhaustion is dropped as expected user condition", () => {
+  it("drops the raw RPCError even when UNHANDLED (onunhandledrejection)", () => {
+    const ev = makeEvent(
+      "payer has not enough RC mana for transaction:has_mana: Account: ai-operator has 81178628 RC, needs 106812114 RC. Please wait to transact or power up HIVE.",
+      [],
+      { type: "RPCError", handled: false }
+    );
+    expect(beforeSend(ev)).toBeNull();
+  });
+
+  it("drops the legacy 'Insufficient Resource Credits' phrasing", () => {
+    expect(beforeSend(makeEvent("Insufficient Resource Credits"))).toBeNull();
+  });
+
+  it("drops the 'needs <N> RC' phrasing", () => {
+    expect(beforeSend(makeEvent("RPCError: ... has 1 RC, needs 248319953 RC ..."))).toBeNull();
+  });
+
+  it("keeps an ordinary application error untouched", () => {
+    const ev = makeEvent("TypeError: cannot read foo of bar", [APP_FRAME]);
+    expect(beforeSend(ev)).toBe(ev);
+  });
+});

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -95,6 +95,13 @@ describe("beforeSend — RC exhaustion is dropped as expected user condition", (
     expect(beforeSend(makeEvent("RPCError: ... has 1 RC, needs 248319953 RC ..."))).toBeNull();
   });
 
+  it("anchors has_mana to the assertion form (has_mana:) and does not over-filter a bare substring", () => {
+    expect(beforeSend(makeEvent("Assert Exception: transaction:has_mana: Account x"))).toBeNull();
+    // A future unrelated error merely containing the substring must NOT be dropped.
+    const unrelated = makeEvent("has_mana_check skipped", [APP_FRAME]);
+    expect(beforeSend(unrelated)).toBe(unrelated);
+  });
+
   it("keeps an ordinary application error untouched", () => {
     const ev = makeEvent("TypeError: cannot read foo of bar", [APP_FRAME]);
     expect(beforeSend(ev)).toBe(ev);

--- a/apps/web/src/utils/deploy-skew.ts
+++ b/apps/web/src/utils/deploy-skew.ts
@@ -1,0 +1,56 @@
+// Pure, framework-free matchers for deploy/version-skew errors — a client tab
+// running a build that no longer matches what the server serves. Kept React-free
+// so both the client Sentry config (sentry.client.config.ts) and the runtime
+// recovery component (features/pwa-install/service-worker-recovery.tsx) can share
+// them without the Sentry config pulling React into its early-loaded module graph.
+
+// Message patterns for a failed chunk / dynamic import — a stale cache or a
+// just-replaced build handing the client a chunk that no longer exists.
+export function isChunkLoadError(message?: string | null): boolean {
+  if (!message) {
+    return false;
+  }
+  return (
+    /ChunkLoadError/i.test(message) ||
+    /Loading chunk [\w-]+ failed/i.test(message) ||
+    /Loading CSS chunk/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /Importing a module script failed/i.test(message) ||
+    /Failed to fetch dynamically imported module/i.test(message)
+  );
+}
+
+// The webpack runtime was handed an undefined module factory: a chunk loaded but
+// references a module id the running runtime doesn't have — a build/version
+// mismatch after a deploy ("Cannot read properties of undefined (reading 'call')"
+// thrown from webpack-*.js, or the Safari equivalent). Require the webpack
+// runtime frame so this never fires on unrelated ".call of undefined" app bugs.
+function isWebpackFactoryError(error: { message?: string; stack?: string }): boolean {
+  const stack = error.stack ?? "";
+  const fromWebpackRuntime =
+    /webpack-[0-9a-f]+\.js/i.test(stack) || /webpack-internal/i.test(stack);
+  if (!fromWebpackRuntime) {
+    return false;
+  }
+  const message = error.message ?? "";
+  return (
+    /Cannot read propert(?:y|ies) of undefined \(reading 'call'\)/i.test(message) || // Chrome
+    /undefined is not an object \(evaluating '[^']*\.call'\)/i.test(message) || // Safari
+    /can't access property ['"]?call\b/i.test(message) || // Firefox (\b so it can't match "callback")
+    /'call' of undefined/i.test(message)
+  );
+}
+
+// True when the error indicates the client is running a build that no longer
+// matches what the server serves (chunk-load failures + webpack factory
+// mismatches). The cure is to reload onto the current build.
+export function isDeploySkewError(error: unknown): boolean {
+  if (typeof error === "string") {
+    return isChunkLoadError(error);
+  }
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const e = error as { message?: string; stack?: string };
+  return isChunkLoadError(e.message) || isWebpackFactoryError(e);
+}

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -1,0 +1,186 @@
+import type * as Sentry from "@sentry/nextjs";
+import { isEmptyCaptureEvent } from "./sentry-empty-capture";
+import { isDeploySkewError } from "./deploy-skew";
+
+// Derive the exact event type Sentry's `beforeSend` hook receives, so this stays
+// in lockstep with the SDK without a runtime import of @sentry/nextjs here.
+type SentryErrorEvent = Parameters<NonNullable<Sentry.BrowserOptions["beforeSend"]>>[0];
+
+/**
+ * The single Sentry `beforeSend` hook for the web client — the only place EVERY
+ * event passes through (render-boundary captures, global handlers, and the
+ * early-error buffer all funnel here). Extracted from sentry.client.config.ts so
+ * its filtering/reclassification rules are unit-testable.
+ *
+ * Returns the (possibly mutated) event to send, or `null` to drop it.
+ */
+export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
+  // Drop value-less captures — captureException(null/undefined/"") produces a
+  // synthetic exception with no message and no stack frames (zero actionable
+  // info, all grouped as the "<unknown>" issue). Only empty + frame-less
+  // events are dropped, so real errors (which always carry a stack or a
+  // message) are never lost. See sentry-empty-capture for the exact rule.
+  if (isEmptyCaptureEvent(event)) {
+    return null;
+  }
+
+  const exceptionType = event.exception?.values?.[0]?.type ?? "";
+  const message = event.exception?.values?.[0]?.value ?? "";
+  const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+  const stackStr = JSON.stringify(frames);
+
+  // Deploy/version skew: a stale tab requests a chunk whose module id changed in
+  // a newer build, so the webpack runtime is handed an undefined module factory
+  // (Chrome "reading 'call'", Firefox "e[c] is undefined", Safari "evaluating
+  // 'e[c].call'") or a dynamic import fails. The render-boundary paths
+  // (global-error.tsx, SentryErrorBoundary) already reclassify these to a single
+  // low-severity "deploy-skew-auto-recovered" issue and reload — but a skew error
+  // thrown from an async chunk import surfaces as `onunhandledrejection`, which
+  // Sentry's GlobalHandlers integration captures DIRECTLY, bypassing those
+  // boundaries and spawning a fresh error-level issue after every deploy. This is
+  // the only hook that sees that path, so reclassify here too into the SAME shape
+  // (so the events merge with the boundary-caught twin instead of grouping anew).
+  // isDeploySkewError matches on `stack`; beforeSend frames carry `filename`, so
+  // join them into a newline string. The webpack-<hash>.js frame requirement in
+  // the matcher keeps this off ordinary ".call of undefined" app bugs. We keep
+  // the event (at warning level) rather than dropping it so skew frequency and
+  // release-spread stay visible.
+  const skewCandidate = {
+    message,
+    stack: frames.map((f) => f.filename ?? "").join("\n")
+  };
+  if (isDeploySkewError(skewCandidate)) {
+    event.level = "warning";
+    event.tags = { ...event.tags, deploy_skew: "true" };
+    event.fingerprint = ["deploy-skew-auto-recovered"];
+    return event;
+  }
+
+  // ECENCY-NEXT-1AA7: an injected page script (pageHook.js / __mm__updateUrl)
+  // JSON.stringify'ing a DOM node. Gate on the injected-script frame so a real
+  // app-side circular-stringify bug (different frames) is still reported.
+  if (
+    /Converting circular structure to JSON/i.test(message) &&
+    /pageHook|__mm__/i.test(stackStr)
+  ) {
+    return null;
+  }
+
+  // Hive RC (Resource Credits) exhaustion is an EXPECTED user condition, never an
+  // Ecency bug: the user's own account is temporarily out of mana, so the chain
+  // rejects the broadcast. The node phrases it several ways ("payer has not enough
+  // RC mana ... has_mana", "Please wait to transact or power up HIVE", "needs <N>
+  // RC"); the app normalizes all of them to an "Insufficient Resource Credits"
+  // toast. Drop ALL of these regardless of the handled flag — un-awaited broadcast
+  // call sites (e.g. the vote slider) surface them as `onunhandledrejection`
+  // (handled=false), which the earlier "Insufficient Resource Credits"-only,
+  // handled-only guard never matched (the raw RPCError carries none of that text).
+  // None of these phrases appear in app code, so over-filter risk is nil.
+  if (
+    /has not enough RC mana|has_mana|Insufficient Resource Credits|Please wait to transact|needs \d+ RC/i.test(
+      message
+    )
+  ) {
+    return null;
+  }
+
+  // AbortController-induced timeouts (TimeoutError / AbortError) ship
+  // with no stack frames, so we can't tell which fetch is at fault.
+  // Walk recent breadcrumbs for the last in-flight fetch URL and tag
+  // the event so we can correlate timeouts to specific endpoints.
+  // Trigger only on the canonical AbortController error names plus the
+  // standard "signal timed out" phrase — a broader /aborted/i match
+  // would also tag unrelated paths (transaction aborts, stream aborts).
+  if (
+    (exceptionType === "TimeoutError" ||
+      exceptionType === "AbortError" ||
+      /signal timed out/i.test(message)) &&
+    !event.tags?.timeoutUrl
+  ) {
+    const crumbs = event.breadcrumbs ?? [];
+    for (let i = crumbs.length - 1; i >= 0; i--) {
+      const c = crumbs[i];
+      const rawUrl = (c.data as { url?: string } | undefined)?.url;
+      if (
+        (c.category === "fetch" || c.category === "xhr") &&
+        typeof rawUrl === "string"
+      ) {
+        // Strip query/hash before tagging — request URLs can carry
+        // tokens or identifiers we don't want as searchable telemetry.
+        let safeUrl: string;
+        try {
+          const parsed = new URL(rawUrl, window.location.origin);
+          safeUrl = `${parsed.origin}${parsed.pathname}`;
+        } catch {
+          safeUrl = rawUrl.split(/[?#]/)[0] ?? "";
+        }
+        if (safeUrl) {
+          event.tags = { ...event.tags, timeoutUrl: safeUrl.slice(0, 200) };
+        }
+        break;
+      }
+    }
+  }
+
+  // React SSR streaming hydration issue triggered by browser extensions
+  // ($RS is React's internal resumable script marker)
+  // Covers old Chrome ≤116 ("Cannot read property 'parentNode' of null"),
+  // new Chrome 117+ ("Cannot read properties of null (reading 'parentNode')"),
+  // Firefox ("can't access property \"parentNode\", a is null"), and
+  // Safari ("null is not an object (evaluating 'a.parentNode')") phrasings.
+  const isParentNodeNull =
+    message.includes("reading 'parentNode'") ||
+    message.includes("property 'parentNode'") ||
+    message.includes('"parentNode"') ||
+    /null is not an object \(evaluating '[a-z]\.parentNode'\)/.test(message);
+  if (isParentNodeNull && stackStr.includes("$RS")) {
+    return null;
+  }
+
+  // Firefox-specific iframe teardown error following a React hydration
+  // mismatch (#418) on profile pages. Symptom — when hydration fails,
+  // React tears down the tree and an iframe's contentWindow becomes null
+  // while some downstream code still tries to access .document on it.
+  // V8-based engines produce a different message for the same access
+  // (`Cannot read properties of null (reading 'document')`) so matching
+  // on the Firefox phrasing alone is engine-specific, but we *also*
+  // require browser=Firefox and a profile-page URL so unrelated iframe
+  // bugs in other surfaces aren't silently dropped. Sample 1% to keep
+  // trend visibility.
+  // TODO(hydration): investigate Firefox-only hydration drift on profile
+  // pages (`/@user/...`) — likely a locale/Date/Intl mismatch or a value
+  // that differs between SSR and the first client render.
+  // event.contexts is loosely typed by @sentry/types; coerce to string.
+  const browserName = String(event.contexts?.browser?.name ?? "");
+  const url = String(event.request?.url ?? "");
+  if (
+    message.includes("can't access property \"document\"") &&
+    message.includes("contentWindow is null") &&
+    /Firefox/i.test(browserName) &&
+    /\/@/.test(url) &&
+    Math.random() > 0.01
+  ) {
+    return null;
+  }
+
+  // Chrome botnet traffic - null/undefined document access from synthetic handler
+  if (
+    /Cannot read properties of (null|undefined) \(reading 'document'\)/.test(
+      message
+    ) &&
+    stackStr.includes("HTMLDocument.c")
+  ) {
+    return null;
+  }
+
+  // Network issues corrupting JS chunk downloads
+  if (
+    /^SyntaxError/.test(exceptionType) &&
+    /Unexpected (end of input|token)/.test(message) &&
+    /chunks?[/\\-]/.test(stackStr)
+  ) {
+    return null;
+  }
+
+  return event;
+}

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -77,7 +77,7 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
   // handled-only guard never matched (the raw RPCError carries none of that text).
   // None of these phrases appear in app code, so over-filter risk is nil.
   if (
-    /has not enough RC mana|has_mana|Insufficient Resource Credits|Please wait to transact|needs \d+ RC/i.test(
+    /has not enough RC mana|has_mana:|Insufficient Resource Credits|Please wait to transact|needs \d+ RC/i.test(
       message
     )
   ) {


### PR DESCRIPTION
## What

After a deploy, two families of client errors spiked in Sentry. Neither is a logic bug, but both were escaping the existing safeguards.

### 1. Webpack deploy-skew (stale tabs)
A tab on a previous build requests a code-split composer chunk (gif picker, video upload) whose module id changed in the new build, so the webpack runtime is handed an undefined module factory — `reading 'call'` (Chrome) / `e[c] is undefined` (Firefox) / `evaluating 'e.call'` (Safari).

`isDeploySkewError` already matches all three phrasings, and the render boundaries (`global-error`, `SentryErrorBoundary`) already reclassify these into a single low-severity `deploy-skew-auto-recovered` group. But when the failing chunk is an **async dynamic import**, the rejection surfaces as `onunhandledrejection` and is captured **directly** by Sentry's global handler — bypassing the boundaries and spawning a fresh error-level issue after every deploy.

**Fix:** wire the matcher into `beforeSend` (the one hook every event passes through) and reclassify into the **same** group, so these merge with the boundary-caught twin instead of grouping anew.

### 2. Resource-Credit exhaustion (expected user condition)
When a user's own account is out of Resource Credits, the chain rejects the broadcast (`...not enough RC mana...Please wait to transact`). This is expected, not an app bug — but:
- the vote slider `await`ed the broadcast with no `catch`, so the rejection escaped as an unhandled rejection (captured as a crash), and
- the existing filter keyed on `"Insufficient Resource Credits"`, which the **raw** RPCError never contains (and it gated on `handled !== false`).

**Fix:** broaden the filter to all phrasings (handled-agnostic), and catch the rejected vote at the call site so the user gets the friendly insufficient-RC toast via the existing `formatError` path.

## Changes
- `utils/deploy-skew.ts` *(new)* — skew matchers, extracted React-free so the client Sentry config can share them; re-exported from `service-worker-recovery` so existing imports are unchanged.
- `utils/sentry-before-send.ts` *(new)* — `beforeSend` extracted for testability; adds skew reclassification + broadened RC drop.
- `sentry.client.config.ts` — now imports the extracted `beforeSend`.
- `entry-vote-btn/index.tsx` — graceful `try/catch` → classified toast.
- `utils/sentry-before-send.spec.ts` *(new)* — regression tests for both behaviors.

## Notes
- The skew reclassification mirrors the existing render-boundary behavior (no release gate; the webpack-runtime-frame requirement keeps it off ordinary `.call of undefined` app bugs). The release tag rides along on the event, so a genuine bug on the live build vs. skew across releases is still distinguishable by release spread.
- This stops the **vote** path's RC rejection from being unhandled; wallet/waves broadcast paths are still unhandled but are now dropped from Sentry by the broadened filter — surfacing their friendly toast is a follow-up.
- The deeper source-level fix for skew (retaining previous builds' immutable `/_next/static` chunks across deploys so stale tabs can still fetch their old chunk) is infra-side and out of scope here.

## Testing
- `vitest run` — full web suite green, including 9 new `beforeSend` specs.
- lint + typecheck clean on touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vote submission failures now keep the dialog open instead of closing unexpectedly, allowing users to adjust and retry their submission.

* **Improvements**
  * Enhanced error diagnostics and filtering provides more accurate error reporting and troubleshooting information.
  * Improved detection of deployment-related version inconsistencies to handle build updates more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->