### PR TITLE
feat(mobile): smaller waves publish, header notification actions, wavy-dash Waves icon

### DIFF
--- a/apps/web/src/features/shared/navbar/navbar-main-sidebar.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-main-sidebar.tsx
@@ -10,15 +10,14 @@ import {
   UilListUl,
   UilTag,
   UilUsersAlt,
-  UilUserSquare,
-  UilWater
+  UilUserSquare
 } from "@tooni/iconscout-unicons-react";
 import { NavbarSideMainMenuItem } from "./sidebar/navbar-side-main-menu-item";
 import pack from "../../../../package.json";
 import { NavbarSideThemeSwitcher } from "@/features/shared/navbar/sidebar";
 import { Button } from "@ui/button";
 import i18next from "i18next";
-import { closeSvg } from "@ui/svg";
+import { closeSvg, WavyDashIcon } from "@ui/svg";
 import { SwitchLang } from "@/features/shared";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
@@ -118,7 +117,7 @@ export function NavbarMainSidebar({ show, setShow, setStepOne }: Props) {
             label={i18next.t("navbar.waves")}
             to="/waves"
             onClick={() => setShow(false)}
-            icon={<UilWater size={16} />}
+            icon={<WavyDashIcon size={16} />}
           />
         </EcencyConfigManager.Conditional>
 

--- a/apps/web/src/features/shared/navbar/navbar-mobile.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-mobile.tsx
@@ -9,10 +9,10 @@ import { NavbarNotificationsButton } from "@/features/shared/navbar/navbar-notif
 import { NavbarSide } from "@/features/shared/navbar/sidebar/navbar-side";
 import { useHideOnScroll } from "@/features/shared/navbar/use-hide-on-scroll";
 import { searchIconSvg } from "@ui/icons";
-import { closeSvg } from "@ui/svg";
+import { closeSvg, WavyDashIcon } from "@ui/svg";
 import { isInAppBrowser } from "@/utils";
 import { useMattermostUnread } from "@/features/chat/mattermost-api";
-import { UilBars, UilComment, UilHomeAlt, UilLock, UilPen, UilWater } from "@tooni/iconscout-unicons-react";
+import { UilBars, UilComment, UilHomeAlt, UilLock, UilPen } from "@tooni/iconscout-unicons-react";
 import { Button } from "@ui/button";
 import clsx from "clsx";
 import i18next from "i18next";
@@ -172,7 +172,7 @@ export function NavbarMobile({
         <Button
           href="/waves"
           appearance="gray-link"
-          icon={<UilWater width={20} height={20} />}
+          icon={<WavyDashIcon size={20} />}
           aria-label={i18next.t("navbar.waves")}
           aria-current={isActive("/waves") ? "page" : undefined}
           className={activeClass(isActive("/waves"))}

--- a/apps/web/src/features/shared/notifications/notifications-actions.tsx
+++ b/apps/web/src/features/shared/notifications/notifications-actions.tsx
@@ -123,21 +123,35 @@ export function NotificationsActions({ filter }: Props) {
     refetchData();
   };
 
+  // Disabled here means CSS `pointer-events: none`, which stops mouse clicks but
+  // not keyboard activation, so the handlers below also guard on these.
+  const markDisabled = markNotifications.isPending || unread === 0;
+  const refreshDisabled = isDataLoading || isUnreadLoading;
+
   return (
     <div className="list-actions">
       <Tooltip content={i18next.t("notifications.mark-all-read")}>
         <span
           className={classNameObject({
             "list-action": true,
-            disabled: markNotifications.isPending || unread === 0
+            disabled: markDisabled
           })}
           role="button"
-          tabIndex={0}
+          tabIndex={markDisabled ? -1 : 0}
+          aria-disabled={markDisabled}
           aria-label={i18next.t("notifications.mark-all-read")}
-          onClick={() => markAsRead()}
+          onClick={() => {
+            if (markDisabled) {
+              return;
+            }
+            markAsRead();
+          }}
           onKeyDown={(e) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
+              if (markDisabled) {
+                return;
+              }
               markAsRead();
             }
           }}
@@ -149,15 +163,24 @@ export function NotificationsActions({ filter }: Props) {
         <span
           className={classNameObject({
             "list-action": true,
-            disabled: isDataLoading || isUnreadLoading
+            disabled: refreshDisabled
           })}
           role="button"
-          tabIndex={0}
+          tabIndex={refreshDisabled ? -1 : 0}
+          aria-disabled={refreshDisabled}
           aria-label={i18next.t("notifications.refresh")}
-          onClick={() => refresh()}
+          onClick={() => {
+            if (refreshDisabled) {
+              return;
+            }
+            refresh();
+          }}
           onKeyDown={(e) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
+              if (refreshDisabled) {
+                return;
+              }
               refresh();
             }
           }}

--- a/apps/web/src/features/shared/notifications/notifications-actions.tsx
+++ b/apps/web/src/features/shared/notifications/notifications-actions.tsx
@@ -1,7 +1,6 @@
 import { useUpdateNotificationsSettings } from "@/api/mutations";
 import { useMarkNotificationsMutation, useSetLastReadMutation } from "@/api/sdk-mutations";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
-import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import { NotificationFilter, NotifyTypes } from "@/enums";
 import { FormControl, Tooltip } from "@/features/ui";
 import {
@@ -31,7 +30,6 @@ interface Props {
 
 export function NotificationsActions({ filter }: Props) {
   const { activeUser } = useActiveAccount();
-  const isMobile = useIsMobile();
 
   const [settings, { set: setSettingItem }] = useMap<Record<NotifyTypes, boolean>>({
     [NotifyTypes.COMMENT]: false,
@@ -127,52 +125,46 @@ export function NotificationsActions({ filter }: Props) {
 
   return (
     <div className="list-actions">
-      {!isMobile ? (
-        <>
-          <Tooltip content={i18next.t("notifications.mark-all-read")}>
-            <span
-              className={classNameObject({
-                "list-action": true,
-                disabled: markNotifications.isPending || unread === 0
-              })}
-              role="button"
-              tabIndex={0}
-              aria-label={i18next.t("notifications.mark-all-read")}
-              onClick={() => markAsRead()}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  markAsRead();
-                }
-              }}
-            >
-              {checkSvg}
-            </span>
-          </Tooltip>
-          <Tooltip content={i18next.t("notifications.refresh")}>
-            <span
-              className={classNameObject({
-                "list-action": true,
-                disabled: isDataLoading || isUnreadLoading
-              })}
-              role="button"
-              tabIndex={0}
-              aria-label={i18next.t("notifications.refresh")}
-              onClick={() => refresh()}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  refresh();
-                }
-              }}
-            >
-              {syncSvg}
-            </span>
-          </Tooltip>
-        </>
-      ) : (
-        <></>
-      )}
+      <Tooltip content={i18next.t("notifications.mark-all-read")}>
+        <span
+          className={classNameObject({
+            "list-action": true,
+            disabled: markNotifications.isPending || unread === 0
+          })}
+          role="button"
+          tabIndex={0}
+          aria-label={i18next.t("notifications.mark-all-read")}
+          onClick={() => markAsRead()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              markAsRead();
+            }
+          }}
+        >
+          {checkSvg}
+        </span>
+      </Tooltip>
+      <Tooltip content={i18next.t("notifications.refresh")}>
+        <span
+          className={classNameObject({
+            "list-action": true,
+            disabled: isDataLoading || isUnreadLoading
+          })}
+          role="button"
+          tabIndex={0}
+          aria-label={i18next.t("notifications.refresh")}
+          onClick={() => refresh()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              refresh();
+            }
+          }}
+        >
+          {syncSvg}
+        </span>
+      </Tooltip>
 
       <Dropdown>
         <DropdownToggle>
@@ -187,48 +179,6 @@ export function NotificationsActions({ filter }: Props) {
         </DropdownToggle>
         <DropdownMenu align="right">
           <DropdownItemHeader>{i18next.t(`notifications.settings`)}</DropdownItemHeader>
-          {isMobile && (
-            <DropdownItem
-              onClick={() => {
-                if (markNotifications.isPending || unread === 0) {
-                  return;
-                }
-                markAsRead();
-              }}
-            >
-              <Tooltip content={i18next.t("notifications.mark-all-read")}>
-                <span
-                  className={classNameObject({
-                    "list-action": true,
-                    disabled: markNotifications.isPending || unread === 0
-                  })}
-                >
-                  {checkSvg}
-                </span>
-              </Tooltip>
-            </DropdownItem>
-          )}
-          {isMobile && (
-            <DropdownItem
-              onClick={() => {
-                if (isDataLoading || isUnreadLoading) {
-                  return;
-                }
-                refresh();
-              }}
-            >
-              <Tooltip content={i18next.t("notifications.refresh")}>
-                <span
-                  className={classNameObject({
-                    "list-action": true,
-                    disabled: isDataLoading || isUnreadLoading
-                  })}
-                >
-                  {syncSvg}
-                </span>
-              </Tooltip>
-            </DropdownItem>
-          )}
           <DropdownItem>
             {getNotificationSettingsItem(i18next.t(`notifications.type-rvotes`), NotifyTypes.VOTE)}
           </DropdownItem>

--- a/apps/web/src/features/ui/svg.tsx
+++ b/apps/web/src/features/ui/svg.tsx
@@ -107,6 +107,39 @@ export const discordSvg = (
   </svg>
 );
 
+// Send / paper-plane glyph for the Waves composer's mobile publish button. A
+// local SVG rather than a unicons import, so it does not need a whitelist entry.
+export const sendSvg = (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M2 21l21-9L2 3v7l15 2-15 2v7z" />
+  </svg>
+);
+
+// Wavy-dash (〰️) icon for the Waves tab: the Twemoji wavy dash, recolored to
+// currentColor so it inherits the navbar's active/inactive states. Exposed as a
+// component with a `size` prop so the bottom navbar (20) and side menu (16) can
+// size it the same way they size the unicons icons.
+export function WavyDashIcon({
+  size = 24,
+  className
+}: {
+  size?: number | string;
+  className?: string;
+}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 36 36"
+      width={size}
+      height={size}
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M27 23c-2.589 0-4.005-2.549-5.374-5.014C20.537 16.026 19.411 14 18 14c-1.412 0-2.537 2.026-3.626 3.986C13.004 20.451 11.588 23 9 23c-2.65 0-3.853-2.706-4.914-5.094C3.038 15.546 2.256 14 1 14a1 1 0 0 1 0-2c2.65 0 3.853 2.706 4.914 5.094C6.962 19.453 7.744 21 9 21c1.412 0 2.537-2.026 3.626-3.986C13.996 14.549 15.412 12 18 12c2.589 0 4.005 2.549 5.374 5.014C24.463 18.974 25.589 21 27 21c1.256 0 2.037-1.547 3.086-3.906C31.147 14.706 32.351 12 35 12a1 1 0 1 1 0 2c-1.256 0-2.037 1.546-3.086 3.906C30.853 20.294 29.649 23 27 23z" />
+    </svg>
+  );
+}
+
 export const wavesSvg = (
   <svg viewBox="0 0 2048 2048" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
     <path

--- a/apps/web/src/features/waves/components/wave-form/index.tsx
+++ b/apps/web/src/features/waves/components/wave-form/index.tsx
@@ -210,6 +210,11 @@ const WaveFormComponent = ({
     return "";
   })();
 
+  // Collapse to the compact send icon only for the normal publish/reply action
+  // on mobile. Edit (save), over-limit (long post) and signed-out states keep
+  // their visible text, since a send icon would misrepresent those actions.
+  const useCompactSubmit = isMobile && !!activeUsername && !entry && !exceedsCharacterLimit;
+
   const handleEmojiPick = useCallback(
     (emoji: string) => {
       const input = textareaRef.current;
@@ -361,7 +366,7 @@ const WaveFormComponent = ({
             setShowVideoUpload(true);
           }}
           submit={
-            isMobile ? (
+            useCompactSubmit ? (
               <Button
                 onClick={handleSubmit}
                 disabled={submitDisabled}

--- a/apps/web/src/features/waves/components/wave-form/index.tsx
+++ b/apps/web/src/features/waves/components/wave-form/index.tsx
@@ -10,6 +10,8 @@ import { ProfileLink, UserAvatar } from "@/features/shared";
 import { WaveFormControl } from "./wave-form-control";
 import i18next from "i18next";
 import { Button } from "@ui/button";
+import { sendSvg } from "@ui/svg";
+import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import { WaveFormToolbar } from "@/features/waves/components/wave-form/wave-form-toolbar";
 import { useWaveSubmit } from "@/features/waves";
 import axios from "axios";
@@ -39,6 +41,7 @@ const WaveFormComponent = ({
 }: Props) => {
   const { username: activeUsername, account, isLoading: isAccountLoading } = useActiveAccount();
   const toggleUIProp = useGlobalStore((s) => s.toggleUiProp);
+  const isMobile = useIsMobile();
 
   const rootRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -150,6 +153,62 @@ const WaveFormComponent = ({
     () => formInteractivityDisabled || !text || !threadHost || (isReply && exceedsCharacterLimit),
     [exceedsCharacterLimit, formInteractivityDisabled, isReply, text, threadHost]
   );
+
+  const handleSubmit = useCallback(() => {
+    if (submitDisabled) {
+      return;
+    }
+    submit({
+      text: text!!,
+      imageName: imageName!!,
+      image: image!!,
+      host: threadHost!!,
+      video: video!!,
+      videoThumbnail: videoThumbnail!!,
+      // Only attach meme data when the current image is still the meme.
+      decentMemes:
+        decentMemes && decentMemes.imageUrl === image && decentMemes.templateIds.length > 0
+          ? {
+              templateIds: decentMemes.templateIds,
+              beneficiaries: decentMemes.beneficiaries
+            }
+          : undefined
+    });
+  }, [
+    submitDisabled,
+    submit,
+    text,
+    imageName,
+    image,
+    threadHost,
+    video,
+    videoThumbnail,
+    decentMemes
+  ]);
+
+  // The action this button performs depends on auth/edit/length state. On mobile
+  // the button collapses to a send icon, so this string drives its accessible
+  // label/tooltip; on desktop it is the visible button text.
+  const submitLabel = (() => {
+    if (!activeUsername && !entry && !exceedsCharacterLimit) {
+      return i18next.t("decks.threads-form.login-and-publish");
+    }
+    if (activeUsername && !replySource && !entry && !exceedsCharacterLimit) {
+      return isPending
+        ? i18next.t("decks.threads-form.publishing")
+        : i18next.t("decks.threads-form.publish");
+    }
+    if (activeUsername && replySource && !entry && !exceedsCharacterLimit) {
+      return isPending ? i18next.t("waves.replying") : i18next.t("waves.reply");
+    }
+    if (exceedsCharacterLimit && !entry && !isReply) {
+      return i18next.t("decks.threads-form.create-regular-post");
+    }
+    if (entry) {
+      return i18next.t("decks.threads-form.save");
+    }
+    return "";
+  })();
 
   const handleEmojiPick = useCallback(
     (emoji: string) => {
@@ -302,55 +361,28 @@ const WaveFormComponent = ({
             setShowVideoUpload(true);
           }}
           submit={
-            <Button
-              onClick={() =>
-                !submitDisabled &&
-                submit({
-                  text: text!!,
-                  imageName: imageName!!,
-                  image: image!!,
-                  host: threadHost!!,
-                  video: video!!,
-                  videoThumbnail: videoThumbnail!!,
-                  // Only attach meme data when the current image is still the meme.
-                  decentMemes:
-                    decentMemes &&
-                    decentMemes.imageUrl === image &&
-                    decentMemes.templateIds.length > 0
-                      ? {
-                          templateIds: decentMemes.templateIds,
-                          beneficiaries: decentMemes.beneficiaries
-                        }
-                      : undefined
-                })
-              }
-              disabled={submitDisabled}
-              isLoading={isPending}
-              className="justify-self-end"
-              size="sm"
-            >
-              {!activeUsername &&
-                !entry &&
-                !exceedsCharacterLimit &&
-                i18next.t("decks.threads-form.login-and-publish")}
-              {activeUsername &&
-                !replySource &&
-                !entry &&
-                !exceedsCharacterLimit &&
-                (isPending
-                  ? i18next.t("decks.threads-form.publishing")
-                  : i18next.t("decks.threads-form.publish"))}
-              {activeUsername &&
-                replySource &&
-                !entry &&
-                !exceedsCharacterLimit &&
-                (isPending ? i18next.t("waves.replying") : i18next.t("waves.reply"))}
-              {exceedsCharacterLimit &&
-                !entry &&
-                !isReply &&
-                i18next.t("decks.threads-form.create-regular-post")}
-              {entry && i18next.t("decks.threads-form.save")}
-            </Button>
+            isMobile ? (
+              <Button
+                onClick={handleSubmit}
+                disabled={submitDisabled}
+                isLoading={isPending}
+                className="justify-self-end"
+                size="sm"
+                icon={sendSvg}
+                aria-label={submitLabel || i18next.t("decks.threads-form.publish")}
+                title={submitLabel || i18next.t("decks.threads-form.publish")}
+              />
+            ) : (
+              <Button
+                onClick={handleSubmit}
+                disabled={submitDisabled}
+                isLoading={isPending}
+                className="justify-self-end"
+                size="sm"
+              >
+                {submitLabel}
+              </Button>
+            )
           }
         />
         <VideoUpload


### PR DESCRIPTION
## What

Three mobile UI adjustments:

1. **Waves composer publish button** (`wave-form/index.tsx`)
   On mobile the "Publish it!" button was wrapping to two lines in the toolbar row. It now collapses to a compact send (paper-plane) icon button. Desktop keeps the full text label. The current action (publish / reply / save / create-long-post / sign-in) is preserved as the button's `aria-label` and `title`. The submit handler was extracted so both variants share it.

2. **Notification actions** (`notifications-actions.tsx`)
   Mark-all-read and refresh now stay in the header, right before the gear, on mobile too (matching desktop), instead of being relocated inside the Sound/Popup Settings popup. The mobile-only copies inside the popup are removed, along with the now-unused `useIsMobile` usage.

3. **Waves icon** (`navbar-mobile.tsx`, `navbar-main-sidebar.tsx`, `svg.tsx`)
   The bottom-nav Waves tab and the side-menu Waves item use a wavy-dash (〰️) icon in place of `UilWater`.

## Notes

- New icons are local SVGs in `features/ui/svg.tsx` (`sendSvg`, `WavyDashIcon`), so they don't need an entry in the unicons whitelist (`features/ui/unicons.tsx`) and add no icon-pack weight. `WavyDashIcon` takes a `size` prop so it sizes like the unicons it sits next to (20 in the bottom nav, 16 in the side menu). Both new icons use `currentColor` so they follow the existing active/inactive states.

## Testing

- `tsc --noEmit`: no new type errors (pre-existing baseline unchanged).
- `eslint` on the changed files: no errors.