### PR TITLE
perf(web): tree-shake shared barrel + lazy tip Transfer — evict write-flow from read pages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,13 @@
   "version": "4.3.9",
   "private": true,
   "packageManager": "pnpm@11.5.0",
+  "sideEffects": [
+    "**/*.scss",
+    "**/*.css",
+    "**/core/sdk-init.ts",
+    "**/polyfills.ts",
+    "**/features/pwa-install/**"
+  ],
   "scripts": {
     "prepare": "next-ws patch",
     "dev": "node ./node_modules/next/dist/bin/next dev",

--- a/apps/web/src/features/shared/entry-tip-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-tip-btn/index.tsx
@@ -4,9 +4,20 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 
 import React, { useMemo, useState } from "react";
 import "./_index.scss";
+import dynamic from "next/dynamic";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import { Account, Entry } from "@/entities";
-import { LoginRequired, Transfer } from "@/features/shared";
+import { LoginRequired } from "@/features/shared/login-required";
+
+// The tip transfer modal is interaction-gated (renders only when the dialog
+// opens) and drags the write-flow → @ecency/wallets → bip39 graph. Load it
+// lazily so that heavy chunk stays off the eager feed/profile/community read
+// path (it was previously pulled in eagerly via EntryVoteBtn → EntryVoteDialog
+// → EntryTipBtn). ssr:false is correct: it never renders during SSR.
+const Transfer = dynamic(
+  () => import("@/features/shared/transfer").then((m) => ({ default: m.Transfer })),
+  { ssr: false }
+);
 import { Tooltip } from "@ui/tooltip";
 import i18next from "i18next";
 import { giftOutlineSvg } from "@ui/svg";

--- a/apps/web/src/features/shared/entry-tip-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-tip-btn/index.tsx
@@ -8,16 +8,6 @@ import dynamic from "next/dynamic";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import { Account, Entry } from "@/entities";
 import { LoginRequired } from "@/features/shared/login-required";
-
-// The tip transfer modal is interaction-gated (renders only when the dialog
-// opens) and drags the write-flow → @ecency/wallets → bip39 graph. Load it
-// lazily so that heavy chunk stays off the eager feed/profile/community read
-// path (it was previously pulled in eagerly via EntryVoteBtn → EntryVoteDialog
-// → EntryTipBtn). ssr:false is correct: it never renders during SSR.
-const Transfer = dynamic(
-  () => import("@/features/shared/transfer").then((m) => ({ default: m.Transfer })),
-  { ssr: false }
-);
 import { Tooltip } from "@ui/tooltip";
 import i18next from "i18next";
 import { giftOutlineSvg } from "@ui/svg";
@@ -27,6 +17,23 @@ import { EcencyConfigManager } from "@/config";
 import { PostTipsResponse } from "@ecency/sdk";
 import { Popover, PopoverContent } from "@/features/ui";
 import { formattedNumber } from "@/utils";
+
+// The tip transfer modal is interaction-gated (renders only when the dialog
+// opens) and drags the write-flow → @ecency/wallets → bip39 graph. Load it
+// lazily so that heavy chunk stays off the eager feed/profile/community read
+// path (previously pulled in eagerly via EntryVoteBtn → EntryVoteDialog →
+// EntryTipBtn). ssr:false is correct: it never renders during SSR.
+const Transfer = dynamic(
+  () => import("@/features/shared/transfer").then((m) => ({ default: m.Transfer })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex items-center justify-center min-h-40 opacity-60">
+        {i18next.t("g.loading")}
+      </div>
+    )
+  }
+);
 
 interface Props {
   entry: Entry;


### PR DESCRIPTION
## What

Read-only **feed / profile / community** pages were loading the entire write-flow graph (`transfer`/`transactions`/`market`/`promote`/`boost` + `@ecency/wallets`) via two paths:
1. The `@/features/shared` `export *` mega-barrel — webpack couldn't tree-shake the unused re-exports because `apps/web` had **no `sideEffects` flag**, so importing one read symbol dragged the whole concatenated namespace.
2. `EntryTipBtn` rendering `<Transfer>` **eagerly** off the `EntryVoteBtn → EntryVoteDialog` path.

## Change (2 edits)

- **`apps/web/package.json`** — scoped `sideEffects` array so webpack tree-shakes unused barrel re-exports app-wide (also clears the residual `_components` barrel from #895). Whitelists the only three side-effect-only modules that must not be pruned:
  `["**/*.scss","**/*.css","**/core/sdk-init.ts","**/polyfills.ts","**/features/pwa-install/**"]`
  (`core/sdk-init` does module-top `ConfigManager.setHiveNodes/setApiHost/setDmca…`; pruning it would silently break the SDK app-wide — hence the whitelist.)
- **`entry-tip-btn`** — lazy-load `<Transfer>` via `next/dynamic(ssr:false)`; it only renders when the tip dialog opens.

## Measured (production `ANALYZE` build)

| Read route | First Load JS before → after |
|---|---|
| `/feed/[...sections]` | 1.03 MB → **829 KB** (−200 KB) |
| `/community/[community]` | 1.03 MB → **955 KB** (−75 KB) |
| `/profile/[username]` | 1.04 MB → **979 KB** (−61 KB) |

`transfer`/`transactions`/`market`/`@ecency/wallets` confirmed gone from the read-page chunks (moved to lazy chunks). Verified statically that `sdk-init`/`polyfills`/`pwa-install` still exist in the build.

## Scope / follow-up

- **In scope:** the barrel tree-shaking (structural, app-wide) + the eager-Transfer eviction.
- **Out of scope (next PR):** the **bip39 wordlists (~220 KB)** still load on read pages — pulled by the global **login-by-key** flow (`key-input` / `use-login-by-key` → `@ecency/wallets`), not the barrel. Evicting it means lazy-loading the login-by-key path (and/or swapping to `@scure/bip39`); separate change, touches auth.

## ⚠️ Required before merge — runtime smoke test

Scoped `sideEffects` changes whole-app tree-shaking, and the dangerous failure mode (a mis-whitelisted glob silently pruning `sdk-init`) is **invisible to CI/vitest** (vitest doesn't tree-shake). Please smoke-test a production build before merging:
- [ ] Hive RPC works (feed/post loads, votes)
- [ ] Login by key + Keychain
- [ ] Transfer / tip dialog opens and works
- [ ] Market swap
- [ ] PWA install prompt
- [ ] DMCA / blacklist filtering active
