### PR TITLE
fix(waves): align reel engagement rail + show vote & tip counts

### DIFF
--- a/apps/web/src/app/waves/_components/waves-reel-item.scss
+++ b/apps/web/src/app/waves/_components/waves-reel-item.scss
@@ -29,12 +29,22 @@
     cursor: pointer;
   }
 
-  &__count {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-    font-size: 12px;
+  // Vote count (heart + number) via EntryVotes: stack icon over count, white,
+  // centered. The voted state keeps its own accent (more specific selector).
+  .entry-votes {
+    .inner-btn {
+      flex-direction: column;
+      gap: 2px;
+      color: #fff;
+    }
+    .heart-icon svg {
+      width: 24px;
+      height: 24px;
+    }
+    .entry-votes__count {
+      color: #fff;
+      font-size: 12px;
+    }
   }
 
   // Upvote chevron: drop the circular themed button background, just a white

--- a/apps/web/src/app/waves/_components/waves-reel-item.scss
+++ b/apps/web/src/app/waves/_components/waves-reel-item.scss
@@ -1,0 +1,77 @@
+// Engagement rail for a reel. Reuses the feed's vote/tip controls but those are
+// styled for a horizontal, theme-colored feed footer — here we normalize them
+// into a uniform vertical column of white, centered "icon over count" cells that
+// stay legible over any video frame.
+.waves-reel-rail {
+  color: #fff;
+
+  // Dark halo so white icons/labels read over bright frames.
+  svg,
+  span,
+  .entry-votes__count,
+  .tip-count {
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.7));
+  }
+
+  // Every control is a centered icon-over-count cell of the same width, so the
+  // chevron / heart / comment / gift line up on one vertical axis.
+  &__item {
+    width: 44px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    color: #fff;
+    font-size: 12px;
+    line-height: 1.1;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+  }
+
+  &__count {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    font-size: 12px;
+  }
+
+  // Upvote chevron: drop the circular themed button background, just a white
+  // arrow centered in the cell.
+  .entry-vote-btn {
+    .btn-vote {
+      background: transparent !important;
+      border: none !important;
+      box-shadow: none !important;
+      padding: 0;
+      width: auto;
+      height: auto;
+      min-width: 0;
+    }
+    svg {
+      width: 26px;
+      height: 26px;
+      color: #fff;
+    }
+  }
+
+  // Tip: stack the gift over its count (instead of side-by-side) and force white.
+  .entry-tip-btn {
+    margin: 0;
+    .inner-btn {
+      flex-direction: column;
+      gap: 2px;
+      color: #fff !important;
+      svg {
+        height: 26px;
+        width: 26px;
+        opacity: 1;
+      }
+    }
+    .tip-count {
+      padding-left: 0;
+      font-size: 12px;
+    }
+  }
+}

--- a/apps/web/src/app/waves/_components/waves-reel-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-reel-item.tsx
@@ -134,7 +134,13 @@ export function WavesReelItem({ item, onReply }: Props) {
           <span>{item.children ?? 0}</span>
         </button>
         {/* Tip + tip count */}
-        <EntryTipBtn entry={item} tipCount={item.tip_count} tippedByViewer={item.tipped_by_viewer} />
+        <div className="waves-reel-rail__item">
+          <EntryTipBtn
+            entry={item}
+            tipCount={item.tip_count}
+            tippedByViewer={item.tipped_by_viewer}
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/waves/_components/waves-reel-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-reel-item.tsx
@@ -4,8 +4,9 @@ import { useEffect, useRef, useState } from "react";
 import i18next from "i18next";
 import { ShortsFeedEntry } from "@ecency/sdk";
 import { EntryVoteBtn, EntryTipBtn, UserAvatar, ProfileLink } from "@/features/shared";
-import { UilComment, UilPlay } from "@tooni/iconscout-unicons-react";
+import { UilComment, UilHeart, UilPlay } from "@tooni/iconscout-unicons-react";
 import { ReelVideo } from "@/app/waves/_components/reel-video";
+import "./waves-reel-item.scss";
 
 interface Props {
   item: ShortsFeedEntry;
@@ -112,22 +113,30 @@ export function WavesReelItem({ item, onReply }: Props) {
         {caption && <div className="mt-2 line-clamp-2 text-sm text-white/90">{caption}</div>}
       </div>
 
-      {/* Engagement rail (bottom-right). The vote/tip controls use theme-colored
-          icons that vanish on bright video frames, so the rail sits on a shaded,
-          blurred pill and every icon/label gets a dark drop-shadow halo — keeping
-          all three controls legible over any frame, not just dark ones. */}
-      <div className="absolute bottom-4 right-2 flex flex-col items-center gap-3 rounded-full bg-black/30 px-1.5 py-3 text-white backdrop-blur-sm [&_span]:drop-shadow-[0_1px_2px_rgba(0,0,0,0.7)] [&_svg]:drop-shadow-[0_1px_2px_rgba(0,0,0,0.7)]">
-        <EntryVoteBtn entry={item} isPostSlider={false} />
+      {/* Engagement rail (bottom-right). Reuses the feed vote/tip controls but
+          the scoped .waves-reel-rail styles normalize them into uniform, white,
+          centered icon-over-count cells that stay legible over any video frame. */}
+      <div className="waves-reel-rail absolute bottom-4 right-2 flex flex-col items-center gap-4 rounded-full bg-black/30 px-2 py-3 backdrop-blur-sm">
+        {/* Upvote (action) + like count */}
+        <div className="waves-reel-rail__item">
+          <EntryVoteBtn entry={item} isPostSlider={false} />
+          <span className="waves-reel-rail__count">
+            <UilHeart className="h-5 w-5" />
+            {item.net_votes ?? 0}
+          </span>
+        </div>
+        {/* Comment */}
         <button
           type="button"
           onClick={() => onReply(item)}
-          className="flex flex-col items-center text-xs"
+          className="waves-reel-rail__item"
           aria-label={i18next.t("g.comment", { defaultValue: "Comment" })}
         >
           <UilComment className="h-6 w-6" />
           <span>{item.children ?? 0}</span>
         </button>
-        <EntryTipBtn entry={item} />
+        {/* Tip + tip count */}
+        <EntryTipBtn entry={item} tipCount={item.tip_count} tippedByViewer={item.tipped_by_viewer} />
       </div>
     </div>
   );

--- a/apps/web/src/app/waves/_components/waves-reel-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-reel-item.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import i18next from "i18next";
 import { ShortsFeedEntry } from "@ecency/sdk";
-import { EntryVoteBtn, EntryTipBtn, UserAvatar, ProfileLink } from "@/features/shared";
-import { UilComment, UilHeart, UilPlay } from "@tooni/iconscout-unicons-react";
+import { EntryVoteBtn, EntryVotes, EntryTipBtn, UserAvatar, ProfileLink } from "@/features/shared";
+import { UilComment, UilPlay } from "@tooni/iconscout-unicons-react";
 import { ReelVideo } from "@/app/waves/_components/reel-video";
 import "./waves-reel-item.scss";
 
@@ -117,13 +117,11 @@ export function WavesReelItem({ item, onReply }: Props) {
           the scoped .waves-reel-rail styles normalize them into uniform, white,
           centered icon-over-count cells that stay legible over any video frame. */}
       <div className="waves-reel-rail absolute bottom-4 right-2 flex flex-col items-center gap-4 rounded-full bg-black/30 px-2 py-3 backdrop-blur-sm">
-        {/* Upvote (action) + like count */}
+        {/* Upvote (action) + live like count (heart). EntryVotes reads the
+            cached entry, so the count updates immediately after voting. */}
         <div className="waves-reel-rail__item">
           <EntryVoteBtn entry={item} isPostSlider={false} />
-          <span className="waves-reel-rail__count">
-            <UilHeart className="h-5 w-5" />
-            {item.net_votes ?? 0}
-          </span>
+          <EntryVotes entry={item} />
         </div>
         {/* Comment */}
         <button


### PR DESCRIPTION
## What

On the Shorts reel rail, the vote (chevron) and tip (gift) controls reused the feed footer's horizontal, theme-colored styling, so they didn't line up with the comment icon and showed **no counts**.

## How

- Scoped `.waves-reel-rail` SCSS normalizes all controls into uniform, **white, centered icon-over-count cells** (same width, one vertical axis).
- **Like count**: heart (`UilHeart`) + `net_votes` under the upvote.
- **Tip count**: pass `tipCount={entry.tip_count}` + `tippedByViewer` to `EntryTipBtn` (it already renders the count + tipped state).
- Voting still uses `EntryVoteBtn` (the weighted-vote chevron/slider) — unchanged, just restyled white.

## Notes
- All `Uil*` icons used are in the curated `unicons.tsx` whitelist (avoids the earlier #130).

## Test plan
- [ ] Shorts: vote / comment / tip icons are aligned, white, each with a count; tip count + tipped state show; vote slider still opens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live vote counts to the reel engagement controls.
  * Updated the engagement rail to show vote and tip actions in a cleaner vertical layout with icons above counts.

* **Style**
  * Refined reel action styling for better readability, including improved contrast and consistent alignment across controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->