### PR TITLE
fix: enable Stripe wallets + route signing to the logged-in extension (Keychain/Keeper hijack)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -261,12 +261,20 @@ const config = {
           { key: "X-Frame-Options", value: "SAMEORIGIN" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-          // Conservative Permissions-Policy: deny only powerful features the
-          // app never requests. We deliberately DO NOT restrict accelerometer,
+          // Conservative Permissions-Policy: deny powerful features the app
+          // never requests. We deliberately DO NOT restrict accelerometer,
           // gyroscope, fullscreen, picture-in-picture, encrypted-media or
           // web-share — the whitelisted video iframe embeds (3Speak/YouTube)
           // request those via their `allow`/`allowfullscreen` attributes, and a
           // top-level `()` here would override the per-iframe grant.
+          // EXCEPTION — payment: delegated to Stripe (self + js.stripe.com +
+          // *.js.stripe.com) so the Payment Element can initialize the Google Pay /
+          // Apple Pay wallet frames. Stripe stamps allow="payment" on its own nested
+          // frames and sub-delegates to pay.google.com / Apple Pay, so those wallet
+          // origins are NOT (and must not be) listed here. The prior `payment=()`
+          // disabled the feature document-wide and blocked the wallets ("payment is
+          // not allowed in this document"); card entry does not use the Payment
+          // Request API, so cards were unaffected.
           {
             key: "Permissions-Policy",
             // NOTE: do not re-add `interest-cohort=()` or `browsing-topics=()`.
@@ -276,7 +284,7 @@ const config = {
             // Sandbox and warns there too. The app uses neither API, so the opt-out
             // tokens bought nothing but console noise.
             value:
-              "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=()"
+              "camera=(), microphone=(), geolocation=(), payment=(self \"https://js.stripe.com\" \"https://*.js.stripe.com\"), usb=(), magnetometer=()"
           },
           // ENFORCING CSP — only directives that cannot break JS/CSS execution
           // or block the app's existing cross-origin fetches/frames/images. We

--- a/apps/web/src/features/shared/login/login.tsx
+++ b/apps/web/src/features/shared/login/login.tsx
@@ -114,6 +114,14 @@ export default function Login() {
         return;
       case "login":
         if (isLoginByKeychainPending) return;
+        // Persist the chosen extension (mirrors handleSelectExtension) so later
+        // signing/broadcast resolves to the SAME extension the user logged in
+        // with. This path fires when exactly one extension is detected and never
+        // recorded a preference; if the user later enables a SECOND extension
+        // (e.g. Keeper alongside Keychain), the broadcast auto-detect — which is
+        // Keeper-first — would otherwise hijack signing and silently drop the
+        // request (dead 60s spinner). extId is defined here (length === 1).
+        if (action.extId) setPreferredExtensionId(action.extId);
         // Sign with the explicit extension so detection and signing can never
         // resolve to different extensions.
         loginByKeychain(action.extId).catch(() => {

--- a/apps/web/src/features/shared/purchase-stripe/stripe-checkout-form.tsx
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-checkout-form.tsx
@@ -57,7 +57,15 @@ export function StripeCheckoutForm({ returnUrl, payLabel, onPaid, onError }: Pro
 
   return (
     <form onSubmit={submit} className="flex flex-col gap-4">
-      <PaymentElement onReady={() => setReady(true)} />
+      {/* Wallets (Google Pay / Apple Pay) explicitly opted in. They render only
+          when the Permissions-Policy `payment` feature is delegated to Stripe (see
+          next.config.js), the browser/device supports a wallet, and -- for Apple
+          Pay -- the domain is registered in the Stripe Dashboard. Card entry is
+          unaffected by all of that. */}
+      <PaymentElement
+        onReady={() => setReady(true)}
+        options={{ wallets: { applePay: "auto", googlePay: "auto" } }}
+      />
       <Button
         type="submit"
         full={true}

--- a/apps/web/src/utils/hive-extensions.ts
+++ b/apps/web/src/utils/hive-extensions.ts
@@ -349,6 +349,18 @@ function pingKeychain(keychain: KeyChainImpl, timeoutMs = 6000): Promise<void> {
   });
 }
 
+// Timeout for a Keychain sign/broadcast request AFTER the worker passed the 6s
+// liveness handshake. An idle/crashed Manifest V3 worker can answer
+// requestHandshake yet silently drop the actual request, so the callback never
+// fires; without this the user sees a dead 60s spinner. 30s surfaces that fast
+// with an actionable message while still leaving ample time to approve the
+// popup. The message deliberately steers the user away from a blind retry on a
+// broadcast (which could double-submit) by tying the retry to "no popup
+// appeared" -- the genuine dropped-request case.
+const KEYCHAIN_REQUEST_TIMEOUT_MS = 30000;
+const KEYCHAIN_TIMEOUT_MESSAGE =
+  "Keychain didn't respond. If no popup appeared, click its icon to wake it, then try again.";
+
 function signBufferViaKeychain(
   keychain: KeyChainImpl,
   account: string,
@@ -363,9 +375,9 @@ function signBufferViaKeychain(
         const timeoutId = setTimeout(() => {
           if (!settled) {
             settled = true;
-            reject(new Error("Extension request timed out. Please try again."));
+            reject(new Error(KEYCHAIN_TIMEOUT_MESSAGE));
           }
-        }, 60000);
+        }, KEYCHAIN_REQUEST_TIMEOUT_MS);
 
         keychain.requestSignBuffer(
           account,
@@ -413,9 +425,9 @@ function broadcastViaKeychain(
       const timeoutId = setTimeout(() => {
         if (!settled) {
           settled = true;
-          reject(new Error("Extension request timed out. Please try again."));
+          reject(new Error(KEYCHAIN_TIMEOUT_MESSAGE));
         }
-      }, 60000);
+      }, KEYCHAIN_REQUEST_TIMEOUT_MS);
 
       keychain.requestBroadcast(
         account,


### PR DESCRIPTION
Post-Stripe-launch web fixes bundled per request: one Stripe wallet enablement, and the RC top-up Keychain signing hang (root-caused to a co-installed Keeper hijacking signing). Independent changes, different files.

## 1. Enable Google Pay / Apple Pay in the Stripe Payment Element
The site-wide `Permissions-Policy` set `payment=()` — an empty allowlist that disables the Payment Request API document-wide — so Stripe's Payment Element could not initialize the Google Pay / Apple Pay wallet frames (`pay.js`: "payment is not allowed in this document"). Card entry does not use that API, so card payments were unaffected (verified working in prod).

- `next.config.js`: `payment=()` → `payment=(self "https://js.stripe.com" "https://*.js.stripe.com")`. We delegate only to Stripe; Stripe stamps `allow="payment"` on its own nested frames and sub-delegates to pay.google.com / Apple Pay, so those wallet origins are intentionally **not** listed. No CSP change needed (wallet frames load inside Stripe's iframe). Verified not to regress the whitelisted video-iframe `allow` grants (they don't use the `payment` feature).
- `stripe-checkout-form.tsx`: opt the `<PaymentElement>` into wallets explicitly.

Server intent is already wallet-eligible (`automatic_payment_methods`, USD, not card-pinned); Apple Pay + Google Pay are enabled in the Stripe Dashboard and `ecency.com` is registered under Payment Method Domains. So both wallets should render once this deploys.

## 2. RC top-up Keychain signing hang (co-installed Keeper hijack)
Reported: RC top-up "Next" (an active-authority op) spins forever, then "Extension request timed out", with **no** Keychain popup. Root cause: the user logged in with **Keychain** while **Keeper** was also installed. The single-extension login path (`decideExtensionLoginAction` → `"login"`, fired when exactly one extension was detected at login time) signed with the explicit extension but **never persisted the preference** — unlike the picker and the auth-upgrade dialog. So later broadcasts fell through to the Keeper-first auto-detect (`getKeychainLikeInstance`), hit Keeper's idle/dead MV3 worker, and the request was silently dropped → dead 60s spinner. (For a Keychain login the SDK correctly dispatches straight to the extension — this is **not** a missing auth-upgrade dialog.)

- `login.tsx`: persist `setPreferredExtensionId(action.extId)` in the `"login"` path too, so signing always resolves to the SAME extension the user logged in with. Resolution-by-preference already handles Keeper's `window.hive_keychain` self-alias via the providers registry. **Primary fix.**
- `hive-extensions.ts`: defense-in-depth — reject a dropped sign/broadcast at 30s (above the 6s liveness ping, still room to approve the popup) with an actionable "wake the extension" message that ties retry to "no popup appeared" (avoids a blind retry that could double-broadcast a points-spend op).

> Existing sessions must **re-login once** (logout → login with Keychain) so the preference is recorded; new logins record it automatically.

## Testing
- Card purchase verified end to end in prod before this change.
- `next.config.js` syntax-checked; rendered `Permissions-Policy` value confirmed.
- Full typecheck / lint / Test-Web-Build left to CI (not run on the origin box).

## Follow-ups (out of this PR)
- Confirm the RC top-up backend dedupes a double broadcast (idempotency); the 30s timeout reduces but does not eliminate a slow-approval retry window.
