### PR TITLE
fix(web): make Extensions login reliable and quiet Permissions-Policy warnings

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -269,8 +269,14 @@ const config = {
           // top-level `()` here would override the per-iframe grant.
           {
             key: "Permissions-Policy",
+            // NOTE: do not re-add `interest-cohort=()` or `browsing-topics=()`.
+            // interest-cohort (FLoC) was removed from Chromium and is unrecognized
+            // in every current browser, so it logged a console warning on every
+            // page. browsing-topics is unrecognized outside Chromium-with-Privacy-
+            // Sandbox and warns there too. The app uses neither API, so the opt-out
+            // tokens bought nothing but console noise.
             value:
-              "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), browsing-topics=(), interest-cohort=()"
+              "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=()"
           },
           // ENFORCING CSP — only directives that cannot break JS/CSS execution
           // or block the app's existing cross-origin fetches/frames/images. We

--- a/apps/web/src/features/shared/login/hooks/use-login-by-keychain.ts
+++ b/apps/web/src/features/shared/login/hooks/use-login-by-keychain.ts
@@ -4,7 +4,7 @@ import { EcencyConfigManager } from "@/config";
 import { getQueryClient } from "@/core/react-query";
 import { getAccountFullQueryOptions } from "@ecency/sdk";
 import { makeHsCode } from "@/utils";
-import { signBufferWithExtension } from "@/utils/hive-extensions";
+import { HiveExtensionId, signBufferWithExtension } from "@/utils/hive-extensions";
 import { shouldUseKeychainMobile } from "@/utils/client";
 import i18next from "i18next";
 import { error } from "../../feedback";
@@ -30,7 +30,7 @@ export function useLoginByKeychain(username: string) {
 
   const mutation = useMutation({
     mutationKey: ["login-by-keychain", username, account],
-    mutationFn: async () => {
+    mutationFn: async (preferredId?: HiveExtensionId) => {
       const accountData = account ?? (await queryClient.fetchQuery(accountQueryOptions));
 
       if (!accountData) {
@@ -74,7 +74,9 @@ export function useLoginByKeychain(username: string) {
 
       // Desktop extension flow (Keychain, Hive Keeper, or Peak Vault)
       const signMessage = async (message: string) => {
-        return signBufferWithExtension(username, message, "Posting").then((r) => r.result);
+        return signBufferWithExtension(username, message, "Posting", null, preferredId).then(
+          (r) => r.result
+        );
       };
 
       const code = await makeHsCode(

--- a/apps/web/src/features/shared/login/login.tsx
+++ b/apps/web/src/features/shared/login/login.tsx
@@ -14,6 +14,7 @@ import { LoginUserByKey } from "./login-user-by-key";
 import { LoginUsersList } from "./login-users-list";
 import { ExtensionInstallList, useShowExtensionInstall } from "../extension-install-list";
 import { ExtensionChooser } from "../extension-chooser";
+import { error } from "../feedback";
 import { motion } from "framer-motion";
 import { TabItem } from "@/features/ui";
 import clsx from "clsx";
@@ -57,9 +58,35 @@ export default function Login() {
   const [showExtensionsInfo, setShowExtensionsInfo] = useState(false);
   const showExtensionInstall = useShowExtensionInstall();
 
+  // Browser extensions inject their globals (window.hive_keychain /
+  // window.hive.providers / window.peakvault) asynchronously, often AFTER this
+  // component mounts. A single mount-time snapshot therefore misses a genuinely
+  // installed extension and wrongly shows the install list. Re-detect on a short
+  // poll (mirrors initKeychain's runWithRetries grace) and on window focus so the
+  // button self-corrects as the extension comes online.
   useEffect(() => {
-    setDetectedExtensions(getDetectedExtensions());
-    setUseKeychainMobile(shouldUseKeychainMobile());
+    let cancelled = false;
+    const detect = () => {
+      if (cancelled) return;
+      const detected = getDetectedExtensions();
+      setDetectedExtensions((prev) =>
+        prev.length === detected.length && prev.every((e, i) => e.id === detected[i].id)
+          ? prev
+          : detected
+      );
+      setUseKeychainMobile(shouldUseKeychainMobile());
+    };
+    detect();
+    const intervalId = setInterval(detect, 200);
+    const stopId = setTimeout(() => clearInterval(intervalId), 2000);
+    const onFocus = () => detect();
+    window.addEventListener("focus", onFocus);
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+      clearTimeout(stopId);
+      window.removeEventListener("focus", onFocus);
+    };
   }, []);
 
   const hasExtensions = detectedExtensions.length > 0 || useKeychainMobile;
@@ -68,22 +95,39 @@ export default function Login() {
     : i18next.t("login.extensions");
 
   const handleExtensionLogin = () => {
-    if (!hasExtensions) {
+    // Re-read detection at click time: an extension may have injected its globals
+    // after the last poll, so we must never act on a stale empty snapshot.
+    const detected = getDetectedExtensions();
+    setDetectedExtensions(detected);
+    const liveHasExtensions = detected.length > 0 || shouldUseKeychainMobile();
+
+    if (!liveHasExtensions) {
       setShowExtensionsInfo(true);
       return;
     }
-    if (detectedExtensions.length > 1) {
+    if (!username) {
+      error(i18next.t("login.write-username"));
+      return;
+    }
+    if (detected.length > 1) {
       // If a saved preference matches a detected extension, use it directly
       const savedId = getPreferredExtensionId();
-      if (!savedId || !detectedExtensions.some((ext) => ext.id === savedId)) {
+      if (!savedId || !detected.some((ext) => ext.id === savedId)) {
         setShowExtensionsInfo(true);
         return;
       }
+      if (isLoginByKeychainPending) return;
+      loginByKeychain(savedId).catch(() => {
+        /* Already handled in onError of the mutation */
+      });
+      return;
     }
     if (isLoginByKeychainPending) {
       return;
     }
-    loginByKeychain().catch(() => {
+    // Exactly one extension: sign with it explicitly so detection and signing can
+    // never resolve to different extensions.
+    loginByKeychain(detected[0]?.id).catch(() => {
       /* Already handled in onError of the mutation */
     });
   };
@@ -91,8 +135,13 @@ export default function Login() {
   const handleSelectExtension = (extId: HiveExtensionId) => {
     setPreferredExtensionId(extId);
     setShowExtensionsInfo(false);
-    if (isLoginByKeychainPending || !username) return;
-    loginByKeychain().catch(() => {});
+    if (isLoginByKeychainPending) return;
+    if (!username) {
+      // Don't silently swallow the click: tell the user what's missing.
+      error(i18next.t("login.write-username"));
+      return;
+    }
+    loginByKeychain(extId).catch(() => {});
   };
 
   return (

--- a/apps/web/src/specs/utils/hive-extensions.spec.ts
+++ b/apps/web/src/specs/utils/hive-extensions.spec.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { signBufferWithExtension } from "../../utils/hive-extensions";
+
+/**
+ * Regression coverage for the Keychain liveness ping added to signBufferViaKeychain.
+ * A Manifest V3 service worker that has gone idle/crashed never calls the sign
+ * callback back; the ping must surface a fast, actionable error instead of the
+ * old 60s opaque spinner, and must wake the worker (handshake) before signing.
+ */
+describe("signBufferWithExtension (Keychain liveness ping)", () => {
+  beforeEach(() => {
+    const w = window as any;
+    delete w.hive_keychain;
+    delete w.hive;
+    delete w.hive_extension;
+    delete w.peakvault;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    const w = window as any;
+    delete w.hive_keychain;
+  });
+
+  it("handshakes to wake the worker before requesting a signature", async () => {
+    const order: string[] = [];
+    (window as any).hive_keychain = {
+      requestHandshake: (cb: () => void) => {
+        order.push("handshake");
+        cb();
+      },
+      requestSignBuffer: (_a: string, _m: string, _t: string, cb: (r: any) => void) => {
+        order.push("sign");
+        cb({ success: true, result: "signature" });
+      }
+    };
+
+    const resp = await signBufferWithExtension("alice", "message", "Posting");
+
+    expect(order).toEqual(["handshake", "sign"]);
+    expect(resp).toMatchObject({ success: true, result: "signature" });
+  });
+
+  it("rejects fast with an actionable message when the worker never responds", async () => {
+    vi.useFakeTimers();
+    const requestSignBuffer = vi.fn();
+    (window as any).hive_keychain = {
+      // Dead/asleep worker: the handshake callback is never invoked.
+      requestHandshake: vi.fn(),
+      requestSignBuffer
+    };
+
+    const promise = signBufferWithExtension("alice", "message", "Posting");
+    const assertion = expect(promise).rejects.toThrow(/not responding/i);
+
+    await vi.advanceTimersByTimeAsync(6000);
+    await assertion;
+
+    // Crucially, we never reach the 60s sign request on a dead worker.
+    expect(requestSignBuffer).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a user cancellation from the sign request", async () => {
+    (window as any).hive_keychain = {
+      requestHandshake: (cb: () => void) => cb(),
+      requestSignBuffer: (_a: string, _m: string, _t: string, cb: (r: any) => void) =>
+        cb({ success: false, error: "user_cancel" })
+    };
+
+    await expect(signBufferWithExtension("alice", "message", "Posting")).rejects.toThrow();
+  });
+});

--- a/apps/web/src/specs/utils/hive-extensions.spec.ts
+++ b/apps/web/src/specs/utils/hive-extensions.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { signBufferWithExtension } from "../../utils/hive-extensions";
+import { broadcastWithExtension, signBufferWithExtension } from "../../utils/hive-extensions";
 
 /**
  * Regression coverage for the Keychain liveness ping added to signBufferViaKeychain.
@@ -69,5 +69,59 @@ describe("signBufferWithExtension (Keychain liveness ping)", () => {
     };
 
     await expect(signBufferWithExtension("alice", "message", "Posting")).rejects.toThrow();
+  });
+});
+
+/**
+ * The same liveness ping guards broadcastViaKeychain, so votes/posts/transfers do
+ * not hang for 60s on an idle/crashed worker either.
+ */
+describe("broadcastWithExtension (Keychain liveness ping)", () => {
+  beforeEach(() => {
+    const w = window as any;
+    delete w.hive_keychain;
+    delete w.hive;
+    delete w.hive_extension;
+    delete w.peakvault;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as any).hive_keychain;
+  });
+
+  it("handshakes before broadcasting", async () => {
+    const order: string[] = [];
+    (window as any).hive_keychain = {
+      requestHandshake: (cb: () => void) => {
+        order.push("handshake");
+        cb();
+      },
+      requestBroadcast: (_a: string, _o: any[], _t: string, cb: (r: any) => void) => {
+        order.push("broadcast");
+        cb({ success: true, result: { id: "tx" } });
+      }
+    };
+
+    await broadcastWithExtension("alice", [["vote", {}]], "posting");
+    expect(order).toEqual(["handshake", "broadcast"]);
+  });
+
+  it("rejects fast when the worker never responds, without reaching broadcast", async () => {
+    vi.useFakeTimers();
+    const requestBroadcast = vi.fn();
+    (window as any).hive_keychain = {
+      requestHandshake: vi.fn(),
+      requestBroadcast
+    };
+
+    const promise = broadcastWithExtension("alice", [["vote", {}]], "posting");
+    const assertion = expect(promise).rejects.toThrow(/not responding/i);
+
+    await vi.advanceTimersByTimeAsync(6000);
+    await assertion;
+
+    expect(requestBroadcast).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/utils/hive-extensions.ts
+++ b/apps/web/src/utils/hive-extensions.ts
@@ -401,7 +401,12 @@ function broadcastViaKeychain(
       );
     });
 
-  return attempt(rpc).then((response) => {
+  // Wake the (possibly idle Manifest V3) worker first so a sleeping/crashed
+  // extension fails fast on votes/posts/transfers too, not just login. The
+  // fallback-node retry below does not re-ping: the worker is already awake.
+  return pingKeychain(keychain)
+    .then(() => attempt(rpc))
+    .then((response) => {
     if (response.success) {
       return response.result;
     }

--- a/apps/web/src/utils/hive-extensions.ts
+++ b/apps/web/src/utils/hive-extensions.ts
@@ -283,6 +283,42 @@ function getPeakVaultInstance(): PeakVaultApi | null {
 // Internal: Keychain-compatible sign/broadcast (callback-based)
 // ---------------------------------------------------------------------------
 
+/**
+ * Fast liveness ping. Keychain-compatible extensions (Keychain, Hive Keeper) run
+ * a Manifest V3 service worker that idles after ~30s; the first request to a
+ * sleeping or crashed worker can silently never call back, leaving the user on a
+ * 60s spinner. requestHandshake wakes the worker and confirms it is reachable, so
+ * a genuinely dead worker fails fast with an actionable message instead. Resolves
+ * for instances that do not expose requestHandshake (the sign request handles
+ * those directly).
+ */
+function pingKeychain(keychain: KeyChainImpl, timeoutMs = 6000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (typeof keychain.requestHandshake !== "function") {
+      resolve();
+      return;
+    }
+    let settled = false;
+    const fail = () => {
+      if (settled) return;
+      settled = true;
+      reject(new Error("Extension is not responding. Click its icon to wake it, then try again."));
+    };
+    const timeoutId = setTimeout(fail, timeoutMs);
+    try {
+      keychain.requestHandshake(() => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        resolve();
+      });
+    } catch {
+      clearTimeout(timeoutId);
+      fail();
+    }
+  });
+}
+
 function signBufferViaKeychain(
   keychain: KeyChainImpl,
   account: string,
@@ -290,32 +326,35 @@ function signBufferViaKeychain(
   authType: AuthorityTypes,
   rpc: string | null
 ): Promise<TxResponse> {
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    const timeoutId = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        reject(new Error("Extension request timed out. Please try again."));
-      }
-    }, 60000);
+  return pingKeychain(keychain).then(
+    () =>
+      new Promise<TxResponse>((resolve, reject) => {
+        let settled = false;
+        const timeoutId = setTimeout(() => {
+          if (!settled) {
+            settled = true;
+            reject(new Error("Extension request timed out. Please try again."));
+          }
+        }, 60000);
 
-    keychain.requestSignBuffer(
-      account,
-      message,
-      authType,
-      (resp: TxResponse) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timeoutId);
-        if (!resp.success) {
-          reject(new Error(extensionErrorMessage(resp, "Operation cancelled")));
-          return;
-        }
-        resolve(resp);
-      },
-      rpc
-    );
-  });
+        keychain.requestSignBuffer(
+          account,
+          message,
+          authType,
+          (resp: TxResponse) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeoutId);
+            if (!resp.success) {
+              reject(new Error(extensionErrorMessage(resp, "Operation cancelled")));
+              return;
+            }
+            resolve(resp);
+          },
+          rpc
+        );
+      })
+  );
 }
 
 /**


### PR DESCRIPTION
## Problem

Two issues reported from the login / "login as" modal:

1. **Clicking "Extensions" could hang on an endless spinner with no feedback.** A Keychain / Hive Keeper Manifest V3 service worker idles after ~30s and can be asleep or crashed when the sign request arrives. Its content script never calls our callback back, so the button spun until the 60s timeout with no indication anything was wrong. The browser console also showed the extension's own `Could not establish connection. Receiving end does not exist.` noise (that part is the extension, not us).
2. **`Permissions-Policy` console warnings on every page** (`Unrecognized feature: 'browsing-topics' / 'interest-cohort'`).

A secondary, latent issue: extension detection was a single synchronous snapshot taken on mount, so a slow-injecting extension could be missed and the install list shown to an already-installed user.

## Changes

- **Liveness ping before signing** (`hive-extensions.ts`): `requestHandshake` wakes the worker and confirms it is reachable before we call `requestSignBuffer`. An unreachable worker now fails in ~6s with `Extension is not responding. Click its icon to wake it, then try again.` instead of a silent 60s spinner. Instances without a handshake API resolve immediately (no behavior change for them).
- **Re-detect at click time + short poll/focus** (`login.tsx`): detection is re-read when the button is clicked, and on a brief poll plus window focus, mirroring `initKeychain`'s existing `runWithRetries` grace. A late-injecting extension is honored rather than dead-ending on the install list.
- **Thread the chosen extension id through the sign call** (`login.tsx`, `use-login-by-keychain.ts`): the selected/detected extension id is passed explicitly so detection and signing can never resolve to different extensions. The chooser's select handler no longer silently swallows a click when the username field is empty; it surfaces the requirement.
- **Drop dead Permissions-Policy tokens** (`next.config.js`): remove `interest-cohort=()` (FLoC, removed from Chromium, unrecognized everywhere) and `browsing-topics=()` (unrecognized outside Chromium-with-Privacy-Sandbox). The app uses neither API, so they only produced console noise. A comment documents why they should not be re-added.

## Tests

Adds `specs/utils/hive-extensions.spec.ts` covering the ping path: handshake-before-sign ordering, fast rejection when the worker never responds (and that we never reach the 60s sign request), and user-cancellation surfacing.

## Notes

The MetaMask Snap login / active-authority correctness work and the external-transfer auto-connect fix are tracked as separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extension responsiveness detection (liveness ping) to verify Keychain is active before signing
  * Implemented preferred extension selection during login

* **Bug Fixes**
  * Improved login validation with clearer error messages
  * Enhanced extension availability detection with real-time polling instead of one-time checks
  * Removed unused permission policy directives to reduce console warnings

* **Tests**
  * Added test coverage for extension liveness detection behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->