### PR TITLE
Hide proposal announcements from users who already voted

### DIFF
--- a/apps/web/src/features/announcement/index.tsx
+++ b/apps/web/src/features/announcement/index.tsx
@@ -8,17 +8,48 @@ import { usePathname } from "next/navigation";
 import { closeSvg } from "@ui/svg";
 import Link from "next/link";
 import i18next from "i18next";
-import { getAnnouncementsQueryOptions } from "@ecency/sdk";
+import { getAnnouncementsQueryOptions, getUserProposalVotesQueryOptions } from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { ProposalVoteAction } from "./proposal-vote-action";
 
 export const Announcements = () => {
-  const { activeUser } = useActiveAccount();
+  const { activeUser, username } = useActiveAccount();
 
   const pathname = usePathname();
 
   const { data: allAnnouncements } = useQuery(getAnnouncementsQueryOptions());
+
+  // Resolve the active user's proposal votes so we can drop proposal-type
+  // announcements they've already supported. This uses the exact same query as
+  // the inline ProposalVoteAction (same key, so it's a shared cache read rather
+  // than a second request), and after an inline vote the mutation invalidates
+  // this key — making the card disappear on its own too.
+  const { data: userVotes, isSuccess: userVotesResolved } = useQuery({
+    ...getUserProposalVotesQueryOptions(username ?? ""),
+    enabled: !!username
+  });
+
+  const votedProposalIds = useMemo(
+    () =>
+      new Set(
+        (userVotes ?? [])
+          .map((vote) => vote.proposal?.proposal_id)
+          .filter((id): id is number => typeof id === "number")
+      ),
+    [userVotes]
+  );
+
+  // Until the votes resolve we can't tell a voter from a non-voter, so hold
+  // proposal announcements back rather than flashing a "support" card that then
+  // vanishes. We gate on success — not merely "fetched" — on purpose: if the
+  // votes lookup errors we keep proposal announcements hidden rather than
+  // re-prompting someone who may have already voted (the whole point of this
+  // filter), accepting that a transient RPC failure briefly hides the card from
+  // non-voters too. Logged-out users have no votes query (it's disabled), so
+  // treat them as ready — auth/path filtering and the action's own login prompt
+  // cover that case.
+  const votesReady = !username || userVotesResolved;
 
   const [show, setShow] = useState(true);
   const [list, setList] = useState<Announcement[]>([]);
@@ -72,8 +103,20 @@ export const Announcements = () => {
         }
       });
 
-    return displayList;
-  }, [activeUser, allAnnouncements, pathname]);
+    return displayList.filter((announcement) => {
+      // Proposal announcements disappear once the user has voted on the proposal
+      // they promote. The inline action votes on the first id, so we mirror that
+      // here. Non-proposal announcements are never affected.
+      const proposalIds = announcement.proposal_ids;
+      if (!proposalIds || proposalIds.length === 0) {
+        return true;
+      }
+      if (!votesReady) {
+        return false;
+      }
+      return !votedProposalIds.has(proposalIds[0]);
+    });
+  }, [activeUser, allAnnouncements, pathname, votedProposalIds, votesReady]);
 
   useEffect(() => {
     setList(superList);

--- a/apps/web/src/features/announcement/index.tsx
+++ b/apps/web/src/features/announcement/index.tsx
@@ -166,7 +166,9 @@ export const Announcements = () => {
     } else {
       const getCurrentData = ls.get("dismiss_announcements");
       for (let i = 0; i < getCurrentData.length; i++) {
-        if (getCurrentData[i].id === clickedBanner.id) {
+        // dismiss_announcements stores bare ids, so compare the number itself —
+        // `.id` on a number is undefined and would never dedup.
+        if (getCurrentData[i] === clickedBanner.id) {
           return;
         }
       }

--- a/apps/web/src/specs/features/announcement/announcements.spec.tsx
+++ b/apps/web/src/specs/features/announcement/announcements.spec.tsx
@@ -1,0 +1,200 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { Announcements } from "@/features/announcement";
+
+const { announcementsRef, votesRef, votesResolvedRef, usernameRef, accountMemo } = vi.hoisted(() => ({
+  announcementsRef: { current: [] as any[] },
+  votesRef: { current: [] as { proposal?: { proposal_id: number } }[] },
+  // Mirrors the votes query's `isSuccess`: true once the lookup has resolved
+  // with data, false while loading or on error.
+  votesResolvedRef: { current: true },
+  usernameRef: { current: "alice" as string | null },
+  // Caches the returned account object so its `activeUser` keeps a stable
+  // reference across renders for a given username. The real useActiveAccount
+  // sources activeUser from the zustand store (stable); returning a fresh object
+  // every call would make the superList useMemo (which deps on activeUser)
+  // recompute each render and refire the setList effect — an infinite loop.
+  accountMemo: { key: undefined as string | null | undefined, value: null as any }
+}));
+
+vi.mock("@/core/hooks/use-active-account", () => ({
+  useActiveAccount: () => {
+    if (accountMemo.key !== usernameRef.current) {
+      accountMemo.key = usernameRef.current;
+      accountMemo.value = {
+        activeUser: usernameRef.current ? { username: usernameRef.current } : null,
+        username: usernameRef.current
+      };
+    }
+    return accountMemo.value;
+  }
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/"
+}));
+
+// Distinct query keys so the useQuery mock below can tell the two queries apart.
+vi.mock("@ecency/sdk", () => ({
+  getAnnouncementsQueryOptions: () => ({
+    queryKey: ["notifications", "announcements"],
+    queryFn: async () => announcementsRef.current
+  }),
+  getUserProposalVotesQueryOptions: (voter: string) => ({
+    queryKey: ["proposals", "votes", "by-user", voter],
+    queryFn: async () => votesRef.current
+  })
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-query")>()),
+  useQuery: (opts: any) =>
+    opts?.queryKey?.[0] === "proposals"
+      ? { data: votesRef.current, isSuccess: votesResolvedRef.current }
+      : { data: announcementsRef.current }
+}));
+
+// Stub the inline action so the test doesn't pull in the vote mutation / SDK
+// broadcast stack; we only care which announcements the parent decides to show.
+vi.mock("@/features/announcement/proposal-vote-action", () => ({
+  ProposalVoteAction: ({ proposalId }: { proposalId: number }) => (
+    <div data-testid="proposal-vote-action">pva:{proposalId}</div>
+  )
+}));
+
+const proposalAnnouncement = {
+  id: 1,
+  title: "Support Ecency proposal",
+  description: "Please support us",
+  button_text: "Support now",
+  button_link: "/proposals/379",
+  path: "/",
+  auth: true,
+  proposal_ids: [379]
+};
+
+const plainAnnouncement = {
+  id: 2,
+  title: "Welcome to Ecency",
+  description: "Check out the new release",
+  button_text: "Read more",
+  button_link: "/about",
+  path: "/",
+  auth: false
+};
+
+describe("Announcements proposal filtering", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    announcementsRef.current = [];
+    votesRef.current = [];
+    votesResolvedRef.current = true;
+    usernameRef.current = "alice";
+  });
+
+  it("shows a proposal announcement the user has not voted on", async () => {
+    announcementsRef.current = [proposalAnnouncement];
+    votesRef.current = [];
+
+    render(<Announcements />);
+
+    expect(await screen.findByText("Support Ecency proposal")).toBeInTheDocument();
+    expect(screen.getByTestId("proposal-vote-action")).toHaveTextContent("pva:379");
+  });
+
+  it("hides a proposal announcement the user has already voted on", () => {
+    announcementsRef.current = [proposalAnnouncement];
+    votesRef.current = [{ proposal: { proposal_id: 379 } }];
+
+    render(<Announcements />);
+
+    expect(screen.queryByText("Support Ecency proposal")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("proposal-vote-action")).not.toBeInTheDocument();
+  });
+
+  it("ignores votes for other proposals when deciding visibility", async () => {
+    announcementsRef.current = [proposalAnnouncement];
+    votesRef.current = [{ proposal: { proposal_id: 283 } }];
+
+    render(<Announcements />);
+
+    expect(await screen.findByText("Support Ecency proposal")).toBeInTheDocument();
+  });
+
+  it("never hides non-proposal announcements based on votes", async () => {
+    announcementsRef.current = [plainAnnouncement];
+    votesRef.current = [{ proposal: { proposal_id: 379 } }];
+
+    render(<Announcements />);
+
+    expect(await screen.findByText("Welcome to Ecency")).toBeInTheDocument();
+  });
+
+  it("filters only the voted proposal out of a mixed list, keeping siblings", async () => {
+    announcementsRef.current = [proposalAnnouncement, plainAnnouncement];
+    votesRef.current = [{ proposal: { proposal_id: 379 } }];
+
+    render(<Announcements />);
+
+    // The voted proposal is dropped; the surviving sibling is the one surfaced.
+    expect(await screen.findByText("Welcome to Ecency")).toBeInTheDocument();
+    expect(screen.queryByText("Support Ecency proposal")).not.toBeInTheDocument();
+  });
+
+  it("holds a proposal announcement back until the votes resolve", () => {
+    announcementsRef.current = [proposalAnnouncement];
+    votesRef.current = [];
+    votesResolvedRef.current = false; // votes query still loading (or errored)
+
+    render(<Announcements />);
+
+    expect(screen.queryByText("Support Ecency proposal")).not.toBeInTheDocument();
+  });
+
+  it("shows proposal announcements to logged-out users without waiting on a (disabled) votes query", async () => {
+    // For logged-out users the votes query is disabled and never resolves
+    // (isSuccess stays false); the `!username` short-circuit must still let an
+    // open proposal announcement through. auth:false so the auth filter doesn't
+    // hide it for an unrelated reason.
+    usernameRef.current = null;
+    votesResolvedRef.current = false;
+    announcementsRef.current = [{ ...proposalAnnouncement, auth: false }];
+    votesRef.current = [];
+
+    render(<Announcements />);
+
+    expect(await screen.findByText("Support Ecency proposal")).toBeInTheDocument();
+  });
+
+  it("keeps an announcement with an empty proposal_ids array visible even before votes resolve", async () => {
+    // proposal_ids: [] takes the non-proposal short-circuit and must win over
+    // the votes-ready gate.
+    votesResolvedRef.current = false;
+    announcementsRef.current = [{ ...proposalAnnouncement, proposal_ids: [] }];
+
+    render(<Announcements />);
+
+    expect(await screen.findByText("Support Ecency proposal")).toBeInTheDocument();
+  });
+
+  it("removes the card live once the user's votes update to include the proposal", async () => {
+    // The parent reads the same votes query key as the inline action, so after
+    // an inline vote the mutation's cache invalidation flows new vote data in
+    // and the card must disappear on the mounted component (guards the useMemo
+    // deps + shared-cache contract).
+    announcementsRef.current = [proposalAnnouncement];
+    votesRef.current = [];
+
+    const { rerender } = render(<Announcements />);
+    expect(await screen.findByText("Support Ecency proposal")).toBeInTheDocument();
+
+    votesRef.current = [{ proposal: { proposal_id: 379 } }];
+    rerender(<Announcements />);
+
+    await waitFor(() =>
+      expect(screen.queryByText("Support Ecency proposal")).not.toBeInTheDocument()
+    );
+  });
+});

--- a/apps/web/src/specs/features/announcement/announcements.spec.tsx
+++ b/apps/web/src/specs/features/announcement/announcements.spec.tsx
@@ -1,12 +1,36 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import { Announcements } from "@/features/announcement";
 
+interface MockAnnouncement {
+  id: number;
+  title: string;
+  description: string;
+  button_text: string;
+  button_link: string;
+  path: string | string[];
+  auth: boolean;
+  proposal_ids?: number[];
+}
+
+interface MockVote {
+  proposal?: { proposal_id: number };
+}
+
+interface MockActiveAccount {
+  activeUser: { username: string } | null;
+  username: string | null;
+}
+
+interface MockQueryOptions {
+  queryKey?: readonly unknown[];
+}
+
 const { announcementsRef, votesRef, votesResolvedRef, usernameRef, accountMemo } = vi.hoisted(() => ({
-  announcementsRef: { current: [] as any[] },
-  votesRef: { current: [] as { proposal?: { proposal_id: number } }[] },
+  announcementsRef: { current: [] as MockAnnouncement[] },
+  votesRef: { current: [] as MockVote[] },
   // Mirrors the votes query's `isSuccess`: true once the lookup has resolved
   // with data, false while loading or on error.
   votesResolvedRef: { current: true },
@@ -16,11 +40,14 @@ const { announcementsRef, votesRef, votesResolvedRef, usernameRef, accountMemo }
   // sources activeUser from the zustand store (stable); returning a fresh object
   // every call would make the superList useMemo (which deps on activeUser)
   // recompute each render and refire the setList effect — an infinite loop.
-  accountMemo: { key: undefined as string | null | undefined, value: null as any }
+  accountMemo: {
+    key: undefined as string | null | undefined,
+    value: null as MockActiveAccount | null
+  }
 }));
 
 vi.mock("@/core/hooks/use-active-account", () => ({
-  useActiveAccount: () => {
+  useActiveAccount: (): MockActiveAccount => {
     if (accountMemo.key !== usernameRef.current) {
       accountMemo.key = usernameRef.current;
       accountMemo.value = {
@@ -28,7 +55,7 @@ vi.mock("@/core/hooks/use-active-account", () => ({
         username: usernameRef.current
       };
     }
-    return accountMemo.value;
+    return accountMemo.value!;
   }
 }));
 
@@ -38,11 +65,15 @@ vi.mock("next/navigation", () => ({
 
 // Distinct query keys so the useQuery mock below can tell the two queries apart.
 vi.mock("@ecency/sdk", () => ({
-  getAnnouncementsQueryOptions: () => ({
+  getAnnouncementsQueryOptions: (): MockQueryOptions & {
+    queryFn: () => Promise<MockAnnouncement[]>;
+  } => ({
     queryKey: ["notifications", "announcements"],
     queryFn: async () => announcementsRef.current
   }),
-  getUserProposalVotesQueryOptions: (voter: string) => ({
+  getUserProposalVotesQueryOptions: (
+    voter: string
+  ): MockQueryOptions & { queryFn: () => Promise<MockVote[]> } => ({
     queryKey: ["proposals", "votes", "by-user", voter],
     queryFn: async () => votesRef.current
   })
@@ -50,7 +81,7 @@ vi.mock("@ecency/sdk", () => ({
 
 vi.mock("@tanstack/react-query", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@tanstack/react-query")>()),
-  useQuery: (opts: any) =>
+  useQuery: (opts: MockQueryOptions) =>
     opts?.queryKey?.[0] === "proposals"
       ? { data: votesRef.current, isSuccess: votesResolvedRef.current }
       : { data: announcementsRef.current }
@@ -64,7 +95,7 @@ vi.mock("@/features/announcement/proposal-vote-action", () => ({
   )
 }));
 
-const proposalAnnouncement = {
+const proposalAnnouncement: MockAnnouncement = {
   id: 1,
   title: "Support Ecency proposal",
   description: "Please support us",
@@ -75,7 +106,7 @@ const proposalAnnouncement = {
   proposal_ids: [379]
 };
 
-const plainAnnouncement = {
+const plainAnnouncement: MockAnnouncement = {
   id: 2,
   title: "Welcome to Ecency",
   description: "Check out the new release",
@@ -196,5 +227,25 @@ describe("Announcements proposal filtering", () => {
     await waitFor(() =>
       expect(screen.queryByText("Support Ecency proposal")).not.toBeInTheDocument()
     );
+  });
+
+  it("appends a dismissed id to dismiss_announcements without clobbering existing ids", () => {
+    // Regression anchor for the dismissClick dedup fix. The dedup *guard* itself
+    // is defensive and unreachable through the UI — an announcement whose id is
+    // already stored is filtered out of the list, so it can't be dismissed
+    // twice — but this exercises the reachable write/append branch the fix lives
+    // in: an existing id is preserved and the new id is appended (the old code
+    // read `.id` off a bare number while building this same array).
+    localStorage.setItem("ecency_dismiss_announcements", JSON.stringify([99]));
+    announcementsRef.current = [plainAnnouncement]; // id 2, non-proposal → always shown
+    const { container } = render(<Announcements />);
+
+    const closeButton = container.querySelector(".close-btn");
+    expect(closeButton).not.toBeNull();
+    fireEvent.click(closeButton as Element);
+
+    expect(JSON.parse(localStorage.getItem("ecency_dismiss_announcements") as string)).toEqual([
+      99, 2
+    ]);
   });
 });


### PR DESCRIPTION
## What

Proposal-type announcement cards already detect whether the active user has voted (the inline support action shows a "Voted" confirmation), but the card was still shown to them. This filters those announcements out of the list entirely, so a user who has already voted on the promoted proposal never sees the card.

## How

- The `Announcements` list resolves the active user's proposal votes using the **same query key** the inline `ProposalVoteAction` uses, so it's a shared React Query cache read rather than a second request. After an inline vote, the existing mutation invalidation flows new vote data in and the card disappears on its own too.
- An announcement is hidden once the user has voted on its first proposal id — exactly the proposal the inline action targets. Non-proposal announcements are never affected.
- Proposal cards are held back until the votes query **succeeds**, so a voter never sees a brief "support" card that then vanishes. An errored votes lookup keeps proposal cards hidden rather than re-prompting someone who may already have voted; logged-out users fall through (the votes query is disabled for them and the existing auth/path filtering applies).

## Tests

Adds `announcements.spec.tsx` (9 tests): not-voted → shown, voted → hidden, other-proposal vote → still shown, mixed list → only the voted card removed, load-gating, logged-out short-circuit, empty `proposal_ids`, and live removal when the user's votes update on a mounted component.

## Also

Fixes a small pre-existing bug in `dismissClick`: `dismiss_announcements` stores bare numeric ids but the dedup guard compared `.id` (undefined on a number), so ids were appended repeatedly. It now compares the number directly. (`laterClick` stores objects and is unchanged.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proposal announcements now intelligently filter based on your voting history.
  * Improved announcement loading state handling to prevent UI flickering.

* **Bug Fixes**
  * Corrected dismissed announcement deduplication logic.

* **Tests**
  * Added comprehensive test coverage for announcement visibility rules and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->