### PR TITLE
fix(home): correct About email + CF-verified visitor stat

### DIFF
--- a/apps/web/src/app/(staticPages)/about/page.tsx
+++ b/apps/web/src/app/(staticPages)/about/page.tsx
@@ -119,7 +119,7 @@ export default function About() {
             <a
               className="contacts-link"
               target="_blank"
-              href="mailto:info@esteem.app?subject=Feedback"
+              href="mailto:hello@ecency.com?subject=Feedback"
               rel="noopener noreferrer"
             >
               {mailSvg} {i18next.t("static.about.contact-email")}

--- a/apps/web/src/app/_components/landing-page/index.tsx
+++ b/apps/web/src/app/_components/landing-page/index.tsx
@@ -130,8 +130,8 @@ export async function LandingPage() {
               ·
             </li>
             <li>
-              <strong className="text-blue-dark-sky dark:text-gray-pinkish">14M+</strong>{" "}
-              {t("landing-page.unique-visitors")}
+              <strong className="text-blue-dark-sky dark:text-gray-pinkish">1M+</strong>{" "}
+              {t("landing-page.daily-visitors")}
             </li>
           </ul>
         </div>

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -2735,6 +2735,7 @@
     "feel-free-join": " Join and lets build together!",
     "posts": "Posts",
     "unique-visitors": "Unique visitors",
+    "daily-visitors": "Daily visitors",
     "points-distrubuted": "Points distributed",
     "new-users": "New users",
     "download-our-application": "Download our application",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -2734,7 +2734,6 @@
     "open-source-desc": "Join and be part of the building team on Web 3.0. Everything that we build is blockchain-based and open source. We welcome tech talents, developers, creators and entrepreneurs.",
     "feel-free-join": " Join and lets build together!",
     "posts": "Posts",
-    "unique-visitors": "Unique visitors",
     "daily-visitors": "Daily visitors",
     "points-distrubuted": "Points distributed",
     "new-users": "New users",


### PR DESCRIPTION
Two small fixes from staging review.

- **About page 'Email us'** pointed to the legacy `info@esteem.app`; now `hello@ecency.com`.
- **Homepage stat** '14M+ unique visitors' was a stale, ambiguous cumulative number. Replaced with **'1M+ daily visitors'**, grounded in Cloudflare zone analytics (trailing 12 months): avg **~957K daily unique visitors**, recent months **~1.5M/day**, ~478M annual page views. Daily framing is used because Cloudflare does not expose a true annual-dedup unique count (summing daily uniques = 344M visitor-days, which would overstate it).