### PR TITLE
feat(api): add /api/speak-audio transcode endpoint for Liketu Speak voice posts

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -71,6 +71,15 @@ ENTRYPOINT ["/tini", "--"]
 
 ENV NODE_ENV=production
 
+# ffmpeg powers the /api/speak-audio endpoint, which transcodes Liketu "Speak"
+# voice posts (Opus/WebM) to AAC/m4a so iOS AVPlayer (react-native-video, Safari)
+# can play them. Runtime-only dependency; the build stage does not need it.
+# Installed before the app artifacts COPY so this apt layer caches across
+# code-only deploys.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg \
+  && rm -rf /var/lib/apt/lists/*
+
 # Carry the Sentry release identifier into the runtime container.
 # Build-args don't cross stage boundaries automatically — each stage that
 # needs them must redeclare ARG. Without this the server and edge runtimes

--- a/apps/web/src/app/api/speak-audio/route.ts
+++ b/apps/web/src/app/api/speak-audio/route.ts
@@ -41,9 +41,12 @@ const MAX_OUTPUT_BYTES = 30 * 1024 * 1024;
 // changes. Long max-age + s-maxage lets both the browser and the CF edge pin it.
 const AUDIO_CACHE_CONTROL = "public, max-age=31536000, s-maxage=31536000, immutable";
 
-// Bound concurrent ffmpeg processes so a burst of cache-miss requests can't
-// saturate the box CPU. Excess requests get a short 503 + Retry-After; CF and
-// the client retry, and by then the cache is usually warm.
+// Bound concurrent source downloads (memory + connections) separately from ffmpeg
+// (CPU): a slow download must not hold a CPU slot, and a cache-miss burst must not
+// buffer unbounded input. Excess on either gate gets a short 503 + Retry-After; CF
+// and the client retry, and by then the cache is usually warm.
+const MAX_CONCURRENT_FETCHES = 8;
+let activeFetches = 0;
 const MAX_CONCURRENT_TRANSCODES = 4;
 let activeTranscodes = 0;
 
@@ -204,14 +207,14 @@ async function resolveAndPin(hostname: string): Promise<Agent> {
 
 /** Download the source audio with the pinned dispatcher, timeout and size cap. */
 async function fetchAudio(url: URL): Promise<Buffer> {
-  // parseSpeakSource already pinned the host, but rebuild the request URL against
-  // a CONSTANT base so the authority can only ever be cdn.liketu.com regardless of
-  // any URL-parsing quirk (userinfo, etc.). Only the validated path + query carry
-  // over — the user value never controls the request host.
-  const safeUrl = new URL(`${url.pathname}${url.search}`, `https://${ALLOWED_HOST}`);
-  const dispatcher = await resolveAndPin(safeUrl.hostname);
+  // parseSpeakSource already validated the host is exactly cdn.liketu.com, so fetch
+  // the validated URL as-is. Do NOT rebuild it from url.pathname against a base — a
+  // pathname like "//evil.com/x" makes `new URL(path, base)` adopt evil.com as the
+  // host. Fetching the original URL keeps the request on the validated host (the
+  // odd path is just a 404 on cdn.liketu.com).
+  const dispatcher = await resolveAndPin(url.hostname);
   try {
-    const res = await fetch(safeUrl, {
+    const res = await fetch(url, {
       redirect: "error", // a content-addressed CDN file should never redirect
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       ...({ dispatcher } as { dispatcher: Agent })
@@ -374,9 +377,19 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    // Fetch first (I/O, already size/timeout-capped). The concurrency cap guards
-    // only the CPU-bound ffmpeg step below, so slow downloads can't starve it.
-    const input = await fetchAudio(url);
+    // Bound downloads and transcodes on separate gates (see the constants above):
+    // the fetch is I/O (memory/connections), ffmpeg is CPU. Capping only one lets
+    // the other be exhausted, which is exactly what two earlier review rounds hit.
+    if (activeFetches >= MAX_CONCURRENT_FETCHES) {
+      return jsonError("BUSY", 503, { "Retry-After": "2" });
+    }
+    activeFetches += 1;
+    let input: Buffer;
+    try {
+      input = await fetchAudio(url);
+    } finally {
+      activeFetches -= 1;
+    }
     const ext = (url.pathname.match(ALLOWED_EXT)?.[0] ?? ".webm").toLowerCase();
 
     if (activeTranscodes >= MAX_CONCURRENT_TRANSCODES) {
@@ -392,11 +405,12 @@ export async function GET(request: NextRequest) {
 
     return buildAudioResponse(output, request.headers.get("range"));
   } catch (e) {
-    const err = e as CodedError;
-    const isTimeout =
-      err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
-    const code = isTimeout ? "FETCH_TIMEOUT" : (err?.code ?? "TRANSCODE_FAILED");
-    const status = isTimeout ? 504 : typeof err?.status === "number" ? err.status : 502;
+    // Only trust code/status from our own CodedError; a stray Node error (e.g. a
+    // filesystem errno from the temp-file dance) must not leak as the client code.
+    const coded = e instanceof CodedError ? e : null;
+    const isTimeout = e instanceof Error && (e.name === "TimeoutError" || e.name === "AbortError");
+    const code = isTimeout ? "FETCH_TIMEOUT" : (coded?.code ?? "TRANSCODE_FAILED");
+    const status = isTimeout ? 504 : (coded?.status ?? 502);
     return jsonError(code, status);
   }
 }

--- a/apps/web/src/app/api/speak-audio/route.ts
+++ b/apps/web/src/app/api/speak-audio/route.ts
@@ -1,4 +1,7 @@
 import { NextRequest } from "next/server";
+// React-free SDK entry: this server route only needs a raw bridge RPC, not the
+// full @ecency/sdk (react-query). @ecency/sdk/hive ships just the tx/RPC engine.
+import { callRPC } from "@ecency/sdk/hive";
 import { Resolver } from "node:dns/promises";
 import { isIP, type LookupFunction } from "node:net";
 import { Agent } from "undici";
@@ -14,16 +17,21 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 // -----------------------------------------------------------------------------
-// /api/speak-audio?src=<cdn.liketu.com ...webm>
+// /api/speak-audio?author=<a>&permlink=<p>
 //
 // Liketu "Speak" voice posts store their audio as Opus-in-WebM on cdn.liketu.com.
 // Browsers (and Android/ExoPlayer) play that natively, but iOS AVPlayer — what
 // react-native-video and Safari use — cannot demux WebM or decode Opus. This
 // endpoint transcodes the clip to AAC/m4a so every client can play it.
 //
-// The source audio is immutable (content-addressed CDN path), so the response is
-// marked immutable + long-TTL: Cloudflare edge-caches each clip and the origin
-// only transcodes on a cache miss (a handful per day at Speak's volume).
+// The clip URL is NOT taken from the request: the endpoint looks the wave up on
+// chain (getPost) and reads json_metadata.speak.audio_url, then validates it is a
+// cdn.liketu.com /liketu/ media file. So the fetch target is derived from trusted
+// on-chain data rather than a user-supplied URL.
+//
+// The audio is immutable (content-addressed), so the response is immutable +
+// long-TTL: Cloudflare edge-caches each clip and the origin only transcodes on a
+// cache miss (a handful per day at Speak's volume).
 // -----------------------------------------------------------------------------
 
 const ALLOWED_HOST = "cdn.liketu.com";
@@ -32,6 +40,7 @@ const ALLOWED_HOST = "cdn.liketu.com";
 // obviously-wrong inputs early.
 const ALLOWED_EXT = /\.(?:webm|mp3|m4a|ogg|wav)$/i;
 
+const LOOKUP_TIMEOUT_MS = 8_000;
 const FETCH_TIMEOUT_MS = 15_000;
 const FFMPEG_TIMEOUT_MS = 30_000;
 const MAX_INPUT_BYTES = 25 * 1024 * 1024; // 25MB — voice clips are well under 1MB
@@ -59,9 +68,26 @@ class CodedError extends Error {
   }
 }
 
+// Hive account names: 3-16 chars, lowercase letters/digits/dot/hyphen. Exported
+// for tests. Keeps the looked-up reference well-formed before it reaches getPost.
+export const isValidAuthor = (a: string | null): a is string => !!a && /^[a-z0-9.-]{3,16}$/.test(a);
+
+// Permlinks: lowercase letters/digits/hyphens (bounded length). Exported for tests.
+export const isValidPermlink = (p: string | null): p is string =>
+  !!p && /^[a-z0-9-]{1,256}$/.test(p);
+
+function safeJsonParse(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Synchronous URL validation: https + exact host allowlist + audio extension +
- * default port only. Exported for unit tests. Returns the parsed URL.
+ * Validate an on-chain speak audio URL: https + exact cdn.liketu.com host +
+ * default port + audio extension + /liketu/ media path. Throws a CodedError on
+ * any failure. Exported for unit tests. Returns the parsed URL.
  */
 export function parseSpeakSource(src: unknown): URL {
   if (!src || typeof src !== "string") {
@@ -375,12 +401,40 @@ function buildAudioResponse(output: Buffer, rangeHeader: string | null): Respons
 }
 
 export async function GET(request: NextRequest) {
+  const author = request.nextUrl.searchParams.get("author");
+  const permlink = request.nextUrl.searchParams.get("permlink");
+  if (!isValidAuthor(author) || !isValidPermlink(permlink)) {
+    return jsonError("INVALID_REF", 400);
+  }
+
+  // Derive the audio URL from the on-chain post (trusted lookup), NOT from a
+  // request parameter, so the eventual fetch target is never directly user-
+  // controlled. The looked-up URL is still validated as a cdn.liketu.com /liketu/
+  // media file before anything is fetched.
   let url: URL;
   try {
-    url = parseSpeakSource(request.nextUrl.searchParams.get("src"));
+    const post = await callRPC<{ json_metadata?: unknown } | null>(
+      "bridge.get_post",
+      { author, permlink, observer: "" },
+      LOOKUP_TIMEOUT_MS
+    );
+    // bridge.get_post usually returns json_metadata already parsed, but tolerate a
+    // raw JSON string too.
+    const raw = post?.json_metadata;
+    const meta = (typeof raw === "string" ? safeJsonParse(raw) : raw) as
+      | { speak?: { audio_url?: string } }
+      | null
+      | undefined;
+    const audioUrl = meta?.speak?.audio_url;
+    if (!audioUrl) {
+      return jsonError("NOT_SPEAK", 404);
+    }
+    url = parseSpeakSource(audioUrl);
   } catch (e) {
-    const err = e as CodedError;
-    return jsonError(err.code ?? "INVALID_SRC", err.status ?? 400);
+    const coded = e instanceof CodedError ? e : null;
+    // CodedError => the on-chain URL failed host/path/ext validation; anything
+    // else => the bridge lookup itself failed. Never leak a stray errno.
+    return coded ? jsonError(coded.code, coded.status) : jsonError("LOOKUP_FAILED", 502);
   }
 
   try {

--- a/apps/web/src/app/api/speak-audio/route.ts
+++ b/apps/web/src/app/api/speak-audio/route.ts
@@ -48,7 +48,10 @@ const MAX_CONCURRENT_TRANSCODES = 4;
 let activeTranscodes = 0;
 
 class CodedError extends Error {
-  constructor(public code: string, public status: number) {
+  constructor(
+    public code: string,
+    public status: number
+  ) {
     super(code);
   }
 }
@@ -104,11 +107,24 @@ function expandIPv6(ip: string): string {
   return [...left, ...mid, ...right].map((g) => g.padStart(4, "0")).join(":");
 }
 
-/** True for non-globally-routable IPs (defense-in-depth against DNS rebinding). */
-function isPrivateIP(ip: string): boolean {
+/**
+ * True for non-globally-routable IPs (defense-in-depth against DNS rebinding).
+ * Mirrors apps/web/src/app/api/import/route.ts — handles IPv4-mapped IPv6 in
+ * both dotted and hex form, plus the reserved/special-use ranges. Exported for tests.
+ */
+export function isPrivateIP(ip: string): boolean {
   let normalized = ip;
   const v4Mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
-  if (v4Mapped) normalized = v4Mapped[1];
+  if (v4Mapped) {
+    normalized = v4Mapped[1];
+  }
+  // IPv4-mapped IPv6 in hex form, e.g. ::ffff:0a00:0001 == 10.0.0.1
+  const v4MappedHex = ip.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (v4MappedHex) {
+    const high = parseInt(v4MappedHex[1], 16);
+    const low = parseInt(v4MappedHex[2], 16);
+    normalized = `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+  }
 
   if (isIP(normalized) === 4) {
     const [a, b, c] = normalized.split(".").map(Number);
@@ -118,8 +134,13 @@ function isPrivateIP(ip: string): boolean {
     if (a === 127) return true; // loopback
     if (a === 169 && b === 254) return true; // link-local
     if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918
+    if (a === 192 && b === 0 && c === 0) return true; // 192.0.0.0/24 IETF protocol
+    if (a === 192 && b === 0 && c === 2) return true; // 192.0.2.0/24 TEST-NET-1
+    if (a === 192 && b === 88 && c === 99) return true; // 192.88.99.0/24 6to4 relay
     if (a === 192 && b === 168) return true; // RFC1918
-    if (a === 192 && b === 0 && c === 0) return true; // IETF protocol
+    if (a === 198 && b >= 18 && b <= 19) return true; // 198.18.0.0/15 benchmarking
+    if (a === 198 && b === 51 && c === 100) return true; // 198.51.100.0/24 TEST-NET-2
+    if (a === 203 && b === 0 && c === 113) return true; // 203.0.113.0/24 TEST-NET-3
     if (a >= 224) return true; // multicast + reserved
     return false;
   }
@@ -131,6 +152,9 @@ function isPrivateIP(ip: string): boolean {
     const g1 = parseInt(full.slice(0, 4), 16);
     if (g1 >= 0xfc00 && g1 <= 0xfdff) return true; // fc00::/7 ULA
     if ((g1 & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+    if (full.startsWith("2001:0db8")) return true; // 2001:db8::/32 documentation
+    if (full.startsWith("2001:0000")) return true; // 2001::/32 Teredo
+    if (full.startsWith("0100:0000:0000:0000")) return true; // 100::/64 discard
     if (g1 >= 0xff00) return true; // ff00::/8 multicast
     return false;
   }
@@ -180,9 +204,14 @@ async function resolveAndPin(hostname: string): Promise<Agent> {
 
 /** Download the source audio with the pinned dispatcher, timeout and size cap. */
 async function fetchAudio(url: URL): Promise<Buffer> {
-  const dispatcher = await resolveAndPin(url.hostname);
+  // parseSpeakSource already pinned the host, but rebuild the request URL against
+  // a CONSTANT base so the authority can only ever be cdn.liketu.com regardless of
+  // any URL-parsing quirk (userinfo, etc.). Only the validated path + query carry
+  // over — the user value never controls the request host.
+  const safeUrl = new URL(`${url.pathname}${url.search}`, `https://${ALLOWED_HOST}`);
+  const dispatcher = await resolveAndPin(safeUrl.hostname);
   try {
-    const res = await fetch(url.toString(), {
+    const res = await fetch(safeUrl, {
       redirect: "error", // a content-addressed CDN file should never redirect
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       ...({ dispatcher } as { dispatcher: Agent })
@@ -244,8 +273,12 @@ async function transcodeToAac(input: Buffer, ext: string): Promise<Buffer> {
         (err) => (err ? reject(new CodedError("TRANSCODE_FAILED", 502)) : resolve())
       );
     });
+    // Only reached when ffmpeg exited 0. Still verify the output is a real MP4
+    // (the `ftyp` box sits at the start) so a truncated/partial file from an
+    // edge-case exit can never be served — and cached — as valid audio.
     const out = await readFile(outPath);
-    if (out.byteLength === 0 || out.byteLength > MAX_OUTPUT_BYTES) {
+    const looksLikeMp4 = out.subarray(0, 16).includes(Buffer.from("ftyp"));
+    if (out.byteLength === 0 || out.byteLength > MAX_OUTPUT_BYTES || !looksLikeMp4) {
       throw new CodedError("TRANSCODE_FAILED", 502);
     }
     return out;
@@ -254,51 +287,116 @@ async function transcodeToAac(input: Buffer, ext: string): Promise<Buffer> {
   }
 }
 
+function jsonError(code: string, status: number, extra?: Record<string, string>): Response {
+  // Errors must never be cached — a cached 503 BUSY or 4xx would outlive its cause.
+  return Response.json(
+    { error: code },
+    { status, headers: { "Cache-Control": "no-store", ...extra } }
+  );
+}
+
+const audioHeaders = (extra: Record<string, string>): Record<string, string> => ({
+  "Content-Type": "audio/mp4",
+  "Accept-Ranges": "bytes",
+  "Cache-Control": AUDIO_CACHE_CONTROL,
+  "X-Content-Type-Options": "nosniff",
+  ...extra
+});
+
+/**
+ * Parse a single HTTP Range header against a known content size. Returns the
+ * inclusive byte range, "unsatisfiable" for an out-of-bounds range, or null when
+ * there is no honourable single range. Exported for tests.
+ */
+export function parseRange(
+  rangeHeader: string | null,
+  size: number
+): { start: number; end: number } | "unsatisfiable" | null {
+  if (!rangeHeader) return null;
+  const m = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+  if (!m) return null;
+  const hasStart = m[1] !== "";
+  const hasEnd = m[2] !== "";
+  if (!hasStart && !hasEnd) return null;
+
+  let start: number;
+  let end: number;
+  if (!hasStart) {
+    // suffix range: final N bytes
+    const n = parseInt(m[2], 10);
+    if (!Number.isFinite(n) || n <= 0) return "unsatisfiable";
+    start = Math.max(0, size - n);
+    end = size - 1;
+  } else {
+    start = parseInt(m[1], 10);
+    end = hasEnd ? parseInt(m[2], 10) : size - 1;
+  }
+  if (Number.isNaN(start) || Number.isNaN(end) || start > end || start >= size) {
+    return "unsatisfiable";
+  }
+  return { start, end: Math.min(end, size - 1) };
+}
+
+/** Build the audio response, honouring a Range request (206/416) when present. */
+function buildAudioResponse(output: Buffer, rangeHeader: string | null): Response {
+  const size = output.byteLength;
+  const range = parseRange(rangeHeader, size);
+  if (range === "unsatisfiable") {
+    return new Response(null, {
+      status: 416,
+      headers: { "Content-Range": `bytes */${size}`, "Cache-Control": "no-store" }
+    });
+  }
+  if (range) {
+    const chunk = output.subarray(range.start, range.end + 1);
+    return new Response(new Uint8Array(chunk), {
+      status: 206,
+      headers: audioHeaders({
+        "Content-Range": `bytes ${range.start}-${range.end}/${size}`,
+        "Content-Length": String(chunk.byteLength)
+      })
+    });
+  }
+  // Node Buffer isn't a DOM BodyInit; hand the Response a plain Uint8Array view.
+  return new Response(new Uint8Array(output), {
+    status: 200,
+    headers: audioHeaders({ "Content-Length": String(size) })
+  });
+}
+
 export async function GET(request: NextRequest) {
   let url: URL;
   try {
     url = parseSpeakSource(request.nextUrl.searchParams.get("src"));
   } catch (e) {
     const err = e as CodedError;
-    return Response.json({ error: err.code }, { status: err.status ?? 400 });
+    return jsonError(err.code ?? "INVALID_SRC", err.status ?? 400);
   }
 
-  if (activeTranscodes >= MAX_CONCURRENT_TRANSCODES) {
-    return Response.json(
-      { error: "BUSY" },
-      { status: 503, headers: { "Retry-After": "2" } }
-    );
-  }
-
-  activeTranscodes += 1;
   try {
+    // Fetch first (I/O, already size/timeout-capped). The concurrency cap guards
+    // only the CPU-bound ffmpeg step below, so slow downloads can't starve it.
     const input = await fetchAudio(url);
     const ext = (url.pathname.match(ALLOWED_EXT)?.[0] ?? ".webm").toLowerCase();
-    const output = await transcodeToAac(input, ext);
 
-    // Node Buffer isn't a DOM BodyInit; hand the Response a plain Uint8Array view.
-    return new Response(new Uint8Array(output), {
-      status: 200,
-      headers: {
-        "Content-Type": "audio/mp4",
-        "Content-Length": String(output.byteLength),
-        "Cache-Control": AUDIO_CACHE_CONTROL,
-        "X-Content-Type-Options": "nosniff"
-      }
-    });
+    if (activeTranscodes >= MAX_CONCURRENT_TRANSCODES) {
+      return jsonError("BUSY", 503, { "Retry-After": "2" });
+    }
+    activeTranscodes += 1;
+    let output: Buffer;
+    try {
+      output = await transcodeToAac(input, ext);
+    } finally {
+      activeTranscodes -= 1;
+    }
+
+    return buildAudioResponse(output, request.headers.get("range"));
   } catch (e) {
     const err = e as CodedError;
-    const status = typeof err?.status === "number" ? err.status : 502;
-    const code =
-      err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError")
-        ? "FETCH_TIMEOUT"
-        : err?.code ?? "TRANSCODE_FAILED";
-    // Never let an error response get cached.
-    return Response.json(
-      { error: code },
-      { status: code === "FETCH_TIMEOUT" ? 504 : status, headers: { "Cache-Control": "no-store" } }
-    );
-  } finally {
-    activeTranscodes -= 1;
+    const isTimeout =
+      err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
+    const code = isTimeout ? "FETCH_TIMEOUT" : (err?.code ?? "TRANSCODE_FAILED");
+    const status = isTimeout ? 504 : typeof err?.status === "number" ? err.status : 502;
+    return jsonError(code, status);
   }
 }

--- a/apps/web/src/app/api/speak-audio/route.ts
+++ b/apps/web/src/app/api/speak-audio/route.ts
@@ -41,6 +41,10 @@ const ALLOWED_HOST = "cdn.liketu.com";
 const ALLOWED_EXT = /\.(?:webm|mp3|m4a|ogg|wav)$/i;
 
 const LOOKUP_TIMEOUT_MS = 8_000;
+// A lagging Hive node can briefly return null for a freshly-posted wave; retry a
+// couple of times with a short backoff before concluding the clip is absent.
+const POST_LOOKUP_RETRIES = 2;
+const LOOKUP_RETRY_DELAY_MS = 350;
 const FETCH_TIMEOUT_MS = 15_000;
 const FFMPEG_TIMEOUT_MS = 30_000;
 const MAX_INPUT_BYTES = 25 * 1024 * 1024; // 25MB — voice clips are well under 1MB
@@ -83,6 +87,8 @@ function safeJsonParse(s: string): unknown {
     return null;
   }
 }
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 /**
  * Validate an on-chain speak audio URL: https + exact cdn.liketu.com host +
@@ -373,8 +379,8 @@ export function parseRange(
   return { start, end: Math.min(end, size - 1) };
 }
 
-/** Build the audio response, honouring a Range request (206/416) when present. */
-function buildAudioResponse(output: Buffer, rangeHeader: string | null): Response {
+/** Build the audio response, honouring a Range request (206/416) when present. Exported for tests. */
+export function buildAudioResponse(output: Buffer, rangeHeader: string | null): Response {
   const size = output.byteLength;
   const range = parseRange(rangeHeader, size);
   if (range === "unsatisfiable") {
@@ -387,10 +393,18 @@ function buildAudioResponse(output: Buffer, rangeHeader: string | null): Respons
     const chunk = output.subarray(range.start, range.end + 1);
     return new Response(new Uint8Array(chunk), {
       status: 206,
-      headers: audioHeaders({
+      headers: {
+        "Content-Type": "audio/mp4",
+        "Accept-Ranges": "bytes",
         "Content-Range": `bytes ${range.start}-${range.end}/${size}`,
-        "Content-Length": String(chunk.byteLength)
-      })
+        "Content-Length": String(chunk.byteLength),
+        // A partial must NEVER be cached as the canonical object: only the full
+        // 200 carries the immutable cache, so a 206 can't poison the cache for a
+        // later no-Range request. (Cloudflare fetches the full object on a range
+        // miss and serves ranges from it, so this doesn't hurt the hit rate.)
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff"
+      }
     });
   }
   // Node Buffer isn't a DOM BodyInit; hand the Response a plain Uint8Array view.
@@ -413,14 +427,26 @@ export async function GET(request: NextRequest) {
   // media file before anything is fetched.
   let url: URL;
   try {
-    const post = await callRPC<{ json_metadata?: unknown } | null>(
-      "bridge.get_post",
-      { author, permlink, observer: "" },
-      LOOKUP_TIMEOUT_MS
-    );
+    // The wave came from the feed, so it exists on chain. Retry a null result a
+    // couple of times (a lagging node can momentarily miss a fresh post) before
+    // concluding it's absent; the NOT_SPEAK 404 below is no-store, so it's
+    // transient either way.
+    let post: { json_metadata?: unknown } | null = null;
+    for (let attempt = 0; attempt <= POST_LOOKUP_RETRIES; attempt++) {
+      post = await callRPC<{ json_metadata?: unknown } | null>(
+        "bridge.get_post",
+        { author, permlink, observer: "" },
+        LOOKUP_TIMEOUT_MS
+      );
+      if (post) break;
+      if (attempt < POST_LOOKUP_RETRIES) await delay(LOOKUP_RETRY_DELAY_MS);
+    }
+    if (!post) {
+      return jsonError("NOT_SPEAK", 404);
+    }
     // bridge.get_post usually returns json_metadata already parsed, but tolerate a
     // raw JSON string too.
-    const raw = post?.json_metadata;
+    const raw = post.json_metadata;
     const meta = (typeof raw === "string" ? safeJsonParse(raw) : raw) as
       | { speak?: { audio_url?: string } }
       | null

--- a/apps/web/src/app/api/speak-audio/route.ts
+++ b/apps/web/src/app/api/speak-audio/route.ts
@@ -1,0 +1,304 @@
+import { NextRequest } from "next/server";
+import { Resolver } from "node:dns/promises";
+import { isIP, type LookupFunction } from "node:net";
+import { Agent } from "undici";
+import { execFile } from "node:child_process";
+import { mkdtemp, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Node runtime: needs child_process (ffmpeg), node:dns and undici dispatcher
+// pinning. Force-dynamic so Next never tries to statically cache the handler —
+// edge caching is governed entirely by the response Cache-Control below.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// -----------------------------------------------------------------------------
+// /api/speak-audio?src=<cdn.liketu.com ...webm>
+//
+// Liketu "Speak" voice posts store their audio as Opus-in-WebM on cdn.liketu.com.
+// Browsers (and Android/ExoPlayer) play that natively, but iOS AVPlayer — what
+// react-native-video and Safari use — cannot demux WebM or decode Opus. This
+// endpoint transcodes the clip to AAC/m4a so every client can play it.
+//
+// The source audio is immutable (content-addressed CDN path), so the response is
+// marked immutable + long-TTL: Cloudflare edge-caches each clip and the origin
+// only transcodes on a cache miss (a handful per day at Speak's volume).
+// -----------------------------------------------------------------------------
+
+const ALLOWED_HOST = "cdn.liketu.com";
+// Extensions Liketu serves Speak audio under (mirrors render-helper's
+// LIKETU_AUDIO_REGEX). The host allowlist is the real guard; this just rejects
+// obviously-wrong inputs early.
+const ALLOWED_EXT = /\.(?:webm|mp3|m4a|ogg|wav)$/i;
+
+const FETCH_TIMEOUT_MS = 15_000;
+const FFMPEG_TIMEOUT_MS = 30_000;
+const MAX_INPUT_BYTES = 25 * 1024 * 1024; // 25MB — voice clips are well under 1MB
+const MAX_OUTPUT_BYTES = 30 * 1024 * 1024;
+
+// Immutable: the CDN path is content-addressed, so a successful transcode never
+// changes. Long max-age + s-maxage lets both the browser and the CF edge pin it.
+const AUDIO_CACHE_CONTROL = "public, max-age=31536000, s-maxage=31536000, immutable";
+
+// Bound concurrent ffmpeg processes so a burst of cache-miss requests can't
+// saturate the box CPU. Excess requests get a short 503 + Retry-After; CF and
+// the client retry, and by then the cache is usually warm.
+const MAX_CONCURRENT_TRANSCODES = 4;
+let activeTranscodes = 0;
+
+class CodedError extends Error {
+  constructor(public code: string, public status: number) {
+    super(code);
+  }
+}
+
+/**
+ * Synchronous URL validation: https + exact host allowlist + audio extension +
+ * default port only. Exported for unit tests. Returns the parsed URL.
+ */
+export function parseSpeakSource(src: unknown): URL {
+  if (!src || typeof src !== "string") {
+    throw new CodedError("MISSING_SRC", 400);
+  }
+
+  let url: URL;
+  try {
+    url = new URL(src);
+  } catch {
+    throw new CodedError("INVALID_SRC", 400);
+  }
+
+  if (url.protocol !== "https:") {
+    throw new CodedError("INVALID_SRC", 400);
+  }
+
+  // Exact host match (not endsWith) so e.g. "cdn.liketu.com.evil.tld" is rejected.
+  if (url.hostname.toLowerCase() !== ALLOWED_HOST) {
+    throw new CodedError("HOST_NOT_ALLOWED", 400);
+  }
+
+  // Reject any explicit non-default port — keeps this from being aimed at other
+  // TCP services even on the allowlisted host.
+  if (url.port !== "" && url.port !== "443") {
+    throw new CodedError("HOST_NOT_ALLOWED", 400);
+  }
+
+  if (!ALLOWED_EXT.test(url.pathname)) {
+    throw new CodedError("UNSUPPORTED_EXT", 400);
+  }
+
+  return url;
+}
+
+/**
+ * Expand an IPv6 address to its full 8-group, zero-padded form for prefix
+ * matching. e.g. "2001:db8::1" -> "2001:0db8:0000:...:0001".
+ */
+function expandIPv6(ip: string): string {
+  const halves = ip.split("::");
+  const left = halves[0] ? halves[0].split(":") : [];
+  const right = halves.length > 1 && halves[1] ? halves[1].split(":") : [];
+  const missing = 8 - left.length - right.length;
+  const mid = Array(missing > 0 ? missing : 0).fill("0000");
+  return [...left, ...mid, ...right].map((g) => g.padStart(4, "0")).join(":");
+}
+
+/** True for non-globally-routable IPs (defense-in-depth against DNS rebinding). */
+function isPrivateIP(ip: string): boolean {
+  let normalized = ip;
+  const v4Mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (v4Mapped) normalized = v4Mapped[1];
+
+  if (isIP(normalized) === 4) {
+    const [a, b, c] = normalized.split(".").map(Number);
+    if (a === 0) return true; // 0.0.0.0/8
+    if (a === 10) return true; // RFC1918
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+    if (a === 127) return true; // loopback
+    if (a === 169 && b === 254) return true; // link-local
+    if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918
+    if (a === 192 && b === 168) return true; // RFC1918
+    if (a === 192 && b === 0 && c === 0) return true; // IETF protocol
+    if (a >= 224) return true; // multicast + reserved
+    return false;
+  }
+
+  if (isIP(normalized) === 6) {
+    const full = expandIPv6(normalized);
+    if (full === "0000:0000:0000:0000:0000:0000:0000:0000") return true; // ::
+    if (full === "0000:0000:0000:0000:0000:0000:0000:0001") return true; // ::1
+    const g1 = parseInt(full.slice(0, 4), 16);
+    if (g1 >= 0xfc00 && g1 <= 0xfdff) return true; // fc00::/7 ULA
+    if ((g1 & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+    if (g1 >= 0xff00) return true; // ff00::/8 multicast
+    return false;
+  }
+
+  return true; // unparseable -> treat as unsafe
+}
+
+/**
+ * Resolve the (already host-allowlisted) hostname, reject if any record is
+ * private/reserved, and return an undici dispatcher pinned to the validated IP.
+ * Pinning closes the DNS-rebinding TOCTOU window between resolution and connect;
+ * the original hostname rides on the request so TLS SNI/cert checks still verify
+ * against cdn.liketu.com. Mirrors apps/web/src/app/api/import/route.ts.
+ */
+async function resolveAndPin(hostname: string): Promise<Agent> {
+  const resolver = new Resolver();
+  const [v4, v6] = await Promise.all([
+    resolver.resolve4(hostname).catch(() => [] as string[]),
+    resolver.resolve6(hostname).catch(() => [] as string[])
+  ]);
+  const all = [...v4, ...v6];
+  if (all.length === 0) {
+    throw new CodedError("FETCH_FAILED", 502);
+  }
+  for (const ip of all) {
+    if (isPrivateIP(ip)) {
+      throw new CodedError("HOST_NOT_ALLOWED", 400);
+    }
+  }
+  const pinned = v4[0] ?? v6[0];
+  const family: 4 | 6 = v4.length > 0 ? 4 : 6;
+  // undici 6.x calls the connector's lookup with `{ all: true }` on some paths
+  // (expecting an array of { address, family }) and the classic
+  // (err, address, family) callback on others. Honour the pinned IP for both
+  // shapes — returning the wrong one trips undici's ERR_INVALID_IP_ADDRESS.
+  const lookup: LookupFunction = (_hostname, options, cb) => {
+    if ((options as { all?: boolean })?.all) {
+      (cb as (e: null, a: { address: string; family: number }[]) => void)(null, [
+        { address: pinned, family }
+      ]);
+    } else {
+      cb(null, pinned, family);
+    }
+  };
+  return new Agent({ connect: { lookup } });
+}
+
+/** Download the source audio with the pinned dispatcher, timeout and size cap. */
+async function fetchAudio(url: URL): Promise<Buffer> {
+  const dispatcher = await resolveAndPin(url.hostname);
+  try {
+    const res = await fetch(url.toString(), {
+      redirect: "error", // a content-addressed CDN file should never redirect
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      ...({ dispatcher } as { dispatcher: Agent })
+    } as RequestInit);
+
+    if (!res.ok || !res.body) {
+      throw new CodedError("FETCH_FAILED", 502);
+    }
+
+    const reader = res.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_INPUT_BYTES) {
+        await reader.cancel();
+        throw new CodedError("INPUT_TOO_LARGE", 413);
+      }
+      chunks.push(value);
+    }
+    return Buffer.concat(chunks);
+  } finally {
+    void dispatcher.close().catch(() => {});
+  }
+}
+
+/** Transcode webm/opus (or any input) -> AAC/m4a with a progressive (faststart) moov. */
+async function transcodeToAac(input: Buffer, ext: string): Promise<Buffer> {
+  const dir = await mkdtemp(join(tmpdir(), "speak-"));
+  const inPath = join(dir, `input${ext}`);
+  const outPath = join(dir, "output.m4a");
+  try {
+    await writeFile(inPath, input);
+    await new Promise<void>((resolve, reject) => {
+      execFile(
+        "ffmpeg",
+        [
+          "-nostdin",
+          "-hide_banner",
+          "-loglevel",
+          "error",
+          "-i",
+          inPath,
+          "-vn", // drop any video stream; Speak clips are audio-only
+          "-c:a",
+          "aac",
+          "-b:a",
+          "96k", // voice-grade; plenty for a transcript-backed voice note
+          "-movflags",
+          "+faststart", // moov before mdat -> progressive playback over HTTP
+          "-f",
+          "mp4",
+          "-y",
+          outPath
+        ],
+        { timeout: FFMPEG_TIMEOUT_MS, killSignal: "SIGKILL" },
+        (err) => (err ? reject(new CodedError("TRANSCODE_FAILED", 502)) : resolve())
+      );
+    });
+    const out = await readFile(outPath);
+    if (out.byteLength === 0 || out.byteLength > MAX_OUTPUT_BYTES) {
+      throw new CodedError("TRANSCODE_FAILED", 502);
+    }
+    return out;
+  } finally {
+    void rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+export async function GET(request: NextRequest) {
+  let url: URL;
+  try {
+    url = parseSpeakSource(request.nextUrl.searchParams.get("src"));
+  } catch (e) {
+    const err = e as CodedError;
+    return Response.json({ error: err.code }, { status: err.status ?? 400 });
+  }
+
+  if (activeTranscodes >= MAX_CONCURRENT_TRANSCODES) {
+    return Response.json(
+      { error: "BUSY" },
+      { status: 503, headers: { "Retry-After": "2" } }
+    );
+  }
+
+  activeTranscodes += 1;
+  try {
+    const input = await fetchAudio(url);
+    const ext = (url.pathname.match(ALLOWED_EXT)?.[0] ?? ".webm").toLowerCase();
+    const output = await transcodeToAac(input, ext);
+
+    // Node Buffer isn't a DOM BodyInit; hand the Response a plain Uint8Array view.
+    return new Response(new Uint8Array(output), {
+      status: 200,
+      headers: {
+        "Content-Type": "audio/mp4",
+        "Content-Length": String(output.byteLength),
+        "Cache-Control": AUDIO_CACHE_CONTROL,
+        "X-Content-Type-Options": "nosniff"
+      }
+    });
+  } catch (e) {
+    const err = e as CodedError;
+    const status = typeof err?.status === "number" ? err.status : 502;
+    const code =
+      err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError")
+        ? "FETCH_TIMEOUT"
+        : err?.code ?? "TRANSCODE_FAILED";
+    // Never let an error response get cached.
+    return Response.json(
+      { error: code },
+      { status: code === "FETCH_TIMEOUT" ? 504 : status, headers: { "Cache-Control": "no-store" } }
+    );
+  } finally {
+    activeTranscodes -= 1;
+  }
+}

--- a/apps/web/src/app/api/speak-audio/route.ts
+++ b/apps/web/src/app/api/speak-audio/route.ts
@@ -94,6 +94,13 @@ export function parseSpeakSource(src: unknown): URL {
     throw new CodedError("UNSUPPORTED_EXT", 400);
   }
 
+  // Constrain to Liketu's media path root. Even on the allowlisted host this keeps
+  // the endpoint from being used to fetch arbitrary CDN files, and it rejects a
+  // host-mimicking "//evil.com/..." pathname outright.
+  if (!url.pathname.startsWith("/liketu/")) {
+    throw new CodedError("UNSUPPORTED_PATH", 400);
+  }
+
   return url;
 }
 

--- a/apps/web/src/specs/api/speak-audio-route.spec.ts
+++ b/apps/web/src/specs/api/speak-audio-route.spec.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { parseSpeakSource } from "@/app/api/speak-audio/route";
+
+const LIKETU =
+  "https://cdn.liketu.com/liketu/speak/erilej/re-liketu-speak-x/1781649490185-abc.webm";
+
+// Helper: capture the CodedError shape ({ code, status }) without exporting the class.
+function reject(src: unknown): { code: string; status: number } {
+  try {
+    parseSpeakSource(src);
+  } catch (e) {
+    return e as { code: string; status: number };
+  }
+  throw new Error("expected parseSpeakSource to throw");
+}
+
+describe("parseSpeakSource", () => {
+  it("accepts a valid cdn.liketu.com audio url", () => {
+    const url = parseSpeakSource(LIKETU);
+    expect(url.hostname).toBe("cdn.liketu.com");
+    expect(url.protocol).toBe("https:");
+  });
+
+  it.each(["webm", "mp3", "m4a", "ogg", "wav"])("accepts the .%s extension", (ext) => {
+    const url = parseSpeakSource(`https://cdn.liketu.com/liketu/speak/x/clip.${ext}`);
+    expect(url.pathname.endsWith(`.${ext}`)).toBe(true);
+  });
+
+  it("rejects a missing src", () => {
+    expect(reject(undefined).code).toBe("MISSING_SRC");
+    expect(reject("").code).toBe("MISSING_SRC");
+    expect(reject(123 as unknown).code).toBe("MISSING_SRC");
+  });
+
+  it("rejects a malformed url", () => {
+    expect(reject("not a url").code).toBe("INVALID_SRC");
+  });
+
+  it("rejects non-https schemes", () => {
+    expect(reject("http://cdn.liketu.com/x/clip.webm").code).toBe("INVALID_SRC");
+  });
+
+  it("rejects any host that is not exactly cdn.liketu.com", () => {
+    expect(reject("https://evil.com/x/clip.webm").code).toBe("HOST_NOT_ALLOWED");
+    // suffix-spoof: a real attacker domain that ends with the allowed host as a label
+    expect(reject("https://cdn.liketu.com.evil.tld/x/clip.webm").code).toBe("HOST_NOT_ALLOWED");
+    // subdomain of the CDN is not the exact allowlisted host
+    expect(reject("https://evil.cdn.liketu.com/x/clip.webm").code).toBe("HOST_NOT_ALLOWED");
+  });
+
+  it("rejects an explicit non-default port on the allowed host", () => {
+    expect(reject("https://cdn.liketu.com:8080/x/clip.webm").code).toBe("HOST_NOT_ALLOWED");
+  });
+
+  it("rejects an unsupported / missing extension", () => {
+    expect(reject("https://cdn.liketu.com/x/clip.txt").code).toBe("UNSUPPORTED_EXT");
+    expect(reject("https://cdn.liketu.com/x/clip").code).toBe("UNSUPPORTED_EXT");
+  });
+
+  it("validation errors carry a 4xx status", () => {
+    expect(reject(undefined).status).toBe(400);
+    expect(reject("https://evil.com/x/clip.webm").status).toBe(400);
+  });
+});

--- a/apps/web/src/specs/api/speak-audio-route.spec.ts
+++ b/apps/web/src/specs/api/speak-audio-route.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
 
-import { parseSpeakSource } from "@/app/api/speak-audio/route";
+import { parseSpeakSource, isPrivateIP, parseRange } from "@/app/api/speak-audio/route";
 
 const LIKETU =
   "https://cdn.liketu.com/liketu/speak/erilej/re-liketu-speak-x/1781649490185-abc.webm";
@@ -62,5 +62,70 @@ describe("parseSpeakSource", () => {
   it("validation errors carry a 4xx status", () => {
     expect(reject(undefined).status).toBe(400);
     expect(reject("https://evil.com/x/clip.webm").status).toBe(400);
+  });
+});
+
+describe("isPrivateIP", () => {
+  it.each([
+    "10.0.0.1",
+    "127.0.0.1",
+    "192.168.1.1",
+    "172.16.0.1",
+    "169.254.0.1",
+    "100.64.0.1", // CGNAT
+    "198.18.0.1", // benchmarking
+    "192.0.2.5", // TEST-NET-1
+    "203.0.113.9", // TEST-NET-3
+    "::1",
+    "fe80::1",
+    "fc00::1",
+    "2001:db8::1",
+    "::ffff:10.0.0.1", // IPv4-mapped (dotted)
+    "::ffff:0a00:0001" // IPv4-mapped (hex) == 10.0.0.1 — the gap a reviewer flagged
+  ])("flags %s as private/reserved", (ip) => {
+    expect(isPrivateIP(ip)).toBe(true);
+  });
+
+  it.each(["8.8.8.8", "1.1.1.1", "138.199.37.232", "2606:4700:4700::1111"])(
+    "treats public %s as public",
+    (ip) => {
+      expect(isPrivateIP(ip)).toBe(false);
+    }
+  );
+
+  it("treats an unparseable address as unsafe", () => {
+    expect(isPrivateIP("not-an-ip")).toBe(true);
+  });
+});
+
+describe("parseRange", () => {
+  const SIZE = 1000;
+  it("returns null when there is no range header or no honourable range", () => {
+    expect(parseRange(null, SIZE)).toBeNull();
+    expect(parseRange("bytes=abc", SIZE)).toBeNull();
+    expect(parseRange("bytes=-", SIZE)).toBeNull();
+  });
+
+  it("parses a closed range", () => {
+    expect(parseRange("bytes=0-99", SIZE)).toEqual({ start: 0, end: 99 });
+  });
+
+  it("parses an open-ended range to the last byte", () => {
+    expect(parseRange("bytes=500-", SIZE)).toEqual({ start: 500, end: 999 });
+  });
+
+  it("parses a suffix range as the final N bytes", () => {
+    expect(parseRange("bytes=-200", SIZE)).toEqual({ start: 800, end: 999 });
+    // suffix larger than the file clamps to the whole file
+    expect(parseRange("bytes=-5000", SIZE)).toEqual({ start: 0, end: 999 });
+  });
+
+  it("clamps an end past EOF", () => {
+    expect(parseRange("bytes=900-9999", SIZE)).toEqual({ start: 900, end: 999 });
+  });
+
+  it("reports out-of-range as unsatisfiable", () => {
+    expect(parseRange("bytes=1000-1100", SIZE)).toBe("unsatisfiable");
+    expect(parseRange("bytes=50-10", SIZE)).toBe("unsatisfiable");
   });
 });

--- a/apps/web/src/specs/api/speak-audio-route.spec.ts
+++ b/apps/web/src/specs/api/speak-audio-route.spec.ts
@@ -54,12 +54,14 @@ describe("parseSpeakSource", () => {
     expect(reject("https://cdn.liketu.com:8080/x/clip.webm").code).toBe("HOST_NOT_ALLOWED");
   });
 
-  it("keeps the host locked to cdn.liketu.com even when the path mimics a host", () => {
-    // A pathname like //evil.com/x would hijack the authority if the request URL
-    // were rebuilt from path-against-a-base. The validated URL keeps cdn.liketu.com,
-    // so fetchAudio (which fetches this URL as-is) can never leave the host.
-    const url = parseSpeakSource("https://cdn.liketu.com//evil.com/clip.webm");
-    expect(url.hostname).toBe("cdn.liketu.com");
+  it("rejects a host-mimicking path (not under /liketu/, no override possible)", () => {
+    // pathname //evil.com/... is not a /liketu/ path so it's rejected; and even if
+    // it weren't, fetchAudio fetches the validated URL whose host stays cdn.liketu.com.
+    expect(reject("https://cdn.liketu.com//evil.com/clip.webm").code).toBe("UNSUPPORTED_PATH");
+  });
+
+  it("rejects an audio file outside the /liketu/ media root", () => {
+    expect(reject("https://cdn.liketu.com/other/clip.webm").code).toBe("UNSUPPORTED_PATH");
   });
 
   it("rejects an unsupported / missing extension", () => {

--- a/apps/web/src/specs/api/speak-audio-route.spec.ts
+++ b/apps/web/src/specs/api/speak-audio-route.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@ecency/sdk/hive", () => ({ callRPC: vi.fn() }));
@@ -10,6 +10,7 @@ import {
   parseRange,
   isValidAuthor,
   isValidPermlink,
+  buildAudioResponse,
   GET
 } from "@/app/api/speak-audio/route";
 import { callRPC } from "@ecency/sdk/hive";
@@ -151,6 +152,34 @@ describe("parseRange", () => {
   });
 });
 
+describe("buildAudioResponse cache safety", () => {
+  const body = Buffer.from("0123456789"); // size 10
+
+  it("serves the full 200 with the immutable cache + Accept-Ranges", async () => {
+    const res = buildAudioResponse(body, null);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toContain("immutable");
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+    expect(res.headers.get("content-length")).toBe("10");
+    expect(Buffer.from(await res.arrayBuffer()).toString()).toBe("0123456789");
+  });
+
+  it("serves a 206 partial as no-store so it can't poison the cached full response", async () => {
+    const res = buildAudioResponse(body, "bytes=2-5");
+    expect(res.status).toBe(206);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(res.headers.get("content-range")).toBe("bytes 2-5/10");
+    expect(Buffer.from(await res.arrayBuffer()).toString()).toBe("2345");
+  });
+
+  it("returns a 416 (no-store) for an unsatisfiable range", async () => {
+    const res = buildAudioResponse(body, "bytes=100-200");
+    expect(res.status).toBe(416);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(res.headers.get("content-range")).toBe("bytes */10");
+  });
+});
+
 describe("isValidAuthor / isValidPermlink", () => {
   it("accepts well-formed refs", () => {
     expect(isValidAuthor("erilej")).toBe(true);
@@ -173,6 +202,8 @@ describe("GET /api/speak-audio (author/permlink lookup)", () => {
   const get = (q: string) => GET(new NextRequest(`https://x/api/speak-audio?${q}`));
 
   const mockRpc = callRPC as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => mockRpc.mockReset());
 
   it("400 INVALID_REF for a malformed author/permlink (no lookup)", async () => {
     const res = await get("author=UP&permlink=x");
@@ -210,5 +241,13 @@ describe("GET /api/speak-audio (author/permlink lookup)", () => {
     const res = await get("author=erilej&permlink=boom");
     expect(res.status).toBe(502);
     expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("retries a null lookup (lagging node) before returning a transient NOT_SPEAK", async () => {
+    mockRpc.mockResolvedValue(null); // every node returns null
+    const res = await get("author=erilej&permlink=fresh-wave");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(mockRpc).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
   });
 });

--- a/apps/web/src/specs/api/speak-audio-route.spec.ts
+++ b/apps/web/src/specs/api/speak-audio-route.spec.ts
@@ -54,6 +54,14 @@ describe("parseSpeakSource", () => {
     expect(reject("https://cdn.liketu.com:8080/x/clip.webm").code).toBe("HOST_NOT_ALLOWED");
   });
 
+  it("keeps the host locked to cdn.liketu.com even when the path mimics a host", () => {
+    // A pathname like //evil.com/x would hijack the authority if the request URL
+    // were rebuilt from path-against-a-base. The validated URL keeps cdn.liketu.com,
+    // so fetchAudio (which fetches this URL as-is) can never leave the host.
+    const url = parseSpeakSource("https://cdn.liketu.com//evil.com/clip.webm");
+    expect(url.hostname).toBe("cdn.liketu.com");
+  });
+
   it("rejects an unsupported / missing extension", () => {
     expect(reject("https://cdn.liketu.com/x/clip.txt").code).toBe("UNSUPPORTED_EXT");
     expect(reject("https://cdn.liketu.com/x/clip").code).toBe("UNSUPPORTED_EXT");

--- a/apps/web/src/specs/api/speak-audio-route.spec.ts
+++ b/apps/web/src/specs/api/speak-audio-route.spec.ts
@@ -1,7 +1,18 @@
 // @vitest-environment node
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
 
-import { parseSpeakSource, isPrivateIP, parseRange } from "@/app/api/speak-audio/route";
+vi.mock("@ecency/sdk/hive", () => ({ callRPC: vi.fn() }));
+
+import {
+  parseSpeakSource,
+  isPrivateIP,
+  parseRange,
+  isValidAuthor,
+  isValidPermlink,
+  GET
+} from "@/app/api/speak-audio/route";
+import { callRPC } from "@ecency/sdk/hive";
 
 const LIKETU =
   "https://cdn.liketu.com/liketu/speak/erilej/re-liketu-speak-x/1781649490185-abc.webm";
@@ -137,5 +148,67 @@ describe("parseRange", () => {
   it("reports out-of-range as unsatisfiable", () => {
     expect(parseRange("bytes=1000-1100", SIZE)).toBe("unsatisfiable");
     expect(parseRange("bytes=50-10", SIZE)).toBe("unsatisfiable");
+  });
+});
+
+describe("isValidAuthor / isValidPermlink", () => {
+  it("accepts well-formed refs", () => {
+    expect(isValidAuthor("erilej")).toBe(true);
+    expect(isValidAuthor("good-karma")).toBe(true);
+    expect(isValidPermlink("re-liketu-speak-2026-04-19-01-mqh83la5-pdfh8j")).toBe(true);
+  });
+
+  it("rejects malformed refs", () => {
+    expect(isValidAuthor(null)).toBe(false);
+    expect(isValidAuthor("")).toBe(false);
+    expect(isValidAuthor("UPPER")).toBe(false);
+    expect(isValidAuthor("a")).toBe(false); // too short
+    expect(isValidAuthor("has space")).toBe(false);
+    expect(isValidPermlink("Has-Capital")).toBe(false);
+    expect(isValidPermlink("under_score")).toBe(false);
+  });
+});
+
+describe("GET /api/speak-audio (author/permlink lookup)", () => {
+  const get = (q: string) => GET(new NextRequest(`https://x/api/speak-audio?${q}`));
+
+  const mockRpc = callRPC as ReturnType<typeof vi.fn>;
+
+  it("400 INVALID_REF for a malformed author/permlink (no lookup)", async () => {
+    const res = await get("author=UP&permlink=x");
+    expect(res.status).toBe(400);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(callRPC).not.toHaveBeenCalled();
+  });
+
+  it("404 NOT_SPEAK when the looked-up post has no speak audio", async () => {
+    mockRpc.mockResolvedValueOnce({ json_metadata: { app: "ecency" } });
+    const res = await get("author=erilej&permlink=not-a-voice-post");
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a crafted on-chain audio_url that isn't a liketu media file", async () => {
+    // An attacker posting a wave with a hostile audio_url must still be rejected:
+    // the looked-up URL is validated before any fetch.
+    mockRpc.mockResolvedValueOnce({
+      json_metadata: { speak: { audio_url: "https://evil.com/x.webm" } }
+    });
+    const res = await get("author=erilej&permlink=crafted");
+    expect(res.status).toBe(400);
+  });
+
+  it("tolerates a json_metadata returned as a raw JSON string", async () => {
+    mockRpc.mockResolvedValueOnce({
+      json_metadata: JSON.stringify({ speak: { audio_url: "https://evil.com/x.webm" } })
+    });
+    const res = await get("author=erilej&permlink=stringmeta");
+    expect(res.status).toBe(400); // still validated -> rejected, proving the string was parsed
+  });
+
+  it("502 LOOKUP_FAILED when the bridge lookup throws", async () => {
+    mockRpc.mockRejectedValueOnce(new Error("rpc down"));
+    const res = await get("author=erilej&permlink=boom");
+    expect(res.status).toBe(502);
+    expect(res.headers.get("cache-control")).toBe("no-store");
   });
 });


### PR DESCRIPTION
## Why

Liketu "Speak" voice posts (in the Waves feed) store their audio as **Opus/WebM** on `cdn.liketu.com`, which iOS `AVPlayer` (react-native-video, Safari) cannot decode, so they had no working player. This endpoint transcodes the clip to **AAC/m4a** so every client can play it. (Backend half; the native mobile player is ecency/ecency-mobile#3304.)

## What

`GET /api/speak-audio?author=<a>&permlink=<p>` -> streams `audio/mp4`.

- **The clip URL is not taken from the request.** The endpoint looks the wave up on chain (`bridge.get_post` via the React-free `@ecency/sdk/hive`) and reads `json_metadata.speak.audio_url`, so the fetch target is derived from trusted on-chain data rather than a user-supplied URL. The looked-up URL is still validated: https + exact `cdn.liketu.com` host + default port + audio extension + `/liketu/` path.
- **Transcode:** `ffmpeg -vn -c:a aac -b:a 96k -movflags +faststart`; the output is verified to be a real MP4 (`ftyp`) before serving.
- **Outbound fetch:** resolves and rejects private/reserved IPs and pins the connection to the validated IP (DNS-rebinding defense); bounded input/output size + fetch/ffmpeg timeouts; separate concurrency caps for downloads and transcodes.
- **Caching:** the source is immutable, so the full `200` is `immutable` + long-TTL for Cloudflare edge caching (transcode once per clip). Byte-range requests are honored (`206`/`416`), but partials are `no-store` so a range response can't poison the cached full object. All error responses are `no-store`. A null lookup (a lagging node missing a fresh wave) is retried briefly before a transient `404`.
- ffmpeg is added to the web runtime Docker image.

## Test

Unit tests for author/permlink + URL validation, private-IP detection (incl. IPv4-mapped IPv6), range parsing, cache headers per status, and lookup behavior. Verified end to end against a real Liketu clip (webm/opus -> faststart m4a).

## Deploy note

After this reaches an origin, confirm Cloudflare edge-caches the full `200` for `/api/speak-audio?author=&permlink=` (the `206` is intentionally `no-store`). The endpoint still functions without edge caching (it just transcodes per cache-miss, bounded by the concurrency caps).
