### PR TITLE
Spotlight: feed layout tweaks, CTA button fix, Plausible tracking

### DIFF
--- a/apps/web/src/app/(dynamicPages)/feed/layout.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/layout.tsx
@@ -19,6 +19,7 @@ export default function FeedLayout({ children }: PropsWithChildren) {
       <Navbar />
       <div className="app-content overflow-hidden entry-index-page">
         <div className="tags-side">
+          <MyFavoritesWidget />
           <TrendingTagsCard />
         </div>
         <div className="entry-page-content">
@@ -28,9 +29,8 @@ export default function FeedLayout({ children }: PropsWithChildren) {
           {children}
         </div>
         <div className="side-menu">
-          <MyFavoritesWidget />
-          <TopCommunitiesWidget />
           <FeatureSpotlightWidget />
+          <TopCommunitiesWidget />
         </div>
       </div>
     </>

--- a/apps/web/src/app/_components/feature-spotlight-widget/index.tsx
+++ b/apps/web/src/app/_components/feature-spotlight-widget/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
 import i18next from "i18next";
 import { useQuery } from "@tanstack/react-query";
@@ -8,6 +8,7 @@ import { getSpotlightsQueryOptions } from "@ecency/sdk";
 import { Button } from "@ui/button";
 import { closeSvg } from "@ui/svg";
 import * as ls from "@/utils/local-storage";
+import { trackEvent } from "@/utils/track-event";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { pickSpotlight } from "./select";
 
@@ -26,16 +27,35 @@ export function FeatureSpotlightWidget() {
     [data, activeUser, pathname, dismissedIds]
   );
 
+  // Count an impression once per shown spotlight so click/dismiss rates are comparable.
+  const spotlightId = spotlight?.id;
+  const spotlightFeature = spotlight?.feature;
+  useEffect(() => {
+    if (spotlightId && spotlightFeature) {
+      trackEvent("Spotlight: Impression", { id: spotlightId, feature: spotlightFeature });
+    }
+  }, [spotlightId, spotlightFeature]);
+
   if (!spotlight) {
     return null;
   }
 
-  const dismiss = () => {
+  const markSeen = () => {
     const current: string[] = ls.get(DISMISS_KEY) ?? [];
     if (!current.includes(spotlight.id)) {
       ls.set(DISMISS_KEY, [...current, spotlight.id]);
     }
     setDismissedIds((prev) => (prev.includes(spotlight.id) ? prev : [...prev, spotlight.id]));
+  };
+
+  const onDismiss = () => {
+    trackEvent("Spotlight: Dismiss", { id: spotlight.id, feature: spotlight.feature });
+    markSeen();
+  };
+
+  const onCtaClick = () => {
+    trackEvent("Spotlight: Click", { id: spotlight.id, feature: spotlight.feature });
+    markSeen();
   };
 
   const copy = spotlight.locales?.[i18next.language] ?? spotlight;
@@ -46,7 +66,7 @@ export function FeatureSpotlightWidget() {
       <Button
         appearance="link"
         className="absolute top-2 right-2"
-        onClick={dismiss}
+        onClick={onDismiss}
         aria-label={i18next.t("feature-spotlight.dismiss")}
       >
         {closeSvg}
@@ -61,7 +81,8 @@ export function FeatureSpotlightWidget() {
           href={spotlight.button_link}
           size="sm"
           appearance="primary"
-          onClick={dismiss}
+          className="inline-flex items-center justify-center"
+          onClick={onCtaClick}
           target={isExternal ? "_blank" : undefined}
           rel={isExternal ? "noopener noreferrer" : undefined}
         >

--- a/apps/web/src/app/_components/feature-spotlight-widget/index.tsx
+++ b/apps/web/src/app/_components/feature-spotlight-widget/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import i18next from "i18next";
 import { useQuery } from "@tanstack/react-query";
@@ -27,11 +27,14 @@ export function FeatureSpotlightWidget() {
     [data, activeUser, pathname, dismissedIds]
   );
 
-  // Count an impression once per shown spotlight so click/dismiss rates are comparable.
+  // Count an impression once per shown spotlight per mount, so a flicker or a StrictMode
+  // effect re-run doesn't double-count; click/dismiss rates stay comparable.
   const spotlightId = spotlight?.id;
   const spotlightFeature = spotlight?.feature;
+  const impressedIds = useRef(new Set<string>());
   useEffect(() => {
-    if (spotlightId && spotlightFeature) {
+    if (spotlightId && spotlightFeature && !impressedIds.current.has(spotlightId)) {
+      impressedIds.current.add(spotlightId);
       trackEvent("Spotlight: Impression", { id: spotlightId, feature: spotlightFeature });
     }
   }, [spotlightId, spotlightFeature]);

--- a/apps/web/src/specs/utils/track-event.spec.ts
+++ b/apps/web/src/specs/utils/track-event.spec.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { trackEvent } from "@/utils/track-event";
+
+const w = window as any;
+
+afterEach(() => {
+  delete w.plausible;
+});
+
+describe("trackEvent", () => {
+  it("calls window.plausible with the event and props", () => {
+    w.plausible = vi.fn();
+    trackEvent("Spotlight: Click", { id: "x", feature: "waves" });
+    expect(w.plausible).toHaveBeenCalledWith("Spotlight: Click", {
+      props: { id: "x", feature: "waves" }
+    });
+  });
+
+  it("queues the event when the script has not loaded yet", () => {
+    trackEvent("Spotlight: Impression", { id: "x", feature: "waves" });
+    expect(w.plausible.q[0]).toEqual([
+      "Spotlight: Impression",
+      { props: { id: "x", feature: "waves" } }
+    ]);
+  });
+
+  it("omits props when none are given", () => {
+    w.plausible = vi.fn();
+    trackEvent("Ping");
+    expect(w.plausible).toHaveBeenCalledWith("Ping", undefined);
+  });
+});

--- a/apps/web/src/utils/track-event.ts
+++ b/apps/web/src/utils/track-event.ts
@@ -1,0 +1,29 @@
+type EventProps = Record<string, string | number | boolean>;
+
+type PlausibleFn = {
+  (event: string, options?: { props?: EventProps }): void;
+  q?: unknown[];
+};
+
+/**
+ * Fire a Plausible custom event. No-op during SSR. The root layout loads the
+ * Plausible script deferred; the queue stub (Plausible's official snippet) keeps
+ * events fired before the script finishes loading from being dropped.
+ */
+export function trackEvent(event: string, props?: EventProps): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const w = window as Window & { plausible?: PlausibleFn };
+  let fn = w.plausible;
+  if (!fn) {
+    const stub: PlausibleFn = (...args: unknown[]) => {
+      (stub.q ??= []).push(args);
+    };
+    w.plausible = stub;
+    fn = stub;
+  }
+
+  fn(event, props ? { props } : undefined);
+}


### PR DESCRIPTION
Follow-up polish on the Feature Spotlight (#913).

**Layout** — moved **My Favorites** to the left rail (above trending topics) and moved the **spotlight card** to the top of the right rail (where favorites was).

**CTA button fix** — the post-review `Button` link-mode rendered an inline `<a>`, which ignores `h-[2rem]`, so "Open Waves" looked cramped/off. Added `inline-flex items-center justify-center` (content-width), matching the existing `anon-user-buttons` convention for link-mode buttons.

**Plausible tracking** — new `trackEvent` util fires `Spotlight: Impression` / `Spotlight: Click` / `Spotlight: Dismiss` with `{ id, feature }` props (impression once per shown card; CTA = Click, X = Dismiss). Uses Plausible's official queue stub so events fired before the deferred script loads are not dropped. +unit tests (15 pass total).

Note: to view these, add the three event names as **goals** in pl.ecency.com; the `id`/`feature` custom props let you break down which spotlight performs best.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature spotlight widget now tracks impressions and user interactions.

* **Layout Changes**
  * Reorganized feed page widget positioning: favorites widget moved to the left column; spotlight and community widgets reordered on the right column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->