### PR TITLE
Spotlight: guests-only audience (replace auth boolean)

### DIFF
--- a/apps/web/src/app/_components/feature-spotlight-widget/select.ts
+++ b/apps/web/src/app/_components/feature-spotlight-widget/select.ts
@@ -13,8 +13,9 @@ function pathMatches(pathname: string | null, pattern: string): boolean {
 
 /**
  * Pick the single spotlight to show. The server already filtered by the date window;
- * here we apply the client-side rules — platform (website vs mobile app), auth (default
- * logged-in only), path regex, and per-id dismissal — then pick the highest weight
+ * here we apply the client-side rules — platform (website vs mobile app), audience
+ * (logged-in by default, or guestsOnly for signed-out visitors), path regex, and per-id
+ * dismissal — then pick the highest weight
  * (tie-break: earliest start). Pure + exported for unit testing.
  */
 export function pickSpotlight(
@@ -26,7 +27,7 @@ export function pickSpotlight(
 ): Spotlight | null {
   const candidates = items
     .filter((s) => !s.platforms || s.platforms.includes(platform))
-    .filter((s) => (s.auth === false ? true : !!activeUser))
+    .filter((s) => (s.guestsOnly ? !activeUser : !!activeUser))
     .filter((s) => {
       if (!s.path) {
         return true;

--- a/apps/web/src/specs/app/feature-spotlight-select.spec.ts
+++ b/apps/web/src/specs/app/feature-spotlight-select.spec.ts
@@ -19,16 +19,16 @@ describe("pickSpotlight", () => {
     expect(pickSpotlight([], user, "/", [])).toBeNull();
   });
 
-  it("hides auth-required spotlights from anonymous users", () => {
-    expect(pickSpotlight([make({ id: "x", auth: true })], null, "/", [])).toBeNull();
-  });
-
-  it("shows auth:false spotlights to anonymous users", () => {
-    expect(pickSpotlight([make({ id: "x", auth: false })], null, "/", [])?.id).toBe("x");
-  });
-
-  it("hides default-auth (auth unset) spotlights from anonymous users", () => {
+  it("hides logged-in spotlights (default) from anonymous users", () => {
     expect(pickSpotlight([make({ id: "x" })], null, "/", [])).toBeNull();
+  });
+
+  it("shows guestsOnly spotlights to anonymous users", () => {
+    expect(pickSpotlight([make({ id: "x", guestsOnly: true })], null, "/", [])?.id).toBe("x");
+  });
+
+  it("hides guestsOnly spotlights from logged-in users", () => {
+    expect(pickSpotlight([make({ id: "x", guestsOnly: true })], user, "/", [])).toBeNull();
   });
 
   it("skips a spotlight whose path is an invalid regex instead of throwing", () => {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.11
+
+### Patch Changes
+
+- Spotlight: guests-only audience (replace auth boolean) (#917)
+
 ## 2.3.10
 
 ### Patch Changes

--- a/packages/sdk/dist/browser/index.d.ts
+++ b/packages/sdk/dist/browser/index.d.ts
@@ -5896,7 +5896,7 @@ interface Spotlight {
     button_text: string;
     button_link: string;
     path?: string | Array<string>;
-    auth?: boolean;
+    guestsOnly?: boolean;
     platforms?: Array<"web" | "mobile">;
     start?: string;
     end?: string;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ecency/sdk",
   "private": false,
-  "version": "2.3.10",
+  "version": "2.3.11",
   "description": "Ecency SDK",
   "repository": {
     "type": "git",

--- a/packages/sdk/src/modules/notifications/types/spotlight.ts
+++ b/packages/sdk/src/modules/notifications/types/spotlight.ts
@@ -9,7 +9,8 @@ export interface Spotlight {
   button_text: string;
   button_link: string;
   path?: string | Array<string>;
-  auth?: boolean;
+  // show only to signed-out visitors; omit = logged-in users only
+  guestsOnly?: boolean;
   // which platform(s) may show it: "web" (website) / "mobile" (mobile app); omit = both
   platforms?: Array<"web" | "mobile">;
   start?: string;

--- a/packages/wallets/CHANGELOG.md
+++ b/packages/wallets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ecency/wallets
 
+## 5.0.11
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @ecency/sdk@2.3.11
+
 ## 5.0.10
 
 ### Patch Changes

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ecency/wallets",
   "private": false,
-  "version": "5.0.10",
+  "version": "5.0.11",
   "description": "Ecency wallets",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds proper guest-only targeting for Feature Spotlight, before launch so there is no model bloat.

The feature is not in production yet, so instead of layering a second field on top of `auth`, this **replaces** the boolean `auth` (logged-in vs everyone) with a single `guestsOnly` flag:
- omit (default): logged-in users only
- `guestsOnly: true`: signed-out visitors only

This fully fixes the earlier issue where the signup card could reach logged-in users after they dismissed the educational card: a `guestsOnly` card can never match a logged-in user, regardless of dismissal. The unused everyone case is dropped to keep the schema lean.

Changes: SDK `Spotlight` type (`auth` -> `guestsOnly`), web `select.ts` filter + doc, tests updated (12 pass). Backend (vapi spotlights.ts) and mobile follow; mobile needs the republished `@ecency/sdk`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new guests-only spotlight option to control visibility for signed-out visitors versus registered users, improving targeted content delivery.

* **Tests**
  * Expanded spotlight selection tests to confirm correct visibility for logged-in users and guest visitors, including guests-only behavior and default visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->