### PR TITLE
fix(comments): tip button before Reply + keyboard-accessible reblog

### DIFF
--- a/apps/web/src/features/shared/discussion/discussion-item.tsx
+++ b/apps/web/src/features/shared/discussion/discussion-item.tsx
@@ -320,6 +320,7 @@ export const DiscussionItem = memo(function DiscussionItem({
               <EntryVoteBtn entry={entry} isPostSlider={false} />
               <EntryPayout entry={entry} />
               <EntryVotes entry={entry} />
+              <EntryTipBtn entry={entry} />
               {canComment && (
                 <a
                   className={`reply-btn ${edit ? "disabled" : ""}`}
@@ -336,7 +337,6 @@ export const DiscussionItem = memo(function DiscussionItem({
                   {i18next.t("g.reply")}
                 </a>
               )}
-              <EntryTipBtn entry={entry} />
               {community && canMute && (
                 <MuteBtn
                   entry={entry}

--- a/apps/web/src/features/shared/entry-reblog-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-reblog-btn/index.tsx
@@ -32,20 +32,32 @@ export function EntryReblogBtn({ entry }: Props) {
         [activeUser, data, reblogs]
     );
 
+    const reblogLabel = reblogged
+        ? i18next.t("entry-reblog.delete-reblog")
+        : i18next.t("entry-reblog.reblog");
+
     const content = (
         <div
             className={`entry-reblog-btn ${reblogged ? "reblogged" : ""} ${
                 isPending ? "in-progress" : ""
             }`}
-        >
-            <Tooltip
-                content={
-                    reblogged
-                        ? i18next.t("entry-reblog.delete-reblog")
-                        : i18next.t("entry-reblog.reblog")
+            role="button"
+            tabIndex={0}
+            aria-label={reblogLabel}
+            aria-pressed={reblogged}
+            onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    // Activation lives on the click handler injected by the
+                    // wrapping LoginRequired / PopoverConfirm, so bridge the
+                    // keyboard event to it. Makes the control reachable and
+                    // operable without a mouse (matches EntryVoteBtn/EntryTipBtn).
+                    e.preventDefault();
+                    (e.currentTarget as HTMLElement).click();
                 }
-            >
-                <a className="inner-btn">
+            }}
+        >
+            <Tooltip content={reblogLabel}>
+                <a className="inner-btn" aria-hidden={true}>
                     {repeatSvg}
                     <span>{data?.reblogs && data.reblogs > 0 ? data.reblogs : ""}</span>
                 </a>

--- a/apps/web/src/features/shared/entry-reblog-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-reblog-btn/index.tsx
@@ -45,7 +45,13 @@ export function EntryReblogBtn({ entry }: Props) {
             tabIndex={0}
             aria-label={reblogLabel}
             aria-pressed={reblogged}
+            aria-disabled={isPending}
             onKeyDown={(e) => {
+                // While a reblog is in flight the SCSS sets pointer-events:none to
+                // block a double-submit via mouse; mirror that for the keyboard
+                // path (which pointer-events can't reach) so Enter/Space can't
+                // reopen the confirm popover and fire a second request.
+                if (isPending) return;
                 if (e.key === "Enter" || e.key === " ") {
                     // Activation lives on the click handler injected by the
                     // wrapping LoginRequired / PopoverConfirm, so bridge the


### PR DESCRIPTION
## What & why

Two small action-bar fixes prompted by community feedback.

### 1. Gift/tip button before Reply (the original ask)
The tip button added in #989 rendered **after** the Reply link in the comment action bar. This moves it ahead of Reply so the order reads:

`Vote → Payout → Votes → 🎁 Tip → Reply`

Reply stays the last primary action before the mute / overflow menu. Comment-only change — feed/profile cards expose a comments-*count* link (not a Reply action) and the gift already sits sensibly there, so they're untouched.

### 2. Reblog button is now keyboard / screen-reader accessible
While auditing the action row (triggered by a screen-reader user's upvote-accessibility report), I found the **reblog button could not be reached or activated without a mouse**. The interactive element — the outer `.entry-reblog-btn` div that `PopoverConfirm` / `LoginRequired` attach the click handler to — had no `role`, no tab stop, and no key handler, and the inner `<a>` had no `href`.

Fix mirrors the existing `EntryVoteBtn` / `EntryTipBtn` pattern: the outer div becomes a real `role="button"` with `tabIndex`, `aria-label` (Reblog / Delete reblog), `aria-pressed`, and Enter/Space activation. The decorative icon + count is marked `aria-hidden` so the control announces a single clean label. Reuses existing i18n keys (no new strings).

## Not changed (already accessible)
- **Upvote button** — already has `role="button"`, dynamic `aria-label`, `aria-pressed`/`aria-expanded`, and keyboard handling (since #769). The reported issue was the mobile app, addressed separately.
- **Votes-count button** — already has `role`/`tabIndex`/keyboard, and the wrapping `Tooltip` injects its `aria-label`.

## Testing
`discussion-item` and `entry-reblog-btn` specs pass (10 tests). No new strings; existing regression tests unchanged.