### PR TITLE
Make prod deploy fail loudly instead of silently passing

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -118,6 +118,7 @@ jobs:
         port: ${{ secrets.SSH_PORT }}
         envs: USE_PRIVATE,PRIVATE_API_ADDR,PRIVATE_API_AUTH,HIVESIGNER_SECRET,SEARCH_API_ADDR,SEARCH_API_SECRET,PLAUSIBLE_API_KEY,CHAINSTACK_API_KEY,CHAINZ_API_KEY,BLOCKSTREAM_CLIENT_ID,BLOCKSTREAM_CLIENT_SECRET,MATTERMOST_TEAM_ID,MATTERMOST_ADMIN_TOKEN,MATTERMOST_BASE_URL,MATTERMOST_WS_ALLOWED_ORIGINS,THREESPEAK_EMBED_API_KEY,SEO_CRON_SECRET,SEO_BLACKLIST_URL
         script: |
+          set -eo pipefail
           export USE_PRIVATE=$USE_PRIVATE
           export PRIVATE_API_ADDR=$PRIVATE_API_ADDR
           export PRIVATE_API_AUTH=$PRIVATE_API_AUTH
@@ -132,15 +133,15 @@ jobs:
           export THREESPEAK_EMBED_API_KEY=$THREESPEAK_EMBED_API_KEY
           export SEO_CRON_SECRET=$SEO_CRON_SECRET
           export SEO_BLACKLIST_URL=$SEO_BLACKLIST_URL
-          set -eo pipefail
           cd ~/vision-next
           git pull origin main
           cd apps/web
           docker network inspect vision >/dev/null 2>&1 || docker network create --driver overlay vision
           docker pull ecency/api:latest
           web_pull="$(docker pull ecency/vision-next:latest)"; printf '%s\n' "$web_pull"
-          docker-compose -f docker-compose.production.yml config > /tmp/vision-stack.yml
-          docker stack deploy -c /tmp/vision-stack.yml vision
+          STACK_FILE="$(mktemp)"; trap 'rm -f "$STACK_FILE"' EXIT
+          docker-compose -f docker-compose.production.yml config > "$STACK_FILE"
+          docker stack deploy -c "$STACK_FILE" vision
           # Don't report a green deploy unless the new image actually rolled out.
           # `docker stack deploy` returns as soon as the spec is committed to Raft
           # (before Swarm populates UpdateStatus), so a crash-on-start (-> rollback)
@@ -203,6 +204,7 @@ jobs:
         port: ${{ secrets.SSH_PORT }}
         envs: USE_PRIVATE,PRIVATE_API_ADDR,PRIVATE_API_AUTH,HIVESIGNER_SECRET,SEARCH_API_ADDR,SEARCH_API_SECRET,PLAUSIBLE_API_KEY,CHAINSTACK_API_KEY,CHAINZ_API_KEY,BLOCKSTREAM_CLIENT_ID,BLOCKSTREAM_CLIENT_SECRET,MATTERMOST_TEAM_ID,MATTERMOST_ADMIN_TOKEN,MATTERMOST_BASE_URL,MATTERMOST_WS_ALLOWED_ORIGINS,THREESPEAK_EMBED_API_KEY,SEO_CRON_SECRET,SEO_BLACKLIST_URL
         script: |
+          set -eo pipefail
           export USE_PRIVATE=$USE_PRIVATE
           export PRIVATE_API_ADDR=$PRIVATE_API_ADDR
           export PRIVATE_API_AUTH=$PRIVATE_API_AUTH
@@ -217,15 +219,15 @@ jobs:
           export THREESPEAK_EMBED_API_KEY=$THREESPEAK_EMBED_API_KEY
           export SEO_CRON_SECRET=$SEO_CRON_SECRET
           export SEO_BLACKLIST_URL=$SEO_BLACKLIST_URL
-          set -eo pipefail
           cd ~/vision-next
           git pull origin main
           cd apps/web
           docker network inspect vision >/dev/null 2>&1 || docker network create --driver overlay vision
           docker pull ecency/api:latest
           web_pull="$(docker pull ecency/vision-next:latest)"; printf '%s\n' "$web_pull"
-          docker-compose -f docker-compose.production.yml config > /tmp/vision-stack.yml
-          docker stack deploy -c /tmp/vision-stack.yml vision
+          STACK_FILE="$(mktemp)"; trap 'rm -f "$STACK_FILE"' EXIT
+          docker-compose -f docker-compose.production.yml config > "$STACK_FILE"
+          docker stack deploy -c "$STACK_FILE" vision
           # Don't report a green deploy unless the new image actually rolled out.
           # `docker stack deploy` returns as soon as the spec is committed to Raft
           # (before Swarm populates UpdateStatus), so a crash-on-start (-> rollback)
@@ -289,6 +291,7 @@ jobs:
         port: ${{ secrets.SSH_PORT }}
         envs: USE_PRIVATE,PRIVATE_API_ADDR,PRIVATE_API_AUTH,HIVESIGNER_SECRET,SEARCH_API_ADDR,SEARCH_API_SECRET,PLAUSIBLE_API_KEY,CHAINSTACK_API_KEY,CHAINZ_API_KEY,BLOCKSTREAM_CLIENT_ID,BLOCKSTREAM_CLIENT_SECRET,MATTERMOST_TEAM_ID,MATTERMOST_ADMIN_TOKEN,MATTERMOST_BASE_URL,MATTERMOST_WS_ALLOWED_ORIGINS,THREESPEAK_EMBED_API_KEY,SEO_CRON_SECRET,SEO_BLACKLIST_URL,WEB_REPLICAS
         script: |
+          set -eo pipefail
           export USE_PRIVATE=$USE_PRIVATE
           export PRIVATE_API_ADDR=$PRIVATE_API_ADDR
           export PRIVATE_API_AUTH=$PRIVATE_API_AUTH
@@ -304,15 +307,15 @@ jobs:
           export SEO_CRON_SECRET=$SEO_CRON_SECRET
           export SEO_BLACKLIST_URL=$SEO_BLACKLIST_URL
           export WEB_REPLICAS=$WEB_REPLICAS
-          set -eo pipefail
           cd ~/vision-next
           git pull origin main
           cd apps/web
           docker network inspect vision >/dev/null 2>&1 || docker network create --driver overlay vision
           docker pull ecency/api:latest
           web_pull="$(docker pull ecency/vision-next:latest)"; printf '%s\n' "$web_pull"
-          docker-compose -f docker-compose.production.yml config > /tmp/vision-stack.yml
-          docker stack deploy -c /tmp/vision-stack.yml vision
+          STACK_FILE="$(mktemp)"; trap 'rm -f "$STACK_FILE"' EXIT
+          docker-compose -f docker-compose.production.yml config > "$STACK_FILE"
+          docker stack deploy -c "$STACK_FILE" vision
           # Don't report a green deploy unless the new image actually rolled out.
           # `docker stack deploy` returns as soon as the spec is committed to Raft
           # (before Swarm populates UpdateStatus), so a crash-on-start (-> rollback)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -132,13 +132,15 @@ jobs:
           export THREESPEAK_EMBED_API_KEY=$THREESPEAK_EMBED_API_KEY
           export SEO_CRON_SECRET=$SEO_CRON_SECRET
           export SEO_BLACKLIST_URL=$SEO_BLACKLIST_URL
+          set -eo pipefail
           cd ~/vision-next
           git pull origin main
           cd apps/web
-          docker network create --driver overlay vision || true
+          docker network inspect vision >/dev/null 2>&1 || docker network create --driver overlay vision
           docker pull ecency/api:latest
           web_pull="$(docker pull ecency/vision-next:latest)"; printf '%s\n' "$web_pull"
-          docker stack deploy -c <(docker-compose -f docker-compose.production.yml config) vision
+          docker-compose -f docker-compose.production.yml config > /tmp/vision-stack.yml
+          docker stack deploy -c /tmp/vision-stack.yml vision
           # Don't report a green deploy unless the new image actually rolled out.
           # `docker stack deploy` returns as soon as the spec is committed to Raft
           # (before Swarm populates UpdateStatus), so a crash-on-start (-> rollback)
@@ -215,13 +217,15 @@ jobs:
           export THREESPEAK_EMBED_API_KEY=$THREESPEAK_EMBED_API_KEY
           export SEO_CRON_SECRET=$SEO_CRON_SECRET
           export SEO_BLACKLIST_URL=$SEO_BLACKLIST_URL
+          set -eo pipefail
           cd ~/vision-next
           git pull origin main
           cd apps/web
-          docker network create --driver overlay vision || true
+          docker network inspect vision >/dev/null 2>&1 || docker network create --driver overlay vision
           docker pull ecency/api:latest
           web_pull="$(docker pull ecency/vision-next:latest)"; printf '%s\n' "$web_pull"
-          docker stack deploy -c <(docker-compose -f docker-compose.production.yml config) vision
+          docker-compose -f docker-compose.production.yml config > /tmp/vision-stack.yml
+          docker stack deploy -c /tmp/vision-stack.yml vision
           # Don't report a green deploy unless the new image actually rolled out.
           # `docker stack deploy` returns as soon as the spec is committed to Raft
           # (before Swarm populates UpdateStatus), so a crash-on-start (-> rollback)
@@ -300,13 +304,15 @@ jobs:
           export SEO_CRON_SECRET=$SEO_CRON_SECRET
           export SEO_BLACKLIST_URL=$SEO_BLACKLIST_URL
           export WEB_REPLICAS=$WEB_REPLICAS
+          set -eo pipefail
           cd ~/vision-next
           git pull origin main
           cd apps/web
-          docker network create --driver overlay vision || true
+          docker network inspect vision >/dev/null 2>&1 || docker network create --driver overlay vision
           docker pull ecency/api:latest
           web_pull="$(docker pull ecency/vision-next:latest)"; printf '%s\n' "$web_pull"
-          docker stack deploy -c <(docker-compose -f docker-compose.production.yml config) vision
+          docker-compose -f docker-compose.production.yml config > /tmp/vision-stack.yml
+          docker stack deploy -c /tmp/vision-stack.yml vision
           # Don't report a green deploy unless the new image actually rolled out.
           # `docker stack deploy` returns as soon as the spec is committed to Raft
           # (before Swarm populates UpdateStatus), so a crash-on-start (-> rollback)


### PR DESCRIPTION
## Problem

The `master.yml` deploy scripts had no error handling. If a step failed — the compose render erroring, the overlay network missing, etc. — the script kept going and the job reported **success** even though **nothing was deployed**. A broken deploy looked green.

## Changes (all three regional deploy jobs)

- **`set -eo pipefail`** — any failed step now aborts the job
- **Render compose to a file first** (`docker-compose ... config > /tmp/vision-stack.yml`) so a `docker-compose` failure stops the deploy instead of feeding an empty/garbage spec to `docker stack deploy` via process substitution
- **Idempotent overlay-network create** (`docker network inspect ... || docker network create ...`) instead of `|| true`, which previously swallowed genuine failures

No behavioral change on a healthy deploy; the difference is that a *broken* deploy now fails instead of passing silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment reliability across regional pipelines with stricter error handling.
  * Swarm network setup now validates creation and fails early if unavailable.
  * Stack deployment renders configuration to a temporary file and ensures proper cleanup for safer, more predictable rollouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->