### PR TITLE
fix(sentry): drop synthetic DOM Event captures in beforeSend

### DIFF
--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -214,3 +214,62 @@ describe("beforeSend — webkit.messageHandlers (non-WKWebView) is dropped", () 
     expect(beforeSend(ev)).toBe(ev);
   });
 });
+
+describe("beforeSend — synthetic DOM Event capture is dropped", () => {
+  // ECENCY-NEXT-1F6Y: captureException handed a DOM `Event`/`ErrorEvent` instead
+  // of an Error (failed resource load onerror, or a promise rejected with the raw
+  // browser event). The SDK wraps the non-Error input as a SYNTHETIC exception
+  // whose `type` is the DOM interface name and whose only frame is its own capture
+  // call. No app frame, no actionable info, overwhelmingly bot/crawler traffic —
+  // dropped as noise. Requires BOTH the DOM type AND the synthetic flag.
+  function makeSynthetic(
+    type: "Event" | "ErrorEvent",
+    opts: { synthetic?: boolean; frames?: { filename?: string }[] } = {}
+  ): Ev {
+    return {
+      exception: {
+        values: [
+          {
+            type,
+            value: `Event \`${type}\` (type=error) captured as exception`,
+            stacktrace: { frames: opts.frames ?? [{ filename: "@sentry/core/exports.js" }] },
+            mechanism: { type: "generic", handled: true, synthetic: opts.synthetic ?? true }
+          }
+        ]
+      }
+    } as unknown as Ev;
+  }
+
+  it("drops a synthetic DOM Event captured as exception", () => {
+    expect(beforeSend(makeSynthetic("Event"))).toBeNull();
+  });
+
+  it("drops a synthetic ErrorEvent captured as exception", () => {
+    expect(beforeSend(makeSynthetic("ErrorEvent"))).toBeNull();
+  });
+
+  it("does NOT drop a DOM-Event-typed exception that is NOT synthetic", () => {
+    // Without the synthetic flag we can't be sure the SDK fabricated it from a
+    // non-Error input, so keep it rather than risk dropping a real capture.
+    const ev = makeSynthetic("Event", { synthetic: false, frames: [APP_FRAME] });
+    expect(beforeSend(ev)).toBe(ev);
+  });
+
+  it("does NOT drop a synthetic capture whose type is a real Error", () => {
+    // `synthetic: true` alone (e.g. a captured non-Error string/object the app
+    // threw with context) must NOT be swept up — only DOM Event types are.
+    const ev = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "boom",
+            stacktrace: { frames: [APP_FRAME] },
+            mechanism: { type: "generic", handled: true, synthetic: true }
+          }
+        ]
+      }
+    } as unknown as Ev;
+    expect(beforeSend(ev)).toBe(ev);
+  });
+});

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -29,6 +29,24 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
   const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
   const stackStr = JSON.stringify(frames);
 
+  // ECENCY-NEXT-1F6Y: a DOM `Event`/`ErrorEvent` handed to captureException
+  // instead of an Error. A failed resource load (<img>/<script>/<link> firing
+  // `onerror`) or a promise rejected with the raw browser event reaches the SDK,
+  // which wraps the non-Error input as a SYNTHETIC exception whose `type` is the
+  // DOM interface name ("Event"/"ErrorEvent") and whose only frame is the SDK's
+  // own capture call (no app frame, no actionable info). These are environmental
+  // — overwhelmingly bot/crawler traffic failing resource fetches on post pages,
+  // never an Ecency bug — and were the project's #1-volume issue, repeatedly
+  // tripping the "Critical errors" alert. You never `throw new Event()`, so a real
+  // error can't carry this type; we additionally require the `synthetic` flag so a
+  // (hypothetical) deliberately-captured Event with real context is still kept.
+  if (
+    (exceptionType === "Event" || exceptionType === "ErrorEvent") &&
+    event.exception?.values?.[0]?.mechanism?.synthetic
+  ) {
+    return null;
+  }
+
   // Deploy/version skew: a stale tab requests a chunk whose module id changed in
   // a newer build, so the webpack runtime is handed an undefined module factory
   // (Chrome "reading 'call'", Firefox "e[c] is undefined", Safari "evaluating


### PR DESCRIPTION
## Problem

The highest-volume issue in the project is `Sentry.captureException()` being handed a DOM `Event`/`ErrorEvent` instead of an `Error`. This happens when a resource fails to load (`<img>`/`<script>`/`<link>` firing `onerror`) or a promise is rejected with the raw browser event. The SDK wraps the non-`Error` input as a **synthetic** exception:

- `type` = the DOM interface name (`Event` / `ErrorEvent`)
- value = `` Event `Event` (type=error) captured as exception ``
- mechanism = `{ type: "generic", synthetic: true, handled: true }`
- the only stack frame is the SDK's own capture call (no app frame)

These carry no actionable information (the page renders fine; nothing is thrown from app code), yet they dominate event volume and repeatedly trip the "Critical errors" alert, causing alert fatigue that masks real incidents.

## Fix

Drop these in the single `beforeSend` hook, matching the existing noise-filter pattern in this file. The guard requires **both**:

1. exception `type` is `Event` or `ErrorEvent` (DOM interface names — a real thrown error is always an `Error` subclass, never these), and
2. the `synthetic` mechanism flag is set (the SDK fabricated the exception from a non-`Error` input).

A genuinely thrown error can never satisfy both, so real bugs are never dropped. Both capture paths (the early-error buffer replay and the post-init global handlers) funnel through `beforeSend`, so this one hook covers all of them.

## Tests

Adds 4 regression specs: drops synthetic `Event` and `ErrorEvent`; keeps a DOM-typed exception that is **not** synthetic; keeps a synthetic capture whose type is a real `Error`. Full `sentry-before-send` suite green (27 tests), no new type or lint errors.