### PR TITLE
fix(waves): reel like = tap-to-upvote heart (drop chevron + slider)

### DIFF
--- a/apps/web/src/app/waves/_components/reel-vote-button.tsx
+++ b/apps/web/src/app/waves/_components/reel-vote-button.tsx
@@ -34,12 +34,14 @@ export function ReelVoteButton({ entry: initialEntry }: { entry: Entry }) {
     [activeUser, entry.active_votes]
   );
 
-  // Mirror the feed's EntryVotes count so the rail matches the rest of the app.
+  // Mirror the feed's EntryVotes count (incl. the top-level total_votes fallback)
+  // so the rail matches the rest of the app and never drops a real count.
   const count = useMemo(
     () =>
       entry.stats?.total_votes ||
       entry.active_votes?.length ||
       entry.net_votes ||
+      entry.total_votes ||
       0,
     [entry]
   );
@@ -57,7 +59,9 @@ export function ReelVoteButton({ entry: initialEntry }: { entry: Entry }) {
         // the SDK reconciles the authoritative payout afterwards).
         const percent = getVoteValue(
           "up",
-          `${activeUser.username}-${entry.post_id}`,
+          // Fall back to permlink if post_id is missing, so reels without a
+          // post_id don't all share one saved weight under `${user}-undefined`.
+          `${activeUser.username}-${entry.post_id ?? entry.permlink}`,
           getVoteValue("upPrevious", activeUser.username, 100, false),
           false
         );
@@ -69,7 +73,7 @@ export function ReelVoteButton({ entry: initialEntry }: { entry: Entry }) {
   };
 
   return (
-    <LoginRequired>
+    <LoginRequired promptOnAnon>
       <button
         type="button"
         onClick={onVote}

--- a/apps/web/src/app/waves/_components/reel-vote-button.tsx
+++ b/apps/web/src/app/waves/_components/reel-vote-button.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import React, { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import i18next from "i18next";
+import { UilHeart } from "@tooni/iconscout-unicons-react";
+import { Entry } from "@/entities";
+import { LoginRequired } from "@/features/shared";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { EcencyEntriesCacheManagement } from "@/core/caches";
+import { useEntryVote } from "@/api/mutations";
+import { getVoteValue } from "@/features/shared/entry-vote-btn/utils";
+import { error } from "@/features/shared/feedback";
+import { formatError } from "@/api/format-error";
+
+/**
+ * TikTok-style like for the reels rail: the heart IS the upvote button — tap to
+ * upvote at the user's default weight, tap again to remove — with a live count
+ * below. Replaces the feed's chevron + vote-slider, which looked orphaned in the
+ * rail and whose slider popover was clipped by the snap scroll-container. Reads
+ * the cached entry so the count/voted state update immediately after voting.
+ */
+export function ReelVoteButton({ entry: initialEntry }: { entry: Entry }) {
+  const { activeUser } = useActiveAccount();
+  const { data: cached } = useQuery(EcencyEntriesCacheManagement.getEntryQuery(initialEntry));
+  const entry = cached ?? initialEntry;
+
+  const { mutateAsync: vote, isPending } = useEntryVote(entry);
+
+  const isVoted = useMemo(
+    () =>
+      !!activeUser &&
+      (entry.active_votes?.some((v) => v.voter === activeUser.username && v.rshares >= 0) ?? false),
+    [activeUser, entry.active_votes]
+  );
+
+  // Mirror the feed's EntryVotes count so the rail matches the rest of the app.
+  const count = useMemo(
+    () =>
+      entry.stats?.total_votes ||
+      entry.active_votes?.length ||
+      entry.net_votes ||
+      0,
+    [entry]
+  );
+
+  const onVote = async () => {
+    if (!activeUser || isPending) {
+      return;
+    }
+    try {
+      if (isVoted) {
+        // Tap again removes the vote.
+        await vote({ weight: 0, estimated: 0 });
+      } else {
+        // Upvote at the user's saved/default weight (estimated is display-only;
+        // the SDK reconciles the authoritative payout afterwards).
+        const percent = getVoteValue(
+          "up",
+          `${activeUser.username}-${entry.post_id}`,
+          getVoteValue("upPrevious", activeUser.username, 100, false),
+          false
+        );
+        await vote({ weight: Math.ceil(percent * 100), estimated: 0 });
+      }
+    } catch (e) {
+      error(...formatError(e));
+    }
+  };
+
+  return (
+    <LoginRequired>
+      <button
+        type="button"
+        onClick={onVote}
+        disabled={isPending}
+        className={`waves-reel-rail__item waves-reel-rail__vote${isVoted ? " is-voted" : ""}`}
+        aria-pressed={isVoted}
+        aria-label={i18next.t("entry-vote-btn.vote", { defaultValue: "Vote" })}
+      >
+        <UilHeart className="h-7 w-7" />
+        <span>{count}</span>
+      </button>
+    </LoginRequired>
+  );
+}

--- a/apps/web/src/app/waves/_components/waves-reel-item.scss
+++ b/apps/web/src/app/waves/_components/waves-reel-item.scss
@@ -1,20 +1,19 @@
-// Engagement rail for a reel. Reuses the feed's vote/tip controls but those are
-// styled for a horizontal, theme-colored feed footer — here we normalize them
-// into a uniform vertical column of white, centered "icon over count" cells that
-// stay legible over any video frame.
+// Engagement rail for a reel. The like is a tap-to-upvote heart; the tip control
+// reuses the feed's EntryTipBtn but is normalized here into the same uniform
+// vertical column of white, centered "icon over count" cells that stay legible
+// over any video frame.
 .waves-reel-rail {
   color: #fff;
 
   // Dark halo so white icons/labels read over bright frames.
   svg,
   span,
-  .entry-votes__count,
   .tip-count {
     filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.7));
   }
 
   // Every control is a centered icon-over-count cell of the same width, so the
-  // chevron / heart / comment / gift line up on one vertical axis.
+  // heart / comment / gift line up on one vertical axis.
   &__item {
     width: 44px;
     display: flex;
@@ -29,40 +28,18 @@
     cursor: pointer;
   }
 
-  // Vote count (heart + number) via EntryVotes: stack icon over count, white,
-  // centered. The voted state keeps its own accent (more specific selector).
-  .entry-votes {
-    .inner-btn {
-      flex-direction: column;
-      gap: 2px;
-      color: #fff;
+  // Like: white heart by default, accent (liked) when the viewer has voted.
+  &__vote {
+    transition: transform 0.1s ease;
+    &:active {
+      transform: scale(0.9);
     }
-    .heart-icon svg {
-      width: 24px;
-      height: 24px;
+    &:disabled {
+      opacity: 0.6;
+      cursor: default;
     }
-    .entry-votes__count {
-      color: #fff;
-      font-size: 12px;
-    }
-  }
-
-  // Upvote chevron: drop the circular themed button background, just a white
-  // arrow centered in the cell.
-  .entry-vote-btn {
-    .btn-vote {
-      background: transparent !important;
-      border: none !important;
-      box-shadow: none !important;
-      padding: 0;
-      width: auto;
-      height: auto;
-      min-width: 0;
-    }
-    svg {
-      width: 26px;
-      height: 26px;
-      color: #fff;
+    &.is-voted {
+      color: #ec4a4a;
     }
   }
 

--- a/apps/web/src/app/waves/_components/waves-reel-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-reel-item.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useRef, useState } from "react";
 import i18next from "i18next";
 import { ShortsFeedEntry } from "@ecency/sdk";
-import { EntryVoteBtn, EntryVotes, EntryTipBtn, UserAvatar, ProfileLink } from "@/features/shared";
+import { EntryTipBtn, UserAvatar, ProfileLink } from "@/features/shared";
 import { UilComment, UilPlay } from "@tooni/iconscout-unicons-react";
 import { ReelVideo } from "@/app/waves/_components/reel-video";
+import { ReelVoteButton } from "@/app/waves/_components/reel-vote-button";
 import "./waves-reel-item.scss";
 
 interface Props {
@@ -117,12 +118,8 @@ export function WavesReelItem({ item, onReply }: Props) {
           the scoped .waves-reel-rail styles normalize them into uniform, white,
           centered icon-over-count cells that stay legible over any video frame. */}
       <div className="waves-reel-rail absolute bottom-4 right-2 flex flex-col items-center gap-4 rounded-full bg-black/30 px-2 py-3 backdrop-blur-sm">
-        {/* Upvote (action) + live like count (heart). EntryVotes reads the
-            cached entry, so the count updates immediately after voting. */}
-        <div className="waves-reel-rail__item">
-          <EntryVoteBtn entry={item} isPostSlider={false} />
-          <EntryVotes entry={item} />
-        </div>
+        {/* Like: heart taps to upvote (default weight), with a live count. */}
+        <ReelVoteButton entry={item} />
         {/* Comment */}
         <button
           type="button"


### PR DESCRIPTION
Follow-up to #1048.

## Problem (reported on staging)
- The reel's upvote **chevron looked broken/orphaned** in the rail.
- Opening the **vote slider clipped/hid** it (the slider popover gets clipped by the reels snap scroll-container).

## Fix
Replace `EntryVoteBtn` (chevron + weighted slider) in the reel rail with a **tap-to-upvote heart** (`ReelVoteButton`):
- Tap = upvote at the user's saved/default weight; tap again = remove the vote.
- Live count + liked (red) state, read from the cached entry (`EcencyEntriesCacheManagement`) so it updates immediately.
- `LoginRequired` gates anon taps. No popover, so nothing to clip.

This is the TikTok-style like the rail was heading toward, and removes the slider-anchor rough edge entirely.

## Test plan
- [ ] Tap heart → upvotes (heart turns red, count +1); tap again → removes (count -1).
- [ ] Logged out → tapping prompts login.
- [ ] Heart / comment / tip stay aligned; no stray chevron; no clipped slider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new heart-style vote control for reel items, with clear voted/unvoted states and vote counts.
  * Users can now tap the control to add or remove their vote directly from the reel engagement rail.

* **Bug Fixes**
  * Improved vote behavior for signed-out users and while an action is in progress.
  * Updated styling for better interaction feedback, including active and disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->