### PR TITLE
fix(rss): also treat Hive bridge "invalid tag" assert as transient

### DIFF
--- a/apps/web/src/features/rss/rss-handler.ts
+++ b/apps/web/src/features/rss/rss-handler.ts
@@ -54,6 +54,11 @@ export function isTransientUpstreamError(e: unknown): boolean {
     /Unable to parse endpoint data/i.test(msg) ||
     /HTTP 5\d\d/.test(msg) ||
     /fetch failed/i.test(msg) ||
-    /Assert Exception:.*(Category|Tag).*does not exist/i.test(msg)
+    // Hive's bridge rejects a bad tag/category two different ways depending on
+    // the input: "...Tag does not exist" for a valid-but-missing one, and
+    // "invalid tag `Foo`" for one that breaks tag-format rules (e.g. mixed
+    // case). Crawlers hit /:filter/:Tag/rss.xml with both, so match both.
+    /Assert Exception:.*(Category|Tag).*does not exist/i.test(msg) ||
+    /Assert Exception:\s*invalid (tag|category)/i.test(msg)
   );
 }

--- a/apps/web/src/specs/features/rss-handler.spec.ts
+++ b/apps/web/src/specs/features/rss-handler.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isTransientUpstreamError } from "@/features/rss/rss-handler";
+
+describe("isTransientUpstreamError", () => {
+  it("treats the Hive bridge `invalid tag` assert as transient (RSS crawler noise)", () => {
+    // Crawlers request /:filter/:Tag/rss.xml with mixed-case tags; the bridge
+    // rejects them with this phrasing, which the original filter missed.
+    expect(
+      isTransientUpstreamError(new Error("RPCError: Assert Exception:invalid tag `Pivot`"))
+    ).toBe(true);
+    expect(isTransientUpstreamError(new Error("Assert Exception:invalid category `Foo`"))).toBe(
+      true
+    );
+  });
+
+  it("still treats the `Tag/Category does not exist` assert as transient", () => {
+    expect(isTransientUpstreamError(new Error("Assert Exception:Tag `nope` does not exist"))).toBe(
+      true
+    );
+    expect(isTransientUpstreamError(new Error("Assert Exception:Category does not exist"))).toBe(
+      true
+    );
+  });
+
+  it("treats network/timeout/upstream-5xx errors as transient", () => {
+    expect(isTransientUpstreamError(Object.assign(new Error("x"), { code: "ECONNRESET" }))).toBe(
+      true
+    );
+    expect(
+      isTransientUpstreamError(Object.assign(new Error("aborted"), { name: "AbortError" }))
+    ).toBe(true);
+    expect(isTransientUpstreamError(new Error("HTTP 503 Service Unavailable"))).toBe(true);
+    expect(isTransientUpstreamError(new Error("fetch failed"))).toBe(true);
+  });
+
+  it("does NOT suppress genuine application errors", () => {
+    expect(isTransientUpstreamError(new Error("Cannot read properties of undefined"))).toBe(false);
+    expect(isTransientUpstreamError(new Error("Assert Exception:something unrelated"))).toBe(false);
+    expect(isTransientUpstreamError(null)).toBe(false);
+    expect(isTransientUpstreamError("just a string")).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up to #921.

## Problem
#921 filtered the `Assert Exception:…(Category|Tag)…does not exist` error that the Hive bridge raises for RSS feed paths pointing at a non-existent tag/category. But the bridge rejects a tag that breaks *format* rules (e.g. mixed-case like `Pivot`, `ENGLISH`, `SaveYourInternet`) with a **different** phrasing:

```
RPCError: Assert Exception:invalid tag `Pivot`
```

Crawlers fan out across `/:filter/:Tag/rss.xml` with both forms, so this variant slipped past #921 and kept surfacing as error-level noise (server-side, no user impact) instead of being treated as the expected transient/garbage-input case.

## Fix
Broaden `isTransientUpstreamError` to also match `Assert Exception: invalid (tag|category)`. The existing `does not exist` clause is unchanged.

## Tests
Adds `rss-handler.spec.ts` (there was no spec for this helper before):
- ✅ `invalid tag` / `invalid category` → transient (regression for this bug)
- ✅ `…does not exist` still transient (no regression to #921)
- ✅ network / timeout / HTTP 5xx / `fetch failed` still transient
- ✅ genuine application errors are **not** suppressed (over-suppression guard)

`vitest run src/specs/features/rss-handler.spec.ts` → 4 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for RSS feed processing to correctly classify temporary upstream connectivity issues and transient crawler-related errors. These failures will no longer trigger unnecessary critical alerts in error monitoring systems.

* **Tests**
  * Added comprehensive test coverage to verify proper classification of transient upstream errors in RSS feed handling, including various network connectivity and crawler-related failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->