### PR TITLE
fix(entry): skip LCP preload when the cover URL can't be resolved (no double-download)

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
@@ -126,7 +126,12 @@ export default async function EntryPage({ params, searchParams }: Props) {
   //     smaller image than develop's CDN-cross-served match preload, so net LCP
   //     for that cohort is not worse.
   //   - Ineligible cover (gif/svg/extensionless/already-proxified): the body
-  //     renders a bare format=match <img>, so preload that (original behavior).
+  //     renders a bare format=match <img>, so preload that.
+  //   - rawCover === null (the fast path couldn't resolve the cover URL — e.g. a
+  //     parenthesized markdown image URL the MD parser bails on): emit NO preload.
+  //     The body may still render an avif <picture>, so a match preload here would
+  //     mismatch the avif <source> and double-download the LCP. The in-body
+  //     fetchpriority="high" <img> still prioritizes the actual fetch.
   const rawCover = getEntryImageRawUrl(entry);
   const coverPicture = rawCover ? buildPictureSources(rawCover) : null;
   const lcpMatch = catchPostImage(entry, 600, 500, "match");
@@ -163,18 +168,19 @@ export default async function EntryPage({ params, searchParams }: Props) {
           imageSizes={IMAGE_SIZES}
           fetchPriority="high"
         />
-      ) : (
-        lcpMatch && (
-          <link
-            rel="preload"
-            as="image"
-            href={lcpMatch}
-            imageSrcSet={lcpMatchSrcSet || undefined}
-            imageSizes={lcpMatchSrcSet ? IMAGE_SIZES : undefined}
-            fetchPriority="high"
-          />
-        )
-      )}
+      ) : rawCover && lcpMatch ? (
+        // Ineligible cover with a resolved raw URL → the body renders a bare
+        // format=match <img>; preload the matching rendition. (When rawCover is
+        // null we intentionally emit nothing — see the comment above.)
+        <link
+          rel="preload"
+          as="image"
+          href={lcpMatch}
+          imageSrcSet={lcpMatchSrcSet || undefined}
+          imageSizes={lcpMatchSrcSet ? IMAGE_SIZES : undefined}
+          fetchPriority="high"
+        />
+      ) : null}
       <EntryPageContextProvider>
         <MdHandler />
         <div className="app-content entry-page bg-fixed bg-contain bg-gradient-to-tr from-blue-dark-sky/20 to-white dark:from-dark-default dark:to-black">

--- a/packages/render-helper/src/catch-post-image.spec.ts
+++ b/packages/render-helper/src/catch-post-image.spec.ts
@@ -133,6 +133,14 @@ describe('getEntryImageRawUrl', () => {
     expect(getEntryImageRawUrl(entry)).toBeNull()
   })
 
+  it('returns null for a parenthesized markdown image URL (MD fast-path bails) — the entry page must then skip the match preload, not preload it against the body avif <picture>', () => {
+    const entry = {
+      author: 'a', permlink: 'p', last_update: '2019-05-10T09:15:21',
+      body: '![x](https://example.com/foo_(bar).jpg)', json_metadata: '{}'
+    } as any
+    expect(getEntryImageRawUrl(entry)).toBeNull()
+  })
+
   it('works on a raw markdown string', () => {
     expect(getEntryImageRawUrl('![x](https://files.peakd.com/x/s.webp)')).toBe('https://files.peakd.com/x/s.webp')
   })


### PR DESCRIPTION
## Problem (follow-up to #928)

When `getEntryImageRawUrl()` returns `null` — which happens when the fast-path body parser bails, e.g. a **parenthesized markdown image URL** like `![x](https://example.com/foo_(bar).jpg)` (`MD_IMAGE_RE`'s `[^)\s]+` truncates at the `)`) — the entry page still preloaded `catchPostImage()`'s `format=match` URL (`catchPostImage` recovers the image via the full renderer).

But the rendered body emits an avif/webp `<picture>` for that same eligible URL. So AVIF-capable browsers download **the avif `<source>` _plus_ the unused match preload** — reintroducing the exact LCP double-download the `<picture>` work removed.

Reproduced: for `![x](https://example.com/foo_(bar).jpg)` with no `json_metadata.image`, `getEntryImageRawUrl` → `null`, `catchPostImage` → a `?format=match` URL, and the body renders `<source type="image/avif" …>` (same `/p/` hash).

Narrow (only posts with **no `json_metadata.image` thumbnail** _and_ a parenthesized first-body-image URL), but it does re-add a duplicate LCP fetch.

## Fix

Gate the match preload on `rawCover !== null`:
- **Eligible cover** → avif preload (unchanged).
- **Resolved ineligible cover** (gif/svg/extensionless) → match preload (unchanged).
- **`rawCover === null`** (fast path couldn't resolve the URL) → **emit no preload**. The body may still render an avif `<picture>`, and a match preload would mismatch it; the in-body `fetchpriority="high"` `<img>` still prioritizes the actual fetch. Trade-off: these rare covers lose the preload head-start, but never double-download.

`apps/web` page-only change. Adds a render-helper test pinning `getEntryImageRawUrl() === null` for a parenthesized markdown image URL (the contract the gate relies on).

## Tests
`pnpm -r test` green: render-helper 1131, web 1506. page.tsx typecheck clean. Empirically confirmed the paren-URL cover now yields no preload.