### PR TITLE
feat(profile): show followers/following as page sections instead of modals

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -336,7 +336,7 @@ const config = {
       },
       {
         source:
-          "/:author(@.+)/:section(posts|blog|comments|replies|communities|trail|wallet|settings|insights|referrals|permissions|rss|rss.xml)",
+          "/:author(@.+)/:section(posts|blog|comments|replies|communities|trail|followers|following|wallet|settings|insights|referrals|permissions|rss|rss.xml)",
         destination: "/profile/:author/:section"
       },
       {

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/_index.scss
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/_index.scss
@@ -5,6 +5,13 @@
   overflow: auto;
   margin-top: 1px;
 
+  // Embedded inside a profile section (/@user/followers): flow with the page
+  // instead of the fixed-height modal scroll box.
+  &.is-page {
+    height: auto;
+    overflow: visible;
+  }
+
   .loading {
     position: absolute;
     left: 0;

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/friends-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/friends-list.tsx
@@ -1,4 +1,6 @@
 import { useMemo, useState } from "react";
+import clsx from "clsx";
+import "./_index.scss";
 import { getFriendsInfiniteQueryOptions, getSearchFriendsQueryOptions } from "@ecency/sdk";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Account } from "@/entities";
@@ -20,9 +22,15 @@ const loadLimit = 30;
 interface Props {
   account: Account;
   mode: "following" | "followers";
+  /**
+   * "modal" (default) keeps the fixed-height scroll box used inside the
+   * followers/following dialogs. "page" lets the list flow naturally inside a
+   * profile section.
+   */
+  variant?: "modal" | "page";
 }
 
-export const FriendsList = ({ account, mode }: Props) => {
+export const FriendsList = ({ account, mode, variant = "modal" }: Props) => {
   const [query, setQuery] = useState("");
   const [type, setType] = useState<FilterFriendsType>();
 
@@ -95,7 +103,7 @@ export const FriendsList = ({ account, mode }: Props) => {
   );
 
   return (
-    <div className="friends-content">
+    <div className={clsx("friends-content", variant === "page" && "is-page")}>
       <div>
         <FilterFriends updateFilterType={(v) => setType(v)} />
       </div>

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/friends-title.ts
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/friends-title.ts
@@ -1,0 +1,24 @@
+import i18next from "i18next";
+import { Account } from "@/entities";
+import { formattedNumber } from "@/utils";
+
+export type FriendsMode = "followers" | "following";
+
+export function getFriendsCount(account: Account, mode: FriendsMode): number | undefined {
+  return mode === "followers"
+    ? account.follow_stats?.follower_count
+    : account.follow_stats?.following_count;
+}
+
+/**
+ * Localized "Followers (N)" / "Following (N)" title shared by the followers
+ * modal and the profile section. Falls back to the plain label while the
+ * follow stats are still loading.
+ */
+export function getFriendsTitle(account: Account, mode: FriendsMode): string {
+  return account.follow_stats
+    ? i18next.t(`friends.${mode}`, {
+        n: formattedNumber(getFriendsCount(account, mode) ?? 0, { fractionDigits: 0 })
+      })
+    : i18next.t(`profile.${mode}`);
+}

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/index.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
-import i18next from "i18next";
-import { formattedNumber } from "@/utils";
 import { Account } from "@/entities";
 import { FriendsList } from "@/app/(dynamicPages)/profile/[username]/_components/friends/friends-list";
+import { getFriendsTitle } from "@/app/(dynamicPages)/profile/[username]/_components/friends/friends-title";
 
 interface Props {
   account: Account;
@@ -13,13 +12,7 @@ export function Followers({ onHide, account }: Props) {
   return (
     <Modal onHide={onHide} show={true} centered={true} size="lg">
       <ModalHeader closeButton={true}>
-        <ModalTitle>
-          {account.follow_stats
-            ? i18next.t("friends.followers", {
-                n: formattedNumber(account.follow_stats.follower_count, { fractionDigits: 0 })
-              })
-            : ""}
-        </ModalTitle>
+        <ModalTitle>{getFriendsTitle(account, "followers")}</ModalTitle>
       </ModalHeader>
       <ModalBody>
         <FriendsList mode="followers" account={account} />
@@ -32,13 +25,7 @@ export function Following({ onHide, account }: Props) {
   return (
     <Modal onHide={onHide} show={true} centered={true} size="lg">
       <ModalHeader closeButton={true}>
-        <ModalTitle>
-          {account.follow_stats
-            ? i18next.t("friends.following", {
-                n: formattedNumber(account.follow_stats.following_count, { fractionDigits: 0 })
-              })
-            : ""}
-        </ModalTitle>
+        <ModalTitle>{getFriendsTitle(account, "following")}</ModalTitle>
       </ModalHeader>
       <ModalBody>
         <FriendsList mode="following" account={account} />

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import i18next from "i18next";
 import { formattedNumber } from "@/utils";

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/profile-friends.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/profile-friends.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import i18next from "i18next";
+import { Account } from "@/entities";
+import { formattedNumber } from "@/utils";
+import { FriendsList } from "./friends-list";
+
+interface Props {
+  account: Account;
+  mode: "followers" | "following";
+}
+
+/**
+ * Renders the followers/following list inside the profile section area
+ * (e.g. /@username/followers) instead of a modal. Reuses {@link FriendsList}
+ * with its page variant.
+ */
+export function ProfileFriends({ account, mode }: Props) {
+  const count =
+    mode === "followers"
+      ? account.follow_stats?.follower_count
+      : account.follow_stats?.following_count;
+  const titleKey = mode === "followers" ? "friends.followers" : "friends.following";
+
+  return (
+    <div className="bg-white/80 dark:bg-dark-200/90 glass-box rounded-none sm:rounded-xl p-4 w-full">
+      <h2 className="text-lg font-semibold mb-2">
+        {account.follow_stats
+          ? i18next.t(titleKey, {
+              n: formattedNumber(count ?? 0, { fractionDigits: 0 })
+            })
+          : i18next.t(mode === "followers" ? "profile.followers" : "profile.following")}
+      </h2>
+      <FriendsList account={account} mode={mode} variant="page" />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/profile-friends.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/profile-friends.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import i18next from "i18next";
 import { Account } from "@/entities";
-import { formattedNumber } from "@/utils";
 import { FriendsList } from "./friends-list";
+import { FriendsMode, getFriendsTitle } from "./friends-title";
 
 interface Props {
   account: Account;
-  mode: "followers" | "following";
+  mode: FriendsMode;
 }
 
 /**
@@ -16,21 +15,9 @@ interface Props {
  * with its page variant.
  */
 export function ProfileFriends({ account, mode }: Props) {
-  const count =
-    mode === "followers"
-      ? account.follow_stats?.follower_count
-      : account.follow_stats?.following_count;
-  const titleKey = mode === "followers" ? "friends.followers" : "friends.following";
-
   return (
     <div className="bg-white/80 dark:bg-dark-200/90 glass-box rounded-none sm:rounded-xl p-4 w-full">
-      <h2 className="text-lg font-semibold mb-2">
-        {account.follow_stats
-          ? i18next.t(titleKey, {
-              n: formattedNumber(count ?? 0, { fractionDigits: 0 })
-            })
-          : i18next.t(mode === "followers" ? "profile.followers" : "profile.following")}
-      </h2>
+      <h2 className="text-lg font-semibold mb-2">{getFriendsTitle(account, mode)}</h2>
       <FriendsList account={account} mode={mode} variant="page" />
     </div>
   );

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -28,7 +28,6 @@ import i18next from "i18next";
 import Image from "next/image";
 import Link from "next/link";
 import { useMemo, useState } from "react";
-import { Followers, Following } from "../friends";
 import { ProfileInfo } from "../profile-info";
 import { ResourceCreditsInfo } from "../rc-info";
 import "./_index.scss";
@@ -57,8 +56,6 @@ export function ProfileCard({ account }: Props) {
   });
   const { data: subscriptions } = useQuery(getAccountSubscriptionsQueryOptions(account?.name));
 
-  const [showFollowers, setShowFollowers] = useState(false);
-  const [showFollowing, setShowFollowing] = useState(false);
   const [imageSrc, setImageSrc] = useState<string>();
   const moderatedCommunities = useMemo(
     () => subscriptions?.filter((x) => x[2] === "mod" || x[2] === "admin" || x[2] === "owner") ?? [],
@@ -120,42 +117,23 @@ export function ProfileCard({ account }: Props) {
         </div>
 
         <div className="grid grid-cols-2 pb-4">
-          <div
+          <Link
+            href={`/@${account.name}/followers`}
             className="hover:text-blue-dark-sky hover:scale-95 duration-300 cursor-pointer"
-            role="button"
-            tabIndex={0}
-            onClick={() => setShowFollowers(true)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                setShowFollowers(true);
-              }
-            }}
           >
             <div className="text-sm opacity-50">{i18next.t("profile.followers")}</div>
             <div className="font-semibold">{data?.follow_stats?.follower_count ?? 0}</div>
-          </div>
-          <div
+          </Link>
+          <Link
+            href={`/@${account.name}/following`}
             className="hover:text-blue-dark-sky hover:scale-95 duration-300 cursor-pointer"
-            role="button"
-            tabIndex={0}
-            onClick={() => setShowFollowing(true)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                setShowFollowing(true);
-              }
-            }}
           >
             <div className="text-sm opacity-50">{i18next.t("profile.following")}</div>
             <div className="font-semibold">{data?.follow_stats?.following_count ?? 0}</div>
-          </div>
+          </Link>
         </div>
       </div>
       <HivePosh username={account.name} className="mb-4" />
-
-      {showFollowers && data && <Followers account={data} onHide={() => setShowFollowers(false)} />}
-      {showFollowing && data && <Following account={data} onHide={() => setShowFollowing(false)} />}
 
       {!isMyProfile && (
         <div className="mb-4 flex gap-2">

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-menu/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-menu/index.tsx
@@ -22,15 +22,13 @@ export function ProfileMenu({ username }: Props) {
   const pathname = usePathname();
   const section = useMemo(() => pathname?.split("/")[2] ?? "posts", [pathname]);
 
-  const kebabMenuItems = [
-    ...["trail", "replies"]
-      .map((x) => ({
-        label: i18next.t(`profile.section-${x}`),
-        href: `/@${username}/${x}`,
-        selected: section === x,
-        id: x
-      }))
-      .filter((item) => !item.selected),
+  const kebabMenuItemsAll = [
+    ...["trail", "replies", "followers", "following"].map((x) => ({
+      label: i18next.t(`profile.section-${x}`),
+      href: `/@${username}/${x}`,
+      selected: section === x,
+      id: x
+    })),
     ...EcencyConfigManager.composeConditionals(
       EcencyConfigManager.withConditional(
         (config) => config.visionFeatures.referrals.enabled,
@@ -43,6 +41,8 @@ export function ProfileMenu({ username }: Props) {
       )
     )
   ];
+  // Hide the current section from the kebab (it's the page you're already on)
+  const kebabMenuItems = kebabMenuItemsAll.filter((item) => !item.selected);
 
   const menuItems = [
     ...[ProfileFilter.blog, ProfileFilter.posts, ProfileFilter.comments, "communities"].map(
@@ -72,14 +72,17 @@ export function ProfileMenu({ username }: Props) {
   ];
 
   const dropDownMenuItems = [...menuItems, ...kebabMenuItems];
+  // Full set (including the active kebab section) used only to resolve the
+  // mobile dropdown label, so being on /followers shows "Followers" not "Blog".
+  const allMenuItems = [...menuItems, ...kebabMenuItemsAll];
 
   return (
     <PageMenu className="pb-4 pt-4 md:pt-0">
       <PageMenuMobileDropdown
         label={
-          dropDownMenuItems.filter((item) => item.id === section).length > 0
+          allMenuItems.some((item) => item.id === section)
             ? i18next.t(`profile.section-${section}`)
-            : i18next.t(`profile.section-${dropDownMenuItems[0].id}`)
+            : i18next.t(`profile.section-${menuItems[0].id}`)
         }
         isSelected={false}
       >

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/followers/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/followers/page.tsx
@@ -1,0 +1,26 @@
+import { notFound } from "next/navigation";
+import { prefetchQuery } from "@/core/react-query";
+import { getAccountFullQueryOptions } from "@ecency/sdk";
+import { Metadata, ResolvingMetadata } from "next";
+import { generateProfileMetadata } from "@/app/(dynamicPages)/profile/[username]/_helpers";
+import { ProfileFriends } from "@/app/(dynamicPages)/profile/[username]/_components/friends/profile-friends";
+
+interface Props {
+  params: Promise<{ username: string }>;
+}
+
+export async function generateMetadata(props: Props, parent: ResolvingMetadata): Promise<Metadata> {
+  const { username } = await props.params;
+  return generateProfileMetadata(username.replace(/%40/g, ""), "followers");
+}
+
+export default async function FollowersPage({ params }: Props) {
+  const { username } = await params;
+  const account = await prefetchQuery(getAccountFullQueryOptions(username.replace(/%40/g, "")));
+
+  if (!account) {
+    return notFound();
+  }
+
+  return <ProfileFriends account={account} mode="followers" />;
+}

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/following/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/following/page.tsx
@@ -1,0 +1,26 @@
+import { notFound } from "next/navigation";
+import { prefetchQuery } from "@/core/react-query";
+import { getAccountFullQueryOptions } from "@ecency/sdk";
+import { Metadata, ResolvingMetadata } from "next";
+import { generateProfileMetadata } from "@/app/(dynamicPages)/profile/[username]/_helpers";
+import { ProfileFriends } from "@/app/(dynamicPages)/profile/[username]/_components/friends/profile-friends";
+
+interface Props {
+  params: Promise<{ username: string }>;
+}
+
+export async function generateMetadata(props: Props, parent: ResolvingMetadata): Promise<Metadata> {
+  const { username } = await props.params;
+  return generateProfileMetadata(username.replace(/%40/g, ""), "following");
+}
+
+export default async function FollowingPage({ params }: Props) {
+  const { username } = await params;
+  const account = await prefetchQuery(getAccountFullQueryOptions(username.replace(/%40/g, "")));
+
+  if (!account) {
+    return notFound();
+  }
+
+  return <ProfileFriends account={account} mode="following" />;
+}

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1170,6 +1170,8 @@
     "follows-you": "Follows you",
     "section-blog": "Blog",
     "section-posts": "Posts",
+    "section-followers": "Followers",
+    "section-following": "Following",
     "section-trail": "Likes",
     "section-comments": "Comments",
     "section-replies": "Replies",

--- a/apps/web/src/features/next-middleware/cache-policy.ts
+++ b/apps/web/src/features/next-middleware/cache-policy.ts
@@ -94,8 +94,11 @@ const NO_CACHE_PROFILE_SECTIONS = new Set([
  *           posts from followed users and should refresh on feed cadence.
  * - `trail` shows the user's curation trail (votes on others' posts),
  *           which also updates faster than authored content.
+ * - `followers` / `following` list other accounts and change as people
+ *           follow/unfollow; deterministic per URL but should refresh on a
+ *           faster cadence than authored content.
  */
-const PROFILE_FEED_SECTIONS = new Set(["feed", "trail"]);
+const PROFILE_FEED_SECTIONS = new Set(["feed", "trail", "followers", "following"]);
 
 /** Static content pages — effectively permanent. */
 const STATIC_PAGES = new Set([
@@ -212,7 +215,7 @@ export function getCachePolicyForPath(pathname: string): CachePolicy | null {
       const second = segments[1];
       if (
         !NO_CACHE_PROFILE_SECTIONS.has(second) &&
-        !["posts", "blog", "comments", "replies", "communities", "trail", "insights", "rss", "rss.xml", "feed"].includes(
+        !["posts", "blog", "comments", "replies", "communities", "trail", "followers", "following", "insights", "rss", "rss.xml", "feed"].includes(
           second
         )
       ) {

--- a/apps/web/src/features/next-middleware/cache-policy.ts
+++ b/apps/web/src/features/next-middleware/cache-policy.ts
@@ -94,11 +94,13 @@ const NO_CACHE_PROFILE_SECTIONS = new Set([
  *           posts from followed users and should refresh on feed cadence.
  * - `trail` shows the user's curation trail (votes on others' posts),
  *           which also updates faster than authored content.
- * - `followers` / `following` list other accounts and change as people
- *           follow/unfollow; deterministic per URL but should refresh on a
- *           faster cadence than authored content.
+ *
+ * NOTE: `followers`/`following` are NOT here — their SSR is viewer-independent
+ * (the list hydrates client-side; only the owner's follow counts render on the
+ * server), so they use the auth-class-equivalent `profile` tier and can share
+ * an edge-cache entry across logged-in users, exactly like posts/blog.
  */
-const PROFILE_FEED_SECTIONS = new Set(["feed", "trail", "followers", "following"]);
+const PROFILE_FEED_SECTIONS = new Set(["feed", "trail"]);
 
 /** Static content pages — effectively permanent. */
 const STATIC_PAGES = new Set([
@@ -335,7 +337,7 @@ export function parseEntryUrl(
     if (
       NO_CACHE_PROFILE_SECTIONS.has(second) ||
       PROFILE_FEED_SECTIONS.has(second) ||
-      ["posts", "blog", "comments", "replies", "communities", "insights", "rss", "rss.xml"].includes(second)
+      ["posts", "blog", "comments", "replies", "communities", "followers", "following", "insights", "rss", "rss.xml"].includes(second)
     ) {
       return null; // profile section, not an entry
     }

--- a/apps/web/src/specs/features/next-middleware/cache-policy.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/cache-policy.spec.ts
@@ -149,7 +149,7 @@ describe("getCachePolicyForPath", () => {
       expect(policy).toEqual({ tier: "profile", sMaxAge: 300, staleWhileRevalidate: 3600 });
     });
 
-    it.each(["posts", "blog", "comments", "replies", "communities"])(
+    it.each(["posts", "blog", "comments", "replies", "communities", "followers", "following"])(
       "returns profile tier for /@alice/%s",
       (section) => {
         const policy = getCachePolicyForPath(`/@alice/${section}`);
@@ -157,7 +157,7 @@ describe("getCachePolicyForPath", () => {
       }
     );
 
-    it.each(["feed", "trail", "followers", "following"])(
+    it.each(["feed", "trail"])(
       "returns profile-feed tier for /@alice/%s (aggregates content from other users)",
       (section) => {
         const policy = getCachePolicyForPath(`/@alice/${section}`);
@@ -166,12 +166,13 @@ describe("getCachePolicyForPath", () => {
     );
 
     it.each(["followers", "following"])(
-      "does not treat /@alice/%s as an entry page",
+      "does not treat /@alice/%s as an entry page (viewer-independent profile tier)",
       (section) => {
         // Regression: a 2-segment /@author/<section> must not fall through to
         // the entry tier (which would cache a follower list as a post for 1h).
+        // SSR is viewer-independent, so it gets the cacheable profile tier.
         const policy = getCachePolicyForPath(`/@alice/${section}`);
-        expect(policy?.tier).not.toBe("entry");
+        expect(policy).toEqual({ tier: "profile", sMaxAge: 300, staleWhileRevalidate: 3600 });
       }
     );
   });

--- a/apps/web/src/specs/features/next-middleware/cache-policy.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/cache-policy.spec.ts
@@ -157,11 +157,21 @@ describe("getCachePolicyForPath", () => {
       }
     );
 
-    it.each(["feed", "trail"])(
+    it.each(["feed", "trail", "followers", "following"])(
       "returns profile-feed tier for /@alice/%s (aggregates content from other users)",
       (section) => {
         const policy = getCachePolicyForPath(`/@alice/${section}`);
         expect(policy).toEqual({ tier: "profile-feed", sMaxAge: 60, staleWhileRevalidate: 300 });
+      }
+    );
+
+    it.each(["followers", "following"])(
+      "does not treat /@alice/%s as an entry page",
+      (section) => {
+        // Regression: a 2-segment /@author/<section> must not fall through to
+        // the entry tier (which would cache a follower list as a post for 1h).
+        const policy = getCachePolicyForPath(`/@alice/${section}`);
+        expect(policy?.tier).not.toBe("entry");
       }
     );
   });
@@ -424,7 +434,9 @@ describe("parseEntryUrl", () => {
     "wallet",
     "settings",
     "feed",
-    "trail"
+    "trail",
+    "followers",
+    "following"
   ])("returns null for profile section /@alice/%s", (section) => {
     expect(parseEntryUrl(`/@alice/${section}`)).toBeNull();
   });

--- a/apps/web/src/specs/utils/posting.spec.ts
+++ b/apps/web/src/specs/utils/posting.spec.ts
@@ -67,6 +67,18 @@ describe("Posting", () => {
     randomSpy.mockRestore();
   });
 
+  it("ensureValidPermlink avoids a reserved profile-section slug", () => {
+    const randomSpy = vi.spyOn(Math, "random").mockImplementation(() => 1.95136022969379);
+
+    // A regex-valid but reserved user-provided permlink must not be returned
+    // as-is, or /@author/followers would resolve to the section page.
+    const result = ensureValidPermlink("followers", "fallback title");
+    expect(result).not.toBe("followers");
+    expect(result.startsWith("followers-")).toBe(true);
+
+    randomSpy.mockRestore();
+  });
+
   it("(1) extractMetadata", () => {
     const input = '<img src="http://www.xx.com/a.png"> @lorem @ipsum';
     expect(extractMetaData(input)).toMatchSnapshot();

--- a/apps/web/src/specs/utils/posting.spec.ts
+++ b/apps/web/src/specs/utils/posting.spec.ts
@@ -34,6 +34,21 @@ describe("Posting", () => {
     randomSpy.mockRestore();
   });
 
+  it("createPermlink avoids reserved profile-section slugs", () => {
+    const randomSpy = vi.spyOn(Math, "random").mockImplementation(() => 1.95136022969379);
+
+    // A title that slugifies to a section name must not become that bare slug,
+    // or /@author/<permlink> would resolve to the section page, not the post.
+    expect(createPermlink("Followers")).not.toBe("followers");
+    expect(createPermlink("Followers").startsWith("followers-")).toBe(true);
+    expect(createPermlink("Wallet").startsWith("wallet-")).toBe(true);
+
+    // Non-section titles are unaffected.
+    expect(createPermlink("My cool post")).toBe("my-cool-post");
+
+    randomSpy.mockRestore();
+  });
+
   it("ensureValidPermlink returns valid permlink unchanged", () => {
     expect(ensureValidPermlink("valid-permlink-1", "fallback title")).toBe(
       "valid-permlink-1"

--- a/apps/web/src/utils/posting.ts
+++ b/apps/web/src/utils/posting.ts
@@ -7,6 +7,13 @@ const permlinkRnd = () => (Math.random() + 1).toString(16).substring(2);
 
 const permlinkPattern = /^[a-z0-9-]{1,255}$/;
 
+// A post permlink must never be exactly a reserved profile-section slug (e.g.
+// "followers", "wallet"), or its canonical /@author/<permlink> URL would
+// resolve to that section page instead of the post. SECTION_LIST is the shared
+// render-helper list of routed sections; referenced lazily (inside the
+// functions) to avoid an import-time evaluation order issue.
+const isReservedSectionSlug = (slug: string): boolean => SECTION_LIST.includes(slug);
+
 export const createPermlink = (title: string, random: boolean = false): string => {
   // Ensure the string is valid and normalized
   let slug = getSlug(title || "", { lang: false, symbols: true }) ?? "";
@@ -34,11 +41,9 @@ export const createPermlink = (title: string, random: boolean = false): string =
     perm = `${perm}-${rnd}`;
   }
 
-  // Never let a post permlink be exactly a reserved profile-section slug (e.g.
-  // "followers", "wallet"): its canonical /@author/<permlink> URL would resolve
-  // to that section page instead of the post. Append random chars to avoid the
-  // collision.
-  if (SECTION_LIST.includes(perm)) {
+  // Append random chars if the slug is exactly a reserved section so the post
+  // can't be shadowed by a section page.
+  if (isReservedSectionSlug(perm)) {
     perm = `${perm}-${permlinkRnd().toLowerCase()}`;
   }
 
@@ -55,7 +60,14 @@ export const ensureValidPermlink = (
 ): string => {
   const normalizedPermlink = permlink?.trim().toLowerCase();
 
-  if (normalizedPermlink && permlinkPattern.test(normalizedPermlink)) {
+  // A regex-valid, user-provided permlink is accepted as-is — unless it is a
+  // reserved section slug, in which case it falls through to createPermlink
+  // (below) which appends random chars to avoid the route collision.
+  if (
+    normalizedPermlink &&
+    permlinkPattern.test(normalizedPermlink) &&
+    !isReservedSectionSlug(normalizedPermlink)
+  ) {
     return normalizedPermlink;
   }
 

--- a/apps/web/src/utils/posting.ts
+++ b/apps/web/src/utils/posting.ts
@@ -1,5 +1,6 @@
 import getSlug from "speakingurl";
 import { diff_match_patch } from "diff-match-patch";
+import { SECTION_LIST } from "@ecency/render-helper";
 import { BeneficiaryRoute, CommentOptions, MetaData, RewardType } from "@/entities";
 
 const permlinkRnd = () => (Math.random() + 1).toString(16).substring(2);
@@ -31,6 +32,14 @@ export const createPermlink = (title: string, random: boolean = false): string =
   if (random) {
     const rnd = permlinkRnd().toLowerCase();
     perm = `${perm}-${rnd}`;
+  }
+
+  // Never let a post permlink be exactly a reserved profile-section slug (e.g.
+  // "followers", "wallet"): its canonical /@author/<permlink> URL would resolve
+  // to that section page instead of the post. Append random chars to avoid the
+  // collision.
+  if (SECTION_LIST.includes(perm)) {
+    perm = `${perm}-${permlinkRnd().toLowerCase()}`;
   }
 
   if (perm.length > 255) {


### PR DESCRIPTION
## What

Converts the **followers** and **following** lists on the profile page from modal dialogs into dedicated profile **sections** at `/@username/followers` and `/@username/following`. The lists now render inside the profile section area (next to the profile card), and the follower/following counts on the profile card link to these routes.

## Why

As real pages, the lists are now **linkable, shareable, bookmarkable, and server-rendered on direct visits / refresh / back-button** — none of which a modal supported. Clicking the counts, typing the URL, refreshing, or opening a shared link all land on the same section.

## Behaviour

- Profile-card follower/following counts → `next/link` to `/@user/followers` and `/@user/following` (previously `role="button"` + modal state).
- Both sections are also reachable from the profile overflow (kebab) menu.
- The followers/following **modal components are kept** — they're still used by the Waves author cards, so `FriendsList` gained a `variant` prop (`"modal"` default = unchanged; `"page"` = flows in the section without the fixed-height scroll box).

## Implementation

- **Routing** — added `followers|following` to the profile `:section` rewrite in `next.config.js` (and the new static `followers/` & `following/` route folders take precedence over the dynamic `[section]` sibling).
- **Pages** — `followers/page.tsx` and `following/page.tsx` mirror the existing `trail` section page (prefetch account, `notFound` guard, metadata) and render the new `ProfileFriends` client component.
- **Reuse** — `ProfileFriends` = heading (with count) + the existing `FriendsList` in its new `page` variant. `FriendsList` now owns its SCSS import so styles load outside the modal too.
- **Menu** — followers/following added to the kebab menu; mobile section-label resolution fixed so being on `/followers` shows "Followers" (and trail/replies labels keep working).
- **Cache policy** — `followers`/`following` are now classified as profile sections in `cache-policy.ts`. Without this, a direct hit to `/@user/following` (a 2-segment URL) was treated as a **post** page and cached for an hour; they now get the profile-feed tier. Includes regression tests. (The render-helper `SECTION_LIST` content-link whitelist already contained both.)
- **i18n** — `profile.section-followers` / `profile.section-following`.

## Testing

- `tsc --noEmit` — no new type errors (verified against `develop` baseline).
- Web test suite passes, including new `cache-policy` cases asserting followers/following are not treated as entry pages and get the profile-feed tier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated followers and following pages accessible at /@username/followers and /@username/following
  * Profile card counts now link directly to these new pages instead of opening modals

* **Bug Fixes**
  * Prevented post titles from creating permalinks that conflict with reserved profile section names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->