### PR TITLE
fix(oembed): return 400 (not 501) for unsupported format

### DIFF
--- a/apps/web/src/app/api/oembed/route.ts
+++ b/apps/web/src/app/api/oembed/route.ts
@@ -30,9 +30,12 @@ export async function GET(request: Request): Promise<Response> {
   const target = searchParams.get("url");
   if (!target) return errorResponse(400);
 
-  // We only implement JSON. Spec: unsupported format → 501.
+  // We only implement JSON. The spec suggests 501 for an unsupported format,
+  // but our Cloudflare failover treats any origin 5xx as "origin unavailable"
+  // and rewrites it to a 502 — so return 400 (the consumer asked for a format
+  // we don't offer, i.e. a client error) to stay correct through the edge.
   const format = searchParams.get("format");
-  if (format && format !== "json") return errorResponse(501);
+  if (format && format !== "json") return errorResponse(400);
 
   const parsed = parseEntryUrl(target);
   if (!parsed) return errorResponse(404);

--- a/apps/web/src/specs/api/oembed-route.spec.ts
+++ b/apps/web/src/specs/api/oembed-route.spec.ts
@@ -33,9 +33,11 @@ describe("GET /api/oembed", () => {
     expect(loadEntry).not.toHaveBeenCalled();
   });
 
-  it("returns 501 for an unsupported (non-json) format", async () => {
+  it("returns 400 for an unsupported (non-json) format", async () => {
+    // 400 not 501: a 5xx from origin gets rewritten to 502 by our CF failover.
     const res = await get(`format=xml&url=${encodeURIComponent("https://ecency.com/@alice/p")}`);
-    expect(res.status).toBe(501);
+    expect(res.status).toBe(400);
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
     expect(loadEntry).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Follow-up to #939. `GET /api/oembed?...&format=xml` returned **502** in production: 501 is a 5xx-class status and our Cloudflare failover rewrites any origin 5xx to a 502. Since an unsupported `format` is a client error, return **400** (passes the edge cleanly). Updates the route test accordingly (now also asserts the `noindex` header on the error).