### PR TITLE
feat(entry): merge post title into author card for prominence

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-ssr.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-ssr.tsx
@@ -21,16 +21,11 @@ interface Props {
 export function EntryPageContentSSR({ entry, isRawContent }: Props) {
   const location = useEntryLocation(entry);
   const postPoll = useEntryPollExtractor(entry);
-  const isComment = !!entry.parent_author;
   return (
     <>
       <div className="entry-header">
         <EntryPageWarnings entry={entry} />
         <EntryPageIsCommentHeader entry={entry} />
-        {!isComment && <h1 className=" px-2 lg:px-0 text-xl sm:text-2xl md:text-[32px] lg:text-[42px] !leading-[1.5] mt-4 mb-6 break-words !font-[var(--font-lora)]">
-          {entry.title}
-        </h1>
-        }
         <EntryPageMainInfo entry={entry} />
       </div>
       {/* SSR static body - wrapped with NSFW check */}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-main-info.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-main-info.tsx
@@ -24,6 +24,11 @@ export function EntryPageMainInfo({ entry }: Props) {
 
   return (
     <div className=" bg-white/80 dark:bg-dark-200/90 rounded-xl flex flex-col mb-4 md:mb-6 lg:mb-8 mt-2 lg:mt-4">
+      {!isComment && (
+        <h1 className="px-3 md:px-4 pt-3 md:pt-4 pb-1 text-2xl md:text-[30px] lg:text-[38px] font-semibold !leading-[1.25] break-words !font-[var(--font-lora)]">
+          {entry.title}
+        </h1>
+      )}
       <div className="p-2 md:p-3 grid grid-cols-1 sm:grid-cols-[1fr_max-content] w-full items-end gap-2">
         <div className="flex items-center gap-2 md:gap-3 truncate overflow-hidden">
           <ProfileLink username={entry.author}>

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-pending-index-view.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-pending-index-view.tsx
@@ -68,7 +68,7 @@ export function EntryPendingIndexView({ entry, isTimedOut }: Props) {
                 </div>
               </div>
 
-              <h1 className="px-2 lg:px-0 text-xl sm:text-2xl md:text-[32px] lg:text-[42px] !leading-[1.5] mt-4 mb-6 break-words !font-[var(--font-lora)]">
+              <h1 className="px-2 lg:px-0 text-2xl md:text-[30px] lg:text-[38px] font-semibold !leading-[1.25] mt-4 mb-6 break-words !font-[var(--font-lora)]">
                 {entry.title}
               </h1>
 


### PR DESCRIPTION
## Summary

The post title on the single-entry page rendered as a standalone `<h1>` sitting on the page's gradient background, visually detached from the solid white author/stats card below it. This made the title look faded and "in the background" rather than reading as the page heading.

This PR moves the title **into the top of the author card** so it shares the same solid surface as the author, community, and stats rows — reading as one cohesive header block. The title is bumped to **semibold** with tighter leading so it stands out.

## Changes

- **`entry-page-main-info.tsx`** — render the post title `<h1>` as the first section inside the author card (posts only, not comments), `font-semibold` + `leading-[1.25]`.
- **`entry-page-content-ssr.tsx`** — remove the old standalone `<h1>` (and the now-unused `isComment` local); the card-embedded title replaces it.
- **`entry-pending-index-view.tsx`** — align the transient "indexing" view's title to the same weight/size for consistency.

## SEO / structure

- The title remains the page's **single `<h1>`** with the post title text — verified one `<h1>` in rendered HTML.
- `<title>` and `og:title` unchanged; JSON-LD structured data intact.
- Moving the `<h1>` within the DOM has no SEO/a11y impact; the document outline is unchanged.

## Testing

Verified locally (dev server) at desktop and mobile widths: title renders bold inside the white author card on both, body and stats unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redundant title display for comment entries.

* **Style**
  * Updated entry title styling for improved visual hierarchy and readability across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->