### PR TITLE
feat(signup): localize free-signup error messages by backend code

### DIFF
--- a/apps/web/src/app/signup/free/_page.tsx
+++ b/apps/web/src/app/signup/free/_page.tsx
@@ -162,6 +162,10 @@ export function FreeSignUp() {
     }
 
     setInProgress(true);
+    // Start each attempt fresh: clear any prior error so a thrown failure without a
+    // code/message (e.g. a network error) can't leave a stale, misleading message
+    // on screen while the Turnstile silently resets.
+    setRegistrationError("");
     try {
       if (!captchaToken) {
         error(i18next.t("login.captcha-check-required"));

--- a/apps/web/src/app/signup/free/_page.tsx
+++ b/apps/web/src/app/signup/free/_page.tsx
@@ -23,6 +23,16 @@ import { useQueryClient } from "@tanstack/react-query";
 const TURNSTILE_SITEKEY =
   process.env.NEXT_PUBLIC_TURNSTILE_SITEKEY || "0x4AAAAAADe6jH7FIi9dBzgR";
 
+// The onboard signup API returns a numeric `code` plus an English `message`.
+// Prefer a translated string keyed by code and fall back to the backend message
+// (then a generic error) so we never surface a bare numeric code or a raw key.
+function resolveSignupError(code?: number | string, message?: string): string {
+  const fallback = message || i18next.t("g.server-error");
+  return code
+    ? i18next.t(`sign-up.error-codes.${code}`, { defaultValue: fallback })
+    : fallback;
+}
+
 export function FreeSignUp() {
   const toggleUIProp = useGlobalStore((s) => s.toggleUiProp);
   const queryClient = useQueryClient();
@@ -160,7 +170,12 @@ export function FreeSignUp() {
 
       const response = await signUp(username, email, referral, captchaToken);
       if (response?.data?.code) {
-        setRegistrationError(String(response.data.code));
+        setRegistrationError(
+          resolveSignupError(
+            response.data.code as number,
+            response.data.message as string | undefined
+          )
+        );
         // Turnstile tokens are single-use; drop it and re-challenge so a retry works.
         setCaptchaToken("");
         turnstileRef.current?.reset();
@@ -170,9 +185,9 @@ export function FreeSignUp() {
       }
     } catch (e) {
       if (e instanceof Error && "data" in e) {
-        const errorData = (e as { data?: { message?: string } }).data;
-        if (errorData?.message) {
-          setRegistrationError(errorData.message);
+        const errorData = (e as { data?: { code?: number; message?: string } }).data;
+        if (errorData?.code || errorData?.message) {
+          setRegistrationError(resolveSignupError(errorData?.code, errorData?.message));
         }
       }
       // Token is consumed on a verification attempt; reset for the next try.

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -395,7 +395,21 @@
     "referral-invalid": "This referral is invalid. Please, try another one",
     "referral-min-length-error": "Length of referral should be at least 3 characters",
     "referral-max-length-error": "Length of referral should be no more than 16 characters",
-    "email-max-length-error": "Length of email should be no more than 72 characters"
+    "email-max-length-error": "Length of email should be no more than 72 characters",
+    "error-codes": {
+      "13": "Username has already been taken",
+      "14": "Email address already registered",
+      "15": "Please enter a valid email address",
+      "16": "Please enter a valid username",
+      "17": "Username is too long, please choose a shorter one",
+      "19": "Please use a permanent email address, or get a Premium account instead",
+      "21": "This referral isn't valid",
+      "28": "Your request couldn't be processed — the signup queue is likely full. Please try again in a few minutes.",
+      "107": "VPN connection detected. Please turn off your VPN and try again, or get a Premium account instead.",
+      "110": "To prevent abuse, we limit the number of accounts per person/network. Please try again from a different network.",
+      "111": "Tor connection detected. Please disable Tor while signing up.",
+      "112": "We couldn't verify your connection right now. Please try again in a few minutes."
+    }
   },
   "onboard": {
     "title-active-user": "Onboard a friend",


### PR DESCRIPTION
## Why

Web parity with ecency-mobile #3291. The free-signup endpoint (`onboard` `AccountCreate`) returns a numeric **`code`** plus an English **`message`**. On the signup page:

- the **non-throw path showed the raw numeric code** to the user (`setRegistrationError(String(response.data.code))` → e.g. a bare `107`), and
- the **throw path showed the raw English message**, so non-English users always got English.

## What

- Added `resolveSignupError(code, message)` — prefers a translated string keyed by code (`sign-up.error-codes.<code>`), falling back to the backend `message`, then `g.server-error`.
- Wired it into **both** paths (non-throw and catch).
- Added `sign-up.error-codes.<code>` to `en-US.json` for the **12 codes the free-signup endpoint can raise**: `13, 14, 15, 16, 17, 19, 21, 28, 107, 110, 111, 112`.

```ts
function resolveSignupError(code?: number | string, message?: string): string {
  const fallback = message || i18next.t("g.server-error");
  return code
    ? i18next.t(`sign-up.error-codes.${code}`, { defaultValue: fallback })
    : fallback;
}
```

## Fallback behaviour (verified against real i18next)

| case | shows |
|------|-------|
| EN / translated locale, mapped code | localized string |
| **untranslated** locale, mapped code | English mapped string (via `fallbackLng: "en-US"`) |
| **unmapped** code (future backend code) | backend `message` |
| code but no message | `g.server-error` |
| no code | backend `message` (unchanged from before) |

Bare-numeric-code display is fixed. Strings are added to `en-US.json` only (other locales translated downstream); codes 104/106/108/109 are internal `QualityControl`/wallet/favorites errors, not raised by free signup, so they're intentionally excluded.

## Verification

- `tsc --noEmit` on `apps/web`: **0 errors in the changed file** (pre-existing baseline errors elsewhere unrelated)
- ESLint clean on `_page.tsx`; `en-US.json` valid JSON
- Resolver behaviour verified at runtime with real i18next (mapped / untranslated-fallback / unmapped / no-code / no-message)