### PR TITLE
fix(web): unify publish mode label into one aligned header

### DIFF
--- a/apps/web/src/app/publish/_components/index.ts
+++ b/apps/web/src/app/publish/_components/index.ts
@@ -1,4 +1,5 @@
 export * from "./publish-action-bar";
+export * from "./publish-mode-header";
 export * from "./publish-editor-toolbar";
 export * from "./publish-validate-post";
 export * from "./publish-onboarding";

--- a/apps/web/src/app/publish/_components/publish-action-bar.tsx
+++ b/apps/web/src/app/publish/_components/publish-action-bar.tsx
@@ -69,7 +69,6 @@ interface Props {
   onBackToClassic: () => void;
   onImport?: (result: ImportResult) => void;
   draftId?: string;
-  lastSaved?: Date | null;
 }
 
 export function PublishActionBar({
@@ -77,8 +76,7 @@ export function PublishActionBar({
   children,
   onBackToClassic,
   onImport,
-  draftId,
-  lastSaved
+  draftId
 }: PropsWithChildren<Props>) {
   const { schedule: scheduleDate, clearAll, title, content } = usePublishState();
 
@@ -106,20 +104,11 @@ export function PublishActionBar({
       transition={{ delay: 0.4 }}
       className="container relative z-[11] justify-between gap-4 px-2 md:px-4 flex flex-col-reverse sm:flex-row sm:items-center max-w-[1024px] py-4 mx-auto publish-action-bar"
     >
-      {/* Community selector leads the group so it stays the prominent anchor on
-          both layouts: inline-first on desktop, and on its own (first) wrapped
-          line on mobile, with the lighter status text trailing after it. */}
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-        <PublishActionBarCommunity />
-        <span className="text-xs text-gray-600 dark:text-gray-400 whitespace-nowrap">
-          {i18next.t("publish.new-content")}
-        </span>
-        {lastSaved && draftId && (
-          <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-            {i18next.t("publish.auto-save")}: {lastSaved.toLocaleTimeString()}
-          </span>
-        )}
-      </div>
+      {/* Left side of the bar is just the community selector. The mode label
+          (New Content / Draft Editing / Post Editing) and the auto-saved time
+          live in the PublishModeHeader rendered above the bar, so they are not
+          duplicated here. */}
+      <PublishActionBarCommunity />
       <div className="w-full sm:w-auto flex justify-end sm:justify-normal items-center gap-2 sm:gap-4">
         <LoginRequired promptOnAnon>
           <Button

--- a/apps/web/src/app/publish/_components/publish-mode-header.tsx
+++ b/apps/web/src/app/publish/_components/publish-mode-header.tsx
@@ -1,0 +1,33 @@
+import i18next from "i18next";
+
+interface Props {
+  /**
+   * The current editing-mode label, one of New Content / Draft Editing / Post
+   * Editing. These are mutually exclusive: a given editor view shows exactly
+   * one, so this header is the single source of truth for the mode indicator.
+   */
+  label: string;
+  lastSaved?: Date | null;
+}
+
+/**
+ * Status header shown directly above the publish action bar. Renders the
+ * mutually-exclusive mode label on the left and, while a draft is being
+ * auto-saved, the last-saved time on the right. Its horizontal padding matches
+ * the action bar (`px-2 md:px-4`) so the label lines up with the community
+ * selector below it on every breakpoint.
+ */
+export function PublishModeHeader({ label, lastSaved }: Props) {
+  return (
+    <div className="container max-w-[1024px] mx-auto text-xs text-gray-600 dark:text-gray-400 px-2 md:px-4 py-2 md:py-0">
+      <div className="flex flex-wrap justify-between items-center">
+        <span>{label}</span>
+        {lastSaved && (
+          <span className="text-gray-500 dark:text-gray-400">
+            {i18next.t("publish.auto-save")}: {lastSaved.toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/publish/_components/publish-mode-header.tsx
+++ b/apps/web/src/app/publish/_components/publish-mode-header.tsx
@@ -24,7 +24,8 @@ export function PublishModeHeader({ label, lastSaved }: Props) {
         <span>{label}</span>
         {lastSaved && (
           <span className="text-gray-500 dark:text-gray-400">
-            {i18next.t("publish.auto-save")}: {lastSaved.toLocaleTimeString()}
+            {i18next.t("publish.auto-save")}:{" "}
+          {lastSaved.toLocaleTimeString(i18next.language || undefined)}
           </span>
         )}
       </div>

--- a/apps/web/src/app/publish/_page.tsx
+++ b/apps/web/src/app/publish/_page.tsx
@@ -89,7 +89,13 @@ export default function Publish() {
       <PublishMultiTabWarning isActiveTab={isActiveTab} />
       {step === "edit" && (
         <>
-          <PublishModeHeader label={i18next.t("publish.new-content")} lastSaved={lastSaved} />
+          {/* Guard on draftId so the auto-saved time only shows once a draft
+              actually exists on the server, matching the prior action-bar logic
+              (`lastSaved && draftId`). */}
+          <PublishModeHeader
+            label={i18next.t("publish.new-content")}
+            lastSaved={draftId ? lastSaved : null}
+          />
           <PublishActionBar
             onPublish={() => setStep("validation")}
             onBackToClassic={() => router.push(routes.SUBMIT)}

--- a/apps/web/src/app/publish/_page.tsx
+++ b/apps/web/src/app/publish/_page.tsx
@@ -2,6 +2,7 @@
 
 import {
   PublishActionBar,
+  PublishModeHeader,
   PublishValidatePost,
   PublishMultiTabWarning
 } from "@/app/publish/_components";
@@ -88,12 +89,12 @@ export default function Publish() {
       <PublishMultiTabWarning isActiveTab={isActiveTab} />
       {step === "edit" && (
         <>
+          <PublishModeHeader label={i18next.t("publish.new-content")} lastSaved={lastSaved} />
           <PublishActionBar
             onPublish={() => setStep("validation")}
             onBackToClassic={() => router.push(routes.SUBMIT)}
             onImport={handleImport}
             draftId={draftId}
-            lastSaved={lastSaved}
           />
           <PublishEditor editor={editor} />
         </>

--- a/apps/web/src/app/publish/drafts/[id]/_page.tsx
+++ b/apps/web/src/app/publish/drafts/[id]/_page.tsx
@@ -5,6 +5,7 @@ import "../../page.scss";
 import {
   PublishActionBar,
   PublishEditor,
+  PublishModeHeader,
   PublishValidatePost,
   PublishMultiTabWarning
 } from "@/app/publish/_components";
@@ -72,16 +73,7 @@ export default function PublishPage() {
       <AnimatePresence>
         {step === "edit" && (
           <>
-            <div className="container max-w-[1024px] mx-auto text-xs text-gray-600 dark:text-gray-400 p-2 md:p-0">
-              <div className="flex flex-wrap justify-between items-center">
-                <span>{i18next.t("publish.draft-mode")}</span>
-                {lastSaved && (
-                  <span className="text-gray-500 dark:text-gray-400">
-                    {i18next.t("publish.auto-save")}: {lastSaved.toLocaleTimeString()}
-                  </span>
-                )}
-              </div>
-            </div>
+            <PublishModeHeader label={i18next.t("publish.draft-mode")} lastSaved={lastSaved} />
             <PublishActionBar
               onPublish={() => setStep("validation")}
               onBackToClassic={() => router.push(`/draft/${params?.id}`)}

--- a/apps/web/src/app/publish/entry/[author]/[permlink]/_page.tsx
+++ b/apps/web/src/app/publish/entry/[author]/[permlink]/_page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PublishEditor } from "@/app/publish/_components";
+import { PublishEditor, PublishModeHeader } from "@/app/publish/_components";
 import { usePublishEditor, usePublishState } from "@/app/publish/_hooks";
 import { useEntryDetector } from "@/app/submit/_hooks";
 import { Entry } from "@/entities";
@@ -83,11 +83,7 @@ export default function Publish() {
       <AnimatePresence>
         {step === "edit" && (
           <>
-            <div className="container max-w-[1024px] mx-auto text-xs text-gray-600 dark:text-gray-400 p-2 md:p-0">
-              <div className="flex flex-wrap justify-between items-center">
-                <span>{i18next.t("publish.edit-mode")}</span>
-              </div>
-            </div>
+            <PublishModeHeader label={i18next.t("publish.edit-mode")} />
             <PublishEntryActionBar entry={entry} onEdit={() => setStep("validation")} />
             <PublishEditor editor={editor} allowToUploadVideo={false} />
           </>

--- a/apps/web/src/specs/app/publish-mode-header.spec.tsx
+++ b/apps/web/src/specs/app/publish-mode-header.spec.tsx
@@ -1,0 +1,30 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { PublishModeHeader } from "@/app/publish/_components/publish-mode-header";
+
+// i18next is globally mocked (see setup-any-spec.ts) to echo keys, so
+// t("publish.auto-save") renders as the literal "publish.auto-save".
+describe("PublishModeHeader", () => {
+  it("renders the provided mode label", () => {
+    render(<PublishModeHeader label="New Content" />);
+    expect(screen.getByText("New Content")).toBeInTheDocument();
+  });
+
+  it("shows the auto-saved time when lastSaved is provided", () => {
+    render(<PublishModeHeader label="Draft Editing" lastSaved={new Date("2026-06-04T10:06:46Z")} />);
+    expect(screen.getByText("Draft Editing")).toBeInTheDocument();
+    expect(screen.getByText(/publish\.auto-save/)).toBeInTheDocument();
+  });
+
+  it("omits the auto-saved time when lastSaved is null", () => {
+    render(<PublishModeHeader label="Post Editing" lastSaved={null} />);
+    expect(screen.getByText("Post Editing")).toBeInTheDocument();
+    expect(screen.queryByText(/publish\.auto-save/)).not.toBeInTheDocument();
+  });
+
+  it("omits the auto-saved time when lastSaved is omitted", () => {
+    render(<PublishModeHeader label="New Content" />);
+    expect(screen.queryByText(/publish\.auto-save/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

The publish editor had two separate, overlapping mode indicators. The shared action bar always rendered **"New Content"**, while the draft and post editing pages each rendered their own top header (**"Draft Editing"** / **"Post Editing"**). On those pages both showed at once, so "New Content" was redundant.

This unifies the three mutually-exclusive labels (`new-content` / `draft-mode` / `edit-mode`) into a single shared `PublishModeHeader` rendered above the action bar, and removes the "New Content" + auto-saved text from the action bar itself.

### Changes
- **New `PublishModeHeader`** component renders the one mode label on the left and the auto-saved time on the right.
- **Action bar** no longer renders "New Content" or the auto-saved span; its left side is now just the community selector. The unused `lastSaved` prop was dropped.
- **All three editor views** (`/publish`, `/publish/drafts/[id]`, `/publish/entry/...`) now render `PublishModeHeader` with their respective label, so the indicators replace one another in the same slot instead of doubling up.
- **Desktop alignment fix:** the header's horizontal padding now matches the action bar (`px-2 md:px-4`), so the mode label lines up with the community selector below it. Previously the header used `md:p-0`, leaving the label ~16px left of the selector.

### Behavior
- New content / draft editing / post editing each show exactly one label, in a consistent position on both desktop and mobile.
- Mobile placement is pixel-identical to before (`px-2`, `py-2`); only desktop horizontal padding changed.
- No i18n changes — all three keys already existed.

## Testing
- ESLint clean on all changed files.
- `tsc --noEmit` introduces no new type errors (still at the pre-existing baseline; none in touched files).
- Not verified in a running browser (dev server needs Node >= 22; only Node 20 available here). The alignment claim rests on both the header and action bar sharing the same `container max-w-[1024px] mx-auto px-2 md:px-4`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized publish interface layout by consolidating mode label and auto-save status information into a dedicated header component across publish pages, improving visual hierarchy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->