### PR TITLE
Show the actual extension (Keeper / Peak Vault) on login account badges

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/permissions/_components/add-keys-steps/step-3-review-keys.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/permissions/_components/add-keys-steps/step-3-review-keys.tsx
@@ -7,6 +7,7 @@ import i18next from "i18next";
 import { useEffect, useRef, useState } from "react";
 import { useKeyDerivationStore } from "../../_hooks";
 import { getLoginType } from "@/utils/user-token";
+import { resolveExtensionAwareLoginType } from "@/utils/login-extension";
 
 type Keys = Record<string, [string, number][]>;
 type KeyAuthority = "owner" | "active" | "posting" | "memo";
@@ -99,7 +100,7 @@ export function Step3ReviewKeys({ mode = "add", initialSelectedKey, onNext, onBa
     return count;
   };
 
-  const loginType = getLoginType(username ?? "");
+  const loginType = resolveExtensionAwareLoginType(getLoginType(username ?? ""), username ?? "");
 
   const getLoginTypeBadge = () => {
     switch (loginType) {
@@ -107,6 +108,10 @@ export function Step3ReviewKeys({ mode = "add", initialSelectedKey, onNext, onBa
         return { label: "MetaMask", className: "bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300" };
       case "keychain":
         return { label: "Keychain", className: "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300" };
+      case "keeper":
+        return { label: "Keeper", className: "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300" };
+      case "peakvault":
+        return { label: "Vault", className: "bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300" };
       case "hivesigner":
         return { label: "HiveSigner", className: "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300" };
       case "privateKey":

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/permissions/_components/manage-key.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/permissions/_components/manage-key.tsx
@@ -9,6 +9,7 @@ import { useCopyToClipboard } from "react-use";
 import { ManageKeyPasswordDialog } from "./manage-key-password-dialog";
 import { useRevealedKeysStore, useKeyDerivationStore } from "../_hooks";
 import { getLoginType } from "@/utils/user-token";
+import { resolveExtensionAwareLoginType } from "@/utils/login-extension";
 
 type Keys = Record<string, [string, number][]>;
 
@@ -41,7 +42,10 @@ export function ManageKey({ keyName, onRevoke }: Props) {
 
   const [showReveal, setShowReveal] = useState(false);
 
-  const loginType = getLoginType(activeUser?.username ?? "");
+  const loginType = resolveExtensionAwareLoginType(
+    getLoginType(activeUser?.username ?? ""),
+    activeUser?.username ?? ""
+  );
 
   const getLoginTypeBadge = () => {
     switch (loginType) {
@@ -49,6 +53,10 @@ export function ManageKey({ keyName, onRevoke }: Props) {
         return { label: "MetaMask", className: "bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300" };
       case "keychain":
         return { label: "Keychain", className: "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300" };
+      case "keeper":
+        return { label: "Keeper", className: "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300" };
+      case "peakvault":
+        return { label: "Vault", className: "bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300" };
       case "hivesigner":
         return { label: "HiveSigner", className: "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300" };
       default:

--- a/apps/web/src/features/shared/login/login-type-badge.tsx
+++ b/apps/web/src/features/shared/login/login-type-badge.tsx
@@ -1,0 +1,103 @@
+import { LoginType } from "@/entities";
+import { ExtensionAwareLoginType, resolveExtensionAwareLoginType } from "@/utils/login-extension";
+import { classNameObject } from "@ui/util";
+import { useEffect, useState } from "react";
+
+// What the badge visually represents. This is display-only and intentionally
+// separate from LoginType: all browser extensions (Keychain, Hive Keeper, Peak
+// Vault) share the Keychain-compatible auth path and are persisted as login
+// type "keychain", so the stored auth type must NOT be changed to tell them
+// apart. The specific extension is read from the account's saved preference.
+type BadgeKind = "metamask" | "keychain" | "keeper" | "peakvault" | "hivesigner" | "privateKey";
+
+const ICONS: Record<BadgeKind, string | null> = {
+  metamask: "/assets/metamask-fox.svg",
+  keeper: "/assets/keeper.svg",
+  peakvault: "/assets/peakvault.svg",
+  keychain: "/assets/keychain.png",
+  hivesigner: "/assets/hive-signer.svg",
+  privateKey: null
+};
+
+const LABELS: Record<BadgeKind, string> = {
+  metamask: "MetaMask",
+  keeper: "Keeper",
+  peakvault: "Vault",
+  keychain: "Keychain",
+  hivesigner: "HiveSigner",
+  privateKey: "Private key"
+};
+
+function toBadgeKind(loginType?: ExtensionAwareLoginType | null): BadgeKind | undefined {
+  switch (loginType) {
+    case "metamask":
+      return "metamask";
+    case "hivesigner":
+      return "hivesigner";
+    case "privateKey":
+      return "privateKey";
+    case "keeper":
+      return "keeper";
+    case "peakvault":
+      return "peakvault";
+    case "keychain":
+    case "keychain-mobile":
+      return "keychain";
+    default:
+      return undefined;
+  }
+}
+
+interface Props {
+  username: string;
+  loginType?: LoginType;
+  compact?: boolean;
+}
+
+/**
+ * Small badge overlaid on a user avatar showing which method that account
+ * logged in with.
+ *
+ * Browser-extension logins are all stored as login type "keychain", so for a
+ * desktop extension login the specific wallet (Keychain / Hive Keeper / Peak
+ * Vault) is resolved from the account's saved per-user extension preference.
+ * This runs in an effect to stay SSR-safe (the preference lives in localStorage)
+ * and avoid a hydration mismatch: first paint uses the stored type, then the
+ * client refines it. Only "keychain" is refined, never "keychain-mobile" -- the
+ * mobile deep-link path is unrelated to the desktop extension preference.
+ */
+export function LoginTypeBadge({ username, loginType, compact = false }: Props) {
+  // First paint uses the stored login type (deterministic / SSR-safe); the
+  // effect then refines a desktop "keychain" login to the actual extension from
+  // the account's saved preference (localStorage, client-only).
+  const [kind, setKind] = useState<BadgeKind | undefined>(() => toBadgeKind(loginType));
+
+  useEffect(() => {
+    setKind(toBadgeKind(resolveExtensionAwareLoginType(loginType, username)));
+  }, [username, loginType]);
+
+  const src = (kind && ICONS[kind]) ?? "/assets/hive-logo.svg";
+  const label = kind ? LABELS[kind] : loginType;
+
+  return (
+    <div
+      className={classNameObject({
+        "absolute -right-0.5 -bottom-0.5 rounded-full bg-white dark:bg-dark-200 flex items-center justify-center shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden":
+          true,
+        "w-[13px] h-[13px]": compact,
+        "w-4 h-4": !compact
+      })}
+      title={label}
+    >
+      <img
+        src={src}
+        alt=""
+        className={classNameObject({
+          "object-contain": true,
+          "w-[9px] h-[9px]": compact,
+          "w-[11px] h-[11px]": !compact
+        })}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/shared/login/login-user-item.tsx
+++ b/apps/web/src/features/shared/login/login-user-item.tsx
@@ -1,5 +1,5 @@
 import { useActiveAccount } from "@/core/hooks/use-active-account";
-import { LoginType, User } from "@/entities";
+import { User } from "@/entities";
 import { UserAvatar } from "@/features/shared";
 import { UilTrash } from "@tooni/iconscout-unicons-react";
 import { Button } from "@ui/button";
@@ -8,42 +8,7 @@ import { classNameObject } from "@ui/util";
 import i18next from "i18next";
 import React, { useRef, useState } from "react";
 import { useDeleteUserFromList, useUserSelect } from "./hooks";
-
-function LoginTypeBadge({
-  loginType,
-  compact = false
-}: {
-  loginType?: LoginType;
-  compact?: boolean;
-}) {
-  const src =
-    loginType === "metamask" ? "/assets/metamask-fox.svg" :
-    loginType === "keychain" || loginType === "keychain-mobile" ? "/assets/keychain.png" :
-    loginType === "hivesigner" ? "/assets/hive-signer.svg" :
-    null;
-
-  return (
-    <div
-      className={classNameObject({
-        "absolute -right-0.5 -bottom-0.5 rounded-full bg-white dark:bg-dark-200 flex items-center justify-center shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden":
-          true,
-        "w-[13px] h-[13px]": compact,
-        "w-4 h-4": !compact
-      })}
-      title={loginType}
-    >
-      <img
-        src={src ?? "/assets/hive-logo.svg"}
-        alt=""
-        className={classNameObject({
-          "object-contain": true,
-          "w-[9px] h-[9px]": compact,
-          "w-[11px] h-[11px]": !compact
-        })}
-      />
-    </div>
-  );
-}
+import { LoginTypeBadge } from "./login-type-badge";
 
 interface Props {
   user: User;
@@ -85,7 +50,7 @@ export function LoginUserItem({ user, compact = false }: Props) {
     >
       <div className="relative flex-shrink-0">
         <UserAvatar username={user.username} size={compact ? "small" : "medium"} />
-        <LoginTypeBadge loginType={user.loginType} compact={compact} />
+        <LoginTypeBadge username={user.username} loginType={user.loginType} compact={compact} />
         {activeUser?.username === user.username && (
           <div className="rounded-full absolute left-0 bottom-0 p-0.5 bg-white dark:bg-dark-200">
             <div className="bg-green w-2 h-2 rounded-full" />

--- a/apps/web/src/specs/features/login/login-type-badge.spec.tsx
+++ b/apps/web/src/specs/features/login/login-type-badge.spec.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+vi.mock("@/utils/hive-extensions", () => ({
+  getPreferredExtensionId: vi.fn()
+}));
+
+import { getPreferredExtensionId } from "@/utils/hive-extensions";
+import { LoginTypeBadge } from "@/features/shared/login/login-type-badge";
+
+function imgSrc(container: HTMLElement) {
+  return container.querySelector("img")?.getAttribute("src");
+}
+
+describe("LoginTypeBadge", () => {
+  beforeEach(() => {
+    (getPreferredExtensionId as any).mockReset();
+    (getPreferredExtensionId as any).mockReturnValue(null);
+  });
+
+  it("shows the Keychain icon for a keychain login with no saved preference", async () => {
+    const { container } = render(<LoginTypeBadge username="alice" loginType="keychain" />);
+    await waitFor(() => expect(imgSrc(container)).toBe("/assets/keychain.png"));
+  });
+
+  it("refines a keychain login to the Keeper icon from the saved per-user preference", async () => {
+    (getPreferredExtensionId as any).mockReturnValue("hive-keeper");
+    const { container } = render(<LoginTypeBadge username="alice" loginType="keychain" />);
+    await waitFor(() => expect(imgSrc(container)).toBe("/assets/keeper.svg"));
+    expect(getPreferredExtensionId).toHaveBeenCalledWith("alice");
+  });
+
+  it("refines a keychain login to the Peak Vault icon from the saved per-user preference", async () => {
+    (getPreferredExtensionId as any).mockReturnValue("peakvault");
+    const { container } = render(<LoginTypeBadge username="alice" loginType="keychain" />);
+    await waitFor(() => expect(imgSrc(container)).toBe("/assets/peakvault.svg"));
+  });
+
+  it("never refines a keychain-mobile login from the desktop extension preference", async () => {
+    // keychain-mobile is the mobile deep-link path; a desktop Keeper preference
+    // must not override its badge.
+    (getPreferredExtensionId as any).mockReturnValue("hive-keeper");
+    const { container } = render(<LoginTypeBadge username="alice" loginType="keychain-mobile" />);
+    await waitFor(() => expect(imgSrc(container)).toBe("/assets/keychain.png"));
+    expect(getPreferredExtensionId).not.toHaveBeenCalled();
+  });
+
+  it("shows the MetaMask icon for a metamask login", async () => {
+    const { container } = render(<LoginTypeBadge username="alice" loginType="metamask" />);
+    await waitFor(() => expect(imgSrc(container)).toBe("/assets/metamask-fox.svg"));
+  });
+
+  it("shows the HiveSigner icon for a hivesigner login", async () => {
+    const { container } = render(<LoginTypeBadge username="alice" loginType="hivesigner" />);
+    await waitFor(() => expect(imgSrc(container)).toBe("/assets/hive-signer.svg"));
+  });
+
+  it("falls back to the Hive logo for a private key login", async () => {
+    const { container } = render(<LoginTypeBadge username="alice" loginType="privateKey" />);
+    await waitFor(() => expect(imgSrc(container)).toBe("/assets/hive-logo.svg"));
+  });
+});

--- a/apps/web/src/specs/features/permissions/step3-login-type-badge.spec.tsx
+++ b/apps/web/src/specs/features/permissions/step3-login-type-badge.spec.tsx
@@ -35,6 +35,7 @@ const mockAccountData = {
 
 describe("Step3ReviewKeys - login type badges", () => {
   beforeEach(() => {
+    localStorage.clear();
     (useActiveAccount as any).mockReturnValue({
       activeUser: { username: "testuser" }
     });
@@ -60,6 +61,26 @@ describe("Step3ReviewKeys - login type badges", () => {
     render(<Step3ReviewKeys onNext={vi.fn()} onBack={vi.fn()} />);
     const badges = screen.getAllByText("HiveSigner");
     expect(badges.length).toBeGreaterThan(0);
+  });
+
+  it("shows Keeper badge for a keychain login with a saved Keeper preference", () => {
+    (getLoginType as any).mockReturnValue("keychain");
+    localStorage.setItem(
+      "ecency_preferred_hive_extension_by_user",
+      JSON.stringify({ testuser: "hive-keeper" })
+    );
+    render(<Step3ReviewKeys onNext={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getAllByText("Keeper").length).toBeGreaterThan(0);
+  });
+
+  it("shows Vault badge for a keychain login with a saved Peak Vault preference", () => {
+    (getLoginType as any).mockReturnValue("keychain");
+    localStorage.setItem(
+      "ecency_preferred_hive_extension_by_user",
+      JSON.stringify({ testuser: "peakvault" })
+    );
+    render(<Step3ReviewKeys onNext={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getAllByText("Vault").length).toBeGreaterThan(0);
   });
 
   it("disables checkboxes when only one key per authority", () => {

--- a/apps/web/src/utils/login-extension.ts
+++ b/apps/web/src/utils/login-extension.ts
@@ -1,0 +1,38 @@
+import { LoginType } from "@/entities";
+import { getPreferredExtensionId } from "@/utils/hive-extensions";
+
+/**
+ * Display-only login kinds: the stored auth `LoginType` plus the specific
+ * browser extension behind a "keychain" login.
+ *
+ * All browser extensions (Keychain, Hive Keeper, Peak Vault) are persisted as
+ * loginType "keychain" because they share the Keychain-compatible auth path
+ * (memo encrypt/decrypt, broadcast adapter, operations all branch on
+ * `loginType === "keychain"`). The stored auth type must therefore stay
+ * "keychain"; the specific wallet is only resolved for display.
+ */
+export type ExtensionAwareLoginType = LoginType | "keeper" | "peakvault";
+
+/**
+ * Resolve which extension a "keychain" login actually used, for DISPLAY only.
+ *
+ * Reads the account's saved per-user extension preference (the login flow
+ * records it for every extension login). Only desktop "keychain" is refined --
+ * "keychain-mobile" is the mobile deep-link path and keeps its Keychain
+ * identity, never inheriting a desktop extension preference. Returns the input
+ * loginType unchanged for every other case. SSR-safe: `getPreferredExtensionId`
+ * returns null without `window`, so this falls back to the stored type.
+ */
+export function resolveExtensionAwareLoginType(
+  loginType: string | null | undefined,
+  username: string
+): ExtensionAwareLoginType | null | undefined {
+  if (loginType === "keychain") {
+    const extId = getPreferredExtensionId(username);
+    if (extId === "hive-keeper") return "keeper";
+    if (extId === "peakvault") return "peakvault";
+  }
+  // Pass through the stored value unchanged (it is a LoginType in practice;
+  // getLoginType is loosely typed as string).
+  return loginType as ExtensionAwareLoginType | null | undefined;
+}


### PR DESCRIPTION
## Problem

Accounts signed in with **Hive Keeper** or **Peak Vault** showed the **Keychain** badge - both in the "Welcome back!" login modal and on the profile permissions key list. Every browser-extension login is persisted as `loginType: "keychain"`, so the badge couldn't tell which extension was used.

## Approach

The stored auth type is intentionally left as `"keychain"`: all these extensions share the Keychain-compatible auth path that memo encrypt/decrypt, the broadcast adapter and `api/operations` all branch on (`loginType === "keychain"`). Changing it would break signing/memo for Keeper/Peak Vault users.

Instead the specific wallet is resolved **for display only**, from the account's saved per-user extension preference (`getPreferredExtensionId`), which the login flow already records for every extension login.

- `resolveExtensionAwareLoginType()` - shared helper: maps a desktop `"keychain"` login to Keeper / Vault from the saved preference. Only `"keychain"` is refined; `"keychain-mobile"` (mobile deep-link path) keeps its Keychain identity.
- `LoginTypeBadge` (login-modal avatar) extracted into its own component and keyed off the helper. The preference read runs in an effect (SSR-safe; first paint uses the stored type, client refines).
- Permissions key badges (`manage-key`, `step-3-review-keys`) use the same helper and gain Keeper / Vault label cases.

Accounts that signed in before the per-user preference existed self-correct on next login.

## Tests

268 pass. New `login-type-badge.spec` covers each method, the preference-based refinement, the private-key fallback, and that `keychain-mobile` is never overridden by a desktop preference; `step3-login-type-badge.spec` gains Keeper / Vault cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added login type badges to display how users logged in, with enhanced support for identifying desktop extensions (Keeper and Peak Vault) alongside existing login methods.
  * Improved key and permission management interfaces to accurately show which extension or login method is being used.

* **Tests**
  * Added test coverage for login type badge rendering and extension identification across various user scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->