### PR TITLE
feat(waves): native HLS reels player (fill, aspect-aware)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -97,6 +97,7 @@
     "highcharts-react-official": "^3.2.1",
     "hive-uri": "^0.2.5",
     "hivesigner": "^4.0.0",
+    "hls.js": "^1.6.16",
     "html-react-parser": "^5.0.7",
     "i18next": "^23.11.5",
     "ioredis": "^5.10.1",

--- a/apps/web/src/app/waves/_components/reel-video.tsx
+++ b/apps/web/src/app/waves/_components/reel-video.tsx
@@ -161,6 +161,10 @@ export function ReelVideo({ video, caption }: Props) {
         loop
         preload="metadata"
         onLoadedMetadata={onLoadedMetadata}
+        // Native-playback failures (Safari/iOS, or the non-hls.js src= path) only
+        // surface as a <video> error event — fall back to the iframe like the
+        // hls.js fatal-error path does.
+        onError={() => setFailed(true)}
         aria-label={caption}
         className="h-full w-full bg-black"
         style={{ objectFit: fit }}

--- a/apps/web/src/app/waves/_components/reel-video.tsx
+++ b/apps/web/src/app/waves/_components/reel-video.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import i18next from "i18next";
+import { ShortVideo } from "@ecency/sdk";
+import { UilVolume, UilVolumeMute } from "@tooni/iconscout-unicons-react";
+
+type Fit = "cover" | "contain";
+
+// Resolve a 3Speak video's HLS stream (manifest.m3u8) from its embed API. The
+// feed only carries the embed *iframe* URL; the reels player streams the
+// manifest straight into a <video> so it can fill the reel via object-fit
+// instead of being letterboxed inside an opaque iframe. Returns the primary URL
+// plus CDN fallbacks, or null when it can't be resolved.
+async function resolveThreeSpeakHls(
+  author: string,
+  permlink: string,
+  signal: AbortSignal
+): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `https://play.3speak.tv/api/embed?v=${encodeURIComponent(author)}/${encodeURIComponent(
+        permlink
+      )}`,
+      { signal }
+    );
+    if (!res.ok) {
+      return null;
+    }
+    const data = await res.json();
+    const url = [data?.videoUrl, data?.videoUrlFallback1, data?.videoUrlFallback2].find(
+      (u: unknown): u is string => typeof u === "string" && u.length > 0
+    );
+    return url ?? null;
+  } catch {
+    return null;
+  }
+}
+
+interface Props {
+  video: ShortVideo;
+  caption: string;
+}
+
+/**
+ * Native HLS reel player. Mounted only for the active reel, it streams the
+ * 3Speak manifest into a muted-autoplay <video> and fits it aspect-aware:
+ * portrait/square clips fill the reel (cover) while landscape clips are
+ * letterboxed (contain) so nothing is cropped. hls.js is dynamically imported
+ * so it never ships in any other page's bundle; Safari plays HLS natively. If
+ * the stream can't be resolved or played, it falls back to the 3Speak iframe.
+ */
+export function ReelVideo({ video, caption }: Props) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [fit, setFit] = useState<Fit>("contain");
+  const [muted, setMuted] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const el = videoRef.current;
+    if (!el) {
+      return;
+    }
+
+    const ac = new AbortController();
+    let cancelled = false;
+    let hls: { destroy: () => void } | null = null;
+
+    (async () => {
+      const src = await resolveThreeSpeakHls(video.author, video.permlink, ac.signal);
+      if (cancelled) {
+        return;
+      }
+      if (!src) {
+        setFailed(true);
+        return;
+      }
+
+      // Safari/iOS play HLS natively; every other browser needs hls.js, loaded
+      // on demand so it stays out of the shared bundle.
+      if (el.canPlayType("application/vnd.apple.mpegurl")) {
+        el.src = src;
+      } else {
+        try {
+          const { default: Hls } = await import("hls.js");
+          if (cancelled) {
+            return;
+          }
+          if (Hls.isSupported()) {
+            const instance = new Hls({ maxBufferLength: 30 });
+            hls = instance;
+            instance.loadSource(src);
+            instance.attachMedia(el);
+            instance.on(Hls.Events.ERROR, (_event, data) => {
+              if (data.fatal) {
+                setFailed(true);
+              }
+            });
+          } else {
+            el.src = src;
+          }
+        } catch {
+          setFailed(true);
+          return;
+        }
+      }
+
+      el.muted = true;
+      // Autoplay may still be rejected by the browser; the poster stays visible.
+      el.play().catch(() => undefined);
+    })();
+
+    return () => {
+      cancelled = true;
+      ac.abort();
+      if (hls) {
+        hls.destroy();
+      }
+      el.removeAttribute("src");
+      el.load();
+    };
+  }, [video.author, video.permlink]);
+
+  const onLoadedMetadata = () => {
+    const el = videoRef.current;
+    if (el?.videoWidth && el.videoHeight) {
+      setFit(el.videoHeight >= el.videoWidth ? "cover" : "contain");
+    }
+  };
+
+  const toggleMuted = () => {
+    const el = videoRef.current;
+    if (!el) {
+      return;
+    }
+    el.muted = !el.muted;
+    setMuted(el.muted);
+  };
+
+  if (failed) {
+    return (
+      <iframe
+        title={`${video.author}/${video.permlink}`}
+        src={`https://play.3speak.tv/watch?v=${encodeURIComponent(video.author)}/${encodeURIComponent(
+          video.permlink
+        )}&mode=iframe&autoplay=true`}
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowFullScreen
+        className="h-full w-full border-0"
+      />
+    );
+  }
+
+  return (
+    <>
+      <video
+        ref={videoRef}
+        poster={video.thumbnail_url ?? undefined}
+        muted={muted}
+        playsInline
+        loop
+        preload="metadata"
+        onLoadedMetadata={onLoadedMetadata}
+        aria-label={caption}
+        className="h-full w-full bg-black"
+        style={{ objectFit: fit }}
+      />
+      <button
+        type="button"
+        onClick={toggleMuted}
+        aria-label={
+          muted
+            ? i18next.t("g.unmute", { defaultValue: "Unmute" })
+            : i18next.t("g.mute", { defaultValue: "Mute" })
+        }
+        className="absolute right-2 top-2 rounded-full bg-black/40 p-2 text-white backdrop-blur-sm"
+      >
+        {muted ? <UilVolumeMute className="h-5 w-5" /> : <UilVolume className="h-5 w-5" />}
+      </button>
+    </>
+  );
+}

--- a/apps/web/src/app/waves/_components/waves-reel-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-reel-item.tsx
@@ -4,8 +4,8 @@ import { useEffect, useRef, useState } from "react";
 import i18next from "i18next";
 import { ShortsFeedEntry } from "@ecency/sdk";
 import { EntryVoteBtn, EntryTipBtn, UserAvatar, ProfileLink } from "@/features/shared";
-import { Button } from "@ui/button";
 import { UilComment, UilPlay } from "@tooni/iconscout-unicons-react";
+import { ReelVideo } from "@/app/waves/_components/reel-video";
 
 interface Props {
   item: ShortsFeedEntry;
@@ -71,13 +71,7 @@ export function WavesReelItem({ item, onReply }: Props) {
           EntryVoteBtn in the rail below) isn't cut off by the reel bounds. */}
       <div className="absolute inset-0 flex items-center justify-center overflow-hidden rounded-2xl">
         {active && video ? (
-          <iframe
-            title={`${item.author}/${item.permlink}`}
-            src={`https://play.3speak.tv/watch?v=${encodeURIComponent(video.author)}/${encodeURIComponent(video.permlink)}&mode=iframe&autoplay=true`}
-            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; web-share"
-            allowFullScreen
-            className="h-full w-full border-0"
-          />
+          <ReelVideo video={video} caption={caption} />
         ) : (
           <button
             type="button"

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -112,6 +112,8 @@
     "clear": "Clear",
     "play": "Play",
     "pause": "Pause",
+    "mute": "Mute",
+    "unmute": "Unmute",
     "start": "Start",
     "updated": "Updated"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,9 @@ importers:
       hivesigner:
         specifier: ^4.0.0
         version: 4.0.0
+      hls.js:
+        specifier: ^1.6.16
+        version: 1.6.16
       html-react-parser:
         specifier: ^5.0.7
         version: 5.2.6(@types/react@19.2.8)(react@19.2.3)
@@ -5892,6 +5895,9 @@ packages:
   hivesigner@4.0.0:
     resolution: {integrity: sha512-51++uSGQOoyYn3zBEQWsq+ZnKfs+p7XI5VEgIwqggBg7jy/sKqER4+SF7dQeAloFEWtrKD3jPBiEQ16ubdEpDw==}
     engines: {node: '>=18.0.0'}
+
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -13253,7 +13259,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.27.7)(jiti@1.21.7)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -13323,7 +13329,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.27.7)(jiti@1.21.7)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/utils@4.1.8':
     dependencies:
@@ -15031,6 +15037,8 @@ snapshots:
   hivesigner@4.0.0:
     dependencies:
       hive-uri: 0.2.8
+
+  hls.js@1.6.16: {}
 
   hoist-non-react-statics@3.3.2:
     dependencies:


### PR DESCRIPTION
## What

Replaces the 3Speak **iframe** in the Shorts reels player with a native `<video>` that streams the 3Speak **HLS manifest** directly, so the video **fills the reel** instead of being letterboxed inside an opaque iframe (an iframe's content can't be sized with `object-fit`).

This is the snapie.io/shorts approach, adapted.

## How

- Resolve the `manifest.m3u8` from `play.3speak.tv/api/embed?v=author/permlink` (primary `videoUrl` + CDN fallbacks; the endpoint and the stream CDN are both CORS-open).
- **Aspect-aware fit** (detected at runtime from the loaded video, since the API carries no dimensions): portrait/square clips fill the reel (`cover`), landscape clips are letterboxed (`contain`) so nothing is cropped.
- **hls.js is dynamically imported** (`await import("hls.js")`) so it never ships in any other page's bundle — it loads only when a reel mounts. Safari/iOS play HLS natively (no hls.js).
- Muted autoplay with a mute toggle; poster from the thumbnail.
- **Falls back to the 3Speak iframe** if the stream can't be resolved or playback fails, so reels keep working if 3Speak's stream API changes.

## Notes

- New dependency: `hls.js` (dynamic-only import, code-split).
- Touches a different region of `waves-reel-item.tsx` than #1044 (rail legibility), so the two don't conflict.

## Test plan

- [ ] Waves → Shorts: a portrait clip fills the reel; a landscape clip is letterboxed (not cropped).
- [ ] Video autoplays muted on scroll; mute toggle works.
- [ ] hls.js loads only on the Shorts tab (not on other pages) — check the network tab / bundle.
- [ ] If a stream fails to resolve, the iframe fallback still plays.
