### PR TITLE
Read next: render cards visible in SSR (CSS entrance, not framer-motion opacity:0)

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/similar-entries/_index.scss
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/similar-entries/_index.scss
@@ -27,6 +27,13 @@
     .similar-entries-list-item {
       cursor: pointer;
 
+      // CSS entrance, staggered via an inline animation-delay per item. Replaces
+      // the framer-motion `initial={{ opacity: 0 }}`, which serialized opacity:0
+      // into the SSR HTML — leaving the strip invisible until hydration and for
+      // no-JS clients. `backwards` holds the start frame through the delay; the
+      // resting state is visible, so the server HTML carries no inline opacity:0.
+      animation: similar-entry-in 0.4s ease backwards;
+
       .item-image {
         align-items: center;
         cursor: pointer;
@@ -71,5 +78,24 @@
         }
       }
     }
+  }
+}
+
+@keyframes similar-entry-in {
+  from {
+    opacity: 0;
+    transform: translateY(-24px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// Respect users who prefer reduced motion — skip the entrance animation.
+@media (prefers-reduced-motion: reduce) {
+  .similar-entries-list .similar-entries-list-body .similar-entries-list-item {
+    animation: none;
   }
 }

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/similar-entries/similar-entry-item.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/similar-entries/similar-entry-item.tsx
@@ -1,9 +1,8 @@
-import { motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
 import { catchPostImage } from "@ecency/render-helper";
 import { TimeLabel } from "@/features/shared/time-label";
-import React, { useMemo, useRef } from "react";
+import React, { useMemo } from "react";
 import { SearchResult } from "@/entities";
 interface Props {
   entry: SearchResult;
@@ -11,7 +10,6 @@ interface Props {
 }
 
 export function SimilarEntryItem({ entry, i }: Props) {
-  const ref = useRef<HTMLDivElement>(null);
   const postImage = useMemo(
     () => catchPostImage(entry.img_url, 600, 500),
     [entry.img_url]
@@ -19,15 +17,12 @@ export function SimilarEntryItem({ entry, i }: Props) {
 
   return (
     <Link href={`/@${entry.author}/${entry.permlink}`} className="no-style">
-      <motion.div
-        ref={ref}
+      {/* Entrance animation is CSS (see _index.scss), staggered per item via
+          animation-delay — keeps the card visible in the SSR HTML (and with JS
+          disabled) instead of framer-motion's serialized opacity:0. */}
+      <div
         className="similar-entries-list-item bg-gray-100 hover:bg-blue-dark-sky-040 dark:bg-gray-900 rounded-2xl overflow-hidden transform transition-transform duration-200 hover:rotate-[1.5deg]"
-        initial={{
-          opacity: 0,
-          y: -24
-        }}
-        animate={{ opacity: 1, y: 0, transition: { delay: i * 0.2 } }}
-        onAnimationComplete={() => ref.current?.style.removeProperty("transform")}
+        style={{ animationDelay: `${i * 0.2}s` }}
       >
         {postImage && (
           <Image
@@ -54,7 +49,7 @@ export function SimilarEntryItem({ entry, i }: Props) {
           <span className="item-footer-author">{entry.author}</span>
           <TimeLabel created={entry.created_at} mode="fullRelative" className="item-footer-date" />
         </div>
-      </motion.div>
+      </div>
     </Link>
   );
 }


### PR DESCRIPTION
## Summary
The "Read next" similar-entry cards animated in with framer-motion `initial={{ opacity: 0 }}`, which serializes `style="opacity:0"` into the **server HTML**. So the strip rendered invisible until hydration — and stayed invisible for JS-disabled clients — even though the links/text are present (a weaker signal for crawlers reading raw HTML).

This swaps the JS entrance for a **CSS keyframe** entrance:
- Resting state is visible, so the SSR HTML carries **no inline `opacity:0`**.
- The staggered fade-in still plays for everyone (CSS animations run without JS), via an inline `animation-delay` per card.
- Adds `prefers-reduced-motion` support.
- Drops the `ref` + `onAnimationComplete` transform-cleanup hack framer-motion needed, and removes framer-motion from this component.

Context: the strip is already server-prefetched and SSR-rendered (verified on prod — real `<a href>` links + titles in raw HTML). This is the cosmetic follow-up so the cards aren't visually hidden pre-hydration / with JS off.

## Test plan
- [x] `tsc --noEmit` adds no errors in the touched files.
- [x] Web render-gate spec passes (5/5).
- [ ] Visual check on staging: cards fade in (staggered), and are visible immediately with JS disabled.