### PR TITLE
feat(config): enable RC top-up feature flag

### DIFF
--- a/apps/web/src/config/config.template.ts
+++ b/apps/web/src/config/config.template.ts
@@ -90,7 +90,7 @@ const CONFIG = {
         enabled: true
       },
       rcTopup: {
-        enabled: false
+        enabled: true
       },
       editHistory: {
         enabled: true

--- a/apps/web/src/config/config.ts
+++ b/apps/web/src/config/config.ts
@@ -89,7 +89,7 @@ const CONFIG = {
         enabled: true
       },
       rcTopup: {
-        enabled: false
+        enabled: true
       },
       editHistory: {
         enabled: true

--- a/apps/web/src/features/shared/rc-topup/rc-topup-dialog.tsx
+++ b/apps/web/src/features/shared/rc-topup/rc-topup-dialog.tsx
@@ -11,7 +11,7 @@ import {
   getPointsQueryOptions,
   getRcDelegationActiveQueryOptions
 } from "@ecency/sdk";
-import { getAccessToken } from "@/utils";
+import { ensureValidToken } from "@/utils";
 import dayjs from "@/utils/dayjs";
 import i18next from "i18next";
 import { LinearProgress } from "@/features/shared";
@@ -32,8 +32,28 @@ interface Props {
  */
 export function RcTopupDialog({ onHide }: Props) {
   const { activeUser } = useActiveAccount();
+  const username = activeUser?.username;
 
-  const accessToken = (activeUser && getAccessToken(activeUser.username)) || "";
+  // Resolve a guaranteed-fresh access token before the token-gated price/active
+  // queries. getAccessToken() returns a STALE token for expired/legacy sessions,
+  // which 401s the private API and leaves the dialog with no duration options;
+  // ensureValidToken awaits the background refresh first.
+  const [accessToken, setAccessToken] = useState("");
+  useEffect(() => {
+    let cancelled = false;
+    if (!username) {
+      setAccessToken("");
+      return;
+    }
+    ensureValidToken(username).then((token) => {
+      if (!cancelled) {
+        setAccessToken(token ?? "");
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [username]);
 
   const { data: prices } = useQuery({
     ...getRcDelegationPricesQueryOptions(accessToken),


### PR DESCRIPTION
Enables `visionFeatures.rcTopup` (in `config.ts` and `config.template.ts`), turning on the RC top-up surfaces shipped behind the flag in #978: the pre-publish Resource Credits check and the Points-funded RC top-up purchase dialog.

Safe to enable now: the backend is deployed and verified end to end — ePoints (reserved-amount sentinel, premium-collision purchase guard, auto-refund of any undeliverable top-up) and the delegator bot (delivers a top-up onto an empty edge, reclaims only an exact sentinel match, premium cleanup + backfill skip the sentinel). With no purchases yet the delegator runs as a no-op until the first top-up is bought.

Flag flip only; no behavior change beyond surfacing the gated feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RC Topup feature is now available and enabled by default in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->