### PR TITLE
fix(web): align mobile scroll-to-top with FAB; lead publish bar with community selector

### DIFF
--- a/apps/web/src/app/publish/_components/publish-action-bar.tsx
+++ b/apps/web/src/app/publish/_components/publish-action-bar.tsx
@@ -106,7 +106,11 @@ export function PublishActionBar({
       transition={{ delay: 0.4 }}
       className="container relative z-[11] justify-between gap-4 px-2 md:px-4 flex flex-col-reverse sm:flex-row sm:items-center max-w-[1024px] py-4 mx-auto publish-action-bar"
     >
+      {/* Community selector leads the group so it stays the prominent anchor on
+          both layouts: inline-first on desktop, and on its own (first) wrapped
+          line on mobile, with the lighter status text trailing after it. */}
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <PublishActionBarCommunity />
         <span className="text-xs text-gray-600 dark:text-gray-400 whitespace-nowrap">
           {i18next.t("publish.new-content")}
         </span>
@@ -115,7 +119,6 @@ export function PublishActionBar({
             {i18next.t("publish.auto-save")}: {lastSaved.toLocaleTimeString()}
           </span>
         )}
-        <PublishActionBarCommunity />
       </div>
       <div className="w-full sm:w-auto flex justify-end sm:justify-normal items-center gap-2 sm:gap-4">
         <LoginRequired promptOnAnon>

--- a/apps/web/src/features/shared/navbar/use-hide-on-scroll.ts
+++ b/apps/web/src/features/shared/navbar/use-hide-on-scroll.ts
@@ -9,12 +9,17 @@ import { useEffect, useState } from "react";
  *
  * @param threshold  minimum px delta before toggling (debounces jitter)
  * @param topOffset  always reveal while within this many px of the top
+ * @param enabled    when false, skips the scroll listener and always reports
+ *                   `false` — e.g. on desktop where the hidden state is unused
  */
-export function useHideOnScroll(threshold = 8, topOffset = 56) {
+export function useHideOnScroll(threshold = 8, topOffset = 56, enabled = true) {
   const [hidden, setHidden] = useState(false);
 
   useEffect(() => {
-    if (typeof window === "undefined") {
+    if (typeof window === "undefined" || !enabled) {
+      // Reset so a control that was hidden on mobile returns to rest if the
+      // viewport grows past the breakpoint (enabled flips to false).
+      setHidden(false);
       return;
     }
 
@@ -46,7 +51,7 @@ export function useHideOnScroll(threshold = 8, topOffset = 56) {
 
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
-  }, [threshold, topOffset]);
+  }, [threshold, topOffset, enabled]);
 
   return hidden;
 }

--- a/apps/web/src/features/shared/scroll-to-top/_index.scss
+++ b/apps/web/src/features/shared/scroll-to-top/_index.scss
@@ -22,6 +22,7 @@
     width: 48px;
     height: 48px;
     bottom: calc(env(safe-area-inset-bottom) + 4.75rem);
+
     // Match the FAB's `transition-transform duration-300` (Tailwind easing) so
     // the pair slides in perfect lockstep when the navbar hides/shows.
     transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);

--- a/apps/web/src/features/shared/scroll-to-top/_index.scss
+++ b/apps/web/src/features/shared/scroll-to-top/_index.scss
@@ -22,11 +22,21 @@
     width: 48px;
     height: 48px;
     bottom: calc(env(safe-area-inset-bottom) + 4.75rem);
+    // Match the FAB's `transition-transform duration-300` (Tailwind easing) so
+    // the pair slides in perfect lockstep when the navbar hides/shows.
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 
     // In the in-app (RN) browser the bottom bar uses a fixed offset, so match
     // the FAB's RN bottom (see the FAB style in navbar-mobile.tsx).
     body.is-inapp-browser & {
       bottom: 7rem;
+    }
+
+    // Drop away with the bottom navbar + FAB on scroll-down (and ride back up on
+    // scroll-up). 200% of the 48px control = 96px, identical to the FAB's
+    // `translate-y-[200%]`, so the two move together as one cluster.
+    &.navbar-hidden {
+      transform: translateY(200%);
     }
   }
 

--- a/apps/web/src/features/shared/scroll-to-top/index.tsx
+++ b/apps/web/src/features/shared/scroll-to-top/index.tsx
@@ -1,45 +1,44 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import "./_index.scss";
 import { chevronUpSvg } from "@/features/ui/svg";
 import i18next from "i18next";
 import { Tooltip } from "@ui/tooltip";
 import { useHideOnScroll } from "@/features/shared/navbar/use-hide-on-scroll";
+import useMedia from "react-use/lib/useMedia";
 import clsx from "clsx";
-import useMount from "react-use/lib/useMount";
-import useUnmount from "react-use/lib/useUnmount";
 
 export function ScrollToTop() {
-  const timerRef = useRef<any>(undefined);
   const [visible, setVisible] = useState(false);
 
   // Share the bottom navbar + compose FAB's hide-on-scroll signal so the whole
   // bottom cluster moves as one: it slides away on scroll-down and returns on
-  // scroll-up, keeping this control level with the FAB instead of stranded above
-  // it. (No-op on desktop — the matching transform is mobile-only in the SCSS.)
-  const hidden = useHideOnScroll();
+  // scroll-up, keeping this control level with the FAB. Gated to the same
+  // breakpoint as the SCSS transform, so the shared hook adds no scroll listener
+  // on desktop, where the hidden state has no visual effect.
+  const isMobile = useMedia("(max-width: 767px)", false);
+  const hidden = useHideOnScroll(8, 56, isMobile);
 
-  useMount(() => {
+  // Single effect with one stable handler: registering and removing the exact
+  // same listener reference avoids a leak across the per-page mount/unmounts.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    const detect = () => setVisible(window.scrollY > window.innerHeight);
+    const onScrollOrResize = () => {
+      clearTimeout(timer);
+      timer = setTimeout(detect, 5);
+    };
+
     detect();
-    window.addEventListener("scroll", scrollChanged);
-    window.addEventListener("resize", scrollChanged);
-  });
-
-  useUnmount(() => {
-    window.removeEventListener("scroll", scrollChanged);
-    window.removeEventListener("resize", scrollChanged);
-    clearTimeout(timerRef.current);
-  });
-
-  const scrollChanged = () => {
-    clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(detect, 5);
-  };
-
-  const detect = () => {
-    setVisible(window.scrollY > window.innerHeight);
-  };
+    window.addEventListener("scroll", onScrollOrResize, { passive: true });
+    window.addEventListener("resize", onScrollOrResize);
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("scroll", onScrollOrResize);
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  }, []);
 
   const scrollToTop = () => window.scrollTo({ top: 0, behavior: "smooth" });
 

--- a/apps/web/src/features/shared/scroll-to-top/index.tsx
+++ b/apps/web/src/features/shared/scroll-to-top/index.tsx
@@ -1,16 +1,24 @@
 "use client";
 
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import "./_index.scss";
 import { chevronUpSvg } from "@/features/ui/svg";
 import i18next from "i18next";
 import { Tooltip } from "@ui/tooltip";
+import { useHideOnScroll } from "@/features/shared/navbar/use-hide-on-scroll";
+import clsx from "clsx";
 import useMount from "react-use/lib/useMount";
 import useUnmount from "react-use/lib/useUnmount";
 
 export function ScrollToTop() {
   const timerRef = useRef<any>(undefined);
-  const buttonRef = useRef<HTMLDivElement | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  // Share the bottom navbar + compose FAB's hide-on-scroll signal so the whole
+  // bottom cluster moves as one: it slides away on scroll-down and returns on
+  // scroll-up, keeping this control level with the FAB instead of stranded above
+  // it. (No-op on desktop — the matching transform is mobile-only in the SCSS.)
+  const hidden = useHideOnScroll();
 
   useMount(() => {
     detect();
@@ -21,6 +29,7 @@ export function ScrollToTop() {
   useUnmount(() => {
     window.removeEventListener("scroll", scrollChanged);
     window.removeEventListener("resize", scrollChanged);
+    clearTimeout(timerRef.current);
   });
 
   const scrollChanged = () => {
@@ -29,39 +38,23 @@ export function ScrollToTop() {
   };
 
   const detect = () => {
-    if (!buttonRef.current) {
-      return;
-    }
-
-    if (window.scrollY > window.innerHeight) {
-      buttonRef.current.classList.add("visible");
-      return;
-    }
-
-    buttonRef.current.classList.remove("visible");
+    setVisible(window.scrollY > window.innerHeight);
   };
+
+  const scrollToTop = () => window.scrollTo({ top: 0, behavior: "smooth" });
 
   return (
     <Tooltip content={i18next.t("scroll-to-top.title")}>
       <div
-        ref={buttonRef}
-        className="scroll-to-top"
+        className={clsx("scroll-to-top", visible && "visible", hidden && "navbar-hidden")}
         role="button"
         tabIndex={0}
         aria-label={i18next.t("scroll-to-top.title")}
-        onClick={() =>
-          window.scrollTo({
-            top: 0,
-            behavior: "smooth"
-          })
-        }
+        onClick={scrollToTop}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
-            window.scrollTo({
-              top: 0,
-              behavior: "smooth"
-            });
+            scrollToTop();
           }
         }}
       >


### PR DESCRIPTION
## Summary

Two small mobile-focused refinements to the bottom controls and the publish editor header, following up on the recent scroll-to-top / FAB unification.

### 1. Keep the mobile scroll-to-top level with the compose FAB
The scroll-to-top button shared the FAB's resting position but not its motion: only the FAB subscribed to the navbar's hide-on-scroll signal, so while scrolling the FAB dropped away with the bottom bar while the scroll-to-top stayed stranded above it (visible misalignment).

The scroll-to-top now consumes the same `useHideOnScroll()` hook and applies the same `translateY(200%)` over an identically sized 48px control, with the same 300ms eased transition. The two now move as one cluster: drop together on scroll-down, ride back up together on scroll-up. The transform is scoped to the mobile breakpoint, so the desktop bottom-right button is untouched. The component's visibility was converted from imperative `classList` toggling to React state so both the `visible` and new `navbar-hidden` classes are driven through `clsx` without clobbering each other.

### 2. Lead the publish action bar with the community selector
On `/publish`, the `New Content` / `Auto saved` status text sat in front of the community selector. The selector now leads the group, so it anchors both layouts:

- Desktop: inline-first on one row, with the status text trailing after it.
- Mobile: on its own first wrapped line, with the status text wrapping below it.

This is a pure source reorder inside the existing `flex flex-wrap` group; no responsive `order-*` classes needed, and the self-contained community box has no sibling-order dependencies.

## Testing
- ESLint clean on all changed files.
- `tsc --noEmit` introduces no new type errors (touched files are type-clean).
- Live mobile verification was not run locally (dev server requires Node >= 22; only Node 20 is available in this environment), so the scroll-lockstep rests on matched constants: same hook, same 48px control, same `translateY(200%)`, same 300ms easing, identical resting `bottom`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Scroll-to-top button now includes smooth transition animations
  * Scroll-to-top button movement synchronized with navbar hide/show behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->