### PR TITLE
feat(chat): modernize channel/DM list with borderless rows

### DIFF
--- a/apps/web/src/app/chats/_components/chats-client.tsx
+++ b/apps/web/src/app/chats/_components/chats-client.tsx
@@ -516,10 +516,10 @@ export function ChatsClient() {
                           href={buildChannelUrl(channel.id)}
                           key={channel.id}
                           className={clsx(
-                            "rounded border p-3 transition",
+                            "rounded-lg border-l-2 p-2.5 transition",
                             isActive
                               ? "border-blue-dark-sky bg-blue-duck-egg dark:bg-dark-default"
-                              : "border-[--border-color] hover:border-blue-dark-sky"
+                              : "border-transparent hover:bg-gray-100 dark:hover:bg-white/5"
                           )}
                           onClickCapture={handleChannelLinkClick}
                         >
@@ -681,10 +681,10 @@ export function ChatsClient() {
                           href={buildChannelUrl(channel.id)}
                           key={channel.id}
                           className={clsx(
-                            "rounded border p-3 transition",
+                            "rounded-lg border-l-2 p-2.5 transition",
                             isActive
                               ? "border-blue-dark-sky bg-blue-duck-egg dark:bg-dark-default"
-                              : "border-[--border-color] hover:border-blue-dark-sky"
+                              : "border-transparent hover:bg-gray-100 dark:hover:bg-white/5"
                           )}
                           onClickCapture={handleChannelLinkClick}
                         >
@@ -781,10 +781,10 @@ export function ChatsClient() {
                           href={buildChannelUrl(channel.id)}
                           key={channel.id}
                           className={clsx(
-                            "rounded border p-3 transition",
+                            "rounded-lg border-l-2 p-2.5 transition",
                             isActive
                               ? "border-blue-dark-sky bg-blue-duck-egg dark:bg-dark-default"
-                              : "border-[--border-color] hover:border-blue-dark-sky"
+                              : "border-transparent hover:bg-gray-100 dark:hover:bg-white/5"
                           )}
                           onClickCapture={handleChannelLinkClick}
                         >
@@ -900,10 +900,10 @@ export function ChatsClient() {
                     href={buildChannelUrl(channel.id)}
                     key={channel.id}
                     className={clsx(
-                      "rounded border p-3 transition",
+                      "rounded-lg border-l-2 p-2.5 transition",
                       isActive
                         ? "border-blue-dark-sky bg-blue-duck-egg dark:bg-dark-default"
-                        : "border-[--border-color] hover:border-blue-dark-sky"
+                        : "border-transparent hover:bg-gray-100 dark:hover:bg-white/5"
                     )}
                     onClickCapture={handleChannelLinkClick}
                   >

--- a/apps/web/src/specs/features/chat/chats-sidebar-styling.spec.ts
+++ b/apps/web/src/specs/features/chat/chats-sidebar-styling.spec.ts
@@ -63,9 +63,14 @@ describe("chats sidebar styling", () => {
     expect(chatsClient).toContain("className={KEBAB_BUTTON_CLASS}");
   });
 
-  it("highlights the active channel with real palette tokens", () => {
+  it("uses borderless list rows: filled active state + left accent + hover fill, not bordered cards", () => {
+    // Modern messaging-list style: rows have no per-row border box. Active row is
+    // a fill plus a subtle 2px left accent; inactive rows show a hover fill.
+    expect(chatsClient).toContain("rounded-lg border-l-2 p-2.5 transition");
     expect(chatsClient).toContain("border-blue-dark-sky bg-blue-duck-egg dark:bg-dark-default");
-    expect(chatsClient).toContain("hover:border-blue-dark-sky");
+    expect(chatsClient).toContain("border-transparent hover:bg-gray-100 dark:hover:bg-white/5");
+    // The old bordered-card row must not come back.
+    expect(chatsClient).not.toContain('"rounded border p-3 transition"');
   });
 
   it("constrains channel-list grids to grid-cols-1 so a long name cannot blow out the column and clip the kebab", () => {


### PR DESCRIPTION
## What

Replaces the per-row bordered "cards" in the chats left pane with a modern messaging-list style (Slack/Discord/Telegram-like), where selection/hover state is shown by **background fill** instead of outlines.

- **Active row:** tinted fill (`bg-blue-duck-egg` / `dark:bg-dark-default`) with a subtle **2px blue left accent** (`border-l-2 border-blue-dark-sky`).
- **Inactive rows:** transparent, with a hover fill (`hover:bg-gray-100` / `dark:hover:bg-white/5`).
- `rounded-lg`, tighter `p-2.5` padding.

The section dividers (FAVORITES / DIRECT MESSAGES) and the previously-merged kebab discoverability, active-highlight, and width-safety fixes all carry over unchanged.

## Why

The bordered "boxes" around every channel/DM were the most dated part of the list. Borderless rows read as one continuous list and match modern chat UIs.

## Preview

Compared three options in a headless-Chrome harness (Current vs borderless fill-only vs borderless fill+accent). This PR implements the **fill + left-accent** variant. Switching to plain fill-only is a one-line change (drop `border-l-2` / the accent), happy to flip it if preferred.

## Testing

- Updated `chats-sidebar-styling.spec.ts` to assert the borderless rows (active fill + accent, inactive hover fill) and forbid the old `rounded border p-3` card.
- Full web suite green (1558 tests).