### PR TITLE
Read next: add staleTime so SSR-hydrated data skips the redundant client refetch

### DIFF
--- a/packages/sdk/src/modules/search/queries/get-similar-entries-query-options.ts
+++ b/packages/sdk/src/modules/search/queries/get-similar-entries-query-options.ts
@@ -133,6 +133,17 @@ export function getSimilarEntriesQueryOptions(entry: Entry) {
 
       return collected;
     },
+    // The entry page server-prefetches this query and dehydrates it. Without a
+    // staleTime, React Query treats the hydrated data as stale and refetches on
+    // mount — issuing a *redundant* /search-api/similar XHR right after
+    // hydration even though SSR already provided the data. That refetch was the
+    // long post-onload tail in the waterfall (held open to the client timeout),
+    // inflating GTmetrix "Fully Loaded" while the visible strip was already
+    // populated from SSR. A staleTime makes the hydrated data fresh so the
+    // client skips that refetch; if SSR delivered nothing (empty cache), the
+    // client still fetches. Recommendations are stable per post (and the cache
+    // key is content-fingerprinted), so 5 min matches the page's ISR cadence.
+    staleTime: 5 * 60 * 1000,
     // Best-effort suggestions strip — never retry-storm a degraded backend.
     // The web QueryClient only disables retries on the server; the browser
     // client keeps React Query's default retry (3×) — and other SDK consumers


### PR DESCRIPTION
## Problem
GTmetrix showed **Fully Loaded 6.0s** on entry pages while every other metric was great (LCP 971ms, TBT 106ms, CLS 0, TTI 2.0s, Perf 96 / Structure 99). The HAR pinned it to a single request:

```
/search-api/similar   start=1.98s  end=5.98s  dur=4000ms  status=[0]
```

It fires right after hydration and is held open until the client timeout (status `[0]` = aborted at 4000ms) — and it's the **last** request to finish, so it sets Fully Loaded ≈ 6.0s. The visible strip was already populated from SSR, so this is a *redundant* refetch ("loads fine in the browser" but inflates Fully Loaded).

## Root cause
`getSimilarEntriesQueryOptions` had no `staleTime`. The entry page server-prefetches and dehydrates the query, but with `staleTime: 0` React Query treats the hydrated data as stale and refetches on mount — issuing the extra `/similar` XHR.

## Fix
Add `staleTime: 5 * 60 * 1000`. SSR-hydrated data is now fresh, so the client **skips** the on-mount refetch. If SSR delivered nothing (empty cache), the client still fetches — the fallback is intact. Also reduces duplicate `/similar` load on the (single-region EU) backend and benefits mobile.

Expected: entry-page **Fully Loaded drops to ~2.5s**; LCP/TBT/CLS unchanged.

## Test plan
- [x] SDK unit tests pass (11/11); SDK builds clean.
- [ ] Re-run GTmetrix on an entry page after deploy — confirm the post-onload `/similar` request is gone and Fully Loaded drops.