### PR TITLE
fix(discover): stop double-converting curator rewards to HP

### DIFF
--- a/apps/web/src/app/discover/@curation/page.tsx
+++ b/apps/web/src/app/discover/@curation/page.tsx
@@ -18,11 +18,7 @@ import { Badge } from "@ui/badge";
 import { UilInfoCircle } from "@tooni/iconscout-unicons-react";
 import { useSearchParams } from "next/navigation";
 
-interface Props {
-  searchParams: Promise<Record<string, string | undefined>>;
-}
-
-export default function CurationPage({ searchParams }: Props) {
+export default function CurationPage() {
   const params = useSearchParams();
 
   const { data } = useQuery(

--- a/apps/web/src/app/discover/@curation/page.tsx
+++ b/apps/web/src/app/discover/@curation/page.tsx
@@ -7,12 +7,12 @@ import {
 } from "@/app/discover/_components";
 import { LeaderBoardDuration } from "@/entities";
 import { EcencyConfigManager } from "@/config";
-import { getDynamicPropsQueryOptions, getDiscoverCurationQueryOptions } from "@ecency/sdk";
+import { getDiscoverCurationQueryOptions } from "@ecency/sdk";
 import { dehydrate, HydrationBoundary, useQuery } from "@tanstack/react-query";
 import { getQueryClient } from "@/core/react-query";
 import i18next from "i18next";
 import { Tooltip } from "@ui/tooltip";
-import { formattedNumber, vestsToHp } from "@/utils";
+import { formattedNumber } from "@/utils";
 import React from "react";
 import { Badge } from "@ui/badge";
 import { UilInfoCircle } from "@tooni/iconscout-unicons-react";
@@ -25,7 +25,6 @@ interface Props {
 export default function CurationPage({ searchParams }: Props) {
   const params = useSearchParams();
 
-  const { data: dynamicProps } = useQuery(getDynamicPropsQueryOptions());
   const { data } = useQuery(
     getDiscoverCurationQueryOptions((params.get("period") as LeaderBoardDuration) ?? "day")
   );
@@ -56,9 +55,9 @@ export default function CurationPage({ searchParams }: Props) {
               {data.map((r, i) => (
                 <UsersTableListItem username={r.account} i={i} key={i}>
                   <div className="text-blue-dark-sky text-sm font-semibold">
-                    {formattedNumber(vestsToHp(r.vests, dynamicProps?.hivePerMVests ?? 1), {
-                      suffix: "HP"
-                    })}
+                    {/* `vests` already holds HP — esync converts VESTS→HP at ingest.
+                        Do not run vestsToHp() here or the value is double-converted. */}
+                    {formattedNumber(r.vests, { suffix: "HP" })}
                   </div>
                   <Badge>{r.votes}</Badge>
                 </UsersTableListItem>

--- a/apps/web/src/specs/app/discover/curation-page.spec.tsx
+++ b/apps/web/src/specs/app/discover/curation-page.spec.tsx
@@ -1,0 +1,80 @@
+import { vi } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// Shared, hoisted state the mocks below read at render time.
+const mocks = vi.hoisted(() => ({ rows: [] as any[], queryClient: null as any }));
+
+// Use the REAL formattedNumber (numeral-based) but avoid pulling the whole
+// @/utils barrel — importActual only the small formatted-number module.
+vi.mock("@/utils", async () => {
+  const actual = (await vi.importActual("@/utils/formatted-number")) as any;
+  return {
+    random: vi.fn(),
+    getAccessToken: vi.fn(() => "mock-token"),
+    formattedNumber: actual.formattedNumber
+  };
+});
+
+// Feature-flag gate -> always render children.
+vi.mock("@/config", () => ({
+  EcencyConfigManager: {
+    Conditional: ({ children }: any) => <>{children}</>
+  }
+}));
+
+// Lightweight table stand-ins so the assertion targets only the reward cell.
+vi.mock("@/app/discover/_components", () => ({
+  UsersTableListLayout: ({ children }: any) => <div>{children}</div>,
+  UsersTableListItem: ({ children, username }: any) => (
+    <div data-username={username}>{children}</div>
+  ),
+  UserTableListHeader: ({ children }: any) => <div>{children}</div>
+}));
+
+vi.mock("@tooni/iconscout-unicons-react", () => ({ UilInfoCircle: () => null }));
+vi.mock("@ui/tooltip", () => ({ Tooltip: ({ children }: any) => <>{children}</> }));
+vi.mock("@ui/badge", () => ({ Badge: ({ children }: any) => <span>{children}</span> }));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams()
+}));
+
+vi.mock("@/core/react-query", () => ({
+  getQueryClient: () => mocks.queryClient
+}));
+
+vi.mock("@ecency/sdk", () => ({
+  getDiscoverCurationQueryOptions: (duration: string) => ({
+    queryKey: ["analytics", "discover-curation", duration],
+    queryFn: async () => mocks.rows
+  })
+}));
+
+import CurationPage from "@/app/discover/@curation/page";
+
+describe("Curators leaderboard — HP display", () => {
+  beforeEach(() => {
+    mocks.queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mocks.rows = [];
+  });
+
+  // Regression guard for the double VESTS->HP conversion bug (PR #934).
+  // The curation API already returns Hive Power in the `vests` field (esync
+  // converts VESTS->HP at ingest), so the page must render it as-is. If
+  // someone re-introduces vestsToHp() here, 250 would become ~250/1e6 *
+  // hivePerMVests and this exact-text assertion would fail.
+  it("renders the curator reward straight through as HP, without a second conversion", async () => {
+    mocks.rows = [{ account: "alice", vests: 250, votes: 12, uniques: 8, efficiency: 1 }];
+
+    render(
+      <QueryClientProvider client={mocks.queryClient}>
+        <CurationPage />
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("250.000 HP")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

The **Curators** leaderboard (`/discover` → curation tab) showed Hive Power values that were far too small (off by a ~1,950x factor).

Root cause is a **double VESTS→HP conversion**:

- The private curation API already returns **Hive Power** — it converts VESTS→HP server-side when the curation-reward op is ingested, and exposes the per-curator sum under a (misleadingly named) `vests` field.
- The page then ran that already-HP value through `vestsToHp()` again — `(vests / 1e6) * hivePerMVests` — shrinking an already-HP number by another ~1/1,950.

So a curator who earned e.g. `~100 HP` rendered as `~0.05 HP`.

## Fix

Render `r.vests` directly with the `HP` suffix — it is already Hive Power. Added an inline comment so this isn't "re-fixed" by re-introducing the conversion. The now-unused dynamic-global-props query is dropped from the page.

**Ranking is unchanged** — ordering is by `efficiency`, computed in the SDK query, not by this displayed value.

## Test plan

- [x] `tsc --noEmit` — no new type errors
- [x] `eslint` on the changed file — clean
- [ ] Visual check on the curators leaderboard: HP values now match each curator's actual curation rewards for the selected period (day/week/month)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HP value calculations on the discover curation page to ensure accurate display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->