### PR TITLE
fix(web): give pasted editor images a valid filename before upload

### DIFF
--- a/apps/web/src/app/publish/_editor-extensions/publish-editor-image-viewer.tsx
+++ b/apps/web/src/app/publish/_editor-extensions/publish-editor-image-viewer.tsx
@@ -78,7 +78,7 @@ export function PublishEditorImageViewer({
         }
       })();
     }
-  }, [isBlob, src, alt, uploadImage, updateAttributes]);
+  }, [isBlob, src, uploadImage, updateAttributes]);
 
   return (
     <NodeViewWrapper

--- a/apps/web/src/app/publish/_editor-extensions/publish-editor-image-viewer.tsx
+++ b/apps/web/src/app/publish/_editor-extensions/publish-editor-image-viewer.tsx
@@ -1,4 +1,5 @@
 import { useUploadImageMutation } from "@/api/sdk-mutations";
+import { extForImageType } from "@/utils";
 import { Button, Popover, PopoverContent } from "@/features/ui";
 import { proxifyImageSrc } from "@ecency/render-helper";
 import i18next from "i18next";
@@ -64,7 +65,12 @@ export function PublishEditorImageViewer({
         try {
           const response = await fetch(src);
           const blob = await response.blob();
-          const file = new File([blob], alt, { type: blob.type });
+          // Pasted images carry no name; `alt` is the caption (often empty), so
+          // deriving the filename from it produced an extension-less upload that
+          // the image server rejects with 400. Always build a valid name+ext.
+          const file = new File([blob], `pasted-image-${Date.now()}.${extForImageType(blob.type)}`, {
+            type: blob.type
+          });
           const { url } = await uploadImage({ file });
           updateAttributes({ src: url });
         } catch {

--- a/apps/web/src/specs/utils/image-file-ext.spec.ts
+++ b/apps/web/src/specs/utils/image-file-ext.spec.ts
@@ -8,6 +8,7 @@ describe("extForImageType", () => {
     expect(extForImageType("image/jpg")).toBe("jpg");
     expect(extForImageType("image/gif")).toBe("gif");
     expect(extForImageType("image/webp")).toBe("webp");
+    expect(extForImageType("image/avif")).toBe("avif");
   });
 
   it("is case-insensitive", () => {

--- a/apps/web/src/specs/utils/image-file-ext.spec.ts
+++ b/apps/web/src/specs/utils/image-file-ext.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { extForImageType } from "@/utils/image-file-ext";
+
+describe("extForImageType", () => {
+  it("maps known image mime types to extensions", () => {
+    expect(extForImageType("image/png")).toBe("png");
+    expect(extForImageType("image/jpeg")).toBe("jpg");
+    expect(extForImageType("image/jpg")).toBe("jpg");
+    expect(extForImageType("image/gif")).toBe("gif");
+    expect(extForImageType("image/webp")).toBe("webp");
+  });
+
+  it("is case-insensitive", () => {
+    expect(extForImageType("IMAGE/PNG")).toBe("png");
+  });
+
+  it("falls back to png for unknown, empty or missing types", () => {
+    expect(extForImageType("application/octet-stream")).toBe("png");
+    expect(extForImageType("")).toBe("png");
+    expect(extForImageType(undefined)).toBe("png");
+    expect(extForImageType(null)).toBe("png");
+  });
+});

--- a/apps/web/src/utils/image-file-ext.ts
+++ b/apps/web/src/utils/image-file-ext.ts
@@ -3,7 +3,8 @@ const IMAGE_MIME_EXT: Record<string, string> = {
   "image/jpeg": "jpg",
   "image/jpg": "jpg",
   "image/gif": "gif",
-  "image/webp": "webp"
+  "image/webp": "webp",
+  "image/avif": "avif"
 };
 
 /**

--- a/apps/web/src/utils/image-file-ext.ts
+++ b/apps/web/src/utils/image-file-ext.ts
@@ -1,0 +1,19 @@
+const IMAGE_MIME_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp"
+};
+
+/**
+ * Resolve a file extension for an image MIME type.
+ *
+ * Used when building an upload `File` from a `Blob` (e.g. a pasted clipboard
+ * image) that has no name of its own. The Ecency image server rejects uploads
+ * whose filename has no valid image extension, so callers must supply one.
+ * Falls back to `png` for unknown/empty types.
+ */
+export function extForImageType(type: string | undefined | null): string {
+  return IMAGE_MIME_EXT[(type ?? "").toLowerCase()] ?? "png";
+}

--- a/apps/web/src/utils/index.ts
+++ b/apps/web/src/utils/index.ts
@@ -43,6 +43,7 @@ export * from "./get-pure-post-text";
 export * from "./speech";
 export * from "./normalize-beneficiary-weight";
 export * from "./safe-decode-uri";
+export * from "./image-file-ext";
 export { default as dayjs } from "./dayjs";
 export * from "./use-synchronized-state";
 export * from "./format-apr";


### PR DESCRIPTION
Pasting an image from the clipboard into the `/publish` editor failed instantly with a "Couldn't upload image." toast, while choosing the same image via the file picker worked.

### Cause
`PublishEditorImageViewer` converts a pasted image (a `blob:` src) into an upload `File` using the image node's caption (`alt`) as the filename:

```js
const file = new File([blob], alt, { type: blob.type }); // alt === "" for a fresh paste
```

The paste handler inserts the node with `alt: ""`, so the `File` has **no name and no extension**. The uploader sends it as multipart `file` with `filename=""`, and the image server rejects an extension-less upload with **HTTP 400**. The file-picker path works because that `File` keeps its real name (e.g. `photo.png`). The upload auth token is identical on both paths, so it's not an auth issue.

### Fix
Always build a valid `pasted-image-<timestamp>.<ext>` filename, deriving the extension from the blob's MIME type via a small `extForImageType` helper. The caption (`alt`) is left untouched.

- `apps/web/src/utils/image-file-ext.ts` — `extForImageType(type)` mime→ext map (png/jpg/gif/webp, defaults to png)
- `apps/web/src/app/publish/_editor-extensions/publish-editor-image-viewer.tsx` — use it when building the upload File
- `apps/web/src/specs/utils/image-file-ext.spec.ts` — unit spec

Note: `/waves` paste uses `clipboardData.items[].getAsFile()`, which yields a properly named `image.png`, so it is not affected by this defect.

### Test
- `vitest run src/specs/utils/image-file-ext.spec.ts` — green
- `tsc --noEmit` — no new errors; eslint clean on touched files
- After deploy: paste a screenshot into `/publish` → upload returns 200 and the blob preview is replaced with a hosted image URL