### PR TITLE
fix(waves): show the feed tip count even when 0 (mobile parity)

### DIFF
--- a/apps/web/src/features/shared/entry-tip-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-tip-btn/index.tsx
@@ -71,11 +71,11 @@ export function EntryTipBtn({
   // have that breakdown — otherwise the button opens the tip dialog directly.
   const hasBreakdown = !!postTips;
   const tipCount = postTips?.meta.count ?? tipCountProp ?? 0;
-  // In the waves feed an explicit count is passed (including 0); show it always
-  // there so the tip count is visible like the adjacent vote/comment counts and
-  // the mobile app. Elsewhere (detail popover, or no feed count) only a positive
-  // count is shown.
-  const showTipNumber = tipCount > 0 || (!hasBreakdown && tipCountProp != null);
+  // Show the count when positive, or whenever the caller passes an explicit (feed)
+  // tipCount — including 0 — so the waves feed shows it like the adjacent
+  // vote/comment counts and the mobile app. Non-feed usages (post list, comments)
+  // pass no tipCount, so a 0 there stays hidden; detail pages pass postTips only.
+  const showTipNumber = tipCount > 0 || tipCountProp != null;
   const tipTotals = Object.entries(postTips?.meta.totals ?? {});
   const tipCountLabel =
     tipCount === 1

--- a/apps/web/src/features/shared/entry-tip-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-tip-btn/index.tsx
@@ -71,6 +71,11 @@ export function EntryTipBtn({
   // have that breakdown — otherwise the button opens the tip dialog directly.
   const hasBreakdown = !!postTips;
   const tipCount = postTips?.meta.count ?? tipCountProp ?? 0;
+  // In the waves feed an explicit count is passed (including 0); show it always
+  // there so the tip count is visible like the adjacent vote/comment counts and
+  // the mobile app. Elsewhere (detail popover, or no feed count) only a positive
+  // count is shown.
+  const showTipNumber = tipCount > 0 || (!hasBreakdown && tipCountProp != null);
   const tipTotals = Object.entries(postTips?.meta.totals ?? {});
   const tipCountLabel =
     tipCount === 1
@@ -120,10 +125,12 @@ export function EntryTipBtn({
         }
       }}
     >
-      <Tooltip content={tippedByViewer ? i18next.t("entry-tip.you-tipped") : i18next.t("entry-tip.title")}>
+      <Tooltip
+        content={tippedByViewer ? i18next.t("entry-tip.you-tipped") : i18next.t("entry-tip.title")}
+      >
         <span className={`inner-btn${tippedByViewer ? " tipped" : ""}`}>
           {giftOutlineSvg}
-          <span className="tip-count">{tipCount > 0 ? tipCount : ""}</span>
+          <span className="tip-count">{showTipNumber ? tipCount : ""}</span>
         </span>
       </Tooltip>
     </div>
@@ -135,20 +142,25 @@ export function EntryTipBtn({
         {inlineTipButton ? (
           inlineTipBtn
         ) : hasBreakdown && tipCount > 0 ? (
-          <Popover directContent={tipButton} behavior="click" show={showPopover} setShow={setShowPopover}>
+          <Popover
+            directContent={tipButton}
+            behavior="click"
+            show={showPopover}
+            setShow={setShowPopover}
+          >
             <PopoverContent>
               <div className="tip-popover">
                 <div className="tip-popover-title">
                   {i18next.t("entry-tip.title")}
-                  <span className="tip-popover-count">
-                    {tipCountLabel}
-                  </span>
+                  <span className="tip-popover-count">{tipCountLabel}</span>
                 </div>
                 <div className="tip-popover-grid">
                   {tipTotals.map(([currency, amount]) => (
                     <div className="tip-row" key={currency}>
                       <span className="tip-currency">{currency}</span>
-                      <span className="tip-amount">{formattedNumber(amount, { fractionDigits: 3 })}</span>
+                      <span className="tip-amount">
+                        {formattedNumber(amount, { fractionDigits: 3 })}
+                      </span>
                     </div>
                   ))}
                 </div>

--- a/apps/web/src/specs/features/shared/entry-tip-btn.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-tip-btn.spec.tsx
@@ -61,12 +61,17 @@ describe("EntryTipBtn — feed-provided tip count + already-tipped state", () =>
     expect(container.querySelector(".inner-btn.tipped")).toBeTruthy();
   });
 
-  it("renders no count and no tipped state for zero tips", () => {
+  it("shows 0 in the feed (parity with vote/comment counts) when tipCount is 0", () => {
     const { container } = renderWithQueryClient(
       <EntryTipBtn entry={mockEntry as any} tipCount={0} />
     );
-    expect(container.querySelector(".tip-count")?.textContent).toBe("");
+    expect(container.querySelector(".tip-count")?.textContent).toBe("0");
     expect(container.querySelector(".inner-btn.tipped")).toBeFalsy();
+  });
+
+  it("renders no number outside the feed (no tipCount prop and no postTips)", () => {
+    const { container } = renderWithQueryClient(<EntryTipBtn entry={mockEntry as any} />);
+    expect(container.querySelector(".tip-count")?.textContent).toBe("");
   });
 
   it("prefers the full postTips breakdown count over the feed fallback", () => {


### PR DESCRIPTION
## What

On the waves feed cards the tip gift showed **no number** for waves with 0 tips, while the adjacent **vote and comment counts show 0** (and the mobile app shows 0 for tips too). This makes the tip count visible and consistent.

## How

`EntryTipBtn` now shows the count whenever the feed passes an explicit `tipCount` (including 0) — i.e. on the waves feed cards. Detail pages (which pass the full `postTips` breakdown) and non-feed usages (post list, comment threads, which pass no `tipCount`) are unchanged and still show a positive-only count.

This is what makes the waves feed tip count match the mobile app once it ships to production.

## Tests

Updated the `EntryTipBtn` spec: feed `tipCount={0}` now renders `0`; a non-feed usage (no `tipCount`, no `postTips`) still renders no number. 5 tests pass.