### PR TITLE
Default search to Relevance over all time

### DIFF
--- a/apps/web/src/app/search/_components/search-advanced-form.tsx
+++ b/apps/web/src/app/search/_components/search-advanced-form.tsx
@@ -17,8 +17,8 @@ export function SearchAdvancedForm() {
   const [type, setType] = useState<SearchType>(SearchType.ALL);
   const [category, setCategory] = useState("");
   const [tags, setTags] = useState("");
-  const [date, setDate] = useLocalStorage<DateOpt>("recent_date", DateOpt.Y);
-  const [sort, setSort] = useState<SearchSort>(SearchSort.NEWEST);
+  const [date, setDate] = useLocalStorage<DateOpt>("recent_date", DateOpt.A);
+  const [sort, setSort] = useState<SearchSort>(SearchSort.RELEVANCE);
   const [hideLow, setHideLow] = useState(false);
   const [includeNsfw, setIncludeNsfw] = useState(false);
 
@@ -33,7 +33,7 @@ export function SearchAdvancedForm() {
       setSearch(searchQuery.query);
     }
 
-    setSort((params?.get("sort") as SearchSort) ?? SearchSort.NEWEST);
+    setSort((params?.get("sort") as SearchSort) ?? SearchSort.RELEVANCE);
     setHideLow(params?.get("hd") !== "0");
     setIncludeNsfw(params?.get("nsfw") === "1");
     const urlDate = params?.get("date") as DateOpt | null;
@@ -91,7 +91,7 @@ export function SearchAdvancedForm() {
 
     const params = new URLSearchParams();
     params.append("q", q);
-    params.append("date", date ?? DateOpt.Y);
+    params.append("date", date ?? DateOpt.A);
     params.append("sort", sort);
     params.append("adv", "1");
     if (!hideLow) params.append("hd", "0");
@@ -156,7 +156,7 @@ export function SearchAdvancedForm() {
         </div>
         <div className="col-span-12 sm:col-span-2 mb-4">
           <label>{i18next.t("search-comment.date")}</label>
-          <FormControl type="select" value={date ?? DateOpt.Y} onChange={dateChanged}>
+          <FormControl type="select" value={date ?? DateOpt.A} onChange={dateChanged}>
             {Object.values(DateOpt).map((x) => (
               <option value={x} key={x}>
                 {i18next.t(`search-comment.date-${x}`)}

--- a/apps/web/src/app/search/_components/search-comment/index.tsx
+++ b/apps/web/src/app/search/_components/search-comment/index.tsx
@@ -10,20 +10,8 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { SearchResult } from "@/entities";
 import { Button } from "@/features/ui";
-import * as ls from "@/utils/local-storage";
-
-enum SearchSort {
-  POPULARITY = "popularity",
-  NEWEST = "newest",
-  RELEVANCE = "relevance"
-}
-
-enum DateOpt {
-  W = "week",
-  M = "month",
-  Y = "year",
-  A = "all"
-}
+import { DateOpt } from "@/enums";
+import { SearchSort } from "@/app/decks/_components/consts";
 
 interface Props {
   disableResults?: boolean;
@@ -36,7 +24,10 @@ export function SearchComment({ disableResults }: Props) {
 
   const since = useMemo(() => {
     let sinceDate: Dayjs | undefined;
-    const dateOpt = params?.get("date") ?? ls.get("recent_date", DateOpt.A);
+    // Default search path is all-time on purpose. Only honor an explicit date
+    // from the URL (set by the advanced form) — not a stale localStorage value,
+    // which would otherwise pin existing users to the old "last year" default.
+    const dateOpt = params?.get("date") ?? DateOpt.A;
     switch (dateOpt) {
       case DateOpt.W:
         sinceDate = dayjs().subtract(1, "week");

--- a/apps/web/src/app/search/_components/search-comment/index.tsx
+++ b/apps/web/src/app/search/_components/search-comment/index.tsx
@@ -36,7 +36,7 @@ export function SearchComment({ disableResults }: Props) {
 
   const since = useMemo(() => {
     let sinceDate: Dayjs | undefined;
-    const dateOpt = params?.get("date") ?? ls.get("recent_date", DateOpt.Y);
+    const dateOpt = params?.get("date") ?? ls.get("recent_date", DateOpt.A);
     switch (dateOpt) {
       case DateOpt.W:
         sinceDate = dayjs().subtract(1, "week");
@@ -62,7 +62,7 @@ export function SearchComment({ disableResults }: Props) {
   } = useInfiniteQuery({
     ...getSearchApiInfiniteQueryOptions(
       params?.get("q") ?? "",
-      params?.get("sort") ?? SearchSort.NEWEST,
+      params?.get("sort") ?? SearchSort.RELEVANCE,
       params?.get("hd") !== "0",
       since,
       undefined,


### PR DESCRIPTION
## Why

We just improved the search ranking in the API (relevance is now BM25 weighted by post value; popularity is text-aware) — but ecency.com's search wasn't using it. The search box navigates to `/search?q=…` with no sort, and the results component defaulted to:

- **sort = `newest`** → users got chronological results and never hit the improved Relevance ranking unless they opened *Advanced* and changed it.
- **date = `Last Year`** (`since` = 1y) → this also *capped* Relevance, hiding the high-value older posts it surfaces.

So the default experience was "newest post from the last year containing the words" — exactly the thin/stale feel, bypassing the improvement.

## Change

Default the main search (`search-comment`) and the advanced form to **`sort=relevance`** and **`date=all`**, matching hivesearcher.com. Newest/Popular and the date window are still available in Advanced; the explicit `case DateOpt.Y` mapping is untouched, so picking "Last Year" still works.

7-line change, defaults only — no API/contract change (the SDK already passes `sort`/`since`/etc.).

## Effect

A plain search now returns the most relevant, valuable, on-topic posts across all time by default (e.g. `travel tips` → substantive guides instead of $0 stubs), instead of just the newest from the past year.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Search Updates**
  * Changed default date filter in advanced search from last year to all time
  * Updated default search result sorting to relevance instead of newest first

<!-- end of auto-generated comment: release notes by coderabbit.ai -->