### PR TITLE
perf(navbar): defer the 5 sidebar user dialogs out of the eager navbar chunk

### DIFF
--- a/apps/web/src/features/shared/navbar/sidebar/navbar-side-main-menu.tsx
+++ b/apps/web/src/features/shared/navbar/sidebar/navbar-side-main-menu.tsx
@@ -1,12 +1,7 @@
 import { EcencyConfigManager } from "@/config";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useGlobalStore } from "@/core/global-store";
-import { BookmarksDialog } from "@/features/shared/bookmarks";
-import { DraftsDialog } from "@/features/shared/drafts";
-import { FragmentsDialog } from "@/features/shared/fragments";
-import { GalleryDialog } from "@/features/shared/gallery";
 import { preloadLoginDialog } from "@/features/shared";
-import { SchedulesDialog } from "@/features/shared/schedules";
 import {
   UilArchive,
   UilClock,
@@ -34,6 +29,33 @@ const MobileLoginQrDialog = dynamic(
   () => import("../../mobile-login-qr").then((m) => m.MobileLoginQrDialog),
   // The dialog renders its own modal/spinner once mounted; render nothing while
   // the (small) chunk streams in rather than an out-of-context placeholder.
+  { ssr: false, loading: () => null }
+);
+
+// These user dialogs are reachable only after the user opens the sidebar menu
+// and clicks the matching item. A static import would bundle all five graphs
+// (gallery/drafts/bookmarks/schedules/fragments) into the shared navbar chunk
+// that loads on every route - including read-only pages where they are never
+// used. Defer them; each render is gated on its open flag below, so the chunk
+// is fetched on first open, not on page load. Mirrors MobileLoginQrDialog.
+const GalleryDialog = dynamic(
+  () => import("@/features/shared/gallery").then((m) => m.GalleryDialog),
+  { ssr: false, loading: () => null }
+);
+const DraftsDialog = dynamic(
+  () => import("@/features/shared/drafts").then((m) => m.DraftsDialog),
+  { ssr: false, loading: () => null }
+);
+const BookmarksDialog = dynamic(
+  () => import("@/features/shared/bookmarks").then((m) => m.BookmarksDialog),
+  { ssr: false, loading: () => null }
+);
+const SchedulesDialog = dynamic(
+  () => import("@/features/shared/schedules").then((m) => m.SchedulesDialog),
+  { ssr: false, loading: () => null }
+);
+const FragmentsDialog = dynamic(
+  () => import("@/features/shared/fragments").then((m) => m.FragmentsDialog),
   { ssr: false, loading: () => null }
 );
 
@@ -167,31 +189,37 @@ export function NavbarSideMainMenu({ onHide }: Props) {
       <EcencyConfigManager.Conditional
         condition={({ visionFeatures }) => visionFeatures.gallery.enabled}
       >
-        <GalleryDialog setShow={(v) => setGallery(v)} show={gallery} />
+        {gallery && <GalleryDialog setShow={(v) => setGallery(v)} show={gallery} />}
       </EcencyConfigManager.Conditional>
 
       <EcencyConfigManager.Conditional
         condition={({ visionFeatures }) => visionFeatures.drafts.enabled}
       >
-        <DraftsDialog show={drafts} setShow={(v) => setDrafts(v)} />
+        {drafts && <DraftsDialog show={drafts} setShow={(v) => setDrafts(v)} />}
       </EcencyConfigManager.Conditional>
 
       <EcencyConfigManager.Conditional
         condition={({ visionFeatures }) => visionFeatures.bookmarks.enabled}
       >
-        <BookmarksDialog show={bookmarks && !!activeUser} setShow={(v) => setBookmarks(v)} />
+        {bookmarks && (
+          <BookmarksDialog show={bookmarks && !!activeUser} setShow={(v) => setBookmarks(v)} />
+        )}
       </EcencyConfigManager.Conditional>
 
       <EcencyConfigManager.Conditional
         condition={({ visionFeatures }) => visionFeatures.schedules.enabled}
       >
-        <SchedulesDialog show={schedules && !!activeUser} setShow={(v) => setSchedules(v)} />
+        {schedules && (
+          <SchedulesDialog show={schedules && !!activeUser} setShow={(v) => setSchedules(v)} />
+        )}
       </EcencyConfigManager.Conditional>
 
       <EcencyConfigManager.Conditional
         condition={({ visionFeatures }) => visionFeatures.fragments.enabled}
       >
-        <FragmentsDialog show={fragments && !!activeUser} setShow={(v) => setFragments(v)} />
+        {fragments && (
+          <FragmentsDialog show={fragments && !!activeUser} setShow={(v) => setFragments(v)} />
+        )}
       </EcencyConfigManager.Conditional>
 
       {mobileLogin && (


### PR DESCRIPTION
Follow-up to #958 (sidebar Search defer), from the verified next-levers investigation.

## Problem
`navbar-side-main-menu.tsx` statically imported five user dialogs - `GalleryDialog`, `DraftsDialog`, `BookmarksDialog`, `SchedulesDialog`, `FragmentsDialog`. The sidebar mounts inside the **global navbar on every route**, so all five dialog graphs (each with its own list/management subtree) shipped in the **shared navbar chunk** of the first-load bundle - on the homepage and read-only post pages too, where they are never opened.

The existing `activeUser` / `EcencyConfigManager.Conditional` render guards do **not** keep them out of the bundle: a static `import` bundles the module whether or not it ever renders.

## Change
Convert all five to `next/dynamic(() => import(...).then(m => m.X), { ssr: false, loading: () => null })` - the exact pattern already used by `MobileLoginQrDialog` in this same file - and gate each render on its open flag (`{gallery && <GalleryDialog .../>}`, etc.) so the chunk is fetched on **first open**, not on page load. Behavior is otherwise unchanged (the dialogs are modals that already controlled their own visibility via `show`).

## Verification (ANALYZE build)
The heavy dialog bodies all **leave** the eager `/` + `/layout` first-load:
- `gallery-list`, `drafts-list`, `bookmarks-list`, `schedules-list`, `fragments-list` - all **absent** from eager chunks (only the dynamic-import name references remain).

Homepage `/` First Load JS: **674 -> 641 kB (-33 kB)**, and because this is the global navbar chunk the saving applies to **every route**. Full suite **1,590 pass**; tsc at baseline; build green.

## Note
These dialogs are also statically imported by the editor/deck/submit/publish toolbars - those routes legitimately use them and will continue to bundle them in their own route chunks. This PR only removes them from the always-loaded navbar chunk.
