### PR TITLE
fix(waves): bare 3Speak player in reels + clean caption

### DIFF
--- a/apps/web/src/app/waves/_components/waves-reel-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-reel-item.tsx
@@ -13,17 +13,26 @@ interface Props {
 }
 
 // The reel already plays the video, so the caption is just the human text:
-// drop markdown images, turn markdown links into their label, and strip bare
-// URLs (e.g. the play.3speak.tv embed link the body carries).
-function buildReelCaption(item: ShortsFeedEntry): string {
-  const raw = item.title?.trim() || item.body?.trim() || "";
-  return raw
+// drop markdown images, the 3Speak "watch" footer link, other markdown links
+// (kept as their label), HTML tags (the composer appends videos as `text<br>url`)
+// and bare URLs (e.g. the play.3speak.tv embed link the body carries).
+function sanitizeCaptionText(value: string): string {
+  return value
     .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[[^\]]*\]\((?:https?:\/\/)?(?:play\.)?3speak[^)]*\)/gi, " ")
     .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/<[^>]+>/g, " ")
     .replace(/https?:\/\/\S+/gi, " ")
+    .replace(/▶️?/g, " ")
     .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, 140);
+    .trim();
+}
+
+// Clean title and body independently so a title that's only a URL/markdown
+// (collapses to empty) falls back to the body text instead of a blank caption.
+function buildReelCaption(item: ShortsFeedEntry): string {
+  const caption = sanitizeCaptionText(item.title ?? "") || sanitizeCaptionText(item.body ?? "");
+  return caption.slice(0, 140);
 }
 
 /**

--- a/apps/web/src/app/waves/_components/waves-reel-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-reel-item.tsx
@@ -12,6 +12,20 @@ interface Props {
   onReply: (item: ShortsFeedEntry) => void;
 }
 
+// The reel already plays the video, so the caption is just the human text:
+// drop markdown images, turn markdown links into their label, and strip bare
+// URLs (e.g. the play.3speak.tv embed link the body carries).
+function buildReelCaption(item: ShortsFeedEntry): string {
+  const raw = item.title?.trim() || item.body?.trim() || "";
+  return raw
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/https?:\/\/\S+/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 140);
+}
+
 /**
  * One full-height reel: the 3Speak video plays only while the item is the one in
  * view (mounting every iframe at once would autoplay/load dozens of videos), with
@@ -37,7 +51,7 @@ export function WavesReelItem({ item, onReply }: Props) {
     return () => observer.disconnect();
   }, []);
 
-  const caption = item.title?.trim() || item.body?.trim().slice(0, 140) || "";
+  const caption = buildReelCaption(item);
 
   return (
     <div
@@ -50,7 +64,7 @@ export function WavesReelItem({ item, onReply }: Props) {
         {active && video ? (
           <iframe
             title={`${item.author}/${item.permlink}`}
-            src={`https://play.3speak.tv/embed?v=${encodeURIComponent(video.author)}/${encodeURIComponent(video.permlink)}&autoplay=true`}
+            src={`https://play.3speak.tv/watch?v=${encodeURIComponent(video.author)}/${encodeURIComponent(video.permlink)}&mode=iframe&autoplay=true`}
             allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen
             className="h-full w-full border-0"


### PR DESCRIPTION
Follow-up to #1039 (Shorts tab), fixing two issues spotted in the reels view:

1. **3Speak chrome instead of the video** — the reel iframe used `play.3speak.tv/embed?v=…`, which renders the 3Speak page header/logo around the video. Switched to the renderer's normalized player URL `play.3speak.tv/watch?v=…&mode=iframe&autoplay=true` (the `mode=iframe` gives the bare player), matching how the post renderer embeds 3Speak everywhere else.
2. **Raw video link in the caption** — the caption showed the body verbatim, including the `play.3speak.tv/embed?…` link. It now strips markdown images/links and bare URLs so only the human text shows.

Web-only (one file). typecheck = develop baseline (no new errors), eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved reel captions by cleaning up markdown, links, URLs, and extra whitespace, with longer text now neatly truncated.
  * Updated active reel playback to use a newer embedded watch view with autoplay support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->