### PR TITLE
fix(stats-proxy): exact-match post pages to stop sibling-permlink overmatch

### DIFF
--- a/apps/web/src/app/api/stats/route.ts
+++ b/apps/web/src/app/api/stats/route.ts
@@ -2,6 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { EcencyConfigManager } from "@/config";
 import { safeDecodeURIComponent } from "@/utils";
 
+// Escape regex metacharacters so a page path is matched literally — an author like
+// `peak.snaps` must not let `.` match an arbitrary character.
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export async function POST(request: NextRequest) {
   const isEnabled = EcencyConfigManager.getConfigValue(
     ({ visionFeatures }) => visionFeatures.plausible.enabled
@@ -28,6 +34,19 @@ export async function POST(request: NextRequest) {
     ? filterBy
     : "event:page";
 
+  // Build the page filter. A trailing-slash URL is a prefix query — e.g. profile
+  // insights sends `/@user/` to pull every page under that user — so keep a
+  // substring `contains`. A full permlink is an exact page: use an end-anchored
+  // `matches` so we still catch every recorded shape (bare, `/hive-123/@…`,
+  // `/tag/@…`) that ENDS in the canonical `/@author/permlink`, without overmatching
+  // a longer sibling permlink (`/@a/p` must not match `/@a/p-2`). Plausible's
+  // `matches` maps to ClickHouse `multiMatchAny` (unanchored regex), so escape the
+  // path and anchor the tail with `$`.
+  const page = safeDecodeURIComponent(url);
+  const pageFilter = page.endsWith("/")
+    ? ["contains", filterDimension, [page]]
+    : ["matches", filterDimension, [`${escapeRegExp(page)}$`]];
+
   const statsHost = EcencyConfigManager.getConfigValue(
     ({ visionFeatures }) => visionFeatures.plausible.host
   );
@@ -47,7 +66,7 @@ export async function POST(request: NextRequest) {
           ({ visionFeatures }) => visionFeatures.plausible.siteId
         ),
         metrics,
-        filters: [["contains", filterDimension, [safeDecodeURIComponent(url)]]],
+        filters: [pageFilter],
         dimensions,
         date_range: dateRange
       }),

--- a/apps/web/src/app/api/stats/route.ts
+++ b/apps/web/src/app/api/stats/route.ts
@@ -42,7 +42,9 @@ export async function POST(request: NextRequest) {
   // a longer sibling permlink (`/@a/p` must not match `/@a/p-2`). Plausible's
   // `matches` maps to ClickHouse `multiMatchAny` (unanchored regex), so escape the
   // path and anchor the tail with `$`.
-  const page = safeDecodeURIComponent(url);
+  // Plausible stores the pathname only, so strip any query string / fragment (e.g.
+  // a comment permalink's `#@author/permlink`) before matching what's recorded.
+  const page = safeDecodeURIComponent(url).split(/[?#]/)[0];
   const pageFilter = page.endsWith("/")
     ? ["contains", filterDimension, [page]]
     : ["matches", filterDimension, [`${escapeRegExp(page)}$`]];


### PR DESCRIPTION
## Problem

The shared `/api/stats` proxy filtered pages with a substring `contains`, so a post's stats query (`/@alice/foo`) also matched longer sibling permlinks like `/@alice/foo-2`. Hive mints prefix-sibling permlinks (reposting the same title appends `-2`, `-3`, …), so affected posts showed inflated view/device counts. Flagged by greptile/codex/coderabbit on the stats PRs (#943, ecency-mobile#3251).

## Fix

Switch full-permlink lookups from `contains` to an **end-anchored `matches`** regex:

- `matches` maps to ClickHouse `multiMatchAny` (unanchored), so an escaped path + `$` matches every recorded page shape that *ends* in the canonical `/@author/permlink` — bare, community (`/hive-123/@…`), tag (`/tag/@…`) — while **excluding** longer siblings (`/@a/p` no longer matches `/@a/p-2` or `/@a/foobar`).
- The path is regex-escaped so an author like `peak.snaps` matches literally (`.` can't match an arbitrary char).
- **Trailing-slash URLs keep `contains`** — profile insights sends `/@user/` to pull *all* pages under a user, which must stay a prefix match.

Validated the exact `multiMatchAny(pathname, ['…$'])` behavior for each path shape (bare/community/tag matched; `-2`/`foobar` siblings excluded; escaped-dot precision) before shipping.

Fixes the overmatch for web (entry-stats) and mobile at once, since both go through this route.
