### PR TITLE
fix(i18n): repair en-US.json broken by waves PR merge

### DIFF
--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -3059,7 +3059,7 @@
     "muted-post": "Muted author's post",
     "not-available": "This wave is no longer available",
     "not-available-hint": "It may have been deleted by its author.",
-    "back-to-waves": "Back to Waves"
+    "back-to-waves": "Back to Waves",
     "source-ecency": "Published via Ecency"
   },
   "events": {


### PR DESCRIPTION
## Problem

`develop` CI is red (Test Web Build, Staging CI/CD, Crowdin Upload). PRs #1013 and #1014 each added keys to the `waves` i18n section right after `muted-post`; merged together the result was missing a comma after `back-to-waves`, so `en-US.json` is invalid JSON. Every apps/web test fails to load i18n, and Crowdin/staging fail to parse it.

## Fix

Add the missing comma after `"back-to-waves": "Back to Waves"`. JSON now parses; previously-failing specs pass again.

Pure merge artifact, not a logic change.