### PR TITLE
fix(home): hero subtitle copy, Signup as primary CTA, brand kicker treatment

### DIFF
--- a/apps/web/src/app/_components/landing-page/index.tsx
+++ b/apps/web/src/app/_components/landing-page/index.tsx
@@ -90,10 +90,12 @@ export async function LandingPage() {
       {/* HERO — fully server-rendered, the LCP element */}
       <section className="relative overflow-hidden bg-gradient-to-b from-blue-duck-egg to-blue-dark-sky-030 dark:from-dark-default dark:to-dark-200">
         <div className="max-w-[1000px] mx-auto px-4 pt-14 pb-12 md:pt-24 md:pb-16 text-center">
-          {/* Brand wordmark instead of the logo mark — the navbar already
-              carries the logo, so the hero leads with the name as text. Text
-              keeps the hero an all-text LCP (no image request). */}
-          <p className="mb-4 font-extrabold tracking-tight text-blue-dark-sky dark:text-gray-pinkish text-xl sm:text-2xl md:text-3xl">
+          {/* Brand kicker (eyebrow) above the headline. The navbar already
+              carries the logo, so the hero leads with the name as a small,
+              uppercase, letter-spaced label - distinct in treatment from the
+              headline so it reads as a brand prefix, not a competing heading.
+              Text only, so the hero stays an all-text LCP (no image request). */}
+          <p className="mb-3 font-bold uppercase tracking-[0.2em] text-blue-dark-sky dark:text-gray-pinkish text-sm md:text-base">
             {defaults.name}
           </p>
           <h1 className="font-extrabold tracking-tight leading-[1.05] text-blue-dark-sky dark:text-gray-pinkish text-[2rem] sm:text-5xl md:text-6xl">

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -2705,7 +2705,7 @@
   "landing-page": {
     "welcome-text": "Ecency",
     "hero-title": "Own your words. Earn for them.",
-    "what-is-ecency": "Freespeech, True ownership, rewarding communities on Web3",
+    "what-is-ecency": "Free speech, true ownership, and rewarding communities on Web3",
     "why-ecency": "Why Ecency",
     "feature-own-desc": "Your account and content live on the blockchain — truly yours, no one can take them away.",
     "feature-earn-desc": "Get rewarded in crypto for your posts, curation and engagement.",

--- a/apps/web/src/features/shared/navbar/anon-user-buttons.tsx
+++ b/apps/web/src/features/shared/navbar/anon-user-buttons.tsx
@@ -13,8 +13,11 @@ export function AnonUserButtons() {
     <></>
   ) : (
     <div className="login-required flex ml-2 gap-2">
+      {/* Login is the secondary action (outline); Signup is the primary CTA
+          (solid) so the conversion path is visually emphasized for new visitors. */}
       <Button
         className="btn-login"
+        outline={true}
         onClick={() => toggleUIProp("login")}
         onMouseEnter={preloadLoginDialog}
         onFocus={preloadLoginDialog}
@@ -23,7 +26,7 @@ export function AnonUserButtons() {
         {i18next.t("g.login")}
       </Button>
 
-      <Button href="/signup" className="flex items-center justify-center" outline={true}>
+      <Button href="/signup" className="flex items-center justify-center">
         {i18next.t("g.signup")}
       </Button>
     </div>


### PR DESCRIPTION
Homepage polish from a design/CTA review of the redesigned hero.

## Changes
1. **Subtitle copy.** `Freespeech, True ownership, rewarding communities on Web3` -> **`Free speech, true ownership, and rewarding communities on Web3`** (fixes "Freespeech" and the inconsistent capitalization; sentence case reads cleaner).

2. **Signup is now the primary CTA.** The navbar had **Login** as the solid/emphasized `Button` and **Signup** as `outline` - backwards for a homepage whose job is conversion. Swapped: Signup is the solid primary, Login is the outline secondary. This reinforces the hero's "Join now" action.

3. **Hero wordmark -> brand kicker.** The `Ecency` wordmark used the same `font-extrabold` + brand-blue treatment as the `<h1>`, just smaller, so the two read as competing headings and muddied the focus. It's now a small uppercase, letter-spaced kicker (`text-sm md:text-base`), so it reads as a brand prefix and the headline is the unambiguous focus. Still text-only, so the hero stays an all-text LCP.

## Notes
- All text/styling only. tsc at baseline, build green, full suite **1,590 pass**.
- Worth a look on staging in both light and dark themes. If you'd prefer the wordmark a bit larger (not full kicker), that's a one-line tweak.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated landing page hero brand prefix to a smaller, uppercase label with letter-spacing.
  * Changed signup button on the navigation bar from outline to solid primary style.

* **Content**
  * Refined landing page headline text for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->