### PR TITLE
feat(waves): publish to hive.flow first, fall back to ecency.waves

### DIFF
--- a/apps/web/src/features/waves/components/wave-form/api/use-wave-create.ts
+++ b/apps/web/src/features/waves/components/wave-form/api/use-wave-create.ts
@@ -8,7 +8,8 @@ import { error } from "@/features/shared";
 import { formatError } from "@/api/format-error";
 import { useWavesApi } from "./use-waves-api";
 import { useCommunityApi } from "./use-community-api";
-import { WaveEntry } from "@/entities";
+import { ECENCY_WAVES_HOSTS, isEcencyWavesHost } from "@/features/waves/enums/wave-hosts";
+import { Entry, WaveEntry } from "@/entities";
 
 export function useWaveCreate() {
   const queryClient = useQueryClient();
@@ -32,22 +33,60 @@ export function useWaveCreate() {
       if (host === "dbuzz") {
         return {
           host,
-          entry: (await communityBasedApiRequest({ host, raw, editingEntry, videoThumbnail })) as WaveEntry
+          entry: (await communityBasedApiRequest({
+            host,
+            raw,
+            editingEntry,
+            videoThumbnail
+          })) as WaveEntry
         };
       }
 
-      const hostEntries = await queryClient.fetchQuery(
-        getAccountPostsQueryOptions(host, ProfileFilter.posts)
-      );
+      // Resolve which container account to publish into and its latest anchor
+      // post. For Ecency's own waves (the standard composer), prefer hive.flow
+      // and fall back to ecency.waves: walk ECENCY_WAVES_HOSTS and take the
+      // first host that currently has a live anchor post. hive.flow is inert
+      // today, so this is ecency.waves until it launches, then switches over
+      // automatically. Explicit non-Ecency hosts (decks: leothreads /
+      // liketu.moments / ...) are used as requested.
+      let resolvedHost = host;
+      let entry: Entry | undefined;
 
-      if (!hostEntries) {
+      if (isEcencyWavesHost(host)) {
+        for (const candidate of ECENCY_WAVES_HOSTS) {
+          try {
+            const entries = await queryClient.fetchQuery(
+              getAccountPostsQueryOptions(candidate, ProfileFilter.posts)
+            );
+            if (entries && entries.length > 0) {
+              resolvedHost = candidate;
+              entry = entries[0];
+              break;
+            }
+          } catch {
+            // hive.flow is pre-provisioned and may not resolve yet; try the next host.
+          }
+        }
+      } else {
+        const hostEntries = await queryClient.fetchQuery(
+          getAccountPostsQueryOptions(host, ProfileFilter.posts)
+        );
+        entry = hostEntries?.[0];
+      }
+
+      if (!entry) {
         throw new Error(i18next.t("decks.threads-form.no-threads-host"));
       }
 
-      const entry = hostEntries[0];
       return {
-        host,
-        entry: (await generalApiRequest({ entry, raw, editingEntry, host, videoThumbnail })) as WaveEntry,
+        host: resolvedHost,
+        entry: (await generalApiRequest({
+          entry,
+          raw,
+          editingEntry,
+          host: resolvedHost,
+          videoThumbnail
+        })) as WaveEntry,
         isEditing: !!editingEntry
       };
     },
@@ -66,8 +105,7 @@ export function useWaveCreate() {
         // uniquely identified by author + permlink (entry.id is not reliable).
         const alreadyPresent = data.pages.some((page) =>
           page.some(
-            (existing) =>
-              existing.author === entry.author && existing.permlink === entry.permlink
+            (existing) => existing.author === entry.author && existing.permlink === entry.permlink
           )
         );
 
@@ -77,9 +115,7 @@ export function useWaveCreate() {
 
         return {
           ...data,
-          pages: data.pages.map((page, index) =>
-            index === 0 ? [entry, ...page] : page
-          )
+          pages: data.pages.map((page, index) => (index === 0 ? [entry, ...page] : page))
         };
       };
 

--- a/apps/web/src/features/waves/components/wave-form/api/use-wave-create.ts
+++ b/apps/web/src/features/waves/components/wave-form/api/use-wave-create.ts
@@ -51,6 +51,7 @@ export function useWaveCreate() {
       // liketu.moments / ...) are used as requested.
       let resolvedHost = host;
       let entry: Entry | undefined;
+      let lastError: unknown;
 
       if (isEcencyWavesHost(host)) {
         for (const candidate of ECENCY_WAVES_HOSTS) {
@@ -63,8 +64,12 @@ export function useWaveCreate() {
               entry = entries[0];
               break;
             }
-          } catch {
-            // hive.flow is pre-provisioned and may not resolve yet; try the next host.
+          } catch (e) {
+            // hive.flow is pre-provisioned and may not resolve yet, so tolerate
+            // its failure and try the next preferred container. Remember the
+            // error so a genuine outage on the fallback (ecency.waves) is
+            // surfaced rather than masked as a missing host.
+            lastError = e;
           }
         }
       } else {
@@ -75,6 +80,9 @@ export function useWaveCreate() {
       }
 
       if (!entry) {
+        if (lastError) {
+          throw lastError;
+        }
         throw new Error(i18next.t("decks.threads-form.no-threads-host"));
       }
 

--- a/apps/web/src/features/waves/components/wave-form/api/use-waves-api.ts
+++ b/apps/web/src/features/waves/components/wave-form/api/use-waves-api.ts
@@ -3,6 +3,7 @@ import { useContext } from "react";
 import { PollsContext } from "@/features/polls";
 import { Entry, FullAccount, WaveEntry } from "@/entities";
 import { createReplyPermlink, createWavePermlink, tempEntry } from "@/utils";
+import { isEcencyWavesHost } from "@/features/waves/enums/wave-hosts";
 import { EntryMetadataManagement } from "@/features/entry-management";
 import { useCommentMutation } from "@/api/sdk-mutations";
 import type { CommentPayload } from "@ecency/sdk";
@@ -10,7 +11,11 @@ import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { validatePostCreating } from "@ecency/sdk";
 import { getQueryClient } from "@/core/react-query";
-import { getAccountFullQueryOptions, getDiscussionsQueryOptions, SortOrder as SDKSortOrder } from "@ecency/sdk";
+import {
+  getAccountFullQueryOptions,
+  getDiscussionsQueryOptions,
+  SortOrder as SDKSortOrder
+} from "@ecency/sdk";
 import { useActiveAccount } from "@/core/hooks";
 import { SortOrder } from "@/enums";
 import { enforceThreeSpeakBeneficiary } from "@/api/threespeak-embed/beneficiary";
@@ -63,7 +68,9 @@ export function useWavesApi() {
 
       let permlink = editingEntry?.permlink ?? createReplyPermlink(entry.author);
 
-      if (host === "ecency.waves" && !editingEntry) {
+      // Ecency's own waves (ecency.waves and, once live, hive.flow) use the
+      // dedicated `wave-*` permlink scheme; other containers use a reply permlink.
+      if (isEcencyWavesHost(host) && !editingEntry) {
         permlink = createWavePermlink();
       }
       const tags = raw.match(/\#[a-zA-Z0-9]+/g)?.map((tag) => tag.replace("#", "")) ?? ["ecency"];
@@ -142,7 +149,12 @@ export function useWavesApi() {
 
       if (!editingEntry) {
         // Inline cache update for discussions list
-        const options = getDiscussionsQueryOptions(entry, SDKSortOrder.created, true, entry?.author);
+        const options = getDiscussionsQueryOptions(
+          entry,
+          SDKSortOrder.created,
+          true,
+          entry?.author
+        );
         queryClient.setQueryData<Entry[]>(options.queryKey, (data) => [...(data ?? []), tempReply]);
         updateRepliesCount(entry.children + 1, entry);
       }

--- a/apps/web/src/features/waves/components/wave-form/index.tsx
+++ b/apps/web/src/features/waves/components/wave-form/index.tsx
@@ -44,8 +44,10 @@ const WaveFormComponent = ({
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const { clearActivePoll, setActivePoll } = useContext(PollsContext);
 
-  // Waves always publish to the Ecency waves container, even though the feed is
-  // unified across containers.
+  // Waves always publish to an Ecency-owned waves container (never third-party
+  // containers), even though the feed is unified across all of them. This is the
+  // requested host; use-wave-create resolves the real container at submit time,
+  // preferring hive.flow over ecency.waves (see ECENCY_WAVES_HOSTS).
   const [threadHost] = useLocalStorage(PREFIX + "_wf_th", "ecency.waves");
   const [text, setText, clearText] = useLocalStorage(PREFIX + "_wf_t", "");
   const [image, setImage, clearImage] = useLocalStorage<string>(PREFIX + "_wf_i", "");

--- a/apps/web/src/features/waves/enums/wave-hosts.ts
+++ b/apps/web/src/features/waves/enums/wave-hosts.ts
@@ -1,8 +1,24 @@
 export enum WaveHosts {
   Testhreads = "testhreads",
+  Flow = "hive.flow",
   Waves = "ecency.waves",
   Leo = "leothreads",
   Dbuzz = "dbuzz",
   Liketu = "liketu.moments",
   PeakSnaps = "peak.snaps"
 }
+
+/**
+ * Ecency's own waves containers, in write-preference order. A new wave from the
+ * standard composer is published into the first one that currently has a live
+ * anchor post: `hive.flow` (the future unified waves+snaps account) once it
+ * launches, otherwise the legacy `ecency.waves`. `hive.flow` is pre-provisioned
+ * and inert today, so this resolves to `ecency.waves` for now and switches over
+ * automatically when `hive.flow` starts posting. The unified feed reads every
+ * container; only these are written to. (Mirrors mobile's `WAVES_HOSTS`.)
+ */
+export const ECENCY_WAVES_HOSTS: readonly string[] = [WaveHosts.Flow, WaveHosts.Waves];
+
+/** True when `host` is one of Ecency's own waves containers (hive.flow / ecency.waves). */
+export const isEcencyWavesHost = (host?: string | null): boolean =>
+  !!host && ECENCY_WAVES_HOSTS.includes(host);

--- a/apps/web/src/features/waves/hooks/use-wave-submit.ts
+++ b/apps/web/src/features/waves/hooks/use-wave-submit.ts
@@ -103,19 +103,22 @@ export function useWaveSubmit(
           editingEntry: editingEntry,
           videoThumbnail: videoThumbnail || undefined
         })) as WaveEntry;
+        if (host) {
+          threadItem.host = host;
+        }
       } else {
-        const { entry } = await create({
+        const created = await create({
           host,
           raw: content,
           editingEntry,
           videoThumbnail: videoThumbnail || undefined
         });
-        threadItem = entry;
+        threadItem = created.entry;
+        // create() resolves the actual container (hive.flow vs ecency.waves);
+        // reflect that on the item rather than the requested host.
+        threadItem.host = created.host ?? host;
       }
 
-      if (host) {
-        threadItem.host = host;
-      }
       threadItem.id = threadItem.post_id;
 
       return threadItem;

--- a/apps/web/src/features/waves/hooks/use-wave-submit.ts
+++ b/apps/web/src/features/waves/hooks/use-wave-submit.ts
@@ -114,9 +114,14 @@ export function useWaveSubmit(
           videoThumbnail: videoThumbnail || undefined
         });
         threadItem = created.entry;
-        // create() resolves the actual container (hive.flow vs ecency.waves);
-        // reflect that on the item rather than the requested host.
-        threadItem.host = created.host ?? host;
+        // For a NEW wave, reflect the container create() actually resolved
+        // (hive.flow vs ecency.waves). For an edit, created.entry already
+        // carries the wave's existing host (it's the edited entry); don't
+        // relabel it to the resolved host, or the cached edit could end up
+        // under the wrong container once hive.flow is live.
+        if (!editingEntry) {
+          threadItem.host = created.host ?? host;
+        }
       }
 
       threadItem.id = threadItem.post_id;

--- a/apps/web/src/specs/features/waves/wave-hosts.spec.ts
+++ b/apps/web/src/specs/features/waves/wave-hosts.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  ECENCY_WAVES_HOSTS,
+  isEcencyWavesHost,
+  WaveHosts
+} from "@/features/waves/enums/wave-hosts";
+
+describe("ECENCY_WAVES_HOSTS", () => {
+  it("publishes to hive.flow first, then ecency.waves", () => {
+    // Write-preference order: a new wave goes to the first host with a live
+    // container, so hive.flow must precede ecency.waves.
+    expect(ECENCY_WAVES_HOSTS).toEqual([WaveHosts.Flow, WaveHosts.Waves]);
+    expect(ECENCY_WAVES_HOSTS[0]).toBe("hive.flow");
+    expect(ECENCY_WAVES_HOSTS[1]).toBe("ecency.waves");
+  });
+});
+
+describe("isEcencyWavesHost", () => {
+  it("recognises Ecency's own waves containers", () => {
+    expect(isEcencyWavesHost("hive.flow")).toBe(true);
+    expect(isEcencyWavesHost("ecency.waves")).toBe(true);
+  });
+
+  it("rejects third-party containers and empty values", () => {
+    expect(isEcencyWavesHost("leothreads")).toBe(false);
+    expect(isEcencyWavesHost("peak.snaps")).toBe(false);
+    expect(isEcencyWavesHost("liketu.moments")).toBe(false);
+    expect(isEcencyWavesHost("")).toBe(false);
+    expect(isEcencyWavesHost(undefined)).toBe(false);
+    expect(isEcencyWavesHost(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Aligns the web wave write path with mobile: new waves prefer the `hive.flow` container and fall back to `ecency.waves`.

Previously the composer always published into `ecency.waves`. Now `use-wave-create` resolves the container at submit time by walking `ECENCY_WAVES_HOSTS` (`[hive.flow, ecency.waves]`) and posting into the first one that currently has a live anchor post.

`hive.flow` is pre-provisioned and inert today, so there is **no behaviour change now** (it resolves to `ecency.waves`); it switches over automatically once `hive.flow` starts posting. The unified feed already reads every container; only Ecency's own containers are written to. Explicit deck hosts (leothreads / liketu.moments / ...) are unchanged.

### Changes
- `wave-hosts`: add `hive.flow`, the ordered `ECENCY_WAVES_HOSTS` list, and `isEcencyWavesHost`.
- `use-wave-create`: resolve the preferred live container; the hive.flow lookup is wrapped so its absence is a clean no-op fallback.
- `use-waves-api`: `hive.flow` waves use the dedicated `wave-*` permlink scheme, like `ecency.waves`.
- `use-wave-submit`: reflect the resolved container on the created item.
- Unit test for the host priority + predicate.

Full web test suite passes locally (1673 tests); typecheck + lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Waves can now be created on an expanded set of supported hosts, including a new host option.
  * Creation flow now better selects the appropriate host automatically when publishing.

* **Bug Fixes**
  * Improved wave/thread submission so the chosen host is retained more consistently after posting.
  * Better handling of host resolution failures when creating waves.

* **Tests**
  * Added coverage for supported wave hosts and host validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->