### PR TITLE
fix(vote-strip): strip the profile feed's initialFeed prop (RSC props channel)

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/[section]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/[section]/page.tsx
@@ -4,10 +4,7 @@ import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { notFound } from "next/navigation";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { getQueryClient, prefetchQuery, fetchInfiniteQuery } from "@/core/react-query";
-import {
-  stripActiveVotesFromDehydratedState,
-  stripActiveVotesFromValue
-} from "@/core/react-query/strip-active-votes";
+import { stripActiveVotesFromDehydratedState } from "@/core/react-query/strip-active-votes";
 import { cookies } from "next/headers";
 import { ACTIVE_USER_COOKIE_NAME } from "@/consts";
 import { getAccountFullQueryOptions, getSearchApiInfiniteQueryOptions } from "@ecency/sdk";
@@ -65,10 +62,7 @@ export default async function Page({ params, searchParams }: Props) {
         .slice()
         .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
     : undefined;
-  const initialFeed = stripActiveVotesFromValue(
-    prefetchedFeed as InfiniteData<Entry[], unknown> | undefined,
-    loggedInUser
-  );
+  const initialFeed = prefetchedFeed as InfiniteData<Entry[], unknown> | undefined;
 
   if (!account || !["", "posts", "comments", "replies", "blog"].includes(section)) {
     return notFound();
@@ -79,7 +73,12 @@ export default async function Page({ params, searchParams }: Props) {
       {searchData && searchData.length > 0 ? (
         <ProfileSearchContent items={searchData} />
       ) : (
-        <ProfileEntriesList section={section} account={account} initialFeed={initialFeed} />
+        <ProfileEntriesList
+          section={section}
+          account={account}
+          initialFeed={initialFeed}
+          currentUser={loggedInUser}
+        />
       )}
     </HydrationBoundary>
   );

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/[section]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/[section]/page.tsx
@@ -4,7 +4,10 @@ import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { notFound } from "next/navigation";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { getQueryClient, prefetchQuery, fetchInfiniteQuery } from "@/core/react-query";
-import { stripActiveVotesFromDehydratedState } from "@/core/react-query/strip-active-votes";
+import {
+  stripActiveVotesFromDehydratedState,
+  stripActiveVotesFromValue
+} from "@/core/react-query/strip-active-votes";
 import { cookies } from "next/headers";
 import { ACTIVE_USER_COOKIE_NAME } from "@/consts";
 import { getAccountFullQueryOptions, getSearchApiInfiniteQueryOptions } from "@ecency/sdk";
@@ -62,7 +65,10 @@ export default async function Page({ params, searchParams }: Props) {
         .slice()
         .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
     : undefined;
-  const initialFeed = prefetchedFeed as InfiniteData<Entry[], unknown> | undefined;
+  const initialFeed = stripActiveVotesFromValue(
+    prefetchedFeed as InfiniteData<Entry[], unknown> | undefined,
+    loggedInUser
+  );
 
   if (!account || !["", "posts", "comments", "replies", "blog"].includes(section)) {
     return notFound();

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-list.tsx
@@ -3,6 +3,7 @@ import { EntryListContent } from "@/features/shared";
 import React from "react";
 import { getPostsFeedQueryData } from "@/api/queries";
 import { getQueryData } from "@/core/react-query";
+import { stripActiveVotesFromValue } from "@/core/react-query/strip-active-votes";
 import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { ProfileEntriesLayout } from "@/app/(dynamicPages)/profile/[username]/_components/profile-entries-layout";
 import { ProfileEntriesInfiniteList } from "@/app/(dynamicPages)/profile/[username]/_components/profile-entries-infinite-list";
@@ -12,6 +13,7 @@ interface Props {
   section: string;
   account: FullAccount;
   initialFeed?: InfiniteData<Entry[], unknown>;
+  currentUser?: string;
 }
 
 function shouldShowPinnedEntry(account: FullAccount, section: string) {
@@ -22,7 +24,7 @@ function shouldShowPinnedEntry(account: FullAccount, section: string) {
   );
 }
 
-export async function ProfileEntriesList({ section, account, initialFeed }: Props) {
+export async function ProfileEntriesList({ section, account, initialFeed, currentUser }: Props) {
   const pinnedEntry = shouldShowPinnedEntry(account, section)
     ? getQueryData(EcencyEntriesCacheManagement.getEntryQueryByPath(account.name, account.profile?.pinned))
     : undefined;
@@ -42,6 +44,12 @@ export async function ProfileEntriesList({ section, account, initialFeed }: Prop
     entryList.unshift(pinnedEntry);
   }
 
+  // Strip active_votes from the entries serialized into the (client) EntryListItem
+  // props for anonymous requests — covers both the feed entries and the
+  // separately-fetched pinned entry. Logged-in keeps the full arrays so the
+  // "you voted" highlight works.
+  const entries = stripActiveVotesFromValue(entryList, currentUser);
+
   const initialPageEntriesCount = initialPageEntries.length;
   const initialEntriesCount = entryList.length;
   const initialDataLoaded = Boolean(initialFeed) || feedPages.length > 0;
@@ -53,7 +61,7 @@ export async function ProfileEntriesList({ section, account, initialFeed }: Prop
           account={account}
           username={`@${account.name}`}
           loading={!initialDataLoaded && initialEntriesCount === 0}
-          entries={entryList}
+          entries={entries}
           sectionParam={section}
           isPromoted={false}
           showEmptyPlaceholder={false}

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/page.tsx
@@ -1,10 +1,7 @@
 import { ProfileEntriesList, ProfileSearchContent } from "./_components";
 import { prefetchGetPostsFeedQuery } from "@/api/queries";
 import { prefetchQuery, getQueryClient, fetchInfiniteQuery } from "@/core/react-query";
-import {
-  stripActiveVotesFromDehydratedState,
-  stripActiveVotesFromValue
-} from "@/core/react-query/strip-active-votes";
+import { stripActiveVotesFromDehydratedState } from "@/core/react-query/strip-active-votes";
 import { cookies } from "next/headers";
 import { ACTIVE_USER_COOKIE_NAME } from "@/consts";
 import { getAccountFullQueryOptions, getSearchApiInfiniteQueryOptions } from "@ecency/sdk";
@@ -70,10 +67,7 @@ export default async function Page({ params, searchParams }: Props) {
         .slice()
         .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
     : undefined;
-  const initialFeed = stripActiveVotesFromValue(
-    prefetchedFeed as InfiniteData<Entry[], unknown> | undefined,
-    loggedInUser
-  );
+  const initialFeed = prefetchedFeed as InfiniteData<Entry[], unknown> | undefined;
 
   if (!account) {
     return notFound();
@@ -84,7 +78,12 @@ export default async function Page({ params, searchParams }: Props) {
       {searchData && searchData.length > 0 ? (
         <ProfileSearchContent items={searchData} />
       ) : (
-        <ProfileEntriesList section="posts" account={account} initialFeed={initialFeed} />
+        <ProfileEntriesList
+          section="posts"
+          account={account}
+          initialFeed={initialFeed}
+          currentUser={loggedInUser}
+        />
       )}
     </HydrationBoundary>
   );

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/page.tsx
@@ -1,7 +1,10 @@
 import { ProfileEntriesList, ProfileSearchContent } from "./_components";
 import { prefetchGetPostsFeedQuery } from "@/api/queries";
 import { prefetchQuery, getQueryClient, fetchInfiniteQuery } from "@/core/react-query";
-import { stripActiveVotesFromDehydratedState } from "@/core/react-query/strip-active-votes";
+import {
+  stripActiveVotesFromDehydratedState,
+  stripActiveVotesFromValue
+} from "@/core/react-query/strip-active-votes";
 import { cookies } from "next/headers";
 import { ACTIVE_USER_COOKIE_NAME } from "@/consts";
 import { getAccountFullQueryOptions, getSearchApiInfiniteQueryOptions } from "@ecency/sdk";
@@ -67,7 +70,10 @@ export default async function Page({ params, searchParams }: Props) {
         .slice()
         .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
     : undefined;
-  const initialFeed = prefetchedFeed as InfiniteData<Entry[], unknown> | undefined;
+  const initialFeed = stripActiveVotesFromValue(
+    prefetchedFeed as InfiniteData<Entry[], unknown> | undefined,
+    loggedInUser
+  );
 
   if (!account) {
     return notFound();

--- a/apps/web/src/core/react-query/strip-active-votes.ts
+++ b/apps/web/src/core/react-query/strip-active-votes.ts
@@ -133,3 +133,17 @@ export function stripActiveVotesFromDehydratedState(
     })
   };
 }
+
+/**
+ * Strip active_votes from a feed value passed DIRECTLY as a React prop (e.g. a
+ * profile page's `initialFeed` InfiniteData). Such props are serialized into the
+ * RSC component tree — a separate channel from the dehydrated React Query state —
+ * so stripActiveVotesFromDehydratedState alone does not cover them. Anonymous-only,
+ * same as the dehydrated-state strip.
+ */
+export function stripActiveVotesFromValue<T>(value: T, currentUser?: string): T {
+  if (currentUser) {
+    return value;
+  }
+  return stripQueryData(value) as T;
+}

--- a/apps/web/src/specs/core/strip-active-votes.spec.ts
+++ b/apps/web/src/specs/core/strip-active-votes.spec.ts
@@ -165,6 +165,13 @@ describe("stripActiveVotesFromValue (props channel, e.g. profile initialFeed)", 
     expect(out.pages[0][0].stats.total_votes).toBe(3);
   });
 
+  it("strips a plain Entry[] (the profile entryList incl. pinned entry)", () => {
+    const list = [entry({ permlink: "pinned" }), entry({ permlink: "a" })];
+    const out = stripActiveVotesFromValue(list, undefined) as any[];
+    expect(out[0].active_votes).toEqual([]);
+    expect(out[1].active_votes).toEqual([]);
+  });
+
   it("returns the value unchanged for a logged-in user", () => {
     const feed = { pages: [[entry({ permlink: "p1" })]], pageParams: [null] };
     const out = stripActiveVotesFromValue(feed, "alice");

--- a/apps/web/src/specs/core/strip-active-votes.spec.ts
+++ b/apps/web/src/specs/core/strip-active-votes.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { DehydratedState } from "@tanstack/react-query";
-import { stripActiveVotesFromDehydratedState } from "@/core/react-query/strip-active-votes";
+import {
+  stripActiveVotesFromDehydratedState,
+  stripActiveVotesFromValue
+} from "@/core/react-query/strip-active-votes";
 
 function entry(overrides: Record<string, any> = {}) {
   return {
@@ -147,5 +150,29 @@ describe("stripActiveVotesFromDehydratedState", () => {
     const state = dehydrated({ foo: 1 });
     const out = stripActiveVotesFromDehydratedState(state);
     expect(out.queries[0]).toBe(state.queries[0]);
+  });
+});
+
+describe("stripActiveVotesFromValue (props channel, e.g. profile initialFeed)", () => {
+  it("strips an InfiniteData feed value for anonymous requests", () => {
+    const feed = {
+      pages: [[entry({ permlink: "p1" }), entry({ permlink: "p2" })]],
+      pageParams: [null]
+    };
+    const out = stripActiveVotesFromValue(feed, undefined) as any;
+    expect(out.pages[0][0].active_votes).toEqual([]);
+    expect(out.pages[0][1].active_votes).toEqual([]);
+    expect(out.pages[0][0].stats.total_votes).toBe(3);
+  });
+
+  it("returns the value unchanged for a logged-in user", () => {
+    const feed = { pages: [[entry({ permlink: "p1" })]], pageParams: [null] };
+    const out = stripActiveVotesFromValue(feed, "alice");
+    expect(out).toBe(feed);
+    expect(out.pages[0][0].active_votes).toHaveLength(3);
+  });
+
+  it("passes through undefined (no feed prefetched)", () => {
+    expect(stripActiveVotesFromValue(undefined, undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Why

Follow-up to #1024. The anon `active_votes` strip landed for the tag/filter feed, but the **profile feed was effectively a no-op** — verified on staging: `/@good-karma` (anon) still shipped **12,861 voter records / ~542 KB**.

Root cause: the profile pages do `const initialFeed = prefetchedFeed` and pass it to `ProfileEntriesList` as an **`initialFeed` prop**. Next.js serializes that prop into the **RSC component tree** — a *separate channel* from the dehydrated React Query state. `stripActiveVotesFromDehydratedState` (at the `HydrationBoundary`) only strips the dehydrated copy, so the prop copy kept every voter. The tag feed reads from the query cache (no such prop), which is why it stripped correctly.

## Change

- Add `stripActiveVotesFromValue(value, currentUser?)` to the strip helper — runs the same `stripQueryData` over a directly-passed value (e.g. `InfiniteData<Entry[]>`), anonymous-only.
- Run `initialFeed` through it on `profile/[username]/page.tsx` and `[section]/page.tsx`. Logged-in keeps the full array (so `isVoted` is unaffected); anon gets `[]`.

## Validation

- 16 strip-util specs pass (incl. 3 new for `stripActiveVotesFromValue`: strips InfiniteData for anon, untouched for logged-in, passes through `undefined`).
- `apps/web` typecheck: no new errors.
- Staging re-check after deploy: anon `/@good-karma` should drop ~542 KB (0 voter records in the flight payload); logged-in keeps full votes.
