### PR TITLE
fix(profile): paint profile card above the fold without a hydration-gated fade

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -70,17 +70,18 @@ export function ProfileCard({ account }: Props) {
   );
 
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      className="rounded-xl w-full overflow-hidden relative p-4"
-    >
+    <div className="rounded-xl w-full overflow-hidden relative p-4">
+      {/* No opacity fade-in here: this card is above the fold, so a
+          framer-motion initial opacity:0 left the whole header (cover, avatar,
+          name) invisible in the SSR HTML until hydration, delaying LCP paint.
+          Render it visible from the server instead. */}
       <Image
           className="absolute top-0 left-0 w-full h-[96px] object-cover"
           src={imageSrc ?? (data?.profile?.cover_image ? `${defaults.imageServer}/u/${data.name}/cover` : "/assets/promote-wave-bg.jpg")}
           alt=""
           width={300}
           height={200}
+          priority
           onError={() => setImageSrc("/assets/promote-wave-bg.jpg")}
       />
 
@@ -227,6 +228,6 @@ export function ProfileCard({ account }: Props) {
       )}
 
       <FinalizeCommunityBanner username={account.name} />
-    </motion.div>
+    </div>
   );
 }


### PR DESCRIPTION
## What

`ProfileCard` (shown at the top of every profile page) wrapped its entire body — cover banner, avatar, name, stats — in a framer-motion `initial={{ opacity: 0 }} animate={{ opacity: 1 }}` fade. Because framer-motion renders the `initial` state during SSR, the card shipped as `opacity:0` in the server HTML and only became visible once the bundle hydrated and ran the animation. For above-the-fold content that defers the LCP paint until hydration.

Confirmed in the live SSR: the profile document contains exactly one `opacity:0` — this wrapper.

## Change

- Replace the wrapper `motion.div` (opacity fade) with a plain `div` so the card paints visible straight from the server. The inner badge/about animations are unchanged.
- Add `priority` to the cover `<Image>` — it's always above the fold, so it shouldn't be lazy-loaded.

One file, +7/-6.

## Notes / scope

- Behavioral effect is purely the loss of a fade-in on the profile header (it now appears immediately). No logic change.
- This targets render-delay on the profile header specifically. Magnitude is best confirmed on staging / via field data, since lab LCP for these pages is throttle-distorted.

## Validation

- `apps/web` typecheck: no new errors (the 2 pre-existing errors in this file are unchanged on develop).
- Existing profile specs pass.
