### PR TITLE
fix(signup): block chain-invalid usernames synchronously before submit

### DIFF
--- a/apps/web/src/app/signup/free/_page.tsx
+++ b/apps/web/src/app/signup/free/_page.tsx
@@ -134,6 +134,16 @@ export function FreeSignUp() {
       return;
     }
 
+    // Re-run the account-name rule synchronously. usernameError is set by a
+    // debounced effect and the input is only `required`, so a fast type-then-submit
+    // (or autofill + Enter) could otherwise carry a chain-invalid name (e.g. a
+    // dot-segment under 3 chars like `name.uk`) through to the backend.
+    const usernameRuleError = getUsernameError(username);
+    if (usernameRuleError) {
+      setUsernameError(usernameRuleError);
+      return;
+    }
+
     if (usernameError || referralError || emailError) {
       return;
     }

--- a/apps/web/src/app/signup/premium/_page.tsx
+++ b/apps/web/src/app/signup/premium/_page.tsx
@@ -169,6 +169,16 @@ export function PremiumSignUp() {
       return;
     }
 
+    // Re-run the account-name rule synchronously. usernameError is set by a
+    // debounced effect and the input is only `required`, so a fast type-then-submit
+    // (or autofill + Enter) could otherwise carry a chain-invalid name (e.g. a
+    // dot-segment under 3 chars like `name.uk`) into checkout and on to the backend.
+    const usernameRuleError = getUsernameError(username);
+    if (usernameRuleError) {
+      setUsernameError(usernameRuleError);
+      return;
+    }
+
     if (usernameError || referralError || emailError) {
       return;
     }

--- a/apps/web/src/specs/utils/username-validation.spec.tsx
+++ b/apps/web/src/specs/utils/username-validation.spec.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+// Import the file directly (not the @/utils barrel, which is globally mocked) to
+// exercise the real rule. i18next is globally mocked to return keys as-is, so a
+// rejected username yields its message key (truthy) and a valid one yields null.
+import { getUsernameError } from "@/utils/username-validation";
+
+describe("getUsernameError", () => {
+  it("accepts valid account names", () => {
+    expect(getUsernameError("ecency")).toBeNull();
+    expect(getUsernameError("good-karma")).toBeNull();
+    expect(getUsernameError("foo.barbaz")).toBeNull();
+    expect(getUsernameError("user123")).toBeNull();
+  });
+
+  it("rejects a too-short trailing dot-segment (paid-signup incident)", () => {
+    // A buyer was charged for `bitgethive.uk`: the whole name is 13 chars but the
+    // `uk` segment is only 2, which the blockchain rejects (RFC 1035). The submit
+    // must block this so it never reaches checkout / the backend.
+    expect(getUsernameError("bitgethive.uk")).toBe("sign-up.username-min-length-error");
+  });
+
+  it("rejects empty, over-length and other invalid names", () => {
+    expect(getUsernameError("")).toBe("sign-up.username-required");
+    expect(getUsernameError("ab")).toBe("sign-up.username-min-length-error");
+    expect(getUsernameError("a2345678901234567")).toBe("sign-up.username-max-length-error");
+    expect(getUsernameError("1abc")).toBe("sign-up.username-starts-number");
+    expect(getUsernameError("ab_cd")).toBe("sign-up.username-contains-symbols-error");
+  });
+
+  it("rejects dot-boundary names (empty leading/trailing segment)", () => {
+    // a leading or trailing dot yields an empty segment, which the < 3 check rejects
+    expect(getUsernameError("abc.")).toBe("sign-up.username-min-length-error");
+    expect(getUsernameError(".abc")).toBe("sign-up.username-min-length-error");
+  });
+});


### PR DESCRIPTION
## Problem

The premium and free signup forms only gate on the `usernameError` state, which is populated by a debounced `useEffect`. The username input is only `required`, so HTML5 `checkValidity()` passes any non-empty value. A fast type-then-submit (or autofill + Enter) can therefore carry a username the blockchain rejects under RFC 1035 (for example a dot-segment shorter than 3 characters, like `name.uk`) into Stripe checkout or the account-create call before the effect has updated the error.

The Stripe backend already validates the name server-side, so no charge goes through, but the request should never reach the backend in the first place.

## Fix

Re-run `getUsernameError(username)` synchronously at the top of both `handleSubmit` handlers and bail before any backend call (existence check, checkout, or `signUp`). Mirrors the synchronous guard used in the mobile register flow.

## Tests

Adds `src/specs/utils/username-validation.spec.ts` covering the incident case (`name.uk`-style short segment) plus valid and other invalid names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Username validation now runs immediately when submitting sign-up forms, preventing invalid usernames from progressing through the signup flow.
  * Fixed several username edge cases, including empty values, length limits, numeric starts, symbols, and invalid trailing segments.

* **Tests**
  * Added coverage for username validation to ensure valid usernames pass and invalid ones return the expected messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->