### PR TITLE
perf(embed): edge-cache the Turnstile widget instead of no-store

### DIFF
--- a/apps/web/src/app/embed/turnstile/route.ts
+++ b/apps/web/src/app/embed/turnstile/route.ts
@@ -74,9 +74,12 @@ export function GET() {
       // via the CF script; nothing here is per-user or sensitive). Edge-cache it so every
       // mobile signup does not re-render on origin SSR: `no-store` forced a fresh origin
       // render per load and ~25% of those 504'd when SSR was busy, blanking the widget.
-      // The content only changes on deploy; stale-while-revalidate avoids any origin wait
-      // at expiry. The CF worker edge-caches HTML whose origin sends s-maxage + no no-store.
-      "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+      // s-maxage lets the CF worker edge-cache (it stores any HTML with s-maxage + no
+      // no-store). max-age=0 keeps the WebView/browser revalidating every load; we omit
+      // stale-while-revalidate on purpose -- the worker uses a hard s-maxage TTL (no SWR),
+      // so SWR would only let a PRIVATE cache serve a day-old widget after a deploy / sitekey
+      // change, for no edge benefit. Still noindex.
+      "Cache-Control": "public, max-age=0, s-maxage=3600",
       "X-Robots-Tag": "noindex, nofollow"
       // NOTE: a per-response Content-Security-Policy is intentionally NOT set here.
       // next.config.js sets a site-wide CSP for source "/:path*", and that global

--- a/apps/web/src/app/embed/turnstile/route.ts
+++ b/apps/web/src/app/embed/turnstile/route.ts
@@ -70,8 +70,13 @@ export function GET() {
   return new Response(html, {
     headers: {
       "Content-Type": "text/html; charset=utf-8",
-      // Keep the document fresh and out of edge/browser caches and indexes.
-      "Cache-Control": "no-store",
+      // Static, identical-for-everyone document (the Turnstile challenge runs client-side
+      // via the CF script; nothing here is per-user or sensitive). Edge-cache it so every
+      // mobile signup does not re-render on origin SSR: `no-store` forced a fresh origin
+      // render per load and ~25% of those 504'd when SSR was busy, blanking the widget.
+      // The content only changes on deploy; stale-while-revalidate avoids any origin wait
+      // at expiry. The CF worker edge-caches HTML whose origin sends s-maxage + no no-store.
+      "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
       "X-Robots-Tag": "noindex, nofollow"
       // NOTE: a per-response Content-Security-Policy is intentionally NOT set here.
       // next.config.js sets a site-wide CSP for source "/:path*", and that global


### PR DESCRIPTION
## What & why

`/embed/turnstile` — the Turnstile widget the mobile app loads for free signup — is served `Cache-Control: no-store`, so **every** mobile signup re-renders it on origin SSR. ~25% of those loads **504'd** today when SSR was busy, blanking the widget. The document is static and identical for everyone (the Turnstile challenge itself runs client-side via the Cloudflare script), so it should be edge-cached.

## Change

`Cache-Control: public, max-age=0, s-maxage=3600, stale-while-revalidate=86400`.

The CF worker edge-caches any HTML whose origin `Cache-Control` carries `s-maxage` and no `no-store`/`private` (its `caches.default` logic), so the widget is served from the edge and origin is hit only ~once/hour/colo; `stale-while-revalidate` avoids an origin wait at expiry. Still `noindex`.

No middleware conflict: `/embed/turnstile` is not in `NO_CACHE_PREFIXES` and `getCachePolicyForPath` returns `null` for it, so the middleware leaves the route's own `Cache-Control` untouched.

## Testing

After deploy:
- `curl -sI https://ecency.com/embed/turnstile` → `cache-control: public, ... s-maxage=3600 ...`
- second request → `x-edge-cache: HIT`
