### PR TITLE
fix(waves): cap quoted-wave embed depth at one level

### DIFF
--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -3055,6 +3055,7 @@
     "tag-feed-clear": "Clear filter",
     "source-feed-indicator": "Viewing {{source}}",
     "shorts-empty": "No shorts yet.",
+    "view-wave": "View wave",
     "add-feed": "Add feed",
     "custom-feeds-title": "Custom feeds",
     "custom-feeds-subtitle": "Pin tags as feeds to see them as tabs here, saved on this device.",

--- a/apps/web/src/features/post-renderer/components/ecency-renderer.tsx
+++ b/apps/web/src/features/post-renderer/components/ecency-renderer.tsx
@@ -23,6 +23,12 @@ interface Props {
   TwitterComponent?: any;
   images?: string[];
   renderOptions?: RenderOptions;
+  /**
+   * Nesting depth of embedded wave quotes (0 = top level). Threaded to
+   * WaveLikePostExtension so quoted waves stop embedding past MAX_EMBED_DEPTH
+   * (showing a compact stub instead of recursively rendering).
+   */
+  embedDepth?: number;
 }
 
 export function EcencyRenderer({
@@ -33,6 +39,7 @@ export function EcencyRenderer({
   TwitterComponent = () => <div>No twitter component</div>,
   images,
   renderOptions,
+  embedDepth = 0,
   ...other
 }: HTMLProps<HTMLDivElement> & Props) {
   const ref = useRef<HTMLDivElement>(null);
@@ -85,7 +92,7 @@ export function EcencyRenderer({
               <ThreeSpeakVideoExtension containerRef={ref} images={images} />
             </>
           )}
-          <WaveLikePostExtension containerRef={ref} />
+          <WaveLikePostExtension containerRef={ref} embedDepth={embedDepth} />
           <TwitterExtension
             containerRef={ref}
             ComponentInstance={TwitterComponent}

--- a/apps/web/src/features/post-renderer/components/extensions/wave-like-post-extension.scss
+++ b/apps/web/src/features/post-renderer/components/extensions/wave-like-post-extension.scss
@@ -93,4 +93,23 @@
     position: relative;
     z-index: 1;
   }
+
+  // Compact one-line stub for quotes beyond the inline-embed depth.
+  &--stub {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+
+    .er-wave-renderer--author-avatar {
+      width: 28px;
+      height: 28px;
+      border-radius: 14px;
+    }
+  }
+
+  &--stub-label {
+    font-size: 0.875rem;
+    color: #357ce6;
+  }
 }

--- a/apps/web/src/features/post-renderer/components/extensions/wave-like-post-extension.tsx
+++ b/apps/web/src/features/post-renderer/components/extensions/wave-like-post-extension.tsx
@@ -11,8 +11,13 @@ import "./wave-like-post-extension.scss";
 import { EcencyRenderer } from "../ecency-renderer";
 import { Logo } from "../icons";
 import defaults from "@/defaults";
+import i18next from "i18next";
 
-export function WaveLikePostRenderer({ link }: { link: string }) {
+// Quoted waves embed inline only one level deep; a quote-of-a-quote renders as a
+// compact stub (avatar + link) instead of recursively rendering full bodies.
+const MAX_EMBED_DEPTH = 1;
+
+export function WaveLikePostRenderer({ link, depth = 1 }: { link: string; depth?: number }) {
   const [author, permlink] = useMemo(() => {
     try {
       const pathname = new URL(link, "https://ecency.com").pathname;
@@ -49,10 +54,12 @@ export function WaveLikePostRenderer({ link }: { link: string }) {
     }
   }, [link]);
 
+  const tooDeep = depth > MAX_EMBED_DEPTH;
   const { data: post } = useQuery({
     ...getPostQueryOptions(author ?? "", permlink ?? ""),
     queryKey: QueryKeys.posts.entry(makeEntryPath("", author ?? "", permlink ?? "")),
-    enabled: !!author && !!permlink,
+    // Skip the fetch entirely when we're only going to render the stub.
+    enabled: !!author && !!permlink && !tooDeep,
   });
 
   const host = useMemo(() => {
@@ -74,8 +81,34 @@ export function WaveLikePostRenderer({ link }: { link: string }) {
     return "";
   }, [post]);
 
-  // Return early if link parsing failed or post not loaded
-  if (!author || !permlink || !post) {
+  // Return early if link parsing failed
+  if (!author || !permlink) {
+    return <></>;
+  }
+
+  // Beyond the inline-embed depth: a compact stub (no fetch, no body) so a
+  // quote-of-a-quote doesn't recurse into deeply nested full cards.
+  if (tooDeep) {
+    return (
+      <a
+        href={`/waves/${author}/${permlink}`}
+        className="er-wave-renderer er-wave-renderer--stub"
+        aria-label={`Open wave by @${author}`}
+      >
+        <img
+          src={`${defaults.imageServer}/u/${author}/avatar/small`}
+          alt={author}
+          className="er-wave-renderer--author-avatar"
+        />
+        <span className="er-wave-renderer--stub-label">
+          @{author} · {i18next.t("waves.view-wave", { defaultValue: "View wave" })}
+        </span>
+      </a>
+    );
+  }
+
+  // Post not loaded yet
+  if (!post) {
     return <></>;
   }
 
@@ -113,7 +146,7 @@ export function WaveLikePostRenderer({ link }: { link: string }) {
         dangerouslySetInnerHTML={{ __html: Logo }}
       />
       <div className="er-wave-renderer--body">
-        <EcencyRenderer value={post.body} />
+        <EcencyRenderer value={post.body} embedDepth={depth} />
       </div>
     </article>
   );
@@ -121,8 +154,10 @@ export function WaveLikePostRenderer({ link }: { link: string }) {
 
 export function WaveLikePostExtension({
   containerRef,
+  embedDepth = 0,
 }: {
   containerRef: RefObject<HTMLElement | null>;
+  embedDepth?: number;
 }) {
   const rootsRef = useRef<ReturnType<typeof createRoot>[]>([]);
 
@@ -155,7 +190,10 @@ export function WaveLikePostExtension({
           rootsRef.current.push(root);
           root.render(
             <QueryClientProvider client={queryClient}>
-              <WaveLikePostRenderer link={element.getAttribute("href") ?? ""} />
+              <WaveLikePostRenderer
+                link={element.getAttribute("href") ?? ""}
+                depth={embedDepth + 1}
+              />
             </QueryClientProvider>
           );
 
@@ -172,7 +210,7 @@ export function WaveLikePostExtension({
       rootsRef.current.forEach(r => r.unmount());
       rootsRef.current = [];
     };
-  }, []);
+  }, [embedDepth]);
 
   return <></>;
 }


### PR DESCRIPTION
A wave that quotes another wave renders the quote's **full body** via `EcencyRenderer`, which itself re-runs `WaveLikePostExtension`. So a quote-of-a-quote-of-a-quote nested **recursively with no limit** — deeply stacked cards, plus a full render + `getPostQueryOptions` fetch + React root at every level (and the deepest one could pull in a whole long-form post with its comment thread).

### Fix
Thread an `embedDepth` through `EcencyRenderer` → `WaveLikePostExtension` → `WaveLikePostRenderer`. Inline embeds are capped at **one level** (`MAX_EMBED_DEPTH = 1`); beyond that a quote renders as a **compact stub** (avatar + "View wave" link, with the fetch skipped) instead of recursing. So the first quote shows inline; a quote inside it is just a link.

### Notes
- Pre-existing behavior, separate from the Shorts work.
- Also a perf win: no recursive fetches / React roots past depth 1.
- Follow-up (discussed, not in this PR): render a quoted long-form **post** (`HivePostLinkExtension`) as a compact preview rather than the full article.

### Verification
typecheck = develop baseline (no new errors); eslint clean; en-US.json valid.