### PR TITLE
fix(3speak): stop duplicate video uploads (use token embed URL)

### DIFF
--- a/apps/web/src/api/threespeak-embed/api.ts
+++ b/apps/web/src/api/threespeak-embed/api.ts
@@ -216,6 +216,8 @@ async function uploadFromHeader(
       headers: { Authorization: `Bearer ${token}` },
       metadata: { filename: file.name },
       onError(error: Error) {
+        // Cancel any in-progress retry before rejecting, mirroring runTusUpload.
+        upload.abort().catch(() => {});
         reject(error);
       },
       onProgress(bytesUploaded: number, bytesTotal: number) {

--- a/apps/web/src/api/threespeak-embed/api.ts
+++ b/apps/web/src/api/threespeak-embed/api.ts
@@ -46,7 +46,7 @@ function getThreeSpeakAuthCode(): string {
 async function requestUploadToken(
   owner: string,
   isShort: boolean
-): Promise<{ token: string; upload_url: string }> {
+): Promise<{ token: string; upload_url: string; permlink?: string; embed_url?: string }> {
   const code = getThreeSpeakAuthCode();
   const response = await fetch("/api/threespeak/upload-token", {
     method: "POST",
@@ -108,11 +108,16 @@ export function getUploadTuning(size: number): { chunkSize: number; parallelUplo
 /**
  * Upload a video file via the TUS resumable upload protocol.
  *
- * Tries the size-tuned settings first (parallel for files > 10MB). Parallel
- * uploads depend on the 3Speak tusd backend supporting the Concatenation
- * extension AND returning X-Embed-URL on the final concat response; if that
- * assumption doesn't hold the parallel attempt fails, so we retry once on the
- * proven sequential path (with a fresh token) rather than failing outright.
+ * The upload token now carries the video's permlink and canonical embed URL
+ * (assigned by the backend at issuance), so the result no longer depends on
+ * reading an X-Embed-URL response header. This is what makes parallel (TUS
+ * Concatenation) uploads reliable: previously, when the final-concat response
+ * didn't surface that header, the client treated a *completed* upload as a
+ * failure and re-uploaded the whole file, producing duplicate uploads.
+ *
+ * Against an older backend that doesn't return a permlink with the token, we
+ * fall back to the proven sequential path and read the embed URL from the
+ * header. Neither path ever re-uploads, so duplicates can't happen.
  */
 export async function uploadVideoEmbed(
   file: File,
@@ -120,117 +125,121 @@ export async function uploadVideoEmbed(
   isShort: boolean,
   progressCallback: (percentage: number) => void
 ): Promise<VideoUploadResult> {
-  const { chunkSize, parallelUploads } = getUploadTuning(file.size);
-
-  try {
-    return await uploadOnce(file, owner, isShort, chunkSize, parallelUploads, progressCallback);
-  } catch (err) {
-    if (parallelUploads > 1) {
-      console.warn("[3Speak Embed] Parallel upload failed; retrying sequentially.", err);
-      progressCallback(0);
-      return uploadOnce(file, owner, isShort, chunkSize, 1, progressCallback);
-    }
-    throw err;
-  }
-}
-
-/**
- * Perform a single TUS upload attempt with an explicit chunk size / parallelism.
- * Obtains a fresh short-lived upload token, then uploads directly to 3Speak.
- */
-async function uploadOnce(
-  file: File,
-  owner: string,
-  isShort: boolean,
-  chunkSize: number,
-  parallelUploads: number,
-  progressCallback: (percentage: number) => void
-): Promise<VideoUploadResult> {
-  // Get upload token from our server (API key stays server-side)
-  const { token, upload_url } = await requestUploadToken(owner, isShort);
+  const { token, upload_url, permlink, embed_url } = await requestUploadToken(owner, isShort);
 
   // Fall back to config endpoint if upload_url not provided
   const endpoint = upload_url || `${getEmbedEndpoint()}/uploads`;
 
+  // Preferred path: the backend assigned the permlink/embed URL up front, so we
+  // run a single upload (parallel for files > 10MB) and resolve with the known
+  // URL on success — no header to capture, no re-upload.
+  if (permlink && embed_url) {
+    const { chunkSize, parallelUploads } = getUploadTuning(file.size);
+    await runTusUpload(file, token, endpoint, chunkSize, parallelUploads, progressCallback);
+    return { embedUrl: embed_url, permlink };
+  }
+
+  // Legacy backend: the embed URL only comes back via the X-Embed-URL header.
+  // Use the sequential path — its single create→response keeps the header
+  // reliable, and because it never re-uploads, a missing header surfaces as an
+  // error instead of silently duplicating the upload.
+  const { chunkSize } = getUploadTuning(file.size);
+  return uploadFromHeader(file, token, endpoint, chunkSize, progressCallback);
+}
+
+const TUS_RETRY_DELAYS = [0, 3000, 5000, 10000, 20000];
+
+/**
+ * Run a TUS upload to completion. Resolves on success, rejects on error.
+ * Aborts in-flight parts on error so a failed parallel upload doesn't keep
+ * pushing bytes in the background.
+ */
+async function runTusUpload(
+  file: File,
+  token: string,
+  endpoint: string,
+  chunkSize: number,
+  parallelUploads: number,
+  progressCallback: (percentage: number) => void
+): Promise<void> {
   // Load TUS on demand: this module's playback helpers (getVideoMetadata,
   // extractPermlink, ...) are imported by the post renderer on read pages, and
   // a top-level import would drag the ~48 KB upload client onto every post.
   const tus = await import("tus-js-client");
 
-  return new Promise<VideoUploadResult>((resolve, reject) => {
-    // With parallelUploads the partial creation responses each carry their own
-    // X-Embed-URL; the canonical one is on the final concatenation request
-    // (Upload-Concat: final). Prefer it, falling back to the last-seen URL so
-    // the sequential path (parallelUploads = 1) keeps its previous behaviour.
-    let embedUrl = "";
-    let finalEmbedUrl = "";
-
+  return new Promise<void>((resolve, reject) => {
     const upload = new tus.Upload(file, {
       endpoint,
       chunkSize,
       parallelUploads,
-      retryDelays: [0, 3000, 5000, 10000, 20000],
-      headers: {
-        Authorization: `Bearer ${token}`
-      },
-      metadata: {
-        filename: file.name
-      },
+      retryDelays: TUS_RETRY_DELAYS,
+      headers: { Authorization: `Bearer ${token}` },
+      metadata: { filename: file.name },
       onError(error: Error) {
-        // Stop any still-in-flight parallel parts so they don't keep uploading
-        // while the caller retries sequentially.
         upload.abort().catch(() => {});
         reject(error);
       },
       onProgress(bytesUploaded: number, bytesTotal: number) {
-        const percentage = Number(((bytesUploaded / bytesTotal) * 100).toFixed(2));
-        progressCallback(percentage);
+        progressCallback(Number(((bytesUploaded / bytesTotal) * 100).toFixed(2)));
       },
       onSuccess() {
-        // The canonical embed URL is the one returned by the final
-        // concatenation request (Upload-Concat: final). In parallel mode we
-        // REQUIRE it: partial creation responses carry their own non-canonical
-        // URLs, so falling back to one would link the post to a transient
-        // partial resource. The sequential path has no concat step, so the
-        // last-seen URL (the final PATCH) is canonical and used as the fallback.
-        if (parallelUploads > 1 && !finalEmbedUrl) {
+        resolve();
+      }
+    });
+
+    upload.start();
+  });
+}
+
+/**
+ * Legacy fallback for backends that don't return a permlink with the token.
+ * Uploads sequentially (parallelUploads = 1) and reads the embed URL from the
+ * X-Embed-URL header on the create response.
+ */
+async function uploadFromHeader(
+  file: File,
+  token: string,
+  endpoint: string,
+  chunkSize: number,
+  progressCallback: (percentage: number) => void
+): Promise<VideoUploadResult> {
+  const tus = await import("tus-js-client");
+
+  return new Promise<VideoUploadResult>((resolve, reject) => {
+    let embedUrl = "";
+
+    const upload = new tus.Upload(file, {
+      endpoint,
+      chunkSize,
+      parallelUploads: 1,
+      retryDelays: TUS_RETRY_DELAYS,
+      headers: { Authorization: `Bearer ${token}` },
+      metadata: { filename: file.name },
+      onError(error: Error) {
+        reject(error);
+      },
+      onProgress(bytesUploaded: number, bytesTotal: number) {
+        progressCallback(Number(((bytesUploaded / bytesTotal) * 100).toFixed(2)));
+      },
+      onSuccess() {
+        if (!embedUrl) {
+          reject(new Error("[3Speak Embed] Upload succeeded but no embed URL was returned"));
+          return;
+        }
+        const permlink = extractPermlink(embedUrl);
+        if (!permlink) {
           reject(
-            new Error(
-              "[3Speak Embed] Parallel upload finished without an X-Embed-URL on the final " +
-                "concatenation response; refusing to fall back to a partial-upload URL."
-            )
+            new Error("[3Speak Embed] Upload succeeded but the permlink could not be extracted")
           );
           return;
         }
-        const resolvedUrl = finalEmbedUrl || embedUrl;
-        if (resolvedUrl) {
-          const permlink = extractPermlink(resolvedUrl);
-          if (!permlink) {
-            reject(
-              new Error("[3Speak Embed] Upload succeeded but the permlink could not be extracted")
-            );
-            return;
-          }
-          resolve({
-            embedUrl: resolvedUrl,
-            permlink
-          });
-        } else {
-          reject(new Error("[3Speak Embed] Upload succeeded but no embed URL was returned"));
-        }
+        resolve({ embedUrl, permlink });
       },
-      onAfterResponse(req: any, res: any) {
+      onAfterResponse(_req: any, res: any) {
         const headerUrl = res.getHeader?.("x-embed-url") || res.getHeader?.("X-Embed-URL");
-        if (!headerUrl) {
-          return;
+        if (headerUrl) {
+          embedUrl = headerUrl;
         }
-        // Prefer the embed URL from the final concatenation request; partial
-        // creation responses (Upload-Concat: partial) may carry their own.
-        const concat = String(req.getHeader?.("Upload-Concat") ?? "");
-        if (concat.startsWith("final")) {
-          finalEmbedUrl = headerUrl;
-        }
-        embedUrl = headerUrl;
       }
     });
 

--- a/apps/web/src/specs/utils/threespeak-embed-api.spec.ts
+++ b/apps/web/src/specs/utils/threespeak-embed-api.spec.ts
@@ -130,83 +130,112 @@ describe("getUploadTuning", () => {
   });
 });
 
-describe("uploadVideoEmbed embed-url resolution", () => {
+// > 10 MB so getUploadTuning selects parallelUploads = 3.
+const bigFile = () =>
+  new File([new Uint8Array(11 * 1024 * 1024)], "big.mp4", { type: "video/mp4" });
+// <= 10 MB so getUploadTuning selects parallelUploads = 1 (sequential).
+const smallFile = () => new File(["x"], "small.mp4", { type: "video/mp4" });
+
+function stubTokenResponse(extra: Record<string, unknown> = {}) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({ token: "tok", upload_url: "https://embed.example/uploads", ...extra })
+    })
+  );
+}
+
+describe("uploadVideoEmbed with a token-bound permlink (preferred path)", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ token: "tok", upload_url: "https://embed.example/uploads" })
-      })
-    );
-  });
-
-  // > 10 MB so getUploadTuning selects parallelUploads = 3.
-  const bigFile = () =>
-    new File([new Uint8Array(11 * 1024 * 1024)], "big.mp4", { type: "video/mp4" });
-  // <= 10 MB so getUploadTuning selects parallelUploads = 1 (sequential).
-  const smallFile = () => new File(["x"], "small.mp4", { type: "video/mp4" });
-
-  it("falls back to sequential when the parallel attempt has no final-concat URL", async () => {
-    tusMock.runUpload = (options) => {
-      if (options.parallelUploads > 1) {
-        // Parallel attempt: only a partial-creation URL, no final concat -> rejects.
-        options.onAfterResponse(
-          mockReq("partial"),
-          mockRes("https://play.3speak.tv/embed?v=a/PART01")
-        );
-        options.onSuccess();
-      } else {
-        // Sequential retry: backend returns a usable embed URL.
-        options.onAfterResponse(mockReq(), mockRes("https://play.3speak.tv/embed?v=a/SEQFALL01"));
-        options.onSuccess();
-      }
-    };
-    const { uploadVideoEmbed } = await import("@/api/threespeak-embed/api");
-    await expect(uploadVideoEmbed(bigFile(), "a", false, () => {})).resolves.toEqual({
-      embedUrl: "https://play.3speak.tv/embed?v=a/SEQFALL01",
-      permlink: "SEQFALL01"
+    // New backend: the token response carries the canonical embed URL up front.
+    stubTokenResponse({
+      permlink: "TOK12345",
+      embed_url: "https://play.3speak.tv/embed?v=a/TOK12345"
     });
   });
 
-  it("resolves a parallel upload to the final-concat embed URL", async () => {
+  it("keeps parallel uploads on for big files and resolves with the token URL", async () => {
+    let seenParallel = -1;
     tusMock.runUpload = (options) => {
-      options.onAfterResponse(
-        mockReq("partial"),
-        mockRes("https://play.3speak.tv/embed?v=a/PART01")
-      );
-      options.onAfterResponse(
-        mockReq("final;https://embed.example/a https://embed.example/b"),
-        mockRes("https://play.3speak.tv/embed?v=a/FINAL567")
-      );
+      seenParallel = options.parallelUploads;
+      // No header capture — success alone resolves to the token's embed URL.
       options.onSuccess();
     };
     const { uploadVideoEmbed } = await import("@/api/threespeak-embed/api");
     await expect(uploadVideoEmbed(bigFile(), "a", false, () => {})).resolves.toEqual({
-      embedUrl: "https://play.3speak.tv/embed?v=a/FINAL567",
-      permlink: "FINAL567"
+      embedUrl: "https://play.3speak.tv/embed?v=a/TOK12345",
+      permlink: "TOK12345"
     });
+    expect(seenParallel).toBe(3);
   });
 
-  it("uses the last-seen embed URL for a sequential upload (no concat step)", async () => {
+  it("uploads small files sequentially and resolves with the token URL", async () => {
+    let seenParallel = -1;
     tusMock.runUpload = (options) => {
-      // Sequential path: requests carry no Upload-Concat header.
-      options.onAfterResponse(mockReq(), mockRes("https://play.3speak.tv/embed?v=a/SEQ12345"));
+      seenParallel = options.parallelUploads;
       options.onSuccess();
     };
     const { uploadVideoEmbed } = await import("@/api/threespeak-embed/api");
     await expect(uploadVideoEmbed(smallFile(), "a", false, () => {})).resolves.toEqual({
-      embedUrl: "https://play.3speak.tv/embed?v=a/SEQ12345",
-      permlink: "SEQ12345"
+      embedUrl: "https://play.3speak.tv/embed?v=a/TOK12345",
+      permlink: "TOK12345"
     });
+    expect(seenParallel).toBe(1);
   });
 
-  it("propagates the error when both the parallel and sequential attempts fail", async () => {
+  it("never re-uploads: a failed upload rejects without a second attempt", async () => {
+    let attempts = 0;
     tusMock.runUpload = (options) => {
+      attempts += 1;
       options.onError(new Error("network down"));
     };
     const { uploadVideoEmbed } = await import("@/api/threespeak-embed/api");
     await expect(uploadVideoEmbed(bigFile(), "a", false, () => {})).rejects.toThrow(/network down/);
+    expect(attempts).toBe(1);
+  });
+});
+
+describe("uploadVideoEmbed against a legacy backend (header fallback)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // Old backend: no permlink/embed_url in the token response.
+    stubTokenResponse();
+  });
+
+  it("uploads sequentially even for big files and reads the X-Embed-URL header", async () => {
+    let seenParallel = -1;
+    tusMock.runUpload = (options) => {
+      seenParallel = options.parallelUploads;
+      options.onAfterResponse(mockReq(), mockRes("https://play.3speak.tv/embed?v=a/SEQ12345"));
+      options.onSuccess();
+    };
+    const { uploadVideoEmbed } = await import("@/api/threespeak-embed/api");
+    await expect(uploadVideoEmbed(bigFile(), "a", false, () => {})).resolves.toEqual({
+      embedUrl: "https://play.3speak.tv/embed?v=a/SEQ12345",
+      permlink: "SEQ12345"
+    });
+    // Legacy path must avoid the racy parallel/concat header delivery.
+    expect(seenParallel).toBe(1);
+  });
+
+  it("rejects when the backend returns no embed URL header", async () => {
+    tusMock.runUpload = (options) => {
+      options.onSuccess();
+    };
+    const { uploadVideoEmbed } = await import("@/api/threespeak-embed/api");
+    await expect(uploadVideoEmbed(smallFile(), "a", false, () => {})).rejects.toThrow(
+      /no embed URL was returned/
+    );
+  });
+
+  it("propagates the upload error", async () => {
+    tusMock.runUpload = (options) => {
+      options.onError(new Error("network down"));
+    };
+    const { uploadVideoEmbed } = await import("@/api/threespeak-embed/api");
+    await expect(uploadVideoEmbed(smallFile(), "a", false, () => {})).rejects.toThrow(/network down/);
   });
 });

--- a/apps/web/src/specs/utils/threespeak-embed-api.spec.ts
+++ b/apps/web/src/specs/utils/threespeak-embed-api.spec.ts
@@ -221,6 +221,24 @@ describe("uploadVideoEmbed against a legacy backend (header fallback)", () => {
     expect(seenParallel).toBe(1);
   });
 
+  it("falls back to the header path when the token carries only a permlink", async () => {
+    // Partial token response (permlink but no embed_url) must not be treated as
+    // the preferred path — it should fall through to the sequential header path.
+    stubTokenResponse({ permlink: "TOK12345" });
+    let seenParallel = -1;
+    tusMock.runUpload = (options) => {
+      seenParallel = options.parallelUploads;
+      options.onAfterResponse(mockReq(), mockRes("https://play.3speak.tv/embed?v=a/SEQ99999"));
+      options.onSuccess();
+    };
+    const { uploadVideoEmbed } = await import("@/api/threespeak-embed/api");
+    await expect(uploadVideoEmbed(bigFile(), "a", false, () => {})).resolves.toEqual({
+      embedUrl: "https://play.3speak.tv/embed?v=a/SEQ99999",
+      permlink: "SEQ99999"
+    });
+    expect(seenParallel).toBe(1);
+  });
+
   it("rejects when the backend returns no embed URL header", async () => {
     tusMock.runUpload = (options) => {
       options.onSuccess();


### PR DESCRIPTION
## Issue

Fixes #920 — uploading a single video produced **multiple identical uploads** on the 3Speak side (the report shows one click creating three full 70 MB uploads with the same IPFS CID).

## Root cause

For files > 10 MB the client uses parallel uploads (`tus-js-client` `parallelUploads: 3`, TUS Concatenation). It **required** an `X-Embed-URL` header on the final-concat response and, when the embed backend didn't surface it, treated the *already-completed* upload as a failure and re-uploaded the entire file with a fresh token (`uploadVideoEmbed`'s parallel→sequential fallback). The header is delivered by the backend via a global, unkeyed FIFO that desyncs under concurrency, and a Concatenation final emits no `204`, so the header was frequently missed — turning every large parallel upload into 2–3 full uploads.

## Fix

The embed backend now assigns the permlink at token issuance and returns `permlink` + `embed_url` alongside the token (companion PR: Mantequilla-Soft/embedvideos#24). The embed URL is therefore known before a single byte is uploaded. `uploadVideoEmbed` now:

- **Preferred path** (token carries a permlink): runs one upload (parallel stays on for large files) and resolves with the token's `embed_url`/`permlink` on success — no header to capture, **no re-upload**.
- **Legacy path** (older backend, no permlink in the token): uploads sequentially and reads the `X-Embed-URL` header. Sequential's single create→response keeps the header reliable, and it never re-uploads — a missing header surfaces as an error instead of silently duplicating.

Neither path re-uploads, so duplicates can't occur regardless of which backend version is deployed. The Ecency `/api/threespeak/upload-token` proxy already forwards the backend response verbatim, so no proxy change is needed.

## Tests

`threespeak-embed-api.spec.ts` rewritten to cover both paths: token-bound permlink (parallel kept on for big files, sequential for small, never re-uploads on error) and the legacy header fallback (sequential even for big files, rejects when no header, propagates errors). Full web suite green (1512 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 3Speak embed uploads now support token-based permlink generation with automatic upload path optimization based on file size.
  * Added fallback mechanism for legacy embed URL resolution via response headers for enhanced compatibility.

* **Improvements**
  * Enhanced upload reliability with improved error handling and operation abort procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->