### PR TITLE
fix(web): always show the extension picker when 2+ extensions are installed

### DIFF
--- a/apps/web/src/features/shared/login/extension-login-action.ts
+++ b/apps/web/src/features/shared/login/extension-login-action.ts
@@ -1,0 +1,30 @@
+import type { DetectedExtension, HiveExtensionId } from "@/utils/hive-extensions";
+
+export type ExtensionLoginAction =
+  | { kind: "install" }
+  | { kind: "needUsername" }
+  | { kind: "picker" }
+  | { kind: "login"; extId?: HiveExtensionId };
+
+/**
+ * Pure decision for the login "Extensions" button. Kept out of the component so
+ * the branching (the bug-prone part) is unit-testable without rendering.
+ *
+ * - no extension detected and no Keychain-mobile fallback -> guide to install
+ * - no username yet -> ask for it first
+ * - 2+ extensions -> always show the picker, so the user chooses the wallet that
+ *   holds THIS account's keys. We never auto-route by a saved preference here: a
+ *   login can target a different account than last time, and signing with the
+ *   wrong extension would fail.
+ * - exactly one extension (or Keychain-mobile) -> sign with it directly
+ */
+export function decideExtensionLoginAction(
+  detected: DetectedExtension[],
+  username: string,
+  useKeychainMobile: boolean
+): ExtensionLoginAction {
+  if (detected.length === 0 && !useKeychainMobile) return { kind: "install" };
+  if (!username) return { kind: "needUsername" };
+  if (detected.length > 1) return { kind: "picker" };
+  return { kind: "login", extId: detected[0]?.id };
+}

--- a/apps/web/src/features/shared/login/login.tsx
+++ b/apps/web/src/features/shared/login/login.tsx
@@ -19,7 +19,7 @@ import { motion } from "framer-motion";
 import { TabItem } from "@/features/ui";
 import clsx from "clsx";
 import { shouldUseKeychainMobile } from "@/utils/client";
-import { DetectedExtension, HiveExtensionId, getDetectedExtensions, getPreferredExtensionId, setPreferredExtensionId } from "@/utils/hive-extensions";
+import { DetectedExtension, HiveExtensionId, getDetectedExtensions, setPreferredExtensionId } from "@/utils/hive-extensions";
 
 export default function Login() {
   const toggleUIProp = useGlobalStore((state) => state.toggleUiProp);
@@ -110,16 +110,11 @@ export default function Login() {
       return;
     }
     if (detected.length > 1) {
-      // If a saved preference matches a detected extension, use it directly
-      const savedId = getPreferredExtensionId();
-      if (!savedId || !detected.some((ext) => ext.id === savedId)) {
-        setShowExtensionsInfo(true);
-        return;
-      }
-      if (isLoginByKeychainPending) return;
-      loginByKeychain(savedId).catch(() => {
-        /* Already handled in onError of the mutation */
-      });
+      // Multiple Hive extensions installed: always show the picker so the user
+      // chooses the wallet that actually holds this account's keys. We do NOT
+      // auto-route by a saved preference here - login can target a different
+      // account than last time, and signing with the wrong extension would fail.
+      setShowExtensionsInfo(true);
       return;
     }
     if (isLoginByKeychainPending) {

--- a/apps/web/src/features/shared/login/login.tsx
+++ b/apps/web/src/features/shared/login/login.tsx
@@ -15,6 +15,7 @@ import { LoginUsersList } from "./login-users-list";
 import { ExtensionInstallList, useShowExtensionInstall } from "../extension-install-list";
 import { ExtensionChooser } from "../extension-chooser";
 import { error } from "../feedback";
+import { decideExtensionLoginAction } from "./extension-login-action";
 import { motion } from "framer-motion";
 import { TabItem } from "@/features/ui";
 import clsx from "clsx";
@@ -99,32 +100,27 @@ export default function Login() {
     // after the last poll, so we must never act on a stale empty snapshot.
     const detected = getDetectedExtensions();
     setDetectedExtensions(detected);
-    const liveHasExtensions = detected.length > 0 || shouldUseKeychainMobile();
 
-    if (!liveHasExtensions) {
-      setShowExtensionsInfo(true);
-      return;
+    const action = decideExtensionLoginAction(detected, username, shouldUseKeychainMobile());
+    switch (action.kind) {
+      // "install" and "picker" both open the modal; its body renders the install
+      // list or the ExtensionChooser based on detectedExtensions.length.
+      case "install":
+      case "picker":
+        setShowExtensionsInfo(true);
+        return;
+      case "needUsername":
+        error(i18next.t("login.write-username"));
+        return;
+      case "login":
+        if (isLoginByKeychainPending) return;
+        // Sign with the explicit extension so detection and signing can never
+        // resolve to different extensions.
+        loginByKeychain(action.extId).catch(() => {
+          /* Already handled in onError of the mutation */
+        });
+        return;
     }
-    if (!username) {
-      error(i18next.t("login.write-username"));
-      return;
-    }
-    if (detected.length > 1) {
-      // Multiple Hive extensions installed: always show the picker so the user
-      // chooses the wallet that actually holds this account's keys. We do NOT
-      // auto-route by a saved preference here - login can target a different
-      // account than last time, and signing with the wrong extension would fail.
-      setShowExtensionsInfo(true);
-      return;
-    }
-    if (isLoginByKeychainPending) {
-      return;
-    }
-    // Exactly one extension: sign with it explicitly so detection and signing can
-    // never resolve to different extensions.
-    loginByKeychain(detected[0]?.id).catch(() => {
-      /* Already handled in onError of the mutation */
-    });
   };
 
   const handleSelectExtension = (extId: HiveExtensionId) => {

--- a/apps/web/src/specs/features/login/extension-login-action.spec.ts
+++ b/apps/web/src/specs/features/login/extension-login-action.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { decideExtensionLoginAction } from "@/features/shared/login/extension-login-action";
+import type { DetectedExtension } from "@/utils/hive-extensions";
+
+const ext = (id: DetectedExtension["id"]): DetectedExtension => ({ id, name: id, icon: "" });
+
+describe("decideExtensionLoginAction", () => {
+  it("guides to install when nothing is detected and Keychain-mobile is unavailable", () => {
+    expect(decideExtensionLoginAction([], "alice", false)).toEqual({ kind: "install" });
+  });
+
+  it("asks for a username first when an extension is present but the field is empty", () => {
+    expect(decideExtensionLoginAction([ext("keychain")], "", false)).toEqual({ kind: "needUsername" });
+  });
+
+  it("always shows the picker with 2+ extensions (regression: must NOT auto-route to one)", () => {
+    expect(
+      decideExtensionLoginAction([ext("keychain"), ext("hive-keeper")], "alice", false)
+    ).toEqual({ kind: "picker" });
+  });
+
+  it("signs directly with the single detected extension", () => {
+    expect(decideExtensionLoginAction([ext("hive-keeper")], "alice", false)).toEqual({
+      kind: "login",
+      extId: "hive-keeper"
+    });
+  });
+
+  it("treats Keychain-mobile (nothing detected) as a direct login", () => {
+    expect(decideExtensionLoginAction([], "alice", true)).toEqual({ kind: "login", extId: undefined });
+  });
+});


### PR DESCRIPTION
## Problem

On production, clicking **Extensions** with both Keychain and Keeper installed went straight to a Keychain sign prompt — no picker. The Extensions button correctly showed both icons (both detected), but the handler auto-routed to a previously-saved preference:

```js
if (detected.length > 1) {
  const savedId = getPreferredExtensionId();          // e.g. "keychain" from a prior pick
  if (!savedId || !detected.some(e => e.id === savedId)) {
    setShowExtensionsInfo(true);                       // picker
    return;
  }
  loginByKeychain(savedId)...                          // <-- skips the picker
}
```

"Remember the chosen extension" is correct for **signing after login** (the logged-in account's extension is fixed). It's **wrong for login**: a login can target a different account whose keys live in the *other* extension, so a stale `keychain` preference signs with the wrong wallet (Keychain doesn't hold a Keeper account's keys → it fails or prompts the wrong wallet).

## Change

When more than one Hive extension is detected, **always show the picker** so the user chooses the wallet that actually holds this account's keys:

```js
if (detected.length > 1) {
  setShowExtensionsInfo(true);
  return;
}
```

- The single-extension fast path is unchanged (one extension → use it directly; a 1-item picker would be pointless).
- The preference is still recorded on selection (`handleSelectExtension → setPreferredExtensionId`) and `loginByKeychain(extId)` signs with the explicitly chosen extension, so post-login signing is unaffected.
- Removed the now-unused `getPreferredExtensionId` import.

## Testing

Typecheck clean. Verified the logic by hand against the merged flow. This is a focused UI-logic change to the login handler; no dedicated component spec was added (the Login component's full render tree is heavily mocked and the prior login work tested the pure util layer instead).