### PR TITLE
feat(entry): oEmbed provider + replace in-post link scrape

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -247,6 +247,18 @@ const config = {
   async headers() {
     return [
       {
+        // Clickjacking protection on every route: our pages may be framed only
+        // by ourselves. Nothing needs cross-origin framing today — the oEmbed
+        // provider returns JSON, not a framable document; HiveSigner uses popup
+        // windows, not iframes. A future type:"rich" /embed route would add a
+        // scoped frame-ancestors exception here.
+        source: "/:path*",
+        headers: [
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          { key: "Content-Security-Policy", value: "frame-ancestors 'self'" }
+        ]
+      },
+      {
         // Hashed static assets (JS, CSS, media) - immutable, cache forever
         source: "/_next/static/:path*",
         headers: [

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/agent-readable.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/agent-readable.ts
@@ -72,15 +72,17 @@ export function agentNotFound(): Response {
 }
 
 /**
- * Fetch a post and return it only if it passes the same indexability gate the
- * entry page uses (blacklist + NSFW + reputation + thin-content). Anything we'd
- * noindex for Googlebot returns null here too → the route handler emits 404.
+ * Fetch a post by author/permlink WITHOUT applying the indexability gate.
  *
  * Prefers condenser_api.get_content (carries root_author/root_permlink, needed
- * for accurate container/wave detection); falls back to bridge.get_post. Mirrors
- * generate-entry-metadata.ts so gating decisions can't drift.
+ * for accurate container/wave detection); falls back to bridge.get_post.
+ * Returns null only when the post genuinely can't be resolved.
+ *
+ * Use this for surfaces that should render any real post (e.g. the oEmbed
+ * provider, which our own in-post link cards consume) and gate visibility
+ * elsewhere. For search-facing surfaces, use loadIndexableEntry instead.
  */
-export async function loadIndexableEntry(
+export async function loadEntry(
   rawAuthor: string,
   rawPermlink: string
 ): Promise<LoadedEntry | null> {
@@ -110,6 +112,25 @@ export async function loadIndexableEntry(
 
   if (!entry || !entry.body || !entry.created) return null;
 
+  return { entry, source };
+}
+
+/**
+ * Fetch a post and return it only if it passes the same indexability gate the
+ * entry page uses (blacklist + NSFW + reputation + thin-content). Anything we'd
+ * noindex for Googlebot returns null here too → the route handler emits 404.
+ *
+ * Mirrors generate-entry-metadata.ts so gating decisions can't drift.
+ */
+export async function loadIndexableEntry(
+  rawAuthor: string,
+  rawPermlink: string
+): Promise<LoadedEntry | null> {
+  const loaded = await loadEntry(rawAuthor, rawPermlink);
+  if (!loaded) return null;
+
+  const { entry } = loaded;
+
   let account: ReputationSource = null;
   let accountFetchFailed = false;
   try {
@@ -125,5 +146,5 @@ export async function loadIndexableEntry(
 
   if (!isIndexable(entry, account, accountFetchFailed, blacklist)) return null;
 
-  return { entry, source };
+  return loaded;
 }

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-card-fields.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-card-fields.ts
@@ -1,0 +1,40 @@
+import { truncate } from "@/utils";
+import { catchPostImage, postBodySummary } from "@ecency/render-helper";
+import type { Entry } from "@/entities";
+
+export interface EntryCardFields {
+  /** ≤67-char title; for a comment, "@author: <body summary>". */
+  title: string;
+  /** ≤160-char summary (author-set description wins). */
+  summary: string;
+  /** 1200×630 cover image, or null when the post has none. */
+  image: string | null;
+  isComment: boolean;
+}
+
+/**
+ * The shared title / summary / image rules for an entry's "card" form.
+ *
+ * Single source of truth so the OpenGraph + Twitter meta tags
+ * (generate-entry-metadata) and the oEmbed provider response can never drift
+ * apart. Pure / fetch-free, exactly like entry-agent-format, so the contract
+ * is trivially unit-tested.
+ */
+export function buildEntryCardFields(entry: Entry): EntryCardFields {
+  const isComment = !!entry.parent_author;
+
+  let title = truncate(entry.title, 67);
+  if (isComment) {
+    const rawCommentTitle = truncate(postBodySummary(entry.body, 12), 67);
+    title = `@${entry.author}: ${rawCommentTitle}`;
+  }
+
+  // Cap at 160 chars to match Google's desktop snippet width; consumers may
+  // truncate further. An author-set json_metadata.description wins.
+  const summary =
+    entry.json_metadata?.description || truncate(postBodySummary(entry.body, 210), 160);
+
+  const image = catchPostImage(entry, 1200, 630, "match");
+
+  return { title, summary, image, isComment };
+}

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
@@ -125,13 +125,15 @@ export async function generateEntryMetadata(
         // oEmbed discovery: lets consumers (WordPress/Ghost/Discourse/Notion…)
         // auto-unfurl a pasted ecency.com post URL into a rich card. Gated to
         // indexable posts only — suppressed/NSFW/blacklisted posts (robots set)
-        // never advertise an embed. Points at THIS page's own URL (ogUrl), so a
-        // reply unfurls as the reply, not its discussion root.
+        // never advertise an embed. Targets the post's own ecency.com URL
+        // (fullUrl): the provider resolves by author/permlink and rejects
+        // non-ecency hosts, so we must NOT use ogUrl/canonical here — those can
+        // be an external site when the author sets json_metadata.canonical_url.
         types:
           robots === undefined
             ? {
                 "application/json+oembed": `${base}/api/oembed?url=${encodeURIComponent(
-                  ogUrl
+                  fullUrl
                 )}&format=json`
               }
             : undefined

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
@@ -1,8 +1,10 @@
-import { parseDate, safeDecodeURIComponent, truncate } from "@/utils";
+import { parseDate, safeDecodeURIComponent } from "@/utils";
 import { entryCanonical } from "@/utils/entry-canonical";
 import { isIndexable, ReputationSource } from "@/utils/entry-indexability";
 import { isAuthorBlacklisted } from "@/features/seo/blacklist-check";
-import { catchPostImage, postBodySummary, isValidPermlink } from "@ecency/render-helper";
+import { isValidPermlink } from "@ecency/render-helper";
+import { buildEntryCardFields } from "./entry-card-fields";
+import type { Entry } from "@/entities";
 import { Metadata } from "next";
 import { getContentQueryOptions, getProfilesQueryOptions } from "@ecency/sdk";
 import { prefetchQuery } from "@/core/react-query";
@@ -49,20 +51,10 @@ export async function generateEntryMetadata(
       }
     }
 
-    const isComment = !!entry.parent_author;
+    // Shared with the oEmbed provider so the meta-tag card and the oEmbed
+    // card can never drift (title/summary/image rules live in one place).
+    const { title, summary, image, isComment } = buildEntryCardFields(entry as Entry);
 
-    let title = truncate(entry.title, 67);
-    if (isComment) {
-      const rawCommentTitle = truncate(postBodySummary(entry.body, 12), 67);
-      title = `@${entry.author}: ${rawCommentTitle}`;
-    }
-
-    // Cap at 160 chars to use Google's full desktop snippet width (~155-160);
-    // it truncates responsively on narrower viewports.
-    const summary =
-      entry.json_metadata?.description || truncate(postBodySummary(entry.body, 210), 160);
-
-    const image = catchPostImage(entry, 1200, 630, "match");
     // Bare /@author/permlink form for this exact page.
     const fullUrl = `${base}/@${entry.author}/${entry.permlink}`;
     const authorUrl = `${base}/@${entry.author}`;
@@ -130,6 +122,19 @@ export async function generateEntryMetadata(
       },
       alternates: {
         canonical: finalCanonical,
+        // oEmbed discovery: lets consumers (WordPress/Ghost/Discourse/Notion…)
+        // auto-unfurl a pasted ecency.com post URL into a rich card. Gated to
+        // indexable posts only — suppressed/NSFW/blacklisted posts (robots set)
+        // never advertise an embed. Points at THIS page's own URL (ogUrl), so a
+        // reply unfurls as the reply, not its discussion root.
+        types:
+          robots === undefined
+            ? {
+                "application/json+oembed": `${base}/api/oembed?url=${encodeURIComponent(
+                  ogUrl
+                )}&format=json`
+              }
+            : undefined
       },
     };
   } catch (e) {

--- a/apps/web/src/app/api/oembed/parse-entry-url.ts
+++ b/apps/web/src/app/api/oembed/parse-entry-url.ts
@@ -1,0 +1,37 @@
+/**
+ * Extract author/permlink from one of OUR canonical post URLs. We only serve
+ * oEmbed for ecency.com URLs; the post is then fetched from Hive by
+ * author/permlink (never by fetching the URL), so there is no SSRF surface.
+ * Accepts both the bare "/@author/permlink" and legacy "/category/@author/
+ * permlink" forms — the permlink is the segment after "@author".
+ */
+export function parseEntryUrl(raw: string): { author: string; permlink: string } | null {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+  if (url.hostname !== "ecency.com" && !url.hostname.endsWith(".ecency.com")) return null;
+
+  const segments = url.pathname
+    .split("/")
+    .filter(Boolean)
+    .map((s) => {
+      try {
+        return decodeURIComponent(s);
+      } catch {
+        return s;
+      }
+    });
+
+  const authorIndex = segments.findIndex((s) => s.startsWith("@"));
+  if (authorIndex === -1) return null;
+
+  const author = segments[authorIndex].slice(1);
+  const permlink = segments[authorIndex + 1] ?? "";
+  if (!author || !permlink) return null;
+
+  return { author, permlink };
+}

--- a/apps/web/src/app/api/oembed/route.ts
+++ b/apps/web/src/app/api/oembed/route.ts
@@ -18,23 +18,26 @@ const OEMBED_HEADERS: Record<string, string> = {
 };
 
 function errorResponse(status: number): Response {
-  return new Response(null, { status, headers: { "Access-Control-Allow-Origin": "*" } });
+  return new Response(null, {
+    status,
+    headers: { "Access-Control-Allow-Origin": "*", "X-Robots-Tag": "noindex" }
+  });
 }
 
 export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+
+  const target = searchParams.get("url");
+  if (!target) return errorResponse(400);
+
+  // We only implement JSON. Spec: unsupported format → 501.
+  const format = searchParams.get("format");
+  if (format && format !== "json") return errorResponse(501);
+
+  const parsed = parseEntryUrl(target);
+  if (!parsed) return errorResponse(404);
+
   try {
-    const { searchParams } = new URL(request.url);
-
-    const target = searchParams.get("url");
-    if (!target) return errorResponse(400);
-
-    // We only implement JSON. Spec: unsupported format → 501.
-    const format = searchParams.get("format");
-    if (format && format !== "json") return errorResponse(501);
-
-    const parsed = parseEntryUrl(target);
-    if (!parsed) return errorResponse(404);
-
     // Option A (lossless): serve card data for ANY resolvable post so our own
     // in-post link cards keep rendering for every link, including suppressed
     // ones. External auto-unfurl is constrained separately — the discovery
@@ -67,7 +70,11 @@ export async function GET(request: Request): Promise<Response> {
     }
 
     return new Response(JSON.stringify(payload), { status: 200, headers: OEMBED_HEADERS });
-  } catch {
-    return errorResponse(404);
+  } catch (e) {
+    // The post parsed and may well exist — a failure building the response is a
+    // server error, not a missing resource. Surface it (5xx) and log, the way
+    // generateEntryMetadata does, instead of masking it as a 404.
+    console.error("oembed: failed to build response for", parsed, e);
+    return errorResponse(500);
   }
 }

--- a/apps/web/src/app/api/oembed/route.ts
+++ b/apps/web/src/app/api/oembed/route.ts
@@ -1,0 +1,73 @@
+import { getServerAppBase } from "@/utils/server-app-base";
+import { loadEntry, AGENT_CACHE_CONTROL } from "@/app/(dynamicPages)/entry/_helpers/agent-readable";
+import { buildEntryCardFields } from "@/app/(dynamicPages)/entry/_helpers/entry-card-fields";
+import { parseEntryUrl } from "./parse-entry-url";
+
+// Reads request.url search params → inherently dynamic; CDN caches via headers.
+export const dynamic = "force-dynamic";
+
+// Public, inert JSON. Mirrors the agent endpoints' cache + noindex posture and
+// adds CORS so browser-side oEmbed consumers can read it. No CSP sandbox here:
+// this is a data API fetched cross-origin, not a document meant to render.
+const OEMBED_HEADERS: Record<string, string> = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": AGENT_CACHE_CONTROL,
+  "Access-Control-Allow-Origin": "*",
+  "X-Content-Type-Options": "nosniff",
+  "X-Robots-Tag": "noindex"
+};
+
+function errorResponse(status: number): Response {
+  return new Response(null, { status, headers: { "Access-Control-Allow-Origin": "*" } });
+}
+
+export async function GET(request: Request): Promise<Response> {
+  try {
+    const { searchParams } = new URL(request.url);
+
+    const target = searchParams.get("url");
+    if (!target) return errorResponse(400);
+
+    // We only implement JSON. Spec: unsupported format → 501.
+    const format = searchParams.get("format");
+    if (format && format !== "json") return errorResponse(501);
+
+    const parsed = parseEntryUrl(target);
+    if (!parsed) return errorResponse(404);
+
+    // Option A (lossless): serve card data for ANY resolvable post so our own
+    // in-post link cards keep rendering for every link, including suppressed
+    // ones. External auto-unfurl is constrained separately — the discovery
+    // <link> on entry pages is emitted for indexable posts only. To gate this
+    // endpoint too, swap loadEntry → loadIndexableEntry.
+    const loaded = await loadEntry(parsed.author, parsed.permlink);
+    if (!loaded) return errorResponse(404);
+
+    const base = await getServerAppBase();
+    const { title, summary, image } = buildEntryCardFields(loaded.entry);
+
+    const payload: Record<string, unknown> = {
+      version: "1.0",
+      type: "link",
+      title,
+      author_name: loaded.entry.author,
+      author_url: `${base}/@${loaded.entry.author}`,
+      provider_name: "Ecency",
+      provider_url: base,
+      cache_age: 300,
+      // Non-standard extension: standard consumers ignore unknown fields;
+      // Ecency's own in-post link enhancer reads it for the card description.
+      description: summary
+    };
+
+    if (image) {
+      payload.thumbnail_url = image;
+      payload.thumbnail_width = 1200;
+      payload.thumbnail_height = 630;
+    }
+
+    return new Response(JSON.stringify(payload), { status: 200, headers: OEMBED_HEADERS });
+  } catch {
+    return errorResponse(404);
+  }
+}

--- a/apps/web/src/features/post-renderer/components/extensions/hive-post-link-extension.tsx
+++ b/apps/web/src/features/post-renderer/components/extensions/hive-post-link-extension.tsx
@@ -54,29 +54,27 @@ export function HivePostLinkRenderer({ link }: { link: string }) {
     }
 
     try {
-      const response = await fetch(`https://ecency.com${cacheKey}`, {
-        method: "GET",
-      });
-      const raw = await response.text();
-      const pageDOM = document.createElement("html");
-      pageDOM.innerHTML = raw;
+      // One small JSON call to our own oEmbed provider instead of fetching and
+      // DOM-parsing the entire post HTML page just for three meta tags. The
+      // provider derives title/description/image from the same source as the
+      // post's og: tags, so the card is unchanged — just far cheaper and
+      // CF-cacheable. Relative URL → resolves against the current origin.
+      const response = await fetch(
+        `/api/oembed?url=${encodeURIComponent(`https://ecency.com${cacheKey}`)}&format=json`,
+        { method: "GET" },
+      );
+      if (!response.ok) return;
+      const oembed = await response.json();
 
-      const rawTitle = pageDOM
-        .querySelector(`meta[property="og:title"]`)
-        ?.getAttribute("content");
-
-      if (rawTitle) {
+      if (oembed?.title) {
         const preview = {
-          title: rawTitle,
+          title: oembed.title as string,
           description:
-            pageDOM
-              .querySelector(`meta[property="og:description"]`)
-              ?.getAttribute("content")
-              ?.substring(0, 71) ?? undefined,
+            typeof oembed.description === "string"
+              ? oembed.description.substring(0, 71)
+              : undefined,
           image:
-            pageDOM
-              .querySelector(`meta[property="og:image"]`)
-              ?.getAttribute("content") ?? undefined,
+            typeof oembed.thumbnail_url === "string" ? oembed.thumbnail_url : undefined,
         };
 
         simpleCache.set(cacheKey, preview);

--- a/apps/web/src/specs/api/oembed-parse-entry-url.spec.ts
+++ b/apps/web/src/specs/api/oembed-parse-entry-url.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { parseEntryUrl } from "@/app/api/oembed/parse-entry-url";
+
+describe("parseEntryUrl", () => {
+  it("parses the bare /@author/permlink form", () => {
+    expect(parseEntryUrl("https://ecency.com/@alice/my-post")).toEqual({
+      author: "alice",
+      permlink: "my-post"
+    });
+  });
+
+  it("parses the legacy /category/@author/permlink form", () => {
+    expect(parseEntryUrl("https://ecency.com/hive-163399/@alice/my-post")).toEqual({
+      author: "alice",
+      permlink: "my-post"
+    });
+  });
+
+  it("ignores query string and hash", () => {
+    expect(parseEntryUrl("https://ecency.com/@alice/my-post?referral=bob#comments")).toEqual({
+      author: "alice",
+      permlink: "my-post"
+    });
+  });
+
+  it("accepts subdomains of ecency.com", () => {
+    expect(parseEntryUrl("https://www.ecency.com/@alice/my-post")).toEqual({
+      author: "alice",
+      permlink: "my-post"
+    });
+  });
+
+  it("decodes percent-encoded segments (e.g. %40 author)", () => {
+    expect(parseEntryUrl("https://ecency.com/%40alice/my-post")).toEqual({
+      author: "alice",
+      permlink: "my-post"
+    });
+  });
+
+  it("rejects non-ecency hosts, including look-alikes", () => {
+    expect(parseEntryUrl("https://peakd.com/@alice/my-post")).toBeNull();
+    expect(parseEntryUrl("https://notecency.com/@alice/my-post")).toBeNull();
+    expect(parseEntryUrl("https://evil.com/@alice/my-post")).toBeNull();
+  });
+
+  it("rejects non-http(s) protocols", () => {
+    expect(parseEntryUrl("ftp://ecency.com/@alice/my-post")).toBeNull();
+    expect(parseEntryUrl("javascript:alert(1)//ecency.com/@a/b")).toBeNull();
+  });
+
+  it("returns null when there is no @author segment", () => {
+    expect(parseEntryUrl("https://ecency.com/trending")).toBeNull();
+    expect(parseEntryUrl("https://ecency.com/")).toBeNull();
+  });
+
+  it("returns null when the permlink is missing (profile root)", () => {
+    expect(parseEntryUrl("https://ecency.com/@alice")).toBeNull();
+  });
+
+  it("returns null for malformed input", () => {
+    expect(parseEntryUrl("not a url")).toBeNull();
+    expect(parseEntryUrl("")).toBeNull();
+  });
+});

--- a/apps/web/src/specs/api/oembed-route.spec.ts
+++ b/apps/web/src/specs/api/oembed-route.spec.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the data + base-url deps so the route test stays isolated from
+// SDK/Redis. parse-entry-url is left real (pure).
+vi.mock("@/app/(dynamicPages)/entry/_helpers/agent-readable", () => ({
+  loadEntry: vi.fn(),
+  AGENT_CACHE_CONTROL: "public, max-age=0, s-maxage=300, stale-while-revalidate=86400"
+}));
+vi.mock("@/app/(dynamicPages)/entry/_helpers/entry-card-fields", () => ({
+  buildEntryCardFields: vi.fn()
+}));
+vi.mock("@/utils/server-app-base", () => ({
+  getServerAppBase: vi.fn(async () => "https://ecency.com")
+}));
+
+import { GET } from "@/app/api/oembed/route";
+import { loadEntry } from "@/app/(dynamicPages)/entry/_helpers/agent-readable";
+import { buildEntryCardFields } from "@/app/(dynamicPages)/entry/_helpers/entry-card-fields";
+
+function get(query: string): Promise<Response> {
+  return GET(new Request(`https://ecency.com/api/oembed?${query}`));
+}
+
+describe("GET /api/oembed", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 400 when the url param is missing", async () => {
+    const res = await get("");
+    expect(res.status).toBe(400);
+    expect(loadEntry).not.toHaveBeenCalled();
+  });
+
+  it("returns 501 for an unsupported (non-json) format", async () => {
+    const res = await get(`format=xml&url=${encodeURIComponent("https://ecency.com/@alice/p")}`);
+    expect(res.status).toBe(501);
+    expect(loadEntry).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a non-ecency url and never touches the loader", async () => {
+    const res = await get(`url=${encodeURIComponent("https://evil.com/@alice/p")}`);
+    expect(res.status).toBe(404);
+    expect(loadEntry).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the post cannot be resolved", async () => {
+    vi.mocked(loadEntry).mockResolvedValue(null);
+    const res = await get(`url=${encodeURIComponent("https://ecency.com/@alice/missing")}`);
+    expect(res.status).toBe(404);
+    expect(loadEntry).toHaveBeenCalledWith("alice", "missing");
+  });
+
+  it("returns a type:link payload with the right fields and headers", async () => {
+    vi.mocked(loadEntry).mockResolvedValue({
+      entry: { author: "alice" } as any,
+      source: "hive_condenser"
+    });
+    vi.mocked(buildEntryCardFields).mockReturnValue({
+      title: "My Title",
+      summary: "My summary",
+      image: "https://img/cover.png",
+      isComment: false
+    });
+
+    const res = await get(`url=${encodeURIComponent("https://ecency.com/@alice/my-post")}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
+    expect(res.headers.get("Cache-Control")).toContain("s-maxage=300");
+
+    expect(await res.json()).toMatchObject({
+      version: "1.0",
+      type: "link",
+      title: "My Title",
+      author_name: "alice",
+      author_url: "https://ecency.com/@alice",
+      provider_name: "Ecency",
+      provider_url: "https://ecency.com",
+      description: "My summary",
+      thumbnail_url: "https://img/cover.png",
+      thumbnail_width: 1200,
+      thumbnail_height: 630,
+      cache_age: 300
+    });
+  });
+
+  it("omits thumbnail fields when the post has no image", async () => {
+    vi.mocked(loadEntry).mockResolvedValue({
+      entry: { author: "alice" } as any,
+      source: "hive_bridge"
+    });
+    vi.mocked(buildEntryCardFields).mockReturnValue({
+      title: "T",
+      summary: "S",
+      image: null,
+      isComment: false
+    });
+
+    const res = await get(`url=${encodeURIComponent("https://ecency.com/@alice/my-post")}`);
+    const body = await res.json();
+    expect(body.thumbnail_url).toBeUndefined();
+    expect(body.thumbnail_width).toBeUndefined();
+  });
+});

--- a/apps/web/src/specs/api/oembed-route.spec.ts
+++ b/apps/web/src/specs/api/oembed-route.spec.ts
@@ -17,6 +17,7 @@ vi.mock("@/utils/server-app-base", () => ({
 import { GET } from "@/app/api/oembed/route";
 import { loadEntry } from "@/app/(dynamicPages)/entry/_helpers/agent-readable";
 import { buildEntryCardFields } from "@/app/(dynamicPages)/entry/_helpers/entry-card-fields";
+import { getServerAppBase } from "@/utils/server-app-base";
 
 function get(query: string): Promise<Response> {
   return GET(new Request(`https://ecency.com/api/oembed?${query}`));
@@ -25,9 +26,10 @@ function get(query: string): Promise<Response> {
 describe("GET /api/oembed", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("returns 400 when the url param is missing", async () => {
+  it("returns 400 when the url param is missing (with noindex)", async () => {
     const res = await get("");
     expect(res.status).toBe(400);
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
     expect(loadEntry).not.toHaveBeenCalled();
   });
 
@@ -100,5 +102,20 @@ describe("GET /api/oembed", () => {
     const body = await res.json();
     expect(body.thumbnail_url).toBeUndefined();
     expect(body.thumbnail_width).toBeUndefined();
+  });
+
+  it("returns 500 (not 404) and logs when building the response throws", async () => {
+    vi.mocked(loadEntry).mockResolvedValue({
+      entry: { author: "alice" } as any,
+      source: "hive_condenser"
+    });
+    vi.mocked(getServerAppBase).mockRejectedValueOnce(new Error("boom"));
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await get(`url=${encodeURIComponent("https://ecency.com/@alice/my-post")}`);
+    expect(res.status).toBe(500);
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
+    expect(err).toHaveBeenCalled();
+    err.mockRestore();
   });
 });

--- a/apps/web/src/specs/app/entry-card-fields.spec.ts
+++ b/apps/web/src/specs/app/entry-card-fields.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The global @/utils mock only exposes random/getAccessToken; restore the real
+// module so buildEntryCardFields gets the real `truncate` (render-helper is not
+// globally mocked, so postBodySummary/catchPostImage are already real).
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<any>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+
+import { buildEntryCardFields } from "@/app/(dynamicPages)/entry/_helpers/entry-card-fields";
+import { truncate } from "@/utils";
+import { postBodySummary, catchPostImage } from "@ecency/render-helper";
+
+function entry(overrides: Record<string, unknown> = {}) {
+  return {
+    author: "alice",
+    permlink: "my-post",
+    title: "Hello World",
+    body: "This is the body of the post with enough words to summarize nicely.",
+    parent_author: "",
+    json_metadata: {},
+    ...overrides
+  };
+}
+
+describe("buildEntryCardFields", () => {
+  it("matches the inline title/summary/image rules for a post (parity lock)", () => {
+    const e = entry({ json_metadata: { image: ["https://example.com/cover.png"] } });
+    expect(buildEntryCardFields(e as any)).toEqual({
+      isComment: false,
+      title: truncate(e.title, 67),
+      summary:
+        (e.json_metadata as any).description || truncate(postBodySummary(e.body, 210), 160),
+      image: catchPostImage(e as any, 1200, 630, "match")
+    });
+  });
+
+  it("formats a comment title as '@author: <body summary>'", () => {
+    const e = entry({ parent_author: "bob", title: "" });
+    const fields = buildEntryCardFields(e as any);
+    expect(fields.isComment).toBe(true);
+    expect(fields.title).toBe(`@${e.author}: ${truncate(postBodySummary(e.body, 12), 67)}`);
+  });
+
+  it("prefers an author-set json_metadata.description for the summary", () => {
+    const e = entry({ json_metadata: { description: "Author provided summary" } });
+    expect(buildEntryCardFields(e as any).summary).toBe("Author provided summary");
+  });
+
+  it("passes catchPostImage through verbatim (incl. its fallback url)", () => {
+    const e = entry({ body: "No inline images here at all.", json_metadata: {} });
+    expect(buildEntryCardFields(e as any).image).toBe(
+      catchPostImage(e as any, 1200, 630, "match")
+    );
+  });
+});


### PR DESCRIPTION
## What

- Adds a standards-compliant **oEmbed provider** at `GET /api/oembed?url=&format=json` (type `link`). An ecency.com post URL now auto-unfurls into a rich card in oEmbed consumers (WordPress, Ghost, Discourse, Notion, …).
- Adds the oEmbed **discovery `<link>`** to entry pages, gated to indexable posts only (suppressed / NSFW / blacklisted posts never advertise an embed).
- **Replaces the in-post Hive-link preview scrape.** The link enhancer used to fetch and DOM-parse the *entire* post HTML page just to read three `og:` meta tags; it now fetches ~1KB of JSON from `/api/oembed` instead. The rendered card is unchanged.

## Why

- Lets a pasted post link render as a live card inside third-party blogs / CMS / forums — reach that the OpenGraph + Twitter meta tags we already emit don't cover.
- The enhancer change is a pure efficiency win: a full HTML document fetch + DOMParser becomes one small, CDN-cacheable JSON call, with no behavioural change to the card.

## How

- `buildEntryCardFields()` pulls the title / summary / image rules into one place, shared by `generate-entry-metadata` and the oEmbed route, so the meta-tag card and the oEmbed card can never drift.
- `loadEntry()` / `loadIndexableEntry()` split in the entry `_helpers`: the provider serves any resolvable post (so in-post cards keep rendering for every link), while only discovery is indexable-gated.
- URL parsing is restricted to ecency.com hosts; posts are fetched from Hive by author/permlink, never by fetching the supplied URL (no SSRF). Responses carry `noindex` + CORS.

## Testing

- 20 new tests: URL parsing (host / path / edge cases), the route handler (400 / 501 / 404 / 200 + headers + payload shape), and a `buildEntryCardFields` parity lock.
- Vitest over the affected areas: 322 passing. Typecheck + ESLint clean on touched files.

## Notes / follow-ups

- oEmbed responses are `type: "link"` (metadata + thumbnail). A future follow-up could add a `type: "rich"` iframe `/embed` route to render a fully-styled card inside third-party article bodies, plus a "Copy embed" share action.
- Separate PR to follow: add site-wide clickjacking protection (`X-Frame-Options` / `frame-ancestors`), which is currently absent.
