### PR TITLE
feat(waves): show payout/votes/replies on following + tag feeds

### DIFF
--- a/apps/web/src/app/waves/_components/waves-list-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-item.tsx
@@ -64,8 +64,6 @@ export const WavesListItem = React.memo(function WavesListItem({
   const { inViewport } = useInViewport(rootRef);
 
   const tagFilter = useOptionalWavesTagFilter();
-  const isTagFiltered = feedType === "for-you" && !!tagFilter?.selectedTag;
-  const shouldHideEngagementCounts = feedType === "following" || isTagFiltered;
 
   const handleTagClick = useCallback(
     (tag: string) => {
@@ -324,9 +322,6 @@ export const WavesListItem = React.memo(function WavesListItem({
             pure={false}
             onEdit={() => setShowEditModal(true)}
             commentsSlot={commentSlot}
-            showVoteSummary={!shouldHideEngagementCounts}
-            showCommentCount={!shouldHideEngagementCounts}
-            showPayout={!shouldHideEngagementCounts}
           />
 
           <Modal centered={true} show={showEditModal} onHide={() => setShowEditModal(false)}>


### PR DESCRIPTION
Follow-up to #971. On staging the following / hashtag waves feeds showed **no** engagement numbers, because those feeds hid the vote count, comment count and payout via `shouldHideEngagementCounts` (introduced back when the esync private-api feeds had no engagement data — showing 0 would have been misleading).

esync now serves `net_votes` / `children` / `pending_payout_value` (+ author/curator) for these feeds (verified on the API), and the cards read them, so the reason to hide is gone.

## Change
Remove the `shouldHideEngagementCounts` gating in `waves-list-item.tsx`. `WaveActions` already defaults `showVoteSummary` / `showCommentCount` / `showPayout` to `true`, so dropping the props shows the counts on the following + tag feeds, consistent with the for-you feed. `tagFilter` is kept (still used for tag-click handling).

Net: payout, vote count and reply count now render on the custom waves feeds. (Mobile has no equivalent feed-type hide — its payout was only value-gated on `>0`, which resolves now that the value is non-zero.)