### PR TITLE
feat(web): agent-readable post endpoints (.md / .json / .discussion.json) + llms.txt

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-discussion/route.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-discussion/route.ts
@@ -1,0 +1,47 @@
+import { prefetchQuery } from "@/core/react-query";
+import { getDiscussionQueryOptions } from "@ecency/sdk";
+import {
+  AGENT_CACHE_CONTROL,
+  agentNotFound,
+  loadIndexableEntry,
+  selfUrl
+} from "@/app/(dynamicPages)/entry/_helpers/agent-readable";
+
+// Reached via the middleware rewrite of `/@author/permlink.discussion.json`.
+// Serves the full comment thread (bridge.get_discussion map) as JSON.
+export const dynamic = "force-dynamic"; // handler runs; CDN caches via headers
+
+interface Props {
+  params: Promise<{ category: string; author: string; permlink: string }>;
+}
+
+export async function GET(_request: Request, { params }: Props): Promise<Response> {
+  try {
+    const { author, permlink } = await params;
+
+    // Gate on the root post: if the post itself is suppressed, so is its thread.
+    const loaded = await loadIndexableEntry(author, permlink);
+    if (!loaded) return agentNotFound();
+
+    const discussion = await prefetchQuery(
+      getDiscussionQueryOptions(loaded.entry.author, loaded.entry.permlink)
+    );
+
+    const body = JSON.stringify({
+      type: "discussion",
+      canonical_url: selfUrl(loaded.entry),
+      source: "hive_bridge",
+      content: discussion ?? {}
+    });
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": AGENT_CACHE_CONTROL
+      }
+    });
+  } catch {
+    return agentNotFound();
+  }
+}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-discussion/route.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-discussion/route.ts
@@ -38,7 +38,11 @@ export async function GET(_request: Request, { params }: Props): Promise<Respons
       status: 200,
       headers: {
         "Content-Type": "application/json; charset=utf-8",
-        "Cache-Control": AGENT_CACHE_CONTROL
+        "Cache-Control": AGENT_CACHE_CONTROL,
+        // Alternate representation of the HTML post — keep it out of the search
+        // index (no duplicate-content competition). Agents fetching the URL
+        // still get the content; X-Robots-Tag only governs indexing.
+        "X-Robots-Tag": "noindex"
       }
     });
   } catch {

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-discussion/route.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-discussion/route.ts
@@ -1,8 +1,8 @@
 import { prefetchQuery } from "@/core/react-query";
 import { getDiscussionQueryOptions } from "@ecency/sdk";
 import {
-  AGENT_CACHE_CONTROL,
   agentNotFound,
+  agentResponse,
   loadIndexableEntry,
   selfUrl
 } from "@/app/(dynamicPages)/entry/_helpers/agent-readable";
@@ -19,32 +19,26 @@ export async function GET(_request: Request, { params }: Props): Promise<Respons
   try {
     const { author, permlink } = await params;
 
-    // Gate on the root post: if the post itself is suppressed, so is its thread.
+    // Gate on the requested entry: if it's suppressed, so is its thread.
     const loaded = await loadIndexableEntry(author, permlink);
     if (!loaded) return agentNotFound();
 
-    const discussion = await prefetchQuery(
-      getDiscussionQueryOptions(loaded.entry.author, loaded.entry.permlink)
-    );
+    // Always return the FULL thread. bridge.get_discussion rooted at a comment
+    // only yields that comment's subtree, so resolve to the discussion root
+    // (root_author/root_permlink when this entry is a reply; itself otherwise).
+    const rootAuthor = loaded.entry.root_author || loaded.entry.author;
+    const rootPermlink = loaded.entry.root_permlink || loaded.entry.permlink;
+
+    const discussion = await prefetchQuery(getDiscussionQueryOptions(rootAuthor, rootPermlink));
 
     const body = JSON.stringify({
       type: "discussion",
-      canonical_url: selfUrl(loaded.entry),
+      canonical_url: selfUrl({ author: rootAuthor, permlink: rootPermlink }),
       source: "hive_bridge",
       content: discussion ?? {}
     });
 
-    return new Response(body, {
-      status: 200,
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        "Cache-Control": AGENT_CACHE_CONTROL,
-        // Alternate representation of the HTML post — keep it out of the search
-        // index (no duplicate-content competition). Agents fetching the URL
-        // still get the content; X-Robots-Tag only governs indexing.
-        "X-Robots-Tag": "noindex"
-      }
-    });
+    return agentResponse(body, "application/json; charset=utf-8");
   } catch {
     return agentNotFound();
   }

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-json/route.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-json/route.ts
@@ -1,0 +1,39 @@
+import {
+  AGENT_CACHE_CONTROL,
+  agentNotFound,
+  loadIndexableEntry,
+  selfUrl
+} from "@/app/(dynamicPages)/entry/_helpers/agent-readable";
+
+// Reached via the middleware rewrite of `/@author/permlink.json`. Serves the
+// post as structured JSON in a small, stable envelope.
+export const dynamic = "force-dynamic"; // handler runs; CDN caches via headers
+
+interface Props {
+  params: Promise<{ category: string; author: string; permlink: string }>;
+}
+
+export async function GET(_request: Request, { params }: Props): Promise<Response> {
+  try {
+    const { author, permlink } = await params;
+    const loaded = await loadIndexableEntry(author, permlink);
+    if (!loaded) return agentNotFound();
+
+    const body = JSON.stringify({
+      type: loaded.entry.parent_author ? "comment" : "post",
+      canonical_url: selfUrl(loaded.entry),
+      source: loaded.source,
+      content: loaded.entry
+    });
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": AGENT_CACHE_CONTROL
+      }
+    });
+  } catch {
+    return agentNotFound();
+  }
+}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-json/route.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-json/route.ts
@@ -30,7 +30,11 @@ export async function GET(_request: Request, { params }: Props): Promise<Respons
       status: 200,
       headers: {
         "Content-Type": "application/json; charset=utf-8",
-        "Cache-Control": AGENT_CACHE_CONTROL
+        "Cache-Control": AGENT_CACHE_CONTROL,
+        // Alternate representation of the HTML post — keep it out of the search
+        // index (no duplicate-content competition). Agents fetching the URL
+        // still get the content; X-Robots-Tag only governs indexing.
+        "X-Robots-Tag": "noindex"
       }
     });
   } catch {

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-json/route.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-json/route.ts
@@ -1,6 +1,6 @@
 import {
-  AGENT_CACHE_CONTROL,
   agentNotFound,
+  agentResponse,
   loadIndexableEntry,
   selfUrl
 } from "@/app/(dynamicPages)/entry/_helpers/agent-readable";
@@ -26,17 +26,7 @@ export async function GET(_request: Request, { params }: Props): Promise<Respons
       content: loaded.entry
     });
 
-    return new Response(body, {
-      status: 200,
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        "Cache-Control": AGENT_CACHE_CONTROL,
-        // Alternate representation of the HTML post — keep it out of the search
-        // index (no duplicate-content competition). Agents fetching the URL
-        // still get the content; X-Robots-Tag only governs indexing.
-        "X-Robots-Tag": "noindex"
-      }
-    });
+    return agentResponse(body, "application/json; charset=utf-8");
   } catch {
     return agentNotFound();
   }

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-md/route.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-md/route.ts
@@ -23,7 +23,11 @@ export async function GET(_request: Request, { params }: Props): Promise<Respons
       status: 200,
       headers: {
         "Content-Type": "text/markdown; charset=utf-8",
-        "Cache-Control": AGENT_CACHE_CONTROL
+        "Cache-Control": AGENT_CACHE_CONTROL,
+        // Alternate representation of the HTML post — keep it out of the search
+        // index (no duplicate-content competition). Agents fetching the URL
+        // still get the content; X-Robots-Tag only governs indexing.
+        "X-Robots-Tag": "noindex"
       }
     });
   } catch {

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-md/route.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-md/route.ts
@@ -1,6 +1,6 @@
 import {
-  AGENT_CACHE_CONTROL,
   agentNotFound,
+  agentResponse,
   loadIndexableEntry,
   renderEntryMarkdown
 } from "@/app/(dynamicPages)/entry/_helpers/agent-readable";
@@ -19,17 +19,7 @@ export async function GET(_request: Request, { params }: Props): Promise<Respons
     const loaded = await loadIndexableEntry(author, permlink);
     if (!loaded) return agentNotFound();
 
-    return new Response(renderEntryMarkdown(loaded.entry), {
-      status: 200,
-      headers: {
-        "Content-Type": "text/markdown; charset=utf-8",
-        "Cache-Control": AGENT_CACHE_CONTROL,
-        // Alternate representation of the HTML post — keep it out of the search
-        // index (no duplicate-content competition). Agents fetching the URL
-        // still get the content; X-Robots-Tag only governs indexing.
-        "X-Robots-Tag": "noindex"
-      }
-    });
+    return agentResponse(renderEntryMarkdown(loaded.entry), "text/markdown; charset=utf-8");
   } catch {
     return agentNotFound();
   }

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-md/route.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/agent-md/route.ts
@@ -1,0 +1,32 @@
+import {
+  AGENT_CACHE_CONTROL,
+  agentNotFound,
+  loadIndexableEntry,
+  renderEntryMarkdown
+} from "@/app/(dynamicPages)/entry/_helpers/agent-readable";
+
+// Reached via the middleware rewrite of `/@author/permlink.md`. Serves the post
+// as a clean Markdown document (YAML front matter + raw on-chain body).
+export const dynamic = "force-dynamic"; // handler runs; CDN caches via headers
+
+interface Props {
+  params: Promise<{ category: string; author: string; permlink: string }>;
+}
+
+export async function GET(_request: Request, { params }: Props): Promise<Response> {
+  try {
+    const { author, permlink } = await params;
+    const loaded = await loadIndexableEntry(author, permlink);
+    if (!loaded) return agentNotFound();
+
+    return new Response(renderEntryMarkdown(loaded.entry), {
+      status: 200,
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Cache-Control": AGENT_CACHE_CONTROL
+      }
+    });
+  } catch {
+    return agentNotFound();
+  }
+}

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/agent-readable.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/agent-readable.ts
@@ -23,6 +23,24 @@ export const AGENT_CACHE_CONTROL = "public, max-age=0, s-maxage=300, stale-while
 // both of which can flip — don't let edges pin it for long.
 const NOT_FOUND_CACHE_CONTROL = "public, max-age=0, s-maxage=60";
 
+// Hive bodies are a markdown/HTML hybrid and CAN carry arbitrary raw HTML/JS
+// (we serve the body verbatim, NOT through the HTML sanitizer). We never send a
+// text/html content type, but harden every response so that raw body can never
+// be content-sniffed or rendered as an executable document on our own origin:
+//   - nosniff           → the declared text/markdown|application/json wins; the
+//                         browser won't re-interpret it as HTML and run scripts.
+//   - CSP default-src 'none'; sandbox → even if forced into a document context,
+//                         nothing loads or executes.
+//   - X-Robots-Tag noindex → alternate representation of the HTML post; keep it
+//                         out of search (no duplicate-content competition).
+// Agents fetching the URL still get the full content — these only govern how a
+// browser would render it and how search engines index it.
+const AGENT_SECURITY_HEADERS: Record<string, string> = {
+  "X-Content-Type-Options": "nosniff",
+  "Content-Security-Policy": "default-src 'none'; sandbox",
+  "X-Robots-Tag": "noindex"
+};
+
 export type EntrySource = "hive_condenser" | "hive_bridge";
 
 export interface LoadedEntry {
@@ -30,10 +48,26 @@ export interface LoadedEntry {
   source: EntrySource;
 }
 
+/** 200 response with the shared cache + security headers for every format. */
+export function agentResponse(body: string, contentType: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": AGENT_CACHE_CONTROL,
+      ...AGENT_SECURITY_HEADERS
+    }
+  });
+}
+
 export function agentNotFound(): Response {
   return new Response("Not found", {
     status: 404,
-    headers: { "Cache-Control": NOT_FOUND_CACHE_CONTROL }
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": NOT_FOUND_CACHE_CONTROL,
+      ...AGENT_SECURITY_HEADERS
+    }
   });
 }
 

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/agent-readable.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/agent-readable.ts
@@ -1,0 +1,95 @@
+import { prefetchQuery } from "@/core/react-query";
+import { EcencyEntriesCacheManagement } from "@/core/caches";
+import { getContentQueryOptions, getProfilesQueryOptions } from "@ecency/sdk";
+import { isIndexable, ReputationSource } from "@/utils/entry-indexability";
+import { isAuthorBlacklisted } from "@/features/seo/blacklist-check";
+import { safeDecodeURIComponent } from "@/utils";
+import type { Entry } from "@/entities";
+
+// Re-exported so route handlers have a single import surface for the endpoints.
+export { selfUrl, renderEntryMarkdown } from "./entry-agent-format";
+
+/**
+ * Shared loader for the agent-readable post endpoints (.md / .json /
+ * .discussion.json). One place for the fetch + suppression policy so all three
+ * formats agree with each other and with what search engines are shown.
+ */
+
+// Edge-cacheable like the entry page's conservative tier; the CF worker/nginx
+// absorb load. Public content, so safe to share across all clients.
+export const AGENT_CACHE_CONTROL = "public, max-age=0, s-maxage=300, stale-while-revalidate=86400";
+
+// Short negative TTL: a 404 here is usually "suppressed" or "not indexed yet",
+// both of which can flip — don't let edges pin it for long.
+const NOT_FOUND_CACHE_CONTROL = "public, max-age=0, s-maxage=60";
+
+export type EntrySource = "hive_condenser" | "hive_bridge";
+
+export interface LoadedEntry {
+  entry: Entry;
+  source: EntrySource;
+}
+
+export function agentNotFound(): Response {
+  return new Response("Not found", {
+    status: 404,
+    headers: { "Cache-Control": NOT_FOUND_CACHE_CONTROL }
+  });
+}
+
+/**
+ * Fetch a post and return it only if it passes the same indexability gate the
+ * entry page uses (blacklist + NSFW + reputation + thin-content). Anything we'd
+ * noindex for Googlebot returns null here too → the route handler emits 404.
+ *
+ * Prefers condenser_api.get_content (carries root_author/root_permlink, needed
+ * for accurate container/wave detection); falls back to bridge.get_post. Mirrors
+ * generate-entry-metadata.ts so gating decisions can't drift.
+ */
+export async function loadIndexableEntry(
+  rawAuthor: string,
+  rawPermlink: string
+): Promise<LoadedEntry | null> {
+  const author = (rawAuthor || "").replace(/%40/g, "").replace("@", "");
+  const permlink = safeDecodeURIComponent(rawPermlink || "").trim();
+  if (!author || !permlink) return null;
+
+  let entry: Entry | null = null;
+  let source: EntrySource = "hive_condenser";
+
+  try {
+    entry = (await prefetchQuery(getContentQueryOptions(author, permlink))) as Entry | null;
+  } catch {
+    entry = null;
+  }
+
+  if (!entry || !entry.body || !entry.created) {
+    try {
+      entry = (await prefetchQuery(
+        EcencyEntriesCacheManagement.getEntryQueryByPath(author, permlink)
+      )) as Entry | null;
+      source = "hive_bridge";
+    } catch {
+      entry = null;
+    }
+  }
+
+  if (!entry || !entry.body || !entry.created) return null;
+
+  let account: ReputationSource = null;
+  let accountFetchFailed = false;
+  try {
+    const profiles = await prefetchQuery(getProfilesQueryOptions([entry.author]));
+    account = profiles?.[0] ?? null;
+  } catch {
+    accountFetchFailed = true;
+  }
+
+  // Shared-Redis read; pass a singleton set so isIndexable keeps its
+  // injected-blacklist contract (same call shape as generate-entry-metadata).
+  const blacklist = (await isAuthorBlacklisted(entry.author)) ? new Set([entry.author]) : undefined;
+
+  if (!isIndexable(entry, account, accountFetchFailed, blacklist)) return null;
+
+  return { entry, source };
+}

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-agent-format.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-agent-format.ts
@@ -1,0 +1,60 @@
+import defaults from "@/defaults";
+import type { Entry } from "@/entities";
+
+/**
+ * Pure formatters for the agent-readable post endpoints. Deliberately free of
+ * data-fetching / Redis imports so the output contract is trivially unit-tested.
+ */
+
+export function selfUrl(entry: Pick<Entry, "author" | "permlink">): string {
+  return `${defaults.base}/@${entry.author}/${entry.permlink}`;
+}
+
+// YAML scalars/sequences via JSON: YAML is a superset of JSON for these, so a
+// JSON-encoded value is always a valid (and correctly escaped) YAML node.
+function yamlLine(key: string, value: unknown): string | null {
+  if (value === undefined || value === null || value === "") return null;
+  if (Array.isArray(value)) {
+    if (value.length === 0) return null;
+    return `${key}: ${JSON.stringify(value)}`;
+  }
+  return `${key}: ${JSON.stringify(value)}`;
+}
+
+function appName(app: unknown): string | undefined {
+  if (typeof app === "string") return app;
+  if (app && typeof app === "object") {
+    const name = (app as { name?: unknown }).name;
+    if (typeof name === "string") return name;
+  }
+  return undefined;
+}
+
+/**
+ * The post as a self-contained Markdown document: YAML front matter + the raw
+ * on-chain body. The body is intentionally NOT re-rendered to HTML — raw Hive
+ * markdown is the most token-efficient form for LLMs to process.
+ */
+export function renderEntryMarkdown(entry: Entry): string {
+  const tags = Array.isArray(entry.json_metadata?.tags) ? entry.json_metadata?.tags : undefined;
+  const isComment = !!entry.parent_author;
+
+  const front = [
+    yamlLine("title", entry.title || undefined),
+    yamlLine("author", `@${entry.author}`),
+    yamlLine("permlink", entry.permlink),
+    yamlLine("type", isComment ? "comment" : "post"),
+    yamlLine("community", entry.community || undefined),
+    yamlLine("community_title", entry.community_title || undefined),
+    yamlLine("category", entry.category || undefined),
+    yamlLine("tags", tags),
+    yamlLine("app", appName(entry.json_metadata?.app)),
+    yamlLine("created", entry.created),
+    yamlLine("updated", entry.updated || entry.last_update || undefined),
+    yamlLine("payout", entry.payout),
+    yamlLine("canonical_url", selfUrl(entry))
+  ].filter(Boolean);
+
+  const heading = entry.title ? `# ${entry.title}\n\n` : "";
+  return `---\n${front.join("\n")}\n---\n\n${heading}${entry.body}\n`;
+}

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-agent-format.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-agent-format.ts
@@ -55,6 +55,8 @@ export function renderEntryMarkdown(entry: Entry): string {
     yamlLine("canonical_url", selfUrl(entry))
   ].filter(Boolean);
 
-  const heading = entry.title ? `# ${entry.title}\n\n` : "";
+  // Collapse any newlines in the title so the H1 stays a single line (on-chain
+  // titles can contain raw line breaks). The front-matter copy is JSON-escaped.
+  const heading = entry.title ? `# ${entry.title.replace(/[\r\n]+/g, " ")}\n\n` : "";
   return `---\n${front.join("\n")}\n---\n\n${heading}${entry.body}\n`;
 }

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -16,7 +16,7 @@ export async function GET(): Promise<Response> {
 
 > Ecency is a web client for the Hive blockchain — a decentralized social network. Every public post and comment is also available in clean, token-efficient Markdown and JSON through stable read-only endpoints, so agents do not need to render or scrape the JavaScript app.
 
-Append a format extension to any post URL. Both the bare form (\`${base}/@author/permlink\`) and the community form (\`${base}/hive-125125/@author/permlink\`) are supported.
+Append a format extension to a post's canonical URL (\`${base}/@author/permlink\`).
 
 ## Read a post
 

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -1,0 +1,47 @@
+import defaults from "@/defaults";
+
+/**
+ * /llms.txt — the emerging convention for telling LLMs / agents how to consume a
+ * site (https://llmstxt.org). Advertises the read-only agent endpoints so tools
+ * fetch clean Markdown/JSON instead of scraping the SPA HTML.
+ */
+export const dynamic = "force-static";
+
+const CACHE = "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800";
+
+export async function GET(): Promise<Response> {
+  const base = defaults.base;
+
+  const body = `# Ecency
+
+> Ecency is a web client for the Hive blockchain — a decentralized social network. Every public post and comment is also available in clean, token-efficient Markdown and JSON through stable read-only endpoints, so agents do not need to render or scrape the JavaScript app.
+
+Append a format extension to any post URL. Both the bare form (\`${base}/@author/permlink\`) and the community form (\`${base}/hive-125125/@author/permlink\`) are supported.
+
+## Read a post
+
+- [Markdown](${base}/@username/permlink.md): the post as a Markdown document — YAML front matter (title, author, tags, dates, canonical URL) followed by the raw on-chain body. Append \`.md\`.
+- [JSON](${base}/@username/permlink.json): the post as structured JSON in a small envelope (\`type\`, \`canonical_url\`, \`source\`, \`content\`). Append \`.json\`.
+- [Discussion JSON](${base}/@username/permlink.discussion.json): the full comment thread as JSON. Append \`.discussion.json\`.
+
+## Notes
+
+- Read-only. These endpoints never expose authenticated actions (voting, commenting, transfers).
+- Content suppressed for policy reasons (spam, NSFW, very low quality) returns 404 — the same posts are withheld from search engines.
+- The underlying data is public on the Hive blockchain; these endpoints are a convenience layer over it.
+
+## More
+
+- [Sitemap](${base}/sitemap.xml)
+- [About Ecency](${base}/about)
+- [Hive blockchain](https://hive.io)
+`;
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": CACHE
+    }
+  });
+}

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -2,28 +2,17 @@ import { MetadataRoute } from "next";
 import defaults from "@/defaults";
 
 export default function robots(): MetadataRoute.Robots {
+  // AI crawlers/agents are intentionally allowed (see also the Cloudflare WAF):
+  // public Hive content is open, and we publish agent-readable endpoints
+  // (/@author/permlink.md|.json) advertised via /llms.txt. So no per-AI-bot
+  // Disallow rules here — only the genuinely non-public/interactive paths.
   return {
     sitemap: `${defaults.base}/sitemap.xml`,
     rules: [
       {
         userAgent: "*",
         allow: "/",
-        disallow: [
-          "/api/",
-          "/draft/",
-          "/publish/",
-          "/signup/",
-          "/auth/",
-          "/wallet/setup-external"
-        ]
-      },
-      {
-        userAgent: "GPTBot",
-        disallow: "/"
-      },
-      {
-        userAgent: "ChatGPT-User",
-        disallow: "/"
+        disallow: ["/api/", "/draft/", "/publish/", "/signup/", "/auth/", "/wallet/setup-external"]
       }
     ]
   };

--- a/apps/web/src/features/next-middleware/handle-agent-readable-rewrite.ts
+++ b/apps/web/src/features/next-middleware/handle-agent-readable-rewrite.ts
@@ -9,10 +9,14 @@ import { NextRequest, NextResponse } from "next/server";
  *   /@author/:permlink.json              → structured JSON (post)
  *   /@author/:permlink.discussion.json   → JSON (full comment thread)
  *
- * Only the bare `/@author/:permlink` form is an agent endpoint — that's the
- * canonical post URL (see generate-entry-metadata / selfUrl). The community form
- * `/:category/@author/:permlink.<ext>` is deliberately NOT matched, so there is
- * a single agent URL per post (no alternate/duplicate surface).
+ * Only the bare `/@author/:permlink` form is matched here — that's the canonical
+ * post URL (see generate-entry-metadata / selfUrl). The community form
+ * `/:category/@author/:permlink.<ext>` still works for callers: the existing 308
+ * redirect in next.config.js consolidates `/:category/@author/:permlink` onto
+ * the bare form (its `:permlink` captures the `.<ext>` too), and redirects run
+ * before middleware — so a community-form link 308s to the bare URL, which then
+ * hits this rewrite. The result is one canonical agent URL per post (a redirect,
+ * never an alternate/duplicate surface).
  *
  * Implemented as a middleware rewrite (mirrors the rss.xml and social-bot
  * rewrites) so a single Route Handler under the existing entry tree serves the

--- a/apps/web/src/features/next-middleware/handle-agent-readable-rewrite.ts
+++ b/apps/web/src/features/next-middleware/handle-agent-readable-rewrite.ts
@@ -1,20 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 
 /**
- * "Agentic web" read-only endpoints. Appending a format extension to any public
- * post URL returns that post in a clean, token-efficient form for LLMs / agents
- * / research tools, instead of the JS-heavy SPA HTML:
+ * "Agentic web" read-only endpoints. Appending a format extension to the
+ * canonical (bare) post URL returns that post in a clean, token-efficient form
+ * for LLMs / agents / research tools, instead of the JS-heavy SPA HTML:
  *
- *   /:category/@author/:permlink.md                → Markdown (front matter + body)
- *   /:category/@author/:permlink.json              → structured JSON (post)
- *   /:category/@author/:permlink.discussion.json   → JSON (full comment thread)
+ *   /@author/:permlink.md                → Markdown (front matter + body)
+ *   /@author/:permlink.json              → structured JSON (post)
+ *   /@author/:permlink.discussion.json   → JSON (full comment thread)
  *
- * The bare `/@author/:permlink.<ext>` form is supported too.
+ * Only the bare `/@author/:permlink` form is an agent endpoint — that's the
+ * canonical post URL (see generate-entry-metadata / selfUrl). The community form
+ * `/:category/@author/:permlink.<ext>` is deliberately NOT matched, so there is
+ * a single agent URL per post (no alternate/duplicate surface).
  *
  * Implemented as a middleware rewrite (mirrors the rss.xml and social-bot
  * rewrites) so a single Route Handler under the existing entry tree serves the
- * response. Middleware runs before next.config rewrites, so the rewritten
- * `/.../:permlink/agent-*` path flows through the existing
+ * response. Middleware runs before next.config rewrites; we inject the default
+ * `created` category so the rewritten path flows through the existing
  * `/:category/:author/:permlink/:sub → /entry/...` rewrite — no config change.
  */
 
@@ -26,12 +29,9 @@ const AGENT_EXTENSIONS: ReadonlyArray<readonly [string, string]> = [
   [".json", "agent-json"]
 ];
 
-// Post URL forms. On-chain permlinks are `[a-z0-9_-]+` (lowercase alnum, hyphen,
-// underscore — never a dot), so stripping a known trailing extension is
-// unambiguous.
-//   /:category/@author/:permlink   (community / category form)
-const CATEGORY_FORM = /^\/[^/]+\/@[^/]+\/[a-z0-9_-]+$/i;
-//   /@author/:permlink             (bare form)
+// The canonical bare post URL: /@author/:permlink. On-chain permlinks are
+// `[a-z0-9_-]+` (lowercase alnum, hyphen, underscore — never a dot), so
+// stripping a known trailing extension is unambiguous.
 const BARE_FORM = /^\/@[^/]+\/[a-z0-9_-]+$/i;
 
 /**
@@ -45,23 +45,17 @@ export function handleAgentReadableRewrite(request: NextRequest): NextResponse |
     if (!path.endsWith(ext)) continue;
 
     const base = path.slice(0, -ext.length);
-    let target: string | null = null;
 
-    if (CATEGORY_FORM.test(base)) {
-      // /:category/@author/:permlink → /:category/@author/:permlink/agent-*
-      target = `${base}/${sub}`;
-    } else if (BARE_FORM.test(base)) {
-      // /@author/:permlink → /created/@author/:permlink/agent-*
-      // `created` is the default category next.config uses for the bare form,
-      // so the existing /:category/:author/:permlink/:sub rewrite resolves it.
-      target = `/created${base}/${sub}`;
-    }
+    // Only the canonical bare form is an agent endpoint. Anything else (a
+    // community-form post URL, or an unrelated path like /foo.json) is left to
+    // normal routing — one agent URL per post, no alternate surface.
+    if (!BARE_FORM.test(base)) return null;
 
-    // Matched an extension but not a post URL (e.g. /foo.json) — don't hijack it.
-    if (!target) return null;
-
+    // /@author/:permlink → /created/@author/:permlink/agent-*
+    // `created` is the default category next.config uses for the bare form, so
+    // the existing /:category/:author/:permlink/:sub rewrite resolves it.
     const url = request.nextUrl.clone();
-    url.pathname = target;
+    url.pathname = `/created${base}/${sub}`;
     return NextResponse.rewrite(url);
   }
 

--- a/apps/web/src/features/next-middleware/handle-agent-readable-rewrite.ts
+++ b/apps/web/src/features/next-middleware/handle-agent-readable-rewrite.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * "Agentic web" read-only endpoints. Appending a format extension to any public
+ * post URL returns that post in a clean, token-efficient form for LLMs / agents
+ * / research tools, instead of the JS-heavy SPA HTML:
+ *
+ *   /:category/@author/:permlink.md                → Markdown (front matter + body)
+ *   /:category/@author/:permlink.json              → structured JSON (post)
+ *   /:category/@author/:permlink.discussion.json   → JSON (full comment thread)
+ *
+ * The bare `/@author/:permlink.<ext>` form is supported too.
+ *
+ * Implemented as a middleware rewrite (mirrors the rss.xml and social-bot
+ * rewrites) so a single Route Handler under the existing entry tree serves the
+ * response. Middleware runs before next.config rewrites, so the rewritten
+ * `/.../:permlink/agent-*` path flows through the existing
+ * `/:category/:author/:permlink/:sub → /entry/...` rewrite — no config change.
+ */
+
+// Public extension → internal sub-route segment under entry/[category]/[author]/[permlink]/.
+// Ordered most-specific-first: `.discussion.json` must be tested before `.json`.
+const AGENT_EXTENSIONS: ReadonlyArray<readonly [string, string]> = [
+  [".discussion.json", "agent-discussion"],
+  [".md", "agent-md"],
+  [".json", "agent-json"]
+];
+
+// Post URL forms. On-chain permlinks are `[a-z0-9-]+` (never contain a dot), so
+// stripping a known trailing extension is unambiguous.
+//   /:category/@author/:permlink   (community / category form)
+const CATEGORY_FORM = /^\/[^/]+\/@[^/]+\/[a-z0-9-]+$/i;
+//   /@author/:permlink             (bare form)
+const BARE_FORM = /^\/@[^/]+\/[a-z0-9-]+$/i;
+
+/**
+ * If the request targets an agent-readable post endpoint, returns the rewrite to
+ * the internal Route Handler; otherwise null (leave routing untouched).
+ */
+export function handleAgentReadableRewrite(request: NextRequest): NextResponse | null {
+  const path = request.nextUrl.pathname;
+
+  for (const [ext, sub] of AGENT_EXTENSIONS) {
+    if (!path.endsWith(ext)) continue;
+
+    const base = path.slice(0, -ext.length);
+    let target: string | null = null;
+
+    if (CATEGORY_FORM.test(base)) {
+      // /:category/@author/:permlink → /:category/@author/:permlink/agent-*
+      target = `${base}/${sub}`;
+    } else if (BARE_FORM.test(base)) {
+      // /@author/:permlink → /created/@author/:permlink/agent-*
+      // `created` is the default category next.config uses for the bare form,
+      // so the existing /:category/:author/:permlink/:sub rewrite resolves it.
+      target = `/created${base}/${sub}`;
+    }
+
+    // Matched an extension but not a post URL (e.g. /foo.json) — don't hijack it.
+    if (!target) return null;
+
+    const url = request.nextUrl.clone();
+    url.pathname = target;
+    return NextResponse.rewrite(url);
+  }
+
+  return null;
+}
+
+export function isAgentReadableRequest(request: NextRequest): boolean {
+  return handleAgentReadableRewrite(request) !== null;
+}

--- a/apps/web/src/features/next-middleware/handle-agent-readable-rewrite.ts
+++ b/apps/web/src/features/next-middleware/handle-agent-readable-rewrite.ts
@@ -26,12 +26,13 @@ const AGENT_EXTENSIONS: ReadonlyArray<readonly [string, string]> = [
   [".json", "agent-json"]
 ];
 
-// Post URL forms. On-chain permlinks are `[a-z0-9-]+` (never contain a dot), so
-// stripping a known trailing extension is unambiguous.
+// Post URL forms. On-chain permlinks are `[a-z0-9_-]+` (lowercase alnum, hyphen,
+// underscore — never a dot), so stripping a known trailing extension is
+// unambiguous.
 //   /:category/@author/:permlink   (community / category form)
-const CATEGORY_FORM = /^\/[^/]+\/@[^/]+\/[a-z0-9-]+$/i;
+const CATEGORY_FORM = /^\/[^/]+\/@[^/]+\/[a-z0-9_-]+$/i;
 //   /@author/:permlink             (bare form)
-const BARE_FORM = /^\/@[^/]+\/[a-z0-9-]+$/i;
+const BARE_FORM = /^\/@[^/]+\/[a-z0-9_-]+$/i;
 
 /**
  * If the request targets an agent-readable post endpoint, returns the rewrite to
@@ -65,8 +66,4 @@ export function handleAgentReadableRewrite(request: NextRequest): NextResponse |
   }
 
   return null;
-}
-
-export function isAgentReadableRequest(request: NextRequest): boolean {
-  return handleAgentReadableRewrite(request) !== null;
 }

--- a/apps/web/src/features/next-middleware/index.ts
+++ b/apps/web/src/features/next-middleware/index.ts
@@ -1,4 +1,5 @@
 export * from "./cache-policy";
+export * from "./handle-agent-readable-rewrite";
 export * from "./handle-decoded-path-redirect";
 export * from "./handle-index-redirect";
 export * from "./handle-rss-xml-rewrite";

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -4,6 +4,7 @@ import {
   buildCacheControlHeader,
   getCachePolicyForPath,
   getEntryTierForAge,
+  handleAgentReadableRewrite,
   handleDecodedPathRedirect,
   handleIndexRedirect,
   isIndexRedirect,
@@ -73,6 +74,11 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     console.warn("Blocked invalid permlink with file extension:", path);
     return new NextResponse("Not found", { status: 404 });
   }
+
+  // Agentic-web read-only endpoints: /@author/permlink.md|.json|.discussion.json
+  // rewrite to a Route Handler that serves clean Markdown/JSON for LLMs & agents.
+  const agentRewrite = handleAgentReadableRewrite(request);
+  if (agentRewrite) return agentRewrite;
 
   const userAgent = request.headers.get("user-agent") || "";
   const isSocialBot =

--- a/apps/web/src/specs/app/entry-agent-format.spec.ts
+++ b/apps/web/src/specs/app/entry-agent-format.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/entities";
+import {
+  renderEntryMarkdown,
+  selfUrl
+} from "@/app/(dynamicPages)/entry/_helpers/entry-agent-format";
+
+function makeEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    author: "alice",
+    permlink: "my-post",
+    title: "Hello World",
+    body: "This is the **raw** on-chain body.\n\n![img](https://x/y.png)",
+    category: "hive-101010",
+    community: "hive-101010",
+    community_title: "Photography",
+    created: "2026-06-03T19:31:27",
+    updated: "2026-06-03T20:00:00",
+    payout: 12.34,
+    json_metadata: { tags: ["hive", "photography"], app: "ecency/4.0" },
+    ...overrides
+  } as unknown as Entry;
+}
+
+describe("renderEntryMarkdown", () => {
+  it("emits YAML front matter, an H1 heading, then the raw body verbatim", () => {
+    const md = renderEntryMarkdown(makeEntry());
+
+    expect(md.startsWith("---\n")).toBe(true);
+    expect(md).toContain('title: "Hello World"');
+    expect(md).toContain('author: "@alice"');
+    expect(md).toContain('permlink: "my-post"');
+    expect(md).toContain('type: "post"');
+    expect(md).toContain('community: "hive-101010"');
+    expect(md).toContain('tags: ["hive","photography"]');
+    expect(md).toContain('app: "ecency/4.0"');
+    expect(md).toContain('canonical_url: "https://ecency.com/@alice/my-post"');
+    // Heading + the body passed through untouched (not re-rendered to HTML).
+    expect(md).toContain("\n# Hello World\n\n");
+    expect(md).toContain("This is the **raw** on-chain body.");
+    expect(md).toContain("![img](https://x/y.png)");
+  });
+
+  it("marks comments as type comment and omits the heading when there is no title", () => {
+    const md = renderEntryMarkdown(
+      makeEntry({ title: "", parent_author: "someone", parent_permlink: "root" })
+    );
+    expect(md).toContain('type: "comment"');
+    expect(md).not.toMatch(/^title:/m);
+    expect(md).not.toContain("\n# ");
+  });
+
+  it("skips empty/missing front-matter fields", () => {
+    const md = renderEntryMarkdown(
+      makeEntry({ community: "", community_title: "", json_metadata: { tags: [] } })
+    );
+    expect(md).not.toContain("community:");
+    expect(md).not.toContain("community_title:");
+    expect(md).not.toContain("tags:");
+    expect(md).not.toContain("app:");
+  });
+
+  it("extracts the app name when json_metadata.app is an object", () => {
+    const md = renderEntryMarkdown(
+      makeEntry({ json_metadata: { app: { name: "ecency", version: "4.0" } } as any })
+    );
+    expect(md).toContain('app: "ecency"');
+  });
+
+  it("selfUrl builds the bare canonical post URL", () => {
+    expect(selfUrl({ author: "alice", permlink: "my-post" })).toBe(
+      "https://ecency.com/@alice/my-post"
+    );
+  });
+});

--- a/apps/web/src/specs/app/entry-agent-format.spec.ts
+++ b/apps/web/src/specs/app/entry-agent-format.spec.ts
@@ -60,6 +60,14 @@ describe("renderEntryMarkdown", () => {
     expect(md).not.toContain("app:");
   });
 
+  it("collapses newlines in the H1 heading (front matter stays escaped)", () => {
+    const md = renderEntryMarkdown(makeEntry({ title: "Line one\nLine two" }));
+    expect(md).toContain("# Line one Line two\n\n");
+    expect(md).not.toContain("# Line one\nLine two");
+    // front matter keeps the title as a single escaped scalar
+    expect(md).toContain('title: "Line one\\nLine two"');
+  });
+
   it("extracts the app name when json_metadata.app is an object", () => {
     const md = renderEntryMarkdown(
       makeEntry({ json_metadata: { app: { name: "ecency", version: "4.0" } } as any })

--- a/apps/web/src/specs/features/next-middleware/handle-agent-readable-rewrite.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/handle-agent-readable-rewrite.spec.ts
@@ -16,26 +16,15 @@ function rewriteTarget(rawPath: string): string | null {
 }
 
 describe("handleAgentReadableRewrite", () => {
-  it("rewrites .md on the community form to the agent-md sub-route", () => {
-    expect(rewriteTarget("/hive-101010/@alice/my-post.md")).toBe(
-      "/hive-101010/@alice/my-post/agent-md"
-    );
+  it("rewrites .md on the bare /@author/permlink form via the default `created` category", () => {
+    expect(rewriteTarget("/@alice/my-post.md")).toBe("/created/@alice/my-post/agent-md");
   });
 
-  it("rewrites .json on the community form to the agent-json sub-route", () => {
-    expect(rewriteTarget("/hive-101010/@alice/my-post.json")).toBe(
-      "/hive-101010/@alice/my-post/agent-json"
-    );
+  it("rewrites .json on the bare form to the agent-json sub-route", () => {
+    expect(rewriteTarget("/@alice/my-post.json")).toBe("/created/@alice/my-post/agent-json");
   });
 
   it("prefers .discussion.json over .json (most-specific extension first)", () => {
-    expect(rewriteTarget("/hive-101010/@alice/my-post.discussion.json")).toBe(
-      "/hive-101010/@alice/my-post/agent-discussion"
-    );
-  });
-
-  it("rewrites the bare /@author/permlink form via the default `created` category", () => {
-    expect(rewriteTarget("/@alice/my-post.md")).toBe("/created/@alice/my-post/agent-md");
     expect(rewriteTarget("/@alice/my-post.discussion.json")).toBe(
       "/created/@alice/my-post/agent-discussion"
     );
@@ -45,9 +34,13 @@ describe("handleAgentReadableRewrite", () => {
     expect(rewriteTarget("/@alice/re-bob-my_post-20240601.md")).toBe(
       "/created/@alice/re-bob-my_post-20240601/agent-md"
     );
-    expect(rewriteTarget("/hive-101010/@alice/a_b_c.json")).toBe(
-      "/hive-101010/@alice/a_b_c/agent-json"
-    );
+  });
+
+  it("does NOT treat the community form as an agent endpoint (single canonical URL per post)", () => {
+    expect(handleAgentReadableRewrite(requestFor("/hive-101010/@alice/my-post.md"))).toBeNull();
+    expect(
+      handleAgentReadableRewrite(requestFor("/hive-101010/@alice/my-post.discussion.json"))
+    ).toBeNull();
   });
 
   it("leaves a normal post URL (no extension) untouched", () => {

--- a/apps/web/src/specs/features/next-middleware/handle-agent-readable-rewrite.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/handle-agent-readable-rewrite.spec.ts
@@ -36,7 +36,12 @@ describe("handleAgentReadableRewrite", () => {
     );
   });
 
-  it("does NOT treat the community form as an agent endpoint (single canonical URL per post)", () => {
+  // The community form never reaches this rewrite as-is: next.config.js
+  // 308-redirects /:category/@author/:permlink onto the bare /@author/:permlink
+  // (its :permlink captures the .<ext> too) and redirects run before middleware.
+  // So this rewrite only ever handles the bare form, and ignores the community
+  // form — which still works end-to-end via that upstream redirect.
+  it("ignores the community form here (consolidated to bare by the upstream 308 redirect)", () => {
     expect(handleAgentReadableRewrite(requestFor("/hive-101010/@alice/my-post.md"))).toBeNull();
     expect(
       handleAgentReadableRewrite(requestFor("/hive-101010/@alice/my-post.discussion.json"))

--- a/apps/web/src/specs/features/next-middleware/handle-agent-readable-rewrite.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/handle-agent-readable-rewrite.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { handleAgentReadableRewrite } from "@/features/next-middleware";
+
+function requestFor(rawPath: string) {
+  return new NextRequest(`https://ecency.com${rawPath}`);
+}
+
+// NextResponse.rewrite encodes the internal destination in this header.
+function rewriteTarget(rawPath: string): string | null {
+  const res = handleAgentReadableRewrite(requestFor(rawPath));
+  if (!res) return null;
+  const header = res.headers.get("x-middleware-rewrite");
+  if (!header) return null;
+  return new URL(header, "https://ecency.com").pathname;
+}
+
+describe("handleAgentReadableRewrite", () => {
+  it("rewrites .md on the community form to the agent-md sub-route", () => {
+    expect(rewriteTarget("/hive-101010/@alice/my-post.md")).toBe(
+      "/hive-101010/@alice/my-post/agent-md"
+    );
+  });
+
+  it("rewrites .json on the community form to the agent-json sub-route", () => {
+    expect(rewriteTarget("/hive-101010/@alice/my-post.json")).toBe(
+      "/hive-101010/@alice/my-post/agent-json"
+    );
+  });
+
+  it("prefers .discussion.json over .json (most-specific extension first)", () => {
+    expect(rewriteTarget("/hive-101010/@alice/my-post.discussion.json")).toBe(
+      "/hive-101010/@alice/my-post/agent-discussion"
+    );
+  });
+
+  it("rewrites the bare /@author/permlink form via the default `created` category", () => {
+    expect(rewriteTarget("/@alice/my-post.md")).toBe("/created/@alice/my-post/agent-md");
+    expect(rewriteTarget("/@alice/my-post.discussion.json")).toBe(
+      "/created/@alice/my-post/agent-discussion"
+    );
+  });
+
+  it("leaves a normal post URL (no extension) untouched", () => {
+    expect(handleAgentReadableRewrite(requestFor("/hive-101010/@alice/my-post"))).toBeNull();
+    expect(handleAgentReadableRewrite(requestFor("/@alice/my-post"))).toBeNull();
+  });
+
+  it("does not hijack a non-post path that happens to end in .json/.md", () => {
+    expect(handleAgentReadableRewrite(requestFor("/sitemap.json"))).toBeNull();
+    expect(handleAgentReadableRewrite(requestFor("/foo/bar.md"))).toBeNull();
+    expect(handleAgentReadableRewrite(requestFor("/llms.txt"))).toBeNull();
+  });
+});

--- a/apps/web/src/specs/features/next-middleware/handle-agent-readable-rewrite.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/handle-agent-readable-rewrite.spec.ts
@@ -41,6 +41,15 @@ describe("handleAgentReadableRewrite", () => {
     );
   });
 
+  it("matches permlinks containing underscores", () => {
+    expect(rewriteTarget("/@alice/re-bob-my_post-20240601.md")).toBe(
+      "/created/@alice/re-bob-my_post-20240601/agent-md"
+    );
+    expect(rewriteTarget("/hive-101010/@alice/a_b_c.json")).toBe(
+      "/hive-101010/@alice/a_b_c/agent-json"
+    );
+  });
+
   it("leaves a normal post URL (no extension) untouched", () => {
     expect(handleAgentReadableRewrite(requestFor("/hive-101010/@alice/my-post"))).toBeNull();
     expect(handleAgentReadableRewrite(requestFor("/@alice/my-post"))).toBeNull();


### PR DESCRIPTION
## Agent-readable post endpoints

Public posts and comments can now be fetched in a clean, machine-friendly format by appending an extension to any post URL — so LLMs, agents and research tools don't have to render or scrape the SPA:

| URL | Returns |
| --- | --- |
| `/@author/permlink.md` | Markdown — YAML front matter (title, author, tags, dates, canonical) + raw on-chain body |
| `/@author/permlink.json` | Structured JSON (`type`, `canonical_url`, `source`, `content`) |
| `/@author/permlink.discussion.json` | Full comment thread as JSON |

Both the bare (`/@author/permlink`) and community (`/hive-xxxxx/@author/permlink`) forms are supported. A new `/llms.txt` advertises the endpoints.

### How it works
- Middleware strips the extension and rewrites into Route Handlers under the existing entry tree — the same pattern as the `rss.xml` and social-bot rewrites, so **no `next.config.js` change**.
- **Suppression parity with SEO:** the endpoints reuse `isIndexable`, so anything we noindex (blacklist / NSFW / low reputation / thin content) returns `404` here too.
- **Edge-cacheable** (`s-maxage=300, stale-while-revalidate=86400`) so the CDN absorbs the load.
- `robots.txt` now allows AI crawlers/agents (removed the `GPTBot` / `ChatGPT-User` `Disallow`).

### Tests
- Rewrite routing: extension precedence (`.discussion.json` before `.json`), bare vs community form, and non-hijack of unrelated paths (`/sitemap.json`, `/llms.txt`).
- Markdown front-matter contract: posts vs comments, empty/missing fields, object-form `app`.
- Existing `next-middleware` suite stays green.

> First live end-to-end check (real Hive data) should happen on the preview/staging deploy.