### PR TITLE
fix(web): fully hide mobile FAB + scroll-to-top when navbar hides (no half-cut)

### DIFF
--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -88,6 +88,11 @@ export function NavbarMobile({
   const activeClass = (active: boolean) =>
     active ? "!bg-blue-duck-egg dark:!bg-gray-800 rounded-lg" : "rounded-lg";
 
+  // Resting distance of the compose FAB (and its scroll-to-top twin) above the
+  // viewport bottom. Reused for the hide transform so the button travels its own
+  // height (100%) plus this offset and clears the edge completely.
+  const fabBottom = isInRn ? "7rem" : "calc(env(safe-area-inset-bottom) + 4.75rem)";
+
   return (
     <>
       {/* Full-width sticky top bar — brand + browse/governance menu (left) and
@@ -229,10 +234,19 @@ export function NavbarMobile({
           // scroll-to-top control on the opposite corner (same size + bottom).
           "md:hidden fixed right-4 z-20 !h-12 !w-12 !rounded-full flex items-center justify-center shadow-lg",
           "transition-transform duration-300",
-          hidden && "translate-y-[200%]",
           step === 1 && "transparent"
         )}
-        style={{ bottom: isInRn ? "7rem" : "calc(env(safe-area-inset-bottom) + 4.75rem)" }}
+        style={{
+          bottom: fabBottom,
+          // When hidden, slide fully off-screen instead of stopping half-cut: a
+          // flat translate-y-[200%] (96px) left ~28px of the 48px button poking
+          // above the edge because it rests `fabBottom` up from it. Travel the
+          // height (100%) + that offset + 1rem so the button and its shadow
+          // clear the viewport bottom. Left undefined when shown so the Button's
+          // `active:scale-95` press feedback isn't overridden by an inline
+          // transform (none <-> translateY still animates).
+          transform: hidden ? `translateY(calc(100% + ${fabBottom} + 1rem))` : undefined
+        }}
       />
 
       {activeUser && <NavbarSide key={`mobile-${activeUser.username}`} show={expanded} setShow={setExpanded} />}

--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -88,10 +88,11 @@ export function NavbarMobile({
   const activeClass = (active: boolean) =>
     active ? "!bg-blue-duck-egg dark:!bg-gray-800 rounded-lg" : "rounded-lg";
 
-  // Resting distance of the compose FAB (and its scroll-to-top twin) above the
-  // viewport bottom. Reused for the hide transform so the button travels its own
-  // height (100%) plus this offset and clears the edge completely.
-  const fabBottom = isInRn ? "7rem" : "calc(env(safe-area-inset-bottom) + 4.75rem)";
+  // Resting offset of the compose FAB (and its scroll-to-top twin) above the
+  // viewport bottom, written without a calc() wrapper so it composes into the
+  // bottom and the hide transform below without nesting calc(). 7rem in the
+  // in-app browser, safe-area + 4.75rem otherwise.
+  const fabBottom = isInRn ? "7rem" : "env(safe-area-inset-bottom) + 4.75rem";
 
   return (
     <>
@@ -237,7 +238,7 @@ export function NavbarMobile({
           step === 1 && "transparent"
         )}
         style={{
-          bottom: fabBottom,
+          bottom: `calc(${fabBottom})`,
           // When hidden, slide fully off-screen instead of stopping half-cut: a
           // flat translate-y-[200%] (96px) left ~28px of the 48px button poking
           // above the edge because it rests `fabBottom` up from it. Travel the

--- a/apps/web/src/features/shared/scroll-to-top/_index.scss
+++ b/apps/web/src/features/shared/scroll-to-top/_index.scss
@@ -33,11 +33,18 @@
       bottom: 7rem;
     }
 
-    // Drop away with the bottom navbar + FAB on scroll-down (and ride back up on
-    // scroll-up). 200% of the 48px control = 96px, identical to the FAB's
-    // `translate-y-[200%]`, so the two move together as one cluster.
+    // Drop fully off-screen with the bottom navbar + FAB on scroll-down (and
+    // ride back up on scroll-up), in lockstep with the FAB. Travel the control's
+    // own height (100%) + its bottom offset + 1rem so the control and its shadow
+    // clear the viewport bottom; a flat translateY(200%) (96px) left ~28px of
+    // the 48px control poking above the edge.
     &.navbar-hidden {
-      transform: translateY(200%);
+      transform: translateY(calc(100% + env(safe-area-inset-bottom) + 4.75rem + 1rem));
+    }
+
+    // In-app (RN) browser uses the fixed 7rem bottom, so match it here.
+    body.is-inapp-browser &.navbar-hidden {
+      transform: translateY(calc(100% + 7rem + 1rem));
     }
   }
 


### PR DESCRIPTION
## Summary

When the navbar hides on scroll-down, the mobile compose FAB and the scroll-to-top button were left **half-cut** at the bottom edge instead of sliding fully away (reported on a real mobile-browser viewport, not a DevTools artifact).

### Cause
Both controls rest `4.75rem` (~76px) above the viewport bottom and are 48px tall, but the hide animation only translated them `translate-y-[200%]` = 2 × 48px = **96px**. Fully clearing a control whose top is at 76 + 48 = 124px needs ≥124px of travel (plus any safe-area inset), so ~28px of each stayed poking above the edge. The bottom tab bar isn't affected because it sits only ~8px up, where 96px clears it.

### Fix
Translate by the control's own height (`100%`) **plus its bottom offset** (`+ 1rem` so the `shadow-lg` clears too), so the top edge lands just below the viewport bottom:

- **FAB** (`navbar-mobile.tsx`): the hide transform moves from a Tailwind class to inline style so it can reuse the same `fabBottom` offset (`7rem` in-app / `calc(env(safe-area-inset-bottom) + 4.75rem)` otherwise). Shown-state transform is left `undefined` so the Button's `active:scale-95` press feedback isn't overridden (`none ↔ translateY` still animates).
- **scroll-to-top** (`_index.scss`): the `.navbar-hidden` transform gets the same `calc(100% + offset + 1rem)`, with an in-app (`7rem`) variant.

The two still move in perfect lockstep (identical offsets, easing `cubic-bezier(0.4, 0, 0.2, 1)`, and 300ms duration). The transform stays scoped to mobile, so the desktop bottom-right scroll-to-top is unchanged.

## Testing
- ESLint clean on changed files.
- `tsc --noEmit` adds no new type errors in touched files.
- Not driven in a live browser (dev server needs Node ≥ 22; only Node 20 here). The fix rests on the geometry above: travel = height + resting offset + buffer ⇒ top edge clears the viewport bottom on any safe-area inset.

## Note
This makes the controls slide **fully away** on scroll-down, consistent with the existing "bottom cluster hides with the navbar" behavior. If the preference is instead to keep them **always visible** (never hide on scroll-down), that's a one-line alternative — say the word and I'll switch it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined positioning calculations for the floating compose button to accurately account for browser-specific behaviors and device safe-area insets, improving placement precision.
  * Enhanced scroll-to-top button animations to align more precisely with navigation and floating button movement during scroll interactions, ensuring consistent behavior across mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->