### PR TITLE
Block exchange-like and uid-numeric usernames at signup

### DIFF
--- a/apps/web/src/app/signup/wallet/_components/steps/signup-wallet-choose-username.tsx
+++ b/apps/web/src/app/signup/wallet/_components/steps/signup-wallet-choose-username.tsx
@@ -6,7 +6,7 @@ import { useDebounce } from "react-use";
 import i18next from "i18next";
 import { useQuery } from "@tanstack/react-query";
 import { checkUsernameWalletsPendingQueryOptions, getAccountsQueryOptions } from "@ecency/sdk";
-import { hasRestrictedUsernamePrefix, isExchangeLikeUsername } from "@/utils";
+import { getUsernameError } from "@/utils";
 
 interface Props {
   initialUsername: string;
@@ -35,37 +35,9 @@ export function SignupWalletChooseUsername({ initialUsername, onAvailableUsernam
       return i18next.t("sign-up.username-in-use");
     }
 
-    if (username.length < 2) {
-      return i18next.t("sign-up.username-max-length-error");
-    } else if (username.length > 16) {
-      return i18next.t("sign-up.username-min-length-error");
-    } else {
-      const parts = username.split(".");
-      for (const item of parts) {
-        if (item.length < 3) {
-          return i18next.t("sign-up.username-min-length-error");
-        } else if (!/^[\x00-\x7F]*$/.test(item[0])) {
-          return i18next.t("sign-up.username-no-ascii-first-letter-error");
-        } else if (!/^([a-zA-Z0-9]|-|\.)+$/.test(item)) {
-          return i18next.t("sign-up.username-contains-symbols-error");
-        } else if (item.includes("--")) {
-          return i18next.t("sign-up.username-contains-double-hyphens");
-        } else if (/^\d/.test(item)) {
-          return i18next.t("sign-up.username-starts-number");
-        }
-      }
-
-      // Block names that look like a known exchange deposit account (see
-      // isExchangeLikeUsername) to avoid confusion with unrecoverable transfers.
-      if (isExchangeLikeUsername(username)) {
-        return i18next.t("sign-up.username-resembles-exchange");
-      }
-
-      // Block the "uid" + digits pattern commonly abused for impersonation.
-      if (hasRestrictedUsernamePrefix(username)) {
-        return i18next.t("sign-up.username-restricted-prefix");
-      }
-    }
+    // Single source of truth for chain-validity + exchange/uid policy. Keeps this
+    // step from drifting from the other signup flows (see getUsernameError).
+    return getUsernameError(username) ?? undefined;
   }, [existingAccount, username, hasTouched, data]);
   const canCreateAccount = useMemo(
     () => !usernameError && username && isSuccess,

--- a/apps/web/src/app/signup/wallet/_components/steps/signup-wallet-choose-username.tsx
+++ b/apps/web/src/app/signup/wallet/_components/steps/signup-wallet-choose-username.tsx
@@ -6,6 +6,7 @@ import { useDebounce } from "react-use";
 import i18next from "i18next";
 import { useQuery } from "@tanstack/react-query";
 import { checkUsernameWalletsPendingQueryOptions, getAccountsQueryOptions } from "@ecency/sdk";
+import { hasRestrictedUsernamePrefix, isExchangeLikeUsername } from "@/utils";
 
 interface Props {
   initialUsername: string;
@@ -52,6 +53,17 @@ export function SignupWalletChooseUsername({ initialUsername, onAvailableUsernam
         } else if (/^\d/.test(item)) {
           return i18next.t("sign-up.username-starts-number");
         }
+      }
+
+      // Block names that look like a known exchange deposit account (see
+      // isExchangeLikeUsername) to avoid confusion with unrecoverable transfers.
+      if (isExchangeLikeUsername(username)) {
+        return i18next.t("sign-up.username-resembles-exchange");
+      }
+
+      // Block the "uid" + digits pattern commonly abused for impersonation.
+      if (hasRestrictedUsernamePrefix(username)) {
+        return i18next.t("sign-up.username-restricted-prefix");
       }
     }
   }, [existingAccount, username, hasTouched, data]);

--- a/apps/web/src/consts/exchange-accounts.ts
+++ b/apps/web/src/consts/exchange-accounts.ts
@@ -14,5 +14,6 @@ export const EXCHANGE_ACCOUNTS = [
   "poloniex",
   "upbit-exchange",
   "onepagex",
-  "bdhivesteem"
+  "bdhivesteem",
+  "bitgethive"
 ];

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -392,6 +392,8 @@
     "username-starts-number": "Should not start with Numbers",
     "username-required": "Username is required",
     "username-in-use": "This username already exists. Set another one",
+    "username-resembles-exchange": "This username is too similar to a crypto exchange account and may confuse others. Please choose a more unique name.",
+    "username-restricted-prefix": "Usernames that start with 'uid' followed by numbers are not allowed, as they are commonly used to impersonate others. Please choose a different name.",
     "referral-invalid": "This referral is invalid. Please, try another one",
     "referral-min-length-error": "Length of referral should be at least 3 characters",
     "referral-max-length-error": "Length of referral should be no more than 16 characters",

--- a/apps/web/src/specs/utils/username-validation.spec.tsx
+++ b/apps/web/src/specs/utils/username-validation.spec.tsx
@@ -23,6 +23,7 @@ describe("getUsernameError", () => {
     expect(getUsernameError("mybittrex")).toBe("sign-up.username-resembles-exchange");
     expect(getUsernameError("coinex")).toBe("sign-up.username-resembles-exchange");
     expect(getUsernameError("bitgethive")).toBe("sign-up.username-resembles-exchange");
+    expect(getUsernameError("bitget")).toBe("sign-up.username-resembles-exchange"); // brand core
   });
 
   it("rejects the uid + digits impersonation pattern", () => {

--- a/apps/web/src/specs/utils/username-validation.spec.tsx
+++ b/apps/web/src/specs/utils/username-validation.spec.tsx
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 // Import the file directly (not the @/utils barrel, which is globally mocked) to
 // exercise the real rule. i18next is globally mocked to return keys as-is, so a
 // rejected username yields its message key (truthy) and a valid one yields null.
-import { getUsernameError } from "@/utils/username-validation";
+import {
+  getUsernameError,
+  hasRestrictedUsernamePrefix,
+  isExchangeLikeUsername
+} from "@/utils/username-validation";
 
 describe("getUsernameError", () => {
   it("accepts valid account names", () => {
@@ -10,6 +14,27 @@ describe("getUsernameError", () => {
     expect(getUsernameError("good-karma")).toBeNull();
     expect(getUsernameError("foo.barbaz")).toBeNull();
     expect(getUsernameError("user123")).toBeNull();
+  });
+
+  it("rejects names that resemble a known exchange account", () => {
+    // chain-valid but confusable with an exchange deposit account
+    expect(getUsernameError("bittrex")).toBe("sign-up.username-resembles-exchange");
+    expect(getUsernameError("huobi-pro")).toBe("sign-up.username-resembles-exchange");
+    expect(getUsernameError("mybittrex")).toBe("sign-up.username-resembles-exchange");
+    expect(getUsernameError("coinex")).toBe("sign-up.username-resembles-exchange");
+    expect(getUsernameError("bitgethive")).toBe("sign-up.username-resembles-exchange");
+  });
+
+  it("rejects the uid + digits impersonation pattern", () => {
+    expect(getUsernameError("uid12345")).toBe("sign-up.username-restricted-prefix");
+    expect(getUsernameError("uid007name")).toBe("sign-up.username-restricted-prefix");
+    // "uid" followed by a letter is an ordinary name, not the phishing pattern
+    expect(getUsernameError("uidev")).toBeNull();
+  });
+
+  it("reports a format error before the exchange-resemblance error", () => {
+    // a malformed look-alike should surface its chain-validity error first
+    expect(getUsernameError("bittrex!")).toBe("sign-up.username-contains-symbols-error");
   });
 
   it("rejects a too-short trailing dot-segment (paid-signup incident)", () => {
@@ -31,5 +56,53 @@ describe("getUsernameError", () => {
     // a leading or trailing dot yields an empty segment, which the < 3 check rejects
     expect(getUsernameError("abc.")).toBe("sign-up.username-min-length-error");
     expect(getUsernameError(".abc")).toBe("sign-up.username-min-length-error");
+  });
+});
+
+describe("isExchangeLikeUsername", () => {
+  it("flags exact, separator-variant and embedded exchange names", () => {
+    expect(isExchangeLikeUsername("blocktrades")).toBe(true);
+    expect(isExchangeLikeUsername("huobipro")).toBe(true); // separator dropped
+    expect(isExchangeLikeUsername("huobi-pro")).toBe(true);
+    expect(isExchangeLikeUsername("blocktrades-official")).toBe(true); // embeds brand
+  });
+
+  it("flags the leading brand portion of a deposit/exchange account", () => {
+    expect(isExchangeLikeUsername("upbit")).toBe(true); // upbit-exchange
+    expect(isExchangeLikeUsername("gateio")).toBe(true); // gateiodeposit
+    expect(isExchangeLikeUsername("deepcrypto")).toBe(true); // deepcrypto8
+  });
+
+  it("flags single-character typos of an exchange name", () => {
+    expect(isExchangeLikeUsername("bittrx")).toBe(true); // bittrex
+    expect(isExchangeLikeUsername("changely")).toBe(true); // changelly
+  });
+
+  it("does not flag ordinary names that merely share a fragment", () => {
+    expect(isExchangeLikeUsername("ecency")).toBe(false);
+    expect(isExchangeLikeUsername("good-karma")).toBe(false);
+    expect(isExchangeLikeUsername("trade")).toBe(false); // substring of blocktrades, not a prefix
+    expect(isExchangeLikeUsername("deposit")).toBe(false);
+    expect(isExchangeLikeUsername("blockchain")).toBe(false);
+    expect(isExchangeLikeUsername("changelog")).toBe(false); // 2 edits from changelly
+    // brand-core check: common-word prefixes of single-token brands stay allowed
+    expect(isExchangeLikeUsername("block")).toBe(false); // prefix of blocktrades
+    expect(isExchangeLikeUsername("change")).toBe(false); // prefix of changelly
+  });
+});
+
+describe("hasRestrictedUsernamePrefix", () => {
+  it("flags 'uid' + digits regardless of separators/case", () => {
+    expect(hasRestrictedUsernamePrefix("uid12345")).toBe(true);
+    expect(hasRestrictedUsernamePrefix("UID999")).toBe(true);
+    expect(hasRestrictedUsernamePrefix("u.i.d.123")).toBe(true);
+  });
+
+  it("does not flag 'uid' followed by letters, or names with uid elsewhere", () => {
+    expect(hasRestrictedUsernamePrefix("uidev")).toBe(false); // uid + letter
+    expect(hasRestrictedUsernamePrefix("uidesign")).toBe(false);
+    expect(hasRestrictedUsernamePrefix("ecency")).toBe(false);
+    expect(hasRestrictedUsernamePrefix("druid")).toBe(false);
+    expect(hasRestrictedUsernamePrefix("fluid")).toBe(false);
   });
 });

--- a/apps/web/src/specs/utils/username-validation.spec.tsx
+++ b/apps/web/src/specs/utils/username-validation.spec.tsx
@@ -51,6 +51,7 @@ describe("getUsernameError", () => {
     expect(getUsernameError("a2345678901234567")).toBe("sign-up.username-max-length-error");
     expect(getUsernameError("1abc")).toBe("sign-up.username-starts-number");
     expect(getUsernameError("ab_cd")).toBe("sign-up.username-contains-symbols-error");
+    expect(getUsernameError("ab--cd")).toBe("sign-up.username-contains-double-hyphens");
   });
 
   it("rejects dot-boundary names (empty leading/trailing segment)", () => {

--- a/apps/web/src/utils/username-validation.ts
+++ b/apps/web/src/utils/username-validation.ts
@@ -1,4 +1,5 @@
 import i18next from "i18next";
+import { EXCHANGE_ACCOUNTS } from "@/consts";
 
 export function getUsernameError(username: string): string | null {
     if (!username) return i18next.t("sign-up.username-required");
@@ -24,5 +25,110 @@ export function getUsernameError(username: string): string | null {
         }
     }
 
+    // Block names that impersonate or are easily confused with a known exchange
+    // deposit account. Sending funds to a look-alike account is unrecoverable, so
+    // we steer the user to a more distinctive name. Checked last, after the
+    // chain-validity rules, so a malformed name shows its format error first.
+    if (isExchangeLikeUsername(username)) {
+        return i18next.t("sign-up.username-resembles-exchange");
+    }
+
+    // Block the "uid" + digits pattern commonly abused for impersonation/phishing.
+    if (hasRestrictedUsernamePrefix(username)) {
+        return i18next.t("sign-up.username-restricted-prefix");
+    }
+
     return null;
+}
+
+// Names of the form "uid" + digits (e.g. "uid12345") mimic the numeric user IDs
+// that exchanges and services assign, and have been used to impersonate them.
+// The check is separator/case-insensitive so "u.i.d.1"-style evasion still trips
+// it, but plain words like "uidev" or "fluid" are left alone.
+export function hasRestrictedUsernamePrefix(username: string): boolean {
+    return /^uid\d/.test(normalizeForExchangeMatch(username));
+}
+
+// Strip everything but lowercase letters and digits so separator-only variations
+// ("huobi-pro" vs "huobipro") and casing collapse to the same comparable form.
+function normalizeForExchangeMatch(value: string): string {
+    return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+// Generic tails that exchanges append to a brand when naming a deposit account.
+const GENERIC_EXCHANGE_SUFFIXES = ["deposit", "exchange", "steem", "hive", "pro"];
+
+// Reduce a normalized account name to its distinctive brand, dropping a trailing
+// generic suffix and trailing digits ("gateiodeposit" -> "gateio",
+// "deepcrypto8" -> "deepcrypto"). Single-token names without such a tail
+// ("bittrex", "blocktrades", "changelly") are returned unchanged, so their
+// ordinary-word prefixes ("block", "change") never become a match target.
+function exchangeBrandCore(normalized: string): string {
+    const core = normalized.replace(/\d+$/, "");
+    const suffix = GENERIC_EXCHANGE_SUFFIXES.find(
+        (s) => core.length > s.length && core.endsWith(s)
+    );
+    return suffix ? core.slice(0, -suffix.length) : core;
+}
+
+// Classic iterative Levenshtein (single rolling row) for short username strings.
+function levenshtein(a: string, b: string): number {
+    if (a === b) return 0;
+    if (a.length === 0) return b.length;
+    if (b.length === 0) return a.length;
+
+    let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+    for (let i = 0; i < a.length; i++) {
+        const curr = [i + 1];
+        for (let j = 0; j < b.length; j++) {
+            const cost = a[i] === b[j] ? 0 : 1;
+            curr.push(Math.min(prev[j + 1] + 1, curr[j] + 1, prev[j] + cost));
+        }
+        prev = curr;
+    }
+    return prev[b.length];
+}
+
+/**
+ * True when `username` is identical or close enough to a known exchange deposit
+ * account that it could be mistaken for one. Matching is intentionally
+ * conservative to avoid false positives on ordinary names:
+ *   1. exact match against the full account or its brand core, ignoring
+ *      separators/casing ("huobi-pro" ~ "huobipro", "coinex" -> coinexdeposit);
+ *   2. the chosen name embeds the full account name ("mybittrex") or, when the
+ *      brand is distinct from the full name, the brand core ("upbitcoin");
+ *   3. a single-character typo of the full account name ("bittrx").
+ */
+export function isExchangeLikeUsername(username: string): boolean {
+    const candidate = normalizeForExchangeMatch(username);
+    // Too short to meaningfully resemble any (>= 7 char) exchange account name.
+    if (candidate.length < 3) return false;
+
+    return EXCHANGE_ACCOUNTS.some((account) => {
+        const exchange = normalizeForExchangeMatch(account);
+        if (!exchange) return false;
+        const core = exchangeBrandCore(exchange);
+
+        // 1. exact match against the full account or its (>= 4 char) brand core
+        if (candidate === exchange) return true;
+        if (core.length >= 4 && candidate === core) return true;
+
+        // 2. the chosen name wraps the whole account name, or the distinct brand core
+        if (candidate.length > exchange.length && candidate.includes(exchange)) return true;
+        if (
+            core !== exchange &&
+            core.length >= 4 &&
+            candidate.length > core.length &&
+            candidate.includes(core)
+        ) {
+            return true;
+        }
+
+        // 3. single-character typo of the full account name at comparable length
+        if (Math.abs(candidate.length - exchange.length) <= 1 && levenshtein(candidate, exchange) <= 1) {
+            return true;
+        }
+
+        return false;
+    });
 }

--- a/apps/web/src/utils/username-validation.ts
+++ b/apps/web/src/utils/username-validation.ts
@@ -63,6 +63,9 @@ const GENERIC_EXCHANGE_SUFFIXES = ["deposit", "exchange", "steem", "hive", "pro"
 // "deepcrypto8" -> "deepcrypto"). Single-token names without such a tail
 // ("bittrex", "blocktrades", "changelly") are returned unchanged, so their
 // ordinary-word prefixes ("block", "change") never become a match target.
+// Strips a single (outermost) suffix, which covers every account in the current
+// list; a future account with a compounded tail (e.g. "brandproexchange") would
+// need this extended to strip iteratively.
 function exchangeBrandCore(normalized: string): string {
     const core = normalized.replace(/\d+$/, "");
     const suffix = GENERIC_EXCHANGE_SUFFIXES.find(
@@ -101,7 +104,8 @@ function levenshtein(a: string, b: string): number {
  */
 export function isExchangeLikeUsername(username: string): boolean {
     const candidate = normalizeForExchangeMatch(username);
-    // Too short to meaningfully resemble any (>= 7 char) exchange account name.
+    // Cheap early-out for 1-2 char inputs; anything still short simply fails every
+    // rule below (brand cores are >= 4, full names >= 7, embed/typo need length).
     if (candidate.length < 3) return false;
 
     return EXCHANGE_ACCOUNTS.some((account) => {
@@ -109,7 +113,9 @@ export function isExchangeLikeUsername(username: string): boolean {
         if (!exchange) return false;
         const core = exchangeBrandCore(exchange);
 
-        // 1. exact match against the full account or its (>= 4 char) brand core
+        // 1. exact match against the full account or its (>= 4 char) brand core.
+        //    The >= 4 guard drops the only sub-4 core ("mxc", from "mxchive"), so a
+        //    3-char fragment can't over-match; "mxchive" is still caught in full.
         if (candidate === exchange) return true;
         if (core.length >= 4 && candidate === core) return true;
 

--- a/apps/web/src/utils/username-validation.ts
+++ b/apps/web/src/utils/username-validation.ts
@@ -20,6 +20,9 @@ export function getUsernameError(username: string): string | null {
         if (/^\d/.test(segment)) {
             return i18next.t("sign-up.username-starts-number");
         }
+        if (segment.includes("--")) {
+            return i18next.t("sign-up.username-contains-double-hyphens");
+        }
         if (segment.startsWith("-") || segment.endsWith("-")) {
             return i18next.t("sign-up.username-invalid-hyphen-position");
         }


### PR DESCRIPTION
## What
Blocks signup usernames that **match or closely resemble a known exchange deposit account**, or that follow the **`uid` + digits** impersonation pattern. Blocked users get a clear message asking them to pick a more unique name.

## Why
Account names that look like an exchange deposit account (or a `uid12345`-style identifier) are easily confused with the real thing and have been used for impersonation. Funds sent to a look-alike account are typically unrecoverable.

## How
- `getUsernameError` now also runs `isExchangeLikeUsername` and `hasRestrictedUsernamePrefix`, so free, premium and invited signup inherit the rule; the wallet signup step (own inline validation) calls the same helpers.
- `isExchangeLikeUsername` matches on: exact (separator/case-insensitive), full-name or brand-core embedding, exact brand core, and single-character typos. Brand core is derived by stripping generic tails (`deposit`/`exchange`/`pro`/`hive`/`steem` + trailing digits), so ordinary words like `block` and `change` are **not** flagged.
- `hasRestrictedUsernamePrefix` matches `uid` followed by a digit (separator-insensitive); plain names like `uidev`/`fluid` are unaffected.
- Added `bitgethive` (Bitget) to the exchange list.
- New strings: `sign-up.username-resembles-exchange`, `sign-up.username-restricted-prefix` (en-US).

## Tests
Extended `username-validation.spec.tsx` (exchange resemblance, brand-core false-positive guards, `uid`+digits, separator handling). Validation + signup/utils specs green.
