### PR TITLE
feat(tip): add tip button to comments, feed cards, and decks

### DIFF
--- a/apps/web/src/app/decks/_components/_deck.scss
+++ b/apps/web/src/app/decks/_components/_deck.scss
@@ -249,7 +249,7 @@
       margin: 0;
     }
 
-    .btn, .entry-votes, .entry-vote-btn, .comments, .entry-payout, .entry-reblog-btn {
+    .btn, .entry-votes, .entry-vote-btn, .comments, .entry-payout, .entry-reblog-btn, .entry-tip-btn {
       color: $secondary;
 
       @include padding(0);
@@ -258,6 +258,17 @@
 
       &:hover, &:active {
         color: $primary;
+      }
+    }
+
+    // The tip button colours its own inner span blue via `@apply text-blue-dark-sky`.
+    // Force it to inherit the muted action-bar colour so the gift icon matches its
+    // grey siblings in the deck column instead of standing out as a blue accent.
+    .entry-tip-btn .inner-btn {
+      color: inherit;
+
+      svg {
+        opacity: 1;
       }
     }
 

--- a/apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss
+++ b/apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss
@@ -106,7 +106,7 @@
     border-bottom: 1px solid $border-color;
     background-color: rgba($primary, 0.05);
 
-    .btn, .entry-votes, .entry-vote-btn, .comments {
+    .btn, .entry-votes, .entry-vote-btn, .comments, .entry-tip-btn {
       color: $secondary;
 
       @include padding(0);
@@ -115,6 +115,17 @@
 
       &:hover, &:active {
         color: $primary;
+      }
+    }
+
+    // The tip button colours its own inner span blue via `@apply text-blue-dark-sky`.
+    // Force it to inherit the muted action-bar colour so the gift icon matches its
+    // grey siblings in this deck post action bar.
+    .entry-tip-btn .inner-btn {
+      color: inherit;
+
+      svg {
+        opacity: 1;
       }
     }
 

--- a/apps/web/src/app/decks/_components/columns/content-viewer/deck-post-viewer.tsx
+++ b/apps/web/src/app/decks/_components/columns/content-viewer/deck-post-viewer.tsx
@@ -10,6 +10,7 @@ import { arrowLeftSvg } from "@ui/svg";
 import i18next from "i18next";
 import {
   EntryInfo,
+  EntryTipBtn,
   EntryVoteBtn,
   EntryVotes,
   PostContentRenderer
@@ -73,6 +74,7 @@ export const DeckPostViewer = ({ entry: initialEntry, onClose, backTitle }: Prop
           <div style={{ paddingRight: 4 }}>{commentSvg}</div>
           {entry.children}
         </div>
+        <EntryTipBtn entry={entry} />
       </div>
       <div className="px-3 dark:[&>*>.comment-preview]:bg-dark-default">
         <DeckPostViewerCommentBox entry={entry} onReplied={() => {}} />

--- a/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
+++ b/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
@@ -9,6 +9,7 @@ import {
   EntryMenu,
   EntryPayout,
   EntryReblogBtn,
+  EntryTipBtn,
   EntryVoteBtn,
   EntryVotes,
   ProfileLink
@@ -279,6 +280,7 @@ export const SearchListItem = ({
           </Link>
 
           <EntryReblogBtn entry={entry} />
+          <EntryTipBtn entry={entry} />
           <EntryMenu alignBottom={false} entry={entry} />
         </div>
       </div>

--- a/apps/web/src/features/shared/discussion/discussion-item.tsx
+++ b/apps/web/src/features/shared/discussion/discussion-item.tsx
@@ -8,6 +8,7 @@ import { SortOrder } from "@/enums";
 import {
   EntryDeleteBtn,
   EntryPayout,
+  EntryTipBtn,
   EntryVoteBtn,
   EntryVotes,
   ProfileLink,
@@ -335,6 +336,7 @@ export const DiscussionItem = memo(function DiscussionItem({
                   {i18next.t("g.reply")}
                 </a>
               )}
+              <EntryTipBtn entry={entry} />
               {community && canMute && (
                 <MuteBtn
                   entry={entry}

--- a/apps/web/src/features/shared/entry-list-item/index.tsx
+++ b/apps/web/src/features/shared/entry-list-item/index.tsx
@@ -11,6 +11,7 @@ import {
   EntryMenu,
   EntryPayout,
   EntryReblogBtn,
+  EntryTipBtn,
   EntryVoteBtn,
   EntryVotes,
   ProfileLink,
@@ -182,6 +183,7 @@ export function EntryListItemComponent({
             </a>
           )}
           <EntryReblogBtn entry={entry} />
+          <EntryTipBtn entry={entry} />
           <div className="border-r border-[--border-color] w-[1px] h-4" />
           <EntryMenu alignBottom={order >= 1} entry={entry} />
         </div>

--- a/apps/web/src/specs/features/shared/discussion-item.spec.tsx
+++ b/apps/web/src/specs/features/shared/discussion-item.spec.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Entry } from "@/entities";
+import { mockEntry } from "@/specs/test-utils";
+
+// `@/utils` is globally mocked to only expose `random` + `getAccessToken`.
+// DiscussionItem uses several real helpers (dateToFormatted, dateToFullRelative,
+// isHiddenPost, createReplyPermlink, makeJsonMetaDataReply). Re-mock locally
+// with importActual so those real implementations are preserved.
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<typeof import("@/utils")>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+
+// The reply / edit / pin mutations broadcast to the chain — stub them so the
+// component renders without an auth/network graph.
+vi.mock("@/api/mutations", () => ({
+  useCreateReply: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateReply: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  usePinReply: () => ({ mutateAsync: vi.fn() })
+}));
+
+// Cache manager used for optimistic mute updates.
+vi.mock("@/core/caches", () => ({
+  EcencyEntriesCacheManagement: {
+    useUpdateEntry: () => ({ updateEntryQueryData: vi.fn() })
+  }
+}));
+
+// Community-context builders (the global SDK mock doesn't expose these).
+vi.mock("@ecency/sdk", async () => ({
+  ...(await vi.importActual<Record<string, unknown>>("@ecency/sdk")),
+  getCommunityContextQueryOptions: vi.fn(() => ({
+    queryKey: ["community-context"],
+    queryFn: async () => ({ subscribed: false, role: "guest" }),
+    enabled: false
+  })),
+  getCommunityPermissions: vi.fn(() => ({ canComment: true })),
+  getCommunityType: vi.fn(() => 1)
+}));
+
+// Stub the action-bar buttons + author chrome from the shared barrel. Keep a
+// deterministic EntryTipBtn stub so we can assert the gift button is present in
+// the comment action bar (regression guard for the tip-on-comments feature).
+vi.mock("@/features/shared", async () => {
+  const Real = await import("react");
+  return {
+    EntryDeleteBtn: ({ children }: any) => Real.createElement("span", null, children),
+    EntryPayout: () => Real.createElement("span", { "data-testid": "entry-payout" }),
+    EntryTipBtn: () => Real.createElement("span", { "data-testid": "entry-tip-btn" }),
+    EntryVoteBtn: () => Real.createElement("span", { "data-testid": "entry-vote-btn" }),
+    EntryVotes: () => Real.createElement("span", { "data-testid": "entry-votes" }),
+    ProfileLink: ({ children }: any) => Real.createElement("span", null, children),
+    ProfilePopover: () => Real.createElement("span", { "data-testid": "profile-popover" }),
+    UserAvatar: ({ username }: any) => Real.createElement("span", null, username)
+  };
+});
+
+vi.mock("@/features/shared/mute-btn", () => ({ MuteBtn: () => null }));
+vi.mock("@/features/shared/entry-link", async () => {
+  const Real = await import("react");
+  return { EntryLink: ({ children }: any) => Real.createElement("span", null, children) };
+});
+// Private discussion child trees — stub so the test focuses on the item's own bar.
+vi.mock("@/features/shared/discussion/discussion-bots", () => ({ DiscussionBots: () => null }));
+vi.mock("@/features/shared/discussion/discussion-item-body", () => ({
+  DiscussionItemBody: () => null
+}));
+vi.mock("@/features/shared/discussion/discussion-list", () => ({ DiscussionList: () => null }));
+vi.mock("@/features/shared/comment", () => ({ Comment: () => null }));
+
+import { DiscussionItem } from "@/features/shared/discussion/discussion-item";
+
+function renderItem(entry: Entry, root: Entry) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DiscussionItem
+        entry={entry}
+        root={root}
+        community={null}
+        isRawContent={false}
+        hideControls={false}
+        discussionList={[]}
+        botsList={[]}
+        mutedUsers={[]}
+        canMute={false}
+      />
+    </QueryClientProvider>
+  );
+}
+
+describe("DiscussionItem", () => {
+  const root = mockEntry({ author: "bob", permlink: "the-post", category: "hive-101" });
+  const comment = mockEntry({
+    author: "alice",
+    permlink: "re-the-post",
+    parent_author: "bob",
+    parent_permlink: "the-post",
+    depth: 1
+  });
+
+  it("renders the tip (gift) button in the comment action bar — the parity fix melinda asked for", () => {
+    renderItem(comment, root);
+
+    expect(screen.getByTestId("entry-tip-btn")).toBeInTheDocument();
+    // It sits alongside the existing comment actions (not replacing them).
+    expect(screen.getByTestId("entry-vote-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("entry-payout")).toBeInTheDocument();
+  });
+
+  it("does not render the action bar (and thus no tip button) when controls are hidden", () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DiscussionItem
+          entry={comment}
+          root={root}
+          community={null}
+          isRawContent={false}
+          hideControls={true}
+          discussionList={[]}
+          botsList={[]}
+          mutedUsers={[]}
+          canMute={false}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(screen.queryByTestId("entry-tip-btn")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/specs/features/shared/entry-list-item.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-list-item.spec.tsx
@@ -72,6 +72,7 @@ vi.mock("@/features/shared", async () => {
       Real.createElement("span", { "data-testid": "entry-payout" }, entry.pending_payout_value),
     EntryVotes: () => Real.createElement("span", { "data-testid": "entry-votes" }),
     EntryReblogBtn: () => Real.createElement("span", { "data-testid": "entry-reblog-btn" }),
+    EntryTipBtn: () => Real.createElement("span", { "data-testid": "entry-tip-btn" }),
     EntryMenu: () => Real.createElement("span", { "data-testid": "entry-menu" })
   };
 });
@@ -261,6 +262,14 @@ describe("EntryListItem", () => {
 
     expect(screen.getByTestId("entry-vote-btn")).toBeInTheDocument();
     expect(screen.getByTestId("entry-menu")).toBeInTheDocument();
+  });
+
+  it("renders the tip (gift) button in the action bar — parity with the mobile tip action", () => {
+    const entry = mockEntry({ author: "bob", permlink: "top-post", title: "Top Post" });
+
+    renderItem(entry, { order: 0 });
+
+    expect(screen.getByTestId("entry-tip-btn")).toBeInTheDocument();
   });
 
   it("mounts the deferred action bar when focus enters the card (keyboard backstop)", async () => {


### PR DESCRIPTION
## Why

Community feedback relayed by **@melinda010100**: *"On app there is tipping icon on comments, but not on website?"* The mobile app shows a gift/tip icon in the action bar of every post and comment, but the web client doesn't.

The web already had a complete `EntryTipBtn` (gift icon → tip `Transfer` dialog pre-filled with the author + a `Tip for @author/permlink` memo), but it was only wired into the **post-detail footer** and **waves**. This PR adds it to the remaining action bars so every post and comment can be tipped, matching mobile.

## What

Adds `<EntryTipBtn entry={entry} />` to:

| Surface | File |
|---|---|
| **Comments** (the primary ask) | `features/shared/discussion/discussion-item.tsx` |
| **Feed / profile / community cards** | `features/shared/entry-list-item/index.tsx` |
| **Deck list cards** | `app/decks/.../deck-search-list-item.tsx` |
| **Deck post action bar** | `app/decks/.../deck-post-viewer.tsx` |

### Notes / design decisions
- **Button-only on these surfaces** — rendered *without* the `postTips` prop, so there's no count badge (matches the mobile gift icon) and, importantly, **no per-item `/private-api/post-tips` fetch** on busy threads/feeds. The post-detail footer keeps its richer count + tippers popover.
- **Bundle-safe** — the heavy `Transfer` flow stays behind `EntryTipBtn`'s `next/dynamic(ssr:false)` boundary, so it only mounts on click. None of the touched files statically pull `Transfer`/`@ecency/wallets`; the read-path bundle is unaffected.
- **Deck styling** — the deck action bars coerce sibling icons to a muted grey via SCSS. Added `.entry-tip-btn` to those selector lists (and `color: inherit` on its inner span) so the gift matches its siblings instead of rendering as a blue accent.
- Reuses existing `entry-tip.*` i18n keys (no new strings).

## Tests
- New regression tests for the **comment** tip button (`discussion-item.spec.tsx`) and the **feed** tip button (`entry-list-item.spec.tsx`).
- `pnpm test src/specs/features/shared` → **232/232 pass**.
- Typecheck adds **0 new errors** (verified against the `develop` baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)