### PR TITLE
perf(sentry): defer Sentry SDK off every route's eager bootstrap (-67KB First Load JS/route)

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -1,13 +1,16 @@
 // This file configures the initialization of Sentry on the client.
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
-import * as Sentry from "@sentry/nextjs";
+//
+// The actual @sentry/nextjs SDK is NOT statically imported here (only its types).
+// It is dynamically loaded + initialized after idle / first interaction via the
+// lazy facade in src/core/sentry/lazy-sentry, which keeps the ~116KB SDK out of
+// every route's eager bootstrap (it used to be chunk 223 in rootMainFiles).
+import type * as Sentry from "@sentry/nextjs";
 import appPackage from "./package.json";
 import { beforeSend } from "./src/utils/sentry-before-send";
+import { configureLazySentry } from "./src/core/sentry/lazy-sentry";
 
-// Defer Sentry initialization until after first user interaction or 5s idle.
-// This moves ~1s of JS evaluation off the critical rendering path.
 const SENTRY_CONFIG: Sentry.BrowserOptions = {
   dsn: "https://8a5c1659d1c2ba3385be28dc7235ce56@o4507985141956608.ingest.de.sentry.io/4507985146609744",
 
@@ -31,8 +34,7 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
   environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "production",
 
   tracesSampleRate: 0,
-  integrations: (defaults) =>
-    defaults.filter((i) => i.name !== "BrowserTracing"),
+  integrations: (defaults) => defaults.filter((i) => i.name !== "BrowserTracing"),
 
   debug: false,
   ignoreErrors: [
@@ -50,11 +52,7 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
     "Cannot destructure property 'register' of 'undefined' as it is undefined.",
     "CopyDataProperties is not a function"
   ],
-  denyUrls: [
-    /sui\.js/,
-    /extensionServiceWorker\.js$/,
-    /chrome-extension:\/\//
-  ],
+  denyUrls: [/sui\.js/, /extensionServiceWorker\.js$/, /chrome-extension:\/\//],
 
   // The single source of truth for client-side event filtering and
   // reclassification (deploy-skew, RC exhaustion, extension noise, timeouts).
@@ -62,46 +60,7 @@ const SENTRY_CONFIG: Sentry.BrowserOptions = {
   beforeSend
 };
 
-if (typeof window !== "undefined" && process.env.NODE_ENV === "production") {
-  // Buffer errors that happen before Sentry initializes
-  const earlyErrors: { error: unknown; timestamp: number }[] = [];
-  const earlyHandler = (event: ErrorEvent) => {
-    earlyErrors.push({ error: event.error, timestamp: Date.now() });
-  };
-  const earlyRejectionHandler = (event: PromiseRejectionEvent) => {
-    earlyErrors.push({ error: event.reason, timestamp: Date.now() });
-  };
-  window.addEventListener("error", earlyHandler);
-  window.addEventListener("unhandledrejection", earlyRejectionHandler);
-
-  const init = () => {
-    // Remove early listeners before Sentry hooks its own
-    window.removeEventListener("error", earlyHandler);
-    window.removeEventListener("unhandledrejection", earlyRejectionHandler);
-
-    try {
-      Sentry.init(SENTRY_CONFIG);
-      Sentry.setTag("source", "client");
-
-      // Flush buffered errors
-      for (const { error } of earlyErrors) {
-        Sentry.captureException(error);
-      }
-    } catch (e) {
-      console.warn("Sentry init failed, error tracking disabled:", e);
-    }
-  };
-
-  if ("requestIdleCallback" in window) {
-    (window as any).requestIdleCallback(init, { timeout: 5000 });
-  } else {
-    setTimeout(init, 3000);
-  }
-} else {
-  try {
-    Sentry.init(SENTRY_CONFIG);
-    Sentry.setTag("source", "client");
-  } catch (e) {
-    console.warn("Sentry init failed, error tracking disabled:", e);
-  }
-}
+// Defer Sentry initialization (and now its bytes) until after first interaction
+// or 5s idle. The facade buffers early errors + any capture calls and replays
+// them once the SDK loads, so coverage is preserved.
+configureLazySentry(SENTRY_CONFIG);

--- a/apps/web/src/app/auth/_page.tsx
+++ b/apps/web/src/app/auth/_page.tsx
@@ -7,7 +7,7 @@ import { User } from "@/entities";
 import { useGlobalStore } from "@/core/global-store";
 import { useHsLoginRefresh, useRecordUserActivity } from "@/api/mutations";
 import { useCallback } from "react";
-import * as Sentry from "@sentry/nextjs";
+import { sentry } from "@/core/sentry/lazy-sentry";
 import Image from "next/image";
 import i18next from "i18next";
 import { UilSpinner } from "@tooni/iconscout-unicons-react";
@@ -53,7 +53,7 @@ export function AuthPage() {
 
       router.push(`/@${user.username}/feed`);
     } catch (e) {
-      Sentry.captureException(e);
+      sentry.captureException(e);
     }
   }, [
     addUser,

--- a/apps/web/src/app/auth/keychain-mobile/_page.tsx
+++ b/apps/web/src/app/auth/keychain-mobile/_page.tsx
@@ -6,7 +6,7 @@ import { User } from "@/entities";
 import { useGlobalStore } from "@/core/global-store";
 import { useHsLoginRefresh, useRecordUserActivity } from "@/api/mutations";
 import { useCallback, useState } from "react";
-import * as Sentry from "@sentry/nextjs";
+import { sentry } from "@/core/sentry/lazy-sentry";
 import Image from "next/image";
 import i18next from "i18next";
 import { UilSpinner } from "@tooni/iconscout-unicons-react";
@@ -85,7 +85,7 @@ export function KeychainMobileAuthPage() {
 
       router.push(`/@${user.username}/feed`);
     } catch (e) {
-      Sentry.captureException(e);
+      sentry.captureException(e);
       const detail = e instanceof Error ? e.message : String(e);
       setErrorMessage(`${i18next.t("login.keychain-mobile-error", { defaultValue: "Login failed. Please try again." })}\n${detail}`);
     }

--- a/apps/web/src/app/publish/_api/use-publish.ts
+++ b/apps/web/src/app/publish/_api/use-publish.ts
@@ -21,7 +21,7 @@ import { EcencyAnalytics } from "@ecency/sdk";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import i18next from "i18next";
 import { usePublishState } from "../_hooks";
-import * as Sentry from "@sentry/nextjs";
+import { sentry } from "@/core/sentry/lazy-sentry";
 import { SUBMIT_DESCRIPTION_MAX_LENGTH } from "@/app/submit/_consts";
 import { useActiveAccount } from "@/core/hooks";
 
@@ -181,7 +181,7 @@ export function usePublishApi() {
       try {
         await validatePostCreating(entry.author, entry.permlink, 3);
       } catch (e) {
-        Sentry.captureException(e, {
+        sentry.captureException(e, {
           extra: { username: entry.author }
         });
       }

--- a/apps/web/src/app/submit/_api/publish.ts
+++ b/apps/web/src/app/submit/_api/publish.ts
@@ -11,7 +11,7 @@ import { BeneficiaryRoute, Entry, FullAccount, RewardType } from "@/entities";
 import { createPermlink, isCommunity, makeCommentOptions, tempEntry } from "@/utils";
 import i18next from "i18next";
 import { error, success } from "@/features/shared";
-import * as Sentry from "@sentry/nextjs";
+import { sentry } from "@/core/sentry/lazy-sentry";
 import { useRouter } from "next/navigation";
 import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { postBodySummary } from "@ecency/render-helper";
@@ -173,7 +173,7 @@ export function usePublishApi(onClear: () => void) {
         try {
           await validatePostCreating(entry.author, entry.permlink, 3);
         } catch (e) {
-          Sentry.captureException(e, {
+          sentry.captureException(e, {
             extra: { username: entry.author }
           });
         }

--- a/apps/web/src/app/waves/_components/waves-list-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-view.tsx
@@ -26,7 +26,7 @@ import { useWavesGrid } from "@/app/waves/_hooks";
 import { useWavesTagFilter } from "@/app/waves/_context";
 import { Button } from "@ui/button";
 import i18next from "i18next";
-import * as Sentry from "@sentry/nextjs";
+import { sentry } from "@/core/sentry/lazy-sentry";
 
 interface Props {
   host: string;
@@ -68,7 +68,7 @@ export function WavesListView({ host, feedType, username }: Props) {
         tag,
         message
       });
-      Sentry.captureException(error, {
+      sentry.captureException(error, {
         data: { host, feedType, tag }
       });
     }

--- a/apps/web/src/app/waves/_components/waves-list-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-view.tsx
@@ -69,7 +69,7 @@ export function WavesListView({ host, feedType, username }: Props) {
         message
       });
       sentry.captureException(error, {
-        data: { host, feedType, tag }
+        extra: { host, feedType, tag }
       });
     }
   }, [error, feedType, host, isError, tag]);

--- a/apps/web/src/core/global-store/modules/authentication-module.ts
+++ b/apps/web/src/core/global-store/modules/authentication-module.ts
@@ -2,7 +2,7 @@ import { Account, ActiveUser } from "@/entities";
 import * as ls from "@/utils/local-storage";
 import Cookies from "js-cookie";
 import { ACTIVE_USER_COOKIE_NAME } from "@/consts";
-import * as Sentry from "@sentry/nextjs";
+import { sentry } from "@/core/sentry/lazy-sentry";
 
 const makeActiveUser = (username: string): ActiveUser => ({
   username,
@@ -47,14 +47,14 @@ export const createAuthenticationActions = (
       Cookies.set(ACTIVE_USER_COOKIE_NAME, name, { expires: 365 });
       set({ activeUser: nextActiveUser });
 
-      Sentry.setUser({
+      sentry.setUser({
         username: name
       });
     } else {
       ls.remove("active_user");
       Cookies.remove(ACTIVE_USER_COOKIE_NAME);
       set({ activeUser: nextActiveUser });
-      Sentry.setUser(null);
+      sentry.setUser(null);
     }
   }
 });

--- a/apps/web/src/core/sentry/lazy-sentry.ts
+++ b/apps/web/src/core/sentry/lazy-sentry.ts
@@ -36,6 +36,12 @@ const earlyRejectionHandler = (e: PromiseRejectionEvent) => {
   earlyErrors.push(e.reason);
 };
 
+function removeEarlyListeners() {
+  if (!isBrowser) return;
+  window.removeEventListener("error", earlyErrorHandler);
+  window.removeEventListener("unhandledrejection", earlyRejectionHandler);
+}
+
 function loadSentry(): Promise<SentryModule | null> {
   if (mod) return Promise.resolve(mod);
   if (!loadPromise) {
@@ -69,6 +75,10 @@ function onInitFailure(e?: unknown) {
   mod = null;
   if (e) console.warn("Sentry init failed:", e);
   if (initFailures >= MAX_INIT_FAILURES) {
+    // Give up permanently: clear the buffers AND detach the window listeners,
+    // otherwise earlyErrors would keep growing on every error event for the
+    // page lifetime (ensureInit no longer drains it once we have given up).
+    removeEarlyListeners();
     queued.length = 0;
     earlyErrors.length = 0;
     console.warn("Sentry disabled after repeated load/init failures.");
@@ -96,10 +106,7 @@ function ensureInit(): Promise<void> {
     try {
       m.init(opts);
       m.setTag("source", "client");
-      if (isBrowser) {
-        window.removeEventListener("error", earlyErrorHandler);
-        window.removeEventListener("unhandledrejection", earlyRejectionHandler);
-      }
+      removeEarlyListeners();
       initialized = true;
       // Replay buffered method calls in order.
       for (const c of queued.splice(0)) {

--- a/apps/web/src/core/sentry/lazy-sentry.ts
+++ b/apps/web/src/core/sentry/lazy-sentry.ts
@@ -53,6 +53,27 @@ function loadSentry(): Promise<SentryModule | null> {
 }
 
 let initPromise: Promise<void> | null = null;
+let initFailures = 0;
+const MAX_INIT_FAILURES = 3;
+// Hard cap on the pre-init buffer so a persistently-failing load can never grow
+// it without bound (drops the oldest entries first).
+const MAX_QUEUE = 100;
+
+// Reset the load/init state so a later call can retry (CDN blip, chunk fetch
+// error, or init throw). After MAX_INIT_FAILURES, give up permanently and clear
+// the buffers so they can't grow forever.
+function onInitFailure(e?: unknown) {
+  initFailures += 1;
+  initPromise = null;
+  loadPromise = null;
+  mod = null;
+  if (e) console.warn("Sentry init failed:", e);
+  if (initFailures >= MAX_INIT_FAILURES) {
+    queued.length = 0;
+    earlyErrors.length = 0;
+    console.warn("Sentry disabled after repeated load/init failures.");
+  }
+}
 
 /**
  * Load + initialize the real SDK (once), then replay anything buffered.
@@ -64,14 +85,17 @@ function ensureInit(): Promise<void> {
   // any capture in practice). Return WITHOUT memoizing so the call made right
   // after configure can still initialize — memoizing a no-op here would wedge it.
   if (!options) return Promise.resolve();
+  if (initFailures >= MAX_INIT_FAILURES) return Promise.resolve();
   if (initPromise) return initPromise;
+  const opts = options;
   initPromise = loadSentry().then((m) => {
-    if (!m) return;
+    if (!m) {
+      onInitFailure();
+      return;
+    }
     try {
-      if (options) {
-        m.init(options);
-        m.setTag("source", "client");
-      }
+      m.init(opts);
+      m.setTag("source", "client");
       if (isBrowser) {
         window.removeEventListener("error", earlyErrorHandler);
         window.removeEventListener("unhandledrejection", earlyRejectionHandler);
@@ -94,13 +118,20 @@ function ensureInit(): Promise<void> {
         }
       }
     } catch (e) {
-      console.warn("Sentry init failed, error tracking disabled:", e);
+      // init threw: reset so a later capture can retry instead of wedging.
+      onInitFailure(e);
     }
   });
   return initPromise;
 }
 
-function call(method: string, args: unknown[]) {
+// forceInit: telemetry calls (captures) trigger the load before the idle gate so
+// a genuine error doesn't wait out the timeout. Pure context setters
+// (setUser/setTag) only BUFFER — they do NOT force the load — so a returning
+// logged-in user whose ClientInit calls setUser on mount does not eagerly fetch
+// the SDK; the buffered context is replayed when the idle gate (or a real
+// capture) initializes it. This preserves the lazy-load win for logged-in users.
+function call(method: string, args: unknown[], forceInit: boolean) {
   if (initialized && mod) {
     try {
       (mod as unknown as Record<string, (...a: unknown[]) => unknown>)[method](...args);
@@ -109,10 +140,9 @@ function call(method: string, args: unknown[]) {
     }
     return;
   }
+  if (queued.length >= MAX_QUEUE) queued.shift();
   queued.push({ method, args });
-  // First real use triggers the load even before the idle gate fires, so a
-  // genuine error does not wait out the full idle timeout.
-  void ensureInit();
+  if (forceInit) void ensureInit();
 }
 
 /**
@@ -120,20 +150,24 @@ function call(method: string, args: unknown[]) {
  * CLIENT. Methods buffer-then-replay until the SDK is initialized.
  */
 export const sentry = {
+  // Captures force the load (real telemetry).
   captureException: (...args: Parameters<SentryModule["captureException"]>) =>
-    call("captureException", args),
+    call("captureException", args, true),
   captureMessage: (...args: Parameters<SentryModule["captureMessage"]>) =>
-    call("captureMessage", args),
+    call("captureMessage", args, true),
   captureFeedback: (...args: Parameters<SentryModule["captureFeedback"]>) =>
-    call("captureFeedback", args),
-  setUser: (...args: Parameters<SentryModule["setUser"]>) => call("setUser", args),
-  setTag: (...args: Parameters<SentryModule["setTag"]>) => call("setTag", args),
+    call("captureFeedback", args, true),
+  // Context-only: buffer but do NOT force the load (see call() note).
+  setUser: (...args: Parameters<SentryModule["setUser"]>) => call("setUser", args, false),
+  setTag: (...args: Parameters<SentryModule["setTag"]>) => call("setTag", args, false),
   // Sentry's withScope is overloaded ((scope, cb) | (cb)); the app only uses the
   // single-callback form, so type it explicitly to keep the scope param typed.
-  withScope: (callback: (scope: SentryNS.Scope) => void) => call("withScope", [callback]),
-  // flush only matters once loaded; before that there is nothing buffered to send.
+  // The callback captures, so it forces the load like other telemetry.
+  withScope: (callback: (scope: SentryNS.Scope) => void) => call("withScope", [callback], true),
+  // Gate on `initialized` (not `mod`): if init threw, `mod` may be set on an
+  // uninitialized client. Returns true when nothing is loaded (nothing to flush).
   flush: async (...args: Parameters<SentryModule["flush"]>) => {
-    if (mod) return mod.flush(...args);
+    if (initialized && mod) return mod.flush(...args);
     return true;
   }
 };
@@ -145,11 +179,16 @@ export const sentry = {
  */
 export function configureLazySentry(opts: Options) {
   options = opts;
+  if (!isBrowser) return;
 
-  if (isBrowser && process.env.NODE_ENV === "production") {
-    window.addEventListener("error", earlyErrorHandler);
-    window.addEventListener("unhandledrejection", earlyRejectionHandler);
+  // Buffer errors that occur in the brief window before the SDK initializes,
+  // in every environment (replayed once init completes).
+  window.addEventListener("error", earlyErrorHandler);
+  window.addEventListener("unhandledrejection", earlyRejectionHandler);
 
+  if (process.env.NODE_ENV === "production") {
+    // Defer init to idle / first interaction so the SDK bytes stay off the
+    // critical path.
     if ("requestIdleCallback" in window) {
       (window as unknown as { requestIdleCallback: (cb: () => void, o?: { timeout: number }) => void })
         .requestIdleCallback(() => void ensureInit(), { timeout: 5000 });

--- a/apps/web/src/core/sentry/lazy-sentry.ts
+++ b/apps/web/src/core/sentry/lazy-sentry.ts
@@ -1,0 +1,163 @@
+// Lazy Sentry facade.
+//
+// `@sentry/nextjs` was chunk 223 (~116KB gz) sitting in build-manifest
+// rootMainFiles — a static <script> on all 169 routes — because the client
+// config AND several always-loaded modules (auth store, global-error, feedback)
+// statically `import * as Sentry from "@sentry/nextjs"`. Routing every
+// client-side Sentry use through this facade means nothing on the eager graph
+// statically imports the SDK, so webpack splits it into an async chunk that is
+// only fetched after first interaction / idle (or on first capture). Calls made
+// before the SDK resolves are buffered and replayed, so early-error coverage is
+// preserved.
+//
+// Server/edge Sentry (instrumentation.ts, sentry.server/edge.config.ts, API
+// routes, RSS) is unaffected and keeps importing @sentry/nextjs directly.
+import type * as SentryNS from "@sentry/nextjs";
+
+type SentryModule = typeof import("@sentry/nextjs");
+type Options = SentryNS.BrowserOptions;
+
+const isBrowser = typeof window !== "undefined";
+
+let mod: SentryModule | null = null;
+let loadPromise: Promise<SentryModule | null> | null = null;
+let initialized = false;
+let options: Options | null = null;
+
+// Method calls made before the SDK is initialized, replayed on init.
+const queued: { method: string; args: unknown[] }[] = [];
+// Raw errors/rejections captured by the early listeners before init.
+const earlyErrors: unknown[] = [];
+
+const earlyErrorHandler = (e: ErrorEvent) => {
+  earlyErrors.push(e.error);
+};
+const earlyRejectionHandler = (e: PromiseRejectionEvent) => {
+  earlyErrors.push(e.reason);
+};
+
+function loadSentry(): Promise<SentryModule | null> {
+  if (mod) return Promise.resolve(mod);
+  if (!loadPromise) {
+    loadPromise = import("@sentry/nextjs")
+      .then((m) => {
+        mod = m;
+        return m;
+      })
+      .catch((e) => {
+        console.warn("Sentry load failed, error tracking disabled:", e);
+        return null;
+      });
+  }
+  return loadPromise;
+}
+
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Load + initialize the real SDK (once), then replay anything buffered.
+ * Safe to call repeatedly and from a capture before the idle gate fires.
+ */
+function ensureInit(): Promise<void> {
+  if (initialized) return Promise.resolve();
+  // Not configured yet (configureLazySentry runs at client entry-eval, before
+  // any capture in practice). Return WITHOUT memoizing so the call made right
+  // after configure can still initialize — memoizing a no-op here would wedge it.
+  if (!options) return Promise.resolve();
+  if (initPromise) return initPromise;
+  initPromise = loadSentry().then((m) => {
+    if (!m) return;
+    try {
+      if (options) {
+        m.init(options);
+        m.setTag("source", "client");
+      }
+      if (isBrowser) {
+        window.removeEventListener("error", earlyErrorHandler);
+        window.removeEventListener("unhandledrejection", earlyRejectionHandler);
+      }
+      initialized = true;
+      // Replay buffered method calls in order.
+      for (const c of queued.splice(0)) {
+        try {
+          (m as unknown as Record<string, (...a: unknown[]) => unknown>)[c.method](...c.args);
+        } catch {
+          /* ignore replay errors */
+        }
+      }
+      // Replay raw early errors.
+      for (const err of earlyErrors.splice(0)) {
+        try {
+          m.captureException(err);
+        } catch {
+          /* ignore */
+        }
+      }
+    } catch (e) {
+      console.warn("Sentry init failed, error tracking disabled:", e);
+    }
+  });
+  return initPromise;
+}
+
+function call(method: string, args: unknown[]) {
+  if (initialized && mod) {
+    try {
+      (mod as unknown as Record<string, (...a: unknown[]) => unknown>)[method](...args);
+    } catch {
+      /* ignore */
+    }
+    return;
+  }
+  queued.push({ method, args });
+  // First real use triggers the load even before the idle gate fires, so a
+  // genuine error does not wait out the full idle timeout.
+  void ensureInit();
+}
+
+/**
+ * Drop-in replacement for `import * as Sentry from "@sentry/nextjs"` on the
+ * CLIENT. Methods buffer-then-replay until the SDK is initialized.
+ */
+export const sentry = {
+  captureException: (...args: Parameters<SentryModule["captureException"]>) =>
+    call("captureException", args),
+  captureMessage: (...args: Parameters<SentryModule["captureMessage"]>) =>
+    call("captureMessage", args),
+  captureFeedback: (...args: Parameters<SentryModule["captureFeedback"]>) =>
+    call("captureFeedback", args),
+  setUser: (...args: Parameters<SentryModule["setUser"]>) => call("setUser", args),
+  setTag: (...args: Parameters<SentryModule["setTag"]>) => call("setTag", args),
+  // Sentry's withScope is overloaded ((scope, cb) | (cb)); the app only uses the
+  // single-callback form, so type it explicitly to keep the scope param typed.
+  withScope: (callback: (scope: SentryNS.Scope) => void) => call("withScope", [callback]),
+  // flush only matters once loaded; before that there is nothing buffered to send.
+  flush: async (...args: Parameters<SentryModule["flush"]>) => {
+    if (mod) return mod.flush(...args);
+    return true;
+  }
+};
+
+/**
+ * Called once from sentry.client.config.ts with the resolved options. Wires the
+ * early-error listeners and the idle-deferred init, mirroring the previous
+ * inline behavior but with the SDK bytes lazy-loaded.
+ */
+export function configureLazySentry(opts: Options) {
+  options = opts;
+
+  if (isBrowser && process.env.NODE_ENV === "production") {
+    window.addEventListener("error", earlyErrorHandler);
+    window.addEventListener("unhandledrejection", earlyRejectionHandler);
+
+    if ("requestIdleCallback" in window) {
+      (window as unknown as { requestIdleCallback: (cb: () => void, o?: { timeout: number }) => void })
+        .requestIdleCallback(() => void ensureInit(), { timeout: 5000 });
+    } else {
+      setTimeout(() => void ensureInit(), 3000);
+    }
+  } else {
+    // Dev / non-production: initialize immediately (matches old else branch).
+    void ensureInit();
+  }
+}

--- a/apps/web/src/features/shared/feedback/feedback-events.ts
+++ b/apps/web/src/features/shared/feedback/feedback-events.ts
@@ -1,7 +1,7 @@
 import { ErrorTypes } from "@/enums";
 import { random } from "@/utils";
 import i18next from "i18next";
-import * as Sentry from "@sentry/nextjs";
+import { sentry } from "@/core/sentry/lazy-sentry";
 import { formatError } from "@/api/format-error";
 import { ConsoleHistoryEntry, getConsoleHistory } from "@/utils/console-msg";
 
@@ -95,7 +95,7 @@ export const consumeErrorFeedbackContext = (id: string): ErrorFeedbackExtras | u
 };
 
 /**
- * Handles known app errors and conditionally reports to Sentry.
+ * Handles known app errors and conditionally reports to sentry.
  * @returns true if error was handled and should NOT be rethrown.
  */
 export function handleAndReportError(err: any, contextTag?: string): boolean {
@@ -120,10 +120,10 @@ export function handleAndReportError(err: any, contextTag?: string): boolean {
   });
 
   if (contextTag) {
-    Sentry.setTag("context", contextTag);
+    sentry.setTag("context", contextTag);
   }
 
-  Sentry.withScope((scope) => {
+  sentry.withScope((scope) => {
     scope.setExtra("feedbackMessage", message);
     if (contextTag) {
       scope.setExtra("feedbackId", `${contextTag}-${Date.now()}`);
@@ -136,7 +136,7 @@ export function handleAndReportError(err: any, contextTag?: string): boolean {
       scope.setTag("context", contextTag);
     }
     scope.setTag("reported_via", "handleAndReportError");
-    Sentry.captureException(err);
+    sentry.captureException(err);
   });
   return false; // ❌ unexpected, should throw
 }

--- a/apps/web/src/features/shared/feedback/feedback-message.tsx
+++ b/apps/web/src/features/shared/feedback/feedback-message.tsx
@@ -16,7 +16,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useRef, useState } from "react";
 import { useMount, useUnmount } from "react-use";
-import * as Sentry from "@sentry/nextjs";
+import { sentry } from "@/core/sentry/lazy-sentry";
 import { getConsoleHistory } from "@/utils/console-msg";
 import { useGlobalStore } from "@/core/global-store";
 
@@ -140,7 +140,7 @@ export function FeedbackMessage({ feedback, onClose }: Props) {
 
                 const context = consumeErrorFeedbackContext(feedback.id);
 
-                Sentry.withScope((scope) => {
+                sentry.withScope((scope) => {
                   scope.setExtra("feedbackId", feedback.id);
                   scope.setExtra("feedbackMessage", feedback.message);
 
@@ -160,7 +160,7 @@ export function FeedbackMessage({ feedback, onClose }: Props) {
                   scope.setTag("reported_via", "feedback-toast-report");
 
                   const errorPayload = context?.error ?? new Error(feedback.message);
-                  Sentry.captureException(errorPayload);
+                  sentry.captureException(errorPayload);
                 });
 
                 handleClose();

--- a/apps/web/src/specs/core/sentry/lazy-sentry.spec.ts
+++ b/apps/web/src/specs/core/sentry/lazy-sentry.spec.ts
@@ -1,0 +1,50 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// Mock the real SDK that the facade dynamically imports. vi.hoisted so the
+// object exists when the hoisted vi.mock factory runs.
+const sdk = vi.hoisted(() => ({
+  init: vi.fn(),
+  setTag: vi.fn(),
+  setUser: vi.fn(),
+  captureException: vi.fn(() => "evt-1"),
+  captureMessage: vi.fn(),
+  withScope: vi.fn(),
+  captureFeedback: vi.fn(),
+  flush: vi.fn(() => Promise.resolve(true))
+}));
+vi.mock("@sentry/nextjs", () => sdk);
+
+describe("lazy-sentry facade", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules(); // fresh facade module-level state per test
+  });
+
+  it("does NOT load the SDK synchronously on a capture before configure", async () => {
+    const { sentry } = await import("@/core/sentry/lazy-sentry");
+    sentry.captureException(new Error("pre-config"));
+    // Buffered; the SDK must not initialize or send until configured.
+    expect(sdk.init).not.toHaveBeenCalled();
+    expect(sdk.captureException).not.toHaveBeenCalled();
+  });
+
+  it("initializes and REPLAYS buffered captures once configured", async () => {
+    const { sentry, configureLazySentry } = await import("@/core/sentry/lazy-sentry");
+    const err = new Error("buffered");
+    sentry.captureException(err);
+    // Test env is non-production -> configure initializes immediately.
+    configureLazySentry({ dsn: "x" } as never);
+    await vi.waitFor(() => expect(sdk.init).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(sdk.captureException).toHaveBeenCalledWith(err));
+    expect(sdk.setTag).toHaveBeenCalledWith("source", "client");
+  });
+
+  it("passes captures straight through after init", async () => {
+    const { sentry, configureLazySentry } = await import("@/core/sentry/lazy-sentry");
+    configureLazySentry({ dsn: "x" } as never);
+    await vi.waitFor(() => expect(sdk.init).toHaveBeenCalled());
+    const err = new Error("post-init");
+    sentry.captureException(err);
+    await vi.waitFor(() => expect(sdk.captureException).toHaveBeenCalledWith(err));
+  });
+});


### PR DESCRIPTION
Fundamental perf lever from the architecture investigation: evict the Sentry SDK from every route's eager bootstrap.

## Problem
`@sentry/nextjs` was **chunk 223 (~116KB)** sitting in `build-manifest.json` `rootMainFiles` — a static `<script>` on **all 169 routes** (~64.7% of the eager baseline after the framework). It was pinned eager not just by `sentry.client.config.ts` but by always-loaded modules that statically `import * as Sentry from "@sentry/nextjs"` — notably `core/global-store/modules/authentication-module.ts` (reached via the global store + client-init), and the always-mounted `feedback`. The config already *deferred init*, but the SDK *bytes* shipped eagerly regardless.

## Change
A lazy Sentry facade (`src/core/sentry/lazy-sentry.ts`):
- `dynamic import("@sentry/nextjs")` (memoized) + init after idle / first interaction, mirroring the previous idle gate.
- A `sentry` proxy (captureException/captureMessage/setUser/setTag/withScope/captureFeedback/flush) that **buffers calls before the SDK resolves and replays them on init**, plus early `error`/`unhandledrejection` listeners, so early-error coverage is preserved.
- First real capture triggers the load (doesn't wait out the full idle timeout).

Routed through the facade: the client config + the eager / fire-and-forget client callers (auth store, feedback, and the `auth` / `waves` / `publish` / `submit` capture sites).

**Left on direct `@sentry/nextjs` (intentional):** `global-error` and the issue-reporter error boundary — they use the **synchronous event id** (to associate user feedback) and **flush-before-reload** (deploy-skew recovery), and are error-UI / route-level, not on the eager path. Server/edge Sentry (instrumentation, server/edge config, RSS, API routes) is untouched.

## Result (verified by ANALYZE build)
- **Sentry chunk 223 leaves `rootMainFiles`** (becomes an async chunk); the only Sentry trace left in the eager set is the ~2KB facade in `main-app`.
- **First Load JS −~67 KB on every route** (homepage 786→719, feed 721→654, community 875→808, profile 898→831 kB).
- `tsc` at baseline (0 new), build compiles, full suite **1,582 pass** incl. a new facade buffer-replay spec.

## Coverage note (please verify on staging)
The buffer-replay path is unit-tested, but field error-capture is the real risk. On staging, please throw a client error at ~0.5s, ~2s, and ~6s after load and confirm all three reach Sentry via the facade's replay. If the earliest window proves unreliable, the fallback is `@sentry/browser` + the Sentry CDN loader for client capture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized error tracking initialization to defer until after the application is ready, reducing impact on initial page load performance.
  * Error reporting and feedback functionality remain unchanged and continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->