### PR TITLE
fix(safe-tweet): quiet the handled tweet-embed failure log

### DIFF
--- a/apps/web/src/features/shared/safe-tweet.tsx
+++ b/apps/web/src/features/shared/safe-tweet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Component, ErrorInfo, ReactNode } from "react";
+import { Component, ReactNode } from "react";
 import dynamic from "next/dynamic";
 import i18next from "i18next";
 
@@ -46,11 +46,13 @@ class TweetErrorBoundary extends Component<BoundaryProps, { hasError: boolean }>
     return { hasError: true };
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    // react-tweet throws inside its own render when X's syndication data shape
-    // shifts (a field it iterates becomes undefined). Catch it so one
-    // unavailable/changed tweet degrades to a link instead of crashing the post.
-    console.error("react-tweet render failed:", error, errorInfo);
+  componentDidCatch(error: Error) {
+    // Expected, handled case — not a crash: react-tweet throws inside its own
+    // render when X's syndication payload is incomplete (the tweet is deleted /
+    // protected / age-restricted, or a field it iterates is absent). We already
+    // degrade to a "view on X" link, so log a single quiet warning instead of an
+    // error + component stack that looks like a real failure (and inflates Sentry).
+    console.warn(`[SafeTweet] tweet ${this.props.id} unavailable; showing fallback link (${error.message})`);
   }
 
   render() {


### PR DESCRIPTION
## What
When a post embeds a tweet that is **deleted / protected / age-restricted** (or whose syndication payload is otherwise incomplete), `react-tweet` throws inside its own render (`TypeError: r is not iterable` — it spreads `entities.*` that aren't present). `SafeTweet`'s error boundary **already** catches this and renders a "view on X" fallback link, so the post is unaffected — this is an expected, handled condition.

The boundary logged it with `console.error("react-tweet render failed:", error, errorInfo)` — full error object **plus component stack** — on every such tweet. That looks like a real crash in the console and inflates Sentry/console noise.

## Change
Downgrade to a single concise `console.warn` (drop the `ErrorInfo`/stack). **No behavior change** — the fallback link and error-boundary recovery are identical.

## Why it's safe
- Verified the mechanism: X syndication returns `__typename=Tweet` + `entities` for valid tweets (render fine) but an HTML error page for unavailable ones (→ the throw). Valid tweets are unaffected.
- No test asserts the old message; no other reference to the removed `ErrorInfo` import.

## Context
Surfaced while diagnosing console output on a post page (alongside the nginx `/_next/static` 502 fix, which was the actual unstyled-page cause and is separate/infra).