### PR TITLE
feat: unified Sign-with-Extension picker across all signing surfaces

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/permissions/_components/account-recovery.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/permissions/_components/account-recovery.tsx
@@ -193,6 +193,7 @@ export function AccountRecovery() {
         <ModalBody>
           <KeyOrHot
             inProgress={isPending}
+            authority="owner"
             onKey={(key) => handleSign("key", key)}
             onKc={() => handleSign("keychain")}
             onHot={() => handleSign("hivesigner")}

--- a/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
+++ b/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
@@ -75,9 +75,9 @@ export function AuthUpgradeDialog() {
   const handleChooseExtension = useCallback((extId: HiveExtensionId) => {
     setChoosing(false);
     setRequest(null);
-    setPreferredExtensionId(extId);
+    if (activeUser?.username) setPreferredExtensionId(activeUser.username, extId);
     resolveAuthUpgrade("keychain");
-  }, []);
+  }, [activeUser?.username]);
 
   if (!request) return null;
 

--- a/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
+++ b/apps/web/src/features/shared/auth-upgrade/auth-upgrade-dialog.tsx
@@ -84,7 +84,12 @@ export function AuthUpgradeDialog() {
   const authority = (request.authority || "active") as "posting" | "active" | "owner";
   const isMetaMaskUser = activeUser && getLoginType(activeUser.username) === "metamask";
   const useKcMobile = shouldUseKeychainMobile(activeUser?.username);
-  const detectedExtensions = getDetectedExtensions();
+  // Peak Vault can't sign owner-authority operations, so don't offer it for
+  // owner flows (e.g. change_recovery_account) where its broadcast would be
+  // rejected even though a compatible extension is available.
+  const detectedExtensions = getDetectedExtensions().filter(
+    (e) => authority !== "owner" || e.id !== "peakvault"
+  );
   // The unified "Sign with Extension" button shows when an extension is
   // installed, or there's a Keychain Mobile / in-app deep-link path. On desktop
   // with no extension we show install links instead (below) — never a dead-end.
@@ -103,6 +108,13 @@ export function AuthUpgradeDialog() {
     if (detectedExtensions.length > 1) {
       setChoosing(true);
       return;
+    }
+    // Persist the lone extension (like KeyOrHot / WalletOperationSign) so a later
+    // broadcast targets it instead of auto-resolving Keeper-first. Without this a
+    // Keychain-only user who then installs Keeper would get hijacked on the next
+    // active-authority sign.
+    if (detectedExtensions.length === 1 && activeUser?.username) {
+      setPreferredExtensionId(activeUser.username, detectedExtensions[0].id);
     }
     setRequest(null);
     resolveAuthUpgrade("keychain");

--- a/apps/web/src/features/shared/key-or-hot/index.tsx
+++ b/apps/web/src/features/shared/key-or-hot/index.tsx
@@ -5,14 +5,22 @@ import { useIsMobile } from "@/utils";
 import { PrivateKey } from "@ecency/sdk";
 import { Button } from "@ui/button";
 import { KeyInput } from "@ui/input";
+import { UilArrowLeft } from "@tooni/iconscout-unicons-react";
 import i18next from "i18next";
 import Image from "next/image";
+import { useCallback, useState } from "react";
 import { OrDivider } from "../or-divider";
 import { MetaMaskSignButton } from "../metamask-sign-button";
+import { ExtensionChooser } from "../extension-chooser";
 import "./index.scss";
 import { shouldUseKeychainMobile } from "@/utils/client";
 import { isInAppBrowser } from "@/utils/keychain";
 import { getLoginType } from "@/utils/user-token";
+import {
+  getDetectedExtensions,
+  setPreferredExtensionId,
+  type HiveExtensionId
+} from "@/utils/hive-extensions";
 
 interface Props {
   inProgress: boolean;
@@ -30,9 +38,37 @@ export function KeyOrHot({ inProgress, onKey, onHot, onKc, onMetaMask, keyOnly, 
   const useKcMobile = shouldUseKeychainMobile(activeUser?.username);
   const isMetaMaskUser = activeUser && getLoginType(activeUser.username) === "metamask";
   const canRenderKeychain = !isMetaMaskUser && onKc && (!isMobileBrowser || useKcMobile || isInAppBrowser());
-  const keychainLabel = useKcMobile
+  const username = activeUser?.username;
+  const [choosing, setChoosing] = useState(false);
+  const detectedExtensions = getDetectedExtensions();
+  const extensionLabel = useKcMobile
     ? i18next.t("key-or-hot.with-keychain-mobile", { defaultValue: "Sign with Keychain Mobile" })
-    : i18next.t("key-or-hot.with-keychain");
+    : i18next.t("key-or-hot.with-extension", { defaultValue: "Sign with Extension" });
+
+  // Unified extension entry. Re-read detection at click time (globals inject
+  // asynchronously). With more than one extension, defer to the chooser;
+  // otherwise persist the lone extension (per username) and sign. The persisted
+  // choice makes the downstream broadcast target it instead of Keeper-first.
+  const handleExtensionSign = useCallback(() => {
+    const detected = getDetectedExtensions();
+    if (detected.length > 1) {
+      setChoosing(true);
+      return;
+    }
+    if (detected.length === 1 && username) {
+      setPreferredExtensionId(username, detected[0].id);
+    }
+    onKc?.();
+  }, [username, onKc]);
+
+  const handleChooseExtension = useCallback(
+    (extId: HiveExtensionId) => {
+      setChoosing(false);
+      if (username) setPreferredExtensionId(username, extId);
+      onKc?.();
+    },
+    [username, onKc]
+  );
 
   if (isMetaMaskUser && onMetaMask && !keyOnly) {
     return (
@@ -49,47 +85,81 @@ export function KeyOrHot({ inProgress, onKey, onHot, onKc, onMetaMask, keyOnly, 
         {!keyOnly && (onHot || canRenderKeychain) && (
           <>
             <OrDivider />
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {onHot && (
+            {choosing ? (
+              <div className="flex flex-col gap-3">
                 <Button
-                  size="lg"
-                  outline={true}
-                  appearance="hivesigner"
-                  onClick={() => onHot()}
-                  icon={
-                    <Image
-                      width={100}
-                      height={100}
-                      src="/assets/hive-signer.svg"
-                      className="w-4 h-4"
-                      alt="hivesigner"
-                    />
-                  }
+                  iconPlacement="left"
+                  appearance="gray-link"
+                  size="sm"
+                  noPadding={true}
+                  onClick={() => setChoosing(false)}
+                  icon={<UilArrowLeft />}
                 >
-                  {i18next.t("key-or-hot.with-hivesigner")}
+                  {i18next.t("g.back")}
                 </Button>
-              )}
+                <ExtensionChooser
+                  extensions={detectedExtensions}
+                  onSelect={handleChooseExtension}
+                />
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {onHot && (
+                  <Button
+                    size="lg"
+                    outline={true}
+                    appearance="hivesigner"
+                    onClick={() => onHot()}
+                    icon={
+                      <Image
+                        width={100}
+                        height={100}
+                        src="/assets/hive-signer.svg"
+                        className="w-4 h-4"
+                        alt="hivesigner"
+                      />
+                    }
+                  >
+                    {i18next.t("key-or-hot.with-hivesigner")}
+                  </Button>
+                )}
 
-              {canRenderKeychain && (
-                <Button
-                  outline={true}
-                  appearance="secondary"
-                  size="lg"
-                  onClick={onKc}
-                  icon={
-                    <Image
-                      width={100}
-                      height={100}
-                      src="/assets/keychain.png"
-                      className="w-4 h-4"
-                      alt="keychain"
-                    />
-                  }
-                >
-                  {keychainLabel}
-                </Button>
-              )}
-            </div>
+                {canRenderKeychain && (
+                  <Button
+                    outline={true}
+                    appearance="secondary"
+                    size="lg"
+                    onClick={handleExtensionSign}
+                    icon={
+                      <div className="flex items-center -space-x-1">
+                        {detectedExtensions.length > 0 ? (
+                          detectedExtensions.map((ext) => (
+                            <Image
+                              key={ext.id}
+                              width={20}
+                              height={20}
+                              src={ext.icon}
+                              className="w-4 h-4 rounded-sm"
+                              alt={ext.name}
+                            />
+                          ))
+                        ) : (
+                          <Image
+                            width={100}
+                            height={100}
+                            src="/assets/keychain.png"
+                            className="w-4 h-4"
+                            alt="extensions"
+                          />
+                        )}
+                      </div>
+                    }
+                  >
+                    {extensionLabel}
+                  </Button>
+                )}
+              </div>
+            )}
           </>
         )}
       </div>

--- a/apps/web/src/features/shared/key-or-hot/index.tsx
+++ b/apps/web/src/features/shared/key-or-hot/index.tsx
@@ -40,7 +40,14 @@ export function KeyOrHot({ inProgress, onKey, onHot, onKc, onMetaMask, keyOnly, 
   const canRenderKeychain = !isMetaMaskUser && onKc && (!isMobileBrowser || useKcMobile || isInAppBrowser());
   const username = activeUser?.username;
   const [choosing, setChoosing] = useState(false);
-  const detectedExtensions = getDetectedExtensions();
+  // Peak Vault can't sign owner-authority operations (broadcastWithExtension
+  // rejects them), so don't offer it for owner flows (e.g. key rotation) where
+  // a compatible extension would otherwise be available.
+  const supportsAuthority = (id: HiveExtensionId) =>
+    authority !== "owner" || id !== "peakvault";
+  const detectedExtensions = getDetectedExtensions().filter((e) =>
+    supportsAuthority(e.id)
+  );
   const extensionLabel = useKcMobile
     ? i18next.t("key-or-hot.with-keychain-mobile", { defaultValue: "Sign with Keychain Mobile" })
     : i18next.t("key-or-hot.with-extension", { defaultValue: "Sign with Extension" });
@@ -50,7 +57,9 @@ export function KeyOrHot({ inProgress, onKey, onHot, onKc, onMetaMask, keyOnly, 
   // otherwise persist the lone extension (per username) and sign. The persisted
   // choice makes the downstream broadcast target it instead of Keeper-first.
   const handleExtensionSign = useCallback(() => {
-    const detected = getDetectedExtensions();
+    const detected = getDetectedExtensions().filter(
+      (e) => authority !== "owner" || e.id !== "peakvault"
+    );
     if (detected.length > 1) {
       setChoosing(true);
       return;
@@ -59,7 +68,7 @@ export function KeyOrHot({ inProgress, onKey, onHot, onKc, onMetaMask, keyOnly, 
       setPreferredExtensionId(username, detected[0].id);
     }
     onKc?.();
-  }, [username, onKc]);
+  }, [authority, username, onKc]);
 
   const handleChooseExtension = useCallback(
     (extId: HiveExtensionId) => {

--- a/apps/web/src/features/shared/login/login.tsx
+++ b/apps/web/src/features/shared/login/login.tsx
@@ -121,7 +121,7 @@ export default function Login() {
         // (e.g. Keeper alongside Keychain), the broadcast auto-detect — which is
         // Keeper-first — would otherwise hijack signing and silently drop the
         // request (dead 60s spinner). extId is defined here (length === 1).
-        if (action.extId) setPreferredExtensionId(action.extId);
+        if (action.extId) setPreferredExtensionId(username, action.extId);
         // Sign with the explicit extension so detection and signing can never
         // resolve to different extensions.
         loginByKeychain(action.extId).catch(() => {
@@ -132,7 +132,7 @@ export default function Login() {
   };
 
   const handleSelectExtension = (extId: HiveExtensionId) => {
-    setPreferredExtensionId(extId);
+    setPreferredExtensionId(username, extId);
     setShowExtensionsInfo(false);
     if (isLoginByKeychainPending) return;
     if (!username) {

--- a/apps/web/src/features/wallet/operations/wallet-operations-sign.tsx
+++ b/apps/web/src/features/wallet/operations/wallet-operations-sign.tsx
@@ -6,7 +6,7 @@ import { AssetOperation, broadcastOperations, useWalletOperation } from "@ecency
 import type { AuthContextV2 } from "@ecency/sdk";
 import { PrivateKey } from "@ecency/sdk";
 import { isWif } from "@ecency/sdk";
-import { UilLock } from "@tooni/iconscout-unicons-react";
+import { UilLock, UilArrowLeft } from "@tooni/iconscout-unicons-react";
 import { motion } from "framer-motion";
 import i18next from "i18next";
 import hs from "hivesigner";
@@ -14,9 +14,17 @@ import Image from "next/image";
 import { useCallback, useEffect, useState, useMemo, useRef } from "react";
 import { WalletOperationSigning } from "./wallet-operations-signing";
 import { shouldUseKeychainMobile } from "@/utils/client";
+import { isInAppBrowser } from "@/utils/keychain";
 import { getLoginType } from "@/utils/user-token";
 import { getWebBroadcastAdapter } from "@/providers/sdk";
 import { buildHsCallbackUrl } from "@/utils/hs-callback";
+import { ExtensionChooser } from "@/features/shared/extension-chooser";
+import {
+  getDetectedExtensions,
+  hasAnyHiveExtension,
+  setPreferredExtensionId,
+  type HiveExtensionId
+} from "@/utils/hive-extensions";
 
 interface Props {
   asset: string;
@@ -33,13 +41,11 @@ export function WalletOperationSign({ data, onSignError, onSignSuccess, asset, o
   const signingKey = useGlobalStore((state) => state.signingKey);
   const setSigningKey = useGlobalStore((state) => state.setSigningKey);
   const useKcMobile = shouldUseKeychainMobile(activeUser?.username);
-  const canUseKeychain = hasKeyChain || useKcMobile;
-  const keychainLabel = useKcMobile
-    ? i18next.t("key-or-hot.with-keychain-mobile", { defaultValue: "Sign with Keychain Mobile" })
-    : i18next.t("key-or-hot.with-keychain");
   const isMetaMaskUser = activeUser && getLoginType(activeUser.username) === "metamask";
 
   const [step, setStep] = useState<"sign" | "signing">("sign");
+  // When >1 extension is installed, swap the buttons for the extension chooser.
+  const [choosing, setChoosing] = useState(false);
 
   // Track which auth method the user chose (set before calling sign)
   const signMethodRef = useRef<{ method: string; key?: PrivateKey }>({ method: "" });
@@ -129,6 +135,50 @@ export function WalletOperationSign({ data, onSignError, onSignSuccess, asset, o
     setStep("signing");
   }, [signingKey, activeUser, sign, data]);
 
+  const username = activeUser?.username;
+
+  // Kicks off the actual keychain-compatible sign. The chosen extension is
+  // persisted (per username) just before this, so the adapter's
+  // broadcastWithExtension routes to it instead of auto-resolving Keeper-first.
+  const doExtensionSign = useCallback(() => {
+    signMethodRef.current = { method: "keychain" };
+    sign(data as any);
+    setStep("signing");
+  }, [sign, data]);
+
+  // Unified "Sign with Extension" entry. Re-read detection at click time (an
+  // extension may inject its globals after render). With more than one, defer to
+  // the chooser; otherwise persist the lone extension and sign.
+  const handleExtensionSign = useCallback(() => {
+    const detected = getDetectedExtensions();
+    if (detected.length > 1) {
+      setChoosing(true);
+      return;
+    }
+    if (detected.length === 1 && username) {
+      setPreferredExtensionId(username, detected[0].id);
+    }
+    doExtensionSign();
+  }, [username, doExtensionSign]);
+
+  const handleChooseExtension = useCallback(
+    (extId: HiveExtensionId) => {
+      setChoosing(false);
+      if (username) setPreferredExtensionId(username, extId);
+      doExtensionSign();
+    },
+    [username, doExtensionSign]
+  );
+
+  const detectedExtensions = getDetectedExtensions();
+  // Show the unified button when any extension is installed, or there's a
+  // Keychain Mobile / in-app deep-link path. Mirrors the auth-upgrade dialog.
+  const showExtensionBtn =
+    detectedExtensions.length > 0 || hasAnyHiveExtension() || useKcMobile || isInAppBrowser();
+  const extensionLabel = useKcMobile
+    ? i18next.t("key-or-hot.with-keychain-mobile", { defaultValue: "Sign with Keychain Mobile" })
+    : i18next.t("key-or-hot.with-extension", { defaultValue: "Sign with Extension" });
+
   return (
     <>
       {step === "sign" && (
@@ -147,6 +197,20 @@ export function WalletOperationSign({ data, onSignError, onSignSuccess, asset, o
                   setStep("signing");
                 }}
               />
+            </div>
+          ) : choosing ? (
+            <div className="col-span-2 flex flex-col gap-3">
+              <Button
+                iconPlacement="left"
+                appearance="gray-link"
+                size="sm"
+                noPadding={true}
+                onClick={() => setChoosing(false)}
+                icon={<UilArrowLeft />}
+              >
+                {i18next.t("g.back")}
+              </Button>
+              <ExtensionChooser extensions={detectedExtensions} onSelect={handleChooseExtension} />
             </div>
           ) : (
             <>
@@ -192,29 +256,40 @@ export function WalletOperationSign({ data, onSignError, onSignSuccess, asset, o
                 {i18next.t("key-or-hot.with-hivesigner")}
               </Button>
 
-              <Button
-                outline={true}
-                appearance="secondary"
-                size="lg"
-                disabled={!canUseKeychain}
-                onClick={() => {
-                  const method = "keychain";
-                  signMethodRef.current = { method };
-                  sign(data as any);
-                  setStep("signing");
-                }}
-                icon={
-                  <Image
-                    width={100}
-                    height={100}
-                    src="/assets/keychain.png"
-                    className="w-4 h-4"
-                    alt="keychain"
-                  />
-                }
-              >
-                {keychainLabel}
-              </Button>
+              {showExtensionBtn && (
+                <Button
+                  outline={true}
+                  appearance="secondary"
+                  size="lg"
+                  onClick={handleExtensionSign}
+                  icon={
+                    <div className="flex items-center -space-x-1">
+                      {detectedExtensions.length > 0 ? (
+                        detectedExtensions.map((ext) => (
+                          <Image
+                            key={ext.id}
+                            width={20}
+                            height={20}
+                            src={ext.icon}
+                            className="w-4 h-4 rounded-sm"
+                            alt={ext.name}
+                          />
+                        ))
+                      ) : (
+                        <Image
+                          width={100}
+                          height={100}
+                          src="/assets/keychain.png"
+                          className="w-4 h-4"
+                          alt="extensions"
+                        />
+                      )}
+                    </div>
+                  }
+                >
+                  {extensionLabel}
+                </Button>
+              )}
             </>
           )}
         </motion.div>

--- a/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
+++ b/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
@@ -112,6 +112,18 @@ describe("AuthUpgradeDialog extension picker", () => {
     expect(h.resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
   });
 
+  it("persists the lone extension on the single-extension sign path (no chooser)", () => {
+    h.detected = [{ id: "keychain", name: "Keychain", icon: "/assets/keychain.png" }];
+    openDialog();
+
+    // One extension => sign directly, but still record the choice so a later
+    // broadcast (after the user installs a second extension) isn't hijacked.
+    fireEvent.click(screen.getByRole("button", { name: /key-or-hot\.with-extension/i }));
+    expect(screen.queryByText("login.extensions-select-description")).toBeNull();
+    expect(h.setPreferredExtensionId).toHaveBeenCalledWith("testuser", "keychain");
+    expect(h.resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
+  });
+
   it("returns from the chooser to the sign options via Back without cancelling", () => {
     openDialog();
     fireEvent.click(screen.getByRole("button", { name: /key-or-hot\.with-extension/i }));

--- a/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
+++ b/apps/web/src/specs/features/shared/auth-upgrade-dialog.spec.tsx
@@ -11,8 +11,15 @@ const h = vi.hoisted(() => ({
     { id: "keychain", name: "Keychain", icon: "/assets/keychain.png" }
   ] as { id: string; name: string; icon: string }[],
   kcMobile: false,
+  username: "testuser",
   setPreferredExtensionId: vi.fn(),
   resolveAuthUpgrade: vi.fn()
+}));
+
+// The dialog only renders for a signed-in user; the global mock returns a null
+// active user, so provide a username so the per-user preference is persisted.
+vi.mock("@/core/hooks/use-active-account", () => ({
+  useActiveAccount: () => ({ activeUser: { username: h.username } })
 }));
 
 // The global test setup stubs @/utils down to a couple of exports; restore the
@@ -29,7 +36,8 @@ vi.mock("@/utils/client", async (importOriginal) => ({
 vi.mock("@/utils/hive-extensions", () => ({
   getDetectedExtensions: () => h.detected,
   hasAnyHiveExtension: () => h.detected.length > 0,
-  setPreferredExtensionId: (id: string | null) => h.setPreferredExtensionId(id)
+  setPreferredExtensionId: (username: string, id: string | null) =>
+    h.setPreferredExtensionId(username, id)
 }));
 
 vi.mock("@/features/shared/auth-upgrade/auth-upgrade-events", () => ({
@@ -90,7 +98,7 @@ describe("AuthUpgradeDialog extension picker", () => {
     // Picking one stores it so broadcastWithExtension targets that extension's
     // own API instead of falling back to Keeper-first.
     fireEvent.click(screen.getByRole("button", { name: /keychain/i }));
-    expect(h.setPreferredExtensionId).toHaveBeenCalledWith("keychain");
+    expect(h.setPreferredExtensionId).toHaveBeenCalledWith("testuser", "keychain");
     expect(h.resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
   });
 
@@ -100,7 +108,7 @@ describe("AuthUpgradeDialog extension picker", () => {
     fireEvent.click(screen.getByRole("button", { name: /key-or-hot\.with-extension/i }));
     fireEvent.click(screen.getByRole("button", { name: /hive keeper/i }));
 
-    expect(h.setPreferredExtensionId).toHaveBeenCalledWith("hive-keeper");
+    expect(h.setPreferredExtensionId).toHaveBeenCalledWith("testuser", "hive-keeper");
     expect(h.resolveAuthUpgrade).toHaveBeenCalledWith("keychain");
   });
 

--- a/apps/web/src/specs/features/shared/key-or-hot-metamask.spec.tsx
+++ b/apps/web/src/specs/features/shared/key-or-hot-metamask.spec.tsx
@@ -124,7 +124,11 @@ describe("KeyOrHot - extension picker (respects the user's chosen extension)", (
     // auto-detects Keeper-first and hijacks a Keychain user.
     expect(ext.setPreferredExtensionId).toHaveBeenCalledWith("alice", "keychain");
     expect(props.onKc).toHaveBeenCalledTimes(1);
-    expect(ext.calls).toEqual(["persist"]);
+    // Order matters: persist must happen BEFORE onKc, or the downstream
+    // broadcast auto-detects (Keeper-first) before the choice is recorded.
+    const persistOrder = ext.setPreferredExtensionId.mock.invocationCallOrder[0];
+    const signOrder = props.onKc.mock.invocationCallOrder[0];
+    expect(persistOrder).toBeLessThan(signOrder);
   });
 
   it("with more than one extension, opens the chooser and routes to the picked one", () => {
@@ -142,6 +146,40 @@ describe("KeyOrHot - extension picker (respects the user's chosen extension)", (
     // Picking Keychain persists Keychain (not Keeper) then signs.
     fireEvent.click(screen.getByRole("button", { name: /keychain/i }));
     expect(ext.setPreferredExtensionId).toHaveBeenCalledWith("alice", "keychain");
+    expect(props.onKc).toHaveBeenCalledTimes(1);
+  });
+
+  it("excludes Peak Vault for owner-authority flows (it can't sign owner ops)", () => {
+    ext.detected = [
+      { id: "hive-keeper", name: "Hive Keeper", icon: "/assets/keeper.svg" },
+      { id: "keychain", name: "Keychain", icon: "/assets/keychain.png" },
+      { id: "peakvault", name: "Peak Vault", icon: "/assets/peakvault.svg" }
+    ];
+    render(<KeyOrHot {...props} authority="owner" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /key-or-hot\.with-extension/i }));
+
+    // Chooser shows Keeper and Keychain, but never Peak Vault for owner ops.
+    expect(screen.getByText("login.extensions-select-description")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /hive keeper/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /keychain/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /peak vault/i })).not.toBeInTheDocument();
+  });
+
+  it("owner flow with Keychain + Peak Vault signs Keychain directly (Peak Vault excluded, no chooser)", () => {
+    ext.detected = [
+      { id: "keychain", name: "Keychain", icon: "/assets/keychain.png" },
+      { id: "peakvault", name: "Peak Vault", icon: "/assets/peakvault.svg" }
+    ];
+    render(<KeyOrHot {...props} authority="owner" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /key-or-hot\.with-extension/i }));
+
+    // After excluding Peak Vault only Keychain remains => signs directly, no
+    // chooser, and never persists/sign with peakvault for an owner op.
+    expect(screen.queryByText("login.extensions-select-description")).not.toBeInTheDocument();
+    expect(ext.setPreferredExtensionId).toHaveBeenCalledWith("alice", "keychain");
+    expect(ext.setPreferredExtensionId).not.toHaveBeenCalledWith("alice", "peakvault");
     expect(props.onKc).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/specs/features/shared/key-or-hot-metamask.spec.tsx
+++ b/apps/web/src/specs/features/shared/key-or-hot-metamask.spec.tsx
@@ -3,6 +3,21 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 
+const ext = vi.hoisted(() => ({
+  detected: [] as { id: string; name: string; icon: string }[],
+  setPreferredExtensionId: vi.fn(),
+  calls: [] as string[]
+}));
+
+vi.mock("@/utils/hive-extensions", () => ({
+  getDetectedExtensions: () => ext.detected,
+  hasAnyHiveExtension: () => ext.detected.length > 0,
+  setPreferredExtensionId: (username: string, id: string | null) => {
+    ext.calls.push("persist");
+    ext.setPreferredExtensionId(username, id);
+  }
+}));
+
 vi.mock("@/core/hooks/use-active-account");
 vi.mock("@/utils/client", () => ({
   shouldUseKeychainMobile: vi.fn(() => false)
@@ -78,5 +93,55 @@ describe("KeyOrHot - MetaMask rendering", () => {
 
     expect(screen.getByText("key-or-hot.with-hivesigner")).toBeInTheDocument();
     expect(screen.queryByTestId("metamask-btn")).not.toBeInTheDocument();
+  });
+});
+
+describe("KeyOrHot - extension picker (respects the user's chosen extension)", () => {
+  const props = {
+    inProgress: false,
+    onKey: vi.fn(),
+    onHot: vi.fn(),
+    onKc: vi.fn(),
+    onMetaMask: vi.fn()
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ext.detected = [];
+    ext.calls = [];
+    (useActiveAccount as any).mockReturnValue({ activeUser: { username: "alice" } });
+    (getLoginType as any).mockReturnValue("keychain");
+  });
+
+  it("with one extension, persists it for the active user BEFORE signing", () => {
+    ext.detected = [{ id: "keychain", name: "Keychain", icon: "/assets/keychain.png" }];
+    render(<KeyOrHot {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /key-or-hot\.with-extension/i }));
+
+    // Regression: the chosen extension must be persisted (so the downstream
+    // broadcast targets it) before onKc fires, otherwise the broadcast
+    // auto-detects Keeper-first and hijacks a Keychain user.
+    expect(ext.setPreferredExtensionId).toHaveBeenCalledWith("alice", "keychain");
+    expect(props.onKc).toHaveBeenCalledTimes(1);
+    expect(ext.calls).toEqual(["persist"]);
+  });
+
+  it("with more than one extension, opens the chooser and routes to the picked one", () => {
+    ext.detected = [
+      { id: "hive-keeper", name: "Hive Keeper", icon: "/assets/keeper.svg" },
+      { id: "keychain", name: "Keychain", icon: "/assets/keychain.png" }
+    ];
+    render(<KeyOrHot {...props} />);
+
+    // First click opens the chooser; it must NOT sign yet (no auto Keeper pick).
+    fireEvent.click(screen.getByRole("button", { name: /key-or-hot\.with-extension/i }));
+    expect(props.onKc).not.toHaveBeenCalled();
+    expect(ext.setPreferredExtensionId).not.toHaveBeenCalled();
+
+    // Picking Keychain persists Keychain (not Keeper) then signs.
+    fireEvent.click(screen.getByRole("button", { name: /keychain/i }));
+    expect(ext.setPreferredExtensionId).toHaveBeenCalledWith("alice", "keychain");
+    expect(props.onKc).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/specs/utils/hive-extensions.spec.ts
+++ b/apps/web/src/specs/utils/hive-extensions.spec.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   broadcastWithExtension,
   getDetectedExtensions,
+  getPreferredExtensionId,
+  resolveKeychainInstance,
+  setPreferredExtensionId,
   signBufferWithExtension
 } from "../../utils/hive-extensions";
 
@@ -233,16 +236,64 @@ describe("Hive Keeper resolution (window.hive primary)", () => {
     (window as any).hive = keeper;
     // Keeper's backward-compat self-alias - NOT a real Keychain.
     (window as any).hive_keychain = keeper;
-    // Stale preference from before the user switched to a Keeper-only setup.
-    localStorage.setItem("ecency_preferred_hive_extension", "keychain");
+    // Stale per-user preference from before the user switched to a Keeper-only setup.
+    setPreferredExtensionId("alice", "keychain");
 
     const resp = await signBufferWithExtension("alice", "message", "Posting");
 
     // Signed through the live window.hive path (handshake then sign)...
     expect(order).toEqual(["handshake", "sign"]);
     expect(resp).toMatchObject({ success: true, result: "signature" });
-    // ...and the stale "keychain" preference self-healed because the alias no
-    // longer resolves to a usable Keychain instance.
-    expect(localStorage.getItem("ecency_preferred_hive_extension")).toBeNull();
+    // ...and alice's stale "keychain" preference self-healed because the alias
+    // no longer resolves to a usable Keychain instance.
+    expect(getPreferredExtensionId("alice")).toBeNull();
+  });
+});
+
+describe("per-username extension preference", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    delete (window as any).hive;
+    delete (window as any).hive_keychain;
+    delete (window as any).peakvault;
+  });
+
+  it("remembers a different extension per account", () => {
+    setPreferredExtensionId("alice", "keychain");
+    setPreferredExtensionId("bob", "hive-keeper");
+
+    expect(getPreferredExtensionId("alice")).toBe("keychain");
+    expect(getPreferredExtensionId("bob")).toBe("hive-keeper");
+  });
+
+  it("does not leak one account's choice to another", () => {
+    setPreferredExtensionId("alice", "keychain");
+    expect(getPreferredExtensionId("bob")).toBeNull();
+  });
+
+  it("falls back to the legacy global preference for accounts without a per-user choice", () => {
+    localStorage.setItem("ecency_preferred_hive_extension", "hive-keeper");
+    expect(getPreferredExtensionId("newcomer")).toBe("hive-keeper");
+    // A per-user choice overrides the legacy global.
+    setPreferredExtensionId("newcomer", "keychain");
+    expect(getPreferredExtensionId("newcomer")).toBe("keychain");
+  });
+
+  it("resolveKeychainInstance honors the account's choice over Keeper-first auto-detect", () => {
+    const keeper: any = { isKeeper: true };
+    const keychain: any = { isKeeper: false };
+    (window as any).hive = keeper;
+    (window as any).hive_keychain = keychain;
+
+    // alice chose Keychain: must resolve the real Keychain, never the Keeper.
+    setPreferredExtensionId("alice", "keychain");
+    expect(resolveKeychainInstance("alice")).toBe(keychain);
+
+    // bob chose Keeper: resolves the live window.hive.
+    setPreferredExtensionId("bob", "hive-keeper");
+    expect(resolveKeychainInstance("bob")).toBe(keeper);
+
+    // No choice → Keeper-first auto-detect (unchanged legacy behavior).
+    expect(resolveKeychainInstance("carol")).toBe(keeper);
   });
 });

--- a/apps/web/src/specs/utils/hive-extensions.spec.ts
+++ b/apps/web/src/specs/utils/hive-extensions.spec.ts
@@ -279,6 +279,19 @@ describe("per-username extension preference", () => {
     expect(getPreferredExtensionId("newcomer")).toBe("keychain");
   });
 
+  it("ignores a corrupted or unknown preference value", () => {
+    // Hand-edited / corrupted per-user map entry.
+    localStorage.setItem(
+      "ecency_preferred_hive_extension_by_user",
+      JSON.stringify({ alice: "evil-injected" })
+    );
+    expect(getPreferredExtensionId("alice")).toBeNull();
+
+    // Corrupted legacy global value is likewise ignored.
+    localStorage.setItem("ecency_preferred_hive_extension", "evil-injected");
+    expect(getPreferredExtensionId("bob")).toBeNull();
+  });
+
   it("resolveKeychainInstance honors the account's choice over Keeper-first auto-detect", () => {
     const keeper: any = { isKeeper: true };
     const keychain: any = { isKeeper: false };

--- a/apps/web/src/utils/hive-extensions.ts
+++ b/apps/web/src/utils/hive-extensions.ts
@@ -136,11 +136,28 @@ const PREFERRED_EXTENSION_KEY = "ecency_preferred_hive_extension";
 // account on Keychain and another on Keeper keeps the right wallet for each.
 const PREFERRED_EXTENSION_MAP_KEY = "ecency_preferred_hive_extension_by_user";
 
+const VALID_EXTENSION_IDS: readonly HiveExtensionId[] = ["keychain", "hive-keeper", "peakvault"];
+
+/** Narrow an untrusted localStorage value to a known extension id. */
+function asHiveExtensionId(value: unknown): HiveExtensionId | null {
+  return typeof value === "string" && (VALID_EXTENSION_IDS as readonly string[]).includes(value)
+    ? (value as HiveExtensionId)
+    : null;
+}
+
 function readPreferenceMap(): Record<string, HiveExtensionId> {
   try {
     const raw = localStorage.getItem(PREFERRED_EXTENSION_MAP_KEY);
     const parsed = raw ? JSON.parse(raw) : null;
-    return parsed && typeof parsed === "object" ? (parsed as Record<string, HiveExtensionId>) : {};
+    if (!parsed || typeof parsed !== "object") return {};
+    // Drop any entry whose value isn't a known extension id (corrupted or
+    // hand-edited storage) so getPreferredExtensionId never returns garbage.
+    const clean: Record<string, HiveExtensionId> = {};
+    for (const [user, id] of Object.entries(parsed as Record<string, unknown>)) {
+      const valid = asHiveExtensionId(id);
+      if (valid) clean[user] = valid;
+    }
+    return clean;
   } catch {
     return {};
   }
@@ -179,7 +196,7 @@ export function getPreferredExtensionId(username?: string): HiveExtensionId | nu
       const fromUser = readPreferenceMap()[username];
       if (fromUser) return fromUser;
     }
-    return (localStorage.getItem(PREFERRED_EXTENSION_KEY) as HiveExtensionId | null) || null;
+    return asHiveExtensionId(localStorage.getItem(PREFERRED_EXTENSION_KEY));
   } catch {
     return null;
   }

--- a/apps/web/src/utils/hive-extensions.ts
+++ b/apps/web/src/utils/hive-extensions.ts
@@ -129,34 +129,79 @@ export function getPreferredExtension(): DetectedExtension | null {
 // User preference (stored in localStorage for persistence across sessions)
 // ---------------------------------------------------------------------------
 
+// Legacy single global preference (pre per-user). Kept read-only as a fallback
+// so existing users aren't reset to auto-detect on first load after this change.
 const PREFERRED_EXTENSION_KEY = "ecency_preferred_hive_extension";
+// Per-username preference map: { [username]: HiveExtensionId }. A user with one
+// account on Keychain and another on Keeper keeps the right wallet for each.
+const PREFERRED_EXTENSION_MAP_KEY = "ecency_preferred_hive_extension_by_user";
+
+function readPreferenceMap(): Record<string, HiveExtensionId> {
+  try {
+    const raw = localStorage.getItem(PREFERRED_EXTENSION_MAP_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, HiveExtensionId>) : {};
+  } catch {
+    return {};
+  }
+}
 
 /**
- * Set the user's preferred extension. Stored in localStorage.
+ * Remember the extension a specific account chose to sign with. Stored per
+ * username in localStorage so each account keeps its own wallet choice. Pass
+ * id=null to forget the account's preference (e.g. the chosen extension was
+ * uninstalled).
  */
-export function setPreferredExtensionId(id: HiveExtensionId | null): void {
-  if (typeof window === "undefined") return;
+export function setPreferredExtensionId(username: string, id: HiveExtensionId | null): void {
+  if (typeof window === "undefined" || !username) return;
   try {
+    const map = readPreferenceMap();
     if (id) {
-      localStorage.setItem(PREFERRED_EXTENSION_KEY, id);
+      map[username] = id;
     } else {
-      localStorage.removeItem(PREFERRED_EXTENSION_KEY);
+      delete map[username];
     }
+    localStorage.setItem(PREFERRED_EXTENSION_MAP_KEY, JSON.stringify(map));
   } catch {
     // Storage blocked (private browsing, quota exceeded) - non-fatal
   }
 }
 
 /**
- * Get the user's preferred extension from localStorage.
+ * Read the preferred extension for an account. Falls back to the legacy global
+ * preference (so users who set one before per-user storage aren't reset), then
+ * to null (auto-detect).
  */
-export function getPreferredExtensionId(): HiveExtensionId | null {
+export function getPreferredExtensionId(username?: string): HiveExtensionId | null {
   if (typeof window === "undefined") return null;
   try {
-    return localStorage.getItem(PREFERRED_EXTENSION_KEY) as HiveExtensionId | null;
+    if (username) {
+      const fromUser = readPreferenceMap()[username];
+      if (fromUser) return fromUser;
+    }
+    return (localStorage.getItem(PREFERRED_EXTENSION_KEY) as HiveExtensionId | null) || null;
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve the Keychain-compatible extension instance to use for `account`,
+ * honoring that account's saved preference. The legacy per-op helpers in
+ * utils/keychain.ts call specialized methods (requestTransfer,
+ * requestWitnessVote, ...) on a single instance, so they need the chosen
+ * Keeper/Keychain rather than whatever owns window.hive_keychain (which Keeper
+ * aliases). A "keychain" preference resolves strictly to the real Keychain (or
+ * null, surfacing "unavailable" rather than silently signing through Keeper);
+ * Peak Vault has no callback API for these specialized requests, so a Peak Vault
+ * preference / no preference falls through to Keeper-first auto-detect.
+ */
+export function resolveKeychainInstance(account?: string): KeyChainImpl | null {
+  if (typeof window === "undefined") return null;
+  const extId = getPreferredExtensionId(account);
+  if (extId === "keychain") return getKeychainInstance();
+  if (extId === "hive-keeper") return getHiveKeeperInstance();
+  return getKeychainLikeInstance();
 }
 
 // ---------------------------------------------------------------------------
@@ -174,7 +219,7 @@ export function signBufferWithExtension(
   rpc: string | null = null,
   preferredId?: HiveExtensionId
 ): Promise<TxResponse> {
-  const extId = preferredId ?? getPreferredExtensionId();
+  const extId = preferredId ?? getPreferredExtensionId(account);
   if (extId) {
     const resolved =
       extId === "peakvault" ? null :
@@ -186,7 +231,7 @@ export function signBufferWithExtension(
     if (resolved) return signBufferViaKeychain(resolved, account, message, authType, rpc);
 
     // Preferred extension no longer available - clear stale preference
-    if (!preferredId) setPreferredExtensionId(null);
+    if (!preferredId) setPreferredExtensionId(account, null);
   }
 
   // Auto-detection fallback
@@ -220,7 +265,7 @@ export function broadcastWithExtension(
   rpc: string | null = null,
   preferredId?: HiveExtensionId
 ): Promise<any> {
-  const extId = preferredId ?? getPreferredExtensionId();
+  const extId = preferredId ?? getPreferredExtensionId(account);
   if (extId) {
     const resolved =
       extId === "peakvault" ? null :
@@ -235,7 +280,7 @@ export function broadcastWithExtension(
     if (resolved) return broadcastViaKeychain(resolved, account, operations, keyType, rpc);
 
     // Preferred extension no longer available - clear stale preference
-    if (!preferredId) setPreferredExtensionId(null);
+    if (!preferredId) setPreferredExtensionId(account, null);
   }
 
   // Auto-detection fallback

--- a/apps/web/src/utils/keychain.ts
+++ b/apps/web/src/utils/keychain.ts
@@ -1,12 +1,13 @@
 import { Symbol } from "./parse-asset";
 import { AppWindow, AuthorityTypes, Keys, TxResponse } from "@/types";
 import { extensionErrorMessage } from "./extension-error";
+import { resolveKeychainInstance } from "./hive-extensions";
 
 declare var window: AppWindow;
 
 export const handshake = (): Promise<void> =>
   new Promise<void>((resolve, reject) => {
-    const keychain = window.hive_keychain;
+    const keychain = resolveKeychainInstance();
     if (!keychain) {
       reject(new Error("Hive Keychain extension is unavailable or disabled."));
       return;
@@ -23,7 +24,7 @@ export const signBuffer = (
   rpc: string | null = null
 ): Promise<TxResponse> =>
   new Promise<TxResponse>((resolve, reject) => {
-    const keychain = window.hive_keychain;
+    const keychain = resolveKeychainInstance(account);
     if (!keychain) {
       reject(new Error("Hive Keychain extension is unavailable or disabled."));
       return;
@@ -52,7 +53,7 @@ export const addAccountAuthority = (
   rpc: string | null = null
 ): Promise<TxResponse> =>
   new Promise<TxResponse>((resolve, reject) => {
-    const keychain = window.hive_keychain;
+    const keychain = resolveKeychainInstance(account);
     if (!keychain) {
       reject(new Error("Hive Keychain extension is unavailable or disabled."));
       return;
@@ -81,7 +82,7 @@ export const removeAccountAuthority = (
   rpc: string | null = null
 ): Promise<TxResponse> =>
   new Promise<TxResponse>((resolve, reject) => {
-    const keychain = window.hive_keychain;
+    const keychain = resolveKeychainInstance(account);
     if (!keychain) {
       reject(new Error("Hive Keychain extension is unavailable or disabled."));
       return;
@@ -112,7 +113,7 @@ export const transfer = (
   rpc: string | null = null
 ): Promise<TxResponse> =>
   new Promise<TxResponse>((resolve, reject) => {
-    const keychain = window.hive_keychain;
+    const keychain = resolveKeychainInstance(account);
     if (!keychain) {
       reject(new Error("Hive Keychain extension is unavailable or disabled."));
       return;
@@ -145,7 +146,7 @@ export const customJson = (
   rpc: string | null = null
 ): Promise<TxResponse> =>
   new Promise<TxResponse>((resolve, reject) => {
-    const keychain = window.hive_keychain;
+    const keychain = resolveKeychainInstance(account);
     if (!keychain) {
       reject(new Error("Hive Keychain extension is unavailable or disabled."));
       return;
@@ -174,7 +175,7 @@ export const broadcast = (
   rpc: string | null = null
 ): Promise<TxResponse> =>
   new Promise<TxResponse>((resolve, reject) => {
-    const keychain = window.hive_keychain;
+    const keychain = resolveKeychainInstance(account);
 
     if (!keychain) {
       reject(new Error("Hive Keychain extension is unavailable or disabled."));
@@ -208,7 +209,7 @@ export const broadcast = (
 
 export const addAccount = (username: string, keys: Keys): Promise<TxResponse> =>
   new Promise<TxResponse>((resolve, reject) => {
-    const keychain = window.hive_keychain;
+    const keychain = resolveKeychainInstance(username);
     if (!keychain) {
       reject(new Error("Hive Keychain extension is unavailable or disabled."));
       return;
@@ -230,7 +231,7 @@ export const witnessVote = (
   rpc: string | null = null
 ): Promise<TxResponse> =>
   new Promise<TxResponse>((resolve, reject) => {
-    const keychain = window.hive_keychain;
+    const keychain = resolveKeychainInstance(account);
     if (!keychain) {
       reject(new Error("Hive Keychain extension is unavailable or disabled."));
       return;
@@ -257,7 +258,7 @@ export const witnessProxy = (
   rpc: string | null = null
 ): Promise<TxResponse> =>
   new Promise<TxResponse>((resolve, reject) => {
-    const keychain = window.hive_keychain;
+    const keychain = resolveKeychainInstance(account);
     if (!keychain) {
       reject(new Error("Hive Keychain extension is unavailable or disabled."));
       return;


### PR DESCRIPTION
## Summary

When a Keychain user signs (transfers, wallet ops, permissions, etc.), the single "Sign with Keychain" button could be silently hijacked by Hive Keeper, because Keeper aliases `window.hive_keychain` and the broadcast auto-detects Keeper-first. With one account on Keychain and another on Keeper, the wrong wallet would answer.

This brings the unified "Sign with Extension" detection and picker that login and the auth-upgrade dialog already use to the remaining single-button signing surfaces, and makes the routing respect the user's explicit choice per account.

## Changes

- **Per-username preference.** The saved extension is now stored per username (a `{username: extId}` map) instead of one global value, falling back to the legacy global key so existing users are not reset. A user keeps Keychain for one account and Keeper for another.
- **Pickers on the remaining surfaces.** `KeyOrHot` and the wallet operations signer (`wallet-operations-sign.tsx`, the transfer dialog in the screenshot) now call `getDetectedExtensions()`, show the shared `ExtensionChooser` when more than one is installed, persist the choice for the active account, then sign with it. A single extension signs directly. Private key, Hivesigner, MetaMask and mobile/in-app paths are unchanged.
- **Legacy helpers honor the choice.** `utils/keychain.ts` per-op helpers now resolve the chosen instance via `resolveKeychainInstance(account)` instead of reading raw `window.hive_keychain`, so a Keychain choice routes to the real Keychain (never Keeper) and a Keeper choice uses the live `window.hive`.

Detection is hybrid by necessity: only Keeper implements the unified `window.hive` registry; Keychain and Peak Vault are detected via their legacy globals, and Keeper's `window.hive_keychain` self-alias is filtered out so it is never offered as a phantom Keychain.

## Tests

- Per-username preference and legacy-global fallback.
- `resolveKeychainInstance` routes to the account's chosen extension, never Keeper-first when a Keychain choice exists.
- `KeyOrHot` picker persists the chosen extension (per username) before `onKc`, and opens the chooser without auto-signing when more than one extension is present.
- Updated the auth-upgrade dialog spec for the per-username signature.

Typecheck adds no new errors over `develop`; all affected specs pass.

## Notes

The funds-transfer flow already used the auth-upgrade picker; this closes the remaining single-button surfaces so the behavior is uniform everywhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now select and save a preferred Hive extension per account, eliminating conflicts across different accounts.
  * Added extension selection UI when multiple Hive extensions are detected during login and signing.

* **Improvements**
  * Enhanced extension detection at sign-in and transaction time for more reliable wallet integration.
  * Signing flows now automatically resolve the correct extension based on user preference and availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->