### PR TITLE
fix(mobile): feed card overflow, list-item bullet, and CSS-skew recovery

### DIFF
--- a/apps/web/src/app/(dynamicPages)/feed/[...sections]/entry-index.scss
+++ b/apps/web/src/app/(dynamicPages)/feed/[...sections]/entry-index.scss
@@ -19,6 +19,13 @@
 
   .entry-page-content {
     flex-grow: 1;
+    // Flex items default to min-width:auto, so this column refuses to shrink
+    // below its content's min-content width. On narrow phones an imageless card
+    // (see .item-image.noImage) has a ~391px intrinsic width, which pushed the
+    // whole column past the viewport inside the overflow-hidden .app-content,
+    // clipping the right edge of every card (and the action bar). min-width:0
+    // lets it shrink to the available width.
+    min-width: 0;
     min-height: 100vh;
 
     &.loading {

--- a/apps/web/src/features/shared/entry-list-item/_index.scss
+++ b/apps/web/src/features/shared/entry-list-item/_index.scss
@@ -171,6 +171,11 @@
   }
 
   @media (max-width: $sm-break) {
+    // The placeholder inherits aspect-ratio:16/9 from the .item-image mixin.
+    // With min-height:220px and an auto width, the browser derives the width
+    // from the height (220 * 16/9 = ~391px) — a fixed width that won't shrink
+    // and overflows narrow viewports. Pin it to the container width instead.
+    width: 100%;
     min-height: 220px;
   }
 }

--- a/apps/web/src/styles/_base.scss
+++ b/apps/web/src/styles/_base.scss
@@ -278,11 +278,16 @@ a {
   }
 }
 
+// "list-item" is also a Tailwind display utility (`.list-item{display:list-item}`),
+// and our list rows (voters, friends, subscribers, RC delegations, search results,
+// <ListItem>, etc.) reuse that class name. They therefore compute display:list-item
+// and inherit a disc marker (list-style-type defaults to disc). It is normally
+// hidden only because the parent grid blockifies the row — so any time the grid
+// CSS isn't applied (first paint / partial CSS) a stray bullet appears.
+// The previous `::marker { display:none; visibility:hidden; content:"" }` guard is
+// a no-op in several engines (display/visibility/content overrides on ::marker are
+// not universally honored). list-style:none removes the marker in every browser
+// and in every CSS-load state.
 .list-item {
-  &::marker {
-    content: "";
-    display: none;
-    opacity: 0;
-    visibility: hidden;
-  }
+  list-style: none;
 }


### PR DESCRIPTION
Fixes mobile rendering issues reported on Chrome at narrow widths (~360px Android).

### 1. Feed cards overflow narrow viewports
Posts without a cover image render `.item-image.noImage`, which inherits `aspect-ratio: 16/9` from the `.item-image` mixin and sets `min-height: 220px` on mobile. With an auto width the browser derives a fixed width from the height (220 × 16/9 ≈ 391px). Combined with `.entry-page-content` keeping the flexbox default `min-width: auto`, the feed column was forced past the `overflow-hidden` viewport on phones narrower than ~404px, clipping the right edge of every card and its action bar.

- `.item-image.noImage` → `width: 100%` on mobile
- `.entry-page-content` → `min-width: 0`

### 2. Stray bullet on list rows
The `list-item` class also matches Tailwind's `.list-item { display: list-item }` utility, so list rows (voters, friends, subscribers, RC delegations, search results, `ListItem`) compute `display: list-item` and inherit a default disc marker. It is hidden only while the parent grid blockifies the row, so a bullet appears whenever that grid CSS is not yet applied. The previous `::marker` override is a no-op in several engines. Replaced with `list-style: none`, which removes the marker in every browser and CSS-load state.

### 3. Recover from a failed CSS-chunk load after deploy
`ServiceWorkerRecovery` only reloaded on thrown JS skew errors. A stale document referencing a CSS hash purged by a later deploy 404s with no thrown error and renders unstyled, so it never recovered. Added a capture-phase listener that treats a failed `/_next/static/css` link as deploy skew and reloads once per session (resource-load errors do not bubble and are not `ErrorEvent`s).

### Verification
- Feed horizontal overflow at 360px and 412px → 0 (was ~59px clipped at 360px)
- Voters `.list-item` marker: `disc` → `none`
- Post page: no overflow (unaffected)
- `service-worker-recovery` spec: 16/16 pass (2 new regression tests added)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout overflow issues affecting narrow phone screens.
  * Enhanced error recovery when CSS resources fail to load, improving app stability.
  * Corrected placeholder sizing for entries without images.
  * Improved cross-browser consistency for list styling.

* **Tests**
  * Added test coverage for CSS loading failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->