### PR TITLE
fix(web): harden MetaMask snap login (version guard + benign cancel)

### DIFF
--- a/apps/web/src/app/signup/wallet/_components/steps/metamask-connect.tsx
+++ b/apps/web/src/app/signup/wallet/_components/steps/metamask-connect.tsx
@@ -182,10 +182,15 @@ export function MetamaskConnect({ username, onVerified, onBack }: Props) {
           setIsLoadingChainAddresses(false);
         }
       }
-    } catch (e) {
+    } catch (e: any) {
+      setIsLoadingChainAddresses(false);
+      // User dismissed the MetaMask connect prompt (EIP-1193 4001): benign cancel,
+      // so don't surface it as an error.
+      if (e?.code === 4001 || /user rejected|user denied/i.test(e?.message ?? "")) {
+        return;
+      }
       console.error("[MetaMask connect] failed:", e);
       error(i18next.t("signup-wallets.metamask.connect-error"));
-      setIsLoadingChainAddresses(false);
     } finally {
       setIsConnecting(false);
     }

--- a/apps/web/src/app/signup/wallet/_components/steps/metamask-connect.tsx
+++ b/apps/web/src/app/signup/wallet/_components/steps/metamask-connect.tsx
@@ -218,7 +218,12 @@ export function MetamaskConnect({ username, onVerified, onBack }: Props) {
 
       success(i18next.t("signup-wallets.validate-funds.validation-success"));
       onVerified(selectedCurrency, connectedAddress, availableAddresses);
-    } catch {
+    } catch (e: any) {
+      // User dismissed the personal_sign dialog (EIP-1193 4001): benign cancel,
+      // so don't surface it as an error (matches connectMetaMask above).
+      if (e?.code === 4001 || /user rejected|user denied/i.test(e?.message ?? "")) {
+        return;
+      }
       error(i18next.t("signup-wallets.metamask.sign-rejected"));
     } finally {
       setIsSigning(false);

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -318,6 +318,8 @@
     "metamask-not-found": "MetaMask not found. Please install MetaMask browser extension.",
     "metamask-no-keys": "Could not get Hive keys from MetaMask snap",
     "metamask-key-mismatch": "MetaMask Hive keys do not match this account. Make sure you are using the same MetaMask wallet used during signup.",
+    "metamask-snap-unavailable": "Could not reach the Hive snap. Unlock MetaMask and try again.",
+    "metamask-snap-outdated": "Please update the Hive snap in MetaMask, then try again.",
     "keychain": "Keychain",
     "extensions": "Extensions",
     "extensions-info-title": "Browser Extensions",

--- a/apps/web/src/features/shared/login/hooks/use-login-by-metamask.ts
+++ b/apps/web/src/features/shared/login/hooks/use-login-by-metamask.ts
@@ -10,6 +10,22 @@ import { formatError } from "@/api/format-error";
 
 const HIVE_SNAP_ID = "npm:@hiveio/metamask-snap";
 
+// Login signs via the snap's hive_encrypt(number[]) branch, which only exists in
+// @hiveio/metamask-snap >= 1.7.0. Request that range so MetaMask prompts an
+// upgrade, and verify the resolved version so an older pinned/cached snap fails
+// with a clear message instead of a generic toast.
+const MIN_SNAP_VERSION = "1.7.0";
+
+/** True when semver `version` is >= `min` (major.minor.patch; ignores pre-release). */
+export function isSnapVersionAtLeast(version: string, min: string): boolean {
+  const parse = (v: string) => v.split(".").map((n) => parseInt(n, 10) || 0);
+  const [a = 0, b = 0, c = 0] = parse(version);
+  const [x = 0, y = 0, z = 0] = parse(min);
+  if (a !== x) return a > x;
+  if (b !== y) return b > y;
+  return c >= z;
+}
+
 interface HivePublicKey {
   publicKey: string;
   role?: string;
@@ -25,10 +41,18 @@ function requireEthereum() {
 }
 
 async function ensureHiveSnap(): Promise<void> {
-  await requireEthereum().request({
+  const result = (await requireEthereum().request({
     method: "wallet_requestSnaps",
-    params: { [HIVE_SNAP_ID]: {} }
-  });
+    params: { [HIVE_SNAP_ID]: { version: `^${MIN_SNAP_VERSION}` } }
+  })) as Record<string, { version?: string }> | undefined;
+
+  const snap = result?.[HIVE_SNAP_ID];
+  if (!snap) {
+    throw new Error(i18next.t("login.metamask-snap-unavailable"));
+  }
+  if (snap.version && !isSnapVersionAtLeast(snap.version, MIN_SNAP_VERSION)) {
+    throw new Error(i18next.t("login.metamask-snap-outdated"));
+  }
 }
 
 async function getHivePublicKeys(): Promise<HivePublicKey[]> {
@@ -126,6 +150,13 @@ export function useLoginByMetaMask(username: string) {
       // 6. Complete login
       await loginInApp(code, null, accountData, "metamask");
     },
-    onError: (e) => error(...formatError(e))
+    onError: (e: any) => {
+      // User dismissed the MetaMask / snap prompt (EIP-1193 4001): benign, so
+      // don't show a scary error toast for a deliberate cancel.
+      if (e?.code === 4001 || /user rejected|user denied/i.test(e?.message ?? "")) {
+        return;
+      }
+      error(...formatError(e));
+    }
   });
 }

--- a/apps/web/src/features/shared/login/hooks/use-login-by-metamask.ts
+++ b/apps/web/src/features/shared/login/hooks/use-login-by-metamask.ts
@@ -50,7 +50,9 @@ async function ensureHiveSnap(): Promise<void> {
   if (!snap) {
     throw new Error(i18next.t("login.metamask-snap-unavailable"));
   }
-  if (snap.version && !isSnapVersionAtLeast(snap.version, MIN_SNAP_VERSION)) {
+  // A snap with no reported version is treated as outdated: signing relies on the
+  // >= 1.7.0 behavior, so fail safe rather than proceed and break cryptically.
+  if (!snap.version || !isSnapVersionAtLeast(snap.version, MIN_SNAP_VERSION)) {
     throw new Error(i18next.t("login.metamask-snap-outdated"));
   }
 }

--- a/apps/web/src/specs/features/login/metamask-snap-version.spec.ts
+++ b/apps/web/src/specs/features/login/metamask-snap-version.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isSnapVersionAtLeast } from "../../../features/shared/login/hooks/use-login-by-metamask";
+
+/**
+ * The Hive snap login depends on @hiveio/metamask-snap >= 1.7.0. The version gate
+ * must compare numerically (not lexically), so 1.10.0 outranks 1.7.0.
+ */
+describe("isSnapVersionAtLeast", () => {
+  it("accepts the exact minimum", () => {
+    expect(isSnapVersionAtLeast("1.7.0", "1.7.0")).toBe(true);
+  });
+
+  it("accepts higher patch / minor / major", () => {
+    expect(isSnapVersionAtLeast("1.7.1", "1.7.0")).toBe(true);
+    expect(isSnapVersionAtLeast("1.8.0", "1.7.0")).toBe(true);
+    expect(isSnapVersionAtLeast("2.0.0", "1.7.0")).toBe(true);
+  });
+
+  it("compares numerically, not lexically (1.10.0 >= 1.7.0)", () => {
+    expect(isSnapVersionAtLeast("1.10.0", "1.7.0")).toBe(true);
+  });
+
+  it("rejects older versions", () => {
+    expect(isSnapVersionAtLeast("1.6.9", "1.7.0")).toBe(false);
+    expect(isSnapVersionAtLeast("1.6.0", "1.7.0")).toBe(false);
+    expect(isSnapVersionAtLeast("0.9.9", "1.7.0")).toBe(false);
+  });
+
+  it("ignores a pre-release suffix on the patch segment", () => {
+    expect(isSnapVersionAtLeast("1.7.0-flask.1", "1.7.0")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem (P1)

Two robustness gaps in the MetaMask Hive-snap login:

1. **Silent failure on an old snap.** Login signs via the snap's `hive_encrypt(number[])` branch, which only exists in `@hiveio/metamask-snap >= 1.7.0` (older versions either lack `hive_encrypt` or throw on a `number[]` buffer). But `wallet_requestSnaps` was called with an empty version range (`{}`), so MetaMask would not upgrade an older installed/cached snap, and the user just got a generic error toast.
2. **User cancellations shown as errors.** Dismissing the MetaMask/snap prompt (EIP-1193 code `4001`) funneled through the generic error path, so a deliberate cancel looked like a failure. The `4001` pattern already exists elsewhere (`external-transfer-dialog.tsx`); the login hook and signup connect just did not use it.

## Changes

- **`use-login-by-metamask.ts`**: request the snap with `version: "^1.7.0"` so MetaMask prompts an install/upgrade to a compatible version, then read the resolved version from the `wallet_requestSnaps` result and fail with a clear "update the Hive snap" / "could not reach the snap" message if it is missing or older. Version comparison is numeric (so `1.10.0 >= 1.7.0`).
- **`use-login-by-metamask.ts` + `signup/.../metamask-connect.tsx`**: treat `4001` (and "user rejected/denied" messages) as a benign cancel, with no error toast.
- Two new i18n strings (`login.metamask-snap-unavailable`, `login.metamask-snap-outdated`), kept under the 80-char `formatError` truncation.

## Tests

Adds `specs/features/login/metamask-snap-version.spec.ts` for the version gate, including the lexical-vs-numeric pitfall (`1.10.0 >= 1.7.0`) and a pre-release suffix.

## Notes

The `hive_encrypt`-as-sign approach is cryptographically correct on snap `1.7.0` (verified), but it is an undocumented overload and renders a misleading "encrypt for yourself" confirmation dialog. A first-class `hive_signBuffer`/`hive_signDigest` RPC on the snap is the proper long-term fix; that is a snap-side change to coordinate with the maintainers, tracked separately. The pre-existing duplicate `Window.ethereum` global type + untyped provider access in these files are part of the type-debt cleanup tracked for after this series.