### PR TITLE
fix(entry-payout): guard missing beneficiaries in EntryPayoutDetail

### DIFF
--- a/apps/web/src/features/shared/entry-payout/entry-payout-detail.tsx
+++ b/apps/web/src/features/shared/entry-payout/entry-payout-detail.tsx
@@ -17,7 +17,7 @@ export function EntryPayoutDetail({ entry }: Props) {
 
   const payoutDate = dateToFullRelative(entry.payout_at);
 
-  const beneficiary = entry.beneficiaries;
+  const beneficiary = entry.beneficiaries ?? [];
   const pendingPayout = parseAsset(entry.pending_payout_value).amount;
   const authorPayout = parseAsset(entry.author_payout_value).amount;
   const curatorPayout = parseAsset(entry.curator_payout_value).amount;

--- a/apps/web/src/specs/features/shared/entry-payout-detail.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-payout-detail.spec.tsx
@@ -1,0 +1,71 @@
+import { vi } from "vitest";
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { EntryPayoutDetail } from "@/features/shared/entry-payout/entry-payout-detail";
+import { mockEntry } from "@/specs/test-utils";
+
+// FormattedCurrency comes from the heavy @/features/shared barrel; stub it.
+vi.mock("@/features/shared", () => ({
+  FormattedCurrency: ({ value, fixAt = 2 }: { value: number; fixAt?: number }) => (
+    <span data-testid="formatted-currency">{`$${value.toFixed(fixAt)}`}</span>
+  )
+}));
+
+// The global @/utils mock only exposes random + getAccessToken, but the
+// component relies on the real parseAsset / dateToFullRelative / formattedNumber.
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+
+vi.mock("@ecency/sdk", async () => ({
+  ...(await vi.importActual("@ecency/sdk")),
+  getDynamicPropsQueryOptions: vi.fn(() => ({ queryKey: ["dynamic-props"], queryFn: vi.fn() }))
+}));
+
+// Keep dynamic props deterministic and synchronous so the component renders
+// without a live QueryClient.
+vi.mock("@tanstack/react-query", async () => ({
+  ...(await vi.importActual("@tanstack/react-query")),
+  useQuery: vi.fn(() => ({ data: { base: 1, quote: 1, hbdPrintRate: 10000 } }))
+}));
+
+describe("EntryPayoutDetail", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not crash when entry.beneficiaries is undefined (waves feed shape)", () => {
+    // Some waves-feed entries arrive without a beneficiaries array. Reading
+    // `.length` on it threw "Cannot read properties of undefined" and tripped
+    // the error boundary on /waves (ECENCY-NEXT-1GDH).
+    const entry = mockEntry({
+      pending_payout_value: "1.234 HBD",
+      author_payout_value: "0.000 HBD",
+      curator_payout_value: "0.000 HBD",
+      max_accepted_payout: "1000000.000 HBD",
+      beneficiaries: undefined
+    });
+
+    const { container } = render(<EntryPayoutDetail entry={entry} />);
+
+    expect(container.querySelector(".payout-popover-content")).not.toBeNull();
+  });
+
+  it("renders the beneficiary breakdown when beneficiaries are present", () => {
+    const entry = mockEntry({
+      pending_payout_value: "1.234 HBD",
+      author_payout_value: "0.000 HBD",
+      curator_payout_value: "0.000 HBD",
+      max_accepted_payout: "1000000.000 HBD",
+      beneficiaries: [{ account: "ecency", weight: 1000 }]
+    });
+
+    const { getByText } = render(<EntryPayoutDetail entry={entry} />);
+
+    expect(getByText(/ecency/)).toBeInTheDocument();
+    expect(getByText(/10%/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

`EntryPayoutDetail` reads `entry.beneficiaries.length` directly. Some entries coming through the waves feed arrive without a `beneficiaries` array, so the access threw `TypeError: Cannot read properties of undefined (reading 'length')` and tripped the error boundary (Retry/Report fallback) on `/waves`.

Every other payout field in this component is parsed defensively (`parseAsset(...)`); `beneficiaries` was the one raw read.

## Fix

Default `beneficiaries` to an empty array:

```ts
const beneficiary = entry.beneficiaries ?? [];
```

## Test

Adds `entry-payout-detail.spec.tsx` rendering the component with `beneficiaries: undefined` (the waves-feed shape) and asserting it no longer throws, plus a case confirming the beneficiary breakdown still renders when present. The regression test fails on the previous code and passes with the guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payout details so they still render when beneficiary data is missing.
  * Prevented crashes in payout views caused by absent beneficiary lists.
* **Tests**
  * Added coverage for empty and populated beneficiary scenarios.
  * Verified payout details display correctly without external data dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->