### PR TITLE
fix(signup): serve Turnstile widget from a hosted /embed route for mobile WebView

### DIFF
--- a/apps/web/src/app/embed/turnstile/page.tsx
+++ b/apps/web/src/app/embed/turnstile/page.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next";
+import { TurnstileEmbed } from "./turnstile-embed";
+
+// Internal utility page consumed by the mobile app's WebView — keep it out of
+// search indexes.
+export const metadata: Metadata = {
+  title: "Turnstile",
+  robots: { index: false, follow: false }
+};
+
+export default function Page() {
+  return <TurnstileEmbed />;
+}

--- a/apps/web/src/app/embed/turnstile/turnstile-embed.tsx
+++ b/apps/web/src/app/embed/turnstile/turnstile-embed.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { Turnstile } from "@/features/shared/turnstile";
+import { AppWindow } from "@/types";
+
+// Public Cloudflare Turnstile sitekey (Managed mode). The token is verified
+// server-side (onboard); the secret never reaches the client.
+const TURNSTILE_SITEKEY =
+  process.env.NEXT_PUBLIC_TURNSTILE_SITEKEY || "0x4AAAAAADe6jH7FIi9dBzgR";
+
+type BridgeMessage = { type: "verify"; token: string } | { type: "expire" } | { type: "error" };
+
+function postToApp(message: BridgeMessage) {
+  const w = window as unknown as AppWindow;
+  w.ReactNativeWebView?.postMessage(JSON.stringify(message));
+}
+
+/**
+ * Standalone Turnstile widget, rendered as a top-level page so the mobile app's
+ * WebView can load it from a real ecency.com URL. Loading a hosted page (instead
+ * of injecting an HTML string with a faked baseUrl) gives the widget a genuine
+ * first-party origin and storage partition — which the Managed challenge needs to
+ * complete. An inline-HTML WebView stalls on "Verifying…" indefinitely. The token
+ * is bridged back to React Native via window.ReactNativeWebView.postMessage; the
+ * native side passes it to signUp() and verifies it server-side.
+ */
+export function TurnstileEmbed() {
+  // The native WebView is transparent; drop the inherited page background so the
+  // widget blends with the modal that hosts it.
+  useEffect(() => {
+    const { documentElement, body } = document;
+    const prevHtml = documentElement.style.background;
+    const prevBody = body.style.background;
+    documentElement.style.background = "transparent";
+    body.style.background = "transparent";
+    return () => {
+      documentElement.style.background = prevHtml;
+      body.style.background = prevBody;
+    };
+  }, []);
+
+  return (
+    <div className="flex items-center justify-center w-full min-h-[76px] p-1">
+      <Turnstile
+        sitekey={TURNSTILE_SITEKEY}
+        onVerify={(token) => postToApp({ type: "verify", token })}
+        onExpire={() => postToApp({ type: "expire" })}
+        onError={() => postToApp({ type: "error" })}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,7 +2,7 @@ import "@/styles/style.scss";
 import "@/core/sdk-init"; // Initialize SDK DMCA filters immediately (SSR)
 import Providers from "@/app/providers";
 import { HiringConsoleLog } from "@/app/_components";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { Theme } from "@/enums";
 import { BannerManager } from "@/features/banners";
 import { ServiceWorkerRecovery } from "@/features/pwa-install";
@@ -72,6 +72,10 @@ const lora = Lora({
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const theme = (await cookies()).get("theme")?.value;
+  // The /embed/* routes are loaded inside the mobile app's WebView (e.g. the
+  // Turnstile widget). Skip analytics there so automated widget loads don't
+  // register as ecency.com pageviews. Path comes from the middleware header.
+  const isEmbedRoute = ((await headers()).get("x-pathname") ?? "").startsWith("/embed");
 
   return (
     <html lang="en" className={`${lora.variable} ${inter.variable}`}>
@@ -99,7 +103,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <link rel="preconnect" href="https://hapi.ecency.com" crossOrigin="anonymous" />
         <JsonLd data={buildOrganizationJsonLd()} />
       </head>
-      <Script defer data-domain="ecency.com" data-api="/pl/api/event" src="/pl/js/script.js" />
+      {!isEmbedRoute && (
+        <Script defer data-domain="ecency.com" data-api="/pl/api/event" src="/pl/js/script.js" />
+      )}
       <body className={theme === Theme.night ? "dark" : ""}>
         <BannerManager />
         <ServiceWorkerRecovery />

--- a/apps/web/src/features/shared/turnstile.tsx
+++ b/apps/web/src/features/shared/turnstile.tsx
@@ -59,13 +59,15 @@ interface Props {
   sitekey: string;
   /** Called with the verification token when the challenge is solved. */
   onVerify: (token: string) => void;
-  /** Called when the token expires/errors or the widget is reset — clear stored token. */
+  /** Called when the token expires or the widget is reset — clear stored token. */
   onExpire?: () => void;
+  /** Called when the challenge errors or the script fails to load. Falls back to onExpire when omitted. */
+  onError?: () => void;
   className?: string;
 }
 
 export const Turnstile = forwardRef<TurnstileHandle, Props>(function Turnstile(
-  { sitekey, onVerify, onExpire, className },
+  { sitekey, onVerify, onExpire, onError, className },
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -74,8 +76,10 @@ export const Turnstile = forwardRef<TurnstileHandle, Props>(function Turnstile(
   // always invokes the current props — safe even if a caller passes inline callbacks.
   const onVerifyRef = useRef(onVerify);
   const onExpireRef = useRef(onExpire);
+  const onErrorRef = useRef(onError);
   onVerifyRef.current = onVerify;
   onExpireRef.current = onExpire;
+  onErrorRef.current = onError;
 
   const [failedToLoad, setFailedToLoad] = useState(false);
 
@@ -108,13 +112,13 @@ export const Turnstile = forwardRef<TurnstileHandle, Props>(function Turnstile(
           sitekey,
           callback: (token: string) => onVerifyRef.current(token),
           "expired-callback": () => onExpireRef.current?.(),
-          "error-callback": () => onExpireRef.current?.()
+          "error-callback": () => (onErrorRef.current ?? onExpireRef.current)?.()
         });
       })
       .catch(() => {
         if (!cancelled) {
           setFailedToLoad(true);
-          onExpireRef.current?.();
+          (onErrorRef.current ?? onExpireRef.current)?.();
         }
       });
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -92,7 +92,12 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     return NextResponse.rewrite(nextUrl);
   }
 
-  const response = NextResponse.next();
+  // Expose the resolved pathname to server components via a request header — the
+  // root layout reads it to skip the analytics script on the /embed/* WebView
+  // routes (server components can't otherwise see the path).
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-pathname", path);
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
   await applyCacheHeaders(request, response, path, event);
   return response;
 }


### PR DESCRIPTION
## Problem

On the mobile app's free-signup screen, the Cloudflare Turnstile widget hangs on the **"Verifying…"** spinner indefinitely (reported on the iOS TestFlight build), so the Register button never enables.

The mobile widget was rendered from an **inline HTML string with a faked `baseUrl`** (`loadHTMLString` in an iOS WKWebView). That injected document has no real first-party origin or storage partition, which the **Managed** challenge needs to complete its verification round-trip and persist clearance — so it stalls without ever firing success or the error callback. The web signup flow (a real `ecency.com` page) works fine with the same sitekey/mode, which isolates the cause to the inline-HTML approach.

## Change

- Add a minimal **`/embed/turnstile`** route that renders only the Turnstile widget and bridges the token to a React Native WebView via `window.ReactNativeWebView.postMessage` (`{ type: "verify" | "expire" | "error", token? }`). The mobile WebView loads this as a real top-level page, so it behaves like the working web signup.
- Add an optional **`onError`** callback to the shared `Turnstile` component (backwards-compatible — `/signup/free` doesn't pass it and keeps falling back to `onExpire`) so the embed can report challenge errors separately from token expiry.
- The page is `noindex`. It's a top-level WebView load, not an iframe, so the site-wide `frame-ancestors 'self'` / `X-Frame-Options` headers don't affect it and no CSP change is needed.

Reuses the existing `Turnstile` component (`features/shared/turnstile.tsx`), the `NEXT_PUBLIC_TURNSTILE_SITEKEY` env var, and the `AppWindow` bridge type.

## Testing

- `tsc --noEmit` and `eslint` clean on the changed files.
- Manual: load `/embed/turnstile` in a mobile WebView (or any browser) → the widget renders and solves; in a WebView the token arrives over the RN bridge.

## Rollout

This is the **web half of a two-repo fix**. The route must be live on production before the mobile change works. Mobile counterpart: ecency/ecency-mobile (loads this page instead of inline HTML).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dedicated Turnstile embed page for standalone security verification widget deployment
  * Enhanced Turnstile widget with improved error handling and configurable error callbacks
  * Improved visual integration in modal and embedded application contexts
  * Extended callback system for more granular error handling and user feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->