### PR TITLE
chore(embed): drop the dead, misleading CSP from the Turnstile embed route

### DIFF
--- a/apps/web/src/app/embed/turnstile/route.ts
+++ b/apps/web/src/app/embed/turnstile/route.ts
@@ -72,16 +72,14 @@ export function GET() {
       "Content-Type": "text/html; charset=utf-8",
       // Keep the document fresh and out of edge/browser caches and indexes.
       "Cache-Control": "no-store",
-      "X-Robots-Tag": "noindex, nofollow",
-      // Lock the document down to the Turnstile challenge platform. The inline
-      // bootstrap script + style block need 'unsafe-inline', and Turnstile
-      // compiles WebAssembly for its challenge, which 'wasm-unsafe-eval' allows
-      // (without it the widget stalls on "Verifying…").
-      "Content-Security-Policy":
-        "default-src 'none'; script-src 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com; " +
-        "frame-src https://challenges.cloudflare.com; connect-src https://challenges.cloudflare.com; " +
-        "style-src 'unsafe-inline'; img-src data: https://challenges.cloudflare.com; " +
-        "base-uri 'none'; form-action 'none'"
+      "X-Robots-Tag": "noindex, nofollow"
+      // NOTE: a per-response Content-Security-Policy is intentionally NOT set here.
+      // next.config.js sets a site-wide CSP for source "/:path*", and that global
+      // header overrides any CSP a route handler returns (verified on prod: the
+      // browser receives the global policy, not a route-level one). A tighter
+      // embed-only CSP would have to be wired in next.config.js, not here. The
+      // widget needs challenges.cloudflare.com for script/frame/connect/img; the
+      // global report-only policy already allows it.
     }
   });
 }


### PR DESCRIPTION
## What
Removes the **dead, never-enforced** `Content-Security-Policy` header from the `/embed/turnstile` route handler, and documents why an embed-specific CSP can't live there.

## Why
While diagnosing the mobile Turnstile stall (ecency-mobile #3284), a live probe of `https://ecency.com/embed/turnstile` showed that the **enforced** CSP is the global one from `next.config.js` (`source: "/:path*"`) — Next.js's config-level `headers()` override any header a route handler returns. So this route's tight CSP was never applied, and its comment ("without `wasm-unsafe-eval` the widget stalls on Verifying…") is both moot and actively misleading (it sent the diagnosis down a wrong path initially).

**No functional change** — the embed already runs under the global CSP, whose report-only `frame-src`/`script-src`/`connect-src` already allow `challenges.cloudflare.com`.

## Notes for whoever promotes the report-only CSP to enforcing (no change here)
- The report-only `frame-src` (next.config.js) already lists `https://challenges.cloudflare.com`, so the Turnstile iframe is covered. Turnstile's internal `about:srcdoc`/`about:blank` frames are children of CF's iframe (governed by CF's CSP, generally exempt from the parent's `frame-src`), so no `about:` token was added — but worth watching the `?p=report` violation reports during promotion to confirm.
- Separately observed during the probe: some security headers appear duplicated, suggesting an edge layer (CF Transform Rule / nginx) also stamps headers — any future CSP work should confirm it isn't clobbered at the edge.

Companion to the mobile fix (ecency-mobile #3284); the actual stall fix is mobile-side (WebView `originWhitelist` + `about:`), not CSP.
