### PR TITLE
Use distinct QR illustration for buy-points-with-QR card

### DIFF
--- a/apps/web/public/assets/undraw-qr-points.svg
+++ b/apps/web/public/assets/undraw-qr-points.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" role="img" aria-label="Buy points by scanning a QR code with the Ecency app">
+<ellipse cx="232" cy="266" rx="118" ry="13" fill="#e6e6e6"/>
+<rect x="152" y="46" width="152" height="212" rx="22" fill="#3f3d56"/>
+<rect x="163" y="64" width="130" height="176" rx="9" fill="#f2f2f2"/>
+<rect x="208" y="55" width="40" height="4" rx="2" fill="#2f2e41"/>
+<rect x="208" y="246" width="40" height="4" rx="2" fill="#e6e6e6"/>
+<rect x="180" y="92" width="24" height="24" fill="#3f3d56"/><rect x="185" y="97" width="14" height="14" fill="#f2f2f2"/><rect x="188" y="100" width="8" height="8" fill="#3f3d56"/>
+<rect x="252" y="92" width="24" height="24" fill="#3f3d56"/><rect x="257" y="97" width="14" height="14" fill="#f2f2f2"/><rect x="260" y="100" width="8" height="8" fill="#3f3d56"/>
+<rect x="180" y="164" width="24" height="24" fill="#3f3d56"/><rect x="185" y="169" width="14" height="14" fill="#f2f2f2"/><rect x="188" y="172" width="8" height="8" fill="#3f3d56"/>
+<rect x="212" y="92" width="8" height="8" fill="#3f3d56"/>
+<rect x="228" y="92" width="8" height="8" fill="#3f3d56"/>
+<rect x="236" y="92" width="8" height="8" fill="#3f3d56"/>
+<rect x="212" y="100" width="8" height="8" fill="#3f3d56"/>
+<rect x="220" y="100" width="8" height="8" fill="#3f3d56"/>
+<rect x="236" y="100" width="8" height="8" fill="#3f3d56"/>
+<rect x="204" y="108" width="8" height="8" fill="#3f3d56"/>
+<rect x="220" y="108" width="8" height="8" fill="#3f3d56"/>
+<rect x="228" y="108" width="8" height="8" fill="#3f3d56"/>
+<rect x="180" y="124" width="8" height="8" fill="#3f3d56"/>
+<rect x="196" y="124" width="8" height="8" fill="#3f3d56"/>
+<rect x="212" y="124" width="8" height="8" fill="#3f3d56"/>
+<rect x="244" y="124" width="8" height="8" fill="#3f3d56"/>
+<rect x="260" y="124" width="8" height="8" fill="#3f3d56"/>
+<rect x="268" y="124" width="8" height="8" fill="#3f3d56"/>
+<rect x="188" y="132" width="8" height="8" fill="#3f3d56"/>
+<rect x="204" y="132" width="8" height="8" fill="#3f3d56"/>
+<rect x="252" y="132" width="8" height="8" fill="#3f3d56"/>
+<rect x="196" y="140" width="8" height="8" fill="#3f3d56"/>
+<rect x="212" y="140" width="8" height="8" fill="#3f3d56"/>
+<rect x="220" y="140" width="8" height="8" fill="#3f3d56"/>
+<rect x="260" y="140" width="8" height="8" fill="#3f3d56"/>
+<rect x="180" y="148" width="8" height="8" fill="#3f3d56"/>
+<rect x="204" y="148" width="8" height="8" fill="#3f3d56"/>
+<rect x="228" y="148" width="8" height="8" fill="#3f3d56"/>
+<rect x="252" y="148" width="8" height="8" fill="#3f3d56"/>
+<rect x="268" y="148" width="8" height="8" fill="#3f3d56"/>
+<rect x="212" y="156" width="8" height="8" fill="#3f3d56"/>
+<rect x="236" y="156" width="8" height="8" fill="#3f3d56"/>
+<rect x="260" y="156" width="8" height="8" fill="#3f3d56"/>
+<rect x="220" y="164" width="8" height="8" fill="#3f3d56"/>
+<rect x="244" y="164" width="8" height="8" fill="#3f3d56"/>
+<rect x="260" y="164" width="8" height="8" fill="#3f3d56"/>
+<rect x="212" y="172" width="8" height="8" fill="#3f3d56"/>
+<rect x="228" y="172" width="8" height="8" fill="#3f3d56"/>
+<rect x="252" y="172" width="8" height="8" fill="#3f3d56"/>
+<rect x="268" y="172" width="8" height="8" fill="#3f3d56"/>
+<rect x="220" y="180" width="8" height="8" fill="#3f3d56"/>
+<rect x="236" y="180" width="8" height="8" fill="#3f3d56"/>
+<rect x="260" y="180" width="8" height="8" fill="#3f3d56"/>
+<rect x="228" y="124" width="8" height="8" fill="#357ce6"/>
+<rect x="236" y="132" width="8" height="8" fill="#357ce6"/>
+<rect x="244" y="140" width="8" height="8" fill="#357ce6"/>
+<rect x="220" y="164" width="8" height="8" fill="#357ce6"/>
+<rect x="252" y="148" width="8" height="8" fill="#357ce6"/>
+<circle cx="322" cy="86" r="34" fill="#357ce6"/>
+<circle cx="322" cy="86" r="25" fill="none" stroke="#ffffff" stroke-width="3" opacity="0.55"/>
+<polygon points="322.0,73.0 325.1,81.8 334.4,82.0 326.9,87.6 329.6,96.5 322.0,91.2 314.4,96.5 317.1,87.6 309.6,82.0 318.9,81.8" fill="#ffffff"/>
+<circle cx="372" cy="150" r="6" fill="#357ce6"/>
+<circle cx="120" cy="120" r="5" fill="#e6e6e6"/>
+<circle cx="356" cy="210" r="4" fill="#e6e6e6"/>
+</svg>

--- a/apps/web/src/app/perks/points/_page.tsx
+++ b/apps/web/src/app/perks/points/_page.tsx
@@ -67,7 +67,7 @@ export function PointsPage() {
 
       <LoginRequired>
         <PointsActionCard
-          imageSrc="/assets/undraw-credit-card.svg"
+          imageSrc="/assets/undraw-qr-points.svg"
           title={i18next.t("perks.buy-points-qr-title")}
           description={i18next.t("perks.buy-points-qr-description")}
           steps={[


### PR DESCRIPTION
On `/perks/points`, the **Buy points with QR** card (mobile app / IAP path) reused the same `undraw-credit-card.svg` illustration as the **Buy points with card** option, so the two cards looked identical.

This adds a dedicated phone + QR code illustration (`undraw-qr-points.svg`) in the existing undraw style and palette, and points the QR card at it. The card-payment and Hive/HBD cards are unchanged.

Diff: 1 new asset + 1 line in `_page.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the icon displayed on the buy points card for improved visual presentation and consistency with the app's design language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->