### PR TITLE
perf(web): bound similar-entries client fetch, lazy comment composer, fix emoji loading

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-discussions.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-discussions.tsx
@@ -5,7 +5,7 @@ import { CommentEngagement } from "@/app/(dynamicPages)/entry/[category]/[author
 import { EcencyConfigManager } from "@/config";
 import { EcencyEntriesCacheManagement, getCommunityCache } from "@/core/caches";
 import { Entry, Community } from "@/entities";
-import { Discussion } from "@/features/shared";
+import { Discussion } from "@/features/shared/discussion";
 import { useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 import { EntryReplySection } from "./entry-reply-section";

--- a/apps/web/src/features/shared/discussion/discussion-item.tsx
+++ b/apps/web/src/features/shared/discussion/discussion-item.tsx
@@ -35,9 +35,17 @@ import { StyledTooltip } from "@ui/tooltip";
 import i18next from "i18next";
 import { memo, useEffect, useMemo, useState, type ReactNode } from "react";
 import appPackage from "../../../../package.json";
+import dynamic from "next/dynamic";
 import { Tsx } from "../../i18n/helper";
-import { Comment } from "../comment";
 import { EntryLink } from "../entry-link";
+
+// The reply/edit composer (markdown editor toolbar, emoji/GIF pickers, textarea
+// autocomplete, polls/video upload) only renders behind the reply/edit toggles
+// below. Load it lazily so the SSR'd comment list doesn't pull the whole
+// composer into the post page's first-load bundle.
+const Comment = dynamic(() => import("../comment").then((m) => ({ default: m.Comment })), {
+  ssr: false
+});
 import { DiscussionBots } from "./discussion-bots";
 import { DiscussionItemBody } from "./discussion-item-body";
 import { DiscussionList } from "./discussion-list";

--- a/apps/web/src/features/shared/index.ts
+++ b/apps/web/src/features/shared/index.ts
@@ -38,7 +38,11 @@ export * from "./entry-reblog-btn";
 export * from "./message-no-data";
 export * from "./entry-info";
 export * from "./bookmark-btn";
-export * from "./discussion";
+// NOTE: ./discussion is intentionally NOT re-exported from this barrel. The
+// Discussion tree (DiscussionList -> DiscussionItem) imports the reply/edit
+// composer, so re-exporting it here dragged that whole path into any page that
+// imports an unrelated symbol from this barrel. Import it directly:
+// `import { Discussion } from "@/features/shared/discussion"`.
 export * from "./entry-delete-btn";
 // NOTE: ./comment (the reply/edit composer) is intentionally NOT re-exported from
 // this barrel. It pulls the markdown editor toolbar, emoji/GIF pickers, textarea

--- a/packages/sdk/src/modules/search/queries/get-similar-entries-query-options.spec.ts
+++ b/packages/sdk/src/modules/search/queries/get-similar-entries-query-options.spec.ts
@@ -191,13 +191,21 @@ describe("getSimilarEntriesQueryOptions", () => {
     expect(payload.tags).toEqual([]);
   });
 
-  it("throws when the request fails so React Query can retry", async () => {
+  it("throws on a failed request so the error surfaces (the strip then hides)", async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
 
     const options = getSimilarEntriesQueryOptions(entry);
     await expect(
       (options.queryFn as QueryFn)({ signal: undefined })
     ).rejects.toThrow(/500/);
+  });
+
+  it("disables retry so a degraded backend can't retry-storm into a long tail", () => {
+    // Regression: the client path had no per-request timeout (fell through to the
+    // SDK's INTERNAL_API_TIMEOUT_MS) and React Query's default client retry (3×)
+    // turned a /search-api/similar outage into a ~29s post-onload tail. This is a
+    // best-effort strip — one attempt, then hide.
+    expect(getSimilarEntriesQueryOptions(entry).retry).toBe(false);
   });
 
   it("exposes a shared min-render threshold of 2", () => {

--- a/packages/sdk/src/modules/search/queries/get-similar-entries-query-options.ts
+++ b/packages/sdk/src/modules/search/queries/get-similar-entries-query-options.ts
@@ -17,11 +17,20 @@ const SIMILAR_ENTRIES_TARGET = 3;
 const SIMILAR_ENTRIES_BODY_LIMIT = 3000;
 
 // On the server the prefetch sits on the entry-page render path, and the search
-// backend is single-region (EU) — so a slow cross-region call (US/SG origins)
-// would stall SSR. Cap the server-side call short and let the strip fall back to
-// a client fetch (only that render misses the in-HTML strip; it's ISR-cached
-// anyway). The client keeps the normal timeout since its fetch doesn't block.
+// backend is single-region (EU) — so anything slower than this stalls SSR for a
+// non-essential "related posts" strip. Keep the SSR cap short and let the strip
+// fall back to a client fetch (only that render misses the in-HTML strip; it's
+// ISR-cached anyway). Do NOT raise this — 2s is the SSR budget.
 const SIMILAR_ENTRIES_SSR_TIMEOUT_MS = 2000;
+
+// The client fetch doesn't block paint, so it previously had no cap and fell
+// through to the SDK's generic INTERNAL_API_TIMEOUT_MS (10s; CF's worker further
+// truncates at ~8s). Combined with React Query's default client retry (3×), a
+// /search-api/similar outage turned this best-effort strip into a multi-second
+// post-onload tail (observed as a ~29s "fully loaded" in GTmetrix). Cap the
+// client call short and disable retry (below) so a degraded backend just hides
+// the strip quickly instead of churning.
+const SIMILAR_ENTRIES_CLIENT_TIMEOUT_MS = 4000;
 
 // The strip is hidden below this many results. A lone suggestion looks
 // sparse. Exported so the web component shares one threshold (filter == render).
@@ -102,8 +111,11 @@ export function getSimilarEntriesQueryOptions(entry: Entry) {
         },
         signal,
         // Short cap server-side so a slow cross-region call can't stall SSR;
-        // the client keeps the default (non-blocking, can wait for results).
-        typeof window === "undefined" ? SIMILAR_ENTRIES_SSR_TIMEOUT_MS : undefined
+        // a slightly longer (but still bounded) cap client-side so a degraded
+        // backend can't hang the request on the SDK's generic 8s timeout.
+        typeof window === "undefined"
+          ? SIMILAR_ENTRIES_SSR_TIMEOUT_MS
+          : SIMILAR_ENTRIES_CLIENT_TIMEOUT_MS
       );
 
       // Light client guard mirroring the render contract: never the source
@@ -120,6 +132,10 @@ export function getSimilarEntriesQueryOptions(entry: Entry) {
       }
 
       return collected;
-    }
+    },
+    // Best-effort suggestions strip — never retry-storm a degraded backend.
+    // The web QueryClient sets retry:false globally, but other SDK consumers
+    // (e.g. mobile) may not, so pin it here too.
+    retry: false
   });
 }


### PR DESCRIPTION
Three follow-ups to the barrel / lazy-load work in #850:

- **similar-entries**: the client fetch had no per-request timeout and fell through to the SDK's generic internal API timeout (10s; the edge truncates ~8s). With React Query's default client retry, a brief `/search-api/similar` backend hiccup turned into a multi-second post-onload tail. Cap the client call at 4s and disable retry (best-effort "related posts" strip). SSR cap stays 2s (the SSR render budget).
- **discussion**: stop re-exporting `./discussion` from the `@/features/shared` barrel and lazy-load the reply/edit composer inside `DiscussionItem` (`next/dynamic`, `ssr:false`). The SSR'd comment list no longer pulls the markdown editor toolbar, emoji/GIF pickers, textarea-autocomplete, polls and video upload into the post page's first-load. Completes the composer isolation flagged in #850 review.
- **emoji**: the lazy picker's loading placeholder rendered a "Loading emojis..." div in the toolbar flow, shifting controls on first open. Render nothing until the fixed-position popover is ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Lazy-load comment composer during discussion rendering to reduce initial page load.

* **Reliability**
  * Improved timeout and retry handling for similar entries search to better manage service disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->