### PR TITLE
Allowlist real feature deps surfaced by CSP report-only monitoring

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -304,8 +304,8 @@ const config = {
               // monitoring as real feature dependencies: Cloudflare Insights (RUM
               // beacon, auto-injected), TradingView (price/chart widgets), and
               // 'wasm-unsafe-eval' for WebAssembly used by wallet/crypto libs.
-              "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://platform.twitter.com https://static.cloudflareinsights.com https://s3.tradingview.com",
-              "script-src-elem 'self' 'unsafe-inline' https://challenges.cloudflare.com https://platform.twitter.com https://static.cloudflareinsights.com https://s3.tradingview.com",
+              "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://platform.twitter.com https://static.cloudflareinsights.com https://s3.tradingview.com https://www.google.com https://www.gstatic.com",
+              "script-src-elem 'self' 'unsafe-inline' https://challenges.cloudflare.com https://platform.twitter.com https://static.cloudflareinsights.com https://s3.tradingview.com https://www.google.com https://www.gstatic.com",
               "style-src 'self' 'unsafe-inline'",
               "font-src 'self' data:",
               [
@@ -320,12 +320,17 @@ const config = {
                 "https://rpc.ankr.com https://bsc-dataseed.binance.org https://explorer.solana.com https://etherscan.io https://bscscan.com",
                 "wss://enotify.ecency.com",
                 // Feature dependencies surfaced by report-only monitoring:
-                "https://static.cloudflareinsights.com https://hiveposh.com https://hiveapi.actifit.io"
+                "https://static.cloudflareinsights.com https://hiveposh.com https://hiveapi.actifit.io",
+                // Firebase Cloud Messaging (web push), the SDK bad-actors list,
+                // tweet embeds (react-tweet) and Google reCAPTCHA (key login):
+                "https://firebaseinstallations.googleapis.com https://fcmregistrations.googleapis.com https://fcm.googleapis.com",
+                "https://esteem-ded08.firebaseio.com wss://esteem-ded08.firebaseio.com",
+                "https://raw.githubusercontent.com https://react-tweet.vercel.app https://cdn.syndication.twimg.com https://www.google.com"
               ].join(" "),
               [
                 "img-src 'self' data: blob:",
                 "https://i.ecency.com https://img.ecency.com https://images.ecency.com https://ecency.com",
-                "https://images.hive.blog https://img.youtube.com",
+                "https://images.hive.blog https://img.youtube.com https://pbs.twimg.com",
                 "https://media.giphy.com https://media0.giphy.com https://media1.giphy.com https://media2.giphy.com https://media3.giphy.com https://media4.giphy.com https://i.giphy.com"
               ].join(" "),
               [
@@ -339,7 +344,8 @@ const config = {
                 "https://archive.org https://rumble.com https://www.brighteon.com https://www.bitchute.com",
                 "https://brandnewtube.com https://www.loom.com https://aureal-embed.web.app",
                 "https://platform.twitter.com https://challenges.cloudflare.com",
-                "https://www.tradingview-widget.com https://s.tradingview.com"
+                "https://www.tradingview-widget.com https://s.tradingview.com",
+                "https://www.google.com"
               ].join(" "),
               "media-src 'self' data: blob: https://i.ecency.com https://images.ecency.com https://ipfs.skatehive.app",
               "worker-src 'self' blob:",

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -321,16 +321,24 @@ const config = {
                 "wss://enotify.ecency.com",
                 // Feature dependencies surfaced by report-only monitoring:
                 "https://static.cloudflareinsights.com https://hiveposh.com https://hiveapi.actifit.io",
-                // Firebase Cloud Messaging (web push), the SDK bad-actors list,
-                // tweet embeds (react-tweet) and Google reCAPTCHA (key login):
+                // Cloudflare Turnstile (signup) widget XHR:
+                "https://challenges.cloudflare.com",
+                // Firebase Cloud Messaging (web push):
                 "https://firebaseinstallations.googleapis.com https://fcmregistrations.googleapis.com https://fcm.googleapis.com",
                 "https://esteem-ded08.firebaseio.com wss://esteem-ded08.firebaseio.com",
-                "https://raw.githubusercontent.com https://react-tweet.vercel.app https://cdn.syndication.twimg.com https://www.google.com"
+                // SDK bad-actors list:
+                "https://raw.githubusercontent.com",
+                // Tweet embeds (react-tweet — data API):
+                "https://react-tweet.vercel.app https://cdn.syndication.twimg.com",
+                // Google reCAPTCHA (key login):
+                "https://www.google.com"
               ].join(" "),
               [
                 "img-src 'self' data: blob:",
                 "https://i.ecency.com https://img.ecency.com https://images.ecency.com https://ecency.com",
-                "https://images.hive.blog https://img.youtube.com https://pbs.twimg.com",
+                "https://images.hive.blog https://img.youtube.com",
+                // Tweet embeds (react-tweet) media + cards, and reCAPTCHA assets:
+                "https://pbs.twimg.com https://cdn.syndication.twimg.com https://www.gstatic.com",
                 "https://media.giphy.com https://media0.giphy.com https://media1.giphy.com https://media2.giphy.com https://media3.giphy.com https://media4.giphy.com https://i.giphy.com"
               ].join(" "),
               [


### PR DESCRIPTION
## Context

Reviewing Sentry after the collector PRs, the report-only monitoring surfaced several **genuine feature dependencies missing from the CSP** — they don't fail today (report-only blocks nothing), but they'd break if the policy were ever promoted to enforcing. This is exactly the signal the monitoring exists to provide.

## Verified in code and added to the report-only policy

| Dependency | Where | Directive |
|---|---|---|
| **Firebase Cloud Messaging** (web push) | `features/push-notifications` (`@firebase/messaging`, project `esteem-ded08`) | `connect-src` |
| **SDK bad-actors list** | `@ecency/sdk` fetches `raw.githubusercontent.com/openhive-network/watchmen/...` | `connect-src` |
| **Tweet embeds** (react-tweet) | `features/shared/safe-tweet.tsx` | `connect-src` + `img-src` (`react-tweet.vercel.app`, `cdn.syndication.twimg.com`, `pbs.twimg.com`) |
| **Google reCAPTCHA** | `login-user-by-key.tsx` (`react-google-recaptcha`) | `script-src`/`frame-src`/`connect-src` (`www.google.com`, `www.gstatic.com`) |

## Notes
- **Report-only**, so zero behaviour change. This completes the allowlist toward eventual enforcement and quiets those (now log-only) false "missing host" reports.
- UGC image hosts (`files.peakd.com`, `i.ibb.co`, …) are intentionally **not** added — that long tail is unbounded and is a separate enforcement-strategy decision (image proxy / permissive `img-src`).
- Our shipped code is otherwise clean: `api/import`, `api/mattermost`, and the `csp-report` route have **0 error issues** in Sentry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security policy to permit additional external content sources, including Google services, TradingView widgets, and YouTube/Twitter image hosts, enabling broader third-party integrations and content display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->