### PR TITLE
fix(sdk): default Transaction.signatures to [] (hive-uri sign crash)

### DIFF
--- a/packages/sdk/src/hive-tx/Transaction.spec.ts
+++ b/packages/sdk/src/hive-tx/Transaction.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { Transaction } from "./Transaction";
+
+// Minimal serializable transaction, as produced externally (e.g. by hive-uri's
+// resolveTransaction) WITHOUT a `signatures` field.
+const baseTx = {
+  ref_block_num: 1234,
+  ref_block_prefix: 5678901,
+  expiration: "2026-06-20T17:00:00",
+  operations: [
+    ["vote", { voter: "alice", author: "bob", permlink: "a-post", weight: 10000 }],
+  ],
+  extensions: [],
+} as any;
+
+describe("Transaction constructor – signatures normalization", () => {
+  it("adds an empty signatures array when the source tx omits it (hive-uri sign regression)", () => {
+    const tx = { ...baseTx }; // no `signatures`
+    const t = new Transaction({ transaction: tx });
+    expect(Array.isArray(t.transaction?.signatures)).toBe(true);
+    expect(t.transaction?.signatures).toEqual([]);
+  });
+
+  it("preserves an existing signatures array", () => {
+    const tx = { ...baseTx, signatures: ["deadbeef"] };
+    const t = new Transaction({ transaction: tx });
+    expect(t.transaction?.signatures).toEqual(["deadbeef"]);
+  });
+
+  it("replaces a non-array signatures value", () => {
+    const tx = { ...baseTx, signatures: null };
+    const t = new Transaction({ transaction: tx });
+    expect(t.transaction?.signatures).toEqual([]);
+  });
+});

--- a/packages/sdk/src/hive-tx/Transaction.ts
+++ b/packages/sdk/src/hive-tx/Transaction.ts
@@ -41,6 +41,13 @@ export class Transaction {
       } else {
         this.transaction = options.transaction
       }
+      // A transaction built externally (e.g. from a hive-uri signing request)
+      // may omit the `signatures` array. sign(), addSignature() and broadcast()
+      // all assume it exists, so normalize it here to avoid
+      // "Cannot read property 'push' of undefined" on sign.
+      if (this.transaction && !Array.isArray(this.transaction.signatures)) {
+        this.transaction.signatures = []
+      }
       this.txId = this.digest().txId
     }
     if (options?.expiration) {


### PR DESCRIPTION
## Problem

Signing a transaction constructed from an existing tx object crashed with:

> TypeError: Cannot read property 'push' of undefined

This is hit by hive-uri signing flows: `hive-uri`'s `resolveTransaction` returns an unsigned tx (`{ ref_block_num, ref_block_prefix, expiration, operations, extensions }`) with **no `signatures` field**. Wrapping it in `new Transaction({ transaction: tx })` and calling `.sign()` then does `this.transaction.signatures.push(...)` on `undefined`.

The constructor only assigns the tx; `signatures` is initialized only on the `create()` path, not when a transaction is provided. `sign()`, `addSignature()` and `broadcast()` (`signatures.length`) all assume the array exists.

## Fix

Normalize `signatures` to `[]` in the constructor whenever a transaction is provided (preserving any existing signatures), so every downstream method is safe regardless of how the tx was built.

## Tests

- `packages/sdk/src/hive-tx/Transaction.spec.ts` (missing / present / non-array signatures)
- `pnpm --filter @ecency/sdk build` (ESM/CJS/DTS clean), full SDK test suite green (404)

## Context

The mobile app shipped a consumer-side guard for this in ecency/ecency-mobile (ensures the hive-uri tx has `signatures: []` before signing). This is the root fix in the SDK so any consumer (web hive-uri, external SDK users) is protected without needing its own guard.