### PR TITLE
fix(sentry): separate staging environment + reclassify $RS hydration-resume noise

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,6 +67,7 @@ jobs:
             SENTRY_ORG=ecency
             SENTRY_PROJECT=ecency-next
             SENTRY_RELEASE=ecency-next@${{ github.sha }}
+            SENTRY_ENVIRONMENT=production
             NEXT_PUBLIC_GMAPS_API_KEY=${{ secrets.GMAPS_API_KEY }}
             NEXT_PUBLIC_GMAPS_MAP_ID=${{ secrets.GMAPS_MAP_ID }}
             PNPM_VERSION=10.18.1

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -68,6 +68,7 @@ jobs:
             SENTRY_ORG=ecency
             SENTRY_PROJECT=ecency-next
             SENTRY_RELEASE=ecency-next@${{ github.sha }}
+            SENTRY_ENVIRONMENT=staging
             NEXT_PUBLIC_GMAPS_API_KEY=${{ secrets.GMAPS_API_KEY }}
             NEXT_PUBLIC_GMAPS_MAP_ID=${{ secrets.GMAPS_MAP_ID }}
             PNPM_VERSION=10.18.1

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -34,10 +34,14 @@ ARG SENTRY_PROJECT
 # Sentry.init agree on the same release identifier — even when the
 # package.json version is unchanged across deploys.
 ARG SENTRY_RELEASE
+# Deploy target ("staging" for alpha, "production" for prod). Inlined into the
+# client bundle at build time (next.config.js `env`) and read by Sentry.init.
+ARG SENTRY_ENVIRONMENT
 ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
 ENV SENTRY_ORG=${SENTRY_ORG}
 ENV SENTRY_PROJECT=${SENTRY_PROJECT}
 ENV SENTRY_RELEASE=${SENTRY_RELEASE}
+ENV SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}
 ENV SENTRY_LOG_LEVEL=debug
 
 # Single build that emits the EXACT assets we ship
@@ -73,6 +77,10 @@ ENV NODE_ENV=production
 # build) and server (tagged at runtime).
 ARG SENTRY_RELEASE
 ENV SENTRY_RELEASE=${SENTRY_RELEASE}
+# Same for the environment label, so the server/edge runtimes tag events with
+# the same staging/production value the client bundle was built with.
+ARG SENTRY_ENVIRONMENT
+ENV SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}
 
 # Copy runtime artifacts from the single build
 COPY --from=base /var/app/package.json ./package.json

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -99,7 +99,10 @@ const config = {
   // (which trips Next's env schema). When absent, Sentry.init falls back
   // to package.json version via `process.env.SENTRY_RELEASE ?? appPackage.version`.
   env: {
-    ...(process.env.SENTRY_RELEASE && { SENTRY_RELEASE: process.env.SENTRY_RELEASE })
+    ...(process.env.SENTRY_RELEASE && { SENTRY_RELEASE: process.env.SENTRY_RELEASE }),
+    // Same treatment for SENTRY_ENVIRONMENT so the client bundle can tag
+    // staging (alpha) vs production. Conditionally spread for the same reason.
+    ...(process.env.SENTRY_ENVIRONMENT && { SENTRY_ENVIRONMENT: process.env.SENTRY_ENVIRONMENT })
   },
   htmlLimitedBots:
     /Mediapartners-Google|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti/,

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -18,6 +18,15 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
   // bundle via the `env` block in next.config.js.
   release: process.env.SENTRY_RELEASE ?? appPackage.version,
 
+  // Distinguish staging (alpha) from production. Alpha runs an otherwise
+  // identical prod build (same DSN, NODE_ENV=production, often the same commit
+  // SHA), so without this label its errors are tagged "production" and trip the
+  // prod "Critical errors" alert + eat prod quota. CI stamps SENTRY_ENVIRONMENT
+  // per deploy (staging.yml="staging", master.yml="production"); inlined into
+  // the client bundle via the `env` block in next.config.js. Defaults to
+  // "production" for local/unset builds.
+  environment: process.env.SENTRY_ENVIRONMENT ?? "production",
+
   tracesSampleRate: 0,
   integrations: (defaults) =>
     defaults.filter((i) => i.name !== "BrowserTracing"),

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -23,9 +23,12 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
   // SHA), so without this label its errors are tagged "production" and trip the
   // prod "Critical errors" alert + eat prod quota. CI stamps SENTRY_ENVIRONMENT
   // per deploy (staging.yml="staging", master.yml="production"); inlined into
-  // the client bundle via the `env` block in next.config.js. Defaults to
-  // "production" for local/unset builds.
-  environment: process.env.SENTRY_ENVIRONMENT ?? "production",
+  // the client bundle via the `env` block in next.config.js. Falls back to
+  // NODE_ENV (so a locally-run prod build is tagged "development", not
+  // "production") then "production". `||` (not `??`) so an empty
+  // SENTRY_ENVIRONMENT — an unset ARG in a non-CI Docker build yields `ENV=""` —
+  // also falls through instead of tagging events with an empty environment.
+  environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "production",
 
   tracesSampleRate: 0,
   integrations: (defaults) =>

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -20,8 +20,10 @@ Sentry.init({
 
   // Tag staging (alpha) vs production so staging noise doesn't trip the prod
   // "Critical errors" alert. Set via the Dockerfile ENV from CI
-  // (staging.yml="staging"); defaults to "production".
-  environment: process.env.SENTRY_ENVIRONMENT ?? "production",
+  // (staging.yml="staging"). `||` chain falls back to NODE_ENV then "production",
+  // and treats an empty SENTRY_ENVIRONMENT (unset ARG in a non-CI build) as unset
+  // (an empty `ENV` would otherwise survive `??` and tag events with "").
+  environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "production",
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -18,6 +18,11 @@ Sentry.init({
   // that don't bump the package.json version.
   release: process.env.SENTRY_RELEASE ?? appPackage.version,
 
+  // Tag staging (alpha) vs production so staging noise doesn't trip the prod
+  // "Critical errors" alert. Set via the Dockerfile ENV from CI
+  // (staging.yml="staging"); defaults to "production".
+  environment: process.env.SENTRY_ENVIRONMENT ?? "production",
+
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   _experiments: { enableLogs: true },

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -19,6 +19,10 @@ Sentry.init({
   // source-map upload and runtime tagging stay aligned across deploys
   // that don't bump the package.json version.
   release: process.env.SENTRY_RELEASE ?? appPackage.version,
+  // Tag staging (alpha) vs production so staging noise doesn't trip the prod
+  // "Critical errors" alert. Set via the Dockerfile ENV from CI
+  // (staging.yml="staging"); defaults to "production".
+  environment: process.env.SENTRY_ENVIRONMENT ?? "production",
   integrations: [nodeProfilingIntegration()],
   _experiments: { enableLogs: true },
   ignoreErrors: [

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -21,8 +21,10 @@ Sentry.init({
   release: process.env.SENTRY_RELEASE ?? appPackage.version,
   // Tag staging (alpha) vs production so staging noise doesn't trip the prod
   // "Critical errors" alert. Set via the Dockerfile ENV from CI
-  // (staging.yml="staging"); defaults to "production".
-  environment: process.env.SENTRY_ENVIRONMENT ?? "production",
+  // (staging.yml="staging"). `||` chain falls back to NODE_ENV then "production",
+  // and treats an empty SENTRY_ENVIRONMENT (unset ARG in a non-CI build) as unset
+  // (an empty `ENV` would otherwise survive `??` and tag events with "").
+  environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "production",
   integrations: [nodeProfilingIntegration()],
   _experiments: { enableLogs: true },
   ignoreErrors: [

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -107,3 +107,37 @@ describe("beforeSend — RC exhaustion is dropped as expected user condition", (
     expect(beforeSend(ev)).toBe(ev);
   });
 });
+
+describe("beforeSend — $RS hydration-resume reclassification", () => {
+  // A React #418 text mismatch regenerates the subtree; React's $RS streaming-
+  // resume script then throws on the removed node. Self-healed noise — reclassify
+  // to one fingerprinted warning (NOT dropped), so a genuine hydration regression
+  // still surfaces. Sentry groups $RS by the permlink, so the frame carries it.
+  const RS_FRAME = {
+    function: "$RS",
+    filename: "app:///@storicious/re-barski-202662t14550715z"
+  } as unknown as { filename?: string };
+
+  it("reclassifies Firefox minified 'b is null' inside a $RS frame", () => {
+    const out = beforeSend(makeEvent("b is null", [RS_FRAME]));
+    expect(out).not.toBeNull();
+    expect(out!.level).toBe("warning");
+    expect(out!.tags?.hydration_autorecovered).toBe("true");
+    expect(out!.fingerprint).toEqual(["hydration-rs-autorecovered"]);
+  });
+
+  it("reclassifies the Chrome 117+ parentNode-null phrasing inside $RS", () => {
+    const out = beforeSend(
+      makeEvent("Cannot read properties of null (reading 'parentNode')", [RS_FRAME])
+    );
+    expect(out!.fingerprint).toEqual(["hydration-rs-autorecovered"]);
+    expect(out!.level).toBe("warning");
+  });
+
+  it("does NOT touch a real 'b is null' app bug with no $RS frame", () => {
+    const ev = makeEvent("b is null", [APP_FRAME]);
+    expect(beforeSend(ev)).toBe(ev);
+    expect(ev.level).toBeUndefined();
+    expect(ev.fingerprint).toBeUndefined();
+  });
+});

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -126,12 +126,28 @@ describe("beforeSend — $RS hydration-resume reclassification", () => {
     expect(out!.fingerprint).toEqual(["hydration-rs-autorecovered"]);
   });
 
-  it("reclassifies the Chrome 117+ parentNode-null phrasing inside $RS", () => {
+  it("reclassifies the Chrome MINIFIED single-letter null read inside $RS", () => {
+    // Exercises the isMinifiedNull second branch specifically (the minified
+    // resume var, not the literal 'parentNode' covered by isParentNodeNull).
+    const out = beforeSend(makeEvent("Cannot read properties of null (reading 'b')", [RS_FRAME]));
+    expect(out!.fingerprint).toEqual(["hydration-rs-autorecovered"]);
+    expect(out!.level).toBe("warning");
+  });
+
+  it("reclassifies the literal parentNode-null phrasing inside $RS (isParentNodeNull)", () => {
     const out = beforeSend(
       makeEvent("Cannot read properties of null (reading 'parentNode')", [RS_FRAME])
     );
     expect(out!.fingerprint).toEqual(["hydration-rs-autorecovered"]);
-    expect(out!.level).toBe("warning");
+  });
+
+  it("does NOT over-match a multi-char null read even with a $RS frame", () => {
+    // The narrowed single-char regex must leave a real "(reading 'document')"
+    // bug as an error, even if a $RS frame happens to be on the stack.
+    const ev = makeEvent("Cannot read properties of null (reading 'document')", [RS_FRAME]);
+    expect(beforeSend(ev)).toBe(ev);
+    expect(ev.level).toBeUndefined();
+    expect(ev.fingerprint).toBeUndefined();
   });
 
   it("does NOT touch a real 'b is null' app bug with no $RS frame", () => {

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -147,7 +147,11 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
     /null is not an object \(evaluating '[a-z]\.parentNode'\)/.test(message);
   const isMinifiedNull =
     /^[a-z] is null$/i.test(message) || // Firefox minified "b is null"
-    /Cannot read properties of null \(reading '[\w$]+'\)/.test(message); // Chrome minified twin
+    // Chrome minified twin — single-char property name only (the $RS resume var
+    // is minified to one letter, e.g. "reading 'b'"). Multi-char names like
+    // 'document'/'innerHTML' are intentionally NOT matched, so an unrelated
+    // null-access that merely co-occurs with a $RS frame stays a real error.
+    /Cannot read properties of null \(reading '[a-z$]'\)/i.test(message);
   if ((isParentNodeNull || isMinifiedNull) && stackStr.includes("$RS")) {
     event.level = "warning";
     event.tags = { ...event.tags, hydration_autorecovered: "true" };

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -122,19 +122,37 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
     }
   }
 
-  // React SSR streaming hydration issue triggered by browser extensions
-  // ($RS is React's internal resumable script marker)
-  // Covers old Chrome ≤116 ("Cannot read property 'parentNode' of null"),
-  // new Chrome 117+ ("Cannot read properties of null (reading 'parentNode')"),
-  // Firefox ("can't access property \"parentNode\", a is null"), and
-  // Safari ("null is not an object (evaluating 'a.parentNode')") phrasings.
+  // React 19 SSR streaming-resume ($RS) crash that FOLLOWS a hydration mismatch.
+  // React #418 (text-content mismatch — commonly a browser extension or
+  // auto-translate rewriting text on legacy/non-English browsers, or a residual
+  // SSR locale/Date drift) tears the subtree down and regenerates it CLIENT-SIDE,
+  // so the user still gets a working page; React's $RS inline resume script then
+  // can't find its now-removed node and throws. Phrasings seen across engines:
+  //   Chrome ≤116  "Cannot read property 'parentNode' of null"
+  //   Chrome 117+  "Cannot read properties of null (reading 'parentNode')"
+  //   Firefox      `can't access property "parentNode", a is null`
+  //   Firefox min. "b is null"  (the resume var is minified to a single letter)
+  //   Safari       "null is not an object (evaluating 'a.parentNode')"
+  // RECLASSIFY (not drop) to ONE low-severity, fingerprinted issue. Sentry groups
+  // $RS by the permlink in its argument, so each post page would otherwise spawn a
+  // fresh error-level issue. Reclassifying stops that per-permlink spam and marks
+  // it auto-recovered, while leaving the underlying #418 fully visible — so a
+  // GENUINE hydration regression would still surface as a spike on this
+  // fingerprint across many users/pages. The $RS-frame requirement keeps this off
+  // ordinary null-access app bugs (those have no $RS in the stack).
   const isParentNodeNull =
     message.includes("reading 'parentNode'") ||
     message.includes("property 'parentNode'") ||
     message.includes('"parentNode"') ||
     /null is not an object \(evaluating '[a-z]\.parentNode'\)/.test(message);
-  if (isParentNodeNull && stackStr.includes("$RS")) {
-    return null;
+  const isMinifiedNull =
+    /^[a-z] is null$/i.test(message) || // Firefox minified "b is null"
+    /Cannot read properties of null \(reading '[\w$]+'\)/.test(message); // Chrome minified twin
+  if ((isParentNodeNull || isMinifiedNull) && stackStr.includes("$RS")) {
+    event.level = "warning";
+    event.tags = { ...event.tags, hydration_autorecovered: "true" };
+    event.fingerprint = ["hydration-rs-autorecovered"];
+    return event;
   }
 
   // Firefox-specific iframe teardown error following a React hydration


### PR DESCRIPTION
## What

Two Sentry observability-hygiene fixes — so staging stops tripping production alerts, and a self-healed hydration crash stops spawning a fresh issue per page.

### 1. Separate the staging Sentry environment
`sentry.{client,server,edge}.config.ts` set `release` but never set `environment`, so it defaulted to `"production"` for **both** staging and prod (same DSN, `NODE_ENV=production`, often the same release SHA). Staging errors were indistinguishable from production and counted toward production alerts + error quota.

- CI now stamps `SENTRY_ENVIRONMENT` per deploy: `staging.yml` → `staging`, `master.yml` → `production`.
- Threaded through the `Dockerfile` (both build stages, mirroring `SENTRY_RELEASE`) and inlined into the client bundle via the `next.config.js` `env` block.
- Defaults to `"production"` for local/unset builds.

### 2. Reclassify the `$RS` streaming-resume crash (don't drop it)
A React #418 text-content hydration mismatch makes React regenerate the subtree on the client (the page still renders); React 19's `$RS` streaming-resume script then throws on the now-removed node (`b is null` / `…parentNode…`). Sentry groups `$RS` by the permlink, so each page spawns a fresh **error-level** issue.

This folds them into one low-severity, fingerprinted `hydration-rs-auto-recovered` issue, gated on a `$RS` frame — **leaving the underlying #418 fully visible** so a genuine hydration regression still surfaces as a spike. Replaces the prior silent `return null` of the `parentNode` variant: we reclassify rather than mask.

## Tests
- `beforeSend` spec: 13/13 (3 new for `$RS`, incl. a guard that a real `b is null` app bug with no `$RS` frame is left untouched).
- `tsc --noEmit` + `next lint` clean on changed files.

## Follow-up (manual — Sentry UI, API token is read-only)
Scope the "Critical errors" metric alert to `environment:production` (and ideally `level:error`) so staging + reclassified warnings no longer count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-based error tracking to distinguish between staging and production environments in error reports
  * Improved handling of auto-recovered hydration errors for better visibility

* **Tests**
  * Added test coverage for hydration error reclassification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->