### PR TITLE
fix: strip emoji before translation to fix language detection

### DIFF
--- a/apps/web/src/api/translation.ts
+++ b/apps/web/src/api/translation.ts
@@ -25,19 +25,57 @@ export interface Language {
   targets: string[];
 }
 
+// Matches emoji, pictographic symbols and their joiners/modifiers. Uses explicit
+// UTF-16 surrogate ranges and \uXXXX escapes (not the `u` flag or
+// \p{Extended_Pictographic}) so it type-checks under an es5 target and behaves
+// identically across engines. The surrogate pair spans U+1F000-1FFFF (emoticons,
+// symbols, transport, flags, skin-tone modifiers); the BMP set covers symbols,
+// dingbats, variation selectors, the zero-width joiner and the keycap combiner.
+const EMOJI_REGEX =
+  /[\uD83C-\uD83F][\uDC00-\uDFFF]|[\u2600-\u27BF\u2300-\u23FF\u2B00-\u2BFF]|[\uFE00-\uFE0F]|\u200D|\u20E3/g;
+
+/**
+ * Splits emoji out of text before it is sent to the translation API. Emoji skew
+ * LibreTranslate's language auto-detection (e.g. Spanish gets detected as
+ * Portuguese, leaving the text untranslated) and are mangled in the output, so
+ * we translate without them and re-attach them to the result.
+ */
+export const stripEmojis = (text: string): { clean: string; emojis: string } => {
+  const emojis: string[] = [];
+  const clean = text
+    .replace(EMOJI_REGEX, (match) => {
+      emojis.push(match);
+      return " ";
+    })
+    .replace(/\s{2,}/g, " ")
+    .trim();
+  return { clean, emojis: emojis.join("") };
+};
+
 export const getTranslation = async (
   text: string,
   source: string,
   target: string
 ): Promise<TranslationResponse> => {
+  const { clean, emojis } = stripEmojis(text);
+
+  // Emoji-only or empty input: nothing to translate, return as-is.
+  if (!clean) {
+    return { translatedText: text };
+  }
+
   const { data } = await translationApi.post<TranslationResponse>("/translate", {
-    q: text,
+    q: clean,
     source,
     target,
     format: "text",
     api_key: ""
   });
-  return data;
+
+  return {
+    ...data,
+    translatedText: emojis ? `${data.translatedText} ${emojis}`.trim() : data.translatedText
+  };
 };
 
 export const getLanguages = async (): Promise<Language[]> => {
@@ -50,4 +88,3 @@ export const getLanguages = async (): Promise<Language[]> => {
     }))
     .filter((lang) => typeof lang.code === 'string' && lang.code.length > 0);
 };
-

--- a/apps/web/src/api/translation.ts
+++ b/apps/web/src/api/translation.ts
@@ -25,29 +25,40 @@ export interface Language {
   targets: string[];
 }
 
-// Matches emoji, pictographic symbols and their joiners/modifiers. Uses explicit
-// UTF-16 surrogate ranges and \uXXXX escapes (not the `u` flag or
+// Matches emoji, pictographic symbols and their joiners/modifiers. Built from
+// \uXXXX escapes and UTF-16 surrogate ranges (not the `u` flag or
 // \p{Extended_Pictographic}) so it type-checks under an es5 target and behaves
-// identically across engines. The surrogate pair spans U+1F000-1FFFF (emoticons,
-// symbols, transport, flags, skin-tone modifiers); the BMP set covers symbols,
-// dingbats, variation selectors, the zero-width joiner and the keycap combiner.
-const EMOJI_REGEX =
-  /[\uD83C-\uD83F][\uDC00-\uDFFF]|[\u2600-\u27BF\u2300-\u23FF\u2B00-\u2BFF]|[\uFE00-\uFE0F]|\u200D|\u20E3/g;
+// identically across engines. The variation selector, keycap combiner and
+// zero-width joiner are only matched together with a base character, so a
+// combiner is never stripped on its own and left orphaned.
+const EMOJI_REGEX = new RegExp(
+  "[\\uD83C-\\uD83F][\\uDC00-\\uDFFF](?:\\uD83C[\\uDFFB-\\uDFFF])?\\uFE0F?" +
+    "(?:\\u200D[\\uD83C-\\uD83F][\\uDC00-\\uDFFF](?:\\uD83C[\\uDFFB-\\uDFFF])?\\uFE0F?)*" +
+    "|[0-9#*]\\uFE0F?\\u20E3" +
+    "|[\\s\\S]\\uFE0F" +
+    "|[\\u2600-\\u27BF\\u2300-\\u23FF\\u2B00-\\u2BFF]",
+  "g"
+);
 
 /**
  * Splits emoji out of text before it is sent to the translation API. Emoji skew
  * LibreTranslate's language auto-detection (e.g. Spanish gets detected as
  * Portuguese, leaving the text untranslated) and are mangled in the output, so
- * we translate without them and re-attach them to the result.
+ * we translate without them and re-attach them to the result. Text with no emoji
+ * is returned untouched so existing whitespace and line breaks are preserved.
  */
 export const stripEmojis = (text: string): { clean: string; emojis: string } => {
   const emojis: string[] = [];
-  const clean = text
-    .replace(EMOJI_REGEX, (match) => {
-      emojis.push(match);
-      return " ";
-    })
-    .replace(/\s{2,}/g, " ")
+  const stripped = text.replace(EMOJI_REGEX, (match) => {
+    emojis.push(match);
+    return " ";
+  });
+  if (emojis.length === 0) {
+    return { clean: text, emojis: "" };
+  }
+  const clean = stripped
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/ ?\n ?/g, "\n")
     .trim();
   return { clean, emojis: emojis.join("") };
 };
@@ -72,6 +83,8 @@ export const getTranslation = async (
     api_key: ""
   });
 
+  // Emoji are re-attached at the end rather than at their original positions;
+  // acceptable for the short posts and messages this is used on.
   return {
     ...data,
     translatedText: emojis ? `${data.translatedText} ${emojis}`.trim() : data.translatedText

--- a/apps/web/src/specs/api/translation.spec.ts
+++ b/apps/web/src/specs/api/translation.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { stripEmojis } from "@/api/translation";
+
+describe("stripEmojis", () => {
+  it("removes trailing emoji and returns them separately", () => {
+    // Regression: 'Mi sobrina posando 😂❤️' was detected as Portuguese because
+    // of the emoji, leaving 'Mi sobrina' untranslated.
+    const { clean, emojis } = stripEmojis("Mi sobrina posando 😂❤️");
+    expect(clean).toBe("Mi sobrina posando");
+    expect(emojis).toBe("😂❤️");
+  });
+
+  it("removes emoji interspersed in the text and collapses whitespace", () => {
+    const { clean, emojis } = stripEmojis("Hola 👋 amigos 😊");
+    expect(clean).toBe("Hola amigos");
+    expect(emojis).toBe("👋😊");
+  });
+
+  it("keeps ZWJ emoji sequences intact when re-joined", () => {
+    const { clean, emojis } = stripEmojis("family 👨‍👩‍👧 photo");
+    expect(clean).toBe("family photo");
+    expect(emojis).toBe("👨‍👩‍👧");
+  });
+
+  it("returns the text unchanged when there are no emoji", () => {
+    const { clean, emojis } = stripEmojis("Hello world");
+    expect(clean).toBe("Hello world");
+    expect(emojis).toBe("");
+  });
+
+  it("yields empty clean text for emoji-only input", () => {
+    const { clean, emojis } = stripEmojis("😂❤️🎉");
+    expect(clean).toBe("");
+    expect(emojis).toBe("😂❤️🎉");
+  });
+});

--- a/apps/web/src/specs/api/translation.spec.ts
+++ b/apps/web/src/specs/api/translation.spec.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { stripEmojis } from "@/api/translation";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }));
+vi.mock("axios", () => ({
+  default: { create: () => ({ post, get: vi.fn() }) }
+}));
+
+import { getTranslation, stripEmojis } from "@/api/translation";
 
 describe("stripEmojis", () => {
   it("removes trailing emoji and returns them separately", () => {
@@ -22,15 +28,75 @@ describe("stripEmojis", () => {
     expect(emojis).toBe("👨‍👩‍👧");
   });
 
+  it("keeps skin-tone modifiers attached to their base emoji", () => {
+    const { clean, emojis } = stripEmojis("thumbs 👍🏽 up");
+    expect(clean).toBe("thumbs up");
+    expect(emojis).toBe("👍🏽");
+  });
+
+  it("removes keycap sequences as a whole (base + combiners)", () => {
+    const { clean, emojis } = stripEmojis("Top 1️⃣ choice");
+    expect(clean).toBe("Top choice");
+    expect(emojis).toBe("1️⃣");
+  });
+
+  it("removes base+variation-selector symbols below U+2300 as a unit", () => {
+    expect(stripEmojis("Copyright ©️ 2024")).toEqual({
+      clean: "Copyright 2024",
+      emojis: "©️"
+    });
+    expect(stripEmojis("Play ▶️ now")).toEqual({ clean: "Play now", emojis: "▶️" });
+  });
+
   it("returns the text unchanged when there are no emoji", () => {
     const { clean, emojis } = stripEmojis("Hello world");
     expect(clean).toBe("Hello world");
     expect(emojis).toBe("");
   });
 
+  it("preserves newlines and spacing when there are no emoji", () => {
+    const { clean, emojis } = stripEmojis("line1\n\nline2");
+    expect(clean).toBe("line1\n\nline2");
+    expect(emojis).toBe("");
+  });
+
+  it("preserves line breaks when emoji are removed", () => {
+    const { clean, emojis } = stripEmojis("para1\n\npara2 🎉");
+    expect(clean).toBe("para1\n\npara2");
+    expect(emojis).toBe("🎉");
+  });
+
+  it("does not strip plain text symbols (arrows, #, *, digits)", () => {
+    const input = "go left ← or right → item #1 *bold* 2 cats";
+    expect(stripEmojis(input)).toEqual({ clean: input, emojis: "" });
+  });
+
   it("yields empty clean text for emoji-only input", () => {
     const { clean, emojis } = stripEmojis("😂❤️🎉");
     expect(clean).toBe("");
     expect(emojis).toBe("😂❤️🎉");
+  });
+});
+
+describe("getTranslation", () => {
+  afterEach(() => post.mockReset());
+
+  it("translates the cleaned text and re-attaches the emoji", async () => {
+    post.mockResolvedValue({ data: { translatedText: "My niece posing" } });
+
+    const result = await getTranslation("Mi sobrina posando 😂❤️", "auto", "en");
+
+    expect(post).toHaveBeenCalledWith(
+      "/translate",
+      expect.objectContaining({ q: "Mi sobrina posando", source: "auto", target: "en" })
+    );
+    expect(result.translatedText).toBe("My niece posing 😂❤️");
+  });
+
+  it("skips the request for emoji-only input and returns it unchanged", async () => {
+    const result = await getTranslation("😂❤️", "auto", "en");
+
+    expect(post).not.toHaveBeenCalled();
+    expect(result.translatedText).toBe("😂❤️");
   });
 });


### PR DESCRIPTION
## Problem

Translation of short, emoji-laden text (common in Waves) often comes back wrong.
Reported example: the Spanish `Mi sobrina posando 😂❤️` translated to
`Mi sobrina posing` (only the last word translated, `Mi sobrina` left in Spanish,
and the 😂 dropped).

## Root cause

The emoji skew the translation service's language auto-detection. With the emoji
present, `Mi sobrina posando 😂❤️` is detected as Portuguese (high confidence)
instead of Spanish; the pt to en model then passes the unrecognized Spanish words
through untranslated. Without the emoji, the same text is correctly detected as
Spanish and translated to `My niece posing`. Emoji are also mangled in the output.

## Fix

Strip emoji (and their joiners/modifiers) out of the text before sending it to the
translate endpoint, then re-attach them to the translated result:

- Detection and translation now run on clean text, so the language is identified
  correctly.
- Emoji are preserved for the user instead of being mangled or dropped.
- Emoji-only input skips the request and returns as-is.

The emoji matcher uses explicit UTF-16 surrogate ranges and `\uXXXX` escapes (no
`u` flag / `\p{Extended_Pictographic}`) so it behaves the same across engines.

## Testing

- Unit tests for the strip helper (trailing, interspersed, ZWJ sequences,
  no-emoji, emoji-only).
- Lint and type check pass.