### PR TITLE
Show Ecency source badge across feeds, comments and search

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-footer-info.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-footer-info.tsx
@@ -1,9 +1,8 @@
-import {ProfileLink, TimeLabel} from "@/features/shared";
+import { EcencySourceBadge, ProfileLink, TimeLabel } from "@/features/shared";
 import i18next from "i18next";
 import { Tsx } from "@/features/i18n/helper";
 import { Entry } from "@/entities";
 import { accountReputation, appName, parseDate } from "@/utils";
-import Image from "next/image";
 import React from "react";
 
 interface Props {
@@ -35,15 +34,10 @@ export function EntryFooterInfo({ entry }: Props) {
             <Tsx k="entry.via-app" args={{ app: appShort }}>
               <a href="/faq#source-label" />
             </Tsx>
-            {isEcency && (
-              <Image
-                className="ecency-source-badge inline-block align-text-bottom ml-1"
-                src="/assets/logo-circle.svg"
-                alt=""
-                width={14}
-                height={14}
-              />
-            )}
+            <EcencySourceBadge
+              app={entry.json_metadata?.app}
+              className="inline-block align-text-bottom ml-1"
+            />
           </div>
         </>
       )}

--- a/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
+++ b/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
@@ -40,6 +40,9 @@ export interface SearchItemProps {
   url: string;
   index: number;
   json_metadata: any;
+  // Search-API rows expose the client as a flat `app` string (json_metadata is
+  // optional there); full entries carry it under json_metadata.app instead.
+  app?: string;
   entry: any;
   onMounted: () => void;
   onEntryView: () => void;
@@ -51,6 +54,7 @@ export const SearchListItem = ({
   community,
   community_title,
   json_metadata,
+  app,
   created,
   index,
   url,
@@ -229,7 +233,7 @@ export const SearchListItem = ({
                 <span className="deck-pinned">{pinSvg}</span>
               </Tooltip>
             )}
-            <EcencySourceBadge app={json_metadata?.app} className="mr-2" />
+            <EcencySourceBadge app={json_metadata?.app ?? app} className="mr-2" />
             <div className="date mb-3">
               <EntryLink target="_blank" entry={entry}>
                 <small>{`${dateToRelative(created)}`}</small>

--- a/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
+++ b/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
@@ -5,6 +5,7 @@ import { commentSvg, voteSvg } from "../../icons";
 import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { dateToRelative, transformMarkedContent, makeEntryPath } from "@/utils";
 import {
+  EcencySourceBadge,
   EntryLink,
   EntryMenu,
   EntryPayout,
@@ -228,6 +229,7 @@ export const SearchListItem = ({
                 <span className="deck-pinned">{pinSvg}</span>
               </Tooltip>
             )}
+            <EcencySourceBadge app={json_metadata?.app} className="mr-2" />
             <div className="date mb-3">
               <EntryLink target="_blank" entry={entry}>
                 <small>{`${dateToRelative(created)}`}</small>

--- a/apps/web/src/app/decks/_components/columns/deck-items/deck-thread-item-header.tsx
+++ b/apps/web/src/app/decks/_components/columns/deck-items/deck-thread-item-header.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ThreadItemEntry } from "../deck-threads-manager";
 import { Spinner } from "@ui/spinner";
-import { UserAvatar } from "@/features/shared";
+import { EcencySourceBadge, UserAvatar } from "@/features/shared";
 import Link from "next/link";
 import i18next from "i18next";
 import { dateToRelative, makeEntryPath } from "@/utils";
@@ -37,6 +37,8 @@ export const DeckThreadItemHeader = ({ entry, hasParent, pure, status }: Props) 
           #{entry.host}
         </Link>
       </div>
+
+      <EcencySourceBadge app={entry.json_metadata?.app} className="ml-1" />
 
       <div className="date">
         {status === "default" && (

--- a/apps/web/src/app/waves/_components/waves-list-item-header.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-item-header.tsx
@@ -1,4 +1,4 @@
-import { UserAvatar } from "@/features/shared";
+import { EcencySourceBadge, UserAvatar } from "@/features/shared";
 import Link from "next/link";
 import i18next from "i18next";
 import { Spinner } from "@ui/spinner";
@@ -10,8 +10,6 @@ import { UilArrowRight, UilMultiply } from "@tooni/iconscout-unicons-react";
 import { TimeLabel } from "@/features/shared";
 import clsx from "clsx";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
-import { appName } from "@/utils";
-import Image from "next/image";
 
 interface Props {
   entry: WaveEntry;
@@ -37,10 +35,6 @@ export function WavesListItemHeader({
   onClose
 }: Props) {
   const { activeUser } = useActiveAccount();
-
-  // Show a small Ecency logo when the wave was published from an Ecency client
-  // (web "ecency/x.y-vision" or "ecency-mobile"), mirroring the post "via" badge.
-  const isEcency = appName(entry.json_metadata?.app).toLowerCase().includes("ecency");
 
   return (
     <div
@@ -81,16 +75,7 @@ export function WavesListItemHeader({
       </div>
 
       <div className="flex items-center gap-2 shrink-0">
-        {isEcency && (
-          <Image
-            className="ecency-source-badge"
-            src="/assets/logo-circle.svg"
-            alt={i18next.t("waves.source-ecency")}
-            title={i18next.t("waves.source-ecency")}
-            width={16}
-            height={16}
-          />
-        )}
+        <EcencySourceBadge app={entry.json_metadata?.app} size={16} />
         {onClose ? (
           <Button
             noPadding={true}

--- a/apps/web/src/features/shared/discussion/discussion-item.tsx
+++ b/apps/web/src/features/shared/discussion/discussion-item.tsx
@@ -6,6 +6,7 @@ import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { Community, Entry } from "@/entities";
 import { SortOrder } from "@/enums";
 import {
+  EcencySourceBadge,
   EntryDeleteBtn,
   EntryPayout,
   EntryTipBtn,
@@ -290,6 +291,7 @@ export const DiscussionItem = memo(function DiscussionItem({
                   </span>
                 </StyledTooltip>
               )}
+              <EcencySourceBadge app={entry.json_metadata?.app} className="ml-3" />
             </div>
           </div>
 

--- a/apps/web/src/features/shared/ecency-source-badge/index.tsx
+++ b/apps/web/src/features/shared/ecency-source-badge/index.tsx
@@ -1,0 +1,43 @@
+import { appName } from "@/utils";
+import clsx from "clsx";
+import i18next from "i18next";
+import Image from "next/image";
+import React from "react";
+
+interface Props {
+  /**
+   * Raw `app` value to inspect — either `json_metadata.app` (a string or a
+   * `{ name }` object) or the flat `app` string returned by the search API.
+   */
+  app: string | { name?: string } | null | undefined;
+  /** Rendered size in px (square). Defaults to 14. */
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Small Ecency logo shown next to content that was published from an Ecency
+ * client ("ecency/x.y-vision" on web, "ecency-mobile" on mobile) so it's clear
+ * at a glance which posts, comments and waves were published by/with Ecency.
+ * Renders nothing for content from any other client.
+ */
+export function EcencySourceBadge({ app, size = 14, className }: Props) {
+  const isEcency = appName(app).toLowerCase().includes("ecency");
+
+  if (!isEcency) {
+    return null;
+  }
+
+  const label = i18next.t("waves.source-ecency");
+
+  return (
+    <Image
+      className={clsx("ecency-source-badge", className)}
+      src="/assets/logo-circle.svg"
+      alt={label}
+      title={label}
+      width={size}
+      height={size}
+    />
+  );
+}

--- a/apps/web/src/features/shared/ecency-source-badge/index.tsx
+++ b/apps/web/src/features/shared/ecency-source-badge/index.tsx
@@ -22,7 +22,10 @@ interface Props {
  * Renders nothing for content from any other client.
  */
 export function EcencySourceBadge({ app, size = 14, className }: Props) {
-  const isEcency = appName(app).toLowerCase().includes("ecency");
+  // Every Ecency client identifier starts with "ecency" (ecency/x.y-vision,
+  // ecency-mobile, ecency.waves), so anchor the match to the start rather than a
+  // loose substring that would also catch lookalikes like "notecency/...".
+  const isEcency = appName(app).toLowerCase().startsWith("ecency");
 
   if (!isEcency) {
     return null;

--- a/apps/web/src/features/shared/entry-info/index.tsx
+++ b/apps/web/src/features/shared/entry-info/index.tsx
@@ -1,7 +1,14 @@
 import "./_index.scss";
 import { accountReputation, parseDate } from "@/utils";
 import { Entry } from "@/entities";
-import {BookmarkBtn, EntryMenu, ProfileLink, TimeLabel, UserAvatar} from "@/features/shared";
+import {
+  BookmarkBtn,
+  EcencySourceBadge,
+  EntryMenu,
+  ProfileLink,
+  TimeLabel,
+  UserAvatar
+} from "@/features/shared";
 import i18next from "i18next";
 import { TagLink } from "@/features/shared/tag";
 import { EcencyConfigManager } from "@/config";
@@ -44,6 +51,10 @@ export const EntryInfo = ({ entry }: Props) => {
               </div>
             </TagLink>
           </div>
+          <EcencySourceBadge
+            app={entry.json_metadata?.app}
+            className="inline-block align-text-bottom ml-1.5"
+          />
         </div>
       </div>
       <span className="flex-spacer" />

--- a/apps/web/src/features/shared/entry-list-item/index.tsx
+++ b/apps/web/src/features/shared/entry-list-item/index.tsx
@@ -8,6 +8,7 @@ import { Account, Community, Entry, FullAccount } from "@/entities";
 import { makeEntryPath } from "@/utils";
 import { pinSvg, repeatSvg } from "@ui/svg";
 import {
+  EcencySourceBadge,
   EntryMenu,
   EntryPayout,
   EntryReblogBtn,
@@ -108,6 +109,10 @@ export function EntryListItemComponent({
           </TagLink>
           <span className="read-mark ml-2" />
           <TimeLabel created={entry.created} />
+          <EcencySourceBadge
+            app={entry.json_metadata?.app}
+            className="inline-block align-text-bottom ml-1.5"
+          />
 
           <EntryListItemPollIcon entry={entryProp} />
         </div>

--- a/apps/web/src/features/shared/index.ts
+++ b/apps/web/src/features/shared/index.ts
@@ -20,6 +20,7 @@ export * from "./follow-controls";
 export * from "./image-upload-button";
 export * from "./list-style-toggle";
 export * from "./detect-bottom";
+export * from "./ecency-source-badge";
 export * from "./search-list-item";
 export * from "./formatted-currency";
 export * from "./entry-list-loading-item";

--- a/apps/web/src/features/shared/search-list-item/index.tsx
+++ b/apps/web/src/features/shared/search-list-item/index.tsx
@@ -3,7 +3,13 @@ import { catchPostImage, postBodySummary, setProxyBase } from "@ecency/render-he
 import "./_index.scss";
 import defaults from "@/defaults";
 import { SearchResult } from "@/entities";
-import { EntryLink, FormattedCurrency, ProfileLink, UserAvatar } from "@/features/shared";
+import {
+  EcencySourceBadge,
+  EntryLink,
+  FormattedCurrency,
+  ProfileLink,
+  UserAvatar
+} from "@/features/shared";
 import { TagLink } from "../tag";
 import { commentSvg, peopleSvg } from "@ui/svg";
 import { accountReputation, dateToFormatted, dateToRelative, transformMarkedContent } from "@/utils";
@@ -59,6 +65,7 @@ export function SearchListItem({ res }: Props) {
           <span className="date ml-2" title={dateFormatted}>
             {dateRelative}
           </span>
+          <EcencySourceBadge app={res.app} className="inline-block align-text-bottom ml-1.5" />
         </div>
       </div>
       <div className="item-body">

--- a/apps/web/src/specs/features/shared/discussion-item.spec.tsx
+++ b/apps/web/src/specs/features/shared/discussion-item.spec.tsx
@@ -49,6 +49,7 @@ vi.mock("@ecency/sdk", async () => ({
 vi.mock("@/features/shared", async () => {
   const Real = await import("react");
   return {
+    EcencySourceBadge: () => null,
     EntryDeleteBtn: ({ children }: any) => Real.createElement("span", null, children),
     EntryPayout: () => Real.createElement("span", { "data-testid": "entry-payout" }),
     EntryTipBtn: () => Real.createElement("span", { "data-testid": "entry-tip-btn" }),

--- a/apps/web/src/specs/features/shared/ecency-source-badge.spec.tsx
+++ b/apps/web/src/specs/features/shared/ecency-source-badge.spec.tsx
@@ -1,0 +1,44 @@
+import { vi } from "vitest";
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// The global @/utils mock only exposes random + getAccessToken; the badge relies
+// on the real appName to detect the Ecency source from json_metadata.app.
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+
+import { EcencySourceBadge } from "@/features/shared/ecency-source-badge";
+
+// i18next is globally mocked to echo keys, so the badge alt is the raw key.
+const BADGE = 'img[alt="waves.source-ecency"]';
+
+describe("EcencySourceBadge", () => {
+  it("renders for the Ecency web client (ecency/x.y-vision)", () => {
+    const { container } = render(<EcencySourceBadge app="ecency/4.4.0-vision" />);
+    expect(container.querySelector(BADGE)).not.toBeNull();
+  });
+
+  it("renders for the Ecency mobile client", () => {
+    const { container } = render(<EcencySourceBadge app="ecency-mobile" />);
+    expect(container.querySelector(BADGE)).not.toBeNull();
+  });
+
+  it("accepts the object form of json_metadata.app ({ name })", () => {
+    const { container } = render(<EcencySourceBadge app={{ name: "ecency/4.4.0-vision" }} />);
+    expect(container.querySelector(BADGE)).not.toBeNull();
+  });
+
+  it("does not render for non-Ecency clients", () => {
+    const { container } = render(<EcencySourceBadge app="skatehive-mobile" />);
+    expect(container.querySelector(BADGE)).toBeNull();
+  });
+
+  it("does not render when app metadata is missing", () => {
+    const { container } = render(<EcencySourceBadge app={undefined} />);
+    expect(container.querySelector(BADGE)).toBeNull();
+  });
+});

--- a/apps/web/src/specs/features/shared/ecency-source-badge.spec.tsx
+++ b/apps/web/src/specs/features/shared/ecency-source-badge.spec.tsx
@@ -37,6 +37,11 @@ describe("EcencySourceBadge", () => {
     expect(container.querySelector(BADGE)).toBeNull();
   });
 
+  it("does not render for lookalike clients that merely contain 'ecency'", () => {
+    const { container } = render(<EcencySourceBadge app="notecency/1.0" />);
+    expect(container.querySelector(BADGE)).toBeNull();
+  });
+
   it("does not render when app metadata is missing", () => {
     const { container } = render(<EcencySourceBadge app={undefined} />);
     expect(container.querySelector(BADGE)).toBeNull();

--- a/apps/web/src/specs/features/shared/entry-list-item.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-list-item.spec.tsx
@@ -62,6 +62,7 @@ vi.mock("@/features/shared", async () => {
   return {
     EntryLink,
     ProfileLink,
+    EcencySourceBadge: () => null,
     UserAvatar: ({ username }: any) =>
       Real.createElement("span", { "data-testid": "user-avatar" }, username),
     ProfilePopover: () => Real.createElement("span", { "data-testid": "profile-popover" }),

--- a/apps/web/src/specs/features/waves/waves-list-item-header-badge.spec.tsx
+++ b/apps/web/src/specs/features/waves/waves-list-item-header-badge.spec.tsx
@@ -12,10 +12,13 @@ vi.mock("@/utils", async () => ({
 }));
 
 // UserAvatar / TimeLabel come from the heavy @/features/shared barrel; stub the
-// two pieces this header uses so the render stays light and deterministic.
-vi.mock("@/features/shared", () => ({
+// two pieces this header uses so the render stays light and deterministic. The
+// Ecency badge is the real component (imported from its own light module) so
+// these assertions keep exercising the shared detection logic.
+vi.mock("@/features/shared", async () => ({
   UserAvatar: () => <div data-testid="avatar" />,
-  TimeLabel: () => <span data-testid="time" />
+  TimeLabel: () => <span data-testid="time" />,
+  ...(await vi.importActual("@/features/shared/ecency-source-badge"))
 }));
 
 import { WavesListItemHeader } from "@/app/waves/_components/waves-list-item-header";


### PR DESCRIPTION
## What

Surfaces the "published via Ecency" badge everywhere we have client/app metadata, so it's clear at a glance which content was published with Ecency. Until now the badge only appeared on waves and the single-post footer.

The detection logic (`appName(app).includes("ecency")`) is unchanged: it matches the Ecency web (`ecency/x.y-vision`) and mobile (`ecency-mobile`) clients and renders nothing for any other client.

## Changes

- New shared `EcencySourceBadge` component (`features/shared/ecency-source-badge`) that takes the raw `app` value (string or `{ name }`) and renders the logo only for Ecency clients.
- Badge added to:
  - Feed list items (`EntryListItem`) — home, profile, community, tag, trending, blog
  - Comment / discussion threads (`DiscussionItem`)
  - Search results (`SearchListItem`)
  - Deck thread items (`DeckThreadItemHeader`) and deck search items
  - Post info header (`EntryInfo`) — used by the deck post viewer and publish-success screen
- Waves header and single-post footer now reuse the shared component instead of inline copies.

Reuses the existing `waves.source-ecency` string and `logo-circle.svg`, so no new assets or copy.

## Tests

- New unit spec for `EcencySourceBadge` (web/mobile/object-form match, non-Ecency and missing-metadata no-render).
- Updated the affected component specs whose `@/features/shared` mocks needed the new export.
- Full web suite green; type check shows no new errors.