### PR TITLE
fix(ci): drop @ecency/sdk from optimizePackageImports to fix build OOM on develop

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -152,12 +152,10 @@ const config = {
       "framer-motion",
       "@sentry/nextjs",
       "@sentry/browser",
-      // @ecency/sdk is safe (pure re-export entrypoint). @ecency/wallets is
-      // intentionally NOT optimized: its index runs rememberScryptBsvVersion()
-      // as a module side effect, and optimizePackageImports rewrites named
-      // imports to bypass the entrypoint, which would skip that guard and
-      // reopen duplicate scrypt/bitcore global errors in wallet flows.
-      "@ecency/sdk",
+      // NOTE: do not add @ecency/sdk / @ecency/wallets here. optimizePackageImports
+      // on the large SDK barrel pushed the production build past CI's ~4GB heap
+      // (OOM, exit 134); @ecency/wallets also has a module-side-effect entrypoint
+      // (rememberScryptBsvVersion) that the optimization would bypass.
     ]
   },
 


### PR DESCRIPTION
## Problem
After #951 merged, `develop` CI went red: both **Test Web Build** and **Staging CI/CD** fail at the `next build` step with a JavaScript heap OOM (`FATAL ERROR: Ineffective mark-compacts near heap limit`, exit 134). Staging deploy is consequently skipped.

`Test Web Build` was green on every develop commit before the merge and failed exactly on the merge commit (`4ce342278`).

## Cause
#951 added `@ecency/sdk` to `experimental.optimizePackageImports`. Applying `optimizePackageImports` to the large SDK barrel makes the compiler expand/rewrite SDK imports across the whole app, which pushed peak build memory past CI's ~4GB Node heap → OOM. (None of the other #951 changes affect build memory; removing the landing SCSS only reduces work.)

## Fix
Remove `@ecency/sdk` from `optimizePackageImports` (restores the pre-#951 known-good list). `@ecency/wallets` was already excluded. The runtime perf wins from #951 (no render-blocking landing CSS, framer-motion removed from Feedback, mobile-only desktop Search) are unaffected.

## Verification
Local production build with the heap capped to 4GB (`--max-old-space-size=4096`, `ANALYZE` unset) to mirror CI:
- **Before** (with `@ecency/sdk` in the list): OOM, exit 134 — reproduces CI.
- **After** (this PR): `✓ Compiled successfully`, exit 0. Homepage route unchanged (786 kB First Load JS).
