### PR TITLE
feat(points): funnel low-RC users to buy Points + clearer purchase steps

### DIFF
--- a/apps/web/src/app/perks/points/_components/points-action-card.tsx
+++ b/apps/web/src/app/perks/points/_components/points-action-card.tsx
@@ -6,6 +6,7 @@ interface Props {
   imageSrc: string;
   title: string;
   description: string;
+  steps?: string[];
   buttonText: ReactNode;
   buttonDisabled?: boolean;
   buttonLoading?: boolean;
@@ -16,6 +17,7 @@ export function PointsActionCard({
   imageSrc,
   title,
   description,
+  steps,
   buttonText,
   buttonDisabled = false,
   buttonLoading = false,
@@ -27,6 +29,13 @@ export function PointsActionCard({
         <Image width={250} height={150} alt="" src={imageSrc} className="mx-auto h-[150px]" />
         <div className="font-bold mt-8 lg:mt-12">{title}</div>
         <div className="opacity-50">{description}</div>
+        {steps && steps.length > 0 && (
+          <ol className="mt-3 flex flex-col gap-1 text-sm opacity-70 list-decimal list-inside">
+            {steps.map((step, i) => (
+              <li key={i}>{step}</li>
+            ))}
+          </ol>
+        )}
       </div>
       <Button size="lg" onClick={onClick} disabled={buttonDisabled} isLoading={buttonLoading}>
         {buttonText}

--- a/apps/web/src/app/perks/points/_components/points-action-card.tsx
+++ b/apps/web/src/app/perks/points/_components/points-action-card.tsx
@@ -31,8 +31,8 @@ export function PointsActionCard({
         <div className="opacity-50">{description}</div>
         {steps && steps.length > 0 && (
           <ol className="mt-3 flex flex-col gap-1 text-sm opacity-70 list-decimal list-inside">
-            {steps.map((step, i) => (
-              <li key={i}>{step}</li>
+            {steps.map((step) => (
+              <li key={step}>{step}</li>
             ))}
           </ol>
         )}

--- a/apps/web/src/app/perks/points/_page.tsx
+++ b/apps/web/src/app/perks/points/_page.tsx
@@ -42,6 +42,11 @@ export function PointsPage() {
           imageSrc="/assets/undraw-credit-card.svg"
           title={i18next.t("perks.buy-points-qr-title")}
           description={i18next.t("perks.buy-points-qr-description")}
+          steps={[
+            i18next.t("perks.buy-points-qr-step-1"),
+            i18next.t("perks.buy-points-qr-step-2"),
+            i18next.t("perks.buy-points-qr-step-3")
+          ]}
           buttonText={i18next.t("perks.buy-points-qr-button")}
           onClick={() => setShowPurchaseQr(true)}
         />
@@ -51,6 +56,11 @@ export function PointsPage() {
           imageSrc="/assets/undraw-transfer.svg"
           title={i18next.t("perks.buy-points-hive-title")}
           description={i18next.t("perks.buy-points-hive-description")}
+          steps={[
+            i18next.t("perks.buy-points-hive-step-1"),
+            i18next.t("perks.buy-points-hive-step-2"),
+            i18next.t("perks.buy-points-hive-step-3")
+          ]}
           buttonText={i18next.t("perks.buy-points-hive-button")}
           onClick={() => router.push("/perks/points/buy-with-hive")}
         />

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -2811,7 +2811,8 @@
     "title": "Top up Resource Credits",
     "sub-title": "Spend Points for a short-term RC boost so you can keep posting",
     "success-message": "Your RC top-up is on the way. It will appear shortly.",
-    "already-active": "You already have an active RC top-up until {{date}}."
+    "already-active": "You already have an active RC top-up until {{date}}.",
+    "get-points": "Buy Points"
   },
   "perks": {
     "page-title": "Welcome to Perks",
@@ -2841,6 +2842,12 @@
     "buy-points-hive-title": "Buy points using Hive/HBD",
     "buy-points-hive-description": "Already have some HIVE or HBD? Swap HIVE/HBD to POINTS quickly",
     "buy-points-hive-button": "Buy with HIVE/HBD",
+    "buy-points-qr-step-1": "Open the QR code",
+    "buy-points-qr-step-2": "Scan it with your phone camera",
+    "buy-points-qr-step-3": "Buy Points in the Ecency app (card, Apple Pay, or Google Pay)",
+    "buy-points-hive-step-1": "Choose HIVE or HBD and an amount",
+    "buy-points-hive-step-2": "Confirm the transfer",
+    "buy-points-hive-step-3": "Your Points are credited",
     "buy-points-hive-success-title": "You`ve got +{{amount}} points",
     "buy-points-hive-success-description": "Points has transferred to your account. Please, check it in a wallet page",
     "claim-points-title": "Claim points",

--- a/apps/web/src/features/shared/rc-precheck/rc-precheck-banner.tsx
+++ b/apps/web/src/features/shared/rc-precheck/rc-precheck-banner.tsx
@@ -74,7 +74,7 @@ export function RcPrecheckBanner({
           <span
             role="button"
             tabIndex={0}
-            className="shrink-0 cursor-pointer font-semibold text-orange hover:underline"
+            className="shrink-0 cursor-pointer font-semibold text-blue-dark-sky hover:underline"
             onClick={onTopUp}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
@@ -103,7 +103,7 @@ export function RcPrecheckBanner({
           <span className="mt-[2px] shrink-0 text-orange">{alertCircleSvg}</span>
           <span>{i18next.t("rc-precheck.low-rc-message")}</span>
         </div>
-        <Button size="sm" appearance="warning" className="self-end sm:self-auto" onClick={onTopUp}>
+        <Button size="sm" className="self-end sm:self-auto" onClick={onTopUp}>
           {i18next.t("rc-precheck.top-up")}
         </Button>
       </div>

--- a/apps/web/src/features/shared/rc-topup/rc-topup-dialog.tsx
+++ b/apps/web/src/features/shared/rc-topup/rc-topup-dialog.tsx
@@ -146,6 +146,16 @@ export function RcTopupDialog({ onHide }: Props) {
                       readOnly={true}
                       value={`${activeUserPoints?.points ?? "0.000"} POINTS`}
                     />
+                    <div className="pl-3 mt-1">
+                      <a
+                        href="/perks/points"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-dark-sky hover:underline text-sm font-semibold"
+                      >
+                        {i18next.t("rc-topup.get-points")}
+                      </a>
+                    </div>
                     {balanceError && <small className="pl-3 text-red">{balanceError}</small>}
                     {isAlreadyActive && (
                       <div>

--- a/apps/web/src/specs/features/perks/points-action-card.spec.tsx
+++ b/apps/web/src/specs/features/perks/points-action-card.spec.tsx
@@ -1,0 +1,49 @@
+import { vi } from "vitest";
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { PointsActionCard } from "@/app/perks/points/_components/points-action-card";
+
+// next/image needs a loader in the test env; render a plain img instead.
+vi.mock("next/image", () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => <img alt={alt} src={src} />
+}));
+
+describe("PointsActionCard", () => {
+  const baseProps = {
+    imageSrc: "/x.svg",
+    title: "Buy with HIVE",
+    description: "Swap HIVE/HBD to POINTS",
+    buttonText: "Buy",
+    onClick: vi.fn()
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  test("renders the numbered steps as list items when provided", () => {
+    render(
+      <PointsActionCard {...baseProps} steps={["First step", "Second step", "Third step"]} />
+    );
+
+    expect(screen.getByText("First step")).toBeInTheDocument();
+    expect(screen.getByText("Second step")).toBeInTheDocument();
+    expect(screen.getByText("Third step")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  test("renders no steps list when steps is omitted or empty", () => {
+    const { rerender } = render(<PointsActionCard {...baseProps} />);
+    expect(screen.queryByRole("listitem")).toBeNull();
+
+    rerender(<PointsActionCard {...baseProps} steps={[]} />);
+    expect(screen.queryByRole("listitem")).toBeNull();
+  });
+
+  test("fires onClick when the action button is pressed", () => {
+    const onClick = vi.fn();
+    render(<PointsActionCard {...baseProps} onClick={onClick} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Follow-up to the RC top-up flow (#981). Closes the dead-end where a user low on Points had no way to get more, and makes the CTAs clearer.

## Changes
- **RC top-up dialog**: an always-visible **Buy Points** link (blue, opens `/perks/points` in a new tab so an in-progress reply/post draft is preserved). Shown regardless of balance, so users can also stock up for later, not only when they hit insufficient funds.
- **RC precheck banner**: the **Top up RC** CTA is now the primary **blue** action. It was an orange button on the orange low-RC banner (and orange text in the compact vote-popover variant), which made it hard to tell it was clickable.
- **Points page (`/perks/points`)**: the QR and HIVE purchase cards now show **numbered, easy-to-follow steps** (new optional `steps` prop on `PointsActionCard`), so a newcomer isn't guessing how each method works.

Strings added to `en-US.json` only. No backend changes. The card-purchase flow stays as-is (QR = in-app purchase, HIVE/HBD = on-chain transfer); a card/Stripe option can slot in later as a third card without touching this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added step-by-step instructions for purchasing points via QR code and HIVE transfer.
  * Added direct link to points section in the top-up dialog.

* **Style**
  * Updated top-up button styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->