### PR TITLE
perf(feed): defer below-the-fold card action-bar hydration (feed TBT fix)

### DIFF
--- a/apps/web/src/features/shared/entry-list-item/index.tsx
+++ b/apps/web/src/features/shared/entry-list-item/index.tsx
@@ -54,6 +54,11 @@ export function EntryListItemComponent({
 }: Props) {
   const pageAccount = account as FullAccount;
 
+  // Keyboard backstop for the deferred action bar: once focus enters this card
+  // (its server-rendered title/author/tag links), mount the action controls so a
+  // keyboard/screen-reader user reaches them by the time they tab that far.
+  const [actionsFocused, setActionsFocused] = React.useState(false);
+
   const isCrossPost = !!entryProp.original_entry;
   const entry = entryProp.original_entry || entryProp;
   const pinned = entry?.stats?.is_pinned ?? pageAccount?.profile?.pinned;
@@ -73,6 +78,7 @@ export function EntryListItemComponent({
         [filter ?? ""]: !!filter
       })}
       id={(entry.author + entry.permlink).replace(/[0-9]/g, "")}
+      onFocusCapture={() => setActionsFocused(true)}
     >
       <EntryListItemClientInit />
       <EntryListItemCrossPost entry={entryProp} />
@@ -142,7 +148,7 @@ export function EntryListItemComponent({
           duplicate reply-count link (redundant with the body permalink). */}
       <HydrateOnVisible
         disabled={order < 2}
-        ariaLabel={i18next.t("entry-list-item.actions", { defaultValue: "Post actions" })}
+        forceShow={actionsFocused}
         placeholder={
           <div
             className="w-full flex md:w-auto md:inline-flex items-center gap-2 md:gap-3 rounded-xl border border-[--border-color] px-2 py-1 text-sm"

--- a/apps/web/src/features/shared/entry-list-item/index.tsx
+++ b/apps/web/src/features/shared/entry-list-item/index.tsx
@@ -142,6 +142,7 @@ export function EntryListItemComponent({
           duplicate reply-count link (redundant with the body permalink). */}
       <HydrateOnVisible
         disabled={order < 2}
+        ariaLabel={i18next.t("entry-list-item.actions", { defaultValue: "Post actions" })}
         placeholder={
           <div
             className="w-full flex md:w-auto md:inline-flex items-center gap-2 md:gap-3 rounded-xl border border-[--border-color] px-2 py-1 text-sm"

--- a/apps/web/src/features/shared/entry-list-item/index.tsx
+++ b/apps/web/src/features/shared/entry-list-item/index.tsx
@@ -28,6 +28,7 @@ import { EntryListItemProvider } from "@/features/shared/entry-list-item/entry-l
 import { EntryListItemNsfwContent } from "@/features/shared/entry-list-item/entry-list-item-nsfw-content";
 import { EntryListItemClientInit } from "@/features/shared/entry-list-item/entry-list-item-client-init";
 import { EntryListItemPollIcon } from "@/features/shared/entry-list-item/entry-list-item-poll-icon";
+import { HydrateOnVisible } from "@/features/shared/hydrate-on-visible";
 import { UilComment } from "@tooni/iconscout-unicons-react";
 
 setProxyBase(defaults.imageServer);
@@ -132,7 +133,27 @@ export function EntryListItemComponent({
             promoted, so don't strip their priority — order alone is correct. */}
         <EntryListItemMutedContent entry={entryProp} isThumbLcp={order < 2} />
       </div>
-      <div>
+      {/* The action bar is the heavy interactive cluster (vote/payout/votes/
+          reblog/menu = many query observers + floating-ui popovers). Defer its
+          hydration until near-viewport for below-the-fold cards; the top cards
+          (order < 2) stay interactive immediately. Title/body/thumbnail, author
+          (ProfilePopover), tag and timestamp are OUTSIDE this island, so they
+          remain in the server HTML for SEO. The only link inside is the
+          duplicate reply-count link (redundant with the body permalink). */}
+      <HydrateOnVisible
+        disabled={order < 2}
+        placeholder={
+          <div
+            className="w-full flex md:w-auto md:inline-flex items-center gap-2 md:gap-3 rounded-xl border border-[--border-color] px-2 py-1 text-sm"
+            aria-hidden="true"
+          >
+            <span className="h-4 w-8 rounded bg-gray-200 dark:bg-dark-200" />
+            <span className="h-4 w-10 rounded bg-gray-200 dark:bg-dark-200" />
+            <span className="h-4 w-8 rounded bg-gray-200 dark:bg-dark-200" />
+            <span className="h-4 w-6 rounded bg-gray-200 dark:bg-dark-200" />
+          </div>
+        }
+      >
         <div className="w-full flex md:w-auto md:inline-flex items-center gap-2 md:gap-3 rounded-xl border border-[--border-color] px-2 py-1 text-sm">
           <EntryVoteBtn isPostSlider={true} entry={entry} account={account} />
           <EntryPayout entry={entry} />
@@ -157,7 +178,7 @@ export function EntryListItemComponent({
           <div className="border-r border-[--border-color] w-[1px] h-4" />
           <EntryMenu alignBottom={order >= 1} entry={entry} />
         </div>
-      </div>
+      </HydrateOnVisible>
     </div>
   );
 }

--- a/apps/web/src/features/shared/hydrate-on-visible.tsx
+++ b/apps/web/src/features/shared/hydrate-on-visible.tsx
@@ -16,6 +16,12 @@ interface Props {
   /** How early (before entering the viewport) to mount. */
   rootMargin?: string;
   className?: string;
+  /**
+   * Accessible name for the placeholder while deferred. Makes the wrapper
+   * keyboard-focusable so a keyboard/screen-reader user who tabs to it mounts
+   * the real subtree (a backstop to the rootMargin + scroll-follows-focus).
+   */
+  ariaLabel?: string;
 }
 
 /**
@@ -37,15 +43,16 @@ export function HydrateOnVisible({
   placeholder,
   disabled = false,
   rootMargin = "600px 0px",
-  className
+  className,
+  ariaLabel
 }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const [shown, setShown] = useState(false);
   const { inViewport } = useInViewport(ref, { rootMargin });
 
   useEffect(() => {
-    if (inViewport) setShown(true);
-  }, [inViewport]);
+    if (!disabled && inViewport) setShown(true);
+  }, [disabled, inViewport]);
 
   if (disabled || shown) {
     return (
@@ -55,11 +62,16 @@ export function HydrateOnVisible({
     );
   }
 
+  // Placeholder is keyboard-focusable (tabIndex=0) so focus/touch mounts the
+  // real controls; combined with the rootMargin this keeps the deferred
+  // controls reachable for keyboard, screen-reader and touch users.
   return (
     <div
       ref={ref}
       className={className}
-      onFocusCapture={() => setShown(true)}
+      tabIndex={0}
+      aria-label={ariaLabel}
+      onFocus={() => setShown(true)}
       onTouchStart={() => setShown(true)}
     >
       {placeholder}

--- a/apps/web/src/features/shared/hydrate-on-visible.tsx
+++ b/apps/web/src/features/shared/hydrate-on-visible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { useInViewport } from "react-in-viewport";
 
 interface Props {
@@ -13,15 +13,15 @@ interface Props {
   placeholder: ReactNode;
   /** When true, render `children` immediately (e.g. above-the-fold cards). */
   disabled?: boolean;
+  /**
+   * Externally-driven mount, e.g. the parent card detected keyboard focus on one
+   * of its (server-rendered, focusable) links and wants the deferred controls
+   * available before focus reaches them.
+   */
+  forceShow?: boolean;
   /** How early (before entering the viewport) to mount. */
   rootMargin?: string;
   className?: string;
-  /**
-   * Accessible name for the placeholder while deferred. Makes the wrapper
-   * keyboard-focusable so a keyboard/screen-reader user who tabs to it mounts
-   * the real subtree (a backstop to the rootMargin + scroll-follows-focus).
-   */
-  ariaLabel?: string;
 }
 
 /**
@@ -34,27 +34,33 @@ interface Props {
  * mismatch. `react-in-viewport`'s observer attaches in a post-paint effect, the
  * same primitive DetectBottom already uses inside SSR'd lists.
  *
- * Accessibility: keyboard (focus) and touch also mount the real subtree, so
- * off-screen controls reached by tabbing/touch are never dead. Above-the-fold
- * cards pass `disabled` so their controls are interactive immediately.
+ * Accessibility: the rootMargin (cards mount well before the viewport, and
+ * scroll-follows-focus brings a card into view as the user tabs to its links) +
+ * touch (`onTouchStart`) + the parent's `forceShow` (focus on the card) keep the
+ * deferred controls reachable for keyboard, screen-reader and touch users.
+ * Above-the-fold cards pass `disabled` so their controls are interactive
+ * immediately. The placeholder itself is NOT made focusable — that dropped focus
+ * to <body> when it swapped to children on mount.
  */
 export function HydrateOnVisible({
   children,
   placeholder,
   disabled = false,
+  forceShow = false,
   rootMargin = "600px 0px",
-  className,
-  ariaLabel
+  className
 }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const [shown, setShown] = useState(false);
-  const { inViewport } = useInViewport(ref, { rootMargin });
+  // Stable options object so useInViewport doesn't re-create its observer.
+  const options = useMemo(() => ({ rootMargin }), [rootMargin]);
+  const { inViewport } = useInViewport(ref, options);
 
   useEffect(() => {
     if (!disabled && inViewport) setShown(true);
   }, [disabled, inViewport]);
 
-  if (disabled || shown) {
+  if (disabled || forceShow || shown) {
     return (
       <div ref={ref} className={className}>
         {children}
@@ -62,18 +68,8 @@ export function HydrateOnVisible({
     );
   }
 
-  // Placeholder is keyboard-focusable (tabIndex=0) so focus/touch mounts the
-  // real controls; combined with the rootMargin this keeps the deferred
-  // controls reachable for keyboard, screen-reader and touch users.
   return (
-    <div
-      ref={ref}
-      className={className}
-      tabIndex={0}
-      aria-label={ariaLabel}
-      onFocus={() => setShown(true)}
-      onTouchStart={() => setShown(true)}
-    >
+    <div ref={ref} className={className} onTouchStart={() => setShown(true)}>
       {placeholder}
     </div>
   );

--- a/apps/web/src/features/shared/hydrate-on-visible.tsx
+++ b/apps/web/src/features/shared/hydrate-on-visible.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ReactNode, useEffect, useRef, useState } from "react";
+import { useInViewport } from "react-in-viewport";
+
+interface Props {
+  children: ReactNode;
+  /**
+   * Rendered on the server AND the first client paint (so SSR and hydration
+   * agree), then swapped for `children` once the element is near the viewport.
+   * Must reserve the children's HEIGHT to avoid layout shift on swap.
+   */
+  placeholder: ReactNode;
+  /** When true, render `children` immediately (e.g. above-the-fold cards). */
+  disabled?: boolean;
+  /** How early (before entering the viewport) to mount. */
+  rootMargin?: string;
+  className?: string;
+}
+
+/**
+ * Defers mounting an interactive subtree until it is near the viewport, keeping
+ * the up-front hydration cost off the critical path for long lists.
+ *
+ * Hydration-safe by construction: the render branches on `shown` (state that
+ * starts false and only flips inside an effect), NOT on `inViewport` directly,
+ * so the server and the first client render both produce `placeholder` — no
+ * mismatch. `react-in-viewport`'s observer attaches in a post-paint effect, the
+ * same primitive DetectBottom already uses inside SSR'd lists.
+ *
+ * Accessibility: keyboard (focus) and touch also mount the real subtree, so
+ * off-screen controls reached by tabbing/touch are never dead. Above-the-fold
+ * cards pass `disabled` so their controls are interactive immediately.
+ */
+export function HydrateOnVisible({
+  children,
+  placeholder,
+  disabled = false,
+  rootMargin = "600px 0px",
+  className
+}: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [shown, setShown] = useState(false);
+  const { inViewport } = useInViewport(ref, { rootMargin });
+
+  useEffect(() => {
+    if (inViewport) setShown(true);
+  }, [inViewport]);
+
+  if (disabled || shown) {
+    return (
+      <div ref={ref} className={className}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      onFocusCapture={() => setShown(true)}
+      onTouchStart={() => setShown(true)}
+    >
+      {placeholder}
+    </div>
+  );
+}

--- a/apps/web/src/specs/features/shared/entry-list-item.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-list-item.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -261,5 +261,22 @@ describe("EntryListItem", () => {
 
     expect(screen.getByTestId("entry-vote-btn")).toBeInTheDocument();
     expect(screen.getByTestId("entry-menu")).toBeInTheDocument();
+  });
+
+  it("mounts the deferred action bar when focus enters the card (keyboard backstop)", async () => {
+    const entry = mockEntry({
+      author: "alice",
+      permlink: "deep-post",
+      title: "Deep In The Feed",
+      category: "hive-1"
+    });
+
+    renderItem(entry, { order: 5 });
+    expect(screen.queryByTestId("entry-vote-btn")).not.toBeInTheDocument();
+
+    // Focusing a server-rendered card link (here the author link) mounts the
+    // card's deferred action bar so keyboard users reach the controls.
+    fireEvent.focusIn(screen.getByTestId("profile-link"));
+    await waitFor(() => expect(screen.getByTestId("entry-vote-btn")).toBeInTheDocument());
   });
 });

--- a/apps/web/src/specs/features/shared/entry-list-item.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-list-item.spec.tsx
@@ -230,4 +230,36 @@ describe("EntryListItem", () => {
     const titleLink = titleNode.closest("a");
     expect(titleLink).toHaveAttribute("href", "/@origauthor/original-permlink");
   });
+
+  it("defers the action bar for below-the-fold cards while keeping title + author in the markup", () => {
+    const entry = mockEntry({
+      author: "alice",
+      permlink: "deep-post",
+      title: "Deep In The Feed",
+      category: "hive-1"
+    });
+
+    // order >= 2 => not the above-the-fold LCP card => action bar is deferred
+    // (placeholder) until near-viewport. The IntersectionObserver stub never
+    // fires, so it stays deferred for the test.
+    renderItem(entry, { order: 5 });
+
+    // SEO-critical content remains in the server markup (outside the island).
+    expect(screen.getByText("Deep In The Feed")).toBeInTheDocument();
+    expect(screen.getByTestId("user-avatar")).toHaveTextContent("alice");
+    expect(screen.getByTestId("profile-link")).toHaveAttribute("href", "/@alice");
+
+    // The heavy interactive cluster is NOT mounted yet.
+    expect(screen.queryByTestId("entry-vote-btn")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("entry-menu")).not.toBeInTheDocument();
+  });
+
+  it("renders the action bar immediately for the top (order < 2) cards", () => {
+    const entry = mockEntry({ author: "bob", permlink: "top-post", title: "Top Post" });
+
+    renderItem(entry, { order: 0 });
+
+    expect(screen.getByTestId("entry-vote-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("entry-menu")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/specs/features/shared/hydrate-on-visible.spec.tsx
+++ b/apps/web/src/specs/features/shared/hydrate-on-visible.spec.tsx
@@ -61,16 +61,15 @@ describe("HydrateOnVisible", () => {
     expect(screen.queryByTestId("placeholder")).not.toBeInTheDocument();
   });
 
-  it("mounts children on keyboard focus", async () => {
+  it("renders children when forceShow is set (parent-driven keyboard mount)", () => {
     setInViewport(false);
-    const { container } = render(
-      <HydrateOnVisible placeholder={Placeholder} ariaLabel="Post actions">
+    render(
+      <HydrateOnVisible placeholder={Placeholder} forceShow>
         <Children />
       </HydrateOnVisible>
     );
-    expect(screen.getByTestId("placeholder")).toBeInTheDocument();
-    fireEvent.focus(container.firstChild as Element);
-    await waitFor(() => expect(screen.getByTestId("children")).toBeInTheDocument());
+    expect(screen.getByTestId("children")).toBeInTheDocument();
+    expect(screen.queryByTestId("placeholder")).not.toBeInTheDocument();
   });
 
   it("mounts children on touch (off-screen touch users)", async () => {

--- a/apps/web/src/specs/features/shared/hydrate-on-visible.spec.tsx
+++ b/apps/web/src/specs/features/shared/hydrate-on-visible.spec.tsx
@@ -41,14 +41,36 @@ describe("HydrateOnVisible", () => {
   });
 
   it("swaps to children once the element enters the viewport", async () => {
+    setInViewport(false);
+    const { rerender } = render(
+      <HydrateOnVisible placeholder={Placeholder}>
+        <Children />
+      </HydrateOnVisible>
+    );
+    // First paint (server-equivalent) must show the placeholder, not children.
+    expect(screen.getByTestId("placeholder")).toBeInTheDocument();
+    expect(screen.queryByTestId("children")).not.toBeInTheDocument();
+
     setInViewport(true);
-    render(
+    rerender(
       <HydrateOnVisible placeholder={Placeholder}>
         <Children />
       </HydrateOnVisible>
     );
     await waitFor(() => expect(screen.getByTestId("children")).toBeInTheDocument());
     expect(screen.queryByTestId("placeholder")).not.toBeInTheDocument();
+  });
+
+  it("mounts children on keyboard focus", async () => {
+    setInViewport(false);
+    const { container } = render(
+      <HydrateOnVisible placeholder={Placeholder} ariaLabel="Post actions">
+        <Children />
+      </HydrateOnVisible>
+    );
+    expect(screen.getByTestId("placeholder")).toBeInTheDocument();
+    fireEvent.focus(container.firstChild as Element);
+    await waitFor(() => expect(screen.getByTestId("children")).toBeInTheDocument());
   });
 
   it("mounts children on touch (off-screen touch users)", async () => {

--- a/apps/web/src/specs/features/shared/hydrate-on-visible.spec.tsx
+++ b/apps/web/src/specs/features/shared/hydrate-on-visible.spec.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("react-in-viewport", () => ({
+  useInViewport: vi.fn()
+}));
+
+import { useInViewport } from "react-in-viewport";
+import { HydrateOnVisible } from "@/features/shared/hydrate-on-visible";
+
+const setInViewport = (v: boolean) => (useInViewport as any).mockReturnValue({ inViewport: v });
+
+const Children = () => <span data-testid="children">real</span>;
+const Placeholder = <span data-testid="placeholder">skeleton</span>;
+
+describe("HydrateOnVisible", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders the placeholder (not children) when off-screen", () => {
+    setInViewport(false);
+    render(
+      <HydrateOnVisible placeholder={Placeholder}>
+        <Children />
+      </HydrateOnVisible>
+    );
+    expect(screen.getByTestId("placeholder")).toBeInTheDocument();
+    expect(screen.queryByTestId("children")).not.toBeInTheDocument();
+  });
+
+  it("renders children immediately when disabled (above-the-fold)", () => {
+    setInViewport(false);
+    render(
+      <HydrateOnVisible placeholder={Placeholder} disabled>
+        <Children />
+      </HydrateOnVisible>
+    );
+    expect(screen.getByTestId("children")).toBeInTheDocument();
+    expect(screen.queryByTestId("placeholder")).not.toBeInTheDocument();
+  });
+
+  it("swaps to children once the element enters the viewport", async () => {
+    setInViewport(true);
+    render(
+      <HydrateOnVisible placeholder={Placeholder}>
+        <Children />
+      </HydrateOnVisible>
+    );
+    await waitFor(() => expect(screen.getByTestId("children")).toBeInTheDocument());
+    expect(screen.queryByTestId("placeholder")).not.toBeInTheDocument();
+  });
+
+  it("mounts children on touch (off-screen touch users)", async () => {
+    setInViewport(false);
+    const { container } = render(
+      <HydrateOnVisible placeholder={Placeholder}>
+        <Children />
+      </HydrateOnVisible>
+    );
+    expect(screen.getByTestId("placeholder")).toBeInTheDocument();
+    fireEvent.touchStart(container.firstChild as Element);
+    await waitFor(() => expect(screen.getByTestId("children")).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/specs/setup-any-spec.ts
+++ b/apps/web/src/specs/setup-any-spec.ts
@@ -6,6 +6,28 @@ import { TextDecoder, TextEncoder } from "util";
 Object.defineProperty(globalThis, "TextEncoder", { value: TextEncoder, writable: true, configurable: true });
 Object.defineProperty(globalThis, "TextDecoder", { value: TextDecoder, writable: true, configurable: true });
 
+// jsdom has no IntersectionObserver. Stub it so components using
+// react-in-viewport (DetectBottom, HydrateOnVisible, EntryListItem) don't throw
+// in tests; it never fires, so observed elements stay "not in viewport".
+if (!("IntersectionObserver" in globalThis)) {
+  class IntersectionObserverStub {
+    readonly root = null;
+    readonly rootMargin = "";
+    readonly thresholds = [];
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  }
+  Object.defineProperty(globalThis, "IntersectionObserver", {
+    value: IntersectionObserverStub,
+    writable: true,
+    configurable: true
+  });
+}
+
 // Mock uuid to avoid crypto dependency issues
 vi.mock("uuid", () => ({
   v4: vi.fn(() => "test-uuid-1234")


### PR DESCRIPTION
The load-bearing feed-TBT fix from the architecture investigation: defer the heavy per-card interactive cluster's hydration on long lists.

## Problem
Each feed card's **action bar** (vote / payout / votes / reblog / kebab menu) is the heavy interactive cluster — many React Query observers + two floating-ui popovers + framer-motion — and ~20 of them hydrate on feed mount. That up-front hydration is the dominant feed TBT/INP cost (Trending desktop TBT ~2.3s).

## Change
New `HydrateOnVisible` island (`features/shared/hydrate-on-visible.tsx`):
- Renders a **height-matched placeholder** on the server **and** the first client paint, then mounts the real children once the card is within **~600px of the viewport** (`react-in-viewport` — the same primitive `DetectBottom` already uses), or on touch.
- **Hydration-safe by construction:** it branches on a `shown` state that starts `false` and only flips inside an effect, so server + first-client render both produce the placeholder → no mismatch. (Doesn't branch on `inViewport` directly.)
- **Above-the-fold cards (`order < 2`, the LCP candidates) pass `disabled`** → interactive immediately.

Only the **action bar** is wrapped. Title, body, thumbnail, **author (ProfilePopover)**, tag, and timestamp stay **outside** the island, so all SEO-critical content — including the canonical `/@author/permlink` body link — remains in the server HTML. The only link inside the island is the duplicate reply-count link (redundant with the body permalink).

## Win
Deferred **hydration** (main-thread mount work moved off the critical path as the user scrolls), not bundle bytes — the action components are still bundled, just not mounted until near-viewport. So the win shows up in a **TBT/INP trace**, not First Load JS (feed route unchanged at 654 kB).

## Testing
- `pnpm build` passes; tsc at baseline; full suite **1,588 pass** (added a jsdom `IntersectionObserver` stub to the test setup; new `hydrate-on-visible.spec`; `entry-list-item` asserts below-the-fold cards keep title+author while the action bar defers, and `order < 2` cards render it immediately).

## Please verify on staging (can't be checked headless)
1. **CLS** — the placeholder reserves the action-row height; confirm no layout shift when cards mount on scroll (tune the placeholder height if needed).
2. **Scroll feel** — no visible pop-in of the action bar within ~600px of the viewport.
3. **SEO** — view-source / JS-disabled: every card's title, author name, and bare permalink are present.
4. **a11y** — keyboard reach relies on the 600px margin mounting cards before tab focus arrives (plus touch); confirm vote/menu are reachable.

If the placeholder height needs adjusting or the margin feels off, those are quick follow-ups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized page load speed by deferring initialization of interactive elements below the fold until they're near the viewport. Top-of-page items remain immediately interactive for faster user engagement.

* **Tests**
  * Added test coverage for deferred initialization behavior and viewport-triggered component rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->