### PR TITLE
perf(feed): replace the 30s all-card re-render fan-out with a self-ticking TimeLabel

### DIFF
--- a/apps/web/src/app/(dynamicPages)/feed/_components/feed-layout.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/_components/feed-layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ListStyle } from "@/enums";
-import React, { PropsWithChildren, useEffect, useRef, useState, useMemo } from "react";
+import { PropsWithChildren, useEffect, useRef, useState } from "react";
 import { useGlobalStore } from "@/core/global-store";
 import { usePostsFeedQuery } from "@/api/queries";
 import { Entry, SearchResponse } from "@/entities";
@@ -34,7 +34,6 @@ export function FeedLayout(props: PropsWithChildren<Props>) {
 
   const [pending, setPending] = useState<Entry[]>([]);
   const [extra, setExtra] = useState<Entry[]>([]);
-  const [now, setNow] = useState(Date.now());
   const latest = useRef<Entry | null>(null);
 
   const firstPageEntries: Entry[] =
@@ -75,7 +74,6 @@ export function FeedLayout(props: PropsWithChildren<Props>) {
           props.observer
         )
       );
-      setNow(Date.now());
       if (!resp || resp.length === 0) return;
 
       // Update existing entries with latest stats
@@ -169,15 +167,10 @@ export function FeedLayout(props: PropsWithChildren<Props>) {
                   sectionParam={props.filter}
                   isPromoted={false}
                   showEmptyPlaceholder={false}
-                  now={now}
               />
           )}
 
-          {React.Children.map(props.children, (child) =>
-              React.isValidElement(child)
-                  ? React.cloneElement(child as React.ReactElement<{ now?: number }>, { now })
-                  : child
-          )}
+          {props.children}
         </div>
       </div>
   );

--- a/apps/web/src/app/(dynamicPages)/feed/_components/feed-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/_components/feed-list.tsx
@@ -15,12 +15,11 @@ interface Props {
   filter: string;
   tag: string;
   observer?: string;
-  now?: number;
 }
 
 type Page = Entry[] | SearchResponse;
 
-export function FeedList({ filter, tag, observer, now }: Props) {
+export function FeedList({ filter, tag, observer }: Props) {
   const searchParams = useSearchParams();
   const noReblog = searchParams?.get("no-reblog") === "true";
   const visionFeatures = EcencyConfigManager.CONFIG.visionFeatures;
@@ -88,7 +87,6 @@ export function FeedList({ filter, tag, observer, now }: Props) {
         isPromoted={visionFeatures.promotions.enabled}
         promotedEntries={promotedPosts ?? []}
         showEmptyPlaceholder={false}
-        now={now}
       />
 
       {/* Show empty state ONLY for personalized feeds, never for global feeds */}

--- a/apps/web/src/core/caches/pin-tracker-cache.ts
+++ b/apps/web/src/core/caches/pin-tracker-cache.ts
@@ -1,37 +1,25 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { QueryIdentifiers } from "../react-query";
-import { getPostsRankedQueryOptions, QueryKeys } from "@ecency/sdk";
-import { useDataLimit } from "@/utils/data-limit";
+import { QueryKeys } from "@ecency/sdk";
 import { formatError } from "@/api/format-error";
 import { usePinPostMutation } from "@/api/sdk-mutations";
 import { Community, Entry } from "@/entities";
-import { isCommunity } from "@/utils";
 import { clone } from "remeda";
 import { error, success } from "@/features/shared";
 import i18next from "i18next";
 
+// The pin flag is already carried per-entry on `entry.stats.is_pinned` (same
+// bridge.get_ranked_posts source that stamped it), so we no longer fetch a whole
+// community ranked list per card just to derive it (that was an extra network
+// call + query observer on every card in the feed). Kept as a LIVE observer on
+// the ENTRY_PIN_TRACK key, seeded from entry.stats, so the optimistic
+// setQueryData in useCommunityPin (below) still flips the in-menu pin label.
 export function useCommunityPinCache(entry: Entry) {
-  const dataLimit = useDataLimit();
-  const { data: rankedPosts } = useQuery({
-    ...getPostsRankedQueryOptions(
-      "created",
-      "",
-      "",
-      dataLimit,
-      entry.category,
-      "",
-      isCommunity(entry.category)
-    )
-  });
-
   return useQuery({
     queryKey: [QueryIdentifiers.ENTRY_PIN_TRACK, entry.post_id],
-    queryFn: async () =>
-      rankedPosts?.find(
-        (x) =>
-          x.author === entry.author && x.permlink === entry.permlink && x.stats?.is_pinned === true
-      ) !== undefined,
-    initialData: entry.stats?.is_pinned ?? false
+    queryFn: () => entry.stats?.is_pinned ?? false,
+    initialData: entry.stats?.is_pinned ?? false,
+    staleTime: Infinity
   });
 }
 

--- a/apps/web/src/core/caches/pin-tracker-cache.ts
+++ b/apps/web/src/core/caches/pin-tracker-cache.ts
@@ -1,25 +1,37 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { QueryIdentifiers } from "../react-query";
-import { QueryKeys } from "@ecency/sdk";
+import { getPostsRankedQueryOptions, QueryKeys } from "@ecency/sdk";
+import { useDataLimit } from "@/utils/data-limit";
 import { formatError } from "@/api/format-error";
 import { usePinPostMutation } from "@/api/sdk-mutations";
 import { Community, Entry } from "@/entities";
+import { isCommunity } from "@/utils";
 import { clone } from "remeda";
 import { error, success } from "@/features/shared";
 import i18next from "i18next";
 
-// The pin flag is already carried per-entry on `entry.stats.is_pinned` (same
-// bridge.get_ranked_posts source that stamped it), so we no longer fetch a whole
-// community ranked list per card just to derive it (that was an extra network
-// call + query observer on every card in the feed). Kept as a LIVE observer on
-// the ENTRY_PIN_TRACK key, seeded from entry.stats, so the optimistic
-// setQueryData in useCommunityPin (below) still flips the in-menu pin label.
 export function useCommunityPinCache(entry: Entry) {
+  const dataLimit = useDataLimit();
+  const { data: rankedPosts } = useQuery({
+    ...getPostsRankedQueryOptions(
+      "created",
+      "",
+      "",
+      dataLimit,
+      entry.category,
+      "",
+      isCommunity(entry.category)
+    )
+  });
+
   return useQuery({
     queryKey: [QueryIdentifiers.ENTRY_PIN_TRACK, entry.post_id],
-    queryFn: () => entry.stats?.is_pinned ?? false,
-    initialData: entry.stats?.is_pinned ?? false,
-    staleTime: Infinity
+    queryFn: async () =>
+      rankedPosts?.find(
+        (x) =>
+          x.author === entry.author && x.permlink === entry.permlink && x.stats?.is_pinned === true
+      ) !== undefined,
+    initialData: entry.stats?.is_pinned ?? false
   });
 }
 

--- a/apps/web/src/features/shared/entry-list-content/index.tsx
+++ b/apps/web/src/features/shared/entry-list-content/index.tsx
@@ -47,7 +47,8 @@ export function EntryListContent({
                       entry={p}
                       promoted={true}
                       order={4}
-                      community={community}                    />
+                      community={community}
+                    />
                   );
                 }
               }
@@ -61,7 +62,8 @@ export function EntryListContent({
                   key={`${e.author}-${e.permlink}`}
                   entry={e}
                   order={i}
-                  community={community}                />
+                  community={community}
+                />
               );
             } else {
               l.push(
@@ -70,7 +72,8 @@ export function EntryListContent({
                   key={`${e.author}-${e.permlink}`}
                   entry={e}
                   order={i}
-                  community={community}                />
+                  community={community}
+                />
               );
             }
             return [...l];

--- a/apps/web/src/features/shared/entry-list-content/index.tsx
+++ b/apps/web/src/features/shared/entry-list-content/index.tsx
@@ -14,7 +14,6 @@ interface Props {
   showEmptyPlaceholder?: boolean;
   account?: Account;
   community?: Community;
-  now?: number;
 }
 
 export function EntryListContent({
@@ -26,8 +25,7 @@ export function EntryListContent({
   username,
   showEmptyPlaceholder = true,
   account,
-  community,
-  now
+  community
 }: Props) {
   let dataToRender = [...entries];
 
@@ -49,9 +47,7 @@ export function EntryListContent({
                       entry={p}
                       promoted={true}
                       order={4}
-                      community={community}
-                      now={now}
-                    />
+                      community={community}                    />
                   );
                 }
               }
@@ -65,9 +61,7 @@ export function EntryListContent({
                   key={`${e.author}-${e.permlink}`}
                   entry={e}
                   order={i}
-                  community={community}
-                  now={now}
-                />
+                  community={community}                />
               );
             } else {
               l.push(
@@ -76,9 +70,7 @@ export function EntryListContent({
                   key={`${e.author}-${e.permlink}`}
                   entry={e}
                   order={i}
-                  community={community}
-                  now={now}
-                />
+                  community={community}                />
               );
             }
             return [...l];

--- a/apps/web/src/features/shared/entry-list-item/index.tsx
+++ b/apps/web/src/features/shared/entry-list-item/index.tsx
@@ -40,7 +40,6 @@ interface Props {
   order: number;
   account?: Account;
   filter?: string;
-  now?: number;
 }
 
 export function EntryListItemComponent({
@@ -50,8 +49,7 @@ export function EntryListItemComponent({
   account,
   promoted = false,
   order,
-  filter,
-  now
+  filter
 }: Props) {
   const pageAccount = account as FullAccount;
 
@@ -101,7 +99,7 @@ export function EntryListItemComponent({
             <>{entry.community_title || entry.category}</>
           </TagLink>
           <span className="read-mark ml-2" />
-          <TimeLabel created={entry.created} refresh={now} />
+          <TimeLabel created={entry.created} />
 
           <EntryListItemPollIcon entry={entryProp} />
         </div>

--- a/apps/web/src/features/shared/time-label/index.tsx
+++ b/apps/web/src/features/shared/time-label/index.tsx
@@ -1,12 +1,53 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import {
   dateToFormatted,
   dateToFormattedUtc,
   dateToFullRelative,
   dateToRelative,
 } from "@/utils";
+
+// ONE shared, ref-counted ticker for all relative TimeLabels. Previously the
+// feed threaded a `now` prop down and bumped it every 30s, which busted
+// React.memo on every card (a recurring long task). Here each relative TimeLabel
+// subscribes to a single module-level 60s interval via useSyncExternalStore, so
+// only the small <span>s re-render on a tick — not the cards — and there is
+// exactly one interval (started on first subscriber, cleared on last) with no
+// per-component interval leak across client navigations.
+const tickListeners = new Set<() => void>();
+let tickInterval: ReturnType<typeof setInterval> | null = null;
+let tickVersion = 0;
+
+function subscribeTick(cb: () => void) {
+  tickListeners.add(cb);
+  if (!tickInterval) {
+    tickInterval = setInterval(() => {
+      tickVersion += 1;
+      tickListeners.forEach((l) => l());
+    }, 60000);
+  }
+  return () => {
+    tickListeners.delete(cb);
+    if (tickListeners.size === 0 && tickInterval) {
+      clearInterval(tickInterval);
+      tickInterval = null;
+    }
+  };
+}
+const getTickSnapshot = () => tickVersion;
+const noopSubscribe = () => () => {};
+const getZero = () => 0;
+
+// Subscribe to the shared ticker only when the label is time-relative (absolute
+// dates never change, so they never tick / re-render).
+function useTick(active: boolean): number {
+  return useSyncExternalStore(
+    active ? subscribeTick : noopSubscribe,
+    active ? getTickSnapshot : getZero,
+    getZero
+  );
+}
 
 type Mode = "relative" | "fullRelative" | "absolute";
 
@@ -40,6 +81,10 @@ export function TimeLabel({
   const [display, setDisplay] = useState<string | null>(null);
   const [localFormatted, setLocalFormatted] = useState<string | null>(null);
 
+  // Self-tick: re-runs the formatting effect ~once a minute for relative modes,
+  // so timestamps stay fresh without the parent re-rendering the whole card.
+  const tick = useTick(mode === "relative" || mode === "fullRelative");
+
   // Numeric UTC — identical on server and client, no hydration mismatch.
   const ssrSafe = dateToFormattedUtc(created);
 
@@ -48,7 +93,9 @@ export function TimeLabel({
     if (mode === "absolute") setDisplay(dateToFormatted(created, format));
     else if (mode === "fullRelative") setDisplay(dateToFullRelative(created));
     else setDisplay(dateToRelative(created));
-  }, [created, refresh, mode, format]);
+    // `refresh` is still honored (waves drives its own ticker); `tick` is the
+    // shared self-ticker.
+  }, [created, refresh, mode, format, tick]);
 
   return (
     <span className={className} title={localFormatted ?? ssrSafe} suppressHydrationWarning>


### PR DESCRIPTION
Replaces the feed's 30s `now`-prop fan-out with a single shared ticker, so the recurring all-card re-render (an INP-spiking long task) is gone. No SSR/SEO/CLS change.

## Problem
`FeedLayout` kept a `now` state, bumped it every 30s, and `cloneElement`-injected it into every child card → each card's `TimeLabel` got a new `refresh` prop → **React.memo busted on all ~20 cards every 30s** (a recurring long task that spikes INP).

## Change
A **single shared, ref-counted ticker inside `TimeLabel`** (`useSyncExternalStore`, 60s). Only the relative-timestamp `<span>`s re-render on a tick now, not the cards. Exactly one interval (started on first subscriber, cleared on last), no per-component leak across navigations. Absolute-mode labels don't subscribe. The `now` prop is removed from `feed-layout` / `feed-list` / `entry-list-content` / `entry-list-item`.
- The separate **30s data refresh** (stats update + "N new posts" pill) is unchanged.
- `TimeLabel` still honors the `refresh` prop, which the **waves** feed drives via its own ticker.

## Testing
- `pnpm build` passes; full suite **1,582 pass** (incl. `time-label.spec`); tsc at baseline.

## Scope note
The per-card pin-fetch optimization was dropped from this PR after review (`entry.stats.is_pinned` isn't reliable for community-context pin state when a post is viewed outside its community feed). It'll be revisited as a deferred (kebab-open) lookup. `content-visibility`, the menu-build defer, the `usePostsFeedQuery` dedupe, and per-card observer collapse remain follow-ups; the hydrate-on-visible island is the separate load-bearing feed-TBT fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved feed interface performance by optimizing how time-dependent elements are updated and rendered, reducing redundant processing while preserving all existing functionality and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->