### PR TITLE
Recover stale tabs from deploy skew without a service worker

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -52,6 +52,16 @@ const withPWA = require("next-pwa")({
       }
     },
     {
+      // Build-id heartbeat for deploy-skew recovery: must ALWAYS hit the network
+      // so a stale tab never compares a service-worker-cached old build id against
+      // itself (the request's `no-store` doesn't bypass the SW Cache API). Listed
+      // before the generic /api/* NetworkFirst rule below — Workbox uses the first
+      // matching route. Offline simply fails the fetch, which the heartbeat treats
+      // as "skip" rather than a stale match.
+      urlPattern: /^https:\/\/ecency\.com\/api\/version(?:\?.*)?$/i,
+      handler: 'NetworkOnly'
+    },
+    {
       // Cache API responses with network-first strategy
       urlPattern: /^https:\/\/ecency\.com\/api\/.*/i,
       handler: 'NetworkFirst',

--- a/apps/web/src/app/api/version/route.ts
+++ b/apps/web/src/app/api/version/route.ts
@@ -1,0 +1,17 @@
+// Build identifier for the currently-deployed server. The client-side deploy-skew
+// heartbeat (features/pwa-install/service-worker-recovery.tsx) polls this on tab
+// refocus and compares it against the build the tab is running (also SENTRY_RELEASE,
+// inlined into the client bundle at build time). A mismatch means the tab is stale
+// and gets reloaded onto the current build.
+//
+// SENTRY_RELEASE is the deploying commit SHA (set in CI, inlined via next.config.js
+// `env`); null in local dev, where skew protection is inactive. Served `no-store`
+// + `force-dynamic` so neither the CDN nor a stale client can serve an old build id.
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return Response.json(
+    { buildId: process.env.SENTRY_RELEASE ?? null },
+    { headers: { "Cache-Control": "no-store" } }
+  );
+}

--- a/apps/web/src/features/pwa-install/service-worker-recovery.tsx
+++ b/apps/web/src/features/pwa-install/service-worker-recovery.tsx
@@ -32,6 +32,50 @@ export function reloadForSkew() {
 // Guards a controllerchange reload against firing twice within one page load.
 let controllerReloadStarted = false;
 
+// Minimum gap between build-id heartbeat checks, so rapid visibility/refocus
+// churn (common on mobile) can't spam /api/version.
+const BUILD_CHECK_THROTTLE_MS = 30_000;
+let lastBuildCheck = 0;
+
+/**
+ * Compares the build this tab is running (`SENTRY_RELEASE`, inlined into the
+ * client bundle at build time) against the currently-deployed server build
+ * (`/api/version`). A mismatch means the tab is stale, so reload onto the
+ * current build.
+ *
+ * This catches what no error ever surfaces: a backgrounded tab restored from
+ * the page cache. It's the dominant skew case on iOS, where Chrome/Firefox have
+ * no service worker (so the controllerchange path below can't fire) and a
+ * restored tab keeps running an old build whose `/_next/static` chunks the new
+ * deploy has since replaced. Reloading heals it without touching auth/storage,
+ * so the user stays logged in.
+ */
+async function checkBuildSkew() {
+  // process.env.SENTRY_RELEASE is replaced with a literal at build time; unset
+  // in local dev, where there are no deploys and skew protection is inactive.
+  const currentBuildId = process.env.SENTRY_RELEASE;
+  if (!currentBuildId) {
+    return;
+  }
+  const now = Date.now();
+  if (now - lastBuildCheck < BUILD_CHECK_THROTTLE_MS) {
+    return;
+  }
+  lastBuildCheck = now;
+  try {
+    const res = await fetch("/api/version", { cache: "no-store" });
+    if (!res.ok) {
+      return;
+    }
+    const { buildId } = (await res.json()) as { buildId?: string | null };
+    if (buildId && buildId !== currentBuildId) {
+      reloadForSkew();
+    }
+  } catch {
+    // Offline or a transient network error — ignore; the next refocus retries.
+  }
+}
+
 /**
  * Recovers users running a build that no longer matches the server — the cause
  * of the post-deploy "Element type is invalid: undefined" / "undefined (reading
@@ -46,6 +90,14 @@ let controllerReloadStarted = false;
  *    initial `clientsClaim` on a first visit and a reload would be spurious.
  * 2. As a safety net, reload once (per session) on an uncaught deploy-skew error
  *    (chunk-load failure or webpack factory mismatch).
+ * 3. Reload when a `/_next/static` asset (a CSS `<link>` or `<script>`) fails to
+ *    load. These resource errors don't bubble and never surface as a
+ *    ChunkLoadError, so (2) misses them — yet a stale document referencing a
+ *    replaced stylesheet renders silently unstyled. Caught in the capture phase.
+ * 4. On tab refocus / page-cache restore, compare the running build against
+ *    `/api/version` and reload on a mismatch — the only signal for a stale tab
+ *    that never threw (the common iOS Chrome/Firefox case, where there's no
+ *    service worker for (1) to use).
  */
 export function ServiceWorkerRecovery() {
   useEffect(() => {
@@ -82,8 +134,46 @@ export function ServiceWorkerRecovery() {
         reloadForSkew();
       }
     };
+
+    // A failed resource load (a <link>/<script> that 404s) fires an `error`
+    // event that does NOT bubble and carries no message — invisible to the
+    // `onError` listener above — so it's only observable in the capture phase
+    // via its `target`. A 404 on a build-versioned `/_next/static` asset means
+    // the running document references a build the server has replaced.
+    const onResourceError = (event: Event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      const url =
+        target.tagName === "LINK"
+          ? (target as HTMLLinkElement).href
+          : target.tagName === "SCRIPT"
+            ? (target as HTMLScriptElement).src
+            : "";
+      if (url.includes("/_next/static/")) {
+        reloadForSkew();
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void checkBuildSkew();
+      }
+    };
+    const onPageShow = (event: PageTransitionEvent) => {
+      // Restored from the page cache (back/forward, iOS tab restore): the
+      // in-memory build predates any deploy that happened while backgrounded.
+      if (event.persisted) {
+        void checkBuildSkew();
+      }
+    };
+
     window.addEventListener("error", onError);
     window.addEventListener("unhandledrejection", onRejection);
+    window.addEventListener("error", onResourceError, true);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("pageshow", onPageShow);
 
     return () => {
       if (armedForController && swContainer) {
@@ -91,6 +181,9 @@ export function ServiceWorkerRecovery() {
       }
       window.removeEventListener("error", onError);
       window.removeEventListener("unhandledrejection", onRejection);
+      window.removeEventListener("error", onResourceError, true);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("pageshow", onPageShow);
     };
   }, []);
 

--- a/apps/web/src/features/pwa-install/service-worker-recovery.tsx
+++ b/apps/web/src/features/pwa-install/service-worker-recovery.tsx
@@ -151,7 +151,17 @@ export function ServiceWorkerRecovery() {
           : target.tagName === "SCRIPT"
             ? (target as HTMLScriptElement).src
             : "";
-      if (url.includes("/_next/static/")) {
+      if (!url) {
+        return;
+      }
+      // Require a same-origin `/_next/static/` path: a foreign asset that merely
+      // contains that substring (e.g. a third-party CDN) is unrelated to our
+      // build and must not burn the session's one skew-recovery reload.
+      const assetUrl = new URL(url, window.location.href);
+      if (
+        assetUrl.origin === window.location.origin &&
+        assetUrl.pathname.startsWith("/_next/static/")
+      ) {
         reloadForSkew();
       }
     };

--- a/apps/web/src/specs/api/version-route.spec.ts
+++ b/apps/web/src/specs/api/version-route.spec.ts
@@ -1,0 +1,26 @@
+// @vitest-environment node
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { GET } from "@/app/api/version/route";
+
+describe("/api/version route", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns the deployed build id from SENTRY_RELEASE", async () => {
+    vi.stubEnv("SENTRY_RELEASE", "ecency-next@abc1234");
+    const res = GET();
+    expect(await res.json()).toEqual({ buildId: "ecency-next@abc1234" });
+  });
+
+  it("returns null when SENTRY_RELEASE is unset (local dev)", async () => {
+    vi.stubEnv("SENTRY_RELEASE", undefined);
+    const res = GET();
+    expect(await res.json()).toEqual({ buildId: null });
+  });
+
+  it("is served no-store so neither CDN nor a stale client caches the build id", () => {
+    const res = GET();
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+});

--- a/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
+++ b/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
@@ -123,11 +123,13 @@ describe("ServiceWorkerRecovery", () => {
     el.dispatchEvent(new Event("error"));
   }
 
+  const origin = window.location.origin;
+
   it("reloads when a /_next/static stylesheet 404s (silently unstyled, no JS error)", () => {
     render(<Recovery />);
     const link = document.createElement("link");
     link.rel = "stylesheet";
-    link.href = "https://ecency.com/_next/static/css/abc123.css";
+    link.href = `${origin}/_next/static/css/abc123.css`;
     dispatchResourceError(link);
     expect(reloadMock).toHaveBeenCalledTimes(1);
   });
@@ -135,20 +137,27 @@ describe("ServiceWorkerRecovery", () => {
   it("reloads when a /_next/static script 404s", () => {
     render(<Recovery />);
     const script = document.createElement("script");
-    script.src = "https://ecency.com/_next/static/chunks/102-deadbeef.js";
+    script.src = `${origin}/_next/static/chunks/102-deadbeef.js`;
     dispatchResourceError(script);
     expect(reloadMock).toHaveBeenCalledTimes(1);
   });
 
   it("ignores asset errors that are not build-versioned /_next/static", () => {
     render(<Recovery />);
+    // Same-origin asset outside /_next/static.
     const link = document.createElement("link");
     link.rel = "stylesheet";
-    link.href = "https://fonts.example.com/inter.css";
+    link.href = `${origin}/fonts/inter.css`;
     dispatchResourceError(link);
+    // Broken image.
     const img = document.createElement("img");
-    img.src = "https://images.ecency.com/u/foo/avatar.png";
+    img.src = `${origin}/u/foo/avatar.png`;
     dispatchResourceError(img);
+    // Foreign-origin URL that merely contains the /_next/static substring — not
+    // our build, must not burn the session's one reload.
+    const foreign = document.createElement("script");
+    foreign.src = "https://cdn.example.com/_next/static/widget.js";
+    dispatchResourceError(foreign);
     expect(reloadMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
+++ b/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 // ServiceWorkerRecovery is imported dynamically per-test (see beforeEach) to reset
 // its module-level reload guards; the pure helpers are imported statically.
 import {
@@ -108,7 +108,106 @@ describe("ServiceWorkerRecovery", () => {
   afterEach(() => {
     Object.defineProperty(window, "location", { configurable: true, value: realLocation });
     delete (navigator as unknown as { serviceWorker?: unknown }).serviceWorker;
+    document.head.querySelectorAll("[data-test-asset]").forEach((el) => el.remove());
+    document.body.querySelectorAll("[data-test-asset]").forEach((el) => el.remove());
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  // Resource-load failures fire only in the capture phase and don't bubble; the
+  // window capture listener still receives them when the element is in the tree.
+  function dispatchResourceError(el: HTMLElement) {
+    el.dataset.testAsset = "1";
+    document.head.appendChild(el);
+    el.dispatchEvent(new Event("error"));
+  }
+
+  it("reloads when a /_next/static stylesheet 404s (silently unstyled, no JS error)", () => {
+    render(<Recovery />);
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "https://ecency.com/_next/static/css/abc123.css";
+    dispatchResourceError(link);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads when a /_next/static script 404s", () => {
+    render(<Recovery />);
+    const script = document.createElement("script");
+    script.src = "https://ecency.com/_next/static/chunks/102-deadbeef.js";
+    dispatchResourceError(script);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores asset errors that are not build-versioned /_next/static", () => {
+    render(<Recovery />);
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "https://fonts.example.com/inter.css";
+    dispatchResourceError(link);
+    const img = document.createElement("img");
+    img.src = "https://images.ecency.com/u/foo/avatar.png";
+    dispatchResourceError(img);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  describe("build-id heartbeat", () => {
+    function mockVersionFetch(buildId: string | null, ok = true) {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok,
+        json: async () => ({ buildId })
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      return fetchMock;
+    }
+
+    it("reloads when the deployed build differs (stale tab refocus)", async () => {
+      vi.stubEnv("SENTRY_RELEASE", "ecency-next@oldsha");
+      const fetchMock = mockVersionFetch("ecency-next@newsha");
+      render(<Recovery />);
+
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      await waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
+      expect(fetchMock).toHaveBeenCalledWith("/api/version", { cache: "no-store" });
+    });
+
+    it("does not reload when the build id matches", async () => {
+      vi.stubEnv("SENTRY_RELEASE", "ecency-next@samesha");
+      mockVersionFetch("ecency-next@samesha");
+      render(<Recovery />);
+
+      document.dispatchEvent(new Event("visibilitychange"));
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(reloadMock).not.toHaveBeenCalled();
+    });
+
+    it("is inert when SENTRY_RELEASE is unset (local dev) — no /api/version poll", async () => {
+      vi.stubEnv("SENTRY_RELEASE", undefined);
+      const fetchMock = mockVersionFetch("ecency-next@newsha");
+      render(<Recovery />);
+
+      document.dispatchEvent(new Event("visibilitychange"));
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(reloadMock).not.toHaveBeenCalled();
+    });
+
+    it("throttles rapid refocus to a single poll", async () => {
+      vi.stubEnv("SENTRY_RELEASE", "ecency-next@samesha");
+      const fetchMock = mockVersionFetch("ecency-next@samesha");
+      render(<Recovery />);
+
+      document.dispatchEvent(new Event("visibilitychange"));
+      document.dispatchEvent(new Event("visibilitychange"));
+      document.dispatchEvent(new Event("visibilitychange"));
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("reloads once on a chunk-load error, then not again in the same session", () => {


### PR DESCRIPTION
## Problem

`ServiceWorkerRecovery` only heals a stale build through the service worker (`controllerchange`) or a thrown `ChunkLoadError` / webpack factory mismatch. Two common post-deploy cases produce no error and so slip through, leaving a returning user pinned to an old build:

1. A CSS `<link>` (or `<script>`) for a `/_next/static` asset that the new build replaced **404s**. A failed resource load doesn't bubble and isn't a `ChunkLoadError`, so nothing fires and the page renders **silently unstyled**.
2. A backgrounded tab **restored from the page cache** keeps running the old build with no navigation and no error. This is the dominant case on iOS, where Chrome/Firefox have **no service worker** at all, so the `controllerchange` path can never fire there.

## Changes

- **Capture-phase asset-load recovery** - listen for `error` in the capture phase and, when a `/_next/static` `<link>`/`<script>` fails, reload onto the current build. Non-build assets (broken images, third-party scripts) are ignored.
- **Build-id heartbeat** - on `visibilitychange`/`pageshow(persisted)`, compare the running build (`SENTRY_RELEASE`, inlined at build time) against a new `GET /api/version` (`no-store`) and reload on a mismatch. Throttled; inert in local dev where `SENTRY_RELEASE` is unset.

Both paths go through the existing `reloadForSkew` (one reload per tab session, guarded against loops), so recovery is a plain reload that **preserves auth/storage - no re-login**.

## Tests

- New `/api/version` route spec (build id passthrough + `no-store`).
- New `ServiceWorkerRecovery` cases: `/_next/static` link/script 404 reloads; non-build asset errors ignored; heartbeat reloads on mismatch, stays put on match, is inert when unset, and throttles rapid refocus.
- Full `apps/web` suite green; tsc + prettier + eslint clean on changed files.