### PR TITLE
perf(navbar): lazy-load sidebar search to evict the search graph from the eager bundle

### DIFF
--- a/apps/web/src/features/shared/navbar/navbar-main-sidebar.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-main-sidebar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   UilCloudComputing,
   UilColumns,
@@ -18,7 +20,7 @@ import { Button } from "@ui/button";
 import i18next from "i18next";
 import { closeSvg } from "@ui/svg";
 import { SwitchLang } from "@/features/shared";
-import { Search } from "@/features/shared/navbar/search";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { ModalSidebar } from "@ui/modal/modal-sidebar";
@@ -27,6 +29,16 @@ import defaults from "@/defaults";
 import { useHydrated } from "@/api/queries";
 import { useMattermostUnread } from "@/features/chat/mattermost-api";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+
+// The full search experience (suggester + transfer/gallery/bookmarks graph) is
+// heavy and only appears inside the opened main sidebar, so load it as a
+// separate chunk instead of eagerly on every route. This was the last static
+// importer of the search module keeping it in the eager navbar/layout bundle;
+// the desktop and mobile navbar searches are already dynamic.
+const Search = dynamic(
+  () => import("@/features/shared/navbar/search").then((m) => ({ default: m.Search })),
+  { ssr: false }
+);
 
 interface Props {
   show: boolean;


### PR DESCRIPTION
Closes the remaining static-import leak of the navbar search graph flagged in earlier perf review.

## Problem
`navbar-main-sidebar.tsx` statically imported the full `Search` component. The main sidebar is mounted by **both** `navbar-desktop` and `navbar-mobile`, so this was the **last** static importer keeping the heavy search graph (search-suggester + search-box + the transfer/gallery dependency tree) in the eager `/layout` + home first-load bundle on every route - even though the desktop and mobile navbar searches were already split via `next/dynamic`.

## Change
Make the sidebar `Search` a `next/dynamic(..., { ssr: false })` import (same pattern as `navbar-desktop`/`navbar-mobile`). Added an explicit `"use client"` directive to the file - it already used client-only hooks (`useRouter`, `useActiveAccount`, `useHydrated`), and the directive makes the `ssr: false` dynamic import unambiguous.

## Verification (ANALYZE build)
After the change, these all **leave** the eager `/` + `/layout` first-load:
- `search-suggester` - absent
- `search-box` / `SearchBox` - absent
- `transfer/transfer-dialog` - absent
- `navbar/search` - absent

Homepage `/` First Load JS: **719 -> 673 kB (-46 kB)**. Full suite: **1,582 pass**; tsc at baseline; build green.

## Out of scope (follow-up)
`GalleryDialog` / `action-my-bookmarks` strings still appear in eager chunks, but they are pulled by the **separate** sidebar create/gallery menu (`navbar-side-main-menu.tsx`) and the editor toolbars - not the search component. Splitting those is a separate change.
