### PR TITLE
feat: DecentMemes meme maker (publish + waves)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -432,6 +432,8 @@ const config = {
                 "https://platform.twitter.com https://challenges.cloudflare.com",
                 "https://www.tradingview-widget.com https://s.tradingview.com",
                 "https://www.google.com",
+                // DecentMemes meme-maker widget (embedded in the publish composer):
+                "https://decentmemes.com",
                 // Stripe.js (card payments): Payment Element + 3DS challenge frames
                 // (js.stripe.com + per-origin subdomains, hooks) and Radar fingerprinting:
                 "https://js.stripe.com https://*.js.stripe.com https://hooks.stripe.com https://m.stripe.network"

--- a/apps/web/src/api/decentmemes/attribution.ts
+++ b/apps/web/src/api/decentmemes/attribution.ts
@@ -1,0 +1,19 @@
+import { aggregateMemeBeneficiaries } from "./beneficiary";
+import { DecentMemesEntry, DecentMemesPayload } from "./types";
+
+/**
+ * Reconcile tracked memes against the actual post body: keep only the memes
+ * whose hosted image is still present, then collapse them into a broadcast
+ * payload (unique template ids + summed beneficiaries). If the user deleted a
+ * meme image, its template id and beneficiaries are dropped here so they never
+ * reach the broadcast.
+ */
+export function collectPresentMemeAttribution(
+  entries: DecentMemesEntry[] = [],
+  body: string = ""
+): DecentMemesPayload {
+  const present = entries.filter((m) => m?.imageUrl && body.includes(m.imageUrl));
+  const templateIds = Array.from(new Set(present.map((m) => m.templateId).filter(Boolean)));
+  const beneficiaries = aggregateMemeBeneficiaries(present.flatMap((m) => m.beneficiaries ?? []));
+  return { templateIds, beneficiaries };
+}

--- a/apps/web/src/api/decentmemes/beneficiary.ts
+++ b/apps/web/src/api/decentmemes/beneficiary.ts
@@ -18,6 +18,12 @@ export const HIVE_MAX_TOTAL_WEIGHT = 10000;
 export const DECENTMEMES_POST_MAX_WEIGHT = 1000;
 
 /**
+ * On a comment / Wave the widget spec allows a larger total (creator 5% +
+ * submitter 10% + 1% frontend), capped at 30% (3000 basis points).
+ */
+export const DECENTMEMES_COMMENT_MAX_WEIGHT = 3000;
+
+/**
  * Lightweight Hive account-name check (defense-in-depth - the widget is the
  * primary authority for who its templates pay). Mirrors the pattern used
  * elsewhere in the app: starts with a letter, 3-16 chars, lowercase letters /
@@ -91,12 +97,13 @@ export interface EnforceResult {
 export function enforceDecentMemesBeneficiary(
   existing: BeneficiaryRoute[] = [],
   memeBeneficiaries: { account?: string; weight?: number }[] = [],
-  author?: string
+  author?: string,
+  maxMemeWeight: number = DECENTMEMES_POST_MAX_WEIGHT
 ): EnforceResult {
   let dropped = false;
 
   // 1. Clean the widget input (invalid account names / weights are dropped) and
-  //    cap the meme contribution to the post max (10%).
+  //    cap the meme contribution to the per-context maximum (10% post / 30% comment).
   let meme = aggregateMemeBeneficiaries(memeBeneficiaries);
   if (author) {
     // Hive rejects any comment_options where a beneficiary equals the author,
@@ -104,7 +111,7 @@ export function enforceDecentMemesBeneficiary(
     // failing the whole broadcast.
     meme = meme.filter((b) => b.account !== author);
   }
-  const postCapped = scaleToCap(meme, DECENTMEMES_POST_MAX_WEIGHT);
+  const postCapped = scaleToCap(meme, maxMemeWeight);
   if (totalWeight(postCapped) < totalWeight(meme)) {
     dropped = true;
   }

--- a/apps/web/src/api/decentmemes/beneficiary.ts
+++ b/apps/web/src/api/decentmemes/beneficiary.ts
@@ -1,0 +1,141 @@
+import { BeneficiaryRoute } from "@/entities";
+
+/**
+ * Hive protocol limits.
+ * - A `comment_options` operation accepts at most 8 beneficiary slots.
+ * - Beneficiary weights are expressed in basis points (10000 = 100%).
+ */
+export const HIVE_MAX_BENEFICIARIES = 8;
+export const HIVE_MAX_TOTAL_WEIGHT = 10000;
+
+/**
+ * DecentMemes policy: the total reward routed to meme creators on a top-level
+ * post is capped at 10% (1000 basis points), matching the widget spec's
+ * post-aggregation cap. The widget dictates these beneficiaries, so we never
+ * trust its numbers blindly - this cap (and the merge logic below) is enforced
+ * entirely on our side.
+ */
+export const DECENTMEMES_POST_MAX_WEIGHT = 1000;
+
+/**
+ * Lightweight Hive account-name check (defense-in-depth - the widget is the
+ * primary authority for who its templates pay). Mirrors the pattern used
+ * elsewhere in the app: starts with a letter, 3-16 chars, lowercase letters /
+ * digits / dot / hyphen. Keeps malformed names from reaching the broadcast,
+ * where they would fail with a cryptic "Invalid account name" error.
+ */
+const HIVE_ACCOUNT_RE = /^[a-z][a-z0-9.-]{2,15}$/;
+
+interface NormalizedBeneficiary {
+  account: string;
+  weight: number;
+}
+
+function totalWeight(list: { weight: number }[]): number {
+  return list.reduce((sum, b) => sum + b.weight, 0);
+}
+
+/**
+ * Aggregate a raw list of meme beneficiaries coming from the widget into a
+ * clean `{ account, weight }` list:
+ * - drops the unsupported `role` field (and any other extra keys)
+ * - drops invalid entries (missing account, non-positive / non-finite weight)
+ * - sums weights for duplicate accounts
+ */
+export function aggregateMemeBeneficiaries(
+  raw: { account?: string; weight?: number }[] = []
+): NormalizedBeneficiary[] {
+  const byAccount = new Map<string, number>();
+  for (const entry of raw) {
+    const account = entry?.account?.trim();
+    const weight = Math.round(Number(entry?.weight));
+    if (!account || !HIVE_ACCOUNT_RE.test(account) || !Number.isFinite(weight) || weight <= 0) {
+      continue;
+    }
+    byAccount.set(account, (byAccount.get(account) ?? 0) + weight);
+  }
+  return Array.from(byAccount.entries()).map(([account, weight]) => ({ account, weight }));
+}
+
+/**
+ * Proportionally scale a beneficiary list down so its total weight does not
+ * exceed `cap`. Entries that round down to 0 are dropped.
+ */
+function scaleToCap(list: NormalizedBeneficiary[], cap: number): NormalizedBeneficiary[] {
+  const total = totalWeight(list);
+  if (total <= cap) {
+    return list;
+  }
+  if (cap <= 0) {
+    return [];
+  }
+  const factor = cap / total;
+  return list
+    .map((b) => ({ account: b.account, weight: Math.floor(b.weight * factor) }))
+    .filter((b) => b.weight > 0);
+}
+
+export interface EnforceResult {
+  beneficiaries: BeneficiaryRoute[];
+  /** True when some meme beneficiaries could not be applied (no slot/weight headroom). */
+  dropped: boolean;
+}
+
+/**
+ * Merge widget-supplied meme beneficiaries into the user's existing beneficiary
+ * list while strictly respecting Hive limits. User-set beneficiaries are never
+ * modified or dropped; only the meme contribution is capped, scaled, or dropped
+ * to fit. Returns `dropped: true` when something had to be left out so the
+ * caller can warn the user instead of letting the broadcast fail silently.
+ */
+export function enforceDecentMemesBeneficiary(
+  existing: BeneficiaryRoute[] = [],
+  memeBeneficiaries: { account?: string; weight?: number }[] = [],
+  author?: string
+): EnforceResult {
+  let dropped = false;
+
+  // 1. Clean the widget input (invalid account names / weights are dropped) and
+  //    cap the meme contribution to the post max (10%).
+  let meme = aggregateMemeBeneficiaries(memeBeneficiaries);
+  if (author) {
+    // Hive rejects any comment_options where a beneficiary equals the author,
+    // so a widget that lists the author is silently filtered out rather than
+    // failing the whole broadcast.
+    meme = meme.filter((b) => b.account !== author);
+  }
+  const postCapped = scaleToCap(meme, DECENTMEMES_POST_MAX_WEIGHT);
+  if (totalWeight(postCapped) < totalWeight(meme)) {
+    dropped = true;
+  }
+  meme = postCapped;
+
+  // 2. Scale the whole meme contribution down to the remaining weight headroom.
+  const existingTotal = totalWeight(existing);
+  const headroom = Math.max(0, HIVE_MAX_TOTAL_WEIGHT - existingTotal);
+  const headroomCapped = scaleToCap(meme, headroom);
+  if (totalWeight(headroomCapped) < totalWeight(meme)) {
+    dropped = true;
+  }
+  meme = headroomCapped;
+
+  // 3. The slot limit only constrains brand-new accounts (bumps reuse a slot).
+  const existingAccounts = new Set(existing.map((b) => b.account));
+  const bumps = meme.filter((b) => existingAccounts.has(b.account));
+  let additions = meme.filter((b) => !existingAccounts.has(b.account));
+
+  const slotHeadroom = Math.max(0, HIVE_MAX_BENEFICIARIES - existing.length);
+  if (additions.length > slotHeadroom) {
+    additions = [...additions].sort((a, b) => b.weight - a.weight).slice(0, slotHeadroom);
+    dropped = true;
+  }
+
+  // 4. Apply bumps to existing entries, then append surviving new additions.
+  const bumpByAccount = new Map(bumps.map((b) => [b.account, b.weight]));
+  const merged: BeneficiaryRoute[] = existing.map((b) =>
+    bumpByAccount.has(b.account) ? { ...b, weight: b.weight + bumpByAccount.get(b.account)! } : b
+  );
+  additions.forEach((b) => merged.push({ account: b.account, weight: b.weight }));
+
+  return { beneficiaries: merged, dropped };
+}

--- a/apps/web/src/api/decentmemes/index.ts
+++ b/apps/web/src/api/decentmemes/index.ts
@@ -1,2 +1,4 @@
 export * from "./beneficiary";
 export * from "./metadata";
+export * from "./types";
+export * from "./attribution";

--- a/apps/web/src/api/decentmemes/index.ts
+++ b/apps/web/src/api/decentmemes/index.ts
@@ -1,0 +1,2 @@
+export * from "./beneficiary";
+export * from "./metadata";

--- a/apps/web/src/api/decentmemes/metadata.ts
+++ b/apps/web/src/api/decentmemes/metadata.ts
@@ -1,0 +1,23 @@
+/** Required tag for posts containing a DecentMemes template (used for reward attribution). */
+export const DECENTMEMES_TAG = "decentmemes";
+
+/** json_metadata schema version for the `decentmemes` block (per the widget spec). */
+export const DECENTMEMES_METADATA_VERSION = 2;
+
+/** Frontend identifier stamped into json_metadata so DecentMemes can attribute the source. */
+export const DECENTMEMES_FRONTEND = "ecency";
+
+/** Mirrors the editor's tag-count limit so we never push the post over the cap. */
+const MAX_TAGS = 10;
+
+/**
+ * Append the required `decentmemes` tag without reordering existing tags
+ * (tag[0] is the post category) or exceeding the tag-count limit. Returns the
+ * original array reference when no change is needed.
+ */
+export function ensureDecentMemesTag(tags: string[] = []): string[] {
+  if (tags.includes(DECENTMEMES_TAG) || tags.length >= MAX_TAGS) {
+    return tags;
+  }
+  return [...tags, DECENTMEMES_TAG];
+}

--- a/apps/web/src/api/decentmemes/types.ts
+++ b/apps/web/src/api/decentmemes/types.ts
@@ -1,0 +1,4 @@
+// The DecentMemes attribution shapes live in `entities` (the lower layer that
+// `entities/private-api/drafts.ts` also depends on) to avoid an entities -> api
+// cycle. Re-exported here so callers can keep importing from `@/api/decentmemes`.
+export type { DecentMemesEntry, DecentMemesPayload } from "@/entities";

--- a/apps/web/src/app/publish/_api/use-publish.ts
+++ b/apps/web/src/app/publish/_api/use-publish.ts
@@ -2,6 +2,7 @@ import { validatePostCreating } from "@ecency/sdk";
 import { enforceThreeSpeakBeneficiary } from "@/api/threespeak-embed";
 import { linkThreeSpeakEmbed } from "@/api/threespeak-embed/link-after-broadcast";
 import {
+  collectPresentMemeAttribution,
   DECENTMEMES_FRONTEND,
   enforceDecentMemesBeneficiary,
   ensureDecentMemesTag
@@ -14,7 +15,7 @@ import { FullAccount, RewardType } from "@/entities";
 import { EntryBodyManagement, EntryMetadataManagement } from "@/features/entry-management";
 import { PollSnapshot } from "@/features/polls";
 import { QueryKeys, type Poll } from "@ecency/sdk";
-import { success } from "@/features/shared";
+import { info, success } from "@/features/shared";
 import {
   createPermlink,
   isCommunity,
@@ -122,8 +123,10 @@ export function usePublishApi() {
 
       const [parentPermlink] = tags!;
 
-      // DecentMemes: a meme was added when at least one template id was collected.
-      const hasMeme = !!decentMemes && decentMemes.templateIds.length > 0;
+      // DecentMemes: reconcile tracked memes against the final body so a meme
+      // whose image was deleted no longer contributes a tag / metadata / beneficiary.
+      const memeAttribution = collectPresentMemeAttribution(decentMemes, cleanBody);
+      const hasMeme = memeAttribution.templateIds.length > 0;
       const finalTags = hasMeme ? ensureDecentMemesTag(tags ?? []) : tags;
 
       const metaBuilder = await EntryMetadataManagement.EntryMetadataManager.shared
@@ -142,7 +145,7 @@ export function usePublishApi() {
         .withPoll(poll)
         .withDecentMemes(
           hasMeme
-            ? { templateIds: decentMemes!.templateIds, frontend: DECENTMEMES_FRONTEND }
+            ? { templateIds: memeAttribution.templateIds, frontend: DECENTMEMES_FRONTEND }
             : undefined
         )
         .build();
@@ -152,11 +155,15 @@ export function usePublishApi() {
         // Merge the widget-supplied meme beneficiaries on our own terms: never
         // trust its numbers - cap to Hive's 8-slot / 100% limits and keep the
         // user's own beneficiaries intact.
-        finalBeneficiaries = enforceDecentMemesBeneficiary(
+        const enforced = enforceDecentMemesBeneficiary(
           finalBeneficiaries,
-          decentMemes!.beneficiaries,
+          memeAttribution.beneficiaries,
           author
-        ).beneficiaries;
+        );
+        finalBeneficiaries = enforced.beneficiaries;
+        if (enforced.dropped) {
+          info(i18next.t("decentmemes.beneficiaries-trimmed"));
+        }
       }
 
       const options = makeCommentOptions(author, permlink, reward as RewardType, finalBeneficiaries);

--- a/apps/web/src/app/publish/_api/use-publish.ts
+++ b/apps/web/src/app/publish/_api/use-publish.ts
@@ -1,6 +1,11 @@
 import { validatePostCreating } from "@ecency/sdk";
 import { enforceThreeSpeakBeneficiary } from "@/api/threespeak-embed";
 import { linkThreeSpeakEmbed } from "@/api/threespeak-embed/link-after-broadcast";
+import {
+  DECENTMEMES_FRONTEND,
+  enforceDecentMemesBeneficiary,
+  ensureDecentMemesTag
+} from "@/api/decentmemes";
 import { useCommentMutation, useReblogMutation } from "@/api/sdk-mutations";
 import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { getQueryClient } from "@/core/react-query";
@@ -40,7 +45,8 @@ export function usePublishApi() {
     isReblogToCommunity,
     poll,
     postLinks,
-    location
+    location,
+    decentMemes
   } = usePublishState();
 
   const { updateEntryQueryData } = EcencyEntriesCacheManagement.useUpdateEntry();
@@ -116,6 +122,10 @@ export function usePublishApi() {
 
       const [parentPermlink] = tags!;
 
+      // DecentMemes: a meme was added when at least one template id was collected.
+      const hasMeme = !!decentMemes && decentMemes.templateIds.length > 0;
+      const finalTags = hasMeme ? ensureDecentMemesTag(tags ?? []) : tags;
+
       const metaBuilder = await EntryMetadataManagement.EntryMetadataManager.shared
         .builder()
         .default()
@@ -124,15 +134,30 @@ export function usePublishApi() {
         .withSummary(
           metaDescription || postBodySummary(cleanBody, SUBMIT_DESCRIPTION_MAX_LENGTH)
         )
-        .withTags(tags)
+        .withTags(finalTags)
         .withPostLinks(postLinks)
         .withLocation(location)
         .withSelectedThumbnail(selectedThumbnail);
       const jsonMeta = metaBuilder
         .withPoll(poll)
+        .withDecentMemes(
+          hasMeme
+            ? { templateIds: decentMemes!.templateIds, frontend: DECENTMEMES_FRONTEND }
+            : undefined
+        )
         .build();
 
-      const finalBeneficiaries = enforceThreeSpeakBeneficiary(beneficiaries, cleanBody);
+      let finalBeneficiaries = enforceThreeSpeakBeneficiary(beneficiaries, cleanBody);
+      if (hasMeme) {
+        // Merge the widget-supplied meme beneficiaries on our own terms: never
+        // trust its numbers - cap to Hive's 8-slot / 100% limits and keep the
+        // user's own beneficiaries intact.
+        finalBeneficiaries = enforceDecentMemesBeneficiary(
+          finalBeneficiaries,
+          decentMemes!.beneficiaries,
+          author
+        ).beneficiaries;
+      }
 
       const options = makeCommentOptions(author, permlink, reward as RewardType, finalBeneficiaries);
 

--- a/apps/web/src/app/publish/_api/use-save-draft.ts
+++ b/apps/web/src/app/publish/_api/use-save-draft.ts
@@ -37,7 +37,8 @@ export function useSaveDraftApi(draftId?: string) {
     selectedThumbnail,
     poll,
     postLinks,
-    location
+    location,
+    decentMemes
   } = usePublishState();
 
   const { mutateAsync: recordActivity } = EcencyAnalytics.useRecordActivity(
@@ -72,7 +73,8 @@ export function useSaveDraftApi(draftId?: string) {
         ...meta,
         beneficiaries: beneficiaries ?? [],
         rewardType: (reward as RewardType) ?? "default",
-        poll
+        poll,
+        decentMemes: decentMemes ?? []
       };
 
       const token = await ensureValidToken(username);

--- a/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
+++ b/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
@@ -116,9 +116,9 @@ const AiAssistDialog = dynamic(
 
 // Code-split the meme maker (iframe + postMessage bridge) so it adds nothing to
 // the initial editor bundle - it only loads when the user clicks the button.
-const PublishMemeMakerDialog = dynamic(
-  () => import("./publish-meme-maker-dialog").then((m) => ({
-    default: m.PublishMemeMakerDialog
+const MemeMakerDialog = dynamic(
+  () => import("@/features/decentmemes").then((m) => ({
+    default: m.MemeMakerDialog
   })),
   { ssr: false }
 );
@@ -778,7 +778,7 @@ export function PublishEditorToolbar({ editor, allowToUploadVideo = true }: Prop
           />
         )}
         {showMemeMaker && (
-          <PublishMemeMakerDialog
+          <MemeMakerDialog
             show={showMemeMaker}
             setShow={setShowMemeMaker}
             onMemeCreated={({ url, alt, templateId, beneficiaries }) => {

--- a/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
+++ b/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
@@ -791,7 +791,7 @@ export function PublishEditorToolbar({ editor, allowToUploadVideo = true }: Prop
                   { type: "paragraph" }
                 ])
                 .run();
-              publishState.addDecentMemesResult({ templateId, beneficiaries });
+              publishState.addDecentMemesResult({ templateId, imageUrl: url, beneficiaries });
               setShowMemeMaker(false);
             }}
           />

--- a/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
+++ b/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
@@ -113,6 +113,15 @@ const AiAssistDialog = dynamic(
   })),
   { ssr: false }
 );
+
+// Code-split the meme maker (iframe + postMessage bridge) so it adds nothing to
+// the initial editor bundle - it only loads when the user clicks the button.
+const PublishMemeMakerDialog = dynamic(
+  () => import("./publish-meme-maker-dialog").then((m) => ({
+    default: m.PublishMemeMakerDialog
+  })),
+  { ssr: false }
+);
 import clsx from "clsx";
 import { TEXT_COLORS, normalizeTextColor } from "../_constants/text-colors";
 
@@ -202,6 +211,7 @@ export function PublishEditorToolbar({ editor, allowToUploadVideo = true }: Prop
   const [showGeoTag, setShowGeoTag] = useState(false);
   const [showAiGenerator, setShowAiGenerator] = useState(false);
   const [showAiAssist, setShowAiAssist] = useState(false);
+  const [showMemeMaker, setShowMemeMaker] = useState(false);
   const [isFocusingTable, setIsFocusingTable] = useState(false);
 
   const activeTextColor = editor?.getAttributes("textStyle")?.color as string | undefined;
@@ -564,6 +574,22 @@ export function PublishEditorToolbar({ editor, allowToUploadVideo = true }: Prop
           </StyledTooltip>
         </EcencyConfigManager.Conditional>
 
+        <EcencyConfigManager.Conditional
+          condition={({ visionFeatures }) => visionFeatures.decentMemes.enabled}
+        >
+          <StyledTooltip content={i18next.t("decentmemes.toolbar-button")}>
+            <LoginRequired>
+              <Button
+                appearance="gray-link"
+                size="sm"
+                icon={<UilImageShare />}
+                onClick={() => setShowMemeMaker(true)}
+                aria-label={i18next.t("decentmemes.toolbar-button")}
+              />
+            </LoginRequired>
+          </StyledTooltip>
+        </EcencyConfigManager.Conditional>
+
         {/*Dialogs*/}
         <PublishEditorToolbarFragments
           showFragments={showFragments}
@@ -748,6 +774,25 @@ export function PublishEditorToolbar({ editor, allowToUploadVideo = true }: Prop
                 }
                 error(i18next.t("ai-assist.error-generic"));
               }
+            }}
+          />
+        )}
+        {showMemeMaker && (
+          <PublishMemeMakerDialog
+            show={showMemeMaker}
+            setShow={setShowMemeMaker}
+            onMemeCreated={({ url, alt, templateId, beneficiaries }) => {
+              editor
+                ?.chain()
+                .focus()
+                .insertContent([
+                  { type: "image", attrs: { src: url, alt } },
+                  { type: "paragraph" },
+                  { type: "paragraph" }
+                ])
+                .run();
+              publishState.addDecentMemesResult({ templateId, beneficiaries });
+              setShowMemeMaker(false);
             }}
           />
         )}

--- a/apps/web/src/app/publish/_components/publish-meme-maker-dialog.tsx
+++ b/apps/web/src/app/publish/_components/publish-meme-maker-dialog.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
+import { Spinner } from "@ui/spinner";
+import i18next from "i18next";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useGlobalStore } from "@/core/global-store";
+import { Theme } from "@/enums";
+import { EcencyConfigManager } from "@/config";
+import { useUploadImageMutation } from "@/api/sdk-mutations";
+import { dataUrlToFile } from "@/utils/data-url-to-file";
+import { BeneficiaryRoute } from "@/entities";
+import { error } from "@/features/shared";
+
+export interface MemeCreatedPayload {
+  url: string;
+  alt: string;
+  templateId: string;
+  beneficiaries: BeneficiaryRoute[];
+}
+
+interface Props {
+  show: boolean;
+  setShow: (show: boolean) => void;
+  onMemeCreated: (payload: MemeCreatedPayload) => void;
+}
+
+type Status = "loading" | "ready" | "uploading" | "error";
+
+// If the widget never loads (offline / blocked / endpoint removed) we fall back
+// to a friendly "unavailable" state instead of leaving the user staring at a
+// blank frame.
+const IFRAME_LOAD_TIMEOUT = 12_000;
+
+function resolveWidgetTheme(theme: Theme): "light" | "dark" {
+  if (theme === Theme.night) {
+    return "dark";
+  }
+  if (theme === Theme.system && typeof window !== "undefined") {
+    return window.matchMedia?.("(prefers-color-scheme: dark)")?.matches ? "dark" : "light";
+  }
+  return "light";
+}
+
+export function PublishMemeMakerDialog({ show, setShow, onMemeCreated }: Props) {
+  const theme = useGlobalStore((s) => s.theme);
+  const widgetTheme = resolveWidgetTheme(theme);
+
+  const config = EcencyConfigManager.getConfigValue(
+    ({ visionFeatures }) => visionFeatures.decentMemes
+  );
+
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const [status, setStatus] = useState<Status>("loading");
+
+  const { mutateAsync: uploadImage } = useUploadImageMutation();
+
+  // Keep the latest callback in a ref so the message listener doesn't need to
+  // re-subscribe on every parent re-render.
+  const onMemeCreatedRef = useRef(onMemeCreated);
+  useEffect(() => {
+    onMemeCreatedRef.current = onMemeCreated;
+  }, [onMemeCreated]);
+
+  const postToWidget = useCallback(
+    (message: object) => {
+      frameRef.current?.contentWindow?.postMessage(message, config.origin);
+    },
+    [config.origin]
+  );
+
+  // Push theme changes to the widget while it is open.
+  useEffect(() => {
+    if (status === "ready" || status === "uploading") {
+      postToWidget({ type: "setTheme", theme: widgetTheme });
+    }
+  }, [widgetTheme, status, postToWidget]);
+
+  // Listen for messages from the widget. Origin is validated strictly.
+  useEffect(() => {
+    if (!show) {
+      return;
+    }
+
+    async function onMessage(event: MessageEvent) {
+      if (event.origin !== config.origin) {
+        return;
+      }
+      const data = event.data;
+      if (!data || typeof data !== "object" || data.type !== "memeCreated") {
+        return;
+      }
+      if (typeof data.imageDataUrl !== "string") {
+        return;
+      }
+
+      try {
+        setStatus("uploading");
+        // The image is re-hosted on our own CDN here, so once this resolves we
+        // have no further runtime dependency on the third-party widget.
+        const file = await dataUrlToFile(data.imageDataUrl, data.imageFileName);
+        const { url } = await uploadImage({ file });
+        if (!url) {
+          throw new Error("Upload returned no URL");
+        }
+
+        const rawBeneficiaries = Array.isArray(data?.beneficiaries?.post)
+          ? data.beneficiaries.post
+          : [];
+        const beneficiaries: BeneficiaryRoute[] = rawBeneficiaries
+          .filter((b: any) => b && typeof b.account === "string" && Number(b.weight) > 0)
+          .map((b: any) => ({ account: b.account, weight: Math.round(Number(b.weight)) }));
+
+        onMemeCreatedRef.current({
+          url,
+          alt: typeof data?.template?.name === "string" ? data.template.name : "meme",
+          templateId: typeof data?.template?.id === "string" ? data.template.id : "",
+          beneficiaries
+        });
+      } catch (e) {
+        setStatus("ready");
+        error(i18next.t("decentmemes.upload-error"));
+      }
+    }
+
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [show, config.origin, uploadImage]);
+
+  // Reset status whenever the dialog is (re)opened, and arm the load timeout.
+  useEffect(() => {
+    if (!show) {
+      setStatus("loading");
+      return;
+    }
+    if (status !== "loading") {
+      return;
+    }
+    const timer = setTimeout(
+      () => setStatus((s) => (s === "loading" ? "error" : s)),
+      IFRAME_LOAD_TIMEOUT
+    );
+    return () => clearTimeout(timer);
+  }, [show, status]);
+
+  const onFrameLoad = useCallback(() => {
+    // Only the initial load moves us out of "loading" - a later reload must not
+    // clobber an in-flight "uploading" (the spinner would vanish mid-upload).
+    setStatus((s) => (s === "loading" ? "ready" : s));
+    // Sending an `account` opts Ecency into the optional 1% "frontend"
+    // beneficiary slot (routed to this Hive account by the widget).
+    postToWidget({
+      type: "frontendInit",
+      theme: widgetTheme,
+      account: config.frontendAccount
+    });
+  }, [postToWidget, widgetTheme, config.frontendAccount]);
+
+  return (
+    <Modal show={show} centered={true} onHide={() => setShow(false)} size="lg">
+      <ModalHeader closeButton={true}>
+        <ModalTitle>{i18next.t("decentmemes.dialog-title")}</ModalTitle>
+      </ModalHeader>
+      <ModalBody>
+        {status === "error" ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
+            <div className="text-lg font-semibold">
+              {i18next.t("decentmemes.unavailable-title")}
+            </div>
+            <div className="opacity-75">{i18next.t("decentmemes.unavailable-description")}</div>
+          </div>
+        ) : (
+          <div className="relative">
+            <iframe
+              ref={frameRef}
+              src={config.widgetUrl}
+              title="DecentMemes"
+              className="w-full rounded-lg"
+              style={{ height: 640, border: 0 }}
+              allow="clipboard-write"
+              onLoad={onFrameLoad}
+              onError={() => setStatus("error")}
+            />
+            {(status === "loading" || status === "uploading") && (
+              <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-white/70 dark:bg-black/70">
+                <Spinner className="w-6 h-6" />
+              </div>
+            )}
+            <div className="mt-2 text-xs opacity-60">
+              {i18next.t("decentmemes.beneficiary-note")}
+            </div>
+          </div>
+        )}
+      </ModalBody>
+    </Modal>
+  );
+}

--- a/apps/web/src/app/publish/_hooks/use-publish-autosave.ts
+++ b/apps/web/src/app/publish/_hooks/use-publish-autosave.ts
@@ -31,7 +31,8 @@ export function usePublishAutosave() {
     selectedThumbnail,
     poll,
     postLinks,
-    location
+    location,
+    decentMemes
   } = usePublishState();
 
   const { mutateAsync: saveToDraft } = useSaveDraftApi(draftId);
@@ -68,7 +69,8 @@ export function usePublishAutosave() {
         selectedThumbnail,
         poll,
         postLinks,
-        location
+        location,
+        decentMemes
       };
       if (isEqual(prevSnapshotRef.current, snapshot)) return;
 
@@ -100,6 +102,7 @@ export function usePublishAutosave() {
       poll,
       postLinks,
       location,
+      decentMemes,
       isActiveTab
     ]
   );

--- a/apps/web/src/app/publish/_hooks/use-publish-state.tsx
+++ b/apps/web/src/app/publish/_hooks/use-publish-state.tsx
@@ -68,6 +68,9 @@ interface PublishStateContextValue {
   skipAutoThumbnailSelection: boolean;
   clearSelectedThumbnail: () => void;
   hasThreeSpeakVideo: boolean;
+  decentMemes: { templateIds: string[]; beneficiaries: BeneficiaryRoute[] } | null;
+  addDecentMemesResult: (result: { templateId: string; beneficiaries: BeneficiaryRoute[] }) => void;
+  clearDecentMemes: () => void;
 }
 
 const PublishStateContext = createContext<PublishStateContextValue | undefined>(undefined);
@@ -94,6 +97,38 @@ export function PublishStateProvider({ children }: { children: React.ReactNode }
   >(undefined);
   const hasThreeSpeakVideo = useMemo(() => hasThreeSpeakEmbed(content), [content]);
   const [poll, setPoll] = usePublishPollState(false);
+  const [decentMemes, setDecentMemes] = useState<{
+    templateIds: string[];
+    beneficiaries: BeneficiaryRoute[];
+  } | null>(null);
+
+  const clearDecentMemes = useCallback(() => setDecentMemes(null), []);
+
+  // Accumulate every meme added to the post: collect unique template ids and
+  // sum the widget-supplied beneficiary weights per account. Final capping
+  // against Hive limits happens at publish time (enforceDecentMemesBeneficiary).
+  const addDecentMemesResult = useCallback(
+    (result: { templateId: string; beneficiaries: BeneficiaryRoute[] }) => {
+      setDecentMemes((prev) => {
+        const templateIds = Array.from(
+          new Set([...(prev?.templateIds ?? []), result.templateId].filter(Boolean))
+        );
+        const byAccount = new Map<string, number>();
+        [...(prev?.beneficiaries ?? []), ...result.beneficiaries].forEach((b) => {
+          if (!b?.account || !(b.weight > 0)) {
+            return;
+          }
+          byAccount.set(b.account, (byAccount.get(b.account) ?? 0) + b.weight);
+        });
+        const beneficiaries = Array.from(byAccount.entries()).map(([account, weight]) => ({
+          account,
+          weight
+        }));
+        return { templateIds, beneficiaries };
+      });
+    },
+    []
+  );
 
   const clearSchedule = useCallback(() => setSchedule(undefined), []);
   const clearSelectedThumbnail = useCallback(() => setSelectedThumbnail(""), []);
@@ -212,6 +247,7 @@ export function PublishStateProvider({ children }: { children: React.ReactNode }
     clearPostLinks();
     clearEntryImages();
     clearLocation();
+    clearDecentMemes();
     setIsReblogToCommunity(false);
   }, [
     setBeneficiaries,
@@ -227,6 +263,7 @@ export function PublishStateProvider({ children }: { children: React.ReactNode }
     clearPostLinks,
     clearEntryImages,
     clearLocation,
+    clearDecentMemes,
     setIsReblogToCommunity
   ]);
 
@@ -265,7 +302,10 @@ export function PublishStateProvider({ children }: { children: React.ReactNode }
         clearLocation,
         skipAutoThumbnailSelection,
         clearSelectedThumbnail: _clearSelectedThumbnail,
-        hasThreeSpeakVideo
+        hasThreeSpeakVideo,
+        decentMemes,
+        addDecentMemesResult,
+        clearDecentMemes
       }}
     >
       {children}

--- a/apps/web/src/app/publish/_hooks/use-publish-state.tsx
+++ b/apps/web/src/app/publish/_hooks/use-publish-state.tsx
@@ -4,6 +4,7 @@ import {
   SUBMIT_TITLE_MAX_LENGTH
 } from "@/app/submit/_consts";
 import { hasThreeSpeakEmbed } from "@/api/threespeak-embed";
+import { DecentMemesEntry } from "@/api/decentmemes";
 import { BeneficiaryRoute, Entry } from "@/entities";
 import { extractMetaData } from "@/utils";
 import dayjs from "@/utils/dayjs";
@@ -68,8 +69,9 @@ interface PublishStateContextValue {
   skipAutoThumbnailSelection: boolean;
   clearSelectedThumbnail: () => void;
   hasThreeSpeakVideo: boolean;
-  decentMemes: { templateIds: string[]; beneficiaries: BeneficiaryRoute[] } | null;
-  addDecentMemesResult: (result: { templateId: string; beneficiaries: BeneficiaryRoute[] }) => void;
+  decentMemes: DecentMemesEntry[];
+  addDecentMemesResult: (entry: DecentMemesEntry) => void;
+  setDecentMemes: (entries: DecentMemesEntry[]) => void;
   clearDecentMemes: () => void;
 }
 
@@ -97,38 +99,16 @@ export function PublishStateProvider({ children }: { children: React.ReactNode }
   >(undefined);
   const hasThreeSpeakVideo = useMemo(() => hasThreeSpeakEmbed(content), [content]);
   const [poll, setPoll] = usePublishPollState(false);
-  const [decentMemes, setDecentMemes] = useState<{
-    templateIds: string[];
-    beneficiaries: BeneficiaryRoute[];
-  } | null>(null);
+  const [decentMemes, setDecentMemes] = useState<DecentMemesEntry[]>([]);
 
-  const clearDecentMemes = useCallback(() => setDecentMemes(null), []);
+  const clearDecentMemes = useCallback(() => setDecentMemes([]), []);
 
-  // Accumulate every meme added to the post: collect unique template ids and
-  // sum the widget-supplied beneficiary weights per account. Final capping
-  // against Hive limits happens at publish time (enforceDecentMemesBeneficiary).
-  const addDecentMemesResult = useCallback(
-    (result: { templateId: string; beneficiaries: BeneficiaryRoute[] }) => {
-      setDecentMemes((prev) => {
-        const templateIds = Array.from(
-          new Set([...(prev?.templateIds ?? []), result.templateId].filter(Boolean))
-        );
-        const byAccount = new Map<string, number>();
-        [...(prev?.beneficiaries ?? []), ...result.beneficiaries].forEach((b) => {
-          if (!b?.account || !(b.weight > 0)) {
-            return;
-          }
-          byAccount.set(b.account, (byAccount.get(b.account) ?? 0) + b.weight);
-        });
-        const beneficiaries = Array.from(byAccount.entries()).map(([account, weight]) => ({
-          account,
-          weight
-        }));
-        return { templateIds, beneficiaries };
-      });
-    },
-    []
-  );
+  // Track each meme added to the post, keyed by its hosted image URL. Dropping
+  // memes whose image was removed, and capping against Hive limits, both happen
+  // at publish time (collectPresentMemeAttribution + enforceDecentMemesBeneficiary).
+  const addDecentMemesResult = useCallback((entry: DecentMemesEntry) => {
+    setDecentMemes((prev) => [...prev.filter((m) => m.imageUrl !== entry.imageUrl), entry]);
+  }, []);
 
   const clearSchedule = useCallback(() => setSchedule(undefined), []);
   const clearSelectedThumbnail = useCallback(() => setSelectedThumbnail(""), []);
@@ -305,6 +285,7 @@ export function PublishStateProvider({ children }: { children: React.ReactNode }
         hasThreeSpeakVideo,
         decentMemes,
         addDecentMemesResult,
+        setDecentMemes,
         clearDecentMemes
       }}
     >

--- a/apps/web/src/app/publish/drafts/[id]/_page.tsx
+++ b/apps/web/src/app/publish/drafts/[id]/_page.tsx
@@ -43,6 +43,7 @@ export default function PublishPage() {
     setSelectedThumbnail,
     setEntryImages,
     setPoll,
+    setDecentMemes,
     clearAll
   } = usePublishState();
 
@@ -62,6 +63,7 @@ export default function PublishPage() {
       setSelectedThumbnail(draft.meta?.image?.[0] ?? "");
       setEntryImages(draft.meta?.image ?? []);
       setPoll(normalizePollSnapshot(draft.meta?.poll));
+      setDecentMemes(draft.meta?.decentMemes ?? []);
     },
     () => setStep("no-draft")
   );

--- a/apps/web/src/config/config.template.ts
+++ b/apps/web/src/config/config.template.ts
@@ -128,6 +128,15 @@ const CONFIG = {
       },
       aiAssist: {
         enabled: true
+      },
+      decentMemes: {
+        enabled: true,
+        // Third-party meme maker embedded as an iframe in the publish composer.
+        widgetUrl: "https://decentmemes.com/widget/",
+        // Exact origin used to validate inbound postMessage events (no trailing slash).
+        origin: "https://decentmemes.com",
+        // Routes the optional 1% "frontend" beneficiary slot to this Hive account.
+        frontendAccount: "ecency"
       }
     },
     service: {

--- a/apps/web/src/config/config.ts
+++ b/apps/web/src/config/config.ts
@@ -127,6 +127,15 @@ const CONFIG = {
       },
       aiAssist: {
         enabled: true
+      },
+      decentMemes: {
+        enabled: true,
+        // Third-party meme maker embedded as an iframe in the publish composer.
+        widgetUrl: "https://decentmemes.com/widget/",
+        // Exact origin used to validate inbound postMessage events (no trailing slash).
+        origin: "https://decentmemes.com",
+        // Routes the optional 1% "frontend" beneficiary slot to this Hive account.
+        frontendAccount: "ecency"
       }
     },
     service: {

--- a/apps/web/src/entities/operations/decentmemes.ts
+++ b/apps/web/src/entities/operations/decentmemes.ts
@@ -1,0 +1,21 @@
+import { BeneficiaryRoute } from "./beneficiary-route";
+
+/**
+ * Broadcast-ready meme attribution: unique template ids plus the aggregated
+ * beneficiaries that get merged into comment_options.
+ */
+export interface DecentMemesPayload {
+  templateIds: string[];
+  beneficiaries: BeneficiaryRoute[];
+}
+
+/**
+ * A single meme added to a composer, tracked with its hosted image URL so the
+ * attribution can be dropped if the image is later removed from the body. Kept
+ * in editor state / drafts; collapses to a {@link DecentMemesPayload} at publish.
+ */
+export interface DecentMemesEntry {
+  templateId: string;
+  imageUrl: string;
+  beneficiaries: BeneficiaryRoute[];
+}

--- a/apps/web/src/entities/operations/index.ts
+++ b/apps/web/src/entities/operations/index.ts
@@ -2,3 +2,4 @@ export * from "./metadata";
 export * from "./beneficiary-route";
 export * from "./comment-options";
 export * from "./reward-type";
+export * from "./decentmemes";

--- a/apps/web/src/entities/operations/metadata.ts
+++ b/apps/web/src/entities/operations/metadata.ts
@@ -13,4 +13,5 @@ export interface MetaData {
   links?: string[];
   links_meta?: Record<string, { image: string; summary: string; title: string }>;
   location?: { coordinates: { lat: number; lng: number }; address?: string };
+  decentmemes?: { v: number; templateIds: string[]; frontend?: string };
 }

--- a/apps/web/src/entities/private-api/drafts.ts
+++ b/apps/web/src/entities/private-api/drafts.ts
@@ -1,10 +1,11 @@
-import { BeneficiaryRoute, MetaData, RewardType } from "../operations";
+import { BeneficiaryRoute, DecentMemesEntry, MetaData, RewardType } from "../operations";
 import { PollSnapshot } from "@/features/polls";
 
 export interface DraftMetadata extends MetaData {
   beneficiaries: BeneficiaryRoute[];
   rewardType: RewardType;
   poll?: PollSnapshot;
+  decentMemes?: DecentMemesEntry[];
 }
 
 export interface Draft {

--- a/apps/web/src/features/decentmemes/index.ts
+++ b/apps/web/src/features/decentmemes/index.ts
@@ -1,0 +1,1 @@
+export * from "./meme-maker-dialog";

--- a/apps/web/src/features/decentmemes/meme-maker-dialog.tsx
+++ b/apps/web/src/features/decentmemes/meme-maker-dialog.tsx
@@ -185,6 +185,12 @@ export function MemeMakerDialog({ show, setShow, onMemeCreated }: Props) {
               className="w-full rounded-lg"
               style={{ height: 640, border: 0 }}
               allow="clipboard-write"
+              // Sandboxed for defense-in-depth: blocks top-level navigation,
+              // downloads, etc. `allow-same-origin` is kept so the widget can use
+              // its own origin's storage; postMessage works regardless. Tightening
+              // further (dropping same-origin) would need confirmation that the
+              // widget does not rely on its own cookies/localStorage.
+              sandbox="allow-scripts allow-same-origin allow-popups"
               onLoad={onFrameLoad}
               onError={() => setStatus("error")}
             />

--- a/apps/web/src/features/decentmemes/meme-maker-dialog.tsx
+++ b/apps/web/src/features/decentmemes/meme-maker-dialog.tsx
@@ -42,7 +42,14 @@ function resolveWidgetTheme(theme: Theme): "light" | "dark" {
   return "light";
 }
 
-export function PublishMemeMakerDialog({ show, setShow, onMemeCreated }: Props) {
+/**
+ * Shared DecentMemes meme-maker dialog. Embeds the third-party widget as a
+ * code-split iframe, talks to it over postMessage (strict origin check), and on
+ * "Add to post" re-uploads the returned PNG through Ecency's own image pipeline
+ * before handing the hosted URL + template + beneficiaries back to the caller.
+ * Used by both the long-form publish composer and the Waves composer.
+ */
+export function MemeMakerDialog({ show, setShow, onMemeCreated }: Props) {
   const theme = useGlobalStore((s) => s.theme);
   const widgetTheme = resolveWidgetTheme(theme);
 

--- a/apps/web/src/features/entry-management/entry-metadata-manager/entry-metadata-builder.ts
+++ b/apps/web/src/features/entry-management/entry-metadata-manager/entry-metadata-builder.ts
@@ -5,6 +5,7 @@ import { getDimensionsFromDataUrl } from "./get-dimensions-from-data-url";
 import { extractMetaData, makeApp } from "@/utils/posting";
 import { makeEntryPath } from "@/utils/make-path";
 import { Entry, MetaData } from "@/entities";
+import { DECENTMEMES_METADATA_VERSION } from "@/api/decentmemes";
 
 const DEFAULT_TAGS = ["ecency"];
 
@@ -152,6 +153,17 @@ export class EntryMetadataBuilder {
     };
 
     return this;
+  }
+
+  public withDecentMemes(data?: { templateIds: string[]; frontend?: string }): this {
+    if (!data || !data.templateIds || data.templateIds.length === 0) {
+      return this;
+    }
+    return this.withField("decentmemes", {
+      v: DECENTMEMES_METADATA_VERSION,
+      templateIds: data.templateIds,
+      ...(data.frontend ? { frontend: data.frontend } : {})
+    });
   }
 
   public build(): MetaData {

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1837,7 +1837,8 @@
     "beneficiary-note": "Adding a meme routes a small beneficiary reward to the meme creator, plus 1% to Ecency.",
     "unavailable-title": "Meme maker is unavailable",
     "unavailable-description": "We couldn't load the meme maker right now. Please try again later.",
-    "upload-error": "Could not add the meme to your post. Please try again."
+    "upload-error": "Could not add the meme to your post. Please try again.",
+    "beneficiaries-trimmed": "Some meme rewards were trimmed to fit the beneficiary limits."
   },
   "gif-picker": {
     "filter-placeholder": "Filter",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1831,6 +1831,14 @@
     "filter-no-match": "No match",
     "recently-used": "Recently Used"
   },
+  "decentmemes": {
+    "toolbar-button": "Make a meme",
+    "dialog-title": "Meme maker",
+    "beneficiary-note": "Adding a meme routes a small beneficiary reward to the meme creator, plus 1% to Ecency.",
+    "unavailable-title": "Meme maker is unavailable",
+    "unavailable-description": "We couldn't load the meme maker right now. Please try again later.",
+    "upload-error": "Could not add the meme to your post. Please try again."
+  },
   "gif-picker": {
     "filter-placeholder": "Filter",
     "credits": "Powered by GIPHY",

--- a/apps/web/src/features/waves/components/wave-form/api/use-wave-create-reply.ts
+++ b/apps/web/src/features/waves/components/wave-form/api/use-wave-create-reply.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { Entry, WaveEntry } from "@/entities";
+import { BeneficiaryRoute, Entry, WaveEntry } from "@/entities";
 import { error, success } from "@/features/shared";
 import { formatError } from "@/api/format-error";
 import { useWavesApi } from "./use-waves-api";
@@ -14,13 +14,23 @@ export function useWaveCreateReply() {
       editingEntry,
       parent,
       raw,
-      videoThumbnail
+      videoThumbnail,
+      decentMemes
     }: {
       parent: Entry;
       raw: string;
       editingEntry?: WaveEntry;
       videoThumbnail?: string;
-    }) => generalApiRequest({ entry: parent, raw, editingEntry, videoThumbnail }),
+      decentMemes?: { templateIds: string[]; beneficiaries: BeneficiaryRoute[] };
+    }) =>
+      generalApiRequest({
+        entry: parent,
+        raw,
+        editingEntry,
+        videoThumbnail,
+        decentMemes,
+        isReply: true
+      }),
     onSuccess: () => success(i18next.t("waves.success-reply")),
     onError: (e) => error(...formatError(e))
   });

--- a/apps/web/src/features/waves/components/wave-form/api/use-wave-create-reply.ts
+++ b/apps/web/src/features/waves/components/wave-form/api/use-wave-create-reply.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
-import { BeneficiaryRoute, Entry, WaveEntry } from "@/entities";
+import { Entry, WaveEntry } from "@/entities";
+import { DecentMemesPayload } from "@/api/decentmemes";
 import { error, success } from "@/features/shared";
 import { formatError } from "@/api/format-error";
 import { useWavesApi } from "./use-waves-api";
@@ -21,7 +22,7 @@ export function useWaveCreateReply() {
       raw: string;
       editingEntry?: WaveEntry;
       videoThumbnail?: string;
-      decentMemes?: { templateIds: string[]; beneficiaries: BeneficiaryRoute[] };
+      decentMemes?: DecentMemesPayload;
     }) =>
       generalApiRequest({
         entry: parent,

--- a/apps/web/src/features/waves/components/wave-form/api/use-wave-create.ts
+++ b/apps/web/src/features/waves/components/wave-form/api/use-wave-create.ts
@@ -9,7 +9,7 @@ import { formatError } from "@/api/format-error";
 import { useWavesApi } from "./use-waves-api";
 import { useCommunityApi } from "./use-community-api";
 import { ECENCY_WAVES_HOSTS, isEcencyWavesHost } from "@/features/waves/enums/wave-hosts";
-import { Entry, WaveEntry } from "@/entities";
+import { BeneficiaryRoute, Entry, WaveEntry } from "@/entities";
 
 export function useWaveCreate() {
   const queryClient = useQueryClient();
@@ -23,12 +23,14 @@ export function useWaveCreate() {
       host,
       raw,
       editingEntry,
-      videoThumbnail
+      videoThumbnail,
+      decentMemes
     }: {
       host: string;
       raw: string;
       editingEntry?: WaveEntry;
       videoThumbnail?: string;
+      decentMemes?: { templateIds: string[]; beneficiaries: BeneficiaryRoute[] };
     }) => {
       if (host === "dbuzz") {
         return {
@@ -93,7 +95,8 @@ export function useWaveCreate() {
           raw,
           editingEntry,
           host: resolvedHost,
-          videoThumbnail
+          videoThumbnail,
+          decentMemes
         })) as WaveEntry,
         isEditing: !!editingEntry
       };

--- a/apps/web/src/features/waves/components/wave-form/api/use-wave-create.ts
+++ b/apps/web/src/features/waves/components/wave-form/api/use-wave-create.ts
@@ -9,7 +9,8 @@ import { formatError } from "@/api/format-error";
 import { useWavesApi } from "./use-waves-api";
 import { useCommunityApi } from "./use-community-api";
 import { ECENCY_WAVES_HOSTS, isEcencyWavesHost } from "@/features/waves/enums/wave-hosts";
-import { BeneficiaryRoute, Entry, WaveEntry } from "@/entities";
+import { Entry, WaveEntry } from "@/entities";
+import { DecentMemesPayload } from "@/api/decentmemes";
 
 export function useWaveCreate() {
   const queryClient = useQueryClient();
@@ -30,7 +31,7 @@ export function useWaveCreate() {
       raw: string;
       editingEntry?: WaveEntry;
       videoThumbnail?: string;
-      decentMemes?: { templateIds: string[]; beneficiaries: BeneficiaryRoute[] };
+      decentMemes?: DecentMemesPayload;
     }) => {
       if (host === "dbuzz") {
         return {

--- a/apps/web/src/features/waves/components/wave-form/api/use-waves-api.ts
+++ b/apps/web/src/features/waves/components/wave-form/api/use-waves-api.ts
@@ -1,12 +1,13 @@
 import { v4 } from "uuid";
 import { useContext } from "react";
 import { PollsContext } from "@/features/polls";
-import { BeneficiaryRoute, Entry, FullAccount, WaveEntry } from "@/entities";
+import { Entry, FullAccount, WaveEntry } from "@/entities";
 import { createReplyPermlink, createWavePermlink, tempEntry } from "@/utils";
 import { isEcencyWavesHost } from "@/features/waves/enums/wave-hosts";
 import {
   DECENTMEMES_COMMENT_MAX_WEIGHT,
   DECENTMEMES_FRONTEND,
+  DecentMemesPayload,
   enforceDecentMemesBeneficiary,
   ensureDecentMemesTag
 } from "@/api/decentmemes";
@@ -26,6 +27,8 @@ import { useActiveAccount } from "@/core/hooks";
 import { SortOrder } from "@/enums";
 import { enforceThreeSpeakBeneficiary } from "@/api/threespeak-embed/beneficiary";
 import { linkThreeSpeakEmbed } from "@/api/threespeak-embed/link-after-broadcast";
+import { info } from "@/features/shared";
+import i18next from "i18next";
 
 export function useWavesApi() {
   const queryClient = useQueryClient();
@@ -52,7 +55,7 @@ export function useWavesApi() {
       editingEntry?: WaveEntry;
       host?: string;
       videoThumbnail?: string;
-      decentMemes?: { templateIds: string[]; beneficiaries: BeneficiaryRoute[] };
+      decentMemes?: DecentMemesPayload;
       isReply?: boolean;
     }) => {
       if (!username) {
@@ -133,12 +136,16 @@ export function useWavesApi() {
       // the DecentMemes meme beneficiaries (comment caps: 30% max) on top.
       let beneficiaries = enforceThreeSpeakBeneficiary([], raw);
       if (applyDecentMemes) {
-        beneficiaries = enforceDecentMemesBeneficiary(
+        const enforced = enforceDecentMemesBeneficiary(
           beneficiaries,
           decentMemes!.beneficiaries,
           username,
           DECENTMEMES_COMMENT_MAX_WEIGHT
-        ).beneficiaries;
+        );
+        beneficiaries = enforced.beneficiaries;
+        if (enforced.dropped) {
+          info(i18next.t("decentmemes.beneficiaries-trimmed"));
+        }
       }
       if (beneficiaries.length > 0) {
         commentPayload.options = {

--- a/apps/web/src/features/waves/components/wave-form/api/use-waves-api.ts
+++ b/apps/web/src/features/waves/components/wave-form/api/use-waves-api.ts
@@ -44,7 +44,8 @@ export function useWavesApi() {
       editingEntry,
       host,
       videoThumbnail,
-      decentMemes
+      decentMemes,
+      isReply
     }: {
       entry: Entry;
       raw: string;
@@ -52,6 +53,7 @@ export function useWavesApi() {
       host?: string;
       videoThumbnail?: string;
       decentMemes?: { templateIds: string[]; beneficiaries: BeneficiaryRoute[] };
+      isReply?: boolean;
     }) => {
       if (!username) {
         throw new Error("[Wave][Thread-base][API] – No active user");
@@ -81,10 +83,13 @@ export function useWavesApi() {
       if (isEcencyWavesHost(host) && !editingEntry) {
         permlink = createWavePermlink();
       }
-      // DecentMemes is only applied to Ecency's own waves containers, never to
-      // third-party hosts (decks: leothreads / liketu / dbuzz) or replies.
+      // DecentMemes applies to new waves on Ecency's own containers
+      // (ecency.waves / hive.flow) and to any reply created from the Ecency
+      // composer (the parent's container does not change who authored the
+      // reply). Third-party new-wave hosts (leothreads / liketu / dbuzz) are
+      // excluded.
       const applyDecentMemes =
-        isEcencyWavesHost(host) && !!decentMemes && decentMemes.templateIds.length > 0;
+        !!decentMemes && decentMemes.templateIds.length > 0 && (isReply || isEcencyWavesHost(host));
 
       const baseTags = raw.match(/\#[a-zA-Z0-9]+/g)?.map((tag) => tag.replace("#", "")) ?? [
         "ecency"

--- a/apps/web/src/features/waves/components/wave-form/api/use-waves-api.ts
+++ b/apps/web/src/features/waves/components/wave-form/api/use-waves-api.ts
@@ -1,9 +1,15 @@
 import { v4 } from "uuid";
 import { useContext } from "react";
 import { PollsContext } from "@/features/polls";
-import { Entry, FullAccount, WaveEntry } from "@/entities";
+import { BeneficiaryRoute, Entry, FullAccount, WaveEntry } from "@/entities";
 import { createReplyPermlink, createWavePermlink, tempEntry } from "@/utils";
 import { isEcencyWavesHost } from "@/features/waves/enums/wave-hosts";
+import {
+  DECENTMEMES_COMMENT_MAX_WEIGHT,
+  DECENTMEMES_FRONTEND,
+  enforceDecentMemesBeneficiary,
+  ensureDecentMemesTag
+} from "@/api/decentmemes";
 import { EntryMetadataManagement } from "@/features/entry-management";
 import { useCommentMutation } from "@/api/sdk-mutations";
 import type { CommentPayload } from "@ecency/sdk";
@@ -37,13 +43,15 @@ export function useWavesApi() {
       raw,
       editingEntry,
       host,
-      videoThumbnail
+      videoThumbnail,
+      decentMemes
     }: {
       entry: Entry;
       raw: string;
       editingEntry?: WaveEntry;
       host?: string;
       videoThumbnail?: string;
+      decentMemes?: { templateIds: string[]; beneficiaries: BeneficiaryRoute[] };
     }) => {
       if (!username) {
         throw new Error("[Wave][Thread-base][API] – No active user");
@@ -73,7 +81,15 @@ export function useWavesApi() {
       if (isEcencyWavesHost(host) && !editingEntry) {
         permlink = createWavePermlink();
       }
-      const tags = raw.match(/\#[a-zA-Z0-9]+/g)?.map((tag) => tag.replace("#", "")) ?? ["ecency"];
+      // DecentMemes is only applied to Ecency's own waves containers, never to
+      // third-party hosts (decks: leothreads / liketu / dbuzz) or replies.
+      const applyDecentMemes =
+        isEcencyWavesHost(host) && !!decentMemes && decentMemes.templateIds.length > 0;
+
+      const baseTags = raw.match(/\#[a-zA-Z0-9]+/g)?.map((tag) => tag.replace("#", "")) ?? [
+        "ecency"
+      ];
+      const tags = applyDecentMemes ? ensureDecentMemesTag(baseTags) : baseTags;
 
       const builder = EntryMetadataManagement.EntryMetadataManager.shared
         .builder()
@@ -84,6 +100,13 @@ export function useWavesApi() {
 
       if (videoThumbnail) {
         await builder.withSelectedThumbnail(videoThumbnail);
+      }
+
+      if (applyDecentMemes) {
+        builder.withDecentMemes({
+          templateIds: decentMemes!.templateIds,
+          frontend: DECENTMEMES_FRONTEND
+        });
       }
 
       const jsonMeta = builder.build();
@@ -101,8 +124,17 @@ export function useWavesApi() {
         rootPermlink: entry.permlink
       };
 
-      // Add 3Speak beneficiary when the wave contains a video embed
-      const beneficiaries = enforceThreeSpeakBeneficiary([], raw);
+      // Add 3Speak beneficiary when the wave contains a video embed, then merge
+      // the DecentMemes meme beneficiaries (comment caps: 30% max) on top.
+      let beneficiaries = enforceThreeSpeakBeneficiary([], raw);
+      if (applyDecentMemes) {
+        beneficiaries = enforceDecentMemesBeneficiary(
+          beneficiaries,
+          decentMemes!.beneficiaries,
+          username,
+          DECENTMEMES_COMMENT_MAX_WEIGHT
+        ).beneficiaries;
+      }
       if (beneficiaries.length > 0) {
         commentPayload.options = {
           beneficiaries: beneficiaries.map((b) => ({

--- a/apps/web/src/features/waves/components/wave-form/index.tsx
+++ b/apps/web/src/features/waves/components/wave-form/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import "./_index.scss";
-import { Entry, WaveEntry } from "@/entities";
+import { BeneficiaryRoute, Entry, WaveEntry } from "@/entities";
 import { PollsContext, PollsManager, useEntryPollExtractor } from "@/features/polls";
 import { useLocalStorage } from "react-use";
 import { PREFIX } from "@/utils/local-storage";
@@ -52,6 +52,14 @@ const WaveFormComponent = ({
   const [text, setText, clearText] = useLocalStorage(PREFIX + "_wf_t", "");
   const [image, setImage, clearImage] = useLocalStorage<string>(PREFIX + "_wf_i", "");
   const [imageName, setImageName, clearImageName] = useLocalStorage<string>(PREFIX + "_wf_in", "");
+  // When the current image is a DecentMemes meme, keep its template + beneficiary
+  // data alongside the image URL. The `imageUrl` guard means that if the image is
+  // later replaced (regular picker / AI), the stale meme data is ignored at submit.
+  const [decentMemes, setDecentMemes, clearDecentMemes] = useLocalStorage<{
+    templateIds: string[];
+    beneficiaries: BeneficiaryRoute[];
+    imageUrl: string;
+  } | null>(PREFIX + "_wf_dm", null);
   const [video, setVideo, clearVideo] = useLocalStorage<string>(PREFIX + "_wf_v", "");
   const [videoThumbnail, setVideoThumbnail, clearVideoThumbnail] = useLocalStorage<string>(
     PREFIX + "_wf_vt",
@@ -117,10 +125,19 @@ const WaveFormComponent = ({
     setText("");
     clearImage();
     clearImageName();
+    clearDecentMemes();
     clearActivePoll();
     clearVideo();
     clearVideoThumbnail();
-  }, [clearActivePoll, clearImage, clearImageName, clearVideo, clearVideoThumbnail, setText]);
+  }, [
+    clearActivePoll,
+    clearImage,
+    clearImageName,
+    clearDecentMemes,
+    clearVideo,
+    clearVideoThumbnail,
+    setText
+  ]);
 
   const { mutateAsync: submit, isPending } = useWaveSubmit(entry, replySource, (item) => {
     clear();
@@ -266,6 +283,15 @@ const WaveFormComponent = ({
             setImage(url);
             setImageName(name);
           }}
+          onAddMeme={({ url, name, templateId, beneficiaries }) => {
+            setImage(url);
+            setImageName(name);
+            setDecentMemes({
+              templateIds: [templateId].filter(Boolean),
+              beneficiaries,
+              imageUrl: url
+            });
+          }}
           onEmojiPick={handleEmojiPick}
           onAddVideo={setVideo}
           onShowVideoUpload={() => {
@@ -285,7 +311,17 @@ const WaveFormComponent = ({
                   image: image!!,
                   host: threadHost!!,
                   video: video!!,
-                  videoThumbnail: videoThumbnail!!
+                  videoThumbnail: videoThumbnail!!,
+                  // Only attach meme data when the current image is still the meme.
+                  decentMemes:
+                    decentMemes &&
+                    decentMemes.imageUrl === image &&
+                    decentMemes.templateIds.length > 0
+                      ? {
+                          templateIds: decentMemes.templateIds,
+                          beneficiaries: decentMemes.beneficiaries
+                        }
+                      : undefined
                 })
               }
               disabled={submitDisabled}

--- a/apps/web/src/features/waves/components/wave-form/wave-form-toolbar.tsx
+++ b/apps/web/src/features/waves/components/wave-form/wave-form-toolbar.tsx
@@ -4,6 +4,7 @@ import { WaveFormEmojiPicker } from "./wave-form-emoji-picker";
 import { Button } from "@ui/button";
 import { UilChart, UilImageShare, UilVideo } from "@tooni/iconscout-unicons-react";
 import { AiImageIcon } from "@/features/shared/ai-image-icon";
+import { LoginRequired } from "@/features/shared";
 import { PollsContext, PollsCreation } from "@/features/polls";
 import { EcencyConfigManager } from "@/config";
 import { BeneficiaryRoute } from "@/entities";
@@ -98,14 +99,16 @@ export const WaveFormToolbar = ({
         <EcencyConfigManager.Conditional
           condition={({ visionFeatures }) => visionFeatures.decentMemes.enabled}
         >
-          <Button
-            appearance="gray-link"
-            icon={<UilImageShare />}
-            onClick={() => setShowMemeMaker(true)}
-            disabled={disabled}
-            aria-label={i18next.t("decentmemes.toolbar-button")}
-            title={i18next.t("decentmemes.toolbar-button")}
-          />
+          <LoginRequired>
+            <Button
+              appearance="gray-link"
+              icon={<UilImageShare />}
+              onClick={() => setShowMemeMaker(true)}
+              disabled={disabled}
+              aria-label={i18next.t("decentmemes.toolbar-button")}
+              title={i18next.t("decentmemes.toolbar-button")}
+            />
+          </LoginRequired>
         </EcencyConfigManager.Conditional>
         <PollsCreation
           existingPoll={activePoll}

--- a/apps/web/src/features/waves/components/wave-form/wave-form-toolbar.tsx
+++ b/apps/web/src/features/waves/components/wave-form/wave-form-toolbar.tsx
@@ -2,10 +2,11 @@ import React, { ReactNode, useContext, useState } from "react";
 import { WaveFormToolbarImagePicker } from "./wave-form-toolbar-image-picker";
 import { WaveFormEmojiPicker } from "./wave-form-emoji-picker";
 import { Button } from "@ui/button";
-import { UilChart, UilVideo } from "@tooni/iconscout-unicons-react";
+import { UilChart, UilImageShare, UilVideo } from "@tooni/iconscout-unicons-react";
 import { AiImageIcon } from "@/features/shared/ai-image-icon";
 import { PollsContext, PollsCreation } from "@/features/polls";
 import { EcencyConfigManager } from "@/config";
+import { BeneficiaryRoute } from "@/entities";
 import i18next from "i18next";
 import dynamic from "next/dynamic";
 
@@ -16,8 +17,22 @@ const AiImageGeneratorDialog = dynamic(
   { ssr: false }
 );
 
+// Code-split: the meme maker (iframe + postMessage) only loads on click.
+const MemeMakerDialog = dynamic(
+  () => import("@/features/decentmemes").then((m) => ({
+    default: m.MemeMakerDialog
+  })),
+  { ssr: false }
+);
+
 interface Props {
   onAddImage: (url: string, name: string) => void;
+  onAddMeme?: (data: {
+    url: string;
+    name: string;
+    templateId: string;
+    beneficiaries: BeneficiaryRoute[];
+  }) => void;
   onEmojiPick: (value: string) => void;
   onAddVideo: (value: string) => void;
   onShowVideoUpload?: () => void;
@@ -30,6 +45,7 @@ interface Props {
 
 export const WaveFormToolbar = ({
   onAddImage,
+  onAddMeme,
   onEmojiPick,
   onShowVideoUpload,
   hasVideo,
@@ -41,6 +57,7 @@ export const WaveFormToolbar = ({
   const { activePoll, setActivePoll, clearActivePoll } = useContext(PollsContext);
   const [show, setShow] = useState(false);
   const [showAiGenerator, setShowAiGenerator] = useState(false);
+  const [showMemeMaker, setShowMemeMaker] = useState(false);
 
   return (
     <div className="flex items-center justify-between py-1.5 border-t border-[--border-color]">
@@ -78,6 +95,18 @@ export const WaveFormToolbar = ({
             aria-label={i18next.t("ai-image-generator.toolbar-button")}
           />
         </EcencyConfigManager.Conditional>
+        <EcencyConfigManager.Conditional
+          condition={({ visionFeatures }) => visionFeatures.decentMemes.enabled}
+        >
+          <Button
+            appearance="gray-link"
+            icon={<UilImageShare />}
+            onClick={() => setShowMemeMaker(true)}
+            disabled={disabled}
+            aria-label={i18next.t("decentmemes.toolbar-button")}
+            title={i18next.t("decentmemes.toolbar-button")}
+          />
+        </EcencyConfigManager.Conditional>
         <PollsCreation
           existingPoll={activePoll}
           show={show}
@@ -95,6 +124,16 @@ export const WaveFormToolbar = ({
           onInsert={(url) => {
             onAddImage(url, "ai-generated");
             setShowAiGenerator(false);
+          }}
+        />
+      )}
+      {showMemeMaker && (
+        <MemeMakerDialog
+          show={showMemeMaker}
+          setShow={setShowMemeMaker}
+          onMemeCreated={({ url, alt, templateId, beneficiaries }) => {
+            onAddMeme?.({ url, name: alt, templateId, beneficiaries });
+            setShowMemeMaker(false);
           }}
         />
       )}

--- a/apps/web/src/features/waves/hooks/use-wave-submit.ts
+++ b/apps/web/src/features/waves/hooks/use-wave-submit.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { BeneficiaryRoute, Entry, WaveEntry } from "@/entities";
+import { Entry, WaveEntry } from "@/entities";
+import { DecentMemesPayload } from "@/api/decentmemes";
 import { useWaveCreate } from "@/features/waves/components/wave-form/api";
 import { useWaveCreateReply } from "@/features/waves/components/wave-form/api/use-wave-create-reply";
 import { useLocalStorage } from "react-use";
@@ -20,7 +21,7 @@ interface Body {
   video: string;
   videoThumbnail: string;
   host: string;
-  decentMemes?: { templateIds: string[]; beneficiaries: BeneficiaryRoute[] };
+  decentMemes?: DecentMemesPayload;
 }
 
 export function useWaveSubmit(

--- a/apps/web/src/features/waves/hooks/use-wave-submit.ts
+++ b/apps/web/src/features/waves/hooks/use-wave-submit.ts
@@ -110,7 +110,8 @@ export function useWaveSubmit(
           parent: replySource,
           raw: content,
           editingEntry: editingEntry,
-          videoThumbnail: videoThumbnail || undefined
+          videoThumbnail: videoThumbnail || undefined,
+          decentMemes
         })) as WaveEntry;
         if (host) {
           threadItem.host = host;

--- a/apps/web/src/features/waves/hooks/use-wave-submit.ts
+++ b/apps/web/src/features/waves/hooks/use-wave-submit.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { Entry, WaveEntry } from "@/entities";
+import { BeneficiaryRoute, Entry, WaveEntry } from "@/entities";
 import { useWaveCreate } from "@/features/waves/components/wave-form/api";
 import { useWaveCreateReply } from "@/features/waves/components/wave-form/api/use-wave-create-reply";
 import { useLocalStorage } from "react-use";
@@ -20,6 +20,7 @@ interface Body {
   video: string;
   videoThumbnail: string;
   host: string;
+  decentMemes?: { templateIds: string[]; beneficiaries: BeneficiaryRoute[] };
 }
 
 export function useWaveSubmit(
@@ -40,7 +41,15 @@ export function useWaveSubmit(
 
   return useMutation({
     mutationKey: ["wave-form-submit", username, replySource, editingEntry],
-    mutationFn: async ({ text, image, imageName, video, videoThumbnail, host }: Body) => {
+    mutationFn: async ({
+      text,
+      image,
+      imageName,
+      video,
+      videoThumbnail,
+      host,
+      decentMemes
+    }: Body) => {
       // Check if user is logged in
       if (!username) {
         toggleUIProp("login");
@@ -111,7 +120,8 @@ export function useWaveSubmit(
           host,
           raw: content,
           editingEntry,
-          videoThumbnail: videoThumbnail || undefined
+          videoThumbnail: videoThumbnail || undefined,
+          decentMemes
         });
         threadItem = created.entry;
         // For a NEW wave, reflect the container create() actually resolved

--- a/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
+++ b/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
@@ -1,0 +1,176 @@
+import { BeneficiaryRoute } from "@/entities";
+import {
+  aggregateMemeBeneficiaries,
+  DECENTMEMES_POST_MAX_WEIGHT,
+  enforceDecentMemesBeneficiary,
+  ensureDecentMemesTag,
+  HIVE_MAX_BENEFICIARIES,
+  HIVE_MAX_TOTAL_WEIGHT
+} from "@/api/decentmemes";
+
+const totalWeight = (list: BeneficiaryRoute[]) => list.reduce((s, b) => s + b.weight, 0);
+
+describe("DecentMemes beneficiaries", () => {
+  describe("aggregateMemeBeneficiaries", () => {
+    it("strips the role field and keeps account + weight", () => {
+      const result = aggregateMemeBeneficiaries([{ account: "alice", weight: 300 } as any]);
+      expect(result).toEqual([{ account: "alice", weight: 300 }]);
+    });
+
+    it("sums duplicate accounts", () => {
+      const result = aggregateMemeBeneficiaries([
+        { account: "alice", weight: 300 },
+        { account: "alice", weight: 100 }
+      ]);
+      expect(result).toEqual([{ account: "alice", weight: 400 }]);
+    });
+
+    it("drops invalid entries (no account, zero/negative/NaN weight)", () => {
+      const result = aggregateMemeBeneficiaries([
+        { account: "", weight: 300 },
+        { account: "bob", weight: 0 },
+        { account: "carol", weight: -5 },
+        { account: "dave", weight: Number.NaN },
+        { account: "erin", weight: 100 }
+      ]);
+      expect(result).toEqual([{ account: "erin", weight: 100 }]);
+    });
+
+    it("drops entries with malformed Hive account names", () => {
+      const result = aggregateMemeBeneficiaries([
+        { account: "UPPERCASE", weight: 100 },
+        { account: "1numericstart", weight: 100 },
+        { account: "x", weight: 100 },
+        { account: "user@invalid", weight: 100 },
+        { account: "good.name", weight: 100 }
+      ]);
+      expect(result).toEqual([{ account: "good.name", weight: 100 }]);
+    });
+  });
+
+  describe("enforceDecentMemesBeneficiary", () => {
+    it("appends meme beneficiaries to an empty user list", () => {
+      const { beneficiaries, dropped } = enforceDecentMemesBeneficiary(
+        [],
+        [
+          { account: "alice", weight: 300, role: "creator" } as any,
+          { account: "ecency", weight: 100, role: "frontend" } as any
+        ]
+      );
+      expect(beneficiaries).toEqual([
+        { account: "alice", weight: 300 },
+        { account: "ecency", weight: 100 }
+      ]);
+      expect(dropped).toBe(false);
+    });
+
+    it("never mutates or drops the user's own beneficiaries", () => {
+      const existing: BeneficiaryRoute[] = [{ account: "bob", weight: 5000 }];
+      const { beneficiaries } = enforceDecentMemesBeneficiary(existing, [
+        { account: "alice", weight: 300 }
+      ]);
+      expect(beneficiaries).toContainEqual({ account: "bob", weight: 5000 });
+      expect(beneficiaries).toContainEqual({ account: "alice", weight: 300 });
+    });
+
+    it("excludes a meme beneficiary that equals the post author", () => {
+      const { beneficiaries } = enforceDecentMemesBeneficiary(
+        [],
+        [
+          { account: "author", weight: 300 },
+          { account: "alice", weight: 200 }
+        ],
+        "author"
+      );
+      expect(beneficiaries.some((b) => b.account === "author")).toBe(false);
+      expect(beneficiaries).toContainEqual({ account: "alice", weight: 200 });
+    });
+
+    it("caps the meme contribution at the 10% post maximum", () => {
+      const { beneficiaries, dropped } = enforceDecentMemesBeneficiary(
+        [],
+        [{ account: "alice", weight: 9000 }]
+      );
+      expect(totalWeight(beneficiaries)).toBeLessThanOrEqual(DECENTMEMES_POST_MAX_WEIGHT);
+      expect(dropped).toBe(true);
+    });
+
+    it("scales meme beneficiaries down to fit the remaining weight headroom", () => {
+      // User already allocated 99.5% -> only 50 bp headroom for memes.
+      const existing: BeneficiaryRoute[] = [{ account: "bob", weight: 9950 }];
+      const { beneficiaries, dropped } = enforceDecentMemesBeneficiary(existing, [
+        { account: "alice", weight: 300 }
+      ]);
+      expect(totalWeight(beneficiaries)).toBeLessThanOrEqual(HIVE_MAX_TOTAL_WEIGHT);
+      expect(dropped).toBe(true);
+    });
+
+    it("drops meme beneficiaries entirely when there is no weight headroom", () => {
+      const existing: BeneficiaryRoute[] = [{ account: "bob", weight: 10000 }];
+      const { beneficiaries, dropped } = enforceDecentMemesBeneficiary(existing, [
+        { account: "alice", weight: 300 }
+      ]);
+      expect(beneficiaries).toEqual([{ account: "bob", weight: 10000 }]);
+      expect(dropped).toBe(true);
+    });
+
+    it("respects the 8-slot limit by dropping the lowest-weight new accounts", () => {
+      const existing: BeneficiaryRoute[] = Array.from({ length: 7 }, (_, i) => ({
+        account: `user${i}`,
+        weight: 100
+      }));
+      const { beneficiaries, dropped } = enforceDecentMemesBeneficiary(existing, [
+        { account: "low", weight: 50 },
+        { account: "high", weight: 200 }
+      ]);
+      expect(beneficiaries.length).toBe(HIVE_MAX_BENEFICIARIES);
+      expect(beneficiaries.some((b) => b.account === "high")).toBe(true);
+      expect(beneficiaries.some((b) => b.account === "low")).toBe(false);
+      expect(dropped).toBe(true);
+    });
+
+    it("bumps an existing account's weight instead of consuming a new slot", () => {
+      const existing: BeneficiaryRoute[] = [{ account: "ecency", weight: 200 }];
+      const { beneficiaries, dropped } = enforceDecentMemesBeneficiary(existing, [
+        { account: "ecency", weight: 100, role: "frontend" } as any
+      ]);
+      expect(beneficiaries).toEqual([{ account: "ecency", weight: 300 }]);
+      expect(dropped).toBe(false);
+    });
+
+    it("produces a list that always satisfies Hive limits", () => {
+      const existing: BeneficiaryRoute[] = [
+        { account: "a", weight: 4000 },
+        { account: "b", weight: 4000 }
+      ];
+      const { beneficiaries } = enforceDecentMemesBeneficiary(existing, [
+        { account: "c", weight: 300 },
+        { account: "d", weight: 300 },
+        { account: "e", weight: 300 }
+      ]);
+      expect(beneficiaries.length).toBeLessThanOrEqual(HIVE_MAX_BENEFICIARIES);
+      expect(totalWeight(beneficiaries)).toBeLessThanOrEqual(HIVE_MAX_TOTAL_WEIGHT);
+    });
+  });
+
+  describe("ensureDecentMemesTag", () => {
+    it("appends the decentmemes tag without reordering existing tags", () => {
+      expect(ensureDecentMemesTag(["photography", "art"])).toEqual([
+        "photography",
+        "art",
+        "decentmemes"
+      ]);
+    });
+
+    it("does not duplicate the tag", () => {
+      const tags = ["photography", "decentmemes"];
+      expect(ensureDecentMemesTag(tags)).toBe(tags);
+    });
+
+    it("does not exceed the 10-tag limit", () => {
+      const tags = Array.from({ length: 10 }, (_, i) => `tag${i}`);
+      expect(ensureDecentMemesTag(tags)).toBe(tags);
+      expect(ensureDecentMemesTag(tags)).not.toContain("decentmemes");
+    });
+  });
+});

--- a/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
+++ b/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
@@ -1,6 +1,7 @@
 import { BeneficiaryRoute } from "@/entities";
 import {
   aggregateMemeBeneficiaries,
+  collectPresentMemeAttribution,
   DECENTMEMES_COMMENT_MAX_WEIGHT,
   DECENTMEMES_POST_MAX_WEIGHT,
   enforceDecentMemesBeneficiary,
@@ -199,6 +200,53 @@ describe("DecentMemes beneficiaries", () => {
       const tags = Array.from({ length: 10 }, (_, i) => `tag${i}`);
       expect(ensureDecentMemesTag(tags)).toBe(tags);
       expect(ensureDecentMemesTag(tags)).not.toContain("decentmemes");
+    });
+  });
+
+  describe("collectPresentMemeAttribution", () => {
+    const entries = [
+      {
+        templateId: "t1",
+        imageUrl: "https://i.ecency.com/a.png",
+        beneficiaries: [{ account: "alice", weight: 300 }]
+      },
+      {
+        templateId: "t2",
+        imageUrl: "https://i.ecency.com/b.png",
+        beneficiaries: [{ account: "bob", weight: 200 }]
+      }
+    ];
+
+    it("keeps only memes whose image is still in the body", () => {
+      const body = "hello ![meme](https://i.ecency.com/a.png) world";
+      const { templateIds, beneficiaries } = collectPresentMemeAttribution(entries, body);
+      expect(templateIds).toEqual(["t1"]);
+      expect(beneficiaries).toEqual([{ account: "alice", weight: 300 }]);
+    });
+
+    it("returns empty attribution when no meme image remains", () => {
+      const { templateIds, beneficiaries } = collectPresentMemeAttribution(
+        entries,
+        "no images here"
+      );
+      expect(templateIds).toEqual([]);
+      expect(beneficiaries).toEqual([]);
+    });
+
+    it("aggregates beneficiaries and dedupes template ids across present memes", () => {
+      const body = "![](https://i.ecency.com/a.png) ![](https://i.ecency.com/b.png)";
+      const withDup = [
+        ...entries,
+        {
+          templateId: "t1",
+          imageUrl: "https://i.ecency.com/a.png",
+          beneficiaries: [{ account: "alice", weight: 100 }]
+        }
+      ];
+      const { templateIds, beneficiaries } = collectPresentMemeAttribution(withDup, body);
+      expect(templateIds.sort()).toEqual(["t1", "t2"]);
+      expect(beneficiaries).toContainEqual({ account: "alice", weight: 400 });
+      expect(beneficiaries).toContainEqual({ account: "bob", weight: 200 });
     });
   });
 });

--- a/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
+++ b/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
@@ -1,6 +1,7 @@
 import { BeneficiaryRoute } from "@/entities";
 import {
   aggregateMemeBeneficiaries,
+  DECENTMEMES_COMMENT_MAX_WEIGHT,
   DECENTMEMES_POST_MAX_WEIGHT,
   enforceDecentMemesBeneficiary,
   ensureDecentMemesTag,
@@ -92,6 +93,33 @@ describe("DecentMemes beneficiaries", () => {
         [{ account: "alice", weight: 9000 }]
       );
       expect(totalWeight(beneficiaries)).toBeLessThanOrEqual(DECENTMEMES_POST_MAX_WEIGHT);
+      expect(dropped).toBe(true);
+    });
+
+    it("caps at the 30% comment maximum when given the comment limit", () => {
+      const { beneficiaries, dropped } = enforceDecentMemesBeneficiary(
+        [],
+        [
+          { account: "alice", weight: 500 },
+          { account: "bob", weight: 1000 },
+          { account: "ecency", weight: 100 }
+        ],
+        undefined,
+        DECENTMEMES_COMMENT_MAX_WEIGHT
+      );
+      // 1600 total is under the 3000 comment cap, so nothing is scaled/dropped.
+      expect(totalWeight(beneficiaries)).toBe(1600);
+      expect(dropped).toBe(false);
+    });
+
+    it("scales a comment meme set down to the 30% cap when it exceeds it", () => {
+      const { beneficiaries, dropped } = enforceDecentMemesBeneficiary(
+        [],
+        [{ account: "alice", weight: 9000 }],
+        undefined,
+        DECENTMEMES_COMMENT_MAX_WEIGHT
+      );
+      expect(totalWeight(beneficiaries)).toBeLessThanOrEqual(DECENTMEMES_COMMENT_MAX_WEIGHT);
       expect(dropped).toBe(true);
     });
 

--- a/apps/web/src/utils/data-url-to-file.ts
+++ b/apps/web/src/utils/data-url-to-file.ts
@@ -1,0 +1,13 @@
+/**
+ * Convert a base64 data URL (e.g. the PNG emitted by the DecentMemes widget via
+ * `postMessage`) into a `File` suitable for the Ecency image-upload pipeline,
+ * which expects a `File` rather than a raw `Blob`.
+ */
+export async function dataUrlToFile(dataUrl: string, filename = "meme.png"): Promise<File> {
+  const blob = await (await fetch(dataUrl)).blob();
+  const type = blob.type || "image/png";
+  // Strip any path components a widget might include in the suggested name.
+  const base = (filename || "meme.png").split(/[\\/]+/).pop() || "meme.png";
+  const safeName = /\.[a-z0-9]+$/i.test(base) ? base : `${base}.png`;
+  return new File([blob], safeName, { type });
+}

--- a/apps/web/src/utils/data-url-to-file.ts
+++ b/apps/web/src/utils/data-url-to-file.ts
@@ -4,6 +4,12 @@
  * which expects a `File` rather than a raw `Blob`.
  */
 export async function dataUrlToFile(dataUrl: string, filename = "meme.png"): Promise<File> {
+  // Defense-in-depth: only ever fetch a base64 data: URI. This guards against a
+  // buggy/compromised widget emitting an http(s) URL, which would otherwise turn
+  // into a live cross-origin request from the user's browser.
+  if (typeof dataUrl !== "string" || !dataUrl.startsWith("data:")) {
+    throw new Error("dataUrlToFile: expected a data: URI");
+  }
   const blob = await (await fetch(dataUrl)).blob();
   const type = blob.type || "image/png";
   // Strip any path components a widget might include in the suggested name.


### PR DESCRIPTION
## Summary

Adds an optional DecentMemes meme maker to both the long-form publish composer and the Waves composer, behind the `visionFeatures.decentMemes` feature flag.

A "Make a meme" toolbar button opens a code-split dialog that embeds the DecentMemes widget (`decentmemes.com/widget/`) as an iframe. On "Add to post" the widget returns a PNG, which is re-uploaded through Ecency's own image pipeline and inserted into the body; the widget-supplied beneficiaries and template metadata are applied to the broadcast.

## Behaviour

- **Code-split / zero initial bundle:** the dialog + iframe live in `features/decentmemes/` and are imported only via `next/dynamic` (`ssr: false`) from each toolbar. The chunk loads on first button click, so no page that renders a composer carries the widget unless the user opens it.
- **postMessage:** strict origin validation; the editor theme is synced to the widget; `frontendInit` routes the optional 1% frontend beneficiary to `@ecency`.
- **Beneficiaries (defensive):** `enforceDecentMemesBeneficiary` caps the meme contribution (10% on a post, 30% on a comment/Wave), fits it into Hive's 8-slot / 100% limits, validates account-name format, excludes the author, and never alters the user's own beneficiaries.
- **Metadata:** `json_metadata.decentmemes` (`v:2` + `templateIds`) and a `decentmemes` tag are added only when a meme is used.
- **Graceful degradation:** if the widget fails to load (timeout / error), a fallback message is shown and the composer stays fully usable.

## Posts

Wired into the publish flow (`use-publish.ts`): meme image inserted into the body, beneficiaries/metadata/tag applied at publish.

## Waves

The meme fills the wave's single image slot (an image-URL guard drops stale meme data if the image is replaced). Beneficiaries/metadata/tag are attached:
- **New waves:** only on Ecency-owned containers (`ecency.waves` / `hive.flow`), never third-party hosts (`leothreads` / `liketu` / `dbuzz`).
- **Replies:** always, for any reply created from the Ecency composer (the parent's container does not change who authored the reply).

Meme data is threaded through `use-wave-submit` -> `use-wave-create(-reply)` -> `use-waves-api`, gated by `isEcencyWavesHost` for new waves and an explicit `isReply` flag for replies. The dbuzz community path is untouched. The shared dialog lives in `features/decentmemes/` and is reused by both composers.

## Config

`visionFeatures.decentMemes` (`enabled`, `widgetUrl`, `origin`, `frontendAccount`). Turning the flag off removes the buttons entirely; there is no persistent state.

## Tests

Unit tests cover the beneficiary capping/merge (post + comment caps), account-name validation, author exclusion, and the tag helper.

## Notes

- Requires `ecency.com` to be in the widget's postMessage allowlist (to confirm against staging).
- Third-party new-wave hosts (`leothreads` / `liketu` / `dbuzz`) insert the meme image only, with no beneficiary, by design.
- Known limitation: deleting the meme image from the body does not retract its beneficiary on posts; on Waves the image-URL guard handles replacement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Meme Maker experience for composing posts and waves, including image insertion and meme details.
  * Meme creations can now carry tags, metadata, and beneficiary settings through publishing workflows.

* **Bug Fixes**
  * Improved beneficiary handling to keep user-defined recipients intact while safely applying meme-related shares within platform limits.
  * Prevented duplicate tags and ensured required meme tags are added only when space allows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->