### PR TITLE
perf(web): keep tus-js-client and qrcode off the read-path bundle

### DIFF
--- a/apps/web/src/api/threespeak-embed/api.ts
+++ b/apps/web/src/api/threespeak-embed/api.ts
@@ -1,4 +1,3 @@
-import * as tus from "tus-js-client";
 import { EcencyConfigManager } from "@/config";
 import * as ls from "@/utils/local-storage";
 import { getAccessToken } from "@/utils/user-token";
@@ -152,6 +151,11 @@ async function uploadOnce(
 
   // Fall back to config endpoint if upload_url not provided
   const endpoint = upload_url || `${getEmbedEndpoint()}/uploads`;
+
+  // Load TUS on demand: this module's playback helpers (getVideoMetadata,
+  // extractPermlink, ...) are imported by the post renderer on read pages, and
+  // a top-level import would drag the ~48 KB upload client onto every post.
+  const tus = await import("tus-js-client");
 
   return new Promise<VideoUploadResult>((resolve, reject) => {
     // With parallelUploads the partial creation responses each carry their own

--- a/apps/web/src/features/shared/navbar/sidebar/navbar-side-main-menu.tsx
+++ b/apps/web/src/features/shared/navbar/sidebar/navbar-side-main-menu.tsx
@@ -23,9 +23,17 @@ import {
 } from "@tooni/iconscout-unicons-react";
 import i18next from "i18next";
 import { ReactNode, useMemo, useState } from "react";
+import dynamic from "next/dynamic";
 import { NavbarSideMainLogout } from "./navbar-side-main-logout";
 import { NavbarSideMainMenuItem } from "./navbar-side-main-menu-item";
-import { MobileLoginQrDialog } from "../../mobile-login-qr";
+
+// Loaded on demand when the user opens mobile login, so `qrcode` (~22 KB) is
+// not bundled onto every page - the navbar renders on all routes, including
+// read-only post pages where the QR login is never used.
+const MobileLoginQrDialog = dynamic(
+  () => import("../../mobile-login-qr").then((m) => m.MobileLoginQrDialog),
+  { ssr: false }
+);
 
 interface Props {
   onHide: () => void;
@@ -184,7 +192,9 @@ export function NavbarSideMainMenu({ onHide }: Props) {
         <FragmentsDialog show={fragments && !!activeUser} setShow={(v) => setFragments(v)} />
       </EcencyConfigManager.Conditional>
 
-      <MobileLoginQrDialog show={mobileLogin} onHide={() => setMobileLogin(false)} />
+      {mobileLogin && (
+        <MobileLoginQrDialog show={mobileLogin} onHide={() => setMobileLogin(false)} />
+      )}
     </>
   );
 }

--- a/apps/web/src/features/shared/navbar/sidebar/navbar-side-main-menu.tsx
+++ b/apps/web/src/features/shared/navbar/sidebar/navbar-side-main-menu.tsx
@@ -32,7 +32,9 @@ import { NavbarSideMainMenuItem } from "./navbar-side-main-menu-item";
 // read-only post pages where the QR login is never used.
 const MobileLoginQrDialog = dynamic(
   () => import("../../mobile-login-qr").then((m) => m.MobileLoginQrDialog),
-  { ssr: false }
+  // The dialog renders its own modal/spinner once mounted; render nothing while
+  // the (small) chunk streams in rather than an out-of-context placeholder.
+  { ssr: false, loading: () => null }
 );
 
 interface Props {


### PR DESCRIPTION
Two compose/login-only libs were statically pulled into read-path modules. Measured against an ANALYZE build intersected with the entry route's First-Load chunk set:

## What actually changed (measured)
- **`tus-js-client` (~48 KB parsed): DEFERRED ✓** — confirmed no longer in the entry route's First-Load. `api/threespeak-embed/api.ts` mixed the TUS uploader with read-side playback helpers under one top-level import; now `await import("tus-js-client")` inside the upload path. This is the real win.
- **`qrcode` (~11 KB gzip): NOT reduced** — still in First-Load via a shared chunk pulled by its *other* importers (purchase-qr / signup / wallet-token). Deferring only the navbar dialog (this PR) doesn't remove it; that would need all qrcode importers deferred. The navbar `next/dynamic` change is kept as a harmless correctness/consistency improvement, **not** a measured size win.

## Net
A modest, verified First-Load reduction (the tus chunk) plus a tidy navbar lazy-load. Honest scope: this is small. Per the broader profiling, the entry First-Load is dominated by structural code (framework, app `features/shared`/`ui`/`i18n`, the render-helper markdown pipeline, `@ecency/sdk`); there is no single heavy culprit to split out.

## Tests
`threespeak-embed-api.spec.ts` 13/13 (mocks `tus-js-client`, validates the dynamic import path). tsc clean; greptile review addressed (`loading: () => null`).
