### PR TITLE
CSP reports: route through a de-duplicating first-party collector (fix Sentry flood)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -245,15 +245,6 @@ const config = {
     ]
   },
   async headers() {
-    // CSP violation reports are delivered to Sentry's Security endpoint, built
-    // from the (public) project DSN already configured in sentry.*.config.ts.
-    // report-to is the modern Reporting API channel; report-uri is the broadly-
-    // supported fallback. Applied to both the enforcing and report-only policies.
-    // NOTE: report-only with a broad script-src can be noisy (browser-extension
-    // injected scripts trigger violations) — tune via Sentry inbound filters /
-    // rate limits if volume is high.
-    const sentryCspReportUri =
-      "https://o4507985141956608.ingest.de.sentry.io/api/4507985146609744/security/?sentry_key=8a5c1659d1c2ba3385be28dc7235ce56";
     return [
       {
         // Clickjacking protection on every route: our pages may be framed only
@@ -266,8 +257,6 @@ const config = {
           { key: "X-Frame-Options", value: "SAMEORIGIN" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-          // Named reporting endpoint (Reporting API) referenced by `report-to`.
-          { key: "Reporting-Endpoints", value: `csp-endpoint="${sentryCspReportUri}"` },
           // Conservative Permissions-Policy: deny only powerful features the
           // app never requests. We deliberately DO NOT restrict accelerometer,
           // gyroscope, fullscreen, picture-in-picture, encrypted-media or
@@ -295,8 +284,7 @@ const config = {
               "base-uri 'self'",
               "frame-ancestors 'self'",
               "form-action 'self'",
-              "report-to csp-endpoint",
-              `report-uri ${sentryCspReportUri}`
+              "report-uri /api/csp-report"
             ].join("; ")
           },
           // REPORT-ONLY CSP — the full inventoried policy. Reports violations
@@ -312,8 +300,12 @@ const config = {
               // Plausible is served first-party via the /pl/ rewrite, so no
               // external analytics host is needed. Turnstile + react-tweet are
               // the only external script origins.
-              "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://platform.twitter.com",
-              "script-src-elem 'self' 'unsafe-inline' https://challenges.cloudflare.com https://platform.twitter.com",
+              // Hosts after the Cloudflare/Twitter pair were surfaced by report-only
+              // monitoring as real feature dependencies: Cloudflare Insights (RUM
+              // beacon, auto-injected), TradingView (price/chart widgets), and
+              // 'wasm-unsafe-eval' for WebAssembly used by wallet/crypto libs.
+              "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://platform.twitter.com https://static.cloudflareinsights.com https://s3.tradingview.com",
+              "script-src-elem 'self' 'unsafe-inline' https://challenges.cloudflare.com https://platform.twitter.com https://static.cloudflareinsights.com https://s3.tradingview.com",
               "style-src 'self' 'unsafe-inline'",
               "font-src 'self' data:",
               [
@@ -326,7 +318,9 @@ const config = {
                 "https://api.coingecko.com https://api.giphy.com",
                 "https://studio.3speak.tv https://embed.3speak.tv https://3speak.tv https://poll.ecency.com https://spk.good-karma.xyz",
                 "https://rpc.ankr.com https://bsc-dataseed.binance.org https://explorer.solana.com https://etherscan.io https://bscscan.com",
-                "wss://enotify.ecency.com"
+                "wss://enotify.ecency.com",
+                // Feature dependencies surfaced by report-only monitoring:
+                "https://static.cloudflareinsights.com https://hiveposh.com https://hiveapi.actifit.io"
               ].join(" "),
               [
                 "img-src 'self' data: blob:",
@@ -344,7 +338,8 @@ const config = {
                 "https://lbry.tv https://odysee.com https://ipfs.skatehive.app https://www.skatehype.com",
                 "https://archive.org https://rumble.com https://www.brighteon.com https://www.bitchute.com",
                 "https://brandnewtube.com https://www.loom.com https://aureal-embed.web.app",
-                "https://platform.twitter.com https://challenges.cloudflare.com"
+                "https://platform.twitter.com https://challenges.cloudflare.com",
+                "https://www.tradingview-widget.com https://s.tradingview.com"
               ].join(" "),
               "media-src 'self' data: blob: https://i.ecency.com https://images.ecency.com https://ipfs.skatehive.app",
               "worker-src 'self' blob:",
@@ -352,8 +347,7 @@ const config = {
               "base-uri 'self'",
               "frame-ancestors 'self'",
               "form-action 'self'",
-              "report-to csp-endpoint",
-              `report-uri ${sentryCspReportUri}`
+              "report-uri /api/csp-report"
             ].join("; ")
           }
         ]

--- a/apps/web/src/app/api/csp-report/route.ts
+++ b/apps/web/src/app/api/csp-report/route.ts
@@ -75,12 +75,17 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   const dir = directive.split(" ")[0];
-  const key = `${dir}|${host}`;
+  // "enforce" means the resource was actually BLOCKED by a live policy; "report"
+  // is report-only. Keep them in separate dedup slots so a report-only violation
+  // never masks a later real (enforced) block of the same directive+host — and
+  // raise an enforced block to error level since that one means something broke.
+  const disposition = String(report["disposition"] || "report");
+  const key = `${disposition}|${dir}|${host}`;
   if (!seen.has(key) && seen.size < MAX_UNIQUE) {
     seen.add(key);
-    Sentry.captureMessage(`CSP report-only: ${dir} blocked ${host}`, {
-      level: "warning",
-      tags: { csp_directive: dir, csp_host: host },
+    Sentry.captureMessage(`CSP ${disposition}: ${dir} blocked ${host}`, {
+      level: disposition === "enforce" ? "error" : "warning",
+      tags: { csp_directive: dir, csp_host: host, csp_disposition: disposition },
       extra: {
         blockedUri: blocked,
         documentUri: report["document-uri"],

--- a/apps/web/src/app/api/csp-report/route.ts
+++ b/apps/web/src/app/api/csp-report/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// First-party CSP violation collector. The report-only policy in next.config.js
+// points `report-uri` here instead of straight at Sentry. Piping a public
+// site's report-only violations directly to Sentry floods it: every page with a
+// third-party widget reports on every load, plus the infinite long tail of
+// browser-extension-injected scripts. Here we (1) drop sources that aren't
+// actionable for our own policy (extension schemes, eval/inline keywords) and
+// (2) de-duplicate by (directive, host) so each genuinely-missing host is
+// surfaced to Sentry EXACTLY ONCE per process — the signal needed to complete
+// the allowlist before the policy is ever promoted to enforcing, without the
+// flood. The dedup set resets on deploy, so a fresh release re-samples the
+// current violation surface (which is what we want when the policy changes).
+
+const seen = new Set<string>();
+// Caps total messages emitted per process — also bounds abuse, since report-uri
+// is unauthenticated by design (browsers POST reports without credentials).
+const MAX_UNIQUE = 2000;
+const MAX_BODY_BYTES = 16 * 1024;
+
+// Not actionable for our policy: browser extensions and in-page eval keywords.
+const IGNORED_PREFIXES = [
+  "chrome-extension",
+  "moz-extension",
+  "safari-extension",
+  "safari-web-extension",
+  "webkit-masked-url",
+  "about:",
+  "chrome:",
+  "edge:"
+];
+const IGNORED_HOSTS = new Set(["inline", "eval", "wasm-eval", "self", ""]);
+
+function hostOf(blocked: string): string {
+  if (!blocked) return "";
+  if (!blocked.includes("://")) return blocked; // keyword disposition (inline/eval/…)
+  try {
+    return new URL(blocked).host || blocked;
+  } catch {
+    return blocked;
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const noContent = () => new NextResponse(null, { status: 204 });
+
+  if (Number(req.headers.get("content-length") || 0) > MAX_BODY_BYTES) {
+    return noContent();
+  }
+
+  let report: Record<string, unknown> | null = null;
+  try {
+    const text = await req.text();
+    if (!text || text.length > MAX_BODY_BYTES) return noContent();
+    const parsed = JSON.parse(text);
+    // report-uri sends { "csp-report": {...} }; tolerate a bare object too.
+    report = (parsed?.["csp-report"] ?? parsed) as Record<string, unknown> | null;
+  } catch {
+    return noContent();
+  }
+  if (!report || typeof report !== "object") return noContent();
+
+  const directive = String(
+    report["effective-directive"] || report["violated-directive"] || ""
+  );
+  const blocked = String(report["blocked-uri"] || "");
+  const host = hostOf(blocked);
+
+  if (IGNORED_HOSTS.has(host) || IGNORED_PREFIXES.some((p) => blocked.startsWith(p))) {
+    return noContent();
+  }
+
+  const dir = directive.split(" ")[0];
+  const key = `${dir}|${host}`;
+  if (!seen.has(key) && seen.size < MAX_UNIQUE) {
+    seen.add(key);
+    Sentry.captureMessage(`CSP report-only: ${dir} blocked ${host}`, {
+      level: "warning",
+      tags: { csp_directive: dir, csp_host: host },
+      extra: {
+        blockedUri: blocked,
+        documentUri: report["document-uri"],
+        violatedDirective: report["violated-directive"]
+      }
+    });
+  }
+
+  return noContent();
+}


### PR DESCRIPTION
## Problem

After #945, Sentry began escalating with `csp`-type issues. They are **report-only** (`disposition: report`) — nothing is blocked and no feature is broken — but the `report-uri` pointed straight at Sentry, and on a public site that floods: every page with a third-party widget reports on every load, plus the long tail of browser-extension-injected scripts.

Several of those violations are **real feature dependencies** (TradingView charts, Cloudflare Insights, `hiveapi.actifit.io`, `hiveposh.com`, WebAssembly) — so the answer is *not* to stop reporting (that's the signal we need before the policy can ever go enforcing), but to make reporting usable.

## Fix

- **First-party collector** (`/api/csp-report`): the report-only `report-uri` now points here instead of at Sentry. It drops extension/eval noise and **de-duplicates by (directive, host)**, forwarding each genuinely-missing host to Sentry **exactly once per process** (bounded, resets on deploy). The flood collapses to a handful of one-per-host signals.
- **Allowlist the dependencies monitoring already surfaced**: added Cloudflare Insights, TradingView, `hiveposh.com`, `hiveapi.actifit.io`, and `'wasm-unsafe-eval'` to the report-only policy — so they stop being reported and are ready for enforcement.
- The Sentry DSN is no longer embedded in `next.config.js` (the collector uses the server SDK).

## Result
Full visibility into what the CSP would block, without flooding Sentry, and the known-critical feature hosts are accounted for. Report-only means **no user impact** either way; immediate stopgap until deploy is to mute the `csp` issues in Sentry.
