### PR TITLE
feat(profile): crawlable numbered archive pages for author sections

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -566,14 +566,6 @@ const config = {
         destination: "/profile/:author/wallet/:token"
       },
       {
-        // Numbered archive pages for author content sections:
-        // /@author/<section>/page/N -> /profile/@author/<section>?page=N.
-        // Author is a single segment (no slashes); placed before the generic
-        // section rewrite so the /page/N suffix is matched first.
-        source: "/:author(@[^/]+)/:section(posts|blog|comments|replies)/page/:page(\\d+)",
-        destination: "/profile/:author/:section?page=:page"
-      },
-      {
         source:
           "/:author(@.+)/:section(posts|blog|comments|replies|communities|trail|followers|following|wallet|settings|insights|referrals|permissions|rss|rss.xml)",
         destination: "/profile/:author/:section"

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -566,6 +566,14 @@ const config = {
         destination: "/profile/:author/wallet/:token"
       },
       {
+        // Numbered archive pages for author content sections:
+        // /@author/<section>/page/N -> /profile/@author/<section>?page=N.
+        // Author is a single segment (no slashes); placed before the generic
+        // section rewrite so the /page/N suffix is matched first.
+        source: "/:author(@[^/]+)/:section(posts|blog|comments|replies)/page/:page(\\d+)",
+        destination: "/profile/:author/:section?page=:page"
+      },
+      {
         source:
           "/:author(@.+)/:section(posts|blog|comments|replies|communities|trail|followers|following|wallet|settings|insights|referrals|permissions|rss|rss.xml)",
         destination: "/profile/:author/:section"

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/[section]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/[section]/page.tsx
@@ -1,8 +1,9 @@
 import { ProfileEntriesList, ProfileSearchContent } from "../_components";
 import { ProfileEntriesArchive } from "@/app/(dynamicPages)/profile/[username]/_components/profile-entries-archive";
 import {
-  fetchAuthorArchivePage,
-  ARCHIVE_MAX_PAGE
+  fetchAuthorCursorPage,
+  archiveCursor,
+  cursorToken
 } from "@/app/(dynamicPages)/profile/[username]/_helpers/author-archive";
 import { prefetchGetPostsFeedQuery } from "@/api/queries";
 import { EcencyEntriesCacheManagement } from "@/core/caches";
@@ -26,39 +27,36 @@ interface Props {
 
 export async function generateMetadata(props: Props, parent: ResolvingMetadata): Promise<Metadata> {
   const { username, section } = await props.params;
-  const { page } = await props.searchParams;
-  return generateProfileMetadata(username.replace(/%40/g, ""), section, Number(page) || 1);
+  const { query, before } = await props.searchParams;
+  const cursor = archiveCursor(section, { query, before });
+  return generateProfileMetadata(
+    username.replace(/%40/g, ""),
+    section,
+    cursor ? cursorToken(cursor) : undefined
+  );
 }
 
 export default async function Page({ params, searchParams }: Props) {
   const { username: usernameParam, section } = await params;
-  const { query: searchParam, page: pageParam } = await searchParams;
+  const { query: searchParam, before: beforeParam } = await searchParams;
   const loggedInUser = (await cookies()).get(ACTIVE_USER_COOKIE_NAME)?.value;
 
   const username = usernameParam.replace(/%40/g, "");
 
-  // Numbered archive page (/@author/<section>/page/N, rewritten to ?page=N).
-  // Only for content sections and only page 2+ (page 1 is the default view).
-  const pageNum = Number(pageParam);
-  const isArchive = !searchParam && Number.isInteger(pageNum) && pageNum >= 2;
-  if (isArchive) {
-    if (!["posts", "comments", "replies", "blog"].includes(section)) {
-      return notFound();
-    }
+  // Cursor archive page (/@author/<section>?before=<author>/<permlink>): O(1),
+  // one fetch of the 20 posts older than the cursor. Page 1 is the clean,
+  // query-less default view; archiveCursor() returns null there.
+  const cursor = archiveCursor(section, { query: searchParam, before: beforeParam });
+  if (cursor) {
     const basePath = `/@${username}/${section}`;
-    // Past the crawlable depth cap — send to the first page rather than 404.
-    if (pageNum > ARCHIVE_MAX_PAGE) {
-      return redirect(basePath);
-    }
     const [account, archive] = await Promise.all([
       prefetchQuery(getAccountFullQueryOptions(username)),
-      fetchAuthorArchivePage(username, section, pageNum)
+      fetchAuthorCursorPage(username, section, cursor)
     ]);
     if (!account) {
       return notFound();
     }
-    // Page beyond the author's content (incl. an exact-multiple-of-20 author
-    // whose page-1 "Older" link points here): redirect to page 1, never a 404.
+    // Stale/invalid cursor (nothing older than it): send to the clean first page.
     if (archive.entries.length === 0) {
       return redirect(basePath);
     }
@@ -70,8 +68,7 @@ export default async function Page({ params, searchParams }: Props) {
           section={section}
           account={account}
           entries={archive.entries}
-          page={pageNum}
-          hasNext={archive.hasNext}
+          olderCursor={archive.nextCursor ? cursorToken(archive.nextCursor) : null}
           currentUser={loggedInUser}
         />
       </HydrationBoundary>

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/[section]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/[section]/page.tsx
@@ -1,7 +1,12 @@
 import { ProfileEntriesList, ProfileSearchContent } from "../_components";
+import { ProfileEntriesArchive } from "@/app/(dynamicPages)/profile/[username]/_components/profile-entries-archive";
+import {
+  fetchAuthorArchivePage,
+  ARCHIVE_MAX_PAGE
+} from "@/app/(dynamicPages)/profile/[username]/_helpers/author-archive";
 import { prefetchGetPostsFeedQuery } from "@/api/queries";
 import { EcencyEntriesCacheManagement } from "@/core/caches";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { getQueryClient, prefetchQuery, fetchInfiniteQuery } from "@/core/react-query";
 import { stripActiveVotesFromDehydratedState } from "@/core/react-query/strip-active-votes";
@@ -21,15 +26,58 @@ interface Props {
 
 export async function generateMetadata(props: Props, parent: ResolvingMetadata): Promise<Metadata> {
   const { username, section } = await props.params;
-  return generateProfileMetadata(username.replace(/%40/g, ""), section);
+  const { page } = await props.searchParams;
+  return generateProfileMetadata(username.replace(/%40/g, ""), section, Number(page) || 1);
 }
 
 export default async function Page({ params, searchParams }: Props) {
   const { username: usernameParam, section } = await params;
-  const { query: searchParam } = await searchParams;
+  const { query: searchParam, page: pageParam } = await searchParams;
   const loggedInUser = (await cookies()).get(ACTIVE_USER_COOKIE_NAME)?.value;
 
   const username = usernameParam.replace(/%40/g, "");
+
+  // Numbered archive page (/@author/<section>/page/N, rewritten to ?page=N).
+  // Only for content sections and only page 2+ (page 1 is the default view).
+  const pageNum = Number(pageParam);
+  const isArchive = !searchParam && Number.isInteger(pageNum) && pageNum >= 2;
+  if (isArchive) {
+    if (!["posts", "comments", "replies", "blog"].includes(section)) {
+      return notFound();
+    }
+    const basePath = `/@${username}/${section}`;
+    // Past the crawlable depth cap — send to the first page rather than 404.
+    if (pageNum > ARCHIVE_MAX_PAGE) {
+      return redirect(basePath);
+    }
+    const [account, archive] = await Promise.all([
+      prefetchQuery(getAccountFullQueryOptions(username)),
+      fetchAuthorArchivePage(username, section, pageNum)
+    ]);
+    if (!account) {
+      return notFound();
+    }
+    // Page beyond the author's content (incl. an exact-multiple-of-20 author
+    // whose page-1 "Older" link points here): redirect to page 1, never a 404.
+    if (archive.entries.length === 0) {
+      return redirect(basePath);
+    }
+    return (
+      <HydrationBoundary
+        state={stripActiveVotesFromDehydratedState(dehydrate(getQueryClient()), loggedInUser)}
+      >
+        <ProfileEntriesArchive
+          section={section}
+          account={account}
+          entries={archive.entries}
+          page={pageNum}
+          hasNext={archive.hasNext}
+          currentUser={loggedInUser}
+        />
+      </HydrationBoundary>
+    );
+  }
+
   const [account, searchPages, prefetchedFeed] = await Promise.all([
     prefetchQuery(getAccountFullQueryOptions(username)),
     searchParam

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-archive.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-archive.tsx
@@ -1,0 +1,51 @@
+import { Entry, FullAccount } from "@/entities";
+import { EntryListContent } from "@/features/shared";
+import { EntryArchivePager } from "@/features/shared/entry-archive-pager";
+import { ProfileEntriesLayout } from "@/app/(dynamicPages)/profile/[username]/_components/profile-entries-layout";
+import { stripActiveVotesFromValue } from "@/core/react-query/strip-active-votes";
+import { ARCHIVE_MAX_PAGE } from "@/app/(dynamicPages)/profile/[username]/_helpers/author-archive";
+
+interface Props {
+  section: string;
+  account: FullAccount;
+  entries: Entry[];
+  page: number;
+  hasNext: boolean;
+  currentUser?: string;
+}
+
+/**
+ * A numbered archive page for an author's section feed: a fully server-rendered
+ * list (no infinite scroll) plus a crawlable prev/next pager. Used for
+ * /@author/<section>/page/N so a crawler can walk the author's history beyond
+ * the sitemap's recent window.
+ */
+export function ProfileEntriesArchive({
+  section,
+  account,
+  entries,
+  page,
+  hasNext,
+  currentUser
+}: Props) {
+  const stripped = stripActiveVotesFromValue(entries, currentUser);
+  return (
+    <ProfileEntriesLayout section={section} username={account.name}>
+      <EntryListContent
+        account={account}
+        username={`@${account.name}`}
+        loading={false}
+        entries={stripped}
+        sectionParam={section}
+        isPromoted={false}
+        showEmptyPlaceholder={false}
+      />
+      <EntryArchivePager
+        basePath={`/@${account.name}/${section}`}
+        page={page}
+        hasNext={hasNext}
+        maxPage={ARCHIVE_MAX_PAGE}
+      />
+    </ProfileEntriesLayout>
+  );
+}

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-archive.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-archive.tsx
@@ -3,29 +3,26 @@ import { EntryListContent } from "@/features/shared";
 import { EntryArchivePager } from "@/features/shared/entry-archive-pager";
 import { ProfileEntriesLayout } from "@/app/(dynamicPages)/profile/[username]/_components/profile-entries-layout";
 import { stripActiveVotesFromValue } from "@/core/react-query/strip-active-votes";
-import { ARCHIVE_MAX_PAGE } from "@/app/(dynamicPages)/profile/[username]/_helpers/author-archive";
 
 interface Props {
   section: string;
   account: FullAccount;
   entries: Entry[];
-  page: number;
-  hasNext: boolean;
+  /** Cursor token ("author/permlink") for the next older page, or null. */
+  olderCursor: string | null;
   currentUser?: string;
 }
 
 /**
- * A numbered archive page for an author's section feed: a fully server-rendered
- * list (no infinite scroll) plus a crawlable prev/next pager. Used for
- * /@author/<section>/page/N so a crawler can walk the author's history beyond
- * the sitemap's recent window.
+ * A cursor archive page for an author's section feed: a fully server-rendered
+ * list (no infinite scroll) plus a crawlable "Older"/"Latest" pager, so a
+ * crawler can walk the author's history beyond the sitemap's recent window.
  */
 export function ProfileEntriesArchive({
   section,
   account,
   entries,
-  page,
-  hasNext,
+  olderCursor,
   currentUser
 }: Props) {
   const stripped = stripActiveVotesFromValue(entries, currentUser);
@@ -42,9 +39,8 @@ export function ProfileEntriesArchive({
       />
       <EntryArchivePager
         basePath={`/@${account.name}/${section}`}
-        page={page}
-        hasNext={hasNext}
-        maxPage={ARCHIVE_MAX_PAGE}
+        olderCursor={olderCursor}
+        showLatest={true}
       />
     </ProfileEntriesLayout>
   );

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-list.tsx
@@ -7,7 +7,15 @@ import { stripActiveVotesFromValue } from "@/core/react-query/strip-active-votes
 import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { ProfileEntriesLayout } from "@/app/(dynamicPages)/profile/[username]/_components/profile-entries-layout";
 import { ProfileEntriesInfiniteList } from "@/app/(dynamicPages)/profile/[username]/_components/profile-entries-infinite-list";
+import { EntryArchivePager } from "@/features/shared/entry-archive-pager";
+import {
+  ARCHIVE_PER_PAGE,
+  ARCHIVE_MAX_PAGE
+} from "@/app/(dynamicPages)/profile/[username]/_helpers/author-archive";
 import type { InfiniteData } from "@tanstack/react-query";
+
+// Content sections that expose a crawlable numbered archive.
+const ARCHIVE_SECTIONS = ["posts", "blog", "comments", "replies"];
 
 interface Props {
   section: string;
@@ -73,6 +81,16 @@ export async function ProfileEntriesList({ section, account, initialFeed, curren
           initialPageEntriesCount={initialPageEntriesCount}
           initialDataLoaded={initialDataLoaded}
         />
+        {/* Crawlable entry into the numbered archive: infinite scroll is the JS
+            enhancement, this pager is the no-JS/crawler path to older posts. */}
+        {ARCHIVE_SECTIONS.includes(section) && initialPageEntriesCount >= ARCHIVE_PER_PAGE && (
+          <EntryArchivePager
+            basePath={`/@${account.name}/${section}`}
+            page={1}
+            hasNext={true}
+            maxPage={ARCHIVE_MAX_PAGE}
+          />
+        )}
       </ProfileEntriesLayout>
     </>
   );

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-list.tsx
@@ -39,13 +39,16 @@ export async function ProfileEntriesList({ section, account, initialFeed, curren
     (getPostsFeedQueryData(section, `@${account.name}`) as InfiniteData<Entry[], unknown> | undefined);
 
   const feedPages = prefetchedFeed?.pages ?? [];
-  const initialPageEntries =
-    (feedPages[0] as Entry[] | undefined)?.filter(
-      (item: Entry) => item.permlink !== account.profile?.pinned
-    ) ?? [];
+  // Raw first feed page (before pinned-filtering): its length + last item are the
+  // TRUE feed-page-1 boundary, so the "Older" archive link and cursor stay
+  // correct even when a pinned post occupies a slot (a full 20-post page whose
+  // pinned entry is filtered would otherwise drop to 19 and suppress the link).
+  const rawFirstPage = (feedPages[0] as Entry[] | undefined) ?? [];
+  const initialPageEntries = rawFirstPage.filter(
+    (item: Entry) => item.permlink !== account.profile?.pinned
+  );
   const entryList = [...initialPageEntries];
-  // Cursor for the "Older" archive link = the last post of feed page 1.
-  const lastOfFirstPage = initialPageEntries[initialPageEntries.length - 1];
+  const lastOfFirstPage = rawFirstPage[rawFirstPage.length - 1];
 
   if (pinnedEntry) {
     entryList.unshift(pinnedEntry);
@@ -84,7 +87,7 @@ export async function ProfileEntriesList({ section, account, initialFeed, curren
             enhancement, this "Older" link is the no-JS/crawler path. The cursor
             is the last post of page 1; shown only when page 1 was full. */}
         {ARCHIVE_SECTIONS.includes(section) &&
-          initialPageEntriesCount >= ARCHIVE_PAGE_SIZE &&
+          rawFirstPage.length >= ARCHIVE_PAGE_SIZE &&
           lastOfFirstPage && (
             <EntryArchivePager
               basePath={`/@${account.name}/${section}`}

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-list.tsx
@@ -9,13 +9,10 @@ import { ProfileEntriesLayout } from "@/app/(dynamicPages)/profile/[username]/_c
 import { ProfileEntriesInfiniteList } from "@/app/(dynamicPages)/profile/[username]/_components/profile-entries-infinite-list";
 import { EntryArchivePager } from "@/features/shared/entry-archive-pager";
 import {
-  ARCHIVE_PER_PAGE,
-  ARCHIVE_MAX_PAGE
+  ARCHIVE_PAGE_SIZE,
+  ARCHIVE_SECTIONS
 } from "@/app/(dynamicPages)/profile/[username]/_helpers/author-archive";
 import type { InfiniteData } from "@tanstack/react-query";
-
-// Content sections that expose a crawlable numbered archive.
-const ARCHIVE_SECTIONS = ["posts", "blog", "comments", "replies"];
 
 interface Props {
   section: string;
@@ -47,6 +44,8 @@ export async function ProfileEntriesList({ section, account, initialFeed, curren
       (item: Entry) => item.permlink !== account.profile?.pinned
     ) ?? [];
   const entryList = [...initialPageEntries];
+  // Cursor for the "Older" archive link = the last post of feed page 1.
+  const lastOfFirstPage = initialPageEntries[initialPageEntries.length - 1];
 
   if (pinnedEntry) {
     entryList.unshift(pinnedEntry);
@@ -81,16 +80,18 @@ export async function ProfileEntriesList({ section, account, initialFeed, curren
           initialPageEntriesCount={initialPageEntriesCount}
           initialDataLoaded={initialDataLoaded}
         />
-        {/* Crawlable entry into the numbered archive: infinite scroll is the JS
-            enhancement, this pager is the no-JS/crawler path to older posts. */}
-        {ARCHIVE_SECTIONS.includes(section) && initialPageEntriesCount >= ARCHIVE_PER_PAGE && (
-          <EntryArchivePager
-            basePath={`/@${account.name}/${section}`}
-            page={1}
-            hasNext={true}
-            maxPage={ARCHIVE_MAX_PAGE}
-          />
-        )}
+        {/* Crawlable entry into the cursor archive: infinite scroll is the JS
+            enhancement, this "Older" link is the no-JS/crawler path. The cursor
+            is the last post of page 1; shown only when page 1 was full. */}
+        {ARCHIVE_SECTIONS.includes(section) &&
+          initialPageEntriesCount >= ARCHIVE_PAGE_SIZE &&
+          lastOfFirstPage && (
+            <EntryArchivePager
+              basePath={`/@${account.name}/${section}`}
+              olderCursor={`${lastOfFirstPage.author}/${lastOfFirstPage.permlink}`}
+              showLatest={false}
+            />
+          )}
       </ProfileEntriesLayout>
     </>
   );

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/author-archive.ts
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/author-archive.ts
@@ -1,0 +1,64 @@
+import { Entry } from "@/entities";
+import { fetchQuery } from "@/core/react-query";
+import { getAccountPostsQueryOptions } from "@ecency/sdk";
+
+// Posts per numbered archive page (matches the feed page size).
+export const ARCHIVE_PER_PAGE = 20;
+// Crawlable depth cap. The Hive bridge is cursor-based (no numeric offset), so
+// page N is reached by walking from the start; capping the depth bounds that
+// walk (page MAX ≈ ceil(MAX*PER_PAGE / 100) sequential RPCs). 10 pages = 200
+// posts/archive, which combined with the sitemap gives Google a deep crawl path
+// without an unbounded walk.
+export const ARCHIVE_MAX_PAGE = 10;
+// Hive bridge caps limit at 100; walk in chunks of 100 to minimize round-trips.
+const CHUNK = 100;
+
+/**
+ * Slice a numbered page out of an accumulated, in-order post list.
+ * `hasNext` is true when at least one post exists beyond this page.
+ * Pure — unit-tested without the network.
+ */
+export function sliceArchivePage(
+  all: Entry[],
+  page: number,
+  perPage = ARCHIVE_PER_PAGE
+): { entries: Entry[]; hasNext: boolean } {
+  const start = (page - 1) * perPage;
+  const end = start + perPage;
+  return { entries: all.slice(start, end), hasNext: all.length > end };
+}
+
+/**
+ * Fetch a single numbered archive page for an author's section feed by walking
+ * the cursor (start_author/start_permlink is EXCLUSIVE — no overlap/dedup).
+ * Returns the page's entries plus whether a further page exists.
+ */
+export async function fetchAuthorArchivePage(
+  username: string,
+  section: string,
+  page: number
+): Promise<{ entries: Entry[]; hasNext: boolean }> {
+  const needed = page * ARCHIVE_PER_PAGE + 1; // +1 to detect a following page
+  const all: Entry[] = [];
+  let startAuthor = "";
+  let startPermlink = "";
+
+  while (all.length < needed) {
+    const chunk = (await fetchQuery(
+      getAccountPostsQueryOptions(username, section, startAuthor, startPermlink, CHUNK)
+    )) as unknown as Entry[] | undefined;
+    if (!chunk || chunk.length === 0) {
+      break;
+    }
+    all.push(...chunk);
+    // Same end-of-feed heuristic the SDK's infinite query uses (length === limit).
+    if (chunk.length < CHUNK) {
+      break;
+    }
+    const last = chunk[chunk.length - 1];
+    startAuthor = last.author;
+    startPermlink = last.permlink;
+  }
+
+  return sliceArchivePage(all, page);
+}

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/author-archive.ts
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/author-archive.ts
@@ -2,63 +2,68 @@ import { Entry } from "@/entities";
 import { fetchQuery } from "@/core/react-query";
 import { getAccountPostsQueryOptions } from "@ecency/sdk";
 
-// Posts per numbered archive page (matches the feed page size).
-export const ARCHIVE_PER_PAGE = 20;
-// Crawlable depth cap. The Hive bridge is cursor-based (no numeric offset), so
-// page N is reached by walking from the start; capping the depth bounds that
-// walk (page MAX ≈ ceil(MAX*PER_PAGE / 100) sequential RPCs). 10 pages = 200
-// posts/archive, which combined with the sitemap gives Google a deep crawl path
-// without an unbounded walk.
-export const ARCHIVE_MAX_PAGE = 10;
-// Hive bridge caps limit at 100; walk in chunks of 100 to minimize round-trips.
-const CHUNK = 100;
+// Hive's bridge.get_account_posts caps `limit` at 20, and it's cursor-based
+// (start_author/start_permlink, exclusive). So archive pages use O(1)
+// cursor-token pagination: one 20-post fetch per page, the "Older" link carries
+// the next cursor. No walking, no depth cap.
+export const ARCHIVE_PAGE_SIZE = 20;
 
-/**
- * Slice a numbered page out of an accumulated, in-order post list.
- * `hasNext` is true when at least one post exists beyond this page.
- * Pure — unit-tested without the network.
- */
-export function sliceArchivePage(
-  all: Entry[],
-  page: number,
-  perPage = ARCHIVE_PER_PAGE
-): { entries: Entry[]; hasNext: boolean } {
-  const start = (page - 1) * perPage;
-  const end = start + perPage;
-  return { entries: all.slice(start, end), hasNext: all.length > end };
+// Content sections that expose a crawlable archive.
+export const ARCHIVE_SECTIONS = ["posts", "blog", "comments", "replies"];
+
+export interface ArchiveCursor {
+  author: string;
+  permlink: string;
 }
 
 /**
- * Fetch a single numbered archive page for an author's section feed by walking
- * the cursor (start_author/start_permlink is EXCLUSIVE — no overlap/dedup).
- * Returns the page's entries plus whether a further page exists.
+ * Single source of truth for "is this an archive request, and what's the
+ * cursor". Used by BOTH the page and generateMetadata so their archive detection
+ * can never diverge. Returns null (default/search view) unless there's a valid
+ * `before=<author>/<permlink>` cursor, no active search, and a content section.
  */
-export async function fetchAuthorArchivePage(
+export function archiveCursor(
+  section: string,
+  params: { query?: string; before?: string }
+): ArchiveCursor | null {
+  if (params.query || !params.before || !ARCHIVE_SECTIONS.includes(section)) {
+    return null;
+  }
+  const idx = params.before.indexOf("/");
+  if (idx <= 0 || idx >= params.before.length - 1) {
+    return null; // must be "author/permlink"
+  }
+  return { author: params.before.slice(0, idx), permlink: params.before.slice(idx + 1) };
+}
+
+/** Serialize a cursor back to its `before=` token. */
+export function cursorToken(c: { author: string; permlink: string }): string {
+  return `${c.author}/${c.permlink}`;
+}
+
+/**
+ * Fetch one archive page (the 20 posts older than `cursor`). O(1) — a single
+ * bridge call. `hasNext`/`nextCursor` use the same full-page heuristic the feed
+ * uses (a full page means there is probably more).
+ */
+export async function fetchAuthorCursorPage(
   username: string,
   section: string,
-  page: number
-): Promise<{ entries: Entry[]; hasNext: boolean }> {
-  const needed = page * ARCHIVE_PER_PAGE + 1; // +1 to detect a following page
-  const all: Entry[] = [];
-  let startAuthor = "";
-  let startPermlink = "";
+  cursor: ArchiveCursor
+): Promise<{ entries: Entry[]; hasNext: boolean; nextCursor: ArchiveCursor | null }> {
+  const entries =
+    ((await fetchQuery(
+      getAccountPostsQueryOptions(
+        username,
+        section,
+        cursor.author,
+        cursor.permlink,
+        ARCHIVE_PAGE_SIZE
+      )
+    )) as unknown as Entry[] | undefined) ?? [];
 
-  while (all.length < needed) {
-    const chunk = (await fetchQuery(
-      getAccountPostsQueryOptions(username, section, startAuthor, startPermlink, CHUNK)
-    )) as unknown as Entry[] | undefined;
-    if (!chunk || chunk.length === 0) {
-      break;
-    }
-    all.push(...chunk);
-    // Same end-of-feed heuristic the SDK's infinite query uses (length === limit).
-    if (chunk.length < CHUNK) {
-      break;
-    }
-    const last = chunk[chunk.length - 1];
-    startAuthor = last.author;
-    startPermlink = last.permlink;
-  }
-
-  return sliceArchivePage(all, page);
+  const hasNext = entries.length === ARCHIVE_PAGE_SIZE;
+  const last = entries[entries.length - 1];
+  const nextCursor = hasNext && last ? { author: last.author, permlink: last.permlink } : null;
+  return { entries, hasNext, nextCursor };
 }

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/generate-profile-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/generate-profile-metadata.ts
@@ -9,7 +9,8 @@ const NOINDEX_REPUTATION_THRESHOLD = 40;
 
 export async function generateProfileMetadata(
   username: string,
-  section = "posts"
+  section = "posts",
+  page = 1
 ): Promise<Metadata> {
   const account = await prefetchQuery(getAccountFullQueryOptions(username));
   if (account) {
@@ -17,13 +18,15 @@ export async function generateProfileMetadata(
     const cleanUsername = username.replace("@", "");
     const metaTitle = `${account.profile?.name || account.name}'s ${
       section ? (section === "engine" ? "tokens" : `${section}`) : ""
-    } on decentralized web`;
+    } on decentralized web${page > 1 ? ` - page ${page}` : ""}`;
     const metaDescription = `${
       account.profile?.about
         ? `${account.profile?.about} ${section ? `${section}` : ""}`
         : `${account.profile?.name || account.name} ${section ? `${section}` : ""}`
     }`;
-    const metaUrl = `/@${cleanUsername}${section ? `/${section}` : ""}`;
+    const isPaginated = page > 1;
+    const baseUrl = `/@${cleanUsername}${section ? `/${section}` : ""}`;
+    const metaUrl = isPaginated ? `${baseUrl}/page/${page}` : baseUrl;
     const metaImage = `${defaults.imageServer}/u/${cleanUsername}/avatar/medium`;
     const metaKeywords = [cleanUsername, `${cleanUsername}'s blog`];
     const rssSections = ["posts", "blog", ""];
@@ -31,7 +34,13 @@ export async function generateProfileMetadata(
     const reputationScore = accountReputation(account.reputation ?? 0);
     const postCount = account.post_count ?? 0;
     const applyNoIndex = reputationScore < NOINDEX_REPUTATION_THRESHOLD || postCount <= 3;
-    const robots = applyNoIndex ? "noindex, nofollow" : undefined;
+    // Paginated archive pages stay out of the index but must let crawlers walk
+    // the pager links (noindex, FOLLOW). Page 1 keeps the reputation-based rule.
+    const robots = isPaginated
+      ? "noindex, follow"
+      : applyNoIndex
+        ? "noindex, nofollow"
+        : undefined;
 
     return {
       title: metaTitle,
@@ -39,11 +48,12 @@ export async function generateProfileMetadata(
       robots,
       alternates: {
         canonical: `${base}${metaUrl}`,
-        ...(rssSections.includes(section) && {
-          types: {
-            "application/rss+xml": `${base}/@${cleanUsername}/rss`,
-          },
-        }),
+        ...(rssSections.includes(section) &&
+          !isPaginated && {
+            types: {
+              "application/rss+xml": `${base}/@${cleanUsername}/rss`,
+            },
+          }),
       },
       openGraph: {
         title: metaTitle,

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/generate-profile-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/generate-profile-metadata.ts
@@ -10,7 +10,8 @@ const NOINDEX_REPUTATION_THRESHOLD = 40;
 export async function generateProfileMetadata(
   username: string,
   section = "posts",
-  page = 1
+  /** Cursor token ("author/permlink") when rendering an older archive page. */
+  cursor?: string
 ): Promise<Metadata> {
   const account = await prefetchQuery(getAccountFullQueryOptions(username));
   if (account) {
@@ -18,15 +19,15 @@ export async function generateProfileMetadata(
     const cleanUsername = username.replace("@", "");
     const metaTitle = `${account.profile?.name || account.name}'s ${
       section ? (section === "engine" ? "tokens" : `${section}`) : ""
-    } on decentralized web${page > 1 ? ` - page ${page}` : ""}`;
+    } on decentralized web${cursor ? " - older posts" : ""}`;
     const metaDescription = `${
       account.profile?.about
         ? `${account.profile?.about} ${section ? `${section}` : ""}`
         : `${account.profile?.name || account.name} ${section ? `${section}` : ""}`
     }`;
-    const isPaginated = page > 1;
+    const isPaginated = !!cursor;
     const baseUrl = `/@${cleanUsername}${section ? `/${section}` : ""}`;
-    const metaUrl = isPaginated ? `${baseUrl}/page/${page}` : baseUrl;
+    const metaUrl = isPaginated ? `${baseUrl}?before=${cursor}` : baseUrl;
     const metaImage = `${defaults.imageServer}/u/${cleanUsername}/avatar/medium`;
     const metaKeywords = [cleanUsername, `${cleanUsername}'s blog`];
     const rssSections = ["posts", "blog", ""];

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1037,9 +1037,8 @@
   },
   "archive-pager": {
     "label": "Pagination",
-    "newer": "← Newer posts",
-    "older": "Older posts →",
-    "page": "Page {{n}}"
+    "latest": "← Latest",
+    "older": "Older →"
   },
   "comment": {
     "body-placeholder": "Write your reply here",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1035,6 +1035,12 @@
     "more-from-author": "From @{{username}}",
     "more-in": "In {{section}}"
   },
+  "archive-pager": {
+    "label": "Pagination",
+    "newer": "← Newer posts",
+    "older": "Older posts →",
+    "page": "Page {{n}}"
+  },
   "comment": {
     "body-placeholder": "Write your reply here",
     "write": "Write",

--- a/apps/web/src/features/shared/entry-archive-pager/index.tsx
+++ b/apps/web/src/features/shared/entry-archive-pager/index.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import { initI18next } from "@/features/i18n";
+import i18next from "i18next";
+
+interface Props {
+  /** Base archive URL without a trailing slash, e.g. "/@enjar/posts". */
+  basePath: string;
+  /** Current page (1 = the default, unnumbered view). */
+  page: number;
+  /** Whether a further page exists. */
+  hasNext: boolean;
+  /** Crawlable depth cap. */
+  maxPage: number;
+}
+
+export interface PagerState {
+  showPrev: boolean;
+  showNext: boolean;
+  prevHref: string;
+  nextHref: string;
+}
+
+/**
+ * Pure pager resolution (which links to show + their hrefs), so the routing
+ * logic is unit-testable without rendering the async server component. Page 1 is
+ * the base URL (no `/page/1`); page N>1 is `${base}/page/${n}`. Returns null when
+ * there is neither a previous nor a next page.
+ */
+export function resolvePager(
+  basePath: string,
+  page: number,
+  hasNext: boolean,
+  maxPage: number
+): PagerState | null {
+  const showPrev = page > 1;
+  const showNext = hasNext && page < maxPage;
+  if (!showPrev && !showNext) {
+    return null;
+  }
+  const href = (n: number) => (n <= 1 ? basePath : `${basePath}/page/${n}`);
+  return { showPrev, showNext, prevHref: href(page - 1), nextHref: href(page + 1) };
+}
+
+/**
+ * Crawlable prev/next pager for numbered archive pages. Server-rendered `<a>`
+ * links give crawlers a durable path through an author/community/tag's full
+ * history (page 1 is the base URL, page N>1 is `${base}/page/${n}`). Also emits
+ * `<link rel="prev|next">` (hoisted to <head>) for crawlers that still use them.
+ * Renders nothing when there is neither a previous nor a next page.
+ */
+export async function EntryArchivePager({ basePath, page, hasNext, maxPage }: Props) {
+  const state = resolvePager(basePath, page, hasNext, maxPage);
+  if (!state) {
+    return null;
+  }
+  const { showPrev, showNext, prevHref, nextHref } = state;
+
+  await initI18next();
+  const linkClass =
+    "text-sm px-3 py-1.5 rounded-lg border border-[--border-color] hover:bg-blue-dark-sky-040 dark:hover:bg-gray-900";
+
+  return (
+    <>
+      {showPrev && <link rel="prev" href={prevHref} />}
+      {showNext && <link rel="next" href={nextHref} />}
+      <nav
+        aria-label={i18next.t("archive-pager.label")}
+        className="entry-archive-pager flex items-center justify-between gap-3 my-6"
+      >
+        {showPrev ? (
+          <Link href={prevHref} rel="prev" className={linkClass}>
+            {i18next.t("archive-pager.newer")}
+          </Link>
+        ) : (
+          <span />
+        )}
+        <span className="text-sm opacity-70">{i18next.t("archive-pager.page", { n: page })}</span>
+        {showNext ? (
+          <Link href={nextHref} rel="next" className={linkClass}>
+            {i18next.t("archive-pager.older")}
+          </Link>
+        ) : (
+          <span />
+        )}
+      </nav>
+    </>
+  );
+}

--- a/apps/web/src/features/shared/entry-archive-pager/index.tsx
+++ b/apps/web/src/features/shared/entry-archive-pager/index.tsx
@@ -3,86 +3,77 @@ import { initI18next } from "@/features/i18n";
 import i18next from "i18next";
 
 interface Props {
-  /** Base archive URL without a trailing slash, e.g. "/@enjar/posts". */
+  /** Base archive URL without a query, e.g. "/@enjar/posts". */
   basePath: string;
-  /** Current page (1 = the default, unnumbered view). */
-  page: number;
-  /** Whether a further page exists. */
-  hasNext: boolean;
-  /** Crawlable depth cap. */
-  maxPage: number;
+  /** Cursor token ("author/permlink") for the next (older) page, or null. */
+  olderCursor: string | null;
+  /** Show a "back to latest" link (true on cursor pages, false on page 1). */
+  showLatest: boolean;
 }
 
 export interface PagerState {
-  showPrev: boolean;
-  showNext: boolean;
-  prevHref: string;
-  nextHref: string;
+  showLatest: boolean;
+  latestHref: string;
+  showOlder: boolean;
+  olderHref: string;
 }
 
 /**
- * Pure pager resolution (which links to show + their hrefs), so the routing
- * logic is unit-testable without rendering the async server component. Page 1 is
- * the base URL (no `/page/1`); page N>1 is `${base}/page/${n}`. Returns null when
- * there is neither a previous nor a next page.
+ * Pure pager resolution, so the routing logic is unit-testable without rendering
+ * the async server component. Page 1 is the clean base URL; older pages are
+ * `${base}?before=<cursor>`. Returns null when there's nothing to link.
  */
 export function resolvePager(
   basePath: string,
-  page: number,
-  hasNext: boolean,
-  maxPage: number
+  olderCursor: string | null,
+  showLatest: boolean
 ): PagerState | null {
-  const showPrev = page > 1;
-  const showNext = hasNext && page < maxPage;
-  if (!showPrev && !showNext) {
+  const showOlder = !!olderCursor;
+  if (!showLatest && !showOlder) {
     return null;
   }
-  const href = (n: number) => (n <= 1 ? basePath : `${basePath}/page/${n}`);
-  return { showPrev, showNext, prevHref: href(page - 1), nextHref: href(page + 1) };
+  return {
+    showLatest,
+    latestHref: basePath,
+    showOlder,
+    olderHref: olderCursor ? `${basePath}?before=${olderCursor}` : basePath
+  };
 }
 
 /**
- * Crawlable prev/next pager for numbered archive pages. Server-rendered `<a>`
- * links give crawlers a durable path through an author/community/tag's full
- * history (page 1 is the base URL, page N>1 is `${base}/page/${n}`). Also emits
- * `<link rel="prev|next">` (hoisted to <head>) for crawlers that still use them.
- * Renders nothing when there is neither a previous nor a next page.
+ * Crawlable cursor pager for archive pages. Server-rendered `<a>` links give
+ * crawlers a durable, O(1)-per-page path through an author/community/tag's full
+ * history (the "Older" link carries the next cursor). Section-agnostic copy.
  */
-export async function EntryArchivePager({ basePath, page, hasNext, maxPage }: Props) {
-  const state = resolvePager(basePath, page, hasNext, maxPage);
+export async function EntryArchivePager({ basePath, olderCursor, showLatest }: Props) {
+  const state = resolvePager(basePath, olderCursor, showLatest);
   if (!state) {
     return null;
   }
-  const { showPrev, showNext, prevHref, nextHref } = state;
 
   await initI18next();
   const linkClass =
     "text-sm px-3 py-1.5 rounded-lg border border-[--border-color] hover:bg-blue-dark-sky-040 dark:hover:bg-gray-900";
 
   return (
-    <>
-      {showPrev && <link rel="prev" href={prevHref} />}
-      {showNext && <link rel="next" href={nextHref} />}
-      <nav
-        aria-label={i18next.t("archive-pager.label")}
-        className="entry-archive-pager flex items-center justify-between gap-3 my-6"
-      >
-        {showPrev ? (
-          <Link href={prevHref} rel="prev" className={linkClass}>
-            {i18next.t("archive-pager.newer")}
-          </Link>
-        ) : (
-          <span />
-        )}
-        <span className="text-sm opacity-70">{i18next.t("archive-pager.page", { n: page })}</span>
-        {showNext ? (
-          <Link href={nextHref} rel="next" className={linkClass}>
-            {i18next.t("archive-pager.older")}
-          </Link>
-        ) : (
-          <span />
-        )}
-      </nav>
-    </>
+    <nav
+      aria-label={i18next.t("archive-pager.label")}
+      className="entry-archive-pager flex items-center justify-between gap-3 my-6"
+    >
+      {state.showLatest ? (
+        <Link href={state.latestHref} className={linkClass}>
+          {i18next.t("archive-pager.latest")}
+        </Link>
+      ) : (
+        <span />
+      )}
+      {state.showOlder ? (
+        <Link href={state.olderHref} rel="next" className={linkClass}>
+          {i18next.t("archive-pager.older")}
+        </Link>
+      ) : (
+        <span />
+      )}
+    </nav>
   );
 }

--- a/apps/web/src/specs/features/profile/author-archive.spec.ts
+++ b/apps/web/src/specs/features/profile/author-archive.spec.ts
@@ -1,57 +1,62 @@
 import { describe, it, expect } from "vitest";
 import {
-  sliceArchivePage,
-  ARCHIVE_PER_PAGE
+  archiveCursor,
+  cursorToken
 } from "@/app/(dynamicPages)/profile/[username]/_helpers/author-archive";
 import { resolvePager } from "@/features/shared/entry-archive-pager";
 
-const items = (n: number) => Array.from({ length: n }, (_, i) => ({ permlink: `p${i}` })) as any[];
-
-describe("sliceArchivePage", () => {
-  it("returns the requested page window and hasNext=true when more exist", () => {
-    const { entries, hasNext } = sliceArchivePage(items(50), 2, ARCHIVE_PER_PAGE);
-    expect(entries).toHaveLength(20);
-    expect(entries[0].permlink).toBe("p20");
-    expect(entries[19].permlink).toBe("p39");
-    expect(hasNext).toBe(true);
+describe("archiveCursor", () => {
+  it("parses a valid before token on a content section", () => {
+    expect(archiveCursor("posts", { before: "enjar/my-post" })).toEqual({
+      author: "enjar",
+      permlink: "my-post"
+    });
   });
 
-  it("returns a partial last page with hasNext=false", () => {
-    const { entries, hasNext } = sliceArchivePage(items(45), 3, ARCHIVE_PER_PAGE); // start 40..60
-    expect(entries).toHaveLength(5);
-    expect(hasNext).toBe(false);
+  it("returns null when a search query is active", () => {
+    expect(archiveCursor("posts", { before: "enjar/my-post", query: "foo" })).toBeNull();
   });
 
-  it("returns empty for a page beyond the content", () => {
-    const { entries, hasNext } = sliceArchivePage(items(30), 3, ARCHIVE_PER_PAGE);
-    expect(entries).toHaveLength(0);
-    expect(hasNext).toBe(false);
+  it("returns null for a non-content section", () => {
+    expect(archiveCursor("wallet", { before: "enjar/my-post" })).toBeNull();
+  });
+
+  it("returns null for malformed / missing tokens", () => {
+    expect(archiveCursor("posts", {})).toBeNull();
+    expect(archiveCursor("posts", { before: "enjar" })).toBeNull(); // no slash
+    expect(archiveCursor("posts", { before: "/my-post" })).toBeNull(); // empty author
+    expect(archiveCursor("posts", { before: "enjar/" })).toBeNull(); // empty permlink
+  });
+
+  it("round-trips through cursorToken", () => {
+    const c = archiveCursor("blog", { before: "alice/a-b-c" })!;
+    expect(cursorToken(c)).toBe("alice/a-b-c");
   });
 });
 
 describe("resolvePager", () => {
   const B = "/@enjar/posts";
 
-  it("page 1 with more pages shows only Next (no /page/1)", () => {
-    const s = resolvePager(B, 1, true, 10)!;
-    expect(s.showPrev).toBe(false);
-    expect(s.showNext).toBe(true);
-    expect(s.nextHref).toBe("/@enjar/posts/page/2");
+  it("page 1 with an older cursor shows only Older (clean base, ?before on older)", () => {
+    const s = resolvePager(B, "enjar/p20", false)!;
+    expect(s.showLatest).toBe(false);
+    expect(s.showOlder).toBe(true);
+    expect(s.olderHref).toBe("/@enjar/posts?before=enjar/p20");
   });
 
-  it("a middle page shows Prev and Next; prev of page 2 is the base", () => {
-    const s = resolvePager(B, 2, true, 10)!;
-    expect(s.prevHref).toBe("/@enjar/posts"); // page 1 = base, no /page/1
-    expect(s.nextHref).toBe("/@enjar/posts/page/3");
+  it("a cursor page shows Latest (clean base) and Older (next cursor)", () => {
+    const s = resolvePager(B, "enjar/p40", true)!;
+    expect(s.latestHref).toBe("/@enjar/posts");
+    expect(s.olderHref).toBe("/@enjar/posts?before=enjar/p40");
   });
 
-  it("caps Next at maxPage", () => {
-    const s = resolvePager(B, 10, true, 10)!;
-    expect(s.showPrev).toBe(true);
-    expect(s.showNext).toBe(false);
+  it("the last page still links back to Latest", () => {
+    const s = resolvePager(B, null, true)!;
+    expect(s.showOlder).toBe(false);
+    expect(s.showLatest).toBe(true);
   });
 
-  it("returns null when there is neither prev nor next", () => {
-    expect(resolvePager(B, 1, false, 10)).toBeNull();
+  it("returns null when there is nothing to link", () => {
+    expect(resolvePager(B, null, false)).toBeNull();
   });
 });

--- a/apps/web/src/specs/features/profile/author-archive.spec.ts
+++ b/apps/web/src/specs/features/profile/author-archive.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  sliceArchivePage,
+  ARCHIVE_PER_PAGE
+} from "@/app/(dynamicPages)/profile/[username]/_helpers/author-archive";
+import { resolvePager } from "@/features/shared/entry-archive-pager";
+
+const items = (n: number) => Array.from({ length: n }, (_, i) => ({ permlink: `p${i}` })) as any[];
+
+describe("sliceArchivePage", () => {
+  it("returns the requested page window and hasNext=true when more exist", () => {
+    const { entries, hasNext } = sliceArchivePage(items(50), 2, ARCHIVE_PER_PAGE);
+    expect(entries).toHaveLength(20);
+    expect(entries[0].permlink).toBe("p20");
+    expect(entries[19].permlink).toBe("p39");
+    expect(hasNext).toBe(true);
+  });
+
+  it("returns a partial last page with hasNext=false", () => {
+    const { entries, hasNext } = sliceArchivePage(items(45), 3, ARCHIVE_PER_PAGE); // start 40..60
+    expect(entries).toHaveLength(5);
+    expect(hasNext).toBe(false);
+  });
+
+  it("returns empty for a page beyond the content", () => {
+    const { entries, hasNext } = sliceArchivePage(items(30), 3, ARCHIVE_PER_PAGE);
+    expect(entries).toHaveLength(0);
+    expect(hasNext).toBe(false);
+  });
+});
+
+describe("resolvePager", () => {
+  const B = "/@enjar/posts";
+
+  it("page 1 with more pages shows only Next (no /page/1)", () => {
+    const s = resolvePager(B, 1, true, 10)!;
+    expect(s.showPrev).toBe(false);
+    expect(s.showNext).toBe(true);
+    expect(s.nextHref).toBe("/@enjar/posts/page/2");
+  });
+
+  it("a middle page shows Prev and Next; prev of page 2 is the base", () => {
+    const s = resolvePager(B, 2, true, 10)!;
+    expect(s.prevHref).toBe("/@enjar/posts"); // page 1 = base, no /page/1
+    expect(s.nextHref).toBe("/@enjar/posts/page/3");
+  });
+
+  it("caps Next at maxPage", () => {
+    const s = resolvePager(B, 10, true, 10)!;
+    expect(s.showPrev).toBe(true);
+    expect(s.showNext).toBe(false);
+  });
+
+  it("returns null when there is neither prev nor next", () => {
+    expect(resolvePager(B, 1, false, 10)).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds crawlable **numbered archive pagination** for author content sections (`/@author/<section>/page/N`, sections `posts|blog|comments|replies`), so the long tail of an author's history is reachable in server HTML beyond the sitemap's recent window. First of the archive-pagination work; the pager/pattern is reusable for community + tag next.

- **Cursor-walk**: the Hive bridge is cursor-based (no numeric offset) and `start_author/start_permlink` is exclusive (verified against the live API — no overlap/dedup). Pages are walked in chunks of 100 and sliced to 20/page, **capped at 10 pages/archive** to bound the walk (~2 RPCs at the deepest page). `sliceArchivePage` + `resolvePager` are pure and unit-tested.
- **Rendering**: numbered pages are fully server-rendered (no infinite scroll) with a reusable crawlable prev/next pager (`EntryArchivePager`). The default view keeps infinite scroll as the JS enhancement and gains a no-JS/crawler "Older posts" link into the chain.
- **Indexation**: page 1 stays indexed as today; pages 2+ are `noindex, follow` + self-canonical `/page/N` + `rel=prev/next`. Empty or over-cap pages `redirect` to page 1 (never a 404), so an exact-multiple-of-20 author's page-1 link can't dangle.
- Routing: `next.config` rewrite `/@author/<section>/page/N` -> `/profile/@author/<section>?page=N`.
- New unit spec; full web suite green; typecheck clean for changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added numbered archive pages for author profile sections, with previous/next navigation and crawlable pagination links.
  * Profile pages now preserve page numbers in URLs and metadata, including correct canonical and paging details.

* **Bug Fixes**
  * Improved handling of out-of-range archive pages by redirecting to the base section instead of showing an error.
  * Updated archive page behavior to better support search, listing, and empty-result states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->