### PR TITLE
fix(routing): resolve bare community URL /hive-NNNNN (404)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -519,6 +519,17 @@ const config = {
         source: "/:category((?!@)[^/]+)/:author(@[^/]+)/:permlink",
         destination: "/:author/:permlink",
         permanent: true
+      },
+      // SEO: a bare community URL (/hive-NNNNN) currently 404s — no route
+      // matches a bare hive-id at the root. Canonicalize it onto the working
+      // /created/:community form (mapped to the community feed by the rewrites
+      // below, and the same path makePath() emits), so the natural community
+      // URL resolves and any inbound links transfer their signal to it.
+      // Single-segment hive-id can only be a community, so this shadows nothing.
+      {
+        source: "/:community(hive-\\d{5,6})",
+        destination: "/created/:community",
+        permanent: true
       }
     ];
   },


### PR DESCRIPTION
A bare community URL such as `/hive-125125` matched no route and returned a 404 (only `/:filter/:community` forms resolve). This adds a permanent redirect that canonicalizes the bare hive-id onto the working `/created/:community` form — the same path `makePath()` emits and the rewrites map to the community feed.

- `source: /:community(hive-\d{5,6})` -> `destination: /created/:community` (308). Single-segment hive-id can only be a community, so it shadows no other route, and the digit pattern matches the existing community rewrites.

Verification after deploy: `GET /hive-125125` -> 308 -> `/created/hive-125125` -> 200 (community feed).
