### PR TITLE
fix(chat): thread panel shows the full conversation, not just loaded posts

### DIFF
--- a/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
@@ -46,7 +46,41 @@ export async function GET(
     const searchParams = req.nextUrl.searchParams;
     const before = searchParams.get("before") || "";
     const around = searchParams.get("around") || "";
+    const thread = searchParams.get("thread") || "";
     const includeOnline = searchParams.get("include_online") === "1";
+
+    // Fetch a complete thread (root + every reply), independent of what is
+    // currently loaded in the channel buffer. Used by the thread panel so it
+    // can show the full conversation even when older messages have scrolled
+    // out of the loaded window.
+    if (thread) {
+      const threadData = await mmUserFetch<{
+        posts: Record<string, any>;
+        order: string[];
+      }>(`/posts/${thread}/thread`, token);
+
+      const threadPosts = Object.values(threadData.posts ?? {})
+        .filter(Boolean)
+        .sort((a, b) => Number(a.create_at) - Number(b.create_at));
+
+      const threadUserIds = Array.from(
+        new Set(threadPosts.map((post) => post.user_id).filter(Boolean))
+      );
+
+      const threadUsers: Record<string, MattermostUser> = {};
+      if (threadUserIds.length) {
+        const fetchedUsers = await mmUserFetch<MattermostUser[]>("/users/ids", token, {
+          method: "POST",
+          body: JSON.stringify(threadUserIds)
+        });
+        for (const user of fetchedUsers) {
+          threadUsers[user.id] = user;
+        }
+      }
+
+      return NextResponse.json({ posts: threadPosts, users: threadUsers, hasMore: false });
+    }
+
     // Reduced from 60 to 40 for better performance on invalidation
     // 40 messages = ~2 screens of chat, good balance between UX and data transfer
     const perPage = searchParams.get("per_page") || "40";

--- a/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
@@ -59,6 +59,17 @@ export async function GET(
         order: string[];
       }>(`/posts/${thread}/thread`, token);
 
+      // The thread endpoint authorizes via the token, not the channelId in the
+      // URL, so verify the requested post actually belongs to this channel
+      // before returning (mirrors the `around` branch's check below).
+      const threadRoot = threadData.posts?.[thread];
+      if (!threadRoot || threadRoot.channel_id !== channelId) {
+        return NextResponse.json(
+          { error: "Thread not found or deleted" },
+          { status: 404 }
+        );
+      }
+
       const threadPosts = Object.values(threadData.posts ?? {})
         .filter(Boolean)
         .sort((a, b) => Number(a.create_at) - Number(b.create_at));

--- a/apps/web/src/features/chat/components/thread-merge.ts
+++ b/apps/web/src/features/chat/components/thread-merge.ts
@@ -1,0 +1,34 @@
+import type { MattermostPost } from "../mattermost-api";
+
+/**
+ * Build the ordered list of posts for the thread panel.
+ *
+ * The thread panel must show the WHOLE conversation (root + every reply), not
+ * just whatever happens to be in the channel's loaded window. We therefore
+ * merge two sources:
+ *  - `serverPosts`: the complete thread fetched from the server by root id.
+ *  - `localPosts`: the channel buffer, which may hold fresher copies (websocket
+ *    edits) and optimistic/pending sends not yet returned by the server.
+ *
+ * Server posts seed the map first; local thread posts then override by id so
+ * the freshest/optimistic copy wins. Result is de-duplicated and sorted oldest
+ * to newest.
+ */
+export function mergeThreadPosts(
+  rootId: string,
+  serverPosts: MattermostPost[] | undefined,
+  localPosts: MattermostPost[]
+): MattermostPost[] {
+  const byId = new Map<string, MattermostPost>();
+
+  for (const post of serverPosts ?? []) {
+    byId.set(post.id, post);
+  }
+  for (const post of localPosts) {
+    if (post.id === rootId || post.root_id === rootId) {
+      byId.set(post.id, post);
+    }
+  }
+
+  return Array.from(byId.values()).sort((a, b) => a.create_at - b.create_at);
+}

--- a/apps/web/src/features/chat/components/thread-panel.tsx
+++ b/apps/web/src/features/chat/components/thread-panel.tsx
@@ -59,7 +59,7 @@ export function ThreadPanel({
               className={clsx(
                 "rounded border border-[--border-color] bg-[--background-color] p-3",
                 post.id === threadRootId &&
-                  "border-blue-200 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/30"
+                  "border-blue-dark-sky bg-blue-duck-egg dark:bg-dark-default"
               )}
             >
               <div className="flex items-start gap-3">

--- a/apps/web/src/features/chat/components/thread-panel.tsx
+++ b/apps/web/src/features/chat/components/thread-panel.tsx
@@ -59,7 +59,7 @@ export function ThreadPanel({
               className={clsx(
                 "rounded border border-[--border-color] bg-[--background-color] p-3",
                 post.id === threadRootId &&
-                  "border-blue-dark-sky bg-blue-duck-egg dark:bg-dark-default"
+                  "border-blue-dark-sky bg-blue-duck-egg dark:border-blue-dusk dark:bg-dark-default"
               )}
             >
               <div className="flex items-start gap-3">

--- a/apps/web/src/features/chat/mattermost-api.ts
+++ b/apps/web/src/features/chat/mattermost-api.ts
@@ -700,6 +700,31 @@ export function useMattermostPostsAround(
   });
 }
 
+export function useMattermostThread(
+  channelId: string | undefined,
+  rootId: string | undefined,
+  enabled: boolean = true
+) {
+  return useQuery({
+    queryKey: ["mattermost-thread", channelId, rootId],
+    enabled: enabled && Boolean(channelId) && Boolean(rootId),
+    staleTime: 30000,
+    retry: 1,
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/mattermost/channels/${channelId}/posts?thread=${rootId}`
+      );
+
+      if (!res.ok) {
+        const data = await safeJson<{ error?: string }>(res).catch(() => null);
+        throw new Error(data?.error || "Unable to load thread");
+      }
+
+      return (await safeJson(res)) as MattermostPostsResponse;
+    }
+  });
+}
+
 export function useMattermostDeletePost(channelId: string | undefined) {
   const queryClient = useQueryClient();
 

--- a/apps/web/src/features/chat/mattermost-channel-view.tsx
+++ b/apps/web/src/features/chat/mattermost-channel-view.tsx
@@ -284,11 +284,14 @@ export function MattermostChannelView({ channelId }: Props) {
     }, new Map());
   }, [posts]);
 
-  const threadRootPost = threadRootId
-    ? postsById.get(threadRootId) ??
+  const threadRootPost = useMemo(() => {
+    if (!threadRootId) return null;
+    return (
+      postsById.get(threadRootId) ??
       (threadData?.posts ?? []).find((post) => post.id === threadRootId) ??
       null
-    : null;
+    );
+  }, [postsById, threadRootId, threadData?.posts]);
 
   const parentPostById = useMemo(() => {
     const parents = new Map<string, MattermostPost>();

--- a/apps/web/src/features/chat/mattermost-channel-view.tsx
+++ b/apps/web/src/features/chat/mattermost-channel-view.tsx
@@ -19,6 +19,7 @@ import {
   useMattermostMarkChannelViewed,
   useMattermostUpdatePost,
   useMattermostPostsAround,
+  useMattermostThread,
   useMattermostJoinChannel
 } from "./mattermost-api";
 import { usePendingPosts } from "./hooks/use-pending-posts";
@@ -43,6 +44,7 @@ import {
 } from "./emoji-utils";
 import { saveDraft, loadDraft, clearDraft } from "./draft-utils";
 import { ThreadPanel } from "./components/thread-panel";
+import { mergeThreadPosts } from "./components/thread-merge";
 import { MessageInput } from "./components/message-input";
 import { type PostItem } from "./components/message-list";
 import { VirtualizedMessageList } from "./components/virtualized-message-list";
@@ -247,19 +249,31 @@ export function MattermostChannelView({ channelId }: Props) {
     return result;
   }, [posts]);
 
+  // Full thread (root + every reply), fetched from the server so the thread
+  // panel shows the whole conversation even when older messages have scrolled
+  // out of the channel's loaded window.
+  const { data: threadData } = useMattermostThread(
+    channelId,
+    threadRootId ?? undefined,
+    Boolean(threadRootId)
+  );
+
   const usersById = useMemo(() => {
-    if (!data?.pages) return {};
-    return data.pages.reduce((acc, page) => {
-      Object.entries(page.users).forEach(([id, user]) => {
-        const normalizedUser: MattermostUser = {
+    const acc: Record<string, MattermostUser> = {};
+    const fold = (users: Record<string, MattermostUser> | undefined) => {
+      if (!users) return;
+      Object.entries(users).forEach(([id, user]) => {
+        acc[id] = {
           ...user,
           username: normalizeUsername(user.username) ?? user.username
         };
-        acc[id] = normalizedUser;
       });
-      return acc;
-    }, {} as Record<string, MattermostUser>);
-  }, [data?.pages, normalizeUsername]);
+    };
+    data?.pages?.forEach((page) => fold(page.users));
+    // Authors of thread-only posts may not appear in the channel buffer.
+    fold(threadData?.users);
+    return acc;
+  }, [data?.pages, threadData?.users, normalizeUsername]);
 
   const channelData = useMemo(() => data?.pages?.[0], [data?.pages]);
 
@@ -270,7 +284,11 @@ export function MattermostChannelView({ channelId }: Props) {
     }, new Map());
   }, [posts]);
 
-  const threadRootPost = threadRootId ? postsById.get(threadRootId) ?? null : null;
+  const threadRootPost = threadRootId
+    ? postsById.get(threadRootId) ??
+      (threadData?.posts ?? []).find((post) => post.id === threadRootId) ??
+      null
+    : null;
 
   const parentPostById = useMemo(() => {
     const parents = new Map<string, MattermostPost>();
@@ -297,11 +315,8 @@ export function MattermostChannelView({ channelId }: Props) {
 
   const threadPosts = useMemo(() => {
     if (!threadRootId) return [];
-    const related = posts.filter(
-      (post) => post.id === threadRootId || post.root_id === threadRootId
-    );
-    return [...related].sort((a, b) => a.create_at - b.create_at);
-  }, [posts, threadRootId]);
+    return mergeThreadPosts(threadRootId, threadData?.posts, posts);
+  }, [posts, threadRootId, threadData?.posts]);
 
   const usersByUsername = useMemo(() => {
     return Object.values(usersById).reduce<Record<string, MattermostUser>>((acc, user) => {

--- a/apps/web/src/specs/features/chat/thread-merge.spec.ts
+++ b/apps/web/src/specs/features/chat/thread-merge.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { mergeThreadPosts } from "@/features/chat/components/thread-merge";
+import type { MattermostPost } from "@/features/chat/mattermost-api";
+
+/**
+ * Regression coverage for the bug where the thread panel only showed messages
+ * already loaded in the channel buffer (e.g. just the most recent reply),
+ * hiding the rest of the conversation. The panel now merges the full
+ * server-fetched thread with the local buffer.
+ */
+
+function makePost(id: string, createAt: number, overrides: Partial<MattermostPost> = {}): MattermostPost {
+  return {
+    id,
+    create_at: createAt,
+    message: `msg-${id}`,
+    user_id: "u",
+    channel_id: "c1",
+    root_id: "",
+    ...overrides
+  } as unknown as MattermostPost;
+}
+
+describe("mergeThreadPosts", () => {
+  it("includes thread posts fetched from the server that are absent from the local buffer", () => {
+    const root = makePost("root", 1);
+    const reply1 = makePost("r1", 2, { root_id: "root" });
+    const reply2 = makePost("r2", 3, { root_id: "root" });
+    // Local buffer only has the latest reply (the reported symptom).
+    const local = [reply2];
+
+    const result = mergeThreadPosts("root", [root, reply1, reply2], local);
+
+    expect(result.map((p) => p.id)).toEqual(["root", "r1", "r2"]);
+  });
+
+  it("returns posts sorted oldest to newest and de-duplicated", () => {
+    const root = makePost("root", 100);
+    const reply = makePost("r1", 50, { root_id: "root" }); // intentionally out of order / older
+    const result = mergeThreadPosts("root", [root, reply], [root, reply]);
+
+    expect(result.map((p) => p.id)).toEqual(["r1", "root"]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("lets the local copy override the server copy (fresher websocket edit)", () => {
+    const serverReply = makePost("r1", 2, { root_id: "root", message: "stale" });
+    const localReply = makePost("r1", 2, { root_id: "root", message: "edited live" });
+
+    const result = mergeThreadPosts("root", [makePost("root", 1), serverReply], [localReply]);
+
+    expect(result.find((p) => p.id === "r1")?.message).toBe("edited live");
+  });
+
+  it("includes optimistic local thread posts not yet returned by the server", () => {
+    const result = mergeThreadPosts(
+      "root",
+      [makePost("root", 1)],
+      [makePost("pending", 5, { root_id: "root", message: "sending..." })]
+    );
+
+    expect(result.map((p) => p.id)).toEqual(["root", "pending"]);
+  });
+
+  it("ignores local posts that are not part of the thread", () => {
+    const result = mergeThreadPosts(
+      "root",
+      [makePost("root", 1)],
+      [makePost("unrelated", 2, { root_id: "other-thread" })]
+    );
+
+    expect(result.map((p) => p.id)).toEqual(["root"]);
+  });
+});


### PR DESCRIPTION
## Problem

Clicking a quoted reply opens the **Thread** panel, but it only shows messages that are already in the channel's loaded window. If the thread's root and earlier replies have scrolled out of that window, the panel shows just the latest message — so a reply looks like it has no context, even though the conversation exists.

## Root cause

`threadPosts` was computed by filtering the locally-loaded `posts` buffer:

```ts
posts.filter(p => p.id === threadRootId || p.root_id === threadRootId)
```

Nothing fetched the thread itself, so anything outside the loaded window was simply absent. (`openThread` already resolves the correct root via `post.root_id`, so the root id was fine — the data just wasn't loaded.)

## Fix

Fetch the complete thread from the server by root id and merge it with the local buffer:

- **Route:** a `?thread=<rootId>` branch on `…/channels/[channelId]/posts` proxies Mattermost `GET /posts/{id}/thread` and returns the ordered thread posts plus their authors.
- **Hook:** `useMattermostThread(channelId, rootId)`.
- **Merge:** `mergeThreadPosts(rootId, serverPosts, localPosts)` — a pure, unit-tested helper. Server thread seeds the list; local thread posts override by id so websocket-fresh edits and optimistic/pending sends win; result is de-duped and sorted oldest→newest.
- **Authors:** thread users are folded into `usersById` so authors outside the loaded window still render names/avatars, and the root post is resolved from the fetched thread when not local.
- **Bonus:** the thread root-post highlight used non-existent Tailwind keys (`bg-blue-50 / dark:bg-blue-900/30 / border-blue-200/700`, which emit no CSS); switched to real tokens (`blue-dark-sky` / `blue-duck-egg` / `dark-default`).

## Testing

- New `thread-merge.spec.ts` (5 cases): server posts absent locally are included; sorted + de-duped; local overrides server; optimistic local posts included; non-thread local posts ignored.
- Full web suite green (1558 tests). No new TypeScript errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for viewing complete message threads, including the root post and all replies from the server.
  
* **Improvements**
  * Enhanced thread display to properly merge server-fetched thread data with local messages.
  * Updated thread styling for better visual clarity.
  * Improved message deduplication and sorting within threads.

* **Tests**
  * Added comprehensive test coverage for thread functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->