### PR TITLE
feat(waves): show Ecency source badge on wave header

### DIFF
--- a/apps/web/src/app/waves/_components/waves-list-item-header.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-item-header.tsx
@@ -10,6 +10,8 @@ import { UilArrowRight, UilMultiply } from "@tooni/iconscout-unicons-react";
 import { TimeLabel } from "@/features/shared";
 import clsx from "clsx";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { appName } from "@/utils";
+import Image from "next/image";
 
 interface Props {
   entry: WaveEntry;
@@ -35,6 +37,10 @@ export function WavesListItemHeader({
   onClose
 }: Props) {
   const { activeUser } = useActiveAccount();
+
+  // Show a small Ecency logo when the wave was published from an Ecency client
+  // (web "ecency/x.y-vision" or "ecency-mobile"), mirroring the post "via" badge.
+  const isEcency = appName(entry.json_metadata?.app).toLowerCase().includes("ecency");
 
   return (
     <div
@@ -74,33 +80,45 @@ export function WavesListItemHeader({
         </div>
       </div>
 
-      {onClose ? (
-        <Button
-          noPadding={true}
-          appearance="gray-link"
-          size="sm"
-          icon={<UilMultiply />}
-          onClick={(e: { stopPropagation: () => void; }) => {
-            e.stopPropagation();
-            onClose();
-          }}
-          aria-label={i18next.t("g.close")}
-          title={i18next.t("g.close")}
-        />
-      ) : (
-        status === "default" &&
-        interactable && (
+      <div className="flex items-center gap-2 shrink-0">
+        {isEcency && (
+          <Image
+            className="ecency-source-badge"
+            src="/assets/logo-circle.svg"
+            alt={i18next.t("waves.source-ecency")}
+            title={i18next.t("waves.source-ecency")}
+            width={16}
+            height={16}
+          />
+        )}
+        {onClose ? (
           <Button
             noPadding={true}
             appearance="gray-link"
-            icon={<UilArrowRight />}
-            iconPlacement="right"
             size="sm"
-            aria-label={i18next.t("waves.view-thread", { defaultValue: "View thread" })}
+            icon={<UilMultiply />}
+            onClick={(e: { stopPropagation: () => void; }) => {
+              e.stopPropagation();
+              onClose();
+            }}
+            aria-label={i18next.t("g.close")}
+            title={i18next.t("g.close")}
           />
-        )
-      )}
-      {status === "pending" && <Spinner className="w-4 h-4" />}
+        ) : (
+          status === "default" &&
+          interactable && (
+            <Button
+              noPadding={true}
+              appearance="gray-link"
+              icon={<UilArrowRight />}
+              iconPlacement="right"
+              size="sm"
+              aria-label={i18next.t("waves.view-thread", { defaultValue: "View thread" })}
+            />
+          )
+        )}
+        {status === "pending" && <Spinner className="w-4 h-4" />}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -3047,7 +3047,8 @@
     "replying": "Replying...",
     "success-reply": "You have replied successfully",
     "success-reply-edit": "You have edited successfully",
-    "muted-post": "Muted author's post"
+    "muted-post": "Muted author's post",
+    "source-ecency": "Published via Ecency"
   },
   "events": {
     "muted": "User is muted",

--- a/apps/web/src/specs/features/waves/waves-list-item-header-badge.spec.tsx
+++ b/apps/web/src/specs/features/waves/waves-list-item-header-badge.spec.tsx
@@ -1,0 +1,69 @@
+import { vi } from "vitest";
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// The global @/utils mock only exposes random + getAccessToken; the component
+// relies on the real appName to detect the Ecency source.
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+
+// UserAvatar / TimeLabel come from the heavy @/features/shared barrel; stub the
+// two pieces this header uses so the render stays light and deterministic.
+vi.mock("@/features/shared", () => ({
+  UserAvatar: () => <div data-testid="avatar" />,
+  TimeLabel: () => <span data-testid="time" />
+}));
+
+import { WavesListItemHeader } from "@/app/waves/_components/waves-list-item-header";
+import { WaveEntry } from "@/entities";
+
+function makeEntry(app?: string): WaveEntry {
+  return {
+    author: "alice",
+    permlink: "p",
+    created: "2026-06-24T00:00:00",
+    json_metadata: app ? { app } : {}
+  } as unknown as WaveEntry;
+}
+
+const baseProps = {
+  hasParent: false,
+  pure: true,
+  status: "default",
+  interactable: true
+} as const;
+
+// i18next is globally mocked to echo keys, so the badge alt is the raw key.
+const BADGE = 'img[alt="waves.source-ecency"]';
+
+describe("WavesListItemHeader Ecency badge", () => {
+  it("renders the Ecency badge for waves published from Ecency web", () => {
+    const { container } = render(
+      <WavesListItemHeader entry={makeEntry("ecency/4.4.0-vision")} {...baseProps} />
+    );
+    expect(container.querySelector(BADGE)).not.toBeNull();
+  });
+
+  it("renders the Ecency badge for the Ecency mobile app", () => {
+    const { container } = render(
+      <WavesListItemHeader entry={makeEntry("ecency-mobile")} {...baseProps} />
+    );
+    expect(container.querySelector(BADGE)).not.toBeNull();
+  });
+
+  it("does not render the badge for non-Ecency clients", () => {
+    const { container } = render(
+      <WavesListItemHeader entry={makeEntry("skatehive-mobile")} {...baseProps} />
+    );
+    expect(container.querySelector(BADGE)).toBeNull();
+  });
+
+  it("does not render the badge when app metadata is absent", () => {
+    const { container } = render(<WavesListItemHeader entry={makeEntry()} {...baseProps} />);
+    expect(container.querySelector(BADGE)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds a small Ecency logo to the right side of each wave's header when the wave was published from an Ecency client, so it's easy to spot at a glance which content originated from Ecency (web or mobile).

This mirrors the existing "published via" indicator on posts (`entry-footer-info.tsx`): same detection (`appName(json_metadata.app)` contains "ecency") and the same `logo-circle.svg` asset.

## Detection

- Matches Ecency web (`ecency/x.y-vision`) and Ecency mobile (`ecency-mobile`).
- Does **not** match other clients (e.g. `skatehive-mobile`, `peakd`).

## Where it shows

The header component (`waves-list-item-header.tsx`) is shared by the waves feed and the single-wave view, so the badge appears in both. Tooltip/alt: "Published via Ecency" (new `waves.source-ecency` string).

No new type errors; lint clean. Matches the sibling `entry-footer-info` pattern (which ships the same badge without a dedicated render test).