### PR TITLE
perf(ssr): strip active_votes from anonymous feed + profile SSR payloads

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-warnings.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-warnings.tsx
@@ -11,7 +11,10 @@ interface Props {
 
 export function EntryPageWarnings({ entry }: Props) {
   const isMuted = !!entry.stats?.gray && entry.net_rshares >= 0 && entry.author_reputation >= 0;
-  const isHidden = isHiddenPost(entry?.net_rshares, entry?.active_votes?.length ?? 0);
+  const isHidden = isHiddenPost(
+    entry?.net_rshares,
+    entry?.stats?.total_votes ?? entry?.active_votes?.length ?? 0
+  );
   const isLowReputation =
     !!entry.stats?.gray && entry.net_rshares >= 0 && entry.author_reputation < 0;
   // New low-reputation account publishing an outbound promo link (SEO/backlink-farm

--- a/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
@@ -8,6 +8,7 @@ import { redirect } from "next/navigation";
 import { generateFeedMetadata } from "@/app/(dynamicPages)/feed/[...sections]/_helpers";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { getQueryClient, prefetchQuery } from "@/core/react-query";
+import { stripActiveVotesFromDehydratedState } from "@/core/react-query/strip-active-votes";
 import { getPromotedPostsQuery } from "@ecency/sdk";
 import { EcencyConfigManager } from "@/config";
 
@@ -40,7 +41,7 @@ export default async function FeedPage({ params, searchParams }: Props) {
   }
 
   return (
-    <HydrationBoundary state={dehydrate(getQueryClient())}>
+    <HydrationBoundary state={stripActiveVotesFromDehydratedState(dehydrate(getQueryClient()), loggedInUser)}>
       <FeedLayout tag={tag} filter={filter} observer={observer}>
         <FeedList filter={filter} tag={tag} observer={observer} />
       </FeedLayout>

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/[section]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/[section]/page.tsx
@@ -4,6 +4,9 @@ import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { notFound } from "next/navigation";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { getQueryClient, prefetchQuery, fetchInfiniteQuery } from "@/core/react-query";
+import { stripActiveVotesFromDehydratedState } from "@/core/react-query/strip-active-votes";
+import { cookies } from "next/headers";
+import { ACTIVE_USER_COOKIE_NAME } from "@/consts";
 import { getAccountFullQueryOptions, getSearchApiInfiniteQueryOptions } from "@ecency/sdk";
 import { Metadata, ResolvingMetadata } from "next";
 import { generateProfileMetadata } from "@/app/(dynamicPages)/profile/[username]/_helpers";
@@ -24,6 +27,7 @@ export async function generateMetadata(props: Props, parent: ResolvingMetadata):
 export default async function Page({ params, searchParams }: Props) {
   const { username: usernameParam, section } = await params;
   const { query: searchParam } = await searchParams;
+  const loggedInUser = (await cookies()).get(ACTIVE_USER_COOKIE_NAME)?.value;
 
   const username = usernameParam.replace(/%40/g, "");
   const [account, searchPages, prefetchedFeed] = await Promise.all([
@@ -65,7 +69,7 @@ export default async function Page({ params, searchParams }: Props) {
   }
 
   return (
-    <HydrationBoundary state={dehydrate(getQueryClient())}>
+    <HydrationBoundary state={stripActiveVotesFromDehydratedState(dehydrate(getQueryClient()), loggedInUser)}>
       {searchData && searchData.length > 0 ? (
         <ProfileSearchContent items={searchData} />
       ) : (

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/page.tsx
@@ -1,6 +1,9 @@
 import { ProfileEntriesList, ProfileSearchContent } from "./_components";
 import { prefetchGetPostsFeedQuery } from "@/api/queries";
 import { prefetchQuery, getQueryClient, fetchInfiniteQuery } from "@/core/react-query";
+import { stripActiveVotesFromDehydratedState } from "@/core/react-query/strip-active-votes";
+import { cookies } from "next/headers";
+import { ACTIVE_USER_COOKIE_NAME } from "@/consts";
 import { getAccountFullQueryOptions, getSearchApiInfiniteQueryOptions } from "@ecency/sdk";
 import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { notFound } from "next/navigation";
@@ -16,9 +19,11 @@ interface Props {
   searchParams: Promise<Record<string, string | undefined>>;
 }
 
-// ISR: profile metadata is stable. Live data (balances, votes) fetched client-side.
-// 5 min revalidation aligned with edge cache TTL.
-export const revalidate = 300;
+// Dynamic: reads the active_user cookie to strip active_votes from the SSR
+// payload for anonymous requests only. The middleware still applies the
+// `profile` tier Cache-Control (s-maxage=300, stale-while-revalidate=3600) by
+// pathname, so the anon variant stays edge-cached on the same refresh window as
+// the previous ISR revalidate.
 
 export async function generateMetadata(props: Props, parent: ResolvingMetadata): Promise<Metadata> {
   const { username } = await props.params;
@@ -29,6 +34,7 @@ export default async function Page({ params, searchParams }: Props) {
   const { username: usernameParam } = await params;
   const username = usernameParam.replace(/%40/g, "");
   const { query: searchParam } = await searchParams;
+  const loggedInUser = (await cookies()).get(ACTIVE_USER_COOKIE_NAME)?.value;
 
   const [account, searchPages, prefetchedFeed] = await Promise.all([
     prefetchQuery(getAccountFullQueryOptions(username)),
@@ -68,7 +74,7 @@ export default async function Page({ params, searchParams }: Props) {
   }
 
   return (
-    <HydrationBoundary state={dehydrate(getQueryClient())}>
+    <HydrationBoundary state={stripActiveVotesFromDehydratedState(dehydrate(getQueryClient()), loggedInUser)}>
       {searchData && searchData.length > 0 ? (
         <ProfileSearchContent items={searchData} />
       ) : (

--- a/apps/web/src/app/waves/_components/waves-list-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-item.tsx
@@ -100,8 +100,8 @@ export const WavesListItem = React.memo(function WavesListItem({
   );
 
   const isHidden = useMemo(
-    () => isHiddenPost(entry?.net_rshares, entry?.active_votes?.length ?? 0),
-    [entry?.net_rshares, entry?.active_votes?.length]
+    () => isHiddenPost(entry?.net_rshares, entry?.stats?.total_votes ?? entry?.active_votes?.length ?? 0),
+    [entry?.net_rshares, entry?.stats?.total_votes, entry?.active_votes?.length]
   );
 
   const isCommunityMuted = entry?.stats?.gray;

--- a/apps/web/src/core/react-query/strip-active-votes.ts
+++ b/apps/web/src/core/react-query/strip-active-votes.ts
@@ -1,0 +1,114 @@
+import type { DehydratedState } from "@tanstack/react-query";
+import type { Entry } from "@/entities";
+
+/**
+ * Drop the full `active_votes` array from entries in a dehydrated React Query
+ * state before it is streamed to the client.
+ *
+ * `bridge.get_post` / `bridge.get_ranked_posts` return every vote as a
+ * `{ voter, rshares }` record. On a high-vote post or a tag/community feed that
+ * is tens to hundreds of KB of voter data that:
+ *   - anonymous visitors (the bulk of cold-load / crawler traffic) never read, and
+ *   - logged-in clients only read after hydration to colour the vote button.
+ * The full voter list shown in the votes dialog is already fetched on demand
+ * (`getEntryActiveVotesQueryOptions`) when the dialog opens, so the eager copy is
+ * redundant. Removing it shrinks the streamed payload + client JSON parse /
+ * hydration cost (a TTI/INP/bandwidth win — the LCP text already paints from HTML).
+ *
+ * Hydration-safety: we only strip entries that also carry `stats.total_votes`, so
+ * every consumer keeps a stable vote COUNT (`isHiddenPost` reads it), and we CLONE
+ * rather than mutate — the server render and SEO indexability read the live
+ * (un-dehydrated) cache, which keeps the full data.
+ */
+
+function isStripableEntry(value: unknown): value is Entry {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const entry = value as Entry;
+  return (
+    Array.isArray(entry.active_votes) &&
+    entry.active_votes.length > 0 &&
+    typeof entry.stats?.total_votes === "number"
+  );
+}
+
+function stripEntry<T>(value: T): T {
+  return isStripableEntry(value) ? ({ ...value, active_votes: [] } as T) : value;
+}
+
+function stripEntryArray<T>(items: T[]): T[] {
+  let changed = false;
+  const next = items.map((item) => {
+    const stripped = stripEntry(item);
+    if (stripped !== item) {
+      changed = true;
+    }
+    return stripped;
+  });
+  return changed ? next : items;
+}
+
+// A feed page is either an Entry[] (ranked/account posts) or a search response
+// object that holds the entries under `results`.
+function stripPage(page: unknown): unknown {
+  if (Array.isArray(page)) {
+    return stripEntryArray(page);
+  }
+  if (page && typeof page === "object" && Array.isArray((page as { results?: unknown }).results)) {
+    const results = stripEntryArray((page as { results: unknown[] }).results);
+    return results === (page as { results: unknown[] }).results ? page : { ...page, results };
+  }
+  return page;
+}
+
+function stripQueryData(data: unknown): unknown {
+  if (!data || typeof data !== "object") {
+    return data;
+  }
+  // Infinite query (feed / profile / community): { pages: Page[], pageParams }
+  if (Array.isArray((data as { pages?: unknown }).pages)) {
+    const pages = (data as { pages: unknown[] }).pages;
+    let changed = false;
+    const next = pages.map((page) => {
+      const stripped = stripPage(page);
+      if (stripped !== page) {
+        changed = true;
+      }
+      return stripped;
+    });
+    return changed ? { ...data, pages: next } : data;
+  }
+  // Plain array of entries (e.g. a discussion list)
+  if (Array.isArray(data)) {
+    return stripEntryArray(data as unknown[]);
+  }
+  // Single entry (post / wave page)
+  return stripEntry(data);
+}
+
+export function stripActiveVotesFromDehydratedState(
+  state: DehydratedState,
+  currentUser?: string
+): DehydratedState {
+  // Only strip for ANONYMOUS requests. Logged-in requests keep the full
+  // active_votes: isVoted (the "you voted" highlight) reads them client-side
+  // after auth loads, and a logged-in cache variant only ever holds public vote
+  // data. Anonymous / crawler requests never need isVoted, and their cache
+  // variant carries no user-specific data, so stripping there is safe and
+  // shrinks the payload that the bulk of cold-load / SEO traffic downloads.
+  if (currentUser) {
+    return state;
+  }
+  return {
+    ...state,
+    queries: state.queries.map((query) => {
+      const data = query.state?.data;
+      const stripped = stripQueryData(data);
+      if (stripped === data) {
+        return query;
+      }
+      return { ...query, state: { ...query.state, data: stripped } };
+    })
+  };
+}

--- a/apps/web/src/core/react-query/strip-active-votes.ts
+++ b/apps/web/src/core/react-query/strip-active-votes.ts
@@ -26,11 +26,12 @@ function isStripableEntry(value: unknown): value is Entry {
     return false;
   }
   const entry = value as Entry;
-  return (
-    Array.isArray(entry.active_votes) &&
-    entry.active_votes.length > 0 &&
-    typeof entry.stats?.total_votes === "number"
-  );
+  // Strip only when a vote COUNT survives elsewhere, so consumers stay
+  // hydration-stable: posts carry it on stats.total_votes; search results carry
+  // it as a top-level total_votes.
+  const hasCount =
+    typeof entry.stats?.total_votes === "number" || typeof entry.total_votes === "number";
+  return Array.isArray(entry.active_votes) && entry.active_votes.length > 0 && hasCount;
 }
 
 function stripEntry<T>(value: T): T {

--- a/apps/web/src/core/react-query/strip-active-votes.ts
+++ b/apps/web/src/core/react-query/strip-active-votes.ts
@@ -85,7 +85,27 @@ function stripQueryData(data: unknown): unknown {
     return stripEntryArray(data as unknown[]);
   }
   // Single entry (post / wave page)
-  return stripEntry(data);
+  const single = stripEntry(data);
+  if (single !== data) {
+    return single;
+  }
+  // Otherwise it may be a keyed map of entries (e.g. a raw bridge.get_discussion
+  // object: { "author/permlink": Entry, ... }). Strip any value that is itself a
+  // stripable entry and leave everything else untouched.
+  return stripKeyedEntries(data as Record<string, unknown>);
+}
+
+function stripKeyedEntries(obj: Record<string, unknown>): Record<string, unknown> {
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const stripped = stripEntry(value);
+    if (stripped !== value) {
+      changed = true;
+    }
+    next[key] = stripped;
+  }
+  return changed ? next : obj;
 }
 
 export function stripActiveVotesFromDehydratedState(

--- a/apps/web/src/features/shared/discussion/discussion-item.tsx
+++ b/apps/web/src/features/shared/discussion/discussion-item.tsx
@@ -118,8 +118,8 @@ export const DiscussionItem = memo(function DiscussionItem({
   const isOwnRoot = useMemo(() => activeUser?.username === root.author, [activeUser, root]);
   const isOwnReply = useMemo(() => activeUser?.username === entry.author, [activeUser, entry]);
   const isHidden = useMemo(
-    () => isHiddenPost(entry.net_rshares, entry.active_votes.length),
-    [entry.net_rshares, entry.active_votes.length]
+    () => isHiddenPost(entry.net_rshares, entry.stats?.total_votes ?? entry.active_votes?.length ?? 0),
+    [entry.net_rshares, entry.stats?.total_votes, entry.active_votes?.length]
   );
   const isMuted = useMemo(
     () => entry.stats?.gray === true && entry.net_rshares >= 0 && entry.author_reputation >= 0,

--- a/apps/web/src/features/shared/entry-list-item/entry-list-item-muted-content.tsx
+++ b/apps/web/src/features/shared/entry-list-item/entry-list-item-muted-content.tsx
@@ -40,8 +40,8 @@ export function EntryListItemMutedContent({ entry: entryProp, isThumbLcp }: Prop
   const isCrossPost = useMemo(() => !!entry.original_entry, [entry.original_entry]);
   const isModMuted = useMemo(() => entry.stats?.gray ?? false, [entry.stats?.gray]);
   const isHidden = useMemo(
-    () => isHiddenPost(entry.net_rshares, entry.active_votes?.length ?? 0),
-    [entry.net_rshares, entry.active_votes?.length]
+    () => isHiddenPost(entry.net_rshares, entry.stats?.total_votes ?? entry.active_votes?.length ?? 0),
+    [entry.net_rshares, entry.stats?.total_votes, entry.active_votes?.length]
   );
   const nsfw = useMemo(
     () =>

--- a/apps/web/src/specs/core/strip-active-votes.spec.ts
+++ b/apps/web/src/specs/core/strip-active-votes.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { DehydratedState } from "@tanstack/react-query";
+import { stripActiveVotesFromDehydratedState } from "@/core/react-query/strip-active-votes";
+
+function entry(overrides: Record<string, any> = {}) {
+  return {
+    author: "alice",
+    permlink: "p",
+    net_rshares: 0,
+    stats: { total_votes: 3, flag_weight: 0, gray: false, hide: false },
+    active_votes: [
+      { voter: "a", rshares: 1 },
+      { voter: "b", rshares: 2 },
+      { voter: "c", rshares: 3 }
+    ],
+    ...overrides
+  };
+}
+
+function dehydrated(data: unknown): DehydratedState {
+  return {
+    mutations: [],
+    queries: [
+      {
+        queryKey: ["posts", "entry", "/@alice/p"],
+        queryHash: "h",
+        state: { data, dataUpdatedAt: 0, status: "success" } as any
+      } as any
+    ]
+  };
+}
+
+describe("stripActiveVotesFromDehydratedState", () => {
+  it("strips active_votes from a single dehydrated entry but keeps stats.total_votes", () => {
+    const e = entry();
+    const out = stripActiveVotesFromDehydratedState(dehydrated(e));
+    const data = out.queries[0].state.data as any;
+    expect(data.active_votes).toEqual([]);
+    expect(data.stats.total_votes).toBe(3);
+    // other fields untouched
+    expect(data.author).toBe("alice");
+  });
+
+  it("does NOT mutate the original entry (clones)", () => {
+    const e = entry();
+    stripActiveVotesFromDehydratedState(dehydrated(e));
+    expect(e.active_votes).toHaveLength(3);
+  });
+
+  it("returns the state UNCHANGED for a logged-in request (currentUser set) — keeps full votes for isVoted", () => {
+    const e = entry();
+    const state = dehydrated(e);
+    const out = stripActiveVotesFromDehydratedState(state, "alice");
+    expect(out).toBe(state);
+    expect((out.queries[0].state.data as any).active_votes).toHaveLength(3);
+  });
+
+  it("strips for an anonymous request (no currentUser)", () => {
+    const e = entry();
+    const out = stripActiveVotesFromDehydratedState(dehydrated(e), undefined);
+    expect((out.queries[0].state.data as any).active_votes).toEqual([]);
+  });
+
+  it("leaves entries WITHOUT stats.total_votes intact (so their vote count stays stable)", () => {
+    const e = entry({ stats: undefined });
+    const out = stripActiveVotesFromDehydratedState(dehydrated(e));
+    expect((out.queries[0].state.data as any).active_votes).toHaveLength(3);
+  });
+
+  it("leaves an entry with already-empty active_votes referentially unchanged", () => {
+    const e = entry({ active_votes: [] });
+    const out = stripActiveVotesFromDehydratedState(dehydrated(e));
+    expect(out.queries[0].state.data).toBe(e);
+  });
+
+  it("strips entries inside an infinite feed (pages of Entry[])", () => {
+    const data = {
+      pages: [[entry({ permlink: "p1" }), entry({ permlink: "p2" })], [entry({ permlink: "p3" })]],
+      pageParams: [null]
+    };
+    const out = stripActiveVotesFromDehydratedState(dehydrated(data));
+    const pages = (out.queries[0].state.data as any).pages;
+    expect(pages[0][0].active_votes).toEqual([]);
+    expect(pages[0][1].active_votes).toEqual([]);
+    expect(pages[1][0].active_votes).toEqual([]);
+    expect(pages[0][0].stats.total_votes).toBe(3);
+  });
+
+  it("strips entries inside an infinite search feed (pages of { results })", () => {
+    const data = {
+      pages: [{ results: [entry({ permlink: "s1" }), entry({ permlink: "s2" })], scroll_id: "x" }],
+      pageParams: [null]
+    };
+    const out = stripActiveVotesFromDehydratedState(dehydrated(data));
+    const page0 = (out.queries[0].state.data as any).pages[0];
+    expect(page0.results[0].active_votes).toEqual([]);
+    expect(page0.results[1].active_votes).toEqual([]);
+    expect(page0.scroll_id).toBe("x");
+  });
+
+  it("strips a plain array of entries (discussion list)", () => {
+    const out = stripActiveVotesFromDehydratedState(
+      dehydrated([entry({ permlink: "r1" }), entry({ permlink: "r2" })])
+    );
+    const arr = out.queries[0].state.data as any[];
+    expect(arr[0].active_votes).toEqual([]);
+    expect(arr[1].active_votes).toEqual([]);
+  });
+
+  it("leaves non-entry query data untouched", () => {
+    const data = { foo: "bar", count: 5 };
+    const out = stripActiveVotesFromDehydratedState(dehydrated(data));
+    expect(out.queries[0].state.data).toBe(data);
+  });
+
+  it("returns the same query objects when nothing changed", () => {
+    const state = dehydrated({ foo: 1 });
+    const out = stripActiveVotesFromDehydratedState(state);
+    expect(out.queries[0]).toBe(state.queries[0]);
+  });
+});

--- a/apps/web/src/specs/core/strip-active-votes.spec.ts
+++ b/apps/web/src/specs/core/strip-active-votes.spec.ts
@@ -125,8 +125,20 @@ describe("stripActiveVotesFromDehydratedState", () => {
     expect(arr[1].active_votes).toEqual([]);
   });
 
+  it("strips a keyed map of entries (raw bridge.get_discussion shape)", () => {
+    const data = {
+      "alice/p1": entry({ permlink: "p1" }),
+      "bob/p2": entry({ permlink: "p2" })
+    };
+    const out = stripActiveVotesFromDehydratedState(dehydrated(data));
+    const d = out.queries[0].state.data as any;
+    expect(d["alice/p1"].active_votes).toEqual([]);
+    expect(d["bob/p2"].active_votes).toEqual([]);
+    expect(d["alice/p1"].stats.total_votes).toBe(3);
+  });
+
   it("leaves non-entry query data untouched", () => {
-    const data = { foo: "bar", count: 5 };
+    const data = { foo: "bar", count: 5, nested: { a: 1 } };
     const out = stripActiveVotesFromDehydratedState(dehydrated(data));
     expect(out.queries[0].state.data).toBe(data);
   });

--- a/apps/web/src/specs/core/strip-active-votes.spec.ts
+++ b/apps/web/src/specs/core/strip-active-votes.spec.ts
@@ -86,6 +86,24 @@ describe("stripActiveVotesFromDehydratedState", () => {
     expect(pages[0][0].stats.total_votes).toBe(3);
   });
 
+  it("strips a search result that carries a top-level total_votes instead of stats.total_votes", () => {
+    const searchResult = {
+      author: "alice",
+      permlink: "s",
+      total_votes: 42,
+      active_votes: [
+        { voter: "a", rshares: 1 },
+        { voter: "b", rshares: 2 }
+      ]
+    };
+    const out = stripActiveVotesFromDehydratedState(
+      dehydrated({ pages: [{ results: [searchResult] }], pageParams: [null] })
+    );
+    const r = (out.queries[0].state.data as any).pages[0].results[0];
+    expect(r.active_votes).toEqual([]);
+    expect(r.total_votes).toBe(42);
+  });
+
   it("strips entries inside an infinite search feed (pages of { results })", () => {
     const data = {
       pages: [{ results: [entry({ permlink: "s1" }), entry({ permlink: "s2" })], scroll_id: "x" }],

--- a/apps/web/src/utils/entry-indexability.ts
+++ b/apps/web/src/utils/entry-indexability.ts
@@ -235,7 +235,8 @@ const passesWaveQualityGate = (entry: Entry): boolean => {
   const children = typeof entry.children === "number" ? entry.children : 0;
   if (children >= WAVE_MIN_CHILDREN) return true;
 
-  const voters = Array.isArray(entry.active_votes) ? entry.active_votes.length : 0;
+  const voters =
+    entry.stats?.total_votes ?? (Array.isArray(entry.active_votes) ? entry.active_votes.length : 0);
   return voters >= WAVE_MIN_VOTERS && effectivePayout(entry) >= WAVE_MIN_PAYOUT;
 };
 


### PR DESCRIPTION
## What

Hive's `bridge.get_post` / `get_ranked_posts` / `get_account_posts` return the full `active_votes` array (a `{ voter, rshares }` record per vote), which gets dehydrated into the SSR payload. On busy tag feeds and profiles that's a large, anon-irrelevant chunk — measured live:

| Page | active_votes in anon SSR |
|---|---|
| Tag feed `/trending/photography` | ~580 KB (~half the page) |
| `/@good-karma` | 542 KB (57% of page, 12.9k voters) |
| `/@taskmaster4450` | 594 KB (57%, 13.8k voters) |
| `/@ecency` | 301 KB (41%, 7k voters) |

Anonymous / crawler visitors — the bulk of these SEO pages' traffic — never read it (the "you voted" highlight is logged-in-only, and the votes dialog already fetches the list on demand). So this strips it **for anonymous requests only**.

## How

- **`stripActiveVotesFromDehydratedState(state, currentUser?)`** (`core/react-query/strip-active-votes.ts`) walks the dehydrated queries and sets `entry.active_votes = []` across the shapes that occur (single entry, infinite `Entry[]`/search-`{results}` pages, discussion arrays). It **returns the state untouched when `currentUser` is set** (logged-in keeps the full array), **clones** rather than mutates (server render + SEO indexability keep full data), and only strips entries that also carry `stats.total_votes` so the vote count stays hydration-stable.
- Applied at the dehydrate boundary of the **tag/filter feed** (`feed/[...sections]`, already cookie-aware) and the **profile account-posts feed** (`profile/[username]` + `[section]`), gated on the `active_user` cookie.
- The profile pages become **dynamic** (cookie read), so the ISR `revalidate = 300` is removed. The cache-policy middleware applies the `profile` tier `Cache-Control` (`s-maxage=300, swr=3600`) by pathname regardless, so the anon variant stays edge-cached on the same window.
- Vote-count consumers routed through `entry.stats.total_votes` (the `isHiddenPost` callers + the wave indexability gate), so they don't depend on the stripped array.

## Why it's safe (verified)

- **Logged-in unaffected:** the helper early-returns when `currentUser` is set, so logged-in keeps the full `active_votes`; `isVoted` reads it client-side unchanged.
- **Edge isolation:** the CF worker keys its HTML cache on `__ec_auth=anon|loggedin` (the same `active_user` cookie) and forwards the cookie to origin — anon and logged-in get separate cache entries, never cross-served.
- **TTFB preserved:** a dynamic+anon route warm-caches at the worker (verified live: `x-edge-cache: HIT`, ~70-90 ms); cold true-miss is masked by `stale-while-revalidate`, same as the old ISR window.
- **UX neutral:** counts via `stats.total_votes`; the #1023 profile-card LCP fix is SSR-byte-identical; hydration unchanged (clone).

## Validation

- New strip-util spec (single entry / infinite / search / discussion shapes, clone-not-mutate, skip-without-stats, logged-in no-op, anon strip).
- `apps/web` typecheck: no new errors. Affected component specs pass (entry-list-item, discussion-item, entry-votes, entry-indexability).

## Staging checks before merge

1. Anon HTML size before/after on a high-vote profile + tag feed — expect ~40-57% smaller; confirm no `active_votes` arrays in the anon flight payload.
2. Anon warm edge: 2nd curl shows `x-edge-cache: HIT`, TTFB ~90 ms, `Cache-Control: ...s-maxage=300, swr=3600`.
3. Anon cold TTFB bounded (few hundred ms, not multi-second).
4. Logged-in (`active_user` cookie): `active_votes` still full, "you voted" highlight works, lands on a separate `__ec_auth=loggedin` entry.
5. Vote counts correct on a high-vote post (from `stats.total_votes`); zero hydration-mismatch console warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved server-side hydration for feeds and profiles to avoid sending active vote details to the browser for anonymous viewing.
* **Bug Fixes**
  * Hidden-content checks and wave quality-gate logic now prefer `stats.total_votes` (falling back to active vote length) for more consistent visibility decisions across entry, discussion, and wave views.
  * Corrected hydration behavior across multiple feed/search result layouts to keep visibility rules accurate after loading.
* **Tests**
  * Added coverage for stripping active votes from dehydrated query data across supported shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->