### PR TITLE
fix(pwa): exclude non-servable assets from the SW precache so it can update

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -12,14 +12,21 @@ const withPWA = require("next-pwa")({
   // runtime against freshly-cached chunks.
   skipWaiting: true,
   clientsClaim: true,
-  // Never precache source maps. We upload them to Sentry and then delete them
-  // from the build output (deleteSourcemapsAfterUpload), so the .map URLs 404 in
-  // production. Workbox's precacheAndRoute fetches every precache entry during
-  // SW install and rejects the whole install on any non-OK response — so a SW
-  // that precached the (now-missing) .map files could never install/update,
-  // stranding users on a stale cache that served mismatched chunks ("Element
-  // type is invalid: undefined" → persistent 500).
-  buildExcludes: [/\.map$/],
+  // Every entry below is fetched during SW install, and Workbox rejects the
+  // WHOLE install on any non-200 (or redirected) response — so the new SW never
+  // activates and returning users stay pinned to their old cached build,
+  // regardless of how many times we deploy. Three families are not cleanly
+  // servable in production and must be kept out of the precache:
+  //   - *.map → uploaded to Sentry then deleted from the build output, so the
+  //     .map URLs 404.
+  //   - app-build-manifest.json → a build-time manifest Next.js does not serve
+  //     under /_next in production, so it 404s.
+  //   - dynamic-route chunks under chunks/app/**/[seg]/** → their bracketed
+  //     filenames are percent-encoded in the manifest (%5B…%5D) and the server
+  //     307-redirects the encoded URL to the decoded path; cache.put() throws on
+  //     a redirected response, which also fails the install. Match the literal
+  //     "[" and the encoded "%5B" so it holds whichever form the manifest uses.
+  buildExcludes: [/\.map$/, /app-build-manifest\.json$/, /(\[|%5B)/],
   // Keep the ~1.6MB geo-tag cities dataset OUT of the install-time precache so
   // it isn't eagerly downloaded for every user — it's fetched on demand when
   // the geo-tag dialog opens and runtime-cached (see /geo rule below).


### PR DESCRIPTION
## Problem

The PWA service worker can't update, so returning users stay pinned to whatever build their SW first cached — new deploys never reach them (only clearing site data does). This is why a recently-deployed fix appeared "not deployed" on devices that had visited before, while incognito / a different origin rendered the current build correctly.

Root cause: Workbox fetches **every** precache entry during SW install and rejects the **whole install** on any non-200 (or redirected) response. The current precache manifest has **74** entries that don't serve a clean 200:

- **`app-build-manifest.json`** (1) — a build-time manifest Next.js does not serve under `/_next` in production → **404**.
- **dynamic-route chunks** under `chunks/app/**/[seg]/**` (73) — their bracketed filenames are percent-encoded in the manifest (`%5B…%5D`), and the server **307-redirects** the encoded URL to the decoded path; `cache.put()` throws on a redirected response.

Either family alone is enough to fail the install, so the new SW never activates.

## Fix

Add both families to `buildExcludes` in `apps/web/next.config.js`, alongside the existing `*.map` rule (same class of problem, previously fixed the same way):

```js
buildExcludes: [/\.map$/, /app-build-manifest\.json$/, /(\[|%5B)/],
```

These chunks are still emitted and served on demand from the network — they're just no longer in the install-time precache.

## Verification

Production build (`pnpm --filter @ecency/web build`) before/after:

- Precache entries: **717 → 643** (exactly the 74 bad entries removed)
- Entries matching `[` / `%5B` / `app-build-manifest.json` / `.map`: **0**
- All **643** remaining precache URLs exist in the build output (serve 200)

Result: the SW install completes, so it can activate/update and returning users get new deploys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline caching reliability by excluding additional build artifacts and dynamic route chunks from precaching.
  * Reduced the risk of app install or update failures caused by invalid cache entries during service worker setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->