### PR TITLE
feat(home): lead the hero with the Ecency wordmark instead of the logo mark

### DIFF
--- a/apps/web/src/app/_components/landing-page/index.tsx
+++ b/apps/web/src/app/_components/landing-page/index.tsx
@@ -90,14 +90,12 @@ export async function LandingPage() {
       {/* HERO — fully server-rendered, the LCP element */}
       <section className="relative overflow-hidden bg-gradient-to-b from-blue-duck-egg to-blue-dark-sky-030 dark:from-dark-default dark:to-dark-200">
         <div className="max-w-[1000px] mx-auto px-4 pt-14 pb-12 md:pt-24 md:pb-16 text-center">
-          <img
-            src={defaults.logo}
-            alt={defaults.name}
-            width={64}
-            height={64}
-            className="mx-auto mb-6 h-14 w-14 md:h-16 md:w-16"
-            fetchPriority="high"
-          />
+          {/* Brand wordmark instead of the logo mark — the navbar already
+              carries the logo, so the hero leads with the name as text. Text
+              keeps the hero an all-text LCP (no image request). */}
+          <p className="mb-5 font-extrabold tracking-tight text-blue-dark-sky dark:text-gray-pinkish text-3xl md:text-4xl">
+            {defaults.name}
+          </p>
           <h1 className="font-extrabold tracking-tight leading-[1.05] text-blue-dark-sky dark:text-gray-pinkish text-[2rem] sm:text-5xl md:text-6xl">
             {t("landing-page.hero-title")}
           </h1>

--- a/apps/web/src/app/_components/landing-page/index.tsx
+++ b/apps/web/src/app/_components/landing-page/index.tsx
@@ -93,7 +93,7 @@ export async function LandingPage() {
           {/* Brand wordmark instead of the logo mark — the navbar already
               carries the logo, so the hero leads with the name as text. Text
               keeps the hero an all-text LCP (no image request). */}
-          <p className="mb-5 font-extrabold tracking-tight text-blue-dark-sky dark:text-gray-pinkish text-3xl md:text-4xl">
+          <p className="mb-4 font-extrabold tracking-tight text-blue-dark-sky dark:text-gray-pinkish text-xl sm:text-2xl md:text-3xl">
             {defaults.name}
           </p>
           <h1 className="font-extrabold tracking-tight leading-[1.05] text-blue-dark-sky dark:text-gray-pinkish text-[2rem] sm:text-5xl md:text-6xl">


### PR DESCRIPTION
## Change
The homepage hero led with the circular logo mark above the headline. Since the navbar already carries the logo, the hero now leads with the **Ecency wordmark as text** instead.

Before: `<img src={logo}>` (64x64, `fetchPriority="high"`) -> headline -> subtitle
After: **Ecency** wordmark (brand-colored, theme-aware) -> headline -> subtitle

## Why
- Removes the redundant logo (navbar already shows it).
- Keeps the hero an **all-text LCP** - drops the high-priority hero image request entirely, so the above-the-fold paint no longer waits on the logo asset.
- Wordmark is sized below the `<h1>` headline, so the headline remains the visual hero / LCP element.

Text only; build green, tsc at baseline, full suite passes. Worth a quick look on staging in both light and dark themes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The landing page hero now displays the brand name as text instead of the logo image, while maintaining the existing title, description, call-to-action, and statistics sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->