### PR TITLE
Allow WASM eval in the Turnstile embed CSP (fixes stuck 'Verifying…')

### DIFF
--- a/apps/web/src/app/embed/turnstile/route.ts
+++ b/apps/web/src/app/embed/turnstile/route.ts
@@ -73,10 +73,12 @@ export function GET() {
       // Keep the document fresh and out of edge/browser caches and indexes.
       "Cache-Control": "no-store",
       "X-Robots-Tag": "noindex, nofollow",
-      // Lock the document down to the Turnstile challenge platform; the inline
-      // bootstrap script and style block need 'unsafe-inline'.
+      // Lock the document down to the Turnstile challenge platform. The inline
+      // bootstrap script + style block need 'unsafe-inline', and Turnstile
+      // compiles WebAssembly for its challenge, which 'wasm-unsafe-eval' allows
+      // (without it the widget stalls on "Verifying…").
       "Content-Security-Policy":
-        "default-src 'none'; script-src 'unsafe-inline' https://challenges.cloudflare.com; " +
+        "default-src 'none'; script-src 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com; " +
         "frame-src https://challenges.cloudflare.com; connect-src https://challenges.cloudflare.com; " +
         "style-src 'unsafe-inline'; img-src data: https://challenges.cloudflare.com; " +
         "base-uri 'none'; form-action 'none'"


### PR DESCRIPTION
## Problem

The static `/embed/turnstile` route (#949) sets its own tight CSP, but `script-src` is `'unsafe-inline' https://challenges.cloudflare.com` — it omits the **WebAssembly-eval** permission. Cloudflare Turnstile compiles WASM for its challenge, and Chromium blocks `WebAssembly.compile/instantiate` unless `script-src` includes `'wasm-unsafe-eval'` (or `'unsafe-eval'`). Without it the widget stalls on **"Verifying…"** — the exact symptom #949 set out to fix. (The prior page-based CSP carried `'unsafe-eval'` for this reason.)

## Fix

Add `'wasm-unsafe-eval'` to the embed route's `script-src`:
```
script-src 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com
```

No behaviour change otherwise; the rest of the tight policy (`default-src 'none'`, frame/connect/style/img scoped to `challenges.cloudflare.com`) is unchanged.
