### PR TITLE
Add feature-spotlight sidebar widget to the feed

### DIFF
--- a/apps/web/src/app/(dynamicPages)/feed/layout.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/layout.tsx
@@ -3,6 +3,7 @@ import { EntryIndexMenu } from "@/app/_components/entry-index-menu";
 import React, { PropsWithChildren } from "react";
 import { TopCommunitiesWidget } from "@/app/_components/top-communities-widget";
 import { MyFavoritesWidget } from "@/app/_components/my-favorites-widget";
+import { FeatureSpotlightWidget } from "@/app/_components/feature-spotlight-widget/lazy";
 import "./[...sections]/entry-index.scss";
 import { Feedback } from "@/features/shared/feedback";
 import { Navbar } from "@/features/shared/navbar";
@@ -29,6 +30,7 @@ export default function FeedLayout({ children }: PropsWithChildren) {
         <div className="side-menu">
           <MyFavoritesWidget />
           <TopCommunitiesWidget />
+          <FeatureSpotlightWidget />
         </div>
       </div>
     </>

--- a/apps/web/src/app/_components/feature-spotlight-widget/index.tsx
+++ b/apps/web/src/app/_components/feature-spotlight-widget/index.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
-import Link from "next/link";
 import i18next from "i18next";
 import { useQuery } from "@tanstack/react-query";
 import { getSpotlightsQueryOptions } from "@ecency/sdk";
@@ -58,24 +57,16 @@ export function FeatureSpotlightWidget() {
       <div className="mt-1 font-semibold">{copy.title}</div>
       <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">{copy.description}</p>
       <div className="mt-3">
-        {isExternal ? (
-          <a
-            href={spotlight.button_link}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={dismiss}
-          >
-            <Button size="sm" appearance="primary">
-              {copy.button_text}
-            </Button>
-          </a>
-        ) : (
-          <Link href={spotlight.button_link} onClick={dismiss}>
-            <Button size="sm" appearance="primary">
-              {copy.button_text}
-            </Button>
-          </Link>
-        )}
+        <Button
+          href={spotlight.button_link}
+          size="sm"
+          appearance="primary"
+          onClick={dismiss}
+          target={isExternal ? "_blank" : undefined}
+          rel={isExternal ? "noopener noreferrer" : undefined}
+        >
+          {copy.button_text}
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/app/_components/feature-spotlight-widget/index.tsx
+++ b/apps/web/src/app/_components/feature-spotlight-widget/index.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import i18next from "i18next";
+import { useQuery } from "@tanstack/react-query";
+import { getSpotlightsQueryOptions } from "@ecency/sdk";
+import { Button } from "@ui/button";
+import { closeSvg } from "@ui/svg";
+import * as ls from "@/utils/local-storage";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { pickSpotlight } from "./select";
+
+const DISMISS_KEY = "dismiss_spotlights";
+
+export function FeatureSpotlightWidget() {
+  const { activeUser } = useActiveAccount();
+  const pathname = usePathname();
+
+  const { data } = useQuery(getSpotlightsQueryOptions());
+
+  const [dismissedIds, setDismissedIds] = useState<string[]>(() => ls.get(DISMISS_KEY) ?? []);
+
+  const spotlight = useMemo(
+    () => pickSpotlight(data ?? [], activeUser, pathname, dismissedIds, "web"),
+    [data, activeUser, pathname, dismissedIds]
+  );
+
+  if (!spotlight) {
+    return null;
+  }
+
+  const dismiss = () => {
+    const current: string[] = ls.get(DISMISS_KEY) ?? [];
+    if (!current.includes(spotlight.id)) {
+      ls.set(DISMISS_KEY, [...current, spotlight.id]);
+    }
+    setDismissedIds((prev) => (prev.includes(spotlight.id) ? prev : [...prev, spotlight.id]));
+  };
+
+  const copy = spotlight.locales?.[i18next.language] ?? spotlight;
+  const isExternal = /^https?:\/\//.test(spotlight.button_link);
+
+  return (
+    <div className="feature-spotlight relative mb-4 rounded-2xl bg-gray-100 p-4 dark:bg-gray-900">
+      <Button
+        appearance="link"
+        className="absolute top-2 right-2"
+        onClick={dismiss}
+        aria-label={i18next.t("feature-spotlight.dismiss")}
+      >
+        {closeSvg}
+      </Button>
+      <div className="text-xs font-semibold uppercase tracking-wide text-blue-dark-sky">
+        {i18next.t("feature-spotlight.label")}
+      </div>
+      <div className="mt-1 font-semibold">{copy.title}</div>
+      <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">{copy.description}</p>
+      <div className="mt-3">
+        {isExternal ? (
+          <a
+            href={spotlight.button_link}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={dismiss}
+          >
+            <Button size="sm" appearance="primary">
+              {copy.button_text}
+            </Button>
+          </a>
+        ) : (
+          <Link href={spotlight.button_link} onClick={dismiss}>
+            <Button size="sm" appearance="primary">
+              {copy.button_text}
+            </Button>
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/_components/feature-spotlight-widget/lazy.tsx
+++ b/apps/web/src/app/_components/feature-spotlight-widget/lazy.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// Client-only: the widget reads localStorage (dismissal) and the active-user store, so
+// SSR would render a card that may be dismissed/empty on the client and flash. ssr:false
+// avoids the flash and keeps it off the First Load JS. It is the last item in the feed
+// sidebar with nothing below it, so an empty `loading` does not shift main content.
+export const FeatureSpotlightWidget = dynamic(
+  () => import("./index").then((m) => m.FeatureSpotlightWidget),
+  {
+    ssr: false,
+    loading: () => null
+  }
+);

--- a/apps/web/src/app/_components/feature-spotlight-widget/select.ts
+++ b/apps/web/src/app/_components/feature-spotlight-widget/select.ts
@@ -1,0 +1,46 @@
+import type { Spotlight } from "@ecency/sdk";
+
+export type SpotlightPlatform = "web" | "mobile";
+
+/**
+ * Pick the single spotlight to show. The server already filtered by the date window;
+ * here we apply the client-side rules — platform (website vs mobile app), auth (default
+ * logged-in only), path regex, and per-id dismissal — then pick the highest weight
+ * (tie-break: earliest start). Pure + exported for unit testing.
+ */
+export function pickSpotlight(
+  items: Spotlight[],
+  activeUser: unknown,
+  pathname: string | null,
+  dismissed: string[],
+  platform: SpotlightPlatform = "web"
+): Spotlight | null {
+  const candidates = items
+    .filter((s) => !s.platforms || s.platforms.includes(platform))
+    .filter((s) => (s.auth === false ? true : !!activeUser))
+    .filter((s) => {
+      if (!s.path) {
+        return true;
+      }
+      if (Array.isArray(s.path)) {
+        return s.path.some((p) => !!pathname?.match(p));
+      }
+      return !!pathname?.match(s.path);
+    })
+    .filter((s) => !dismissed.includes(s.id));
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.reduce((best, s) => {
+    const bestWeight = best.weight ?? 0;
+    const weight = s.weight ?? 0;
+    if (weight !== bestWeight) {
+      return weight > bestWeight ? s : best;
+    }
+    const bestStart = best.start ? new Date(best.start).getTime() : 0;
+    const start = s.start ? new Date(s.start).getTime() : 0;
+    return start < bestStart ? s : best;
+  });
+}

--- a/apps/web/src/app/_components/feature-spotlight-widget/select.ts
+++ b/apps/web/src/app/_components/feature-spotlight-widget/select.ts
@@ -2,6 +2,15 @@ import type { Spotlight } from "@ecency/sdk";
 
 export type SpotlightPlatform = "web" | "mobile";
 
+function pathMatches(pathname: string | null, pattern: string): boolean {
+  try {
+    return !!pathname?.match(pattern);
+  } catch {
+    // A malformed regex from the API must skip that spotlight, not crash the chain.
+    return false;
+  }
+}
+
 /**
  * Pick the single spotlight to show. The server already filtered by the date window;
  * here we apply the client-side rules — platform (website vs mobile app), auth (default
@@ -23,9 +32,9 @@ export function pickSpotlight(
         return true;
       }
       if (Array.isArray(s.path)) {
-        return s.path.some((p) => !!pathname?.match(p));
+        return s.path.some((p) => pathMatches(pathname, p));
       }
-      return !!pathname?.match(s.path);
+      return pathMatches(pathname, s.path);
     })
     .filter((s) => !dismissed.includes(s.id));
 

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -134,6 +134,10 @@
     "view-proposal": "View proposal",
     "vote-success": "Thank you for supporting Ecency!"
   },
+  "feature-spotlight": {
+    "label": "Did you know?",
+    "dismiss": "Dismiss"
+  },
   "floating-faq": {
     "toggle-icon-info": "Click to expand",
     "help": "Help",

--- a/apps/web/src/specs/app/feature-spotlight-select.spec.ts
+++ b/apps/web/src/specs/app/feature-spotlight-select.spec.ts
@@ -27,6 +27,15 @@ describe("pickSpotlight", () => {
     expect(pickSpotlight([make({ id: "x", auth: false })], null, "/", [])?.id).toBe("x");
   });
 
+  it("hides default-auth (auth unset) spotlights from anonymous users", () => {
+    expect(pickSpotlight([make({ id: "x" })], null, "/", [])).toBeNull();
+  });
+
+  it("skips a spotlight whose path is an invalid regex instead of throwing", () => {
+    const items = [make({ id: "bad", path: "[broken" }), make({ id: "ok" })];
+    expect(pickSpotlight(items, user, "/", [])?.id).toBe("ok");
+  });
+
   it("filters by platform — a mobile-only spotlight is hidden on web", () => {
     const items = [make({ id: "m", platforms: ["mobile"] })];
     expect(pickSpotlight(items, user, "/", [], "web")).toBeNull();

--- a/apps/web/src/specs/app/feature-spotlight-select.spec.ts
+++ b/apps/web/src/specs/app/feature-spotlight-select.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import type { Spotlight } from "@ecency/sdk";
+import { pickSpotlight } from "@/app/_components/feature-spotlight-widget/select";
+
+const base: Spotlight = {
+  id: "a",
+  feature: "waves",
+  title: "t",
+  description: "d",
+  button_text: "b",
+  button_link: "/waves"
+};
+
+const make = (over: Partial<Spotlight>): Spotlight => ({ ...base, ...over });
+const user = { username: "u" };
+
+describe("pickSpotlight", () => {
+  it("returns null when there are no items", () => {
+    expect(pickSpotlight([], user, "/", [])).toBeNull();
+  });
+
+  it("hides auth-required spotlights from anonymous users", () => {
+    expect(pickSpotlight([make({ id: "x", auth: true })], null, "/", [])).toBeNull();
+  });
+
+  it("shows auth:false spotlights to anonymous users", () => {
+    expect(pickSpotlight([make({ id: "x", auth: false })], null, "/", [])?.id).toBe("x");
+  });
+
+  it("filters by platform — a mobile-only spotlight is hidden on web", () => {
+    const items = [make({ id: "m", platforms: ["mobile"] })];
+    expect(pickSpotlight(items, user, "/", [], "web")).toBeNull();
+    expect(pickSpotlight(items, user, "/", [], "mobile")?.id).toBe("m");
+  });
+
+  it("treats missing platforms as all platforms", () => {
+    const items = [make({ id: "all" })];
+    expect(pickSpotlight(items, user, "/", [], "web")?.id).toBe("all");
+    expect(pickSpotlight(items, user, "/", [], "mobile")?.id).toBe("all");
+  });
+
+  it("respects a path regex", () => {
+    const items = [make({ id: "p", path: "^/waves" })];
+    expect(pickSpotlight(items, user, "/communities", [])).toBeNull();
+    expect(pickSpotlight(items, user, "/waves", [])?.id).toBe("p");
+  });
+
+  it("supports path arrays", () => {
+    const items = [make({ id: "p", path: ["^/waves", "^/polls"] })];
+    expect(pickSpotlight(items, user, "/polls", [])?.id).toBe("p");
+  });
+
+  it("excludes dismissed ids", () => {
+    expect(pickSpotlight([make({ id: "seen" })], user, "/", ["seen"])).toBeNull();
+  });
+
+  it("picks the highest weight", () => {
+    const items = [make({ id: "lo", weight: 1 }), make({ id: "hi", weight: 10 })];
+    expect(pickSpotlight(items, user, "/", [])?.id).toBe("hi");
+  });
+
+  it("breaks weight ties by earliest start", () => {
+    const items = [
+      make({ id: "late", weight: 5, start: "2026-06-10" }),
+      make({ id: "early", weight: 5, start: "2026-06-01" })
+    ];
+    expect(pickSpotlight(items, user, "/", [])?.id).toBe("early");
+  });
+});

--- a/apps/web/src/specs/setup-any-spec.ts
+++ b/apps/web/src/specs/setup-any-spec.ts
@@ -48,6 +48,7 @@ vi.mock("@ecency/sdk", () => ({
   getAccountDelegationsQueryOptions: vi.fn((username) => ({ queryKey: ['assets', 'account-delegations', username], queryFn: vi.fn() })),
   getBoostPlusPricesQueryOptions: vi.fn(() => ({ queryKey: ['boost-prices'], queryFn: vi.fn() })),
   getPointsQueryOptions: vi.fn(() => ({ queryKey: ['points'], queryFn: vi.fn() })),
+  getSpotlightsQueryOptions: vi.fn(() => ({ queryKey: ['notifications', 'spotlights'], queryFn: vi.fn() })),
   getBoostPlusAccountPricesQueryOptions: vi.fn(() => ({ queryKey: ['boost-account'], queryFn: vi.fn() })),
   getDeletedEntryQueryOptions: vi.fn((author, permlink) => ({
     queryKey: ['posts', 'deleted-entry', `@${author}/${permlink}`],


### PR DESCRIPTION
Adds the website side of the Feature Spotlight: a dismissible card in the feed right sidebar that surfaces one under-used feature at a time.

- Lazy, client-only (`ssr:false`) — stays off First Load JS and never flashes a card thats dismissed client-side.
- Selection (`select.ts`, unit-tested, 10 cases): filters by **platform** (`web` vs `mobile` app), auth (default logged-in only), `path` regex, and per-id dismissal (`dismiss_spotlights` in localStorage); then picks the highest `weight` (tie-break earliest `start`).
- i18n chrome under `feature-spotlight.*`; dynamic title/description come from the feed with optional per-locale overrides.
- CTA: internal route via next `<Link>`, external via `<a>`; dismisses on click.

Stacked on #912 (the `@ecency/sdk` `Spotlight` type + `getSpotlightsQueryOptions`) — base will retarget to `develop` once that merges. Backend endpoint: ecency/vision-api #27.