### PR TITLE
feat(entry): durable on-post internal links + visible breadcrumb

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-breadcrumbs.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-breadcrumbs.ts
@@ -1,0 +1,46 @@
+import { Entry } from "@/entities";
+
+export interface BreadcrumbCrumb {
+  name: string;
+  /** Relative path for the visible link. */
+  path: string;
+  /** Absolute URL for the BreadcrumbList JSON-LD. */
+  url: string;
+}
+
+/**
+ * Build the breadcrumb trail for a post, shared by the visible <nav> and the
+ * BreadcrumbList JSON-LD so the two never drift. Top-level posts only (comments
+ * return []). The section crumb is omitted when the category is a raw
+ * "hive-12345" id and there is no community title, so the trail never surfaces a
+ * machine id (mirrors buildArticleJsonLd's articleSection + resolveRelatedSource).
+ */
+export function buildEntryBreadcrumbs(
+  entry: Pick<
+    Entry,
+    "parent_author" | "category" | "community_title" | "title" | "author" | "permlink"
+  >,
+  opts: { siteName: string; base: string; entryUrl: string }
+): BreadcrumbCrumb[] {
+  if (entry.parent_author) {
+    return [];
+  }
+
+  const { siteName, base, entryUrl } = opts;
+  const isCommunityId = /^hive-\d+$/.test(entry.category ?? "");
+  const sectionName = entry.community_title || (isCommunityId ? null : `#${entry.category}`);
+
+  return [
+    { name: siteName, path: "/", url: base },
+    ...(sectionName
+      ? [
+          {
+            name: sectionName,
+            path: `/trending/${entry.category}`,
+            url: `${base}/trending/${entry.category}`
+          }
+        ]
+      : []),
+    { name: entry.title, path: `/@${entry.author}/${entry.permlink}`, url: entryUrl }
+  ];
+}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-breadcrumb.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-breadcrumb.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+
+export interface BreadcrumbItem {
+  name: string;
+  /** Relative path for the visible link, e.g. "/", "/trending/foo". */
+  path: string;
+}
+
+interface Props {
+  items: BreadcrumbItem[];
+}
+
+/**
+ * Visible, server-rendered breadcrumb trail. Driven by the same items array
+ * that builds the BreadcrumbList JSON-LD (in page.tsx) so the two never drift.
+ * Every crumb except the last is a crawlable `<a href>`; the last item is the
+ * current page, rendered as plain text.
+ */
+export function EntryPageBreadcrumb({ items }: Props) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="Breadcrumb" className="entry-breadcrumb text-sm opacity-75 mb-2 px-2 md:px-0">
+      <ol className="flex flex-wrap items-center gap-1">
+        {items.map((item, i) => {
+          const isLast = i === items.length - 1;
+          return (
+            <li key={`${item.path}-${i}`} className="flex items-center gap-1 min-w-0">
+              {isLast ? (
+                <span aria-current="page" className="truncate max-w-[18rem]">
+                  {item.name}
+                </span>
+              ) : (
+                <>
+                  <Link href={item.path} className="hover:underline whitespace-nowrap">
+                    {item.name}
+                  </Link>
+                  <span aria-hidden="true">/</span>
+                </>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-more-from-author.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-more-from-author.tsx
@@ -1,0 +1,58 @@
+import { Entry } from "@/entities";
+import { fetchQuery } from "@/core/react-query";
+import { getAccountPostsQueryOptions } from "@ecency/sdk";
+import { initI18next } from "@/features/i18n";
+import i18next from "i18next";
+import { EntryRelatedList } from "./entry-related-list";
+import { isLinkableRelated } from "./entry-related-source";
+
+const FETCH_LIMIT = 12;
+const RENDER_COUNT = 6;
+const MIN_RENDER = 2;
+
+interface Props {
+  entry: Entry;
+}
+
+/**
+ * "More from @author" — durable, server-rendered links to the author's other
+ * recent posts. Async server component: the `fetchQuery` resolves during the
+ * render pass (bounded by the SSR timeout), so the links are in the initial
+ * server HTML and crawlable. The fetched data is NOT dehydrated into the client
+ * payload because the entry page captures its dehydrate snapshot before this
+ * subtree renders. Shown for top-level posts only.
+ */
+export async function EntryPageMoreFromAuthor({ entry }: Props) {
+  if (entry.parent_author) {
+    return null;
+  }
+
+  // SDK and web both model a Hive post as `Entry`; the SDK/web type split is
+  // deliberately deferred (see SimilarEntries), so cross the boundary once here.
+  const posts = (await fetchQuery(
+    getAccountPostsQueryOptions(entry.author, "posts", "", "", FETCH_LIMIT)
+  )) as unknown as Entry[] | undefined;
+
+  const seen = new Set<string>([entry.permlink]);
+  const entries = (posts ?? [])
+    .filter((p) => {
+      if (p.author !== entry.author || seen.has(p.permlink) || !isLinkableRelated(p)) {
+        return false;
+      }
+      seen.add(p.permlink);
+      return true;
+    })
+    .slice(0, RENDER_COUNT);
+
+  if (entries.length < MIN_RENDER) {
+    return null;
+  }
+
+  await initI18next();
+  return (
+    <EntryRelatedList
+      title={i18next.t("related-posts.more-from-author", { username: entry.author })}
+      entries={entries}
+    />
+  );
+}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-more-in-tag.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-more-in-tag.tsx
@@ -1,0 +1,64 @@
+import { Entry } from "@/entities";
+import { fetchQuery } from "@/core/react-query";
+import { getPostsRankedQueryOptions } from "@ecency/sdk";
+import { initI18next } from "@/features/i18n";
+import i18next from "i18next";
+import { EntryRelatedList } from "./entry-related-list";
+import { resolveRelatedSource, isLinkableRelated } from "./entry-related-source";
+
+const FETCH_LIMIT = 12;
+const RENDER_COUNT = 6;
+const MIN_RENDER = 2;
+
+interface Props {
+  entry: Entry;
+}
+
+/**
+ * "More in {community or #tag}" — durable, server-rendered links to other
+ * recent posts in the same community/tag. Async server component (see
+ * EntryPageMoreFromAuthor for the SSR/dehydration rationale). Excludes the
+ * current post and the post's own author so it doesn't duplicate the
+ * "More from author" block or self-link. Top-level posts only.
+ */
+export async function EntryPageMoreInTag({ entry }: Props) {
+  if (entry.parent_author) {
+    return null;
+  }
+
+  const source = resolveRelatedSource(entry);
+  if (!source) {
+    return null;
+  }
+
+  // SDK/web Entry boundary cast (see EntryPageMoreFromAuthor).
+  const posts = (await fetchQuery(
+    getPostsRankedQueryOptions("created", "", "", FETCH_LIMIT, source.tag)
+  )) as unknown as Entry[] | undefined;
+
+  // This is a cross-author feed, so dedup on author+permlink: a Hive permlink is
+  // unique only per author, and distinct posts can share a slug.
+  const seen = new Set<string>();
+  const entries = (posts ?? [])
+    .filter((p) => {
+      const key = `${p.author}/${p.permlink}`;
+      if (p.author === entry.author || seen.has(key) || !isLinkableRelated(p)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
+    .slice(0, RENDER_COUNT);
+
+  if (entries.length < MIN_RENDER) {
+    return null;
+  }
+
+  await initI18next();
+  return (
+    <EntryRelatedList
+      title={i18next.t("related-posts.more-in", { section: source.section })}
+      entries={entries}
+    />
+  );
+}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-card.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-card.tsx
@@ -1,0 +1,59 @@
+import Image from "next/image";
+import Link from "next/link";
+import { catchPostImage } from "@ecency/render-helper";
+import { Entry } from "@/entities";
+import { makeEntryPath } from "@/utils/make-path";
+import { dateToFullRelative } from "@/utils/parse-date";
+
+interface Props {
+  entry: Entry;
+  i: number;
+}
+
+/**
+ * A single related-post card. Pure server component: the `<a href>` is always
+ * present in the initial SSR HTML (no `use client`, no query subscription), so
+ * it is a durable internal link crawlers can follow. Visually mirrors
+ * SimilarEntryItem but renders the timestamp as a static `<time>` (server-safe)
+ * instead of the client-only TimeLabel, and links via makeEntryPath so the href
+ * is the canonical bare /@author/permlink form (no redirect hop).
+ */
+export function EntryRelatedCard({ entry, i }: Props) {
+  const postImage = catchPostImage(entry, 600, 500);
+
+  return (
+    <Link href={makeEntryPath(entry.category, entry.author, entry.permlink)} className="no-style">
+      <div
+        className="similar-entries-list-item bg-gray-100 hover:bg-blue-dark-sky-040 dark:bg-gray-900 rounded-2xl overflow-hidden transform transition-transform duration-200 hover:rotate-[1.5deg]"
+        style={{ animationDelay: `${i * 0.2}s` }}
+      >
+        {postImage ? (
+          <Image
+            src={postImage}
+            alt={entry.title}
+            width={1000}
+            height={1000}
+            className="object-cover w-full h-[8rem]"
+          />
+        ) : (
+          <div className="w-full h-[8rem] flex items-center justify-center bg-gray-200 dark:bg-dark-default">
+            <Image
+              src="/assets/noimage.svg"
+              alt={entry.title}
+              width={1000}
+              height={1000}
+              className="w-8 h-8"
+            />
+          </div>
+        )}
+        <div className="truncate py-2 px-4">{entry.title}</div>
+        <div className="item-footer py-2 px-4">
+          <span className="item-footer-author">{entry.author}</span>
+          <time className="item-footer-date" dateTime={entry.created}>
+            {dateToFullRelative(entry.created)}
+          </time>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-card.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-card.tsx
@@ -33,6 +33,9 @@ export function EntryRelatedCard({ entry, i }: Props) {
             alt={entry.title}
             width={1000}
             height={1000}
+            // 1 col on mobile (100vw), 3 cols at >=sm (~33vw) — so the optimizer
+            // serves a card-sized rendition instead of a full-width one.
+            sizes="(max-width: 640px) 100vw, 33vw"
             className="object-cover w-full h-[8rem]"
           />
         ) : (

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-list.tsx
@@ -1,0 +1,34 @@
+import { Entry } from "@/entities";
+import { EntryRelatedCard } from "./entry-related-card";
+// Reuse the "Read next" strip styling so these blocks match SimilarEntries.
+import "./similar-entries/_index.scss";
+
+interface Props {
+  title: string;
+  entries: Entry[];
+}
+
+/**
+ * A titled grid of related-post links, server-rendered. Shares the
+ * `.similar-entries-list` markup/styles with the "Read next" strip so the
+ * on-post related blocks ("More from author", "More in {community/tag}") look
+ * consistent. Renders nothing when there is nothing to link.
+ */
+export function EntryRelatedList({ title, entries }: Props) {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="similar-entries-list">
+      <div className="similar-entries-list-header">
+        <div className="list-header-text">{title}</div>
+      </div>
+      <div className="similar-entries-list-body grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {entries.map((entry, i) => (
+          <EntryRelatedCard entry={entry} i={i} key={`${entry.author}-${entry.permlink}`} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-source.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-source.ts
@@ -1,0 +1,55 @@
+import { Entry } from "@/entities";
+import { isNsfwEntry } from "@/utils/nsfw-detection";
+
+/**
+ * Whether a related post is safe to surface as an on-page internal link.
+ * Mirrors the feed's SSR hiding so these crawlable SEO links never point at
+ * NSFW posts or mod-muted ("gray") posts.
+ */
+export function isLinkableRelated(
+  entry: Pick<Entry, "category" | "title" | "json_metadata" | "stats">
+): boolean {
+  if (entry.stats?.gray) {
+    return false;
+  }
+  return !isNsfwEntry(entry);
+}
+
+export interface RelatedSource {
+  /** Feed query tag: a community id (hive-xxxxx) or a plain tag. */
+  tag: string;
+  /** Human heading: the community title, or "#tag". Never a raw hive id. */
+  section: string;
+}
+
+/**
+ * Resolve the feed source + heading for the "More in ..." block.
+ * Prefers the post's community (queried by id, labelled with its title); falls
+ * back to the post's primary tag. Returns null when there is nothing sensible
+ * to link, and never surfaces a raw "hive-12345" id as a heading.
+ *
+ * Pure (no I/O) so it can be unit-tested without the render/fetch chain.
+ */
+export function resolveRelatedSource(
+  entry: Pick<Entry, "category" | "community" | "community_title" | "json_metadata">
+): RelatedSource | null {
+  const isCommunityId = /^hive-\d+$/.test(entry.category ?? "");
+  const tags = entry.json_metadata?.tags;
+  const firstTag = Array.isArray(tags)
+    ? tags.find(
+        // Exclude hive-id-shaped tags so the heading is never a raw "#hive-12345".
+        (t): t is string => typeof t === "string" && t.length > 0 && !/^hive-\d+$/.test(t)
+      )
+    : undefined;
+
+  if (entry.community && entry.community_title) {
+    return { tag: entry.community, section: entry.community_title };
+  }
+  if (!isCommunityId && entry.category) {
+    return { tag: entry.category, section: `#${entry.category}` };
+  }
+  if (firstTag) {
+    return { tag: firstTag, section: `#${firstTag}` };
+  }
+  return null;
+}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/similar-entries/similar-entry-item.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/similar-entries/similar-entry-item.tsx
@@ -30,6 +30,9 @@ export function SimilarEntryItem({ entry, i }: Props) {
             alt={entry.title}
             width={1000}
             height={1000}
+            // 1 col on mobile (100vw), 3 cols at >=sm (~33vw) — so the optimizer
+            // serves a card-sized rendition instead of a full-width one.
+            sizes="(max-width: 640px) 100vw, 33vw"
             className="object-cover w-full h-[8rem]"
           />
         )}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { prefetchQuery, getQueryClient } from "@/core/react-query";
 import { getAccountFullQueryOptions, getSimilarEntriesQueryOptions } from "@ecency/sdk";
 import {
@@ -10,6 +11,9 @@ import {
 import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { EntryPageContentClient } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-client";
 import { EntryPageContentSSR } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-ssr";
+import { EntryPageBreadcrumb } from "./_components/entry-page-breadcrumb";
+import { EntryPageMoreFromAuthor } from "./_components/entry-page-more-from-author";
+import { EntryPageMoreInTag } from "./_components/entry-page-more-in-tag";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { Metadata, ResolvingMetadata } from "next";
 import { notFound, redirect } from "next/navigation";
@@ -143,18 +147,27 @@ export default async function EntryPage({ params, searchParams }: Props) {
   // rather than the category-prefixed path, which only 307-redirects to it.
   const base = (await getServerAppBase()).replace(/\/+$/, "");
   const entryUrl = entryCanonical(entry, base) ?? `${base}/@${entry.author}/${entry.permlink}`;
+  // Breadcrumb trail shared by the visible <nav> and the BreadcrumbList JSON-LD
+  // so the two never drift. Top-level posts only (comments carry no trail).
+  // `path` drives the visible relative links; `url` is the absolute form for
+  // structured data.
+  const breadcrumbs = entry.parent_author
+    ? []
+    : [
+        { name: defaults.name, path: "/", url: base },
+        {
+          name: entry.community_title || `#${entry.category}`,
+          path: `/trending/${entry.category}`,
+          url: `${base}/trending/${entry.category}`
+        },
+        { name: entry.title, path: `/@${entry.author}/${entry.permlink}`, url: entryUrl }
+      ];
+
   const structuredData = entry.parent_author
     ? null
     : [
         buildArticleJsonLd({ entry, account, url: entryUrl, base }),
-        buildBreadcrumbJsonLd([
-          { name: defaults.name, url: base },
-          {
-            name: entry.community_title || `#${entry.category}`,
-            url: `${base}/trending/${entry.category}`
-          },
-          { name: entry.title, url: entryUrl }
-        ])
+        buildBreadcrumbJsonLd(breadcrumbs.map((c) => ({ name: c.name, url: c.url })))
       ];
 
   return (
@@ -186,9 +199,22 @@ export default async function EntryPage({ params, searchParams }: Props) {
         <div className="app-content entry-page bg-fixed bg-contain bg-gradient-to-tr from-blue-dark-sky/20 to-white dark:from-dark-default dark:to-black">
           <div className="the-entry">
             <EntryPageCrossPostHeader entry={entry} />
+            {breadcrumbs.length > 0 && <EntryPageBreadcrumb items={breadcrumbs} />}
             {structuredData && <JsonLd data={structuredData} />}
             <EntryRenderBoundary>
               <EntryPageContentSSR entry={entry} isRawContent={isRawContent} />
+              {/* Durable, server-rendered internal links so crawlers can reach
+                  the author's other posts and the community/tag beyond the
+                  sitemap. Each renders nothing when there's too little to link.
+                  Wrapped in Suspense so their (bounded) feed fetches stream as a
+                  later chunk instead of gating the post body's flush / LCP — the
+                  <a href> links still ship in the same streamed HTML response. */}
+              <Suspense fallback={null}>
+                <EntryPageMoreFromAuthor entry={entry} />
+              </Suspense>
+              <Suspense fallback={null}>
+                <EntryPageMoreInTag entry={entry} />
+              </Suspense>
               <EntryPageContentClient entry={entry} />
               <EntryPageDiscussionsWrapper entry={entry} category={category} />
             </EntryRenderBoundary>

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
@@ -12,6 +12,7 @@ import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { EntryPageContentClient } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-client";
 import { EntryPageContentSSR } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-ssr";
 import { EntryPageBreadcrumb } from "./_components/entry-page-breadcrumb";
+import { buildEntryBreadcrumbs } from "./_components/entry-breadcrumbs";
 import { EntryPageMoreFromAuthor } from "./_components/entry-page-more-from-author";
 import { EntryPageMoreInTag } from "./_components/entry-page-more-in-tag";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
@@ -148,20 +149,12 @@ export default async function EntryPage({ params, searchParams }: Props) {
   const base = (await getServerAppBase()).replace(/\/+$/, "");
   const entryUrl = entryCanonical(entry, base) ?? `${base}/@${entry.author}/${entry.permlink}`;
   // Breadcrumb trail shared by the visible <nav> and the BreadcrumbList JSON-LD
-  // so the two never drift. Top-level posts only (comments carry no trail).
-  // `path` drives the visible relative links; `url` is the absolute form for
-  // structured data.
-  const breadcrumbs = entry.parent_author
-    ? []
-    : [
-        { name: defaults.name, path: "/", url: base },
-        {
-          name: entry.community_title || `#${entry.category}`,
-          path: `/trending/${entry.category}`,
-          url: `${base}/trending/${entry.category}`
-        },
-        { name: entry.title, path: `/@${entry.author}/${entry.permlink}`, url: entryUrl }
-      ];
+  // so the two never drift (and never surface a raw hive-id section).
+  const breadcrumbs = buildEntryBreadcrumbs(entry, {
+    siteName: defaults.name,
+    base,
+    entryUrl
+  });
 
   const structuredData = entry.parent_author
     ? null

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1031,6 +1031,10 @@
   "similar-entries": {
     "title": "Read next"
   },
+  "related-posts": {
+    "more-from-author": "More from @{{username}}",
+    "more-in": "More in {{section}}"
+  },
   "comment": {
     "body-placeholder": "Write your reply here",
     "write": "Write",

--- a/apps/web/src/specs/features/entry/entry-related.spec.tsx
+++ b/apps/web/src/specs/features/entry/entry-related.spec.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import {
+  resolveRelatedSource,
+  isLinkableRelated
+} from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-source";
+import { EntryPageBreadcrumb } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-breadcrumb";
+import { EntryRelatedList } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-list";
+import { mockEntry } from "@/specs/test-utils";
+
+// Render next/link and next/image as plain DOM so we can assert on hrefs.
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: any) => (
+    <a href={typeof href === "string" ? href : href?.pathname} {...rest}>
+      {children}
+    </a>
+  )
+}));
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: any) => <img src={typeof src === "string" ? src : src?.src} alt={alt} />
+}));
+
+describe("resolveRelatedSource", () => {
+  it("prefers the community (id) labelled with its title", () => {
+    expect(
+      resolveRelatedSource({
+        category: "hive-125125",
+        community: "hive-125125",
+        community_title: "Ecency",
+        json_metadata: { tags: ["ecency", "dev"] }
+      })
+    ).toEqual({ tag: "hive-125125", section: "Ecency" });
+  });
+
+  it("uses the category tag for a non-community post", () => {
+    expect(
+      resolveRelatedSource({
+        category: "photography",
+        community: undefined,
+        community_title: undefined,
+        json_metadata: { tags: ["photography", "art"] }
+      })
+    ).toEqual({ tag: "photography", section: "#photography" });
+  });
+
+  it("never shows a raw hive id heading: falls back to the primary tag", () => {
+    // Community post whose community_title is missing and category is a raw id.
+    expect(
+      resolveRelatedSource({
+        category: "hive-125125",
+        community: "hive-125125",
+        community_title: undefined,
+        json_metadata: { tags: ["travel", "blog"] }
+      })
+    ).toEqual({ tag: "travel", section: "#travel" });
+  });
+
+  it("skips hive-id-shaped tags when picking the fallback heading", () => {
+    expect(
+      resolveRelatedSource({
+        category: "hive-125125",
+        community: "hive-125125",
+        community_title: undefined,
+        json_metadata: { tags: ["hive-125125", "travel"] }
+      })
+    ).toEqual({ tag: "travel", section: "#travel" });
+  });
+
+  it("returns null when there is nothing to link", () => {
+    expect(
+      resolveRelatedSource({
+        category: "hive-125125",
+        community: "hive-125125",
+        community_title: undefined,
+        json_metadata: { tags: [] }
+      })
+    ).toBeNull();
+  });
+
+  it("returns null when the only tags are hive-id-shaped", () => {
+    expect(
+      resolveRelatedSource({
+        category: "hive-125125",
+        community: "hive-125125",
+        community_title: undefined,
+        json_metadata: { tags: ["hive-125125", "hive-999"] }
+      })
+    ).toBeNull();
+  });
+});
+
+describe("isLinkableRelated", () => {
+  const base = { category: "photography", title: "A nice photo", json_metadata: { tags: ["photography"] }, stats: null };
+
+  it("allows a normal SFW post", () => {
+    expect(isLinkableRelated(base)).toBe(true);
+  });
+
+  it("rejects NSFW-tagged posts", () => {
+    expect(isLinkableRelated({ ...base, json_metadata: { tags: ["nsfw"] } })).toBe(false);
+  });
+
+  it("rejects mod-muted (gray) posts", () => {
+    expect(isLinkableRelated({ ...base, stats: { gray: true } as any })).toBe(false);
+  });
+});
+
+describe("EntryPageBreadcrumb", () => {
+  const items = [
+    { name: "Ecency", path: "/" },
+    { name: "#photography", path: "/trending/photography" },
+    { name: "My Post", path: "/@alice/my-post" }
+  ];
+
+  it("renders all but the last crumb as crawlable links", () => {
+    render(<EntryPageBreadcrumb items={items} />);
+    expect(screen.getByRole("link", { name: "Ecency" }).getAttribute("href")).toBe("/");
+    expect(screen.getByRole("link", { name: "#photography" }).getAttribute("href")).toBe(
+      "/trending/photography"
+    );
+  });
+
+  it("renders the current (last) item as plain text, not a link", () => {
+    render(<EntryPageBreadcrumb items={items} />);
+    expect(screen.queryByRole("link", { name: "My Post" })).toBeNull();
+    expect(screen.getByText("My Post").getAttribute("aria-current")).toBe("page");
+  });
+
+  it("renders nothing when there are no items", () => {
+    const { container } = render(<EntryPageBreadcrumb items={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("EntryRelatedList", () => {
+  it("renders a heading and a canonical bare link per entry", () => {
+    const entries = [
+      mockEntry({ author: "alice", permlink: "post-1", category: "photography", title: "Post One" }),
+      mockEntry({ author: "bob", permlink: "post-2", category: "photography", title: "Post Two" })
+    ];
+    render(<EntryRelatedList title="More in #photography" entries={entries} />);
+
+    expect(screen.getByText("More in #photography")).not.toBeNull();
+    const links = screen.getAllByRole("link");
+    const hrefs = links.map((l) => l.getAttribute("href"));
+    expect(hrefs).toContain("/@alice/post-1");
+    expect(hrefs).toContain("/@bob/post-2");
+  });
+
+  it("renders nothing when there are no entries", () => {
+    const { container } = render(<EntryRelatedList title="More in #x" entries={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/apps/web/src/specs/features/entry/entry-related.spec.tsx
+++ b/apps/web/src/specs/features/entry/entry-related.spec.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-source";
 import { EntryPageBreadcrumb } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-breadcrumb";
 import { EntryRelatedList } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-list";
+import { buildEntryBreadcrumbs } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-breadcrumbs";
 import { mockEntry } from "@/specs/test-utils";
 
 // Render next/link and next/image as plain DOM so we can assert on hrefs.
@@ -103,6 +104,44 @@ describe("isLinkableRelated", () => {
 
   it("rejects mod-muted (gray) posts", () => {
     expect(isLinkableRelated({ ...base, stats: { gray: true } as any })).toBe(false);
+  });
+});
+
+describe("buildEntryBreadcrumbs", () => {
+  const opts = { siteName: "Ecency", base: "https://ecency.com", entryUrl: "https://ecency.com/@alice/p" };
+
+  it("builds Home > #tag > title for a normal tag post", () => {
+    const crumbs = buildEntryBreadcrumbs(
+      { parent_author: undefined, category: "photography", community_title: undefined, title: "Pic", author: "alice", permlink: "p" },
+      opts
+    );
+    expect(crumbs.map((c) => c.name)).toEqual(["Ecency", "#photography", "Pic"]);
+    expect(crumbs[1].path).toBe("/trending/photography");
+  });
+
+  it("uses the community title as the section for a community post", () => {
+    const crumbs = buildEntryBreadcrumbs(
+      { parent_author: undefined, category: "hive-125125", community_title: "Ecency", title: "Pic", author: "alice", permlink: "p" },
+      opts
+    );
+    expect(crumbs.map((c) => c.name)).toEqual(["Ecency", "Ecency", "Pic"]);
+  });
+
+  it("omits the section crumb (no raw hive id) when a community post has no title", () => {
+    const crumbs = buildEntryBreadcrumbs(
+      { parent_author: undefined, category: "hive-125125", community_title: undefined, title: "Pic", author: "alice", permlink: "p" },
+      opts
+    );
+    expect(crumbs.map((c) => c.name)).toEqual(["Ecency", "Pic"]);
+    expect(crumbs.some((c) => c.name.includes("hive-"))).toBe(false);
+  });
+
+  it("returns no trail for a comment", () => {
+    const crumbs = buildEntryBreadcrumbs(
+      { parent_author: "bob", category: "photography", community_title: undefined, title: "re", author: "alice", permlink: "p" },
+      opts
+    );
+    expect(crumbs).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Adds two server-rendered related-post blocks to the post page ("More from author" and "More in {community/tag}") plus a visible breadcrumb.

- Async server components fed by existing SDK queries (`getAccountPostsQueryOptions`, `getPostsRankedQueryOptions`); links render in the initial SSR HTML.
- Wrapped in `Suspense` so the bounded feed fetches stream as a later chunk instead of gating the post body.
- Canonical bare `/@author/permlink` hrefs; excludes the current post, the author's own posts (in the tag block), duplicates, NSFW, and mod-muted posts.
- The breadcrumb shares one source array with the existing `BreadcrumbList` JSON-LD so the two never drift.
- New unit spec (14 cases); full web test suite green; typecheck clean for changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added breadcrumb navigation on entry pages for easier backtracking.
  * Added “More from author” and “More in tag” related-content sections.
  * Added related entry cards and a related entries grid for richer discovery.

* **Bug Fixes**
  * Improved related-content filtering to avoid invalid, duplicate, or irrelevant links.
  * Hidden related links for muted or NSFW content.
  * Updated entry pages to render related sections progressively for smoother loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->