### PR TITLE
fix(web): resolve Hive Keeper via live window.hive, not a dead hive_extension check

### DIFF
--- a/apps/web/src/core/global-store/modules/global-module.ts
+++ b/apps/web/src/core/global-store/modules/global-module.ts
@@ -166,8 +166,10 @@ export function createGlobalActions(set: (state: Partial<State>) => void, getSta
           return true;
         }
 
-        // Prefer Hive Keeper (guarded by hive_extension flag) then Keychain
-        const hiveExtension = (w.hive_extension && w.hive) || w.hive_keychain;
+        // Prefer Hive Keeper (it owns window.hive and flags isKeeper on it),
+        // then Keychain. window.hive_extension lives only in Keeper's
+        // content-script world and is not visible here, so it can't be used.
+        const hiveExtension = (w.hive?.isKeeper && w.hive) || w.hive_keychain;
 
         if (!hiveExtension) {
           return false;

--- a/apps/web/src/specs/utils/hive-extensions.spec.ts
+++ b/apps/web/src/specs/utils/hive-extensions.spec.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { broadcastWithExtension, signBufferWithExtension } from "../../utils/hive-extensions";
+import {
+  broadcastWithExtension,
+  getDetectedExtensions,
+  signBufferWithExtension
+} from "../../utils/hive-extensions";
 
 /**
  * Regression coverage for the Keychain liveness ping added to signBufferViaKeychain.
@@ -123,5 +127,93 @@ describe("broadcastWithExtension (Keychain liveness ping)", () => {
     await assertion;
 
     expect(requestBroadcast).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Keeper owns window.hive and is the only extension that has adopted the unified
+ * protocol. We must sign through that live window.hive object (flagged
+ * isKeeper) rather than the providers registry entry: routing Keeper signing
+ * through the registry handed back a non-live instance whose callback never
+ * fired, so login spun for 60s and never opened the extension. window.hive_extension
+ * is a content-script-world marker that never reaches the page, so it cannot be
+ * used to detect or resolve Keeper.
+ */
+describe("Hive Keeper resolution (window.hive primary)", () => {
+  beforeEach(() => {
+    const w = window as any;
+    delete w.hive_keychain;
+    delete w.hive;
+    delete w.hive_extension;
+    delete w.peakvault;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    const w = window as any;
+    delete w.hive_keychain;
+    delete w.hive;
+    delete w.peakvault;
+  });
+
+  it("signs through the live window.hive, not a stale providers-registry entry", async () => {
+    const order: string[] = [];
+    const requestSignBuffer = vi.fn(
+      (_a: string, _m: string, _t: string, cb: (r: any) => void) => {
+        order.push("sign");
+        cb({ success: true, result: "signature" });
+      }
+    );
+    const liveKeeper: any = {
+      isKeeper: true,
+      requestHandshake: (cb: () => void) => {
+        order.push("handshake");
+        cb();
+      },
+      requestSignBuffer
+    };
+    // A stale/non-live provider object that never calls its callback back -
+    // resolving Keeper through this is exactly what caused the 60s hang.
+    const staleProvider = { requestHandshake: (cb: () => void) => cb(), requestSignBuffer: vi.fn() };
+    liveKeeper.providers = [
+      { name: "Hive Keeper", rdns: "com.ecency.keeper", provider: staleProvider }
+    ];
+    (window as any).hive = liveKeeper;
+
+    const resp = await signBufferWithExtension("alice", "message", "Posting", null, "hive-keeper");
+
+    expect(order).toEqual(["handshake", "sign"]);
+    expect(resp).toMatchObject({ success: true, result: "signature" });
+    expect(requestSignBuffer).toHaveBeenCalledTimes(1);
+    expect(staleProvider.requestSignBuffer).not.toHaveBeenCalled();
+  });
+
+  it("detects Keeper via window.hive.isKeeper (not window.hive_extension)", () => {
+    (window as any).hive = { isKeeper: true, requestHandshake: vi.fn(), requestSignBuffer: vi.fn() };
+
+    const ids = getDetectedExtensions().map((e) => e.id);
+    expect(ids).toContain("hive-keeper");
+  });
+
+  it("does not surface Keeper's window.hive_keychain self-alias as a phantom Keychain", () => {
+    // Keeper-only browser: it aliases itself onto window.hive_keychain for
+    // backward compat, but that is the same isKeeper object - not a real Keychain.
+    const keeper: any = { isKeeper: true, requestHandshake: vi.fn(), requestSignBuffer: vi.fn() };
+    (window as any).hive = keeper;
+    (window as any).hive_keychain = keeper;
+
+    const ids = getDetectedExtensions().map((e) => e.id);
+    expect(ids).toContain("hive-keeper");
+    expect(ids).not.toContain("keychain");
+  });
+
+  it("still detects a genuine Keychain (no isKeeper flag) alongside Keeper", () => {
+    (window as any).hive = { isKeeper: true, requestHandshake: vi.fn(), requestSignBuffer: vi.fn() };
+    (window as any).hive_keychain = { requestHandshake: vi.fn(), requestSignBuffer: vi.fn() };
+
+    const ids = getDetectedExtensions().map((e) => e.id);
+    expect(ids).toContain("hive-keeper");
+    expect(ids).toContain("keychain");
   });
 });

--- a/apps/web/src/specs/utils/hive-extensions.spec.ts
+++ b/apps/web/src/specs/utils/hive-extensions.spec.ts
@@ -216,4 +216,33 @@ describe("Hive Keeper resolution (window.hive primary)", () => {
     expect(ids).toContain("hive-keeper");
     expect(ids).toContain("keychain");
   });
+
+  it("clears a stale 'keychain' preference in a Keeper-only browser and signs via window.hive", async () => {
+    const order: string[] = [];
+    const keeper: any = {
+      isKeeper: true,
+      requestHandshake: (cb: () => void) => {
+        order.push("handshake");
+        cb();
+      },
+      requestSignBuffer: (_a: string, _m: string, _t: string, cb: (r: any) => void) => {
+        order.push("sign");
+        cb({ success: true, result: "signature" });
+      }
+    };
+    (window as any).hive = keeper;
+    // Keeper's backward-compat self-alias - NOT a real Keychain.
+    (window as any).hive_keychain = keeper;
+    // Stale preference from before the user switched to a Keeper-only setup.
+    localStorage.setItem("ecency_preferred_hive_extension", "keychain");
+
+    const resp = await signBufferWithExtension("alice", "message", "Posting");
+
+    // Signed through the live window.hive path (handshake then sign)...
+    expect(order).toEqual(["handshake", "sign"]);
+    expect(resp).toMatchObject({ success: true, result: "signature" });
+    // ...and the stale "keychain" preference self-healed because the alias no
+    // longer resolves to a usable Keychain instance.
+    expect(localStorage.getItem("ecency_preferred_hive_extension")).toBeNull();
+  });
 });

--- a/apps/web/src/types/app-window.ts
+++ b/apps/web/src/types/app-window.ts
@@ -19,14 +19,40 @@ export interface PeakVaultApi {
   ) => Promise<{ success: boolean; error: string; account: string; publicKey?: string; result: any }>;
 }
 
+/** A Hive Unified Wallet Protocol provider registry entry (window.hive.providers[]). */
+export interface HiveWalletProviderEntry {
+  name: string;
+  rdns: string;
+  provider: KeyChainImpl;
+}
+
+/**
+ * A Keychain-compatible wallet global, plus the optional Hive Unified Wallet
+ * Protocol identity flags and provider registry that Keeper sets on window.hive.
+ */
+export type HiveWalletApi = KeyChainImpl & {
+  isKeeper?: boolean;
+  isKeychain?: boolean;
+  isVault?: boolean;
+  providers?: HiveWalletProviderEntry[];
+};
+
 export interface AppWindow extends Window {
   usePrivate: boolean;
   nws?: WebSocket;
   comTag?: {};
-  hive_keychain?: KeyChainImpl;
-  /** Hive Keeper extension (Ecency) - same API as Keychain */
-  hive?: KeyChainImpl;
-  /** Hive Keeper sets this to true when injected */
+  hive_keychain?: HiveWalletApi;
+  /**
+   * Hive Keeper extension (Ecency) - same API as Keychain. Keeper owns this
+   * global, sets `isKeeper`, and registers the unified-protocol `providers`
+   * registry on it.
+   */
+  hive?: HiveWalletApi;
+  /**
+   * Set by Keeper's content script in its own isolated world only. It is NOT
+   * visible to page scripts, so do not gate Keeper detection/resolution on it -
+   * use `window.hive.isKeeper` instead.
+   */
   hive_extension?: boolean;
   /** Peak Vault extension (PeakD) - promise-based API */
   peakvault?: PeakVaultApi;

--- a/apps/web/src/utils/hive-extensions.ts
+++ b/apps/web/src/utils/hive-extensions.ts
@@ -5,8 +5,15 @@
  * falls back to legacy per-global detection for wallets that haven't adopted
  * the protocol yet:
  * - Hive Keychain (window.hive_keychain)
- * - Hive Keeper (window.hive + window.hive_extension)
+ * - Hive Keeper (window.hive, flagged with window.hive.isKeeper)
  * - Peak Vault (window.peakvault)
+ *
+ * Keeper owns window.hive and is the only extension that has adopted the
+ * unified protocol so far. We key off the page-visible window.hive.isKeeper
+ * flag it sets, NOT window.hive_extension: that marker is written only in
+ * Keeper's content-script (isolated) world and is never visible to this page
+ * script, so relying on it silently fails (resolves no Keeper instance and
+ * hangs on a 60s sign timeout).
  *
  * Provides a single detection + broadcast/sign API so the rest of the app
  * doesn't need to know which extension the user has installed.
@@ -73,11 +80,19 @@ export function getDetectedExtensions(): DetectedExtension[] {
     }
   }
 
-  // Legacy per-global detection (fills in wallets not yet in providers)
-  if ((window as any).hive && (window as any).hive_extension) {
+  // Direct detection (fills in wallets not yet in providers).
+  const hive = (window as any).hive;
+  // Keeper flags its own window.hive with isKeeper. (window.hive_extension is a
+  // content-script-world marker that never reaches this page script, so it
+  // can't be used here.)
+  if (hive?.isKeeper) {
     add({ id: "hive-keeper", name: "Hive Keeper", icon: "/assets/keeper.svg" });
   }
-  if ((window as any).hive_keychain) {
+  // Keeper aliases itself onto window.hive_keychain for backward compatibility,
+  // so a Keeper-only browser would otherwise surface a phantom "Keychain"
+  // choice. Skip that self-alias; a real Keychain never sets isKeeper.
+  const keychain = (window as any).hive_keychain;
+  if (keychain && !keychain.isKeeper) {
     add({ id: "keychain", name: "Keychain", icon: "/assets/keychain.png" });
   }
   if ((window as any).peakvault) {
@@ -96,7 +111,7 @@ export function hasAnyHiveExtension(): boolean {
   if (providers?.some((p) => Boolean(RDNS_MAP[p.rdns]))) return true;
   return !!(
     (window as any).hive_keychain ||
-    ((window as any).hive && (window as any).hive_extension) ||
+    (window as any).hive?.isKeeper ||
     (window as any).peakvault
   );
 }
@@ -263,8 +278,16 @@ function getKeychainLikeInstance(): KeyChainImpl | null {
 
 function getHiveKeeperInstance(): KeyChainImpl | null {
   if (typeof window === "undefined") return null;
-  return getProviderByRdns("com.ecency.keeper")
-    || ((window as any).hive && (window as any).hive_extension ? (window as any).hive : null);
+  const hive = (window as any).hive;
+  // Keeper owns window.hive and is the only extension that has adopted the
+  // unified protocol, so prefer that live object directly: it is the instance
+  // Keeper wired its own response listener to, so sign/broadcast requests round
+  // trip reliably. Going through the providers registry can hand back a stale
+  // or non-live object (login then hangs on a 60s timeout with no popup).
+  if (hive?.isKeeper) return hive;
+  // Another wallet may own window.hive (e.g. Peak Vault loaded first): fall back
+  // to Keeper's entry in the providers registry.
+  return getProviderByRdns("com.ecency.keeper");
 }
 
 function getKeychainInstance(): KeyChainImpl | null {

--- a/apps/web/src/utils/hive-extensions.ts
+++ b/apps/web/src/utils/hive-extensions.ts
@@ -292,8 +292,15 @@ function getHiveKeeperInstance(): KeyChainImpl | null {
 
 function getKeychainInstance(): KeyChainImpl | null {
   if (typeof window === "undefined") return null;
-  return getProviderByRdns("com.hivekeychain")
-    || ((window as any).hive_keychain ?? null);
+  const fromRegistry = getProviderByRdns("com.hivekeychain");
+  if (fromRegistry) return fromRegistry;
+  // Skip Keeper's backward-compat self-alias on window.hive_keychain (it carries
+  // isKeeper; a real Keychain never does). Returning it here would resolve a
+  // stale "keychain" preference to a non-null instance, so the caller's
+  // "preferred extension no longer available" cleanup would never clear it and
+  // signing would route through the alias instead of the live window.hive path.
+  const keychain = (window as any).hive_keychain;
+  return keychain && !keychain.isKeeper ? keychain : null;
 }
 
 function getPeakVaultInstance(): PeakVaultApi | null {


### PR DESCRIPTION
## Problem

On the login dialog's **Choose Extension** picker, clicking **Hive Keeper** did nothing but spin, never opened the Keeper extension, and after 60s showed an `Extension request timed out. Please try again.` toast.

## Root cause

Keeper is the only extension that has adopted the Hive Unified Wallet Protocol: it owns `window.hive`, flags itself with `window.hive.isKeeper`, and registers a `com.ecency.keeper` entry in `window.hive.providers[]`.

The web app resolved/detected Keeper by gating on `window.hive_extension`. Keeper sets that flag **only in its content-script (isolated) world**, so it is never visible to page scripts. That made the direct branch dead code and forced Keeper resolution through the providers registry, whose instance did not round-trip the sign callback. The result was a 60s hang with no popup.

`window.hive_extension` is also not reliable for detection, so a Keeper-only browser additionally surfaced a phantom **Keychain** row (Keeper aliases itself onto `window.hive_keychain` for backward compatibility).

## Fix

- Resolve and detect Keeper via the page-visible `window.hive.isKeeper` flag, targeting the live `window.hive` object directly (the instance Keeper wired its own response listener to). Use the providers registry only as a fallback for when another wallet owns `window.hive`.
- Drop every reliance on `window.hive_extension` (`getHiveKeeperInstance`, `getDetectedExtensions`, `hasAnyHiveExtension`, and the `hasKeyChain` gate in `global-module`).
- Suppress Keeper's `window.hive_keychain` self-alias so it no longer appears as a separate Keychain choice (a real Keychain never sets `isKeeper`).
- Type `window.hive` as `HiveWalletApi` (`isKeeper`/`providers`) and document that `hive_extension` is not page-visible.

No extension changes are required: the Keeper extension implements the protocol correctly (providers registry, `extension_id` routing, and the `extension_id` validation whitelist are all present). This was an integration issue on the web side.

## Tests

- 4 regression tests: Keeper signs through the live `window.hive` rather than a stale providers entry, `isKeeper` detection, and the self-alias dedupe.
- Full web suite passes (1610 tests). No new type errors in the changed files.

## Note

Bug reported alongside this (broken Keychain logo in the picker) was a transient 429 on the static asset host, not a code issue (`images.unoptimized` serves the asset directly).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Hive Keeper wallet extension detection and selection using updated identification methods for improved compatibility.

* **Tests**
  * Added comprehensive test suite for Hive Keeper wallet resolution, covering detection mechanisms and multi-wallet compatibility verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->