### PR TITLE
fix(chat): reply preview quotes the parent message, not itself

### DIFF
--- a/apps/web/src/features/chat/components/message-item.tsx
+++ b/apps/web/src/features/chat/components/message-item.tsx
@@ -11,7 +11,8 @@ import {
 } from "@ui/dropdown";
 import { Popover, PopoverContent } from "@ui/popover";
 import { formatRelativeTime, getAvatarUrl } from "../format-utils";
-import { getNativeEmojiFromShortcode, decodeMessageEmojis } from "../emoji-utils";
+import { getNativeEmojiFromShortcode } from "../emoji-utils";
+import { resolveReplyPreview } from "./reply-preview";
 import { MessageTranslate } from "./message-translate";
 import clsx from "clsx";
 import React, { memo, useEffect, useState } from "react";
@@ -308,20 +309,14 @@ function MessageItemInner({
               {post.root_id &&
                 (() => {
                   const rootPost = postsById.get(post.root_id!) ?? post;
-                  const parentFromPropsId = post.props?.parent_id as string | undefined;
-                  const parentPost =
-                    parentPostById.get(post.id) ||
-                    (parentFromPropsId ? postsById.get(parentFromPropsId) : undefined);
-                  const parentMessage = parentPost
-                    ? getDecodedDisplayMessage(parentPost)
-                    : typeof post.props?.parent_message === "string"
-                      ? decodeMessageEmojis(post.props.parent_message)
-                      : undefined;
-                  const parentUsername = parentPost
-                    ? getDisplayName(parentPost)
-                    : normalizeUsername(post.props?.parent_username as string | undefined);
+                  const { parentUsername, parentMessage } = resolveReplyPreview(
+                    post,
+                    postsById,
+                    parentPostById,
+                    { getDecodedDisplayMessage, getDisplayName, normalizeUsername }
+                  );
 
-                  if (!parentPost && !parentMessage && !parentUsername) return null;
+                  if (!parentMessage && !parentUsername) return null;
 
                   return (
                     <button
@@ -335,7 +330,7 @@ function MessageItemInner({
                     >
                       <span className="font-medium">{parentUsername || "conversation"}</span>
                       {parentMessage && (
-                        <span className="line-clamp-1 opacity-70"> {getDecodedDisplayMessage(postsById.get(post.root_id!) ?? post)}</span>
+                        <span className="line-clamp-1 opacity-70"> {parentMessage}</span>
                       )}
                     </button>
                   );

--- a/apps/web/src/features/chat/components/reply-preview.ts
+++ b/apps/web/src/features/chat/components/reply-preview.ts
@@ -32,9 +32,14 @@ export function resolveReplyPreview(
   }
 ): ReplyPreview {
   const parentFromPropsId = post.props?.parent_id as string | undefined;
-  const candidate =
-    (parentFromPropsId ? postsById.get(parentFromPropsId) : undefined) ||
-    parentPostById.get(post.id);
+  // When an explicit reply target exists, resolve ONLY from it — never fall back
+  // to the chronological heuristic. If that parent post isn't in the loaded
+  // window, `candidate` stays undefined and we use the captured
+  // `parent_message`/`parent_username` props below, rather than quoting an
+  // unrelated neighbouring message from the heuristic.
+  const candidate = parentFromPropsId
+    ? postsById.get(parentFromPropsId)
+    : parentPostById.get(post.id);
   const parentPost = candidate && candidate.id !== post.id ? candidate : undefined;
 
   const parentMessage = parentPost

--- a/apps/web/src/features/chat/components/reply-preview.ts
+++ b/apps/web/src/features/chat/components/reply-preview.ts
@@ -1,0 +1,51 @@
+import type { MattermostPost } from "../mattermost-api";
+import { decodeMessageEmojis } from "../emoji-utils";
+
+export interface ReplyPreview {
+  parentUsername?: string;
+  parentMessage?: string;
+}
+
+/**
+ * Resolve the "replying to" preview (author + excerpt) shown above a threaded
+ * message.
+ *
+ * Correctness rules — a reply must reference the message it actually replied
+ * to, never itself:
+ *  - Prefer the explicit reply target `props.parent_id` over the chronological
+ *    "previous message in the thread" heuristic (`parentPostById`).
+ *  - Never resolve the parent to the message itself (guards against bad data
+ *    where `parent_id === post.id`).
+ *  - When the parent post isn't loaded, fall back to the `parent_message` /
+ *    `parent_username` props captured at send time — never to the root post or
+ *    the message's own text (the previous behaviour, which made a reply quote
+ *    itself whenever the root post was outside the loaded window).
+ */
+export function resolveReplyPreview(
+  post: MattermostPost,
+  postsById: Map<string, MattermostPost>,
+  parentPostById: Map<string, MattermostPost>,
+  helpers: {
+    getDecodedDisplayMessage: (post: MattermostPost) => string;
+    getDisplayName: (post: MattermostPost) => string;
+    normalizeUsername: (username?: string | null) => string | undefined;
+  }
+): ReplyPreview {
+  const parentFromPropsId = post.props?.parent_id as string | undefined;
+  const candidate =
+    (parentFromPropsId ? postsById.get(parentFromPropsId) : undefined) ||
+    parentPostById.get(post.id);
+  const parentPost = candidate && candidate.id !== post.id ? candidate : undefined;
+
+  const parentMessage = parentPost
+    ? helpers.getDecodedDisplayMessage(parentPost)
+    : typeof post.props?.parent_message === "string"
+      ? decodeMessageEmojis(post.props.parent_message)
+      : undefined;
+
+  const parentUsername = parentPost
+    ? helpers.getDisplayName(parentPost)
+    : helpers.normalizeUsername(post.props?.parent_username as string | undefined);
+
+  return { parentUsername, parentMessage };
+}

--- a/apps/web/src/specs/features/chat/reply-preview.spec.ts
+++ b/apps/web/src/specs/features/chat/reply-preview.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { resolveReplyPreview } from "@/features/chat/components/reply-preview";
+import type { MattermostPost } from "@/features/chat/mattermost-api";
+
+/**
+ * Regression coverage for the bug where a threaded reply quoted ITSELF instead
+ * of the message it replied to: when the root post was outside the loaded
+ * window, the preview fell back to the current post's own text.
+ */
+
+function makePost(overrides: Partial<MattermostPost> & { id: string }): MattermostPost {
+  return {
+    id: overrides.id,
+    message: "",
+    user_id: "",
+    channel_id: "c1",
+    create_at: 0,
+    ...overrides
+  } as unknown as MattermostPost;
+}
+
+const helpers = {
+  getDecodedDisplayMessage: (post: MattermostPost) => post.message,
+  getDisplayName: (post: MattermostPost) => `@${post.user_id}`,
+  normalizeUsername: (username?: string | null) =>
+    username ? username.replace(/^@/, "") : undefined
+};
+
+describe("resolveReplyPreview", () => {
+  it("never quotes the message itself when the root/parent post is not loaded", () => {
+    // The reported bug: a reply whose root post is outside the loaded window.
+    const reply = makePost({
+      id: "reply1",
+      user_id: "artgirl",
+      message: "Hello @ecency any help for this? The 3 buttons are still not showing",
+      root_id: "root-not-loaded",
+      props: {
+        parent_id: "parent-not-loaded",
+        parent_username: "ecency",
+        parent_message: "Sorry to hear that, which browser are you on?"
+      }
+    });
+
+    const result = resolveReplyPreview(reply, new Map(), new Map(), helpers);
+
+    expect(result.parentUsername).toBe("ecency");
+    expect(result.parentMessage).toBe("Sorry to hear that, which browser are you on?");
+    // Crucially, it must NOT echo the reply's own text.
+    expect(result.parentMessage).not.toBe(reply.message);
+  });
+
+  it("prefers the explicit parent_id over the chronological thread heuristic", () => {
+    const reply = makePost({
+      id: "reply1",
+      user_id: "artgirl",
+      message: "thanks!",
+      root_id: "root1",
+      props: { parent_id: "real-parent" }
+    });
+    const realParent = makePost({ id: "real-parent", user_id: "ecency", message: "the actual answer" });
+    const heuristicParent = makePost({ id: "other", user_id: "someone", message: "an unrelated earlier message" });
+
+    const postsById = new Map([[realParent.id, realParent]]);
+    const parentPostById = new Map([[reply.id, heuristicParent]]);
+
+    const result = resolveReplyPreview(reply, postsById, parentPostById, helpers);
+
+    expect(result.parentUsername).toBe("@ecency");
+    expect(result.parentMessage).toBe("the actual answer");
+  });
+
+  it("falls back to the chronological heuristic when no explicit parent_id is present", () => {
+    const reply = makePost({ id: "reply1", user_id: "artgirl", message: "thanks!", root_id: "root1" });
+    const heuristicParent = makePost({ id: "prev", user_id: "ecency", message: "previous message in thread" });
+
+    const result = resolveReplyPreview(reply, new Map(), new Map([[reply.id, heuristicParent]]), helpers);
+
+    expect(result.parentUsername).toBe("@ecency");
+    expect(result.parentMessage).toBe("previous message in thread");
+  });
+
+  it("guards against bad data where parent_id points at the post itself", () => {
+    const reply = makePost({
+      id: "reply1",
+      user_id: "artgirl",
+      message: "self referencing body",
+      root_id: "root1",
+      props: { parent_id: "reply1" }
+    });
+    const postsById = new Map([[reply.id, reply]]);
+
+    const result = resolveReplyPreview(reply, postsById, new Map(), helpers);
+
+    // No usable parent info → empty preview rather than quoting itself.
+    expect(result.parentMessage).toBeUndefined();
+    expect(result.parentUsername).toBeUndefined();
+  });
+});

--- a/apps/web/src/specs/features/chat/reply-preview.spec.ts
+++ b/apps/web/src/specs/features/chat/reply-preview.spec.ts
@@ -79,6 +79,31 @@ describe("resolveReplyPreview", () => {
     expect(result.parentMessage).toBe("previous message in thread");
   });
 
+  it("uses the captured parent props (not the heuristic neighbor) when parent_id is set but the parent post isn't loaded", () => {
+    // Deep in a long thread: the real parent scrolled out of the loaded window,
+    // but an unrelated earlier reply IS loaded and sits in the heuristic map.
+    // The explicit parent_id must win → fall through to the captured props,
+    // never the neighbor.
+    const reply = makePost({
+      id: "reply1",
+      user_id: "artgirl",
+      message: "thanks for the help!",
+      root_id: "root1",
+      props: {
+        parent_id: "real-parent-not-loaded",
+        parent_username: "ecency",
+        parent_message: "try clearing your cache"
+      }
+    });
+    const heuristicNeighbor = makePost({ id: "neighbor", user_id: "someoneelse", message: "an unrelated earlier reply" });
+
+    const result = resolveReplyPreview(reply, new Map(), new Map([[reply.id, heuristicNeighbor]]), helpers);
+
+    expect(result.parentUsername).toBe("ecency");
+    expect(result.parentMessage).toBe("try clearing your cache");
+    expect(result.parentMessage).not.toBe(heuristicNeighbor.message);
+  });
+
   it("guards against bad data where parent_id points at the post itself", () => {
     const reply = makePost({
       id: "reply1",


### PR DESCRIPTION
## Problem
In chat threads, a reply's "replying to" preview quoted **itself** instead of the message it replied to — the quoted excerpt was identical to the reply's own body (see report below, where `@artgirl`'s reply quotes `@artgirl`'s same text).
## Root cause
In `message-item.tsx`, the preview computed the parent author/excerpt correctly into `parentMessage`/`parentUsername`, but the rendered excerpt ignored them and instead used:
```tsx
{getDecodedDisplayMessage(postsById.get(post.root_id!) ?? post)}
```
Two defects:
1. **Self-reference:** when the root post was outside the loaded window, `postsById.get(post.root_id)` is `undefined`, so it fell back to `?? post` — the current message — and the reply quoted itself.
2. **Wrong message + author mismatch:** it used the **root** post's text under the **parent's** username, so nested replies showed the author of one message with the text of another.
A third, related correctness issue: the resolver preferred a chronological "previous message in the thread" heuristic (`parentPostById`) over the explicit reply target (`props.parent_id`), so it could reference the wrong message even when the real parent was known.
## Fix
Extract a pure, unit-tested `resolveReplyPreview` (`reply-preview.ts`) that:
- **prefers the explicit `props.parent_id`** over the chronological heuristic,
- **never resolves the parent to the message itself** (guards `parent_id === post.id` bad data),
- **falls back to the `parent_message`/`parent_username` props** captured at send time when the parent post isn't loaded — never to the root post or the message's own text.
`message-item.tsx` now renders the resolved parent excerpt.
## Testing
- New unit test `reply-preview.spec.ts` (4 cases): self-reference guard when root/parent not loaded, prefer `parent_id` over heuristic, heuristic fallback, and `parent_id === post.id` guard.
- Chat specs green.
