### PR TITLE
feat(seo): add tags.xml sitemap shard of top tag hub pages

### DIFF
--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -20,6 +20,7 @@
 import { getSeoRedis, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
 import { cronAuthorized, notFound } from "@/features/seo/cron-auth";
 import { SITEMAP_SHARDS } from "@/features/seo/sitemap-shards";
+import { harvestPostTags, selectTopTags } from "@/features/seo/sitemap-tags";
 import { isIndexable, canonicalTarget } from "@/utils/entry-indexability";
 import { isNsfwCommunity } from "@/utils/nsfw-detection";
 import { Entry } from "@/entities";
@@ -54,6 +55,11 @@ const TIME_BUDGET_MS = 90_000;
 const MAX_PAGES = 150;
 const WINDOW_MS = 48 * 60 * 60_000;
 const PAGE = 20;
+// Tag hub shard: the top-N most-used tags seen in this walk, emitted as
+// /created/<tag> (the canonical, internally-linked tag feed). TAG_MIN_COUNT
+// drops one-off long-tail tags that aren't useful as standalone hub pages.
+const TAGS_LIMIT = 200;
+const TAG_MIN_COUNT = 2;
 // Communities: a small, stable hub set (not a freshness walk). list_communities
 // caps at 100/page → 5 pages ≈ top ~500 by rank. Cheap, independent of the
 // post-walk time budget.
@@ -243,6 +249,9 @@ export async function POST(req: Request): Promise<Response> {
   // community id -> newest post day (YYYY-MM-DD) seen in the freshness
   // window. Free: derived from the post walk below, no extra RPC.
   const communityLatest = new Map<string, string>();
+  // tag -> #posts using it in the freshness window. Also free from the walk;
+  // feeds the top-N /created/<tag> hub shard (tags.xml).
+  const tagCounts = new Map<string, number>();
   let startAuthor: string | undefined;
   let startPermlink: string | undefined;
   let pages = 0;
@@ -312,6 +321,9 @@ export async function POST(req: Request): Promise<Response> {
       if (!loc || !loc.startsWith(`${BASE}/`)) continue;
       postUrls.push({ loc, lastmod: (e.updated || e.created || "").slice(0, 10) });
       if (e.author) authors.add(e.author);
+      // Tag popularity from the same indexable posts (NSFW/blacklist/thin
+      // already filtered by isIndexable above). Free — no extra RPC.
+      harvestPostTags(tagCounts, e.category, e.json_metadata?.tags);
     }
   }
 
@@ -358,6 +370,13 @@ export async function POST(req: Request): Promise<Response> {
       ? { loc: `${BASE}/created/${name}`, lastmod }
       : { loc: `${BASE}/created/${name}` };
   });
+  // Top-N tag hub pages (/created/<tag>) — community ids/NSFW/long-tail dropped
+  // by selectTopTags. lastmod=nowDay: a /created feed changes whenever the tag
+  // gets a new post, and a tag only reaches the top-N because it's active.
+  const tagUrls: SitemapUrl[] = selectTopTags(tagCounts, TAGS_LIMIT, TAG_MIN_COUNT).map((tag) => ({
+    loc: `${BASE}/created/${tag}`,
+    lastmod: nowDay
+  }));
 
   // Stale-preserving guard (mirrors the blacklist/communities delta-sanity):
   // a budget- or error-truncated walk must NOT overwrite a good posts/authors
@@ -379,7 +398,7 @@ export async function POST(req: Request): Promise<Response> {
   // explicit lastGood === 0 short-circuit still covers the true bootstrap.
   const acceptWalk =
     reachedCutoff || lastGood === 0 || postUrls.length >= Math.ceil(lastGood * 0.5);
-  const WALK_DERIVED = new Set<string>(["posts.xml", "authors.xml"]);
+  const WALK_DERIVED = new Set<string>(["posts.xml", "authors.xml", "tags.xml"]);
 
   // Writer/index/route stay in lockstep: every shard we emit — and every
   // child the index points at — comes from the single shared SITEMAP_SHARDS
@@ -389,6 +408,7 @@ export async function POST(req: Request): Promise<Response> {
     "posts.xml": urlset(postUrls),
     "authors.xml": urlset(authorUrls),
     "communities.xml": urlset(communityUrls),
+    "tags.xml": urlset(tagUrls),
     "static.xml": urlset(staticUrls)
   };
 
@@ -425,6 +445,7 @@ export async function POST(req: Request): Promise<Response> {
         posts: postUrls.length,
         authors: authorUrls.length,
         communities: communityUrls.length,
+        tags: tagUrls.length,
         pages,
         ms: Date.now() - started,
         reachedCutoff,
@@ -449,6 +470,7 @@ export async function POST(req: Request): Promise<Response> {
       posts: postUrls.length,
       authors: authorUrls.length,
       communities: communityUrls.length,
+      tags: tagUrls.length,
       pages,
       ms: Date.now() - started,
       reachedCutoff,

--- a/apps/web/src/features/seo/sitemap-shards.ts
+++ b/apps/web/src/features/seo/sitemap-shards.ts
@@ -13,6 +13,7 @@ export const SITEMAP_SHARDS = [
   "posts.xml",
   "authors.xml",
   "communities.xml",
+  "tags.xml",
   "static.xml"
 ] as const;
 

--- a/apps/web/src/features/seo/sitemap-tags.ts
+++ b/apps/web/src/features/seo/sitemap-tags.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure helpers for the sitemap "tags.xml" shard: harvesting tag popularity
+ * from the freshness walk and selecting the emittable top-N tag hub URLs.
+ *
+ * Kept out of the route handler so the selection rules (valid bare Hive tag,
+ * community/NSFW exclusion, min-count + cap, deterministic order) are
+ * unit-testable without the live RPC/Redis surface — mirroring the pure
+ * allowlist split in sitemap-shards.ts.
+ *
+ * Why /created/<tag>: that is the canonical, internally-linked tag feed. The
+ * shared TagLink (and community pages) default to the `created` filter, and
+ * each feed page self-canonicals to /<filter>/<tag>. Listing /created/<tag>
+ * reinforces the URL crawlers already see linked instead of introducing a
+ * competing /trending/ surface. Community ids (hive-NNN) are excluded here:
+ * communities.xml already emits them as /created/hive-NNN, so listing them
+ * again would duplicate that shard.
+ */
+import { isNsfwTag } from "@/utils/nsfw-detection";
+
+// A valid bare Hive tag for a public feed hub: lowercase, starts/ends
+// alphanumeric, internal hyphens allowed, 1–50 chars. This rejects "@author"
+// feeds (not a tag), empty/whitespace, uppercase, and any non-ASCII tag — the
+// last on purpose: /created/<loc> is emitted verbatim (no percent-encoding),
+// so we only list URL-safe ASCII tags. Non-latin tags' posts still appear in
+// posts.xml; only the aggregated hub page is skipped.
+const TAG_RE = /^[a-z0-9](?:[a-z0-9-]{0,48}[a-z0-9])?$/;
+const COMMUNITY_RE = /^hive-\d+$/;
+
+export function isEmittableTag(tag: string): boolean {
+  if (!TAG_RE.test(tag)) return false;
+  if (COMMUNITY_RE.test(tag)) return false; // owned by communities.xml
+  if (isNsfwTag(tag)) return false;
+  return true;
+}
+
+/**
+ * Fold one post's category + json_metadata tags into `counts` (lowercased /
+ * trimmed). Deduped within the post so a post whose category repeats a tag — or
+ * whose tags array has duplicates — contributes at most +1 to each tag, keeping
+ * the count an honest "posts using this tag" popularity signal.
+ */
+export function harvestPostTags(
+  counts: Map<string, number>,
+  category: string | null | undefined,
+  tags: readonly unknown[] | null | undefined
+): void {
+  const inPost = new Set<string>();
+  const add = (raw: unknown) => {
+    if (typeof raw !== "string") return;
+    const t = raw.toLowerCase().trim();
+    if (t) inPost.add(t);
+  };
+  add(category);
+  if (Array.isArray(tags)) for (const t of tags) add(t);
+  inPost.forEach((t) => counts.set(t, (counts.get(t) ?? 0) + 1));
+}
+
+/**
+ * The emittable top-N tags by popularity. Deterministic: count desc, then tag
+ * asc — a stable order across runs (stable sitemap, testable). `minCount` drops
+ * one-off long-tail tags that are noise as standalone hub pages.
+ */
+export function selectTopTags(
+  counts: ReadonlyMap<string, number>,
+  limit: number,
+  minCount: number
+): string[] {
+  return Array.from(counts.entries())
+    .filter(([tag, n]) => n >= minCount && isEmittableTag(tag))
+    .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+    .slice(0, limit)
+    .map(([tag]) => tag);
+}

--- a/apps/web/src/specs/features/seo/sitemap-tags.spec.ts
+++ b/apps/web/src/specs/features/seo/sitemap-tags.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { isEmittableTag, harvestPostTags, selectTopTags } from "@/features/seo/sitemap-tags";
+
+describe("sitemap-tags", () => {
+  describe("isEmittableTag", () => {
+    it("accepts valid bare hive tags (incl. internal hyphens/digits)", () => {
+      expect(isEmittableTag("photography")).toBe(true);
+      expect(isEmittableTag("hive-blog")).toBe(true);
+      expect(isEmittableTag("web3")).toBe(true);
+      expect(isEmittableTag("a")).toBe(true);
+    });
+
+    it("rejects community ids (owned by communities.xml)", () => {
+      expect(isEmittableTag("hive-125125")).toBe(false);
+      expect(isEmittableTag("hive-1")).toBe(false);
+    });
+
+    it("rejects @author feeds, empty, uppercase, spaces, edge hyphens, non-ascii", () => {
+      expect(isEmittableTag("@ecency")).toBe(false);
+      expect(isEmittableTag("")).toBe(false);
+      expect(isEmittableTag("Photo")).toBe(false);
+      expect(isEmittableTag("a b")).toBe(false);
+      expect(isEmittableTag("-lead")).toBe(false);
+      expect(isEmittableTag("trail-")).toBe(false);
+      expect(isEmittableTag("café")).toBe(false);
+    });
+
+    it("rejects NSFW tags", () => {
+      expect(isEmittableTag("nsfw")).toBe(false);
+      expect(isEmittableTag("porn")).toBe(false);
+      expect(isEmittableTag("nudeart")).toBe(false);
+    });
+  });
+
+  describe("harvestPostTags", () => {
+    it("counts category + tags, deduped within a single post", () => {
+      const c = new Map<string, number>();
+      harvestPostTags(c, "photography", ["photography", "art", "art"]);
+      expect(c.get("photography")).toBe(1); // category === a tag -> counted once
+      expect(c.get("art")).toBe(1);
+    });
+
+    it("lowercases/trims and ignores empties / non-strings", () => {
+      const c = new Map<string, number>();
+      harvestPostTags(c, "  Travel ", ["Nature", "", 5 as unknown as string, null]);
+      expect(c.get("travel")).toBe(1);
+      expect(c.get("nature")).toBe(1);
+      expect(c.has("")).toBe(false);
+    });
+
+    it("accumulates across posts", () => {
+      const c = new Map<string, number>();
+      harvestPostTags(c, "art", ["x"]);
+      harvestPostTags(c, "art", ["y"]);
+      harvestPostTags(c, null, undefined);
+      expect(c.get("art")).toBe(2);
+    });
+  });
+
+  describe("selectTopTags", () => {
+    it("applies minCount, drops non-emittable, caps at limit, sorts count desc then tag asc", () => {
+      const counts = new Map<string, number>([
+        ["photography", 5],
+        ["art", 5], // ties with photography -> alpha: art before photography
+        ["travel", 3],
+        ["rare", 1], // below minCount
+        ["hive-1", 9], // community excluded
+        ["nsfw", 9], // nsfw excluded
+        ["web3", 2]
+      ]);
+      expect(selectTopTags(counts, 3, 2)).toEqual(["art", "photography", "travel"]);
+    });
+
+    it("respects the limit", () => {
+      const counts = new Map<string, number>([
+        ["a", 3],
+        ["b", 3],
+        ["c", 3]
+      ]);
+      expect(selectTopTags(counts, 2, 1)).toEqual(["a", "b"]);
+    });
+
+    it("returns [] when nothing clears minCount", () => {
+      expect(selectTopTags(new Map([["x", 1]]), 10, 2)).toEqual([]);
+    });
+  });
+});

--- a/apps/web/src/specs/features/seo/sitemap-tags.spec.ts
+++ b/apps/web/src/specs/features/seo/sitemap-tags.spec.ts
@@ -25,10 +25,13 @@ describe("sitemap-tags", () => {
       expect(isEmittableTag("café")).toBe(false);
     });
 
-    it("rejects NSFW tags", () => {
+    it("rejects NSFW tags incl. compound single-token forms (no \\b boundary)", () => {
       expect(isEmittableTag("nsfw")).toBe(false);
       expect(isEmittableTag("porn")).toBe(false);
       expect(isEmittableTag("nudeart")).toBe(false);
+      expect(isEmittableTag("xporn")).toBe(false);
+      expect(isEmittableTag("aporn")).toBe(false);
+      expect(isEmittableTag("softnude")).toBe(false);
     });
   });
 

--- a/apps/web/src/utils/nsfw-detection.ts
+++ b/apps/web/src/utils/nsfw-detection.ts
@@ -27,6 +27,14 @@ export interface NsfwCheckableEntry {
 // only ever used as an additive bonus signal alongside this set.
 export const isNsfwCommunity = (name: string): boolean => NSFW_COMMUNITIES.has(name);
 
+// True if a bare tag/feed name should be kept off SFW surfaces (e.g. the tags
+// sitemap shard). Applies the same curated NSFW tag/community sets and the title
+// stem regex to the tag itself, so "porn"/"nude"/etc. as a tag are excluded.
+export const isNsfwTag = (tag: string): boolean => {
+  const t = tag.toLowerCase().trim();
+  return NSFW_TAGS.has(t) || NSFW_COMMUNITIES.has(t) || NSFW_TITLE_REGEX.test(t);
+};
+
 export const isNsfwEntry = (entry: NsfwCheckableEntry): boolean => {
   const candidates: string[] = [];
   if (entry.category) candidates.push(entry.category);

--- a/apps/web/src/utils/nsfw-detection.ts
+++ b/apps/web/src/utils/nsfw-detection.ts
@@ -15,6 +15,10 @@ const NSFW_COMMUNITIES = new Set<string>([
 // Word-boundary match on a conservative stem list; trailing letters allowed so "porn"
 // catches "pornstar", "masturbat" catches "masturbation/masturbating", etc.
 const NSFW_TITLE_REGEX = /\b(porn|pornstar|nude|xxx|masturbat|erotica?|sextape|fetish)\w*/i;
+// Tag variant: tags are single tokens, so the title regex's \b word boundaries
+// miss compound forms ("xporn", "softnude"). Match the same stems as substrings
+// for bare tags — conservative on a public SFW surface (the tags sitemap).
+const NSFW_TAG_REGEX = /(porn|nude|xxx|masturbat|erotic|sextape|fetish)/i;
 
 export interface NsfwCheckableEntry {
   category?: string | null;
@@ -28,11 +32,12 @@ export interface NsfwCheckableEntry {
 export const isNsfwCommunity = (name: string): boolean => NSFW_COMMUNITIES.has(name);
 
 // True if a bare tag/feed name should be kept off SFW surfaces (e.g. the tags
-// sitemap shard). Applies the same curated NSFW tag/community sets and the title
-// stem regex to the tag itself, so "porn"/"nude"/etc. as a tag are excluded.
+// sitemap shard). Uses the curated NSFW tag/community sets plus a substring stem
+// match (NSFW_TAG_REGEX), so compound single-token forms like "xporn" are
+// excluded — not just bare stems the title regex's \b would catch.
 export const isNsfwTag = (tag: string): boolean => {
   const t = tag.toLowerCase().trim();
-  return NSFW_TAGS.has(t) || NSFW_COMMUNITIES.has(t) || NSFW_TITLE_REGEX.test(t);
+  return NSFW_TAGS.has(t) || NSFW_COMMUNITIES.has(t) || NSFW_TAG_REGEX.test(t);
 };
 
 export const isNsfwEntry = (entry: NsfwCheckableEntry): boolean => {


### PR DESCRIPTION
Adds a new **tags.xml** child shard to the precomputed sitemap, listing the top-N most-used tags as **/created/<tag>** hub pages — extending discovery coverage beyond posts/authors/communities/static.

### What
- Harvests tag popularity **for free** from the existing freshness walk (no extra RPC), exactly like `communityLatest` — counts `category` + `json_metadata.tags` per indexable post.
- Emits the top-N (200, min 2 posts) as `/created/<tag>`. That is the **canonical, internally-linked** tag feed: `TagLink` (and community pages) default to the `created` filter, and each feed page self-canonicals to `/<filter>/<tag>` — so the shard reinforces URLs crawlers already see linked rather than introducing a competing surface.
- Excludes community ids (`hive-NNN`) — already emitted by `communities.xml` as `/created/hive-NNN` — and drops NSFW + one-off long-tail tags.

### Why
Tag feed pages are indexable (`generateFeedMetadata` sets a self-canonical, title, description, RSS; no `noindex`) but were not listed anywhere in the sitemap. They are high-value evergreen discovery hubs that funnel crawlers into many posts.

### Design
- Pure selection logic in `features/seo/sitemap-tags.ts` (`isEmittableTag` / `harvestPostTags` / `selectTopTags`), unit-tested — mirrors the pure-allowlist split in `sitemap-shards.ts`.
- `tags.xml` joins the shared `SITEMAP_SHARDS` allowlist (writer/index/reader stay in lockstep by construction — the typed `shardXml` record makes a missing key a compile error) and the `WALK_DERIVED` stale-preserving set, so a budget/error-truncated walk keeps the last-good blob instead of overwriting it.
- Deterministic ordering (count desc, tag asc) → stable sitemap across runs.

### Tests
`src/specs/features/seo/sitemap-tags.spec.ts` — 10 cases covering tag validity (community/NSFW/@author/non-ascii exclusion), per-post dedupe + accumulation, and min-count/limit/ordering. Full suite green; `tsc` clean on changed files.