### PR TITLE
fix(waves): keep shorts reel engagement controls legible

### DIFF
--- a/apps/web/src/app/waves/_components/waves-reel-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-reel-item.tsx
@@ -118,8 +118,11 @@ export function WavesReelItem({ item, onReply }: Props) {
         {caption && <div className="mt-2 line-clamp-2 text-sm text-white/90">{caption}</div>}
       </div>
 
-      {/* Engagement rail (bottom-right) */}
-      <div className="absolute bottom-4 right-2 flex flex-col items-center gap-3 text-white">
+      {/* Engagement rail (bottom-right). The vote/tip controls use theme-colored
+          icons that vanish on bright video frames, so the rail sits on a shaded,
+          blurred pill and every icon/label gets a dark drop-shadow halo — keeping
+          all three controls legible over any frame, not just dark ones. */}
+      <div className="absolute bottom-4 right-2 flex flex-col items-center gap-3 rounded-full bg-black/30 px-1.5 py-3 text-white backdrop-blur-sm [&_span]:drop-shadow-[0_1px_2px_rgba(0,0,0,0.7)] [&_svg]:drop-shadow-[0_1px_2px_rgba(0,0,0,0.7)]">
         <EntryVoteBtn entry={item} isPostSlider={false} />
         <button
           type="button"


### PR DESCRIPTION
## What

Follow-up to the Shorts reels player (#1039/#1040): the vote and tip controls were hard to see on bright video frames.

## Why

`EntryVoteBtn` and `EntryTipBtn` render theme-colored icons. On the reels overlay those vanish over light frames (e.g. a white wall); only the white comment icon stayed reliably visible.

## How

Put the engagement rail on a shaded, blurred pill (`bg-black/30 backdrop-blur-sm`) and give every icon/label a dark drop-shadow halo, so all three controls (vote / comment / tip) read over any frame, not just dark ones. No changes to the shared `EntryVoteBtn` / `EntryTipBtn` components — styling is applied at the rail container only.

## Test plan

- [ ] Waves → Shorts: vote, comment and tip controls are clearly visible over both bright and dark reels.
- [ ] Vote slider and tip dialog still open correctly (not clipped by the pill).
