### PR TITLE
feat(waves): show tip count + already-tipped state in the waves feed

### DIFF
--- a/apps/web/src/app/waves/_components/waves-masonry-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-masonry-view.tsx
@@ -12,12 +12,20 @@ import { useWavesAutoRefresh } from "@/app/waves/_hooks";
 import { WavesRefreshPopup } from "@/app/waves/_components";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
-export function WavesMasonryView() {
+interface Props {
+  username?: string;
+}
+
+export function WavesMasonryView({ username }: Props) {
+  // The logged-in user is the observer: server-side mute filtering plus the
+  // tipped_by_viewer feed flag (only populated for observer feeds) — same as the
+  // list view.
+  const observer = username || undefined;
   const { data, fetchNextPage, isError, hasNextPage, refetch } = useInfiniteQuery(
-    getWavesFeedQueryOptions()
+    getWavesFeedQueryOptions({ observer })
   );
   const dataFlow = useInfiniteDataFlow(data);
-  const { newWaves, clear, now } = useWavesAutoRefresh(dataFlow[0]);
+  const { newWaves, clear, now } = useWavesAutoRefresh(dataFlow[0], observer);
 
   const [replyingEntry, setReplyingEntry] = useState<WaveEntry>();
 

--- a/apps/web/src/app/waves/_page.tsx
+++ b/apps/web/src/app/waves/_page.tsx
@@ -130,7 +130,9 @@ export function WavesPage() {
       {grid === "feed" && (
         <WavesListView feedType={feedType} username={activeUser?.username} />
       )}
-      {grid === "masonry" && !selectedTag && !isFollowing && <WavesMasonryView />}
+      {grid === "masonry" && !selectedTag && !isFollowing && (
+        <WavesMasonryView username={activeUser?.username} />
+      )}
     </>
   );
 }

--- a/apps/web/src/entities/entries.ts
+++ b/apps/web/src/entities/entries.ts
@@ -69,6 +69,12 @@ export interface Entry {
   // Post-level upvote count. The waves private-api feeds return this but no
   // active_votes, so it is the vote-count source for those feeds.
   net_votes?: number;
+  // Tip totals from the waves feed (esync), so a feed card can show a tip count
+  // and an already-tipped state without a per-item /post-tips call. `tip_count`
+  // is the number of tips the post received; `tipped_by_viewer` is true when the
+  // requesting `observer` has already tipped it (present only on observer feeds).
+  tip_count?: number;
+  tipped_by_viewer?: boolean;
   parent_author?: string;
   parent_permlink?: string;
   root_author?: string;

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -551,6 +551,7 @@
     "title": "Tip",
     "tip": "Tip",
     "send-tip": "Send a tip",
+    "you-tipped": "You tipped this",
     "count": "{{count}} tip",
     "count_plural": "{{count}} tips"
   },

--- a/apps/web/src/features/shared/entry-tip-btn/_index.scss
+++ b/apps/web/src/features/shared/entry-tip-btn/_index.scss
@@ -23,6 +23,19 @@
     .tip-count {
       padding-left: 6px;
     }
+
+    // The viewing user has already tipped this post (waves feed). Make the gift
+    // solid (full opacity) and the count bold so it reads as an active state at
+    // a glance, without needing to open the post.
+    &.tipped {
+      svg {
+        opacity: 1;
+      }
+
+      .tip-count {
+        font-weight: 700;
+      }
+    }
   }
 }
 

--- a/apps/web/src/features/shared/entry-tip-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-tip-btn/index.tsx
@@ -42,6 +42,11 @@ interface Props {
   handleClickAway?: () => void;
   postTips?: PostTipsResponse;
   inlineTipButton?: boolean;
+  // Feed-provided fallbacks (waves feed) so a card can show the count and an
+  // already-tipped state without the per-item /post-tips fetch that detail pages
+  // make. When `postTips` (the full breakdown) is present it wins.
+  tipCount?: number;
+  tippedByViewer?: boolean;
 }
 
 export function EntryTipBtn({
@@ -50,7 +55,9 @@ export function EntryTipBtn({
   handleClickAway,
   account,
   postTips,
-  inlineTipButton
+  inlineTipButton,
+  tipCount: tipCountProp,
+  tippedByViewer
 }: Props) {
   const { activeUser } = useActiveAccount();
 
@@ -59,7 +66,11 @@ export function EntryTipBtn({
 
   const to = useMemo(() => entry.author, [entry]);
   const memo = useMemo(() => `Tip for @${entry.author}/${entry.permlink}`, [entry]);
-  const tipCount = postTips?.meta.count ?? 0;
+  // Only the detail-page caller passes the full `postTips` breakdown; the feed
+  // passes just a count. The popover (per-currency totals) is shown only when we
+  // have that breakdown — otherwise the button opens the tip dialog directly.
+  const hasBreakdown = !!postTips;
+  const tipCount = postTips?.meta.count ?? tipCountProp ?? 0;
   const tipTotals = Object.entries(postTips?.meta.totals ?? {});
   const tipCountLabel =
     tipCount === 1
@@ -92,7 +103,7 @@ export function EntryTipBtn({
       tabIndex={0}
       aria-label={i18next.t("entry-tip.title")}
       onClick={() => {
-        if (tipCount > 0) {
+        if (hasBreakdown && tipCount > 0) {
           setShowPopover((state) => !state);
         } else {
           openTransferDialog();
@@ -101,7 +112,7 @@ export function EntryTipBtn({
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          if (tipCount > 0) {
+          if (hasBreakdown && tipCount > 0) {
             setShowPopover((state) => !state);
           } else {
             openTransferDialog();
@@ -109,8 +120,8 @@ export function EntryTipBtn({
         }
       }}
     >
-      <Tooltip content={i18next.t("entry-tip.title")}>
-        <span className="inner-btn">
+      <Tooltip content={tippedByViewer ? i18next.t("entry-tip.you-tipped") : i18next.t("entry-tip.title")}>
+        <span className={`inner-btn${tippedByViewer ? " tipped" : ""}`}>
           {giftOutlineSvg}
           <span className="tip-count">{tipCount > 0 ? tipCount : ""}</span>
         </span>
@@ -123,7 +134,7 @@ export function EntryTipBtn({
       <LoginRequired promptOnAnon>
         {inlineTipButton ? (
           inlineTipBtn
-        ) : tipCount > 0 ? (
+        ) : hasBreakdown && tipCount > 0 ? (
           <Popover directContent={tipButton} behavior="click" show={showPopover} setShow={setShowPopover}>
             <PopoverContent>
               <div className="tip-popover">

--- a/apps/web/src/features/waves/components/wave-actions.tsx
+++ b/apps/web/src/features/waves/components/wave-actions.tsx
@@ -74,7 +74,12 @@ export function WaveActions({
                 {commentsSlot ?? entry?.children}
               </div>
             </Button>
-            <EntryTipBtn entry={entry!} postTips={postTips} />
+            <EntryTipBtn
+              entry={entry!}
+              postTips={postTips}
+              tipCount={entry?.tip_count}
+              tippedByViewer={entry?.tipped_by_viewer}
+            />
           </div>
           <div>
             <EntryMenu entry={entry!} />

--- a/apps/web/src/specs/features/shared/entry-tip-btn.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-tip-btn.spec.tsx
@@ -1,0 +1,82 @@
+import { vi } from "vitest";
+import React from "react";
+import { screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { renderWithQueryClient, mockEntry } from "@/specs/test-utils";
+
+// LoginRequired only renders its (gated) children for a logged-in user.
+vi.mock("@/core/hooks/use-active-account", () => ({
+  useActiveAccount: vi.fn(() => ({
+    activeUser: { username: "alice" },
+    username: "alice",
+    account: null,
+    isLoading: false,
+    isPending: false,
+    isError: false,
+    isSuccess: true,
+    error: null,
+    refetch: vi.fn()
+  }))
+}));
+
+// `@/utils` is globally mocked to only expose `random` + `getAccessToken`;
+// EntryTipBtn's popover uses `formattedNumber`. Re-mock with importActual so the
+// real helpers stay available while the globally stubbed ones remain stubbed.
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<typeof import("@/utils")>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+
+// Tooltip + Popover are presentational wrappers here; render their content
+// inline so the assertions don't depend on hover/portal behavior.
+vi.mock("@ui/tooltip", () => ({
+  Tooltip: ({ children }: any) => <>{children}</>
+}));
+vi.mock("@/features/ui", () => ({
+  Popover: ({ directContent, children }: any) => (
+    <>
+      {directContent}
+      {children}
+    </>
+  ),
+  PopoverContent: ({ children }: any) => <>{children}</>
+}));
+
+import { EntryTipBtn } from "@/features/shared/entry-tip-btn";
+import type { PostTipsResponse } from "@ecency/sdk";
+
+describe("EntryTipBtn — feed-provided tip count + already-tipped state", () => {
+  it("shows the feed-provided tip count without a postTips fetch", () => {
+    const { container } = renderWithQueryClient(
+      <EntryTipBtn entry={mockEntry as any} tipCount={3} />
+    );
+    expect(container.querySelector(".tip-count")?.textContent).toBe("3");
+  });
+
+  it("flags the button as already-tipped when tippedByViewer is set", () => {
+    const { container } = renderWithQueryClient(
+      <EntryTipBtn entry={mockEntry as any} tipCount={2} tippedByViewer={true} />
+    );
+    expect(container.querySelector(".inner-btn.tipped")).toBeTruthy();
+  });
+
+  it("renders no count and no tipped state for zero tips", () => {
+    const { container } = renderWithQueryClient(
+      <EntryTipBtn entry={mockEntry as any} tipCount={0} />
+    );
+    expect(container.querySelector(".tip-count")?.textContent).toBe("");
+    expect(container.querySelector(".inner-btn.tipped")).toBeFalsy();
+  });
+
+  it("prefers the full postTips breakdown count over the feed fallback", () => {
+    const postTips: PostTipsResponse = {
+      meta: { count: 5, totals: { POINT: 250 } },
+      list: []
+    };
+    const { container } = renderWithQueryClient(
+      <EntryTipBtn entry={mockEntry as any} postTips={postTips} tipCount={1} />
+    );
+    expect(container.querySelector(".tip-count")?.textContent).toBe("5");
+  });
+});

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.26
+
+### Patch Changes
+
+- feat(waves): show tip count + already-tipped state in the waves feed (#1031)
+
 ## 2.3.25
 
 ### Patch Changes

--- a/packages/sdk/dist/browser/index.d.ts
+++ b/packages/sdk/dist/browser/index.d.ts
@@ -3408,6 +3408,8 @@ interface Entry$1 {
     max_accepted_payout: string;
     net_rshares: number;
     net_votes?: number;
+    tip_count?: number;
+    tipped_by_viewer?: boolean;
     parent_author?: string;
     parent_permlink?: string;
     payout: number;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ecency/sdk",
   "private": false,
-  "version": "2.3.25",
+  "version": "2.3.26",
   "description": "Ecency SDK",
   "repository": {
     "type": "git",

--- a/packages/sdk/src/modules/posts/types/entry.ts
+++ b/packages/sdk/src/modules/posts/types/entry.ts
@@ -69,6 +69,12 @@ export interface Entry {
   // Post-level upvote count. The waves private-api feeds (esync) return this but
   // no active_votes, so it is the vote-count source for those feeds.
   net_votes?: number;
+  // Tip totals from the waves feed (esync), so a feed card can show a tip count
+  // and an already-tipped state without a per-item /post-tips call. `tip_count`
+  // is the number of tips the post received; `tipped_by_viewer` is true when the
+  // requesting `observer` has already tipped it (present only on observer feeds).
+  tip_count?: number;
+  tipped_by_viewer?: boolean;
   parent_author?: string;
   parent_permlink?: string;
   payout: number;

--- a/packages/wallets/CHANGELOG.md
+++ b/packages/wallets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ecency/wallets
 
+## 5.0.25
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @ecency/sdk@2.3.26
+
 ## 5.0.24
 
 ### Patch Changes

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ecency/wallets",
   "private": false,
-  "version": "5.0.24",
+  "version": "5.0.25",
   "description": "Ecency wallets",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

Show a wave's **tip count** in the waves feed, and highlight waves the viewing user has **already tipped** — without opening the post.

## Why

Tip counts are only shown on the single post/wave page today (which fetches `/post-tips` per item). In the feed there is no tip indicator, so a tipped wave looks untipped and you can't tell at a glance whether you already tipped it. A user reported tipping many posts but seeing no counts anywhere — because they tip from the feed.

## How

Backed by esync-py #17, which adds additive `tip_count` and `tipped_by_viewer` fields to every `/waves/feed` item (one batched indexed lookup per page; `tipped_by_viewer` is computed from the `observer` the feed already sends).

- **Entry type (sdk + web):** additive optional `tip_count` / `tipped_by_viewer`. The feed already passes these through `normalizeWaveEntryFromApi` (object spread), so the wiring is types only.
- **EntryTipBtn:** accepts feed-provided `tipCount` / `tippedByViewer`. The full `postTips` breakdown (detail pages) still wins and still shows the per-currency popover; with only a feed count the button shows the count and opens the tip dialog on click. An already-tipped wave renders a solid gift + bold count + a "You tipped this" tooltip.
- **WaveActions** reads the fields off the wave entry it is already given, so the feed card lights up with **no extra per-item request**.

## Tests

Added an `EntryTipBtn` feed-mode spec: count rendering, already-tipped class, zero-state, and `postTips`-precedence.

## Notes

- Backward compatible; purely additive.
- Requires esync-py #17 deployed (done).
- Mobile is a follow-up (after the SDK release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tip buttons now display tip counts from feed data and indicate when you’ve already tipped.
  * Tip popovers and interactions now adapt based on whether detailed tip breakdown data is available, with observer/feed support.

* **Bug Fixes**
  * Improved consistency of tip counts and “active/already-tipped” styling across different waves entry views.

* **Tests**
  * Added coverage for feed-provided tip count rendering, already-tipped visual state, and correct fallback vs breakdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->