### PR TITLE
fix(vote): open vote slider without blocking on the previous-vote fetch

### DIFF
--- a/apps/web/src/features/shared/entry-vote-btn/entry-vote-dialog.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/entry-vote-dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import * as ls from "@/utils/local-storage";
 import { Button } from "@ui/button";
 import i18next from "i18next";
@@ -81,6 +81,28 @@ export function EntryVoteDialog({
   const [wrongValueDown, setWrongValueDown] = useState(false);
   const [showRemove, setShowRemove] = useState(false);
   const [showWarning, setShowWarning] = useState(false);
+
+  // The parent now opens this dialog immediately and resolves the user's
+  // previous vote in the background (so the open isn't blocked on a network
+  // fetch — an INP win), where it used to mount this dialog only after the value
+  // was already known. When that value arrives after mount, apply it to the
+  // slider the same way the initial state above would have. Apply it exactly
+  // once (the first truthy value) so a re-render can't yank the slider back
+  // after the user starts adjusting it.
+  const appliedPreviousRef = useRef(false);
+  useEffect(() => {
+    if (appliedPreviousRef.current || !previousVotedValue) {
+      return;
+    }
+    appliedPreviousRef.current = true;
+    if (upVoted) {
+      setUpSliderVal(previousVotedValue);
+      setInitialVoteValues((v) => ({ ...v, up: previousVotedValue }));
+    } else if (downVoted) {
+      setDownSliderVal(previousVotedValue);
+      setInitialVoteValues((v) => ({ ...v, down: previousVotedValue }));
+    }
+  }, [previousVotedValue, upVoted, downVoted]);
 
   const isPaidOut = entry.is_paidout;
 

--- a/apps/web/src/features/shared/entry-vote-btn/entry-vote-dialog.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/entry-vote-dialog.tsx
@@ -85,16 +85,29 @@ export function EntryVoteDialog({
   // The parent now opens this dialog immediately and resolves the user's
   // previous vote in the background (so the open isn't blocked on a network
   // fetch — an INP win), where it used to mount this dialog only after the value
-  // was already known. When that value arrives after mount, apply it to the
-  // slider the same way the initial state above would have. Apply it exactly
-  // once (the first truthy value) so a re-render can't yank the slider back
-  // after the user starts adjusting it.
+  // was already known. The slider is therefore interactive before the value
+  // arrives. When it arrives, apply it to the slider the same way the initial
+  // state above would have — but only the first time, and never once the user
+  // has actually started adjusting the slider, so a slow fetch can't reset a
+  // weight they already chose.
+  //
+  // `userTouchedRef` is flipped from real pointer/keyboard input on the slider
+  // (capture phase, below). InputVote calls setValue() programmatically on mount
+  // and on clamp, so a handler-based "touched" flag would false-trigger; DOM
+  // input events do not fire for those programmatic echoes.
   const appliedPreviousRef = useRef(false);
+  const userTouchedRef = useRef(false);
+  const markTouched = useCallback(() => {
+    userTouchedRef.current = true;
+  }, []);
   useEffect(() => {
     if (appliedPreviousRef.current || !previousVotedValue) {
       return;
     }
     appliedPreviousRef.current = true;
+    if (userTouchedRef.current) {
+      return;
+    }
     if (upVoted) {
       setUpSliderVal(previousVotedValue);
       setInitialVoteValues((v) => ({ ...v, up: previousVotedValue }));
@@ -223,7 +236,12 @@ export function EntryVoteDialog({
               <FormattedCurrency value={estimate(upSliderVal)} fixAt={3} />
             </div>
             <div className="space" />
-            <div className="slider slider-up">
+            <div
+              className="slider slider-up"
+              onMouseDownCapture={markTouched}
+              onTouchStartCapture={markTouched}
+              onKeyDownCapture={markTouched}
+            >
               <InputVote value={upSliderVal} setValue={(x) => upSliderChanged(x)} />
             </div>
             <div className="percentage" />
@@ -275,7 +293,12 @@ export function EntryVoteDialog({
             <div className="estimated">
               <FormattedCurrency value={estimate(downSliderVal)} fixAt={3} />
             </div>
-            <div className="slider slider-down">
+            <div
+              className="slider slider-down"
+              onMouseDownCapture={markTouched}
+              onTouchStartCapture={markTouched}
+              onKeyDownCapture={markTouched}
+            >
               <InputVote
                 mode="negative"
                 value={downSliderVal}

--- a/apps/web/src/features/shared/entry-vote-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/index.tsx
@@ -165,6 +165,15 @@ export function EntryVoteBtn({ entry: originalEntry, isPostSlider, account }: Pr
     };
   }, [dialog, getPreviousVote]);
 
+  // Reset the cached previous vote when this button is reused for a different
+  // post or the active user changes. previousVotedValue is component state that
+  // persists across prop changes, and the dialog captures it at mount, so
+  // without this a reopened slider could seed from a prior entry's (or user's)
+  // vote weight before the new lookup resolves.
+  useEffect(() => {
+    setPreviousVotedValue(undefined);
+  }, [originalEntry.post_id, activeUser?.username]);
+
   return (
     <LoginRequired promptOnAnon>
       <div ref={rootRef}>

--- a/apps/web/src/features/shared/entry-vote-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import "./_index.scss";
 import * as ss from "@/utils/session-storage";
 import { LoginRequired } from "@/features/shared";
@@ -133,26 +133,36 @@ export function EntryVoteBtn({ entry: originalEntry, isPostSlider, account }: Pr
       return null;
     }
   }, [activeUser, entry, isVoted, queryClient]);
-  const toggleDialog = useCallback(() => {
-    // Closing: just close.
-    if (dialog) {
-      setDialog(false);
+  const toggleDialog = useCallback(() => setDialog((d) => !d), []);
+
+  // Resolve the user's previous vote WHILE the slider is open rather than before
+  // opening it, so the open paints immediately instead of blocking on
+  // getPreviousVote()'s network fetch (the prior-vote lookup on an already-voted
+  // post with a cold session cache). That await used to gate the open and inflate
+  // INP on this interaction. The cleanup drops a stale resolution if the slider
+  // closes, or the entry/account changes (getPreviousVote identity changes),
+  // before the fetch returns — so a late result can never prefill another post's
+  // (or user's) vote weight.
+  useEffect(() => {
+    if (!dialog) {
       return;
     }
-
-    // Opening: open the slider immediately so the tap paints without waiting on
-    // getPreviousVote(), which can do a network fetch for the user's prior vote
-    // on an already-voted post (session-cache miss). Awaiting it here used to
-    // block the dialog open and inflate INP on that interaction. The dialog
-    // syncs to the resolved value reactively once it arrives (see the
-    // previousVotedValue effect in entry-vote-dialog).
-    setDialog(true);
+    let active = true;
     getPreviousVote()
-      .then((preVote) => setPreviousVotedValue(preVote ?? undefined))
+      .then((preVote) => {
+        if (active) {
+          setPreviousVotedValue(preVote ?? undefined);
+        }
+      })
       .catch((e) => {
         console.error("entry-vote-btn failed to load previous vote", e);
-        setPreviousVotedValue(undefined);
+        if (active) {
+          setPreviousVotedValue(undefined);
+        }
       });
+    return () => {
+      active = false;
+    };
   }, [dialog, getPreviousVote]);
 
   return (

--- a/apps/web/src/features/shared/entry-vote-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/index.tsx
@@ -133,19 +133,26 @@ export function EntryVoteBtn({ entry: originalEntry, isPostSlider, account }: Pr
       return null;
     }
   }, [activeUser, entry, isVoted, queryClient]);
-  const toggleDialog = useCallback(async () => {
-    //if dialog is closing do nothing and close
-    if (!dialog) {
-      try {
-        const preVote = await getPreviousVote();
-        setPreviousVotedValue(preVote);
-      } catch (e) {
-        console.error("entry-vote-btn failed to toggle dialog", e);
-        setPreviousVotedValue(undefined);
-      }
+  const toggleDialog = useCallback(() => {
+    // Closing: just close.
+    if (dialog) {
+      setDialog(false);
+      return;
     }
 
-    setDialog(!dialog);
+    // Opening: open the slider immediately so the tap paints without waiting on
+    // getPreviousVote(), which can do a network fetch for the user's prior vote
+    // on an already-voted post (session-cache miss). Awaiting it here used to
+    // block the dialog open and inflate INP on that interaction. The dialog
+    // syncs to the resolved value reactively once it arrives (see the
+    // previousVotedValue effect in entry-vote-dialog).
+    setDialog(true);
+    getPreviousVote()
+      .then((preVote) => setPreviousVotedValue(preVote ?? undefined))
+      .catch((e) => {
+        console.error("entry-vote-btn failed to load previous vote", e);
+        setPreviousVotedValue(undefined);
+      });
   }, [dialog, getPreviousVote]);
 
   return (

--- a/apps/web/src/specs/features/shared/entry-vote-btn.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-vote-btn.spec.tsx
@@ -104,4 +104,49 @@ describe("EntryVoteBtn — opening the slider is not blocked on the previous-vot
     fireEvent.click(screen.getByRole("button"));
     await waitFor(() => expect(screen.queryByTestId("vote-dialog")).not.toBeInTheDocument());
   });
+
+  it("does not seed a reused button's slider with the previous post's vote", async () => {
+    const entryA = mockEntry({
+      author: "bob",
+      permlink: "a",
+      post_id: 1,
+      active_votes: [{ voter: "alice", rshares: 100 }] as any
+    });
+    const entryB = mockEntry({
+      author: "carol",
+      permlink: "b",
+      post_id: 2,
+      active_votes: [{ voter: "alice", rshares: 50 }] as any
+    });
+
+    const queryClient = createTestQueryClient();
+    // First open (A) resolves to 75%; the second open (B) stays pending so that any
+    // leaked value would have to come from A's cached previousVotedValue, not B's fetch.
+    let calls = 0;
+    let resolveA: (v: any) => void = () => {};
+    vi.spyOn(queryClient, "fetchQuery").mockImplementation((() => {
+      calls += 1;
+      if (calls === 1) return new Promise((res) => (resolveA = res));
+      return new Promise(() => {});
+    }) as any);
+
+    const utils = renderWithQueryClient(<EntryVoteBtn entry={entryA} isPostSlider={true} />, {
+      queryClient
+    });
+
+    fireEvent.click(screen.getByRole("button"));
+    await screen.findByTestId("vote-dialog");
+    resolveA([{ voter: "alice", percent: 75, rshares: 100, time: "2024-01-01T00:00:00" }]);
+    await waitFor(() => expect(screen.getByTestId("vote-dialog")).toHaveTextContent("prev:75"));
+
+    // Close, then reuse the SAME button instance for a different post.
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => expect(screen.queryByTestId("vote-dialog")).not.toBeInTheDocument());
+    utils.rerender(<EntryVoteBtn entry={entryB} isPostSlider={true} />);
+
+    // Open B (its fetch is pending): the slider must not be seeded with A's 75%.
+    fireEvent.click(screen.getByRole("button"));
+    const dialogB = await screen.findByTestId("vote-dialog");
+    expect(dialogB).toHaveTextContent("prev:none");
+  });
 });

--- a/apps/web/src/specs/features/shared/entry-vote-btn.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-vote-btn.spec.tsx
@@ -1,0 +1,107 @@
+import { vi } from "vitest";
+import React from "react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { renderWithQueryClient, mockEntry, createTestQueryClient } from "@/specs/test-utils";
+
+// Log a user in so LoginRequired renders the button and the vote slider can mount.
+vi.mock("@/core/hooks/use-active-account", () => ({
+  useActiveAccount: vi.fn(() => ({
+    activeUser: { username: "alice" },
+    username: "alice",
+    account: null,
+    isLoading: false,
+    isPending: false,
+    isError: false,
+    isSuccess: true,
+    error: null,
+    refetch: vi.fn()
+  }))
+}));
+
+// The component reads its entry through EcencyEntriesCacheManagement.getEntryQuery.
+// Stub it to a plain query whose initialData is the passed entry (renders sync, no network).
+vi.mock("@/core/caches", () => ({
+  EcencyEntriesCacheManagement: {
+    getEntryQuery: (initialEntry: any) => ({
+      queryKey: ["entry", initialEntry?.author, initialEntry?.permlink],
+      queryFn: () => initialEntry,
+      initialData: initialEntry,
+      enabled: !!initialEntry
+    })
+  }
+}));
+
+vi.mock("@/api/mutations", () => ({
+  useEntryVote: () => ({ mutateAsync: vi.fn(), isPending: false })
+}));
+
+// prepareVotes() reads parseAsset/parseDate from the globally-mocked @/utils; pass the
+// fetched votes straight through so the test doesn't depend on those internals.
+vi.mock("@/features/shared/entry-vote-btn/utils", () => ({
+  prepareVotes: (_entry: any, votes: any[]) => votes
+}));
+
+// The slider dialog is loaded via next/dynamic and pulls in SDK vote-value queries we
+// don't exercise here. Replace it with a marker that records the previousVotedValue prop
+// it receives, so we can assert (a) it mounts and (b) the resolved value reaches it.
+vi.mock("@/features/shared/entry-vote-btn/entry-vote-dialog", () => ({
+  EntryVoteDialog: ({ previousVotedValue }: { previousVotedValue: number | undefined }) => (
+    <div data-testid="vote-dialog">
+      prev:{previousVotedValue === undefined ? "none" : previousVotedValue}
+    </div>
+  )
+}));
+
+import { EntryVoteBtn } from "@/features/shared/entry-vote-btn";
+
+describe("EntryVoteBtn — opening the slider is not blocked on the previous-vote fetch (INP)", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("opens the slider while the previous-vote fetch is still pending, then forwards the resolved value", async () => {
+    // An already-upvoted post: opening the slider takes getPreviousVote()'s network
+    // branch (session-cache miss -> queryClient.fetchQuery for the prior vote weight).
+    const entry = mockEntry({
+      author: "bob",
+      permlink: "a-post",
+      post_id: 999,
+      active_votes: [{ voter: "alice", rshares: 100 }] as any
+    });
+
+    const queryClient = createTestQueryClient();
+    // Hold the previous-vote fetch open so we can prove the dialog opens before it resolves.
+    let resolveFetch: (v: any) => void = () => {};
+    const fetchPromise = new Promise((res) => (resolveFetch = res));
+    const fetchSpy = vi.spyOn(queryClient, "fetchQuery").mockReturnValue(fetchPromise as any);
+
+    renderWithQueryClient(<EntryVoteBtn entry={entry} isPostSlider={true} />, { queryClient });
+
+    // Open the slider.
+    fireEvent.click(screen.getByRole("button"));
+
+    // The slider appears even though the previous-vote fetch is still pending — i.e. the
+    // open did NOT await the network call. That await used to block the open and inflate INP.
+    const dialog = await screen.findByTestId("vote-dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(dialog).toHaveTextContent("prev:none"); // value not resolved yet
+
+    // Once the fetch resolves, the prior vote weight (75%) is forwarded to the slider.
+    resolveFetch([{ voter: "alice", percent: 75, rshares: 100, time: "2024-01-01T00:00:00" }]);
+    await waitFor(() => expect(screen.getByTestId("vote-dialog")).toHaveTextContent("prev:75"));
+  });
+
+  it("toggles the slider closed on a second click", async () => {
+    const entry = mockEntry({ author: "bob", permlink: "b-post", post_id: 1000, active_votes: [] });
+    renderWithQueryClient(<EntryVoteBtn entry={entry} isPostSlider={true} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(await screen.findByTestId("vote-dialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => expect(screen.queryByTestId("vote-dialog")).not.toBeInTheDocument());
+  });
+});

--- a/apps/web/src/specs/features/shared/entry-vote-dialog.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-vote-dialog.spec.tsx
@@ -1,0 +1,70 @@
+import { vi } from "vitest";
+import React from "react";
+import { screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { renderWithQueryClient, mockEntry } from "@/specs/test-utils";
+
+// The RC pre-check banner pulls in its own SDK/mutation chain we don't exercise here.
+vi.mock("@/features/shared/rc-precheck", () => ({
+  RcPrecheckBanner: () => null
+}));
+
+// FormattedCurrency formats via formattedNumber from the globally-mocked @/utils;
+// stub it (the @/features/shared barrel re-export resolves to this module).
+vi.mock("@/features/shared/formatted-currency", () => ({
+  FormattedCurrency: ({ value }: { value: number }) => <span>{value}</span>
+}));
+
+import { EntryVoteDialog } from "@/features/shared/entry-vote-btn/entry-vote-dialog";
+
+function renderDialog(previousVotedValue: number | undefined) {
+  const entry = mockEntry({ author: "bob", permlink: "p", post_id: 7, is_paidout: false });
+  const props = {
+    entry,
+    account: undefined,
+    upVoted: true,
+    downVoted: false,
+    isPostSlider: true,
+    previousVotedValue,
+    setTipDialogMounted: vi.fn(),
+    onClick: vi.fn(),
+    handleClickAway: vi.fn(),
+    isVoted: { upVoted: true, downVoted: false },
+    isVotingLoading: false
+  };
+  const utils = renderWithQueryClient(<EntryVoteDialog {...props} />);
+  const rerender = (next: number | undefined) =>
+    utils.rerender(<EntryVoteDialog {...props} previousVotedValue={next} />);
+  return { ...utils, rerender };
+}
+
+describe("EntryVoteDialog — applying a late previous-vote value", () => {
+  beforeEach(() => window.sessionStorage.clear());
+  afterEach(() => vi.clearAllMocks());
+
+  it("syncs the slider to the previous vote when it resolves after open (user has not touched it)", () => {
+    const { rerender } = renderDialog(undefined);
+
+    const slider = screen.getByRole("slider");
+    // Opens at the default fallback weight (100%) before the previous vote loads.
+    expect(slider).toHaveAttribute("aria-valuenow", "100");
+
+    // The prior vote (40%) arrives in the background.
+    rerender(40);
+    expect(screen.getByRole("slider")).toHaveAttribute("aria-valuenow", "40");
+  });
+
+  it("does NOT override a weight the user already started adjusting while it loaded", () => {
+    const { rerender } = renderDialog(undefined);
+
+    const slider = screen.getByRole("slider");
+    // The user grabs the slider (genuine pointer input) and sets 65% before the fetch resolves.
+    fireEvent.mouseDown(slider);
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "65" } });
+    expect(screen.getByRole("slider")).toHaveAttribute("aria-valuenow", "65");
+
+    // The late prior vote (40%) must not clobber the user's in-progress choice.
+    rerender(40);
+    expect(screen.getByRole("slider")).toHaveAttribute("aria-valuenow", "65");
+  });
+});

--- a/apps/web/src/specs/setup-any-spec.ts
+++ b/apps/web/src/specs/setup-any-spec.ts
@@ -125,6 +125,12 @@ vi.mock("@ecency/sdk", () => ({
     queryKey: ["posts", "active-votes", entry?.author, entry?.permlink],
     queryFn: vi.fn()
   })),
+  getDynamicPropsQueryOptions: vi.fn(() => ({
+    queryKey: ["dynamic-props"],
+    queryFn: vi.fn()
+  })),
+  votingPower: vi.fn(() => 0),
+  votingValue: vi.fn(() => 0),
   useBookmarkAdd: vi.fn(),
   useBookmarkDelete: vi.fn(),
   useAccountRevokeKey: vi.fn(() => ({ mutateAsync: vi.fn() })),

--- a/apps/web/src/specs/setup-any-spec.ts
+++ b/apps/web/src/specs/setup-any-spec.ts
@@ -121,6 +121,10 @@ vi.mock("@ecency/sdk", () => ({
     queryKey: ["posts", "deleted-entry", `@${author}/${permlink}`],
     queryFn: vi.fn()
   })),
+  getEntryActiveVotesQueryOptions: vi.fn((entry) => ({
+    queryKey: ["posts", "active-votes", entry?.author, entry?.permlink],
+    queryFn: vi.fn()
+  })),
   useBookmarkAdd: vi.fn(),
   useBookmarkDelete: vi.fn(),
   useAccountRevokeKey: vi.fn(() => ({ mutateAsync: vi.fn() })),


### PR DESCRIPTION
## What

Opening the vote slider used to `await getPreviousVote()` before opening the dialog. On a post the user has already voted on, when the prior vote weight isn't in session cache, `getPreviousVote()` does a network fetch (`getEntryActiveVotesQueryOptions`) to recover it. That made the slider open wait on RPC latency, which shows up as poor INP (interaction responsiveness) on that tap.

## Change

- `entry-vote-btn/index.tsx`: `toggleDialog` now opens the slider immediately and resolves the previous vote in the background (`getPreviousVote().then(setPreviousVotedValue)`), instead of awaiting it before `setDialog(true)`.
- `entry-vote-dialog.tsx`: `EntryVoteDialog` initializes its slider state from `previousVotedValue` only at mount (via `useState`), so it would otherwise miss a value that now arrives after open. It now applies a late-arriving `previousVotedValue` to the slider **exactly once**, guarded so a re-render can't override a value the user has already started adjusting.

Behavior is preserved for the common case: an already-voted user still sees their prior vote weight pre-filled; it just no longer blocks the slider from opening.

## Tests

- New `entry-vote-btn.spec.tsx`: asserts the slider opens while the previous-vote fetch is still pending, that the resolved value is then forwarded to the slider, and that a second tap closes it.
- Adds the missing `getEntryActiveVotesQueryOptions` stub to the shared `setup-any-spec.ts`.
- `apps/web` typecheck: no new errors. `features/shared` suite: 242 passing (incl. existing entry-list-item / discussion-item / entry-votes specs that render this button).

## Manual check suggestion

On an already-voted post with a cold session cache, open the vote slider: it should open instantly and still fill in your previous vote percentage once it loads.
