### PR TITLE
feat(feed,community): cursor-token archive pagination for tag + community feeds

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/page.tsx
@@ -1,7 +1,8 @@
 import { getCommunityCache } from "@/core/caches";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { prefetchGetPostsFeedQuery } from "@/api/queries";
 import { EntryListContent } from "@/features/shared/entry-list-content";
+import { EntryArchivePager } from "@/features/shared/entry-archive-pager";
 import { LinearProgress } from "@/features/shared/linear-progress";
 import { dehydrate, HydrationBoundary, InfiniteData } from "@tanstack/react-query";
 import { getQueryClient, prefetchQuery } from "@/core/react-query";
@@ -11,16 +12,26 @@ import { CommunityContentSearch } from "../_components/community-content-search"
 import { ProfileEntriesLayout } from "@/app/(dynamicPages)/profile/[username]/_components/profile-entries-layout";
 import { CommunityContentInfiniteList } from "../_components/community-content-infinite-list";
 import { Entry, SearchResponse } from "@/entities";
+import {
+  ARCHIVE_FILTERS,
+  ARCHIVE_PAGE_SIZE,
+  cursorToken,
+  fetchRankedCursorPage,
+  parseArchiveCursor
+} from "@/features/seo/ranked-archive";
 
 type Page = Entry[] | SearchResponse;
 
 interface Props {
   params: Promise<{ tag: string; community: string }>;
+  searchParams: Promise<Record<string, string>>;
 }
 
 export async function generateMetadata(props: Props, parent: ResolvingMetadata): Promise<Metadata> {
   const { community, tag } = await props.params;
-  return generateCommunityMetadata(community, tag);
+  const { before } = await props.searchParams;
+  const cursor = ARCHIVE_FILTERS.includes(tag) ? parseArchiveCursor(before) : null;
+  return generateCommunityMetadata(community, tag, cursor ? cursorToken(cursor) : undefined);
 }
 
 function pageToEntries(p: Page): Entry[] {
@@ -29,8 +40,42 @@ function pageToEntries(p: Page): Entry[] {
   return (p as any).items ?? (p as any).results ?? [];
 }
 
-export default async function CommunityPostsPage({ params }: Props) {
+export default async function CommunityPostsPage({ params, searchParams }: Props) {
   const { community, tag } = await params;
+  const { before } = await searchParams;
+  const basePath = `/${tag}/${community}`;
+  const cursor = ARCHIVE_FILTERS.includes(tag) ? parseArchiveCursor(before) : null;
+
+  // Cursor archive page: one O(1) fetch of the 20 posts older than the cursor,
+  // fully server-rendered (no infinite scroll) with a crawlable pager.
+  if (cursor) {
+    const [communityData, archive] = await Promise.all([
+      prefetchQuery(getCommunityCache(community)),
+      fetchRankedCursorPage(tag, community, cursor)
+    ]);
+    if (!communityData) return notFound();
+    if (archive.entries.length === 0) return redirect(basePath); // stale cursor
+
+    return (
+      <HydrationBoundary state={dehydrate(getQueryClient())}>
+        <ProfileEntriesLayout section={tag} username={community}>
+          <EntryListContent
+            community={communityData}
+            username={community}
+            isPromoted={false}
+            entries={archive.entries}
+            loading={false}
+            sectionParam={tag}
+          />
+          <EntryArchivePager
+            basePath={basePath}
+            olderCursor={archive.nextCursor ? cursorToken(archive.nextCursor) : null}
+            showLatest={true}
+          />
+        </ProfileEntriesLayout>
+      </HydrationBoundary>
+    );
+  }
 
   const [communityData, data] = await Promise.all([
     prefetchQuery(getCommunityCache(community)),
@@ -44,28 +89,38 @@ export default async function CommunityPostsPage({ params }: Props) {
   }
 
   const flatEntries = data.pages.flatMap(pageToEntries);
+  // Crawlable "Older" entry into the cursor chain when page 1 is full.
+  const firstPage = pageToEntries((data as InfiniteData<Page, unknown>).pages[0]);
+  const lastOfFirst = firstPage[firstPage.length - 1];
+  const olderCursor =
+    ARCHIVE_FILTERS.includes(tag) && firstPage.length >= ARCHIVE_PAGE_SIZE && lastOfFirst
+      ? `${lastOfFirst.author}/${lastOfFirst.permlink}`
+      : null;
 
   return (
-      <HydrationBoundary state={dehydrate(getQueryClient())}>
-        {data.pages.length === 0 ? <LinearProgress /> : null}
+    <HydrationBoundary state={dehydrate(getQueryClient())}>
+      {data.pages.length === 0 ? <LinearProgress /> : null}
 
-        {["hot", "created", "trending"].includes(tag) && data.pages.length > 0 && (
-            <div className="searchProfile">
-              <CommunityContentSearch community={communityData} filter={tag} />
-            </div>
+      {["hot", "created", "trending"].includes(tag) && data.pages.length > 0 && (
+        <div className="searchProfile">
+          <CommunityContentSearch community={communityData} filter={tag} />
+        </div>
+      )}
+
+      <ProfileEntriesLayout section={tag} username={community}>
+        <EntryListContent
+          community={communityData}
+          username={community}
+          isPromoted={false}
+          entries={flatEntries}
+          loading={false}
+          sectionParam={tag}
+        />
+        <CommunityContentInfiniteList community={communityData} section={tag} />
+        {olderCursor && (
+          <EntryArchivePager basePath={basePath} olderCursor={olderCursor} showLatest={false} />
         )}
-
-        <ProfileEntriesLayout section={tag} username={community}>
-          <EntryListContent
-              community={communityData}
-              username={community}
-              isPromoted={false}
-              entries={flatEntries}
-              loading={false}
-              sectionParam={tag}
-          />
-          <CommunityContentInfiniteList community={communityData} section={tag} />
-        </ProfileEntriesLayout>
-      </HydrationBoundary>
+      </ProfileEntriesLayout>
+    </HydrationBoundary>
   );
 }

--- a/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/page.tsx
@@ -13,10 +13,10 @@ import { ProfileEntriesLayout } from "@/app/(dynamicPages)/profile/[username]/_c
 import { CommunityContentInfiniteList } from "../_components/community-content-infinite-list";
 import { Entry, SearchResponse } from "@/entities";
 import {
-  ARCHIVE_FILTERS,
   ARCHIVE_PAGE_SIZE,
   cursorToken,
   fetchRankedCursorPage,
+  isArchivableFilter,
   parseArchiveCursor
 } from "@/features/seo/ranked-archive";
 
@@ -30,7 +30,7 @@ interface Props {
 export async function generateMetadata(props: Props, parent: ResolvingMetadata): Promise<Metadata> {
   const { community, tag } = await props.params;
   const { before } = await props.searchParams;
-  const cursor = ARCHIVE_FILTERS.includes(tag) ? parseArchiveCursor(before) : null;
+  const cursor = isArchivableFilter(tag) ? parseArchiveCursor(before) : null;
   return generateCommunityMetadata(community, tag, cursor ? cursorToken(cursor) : undefined);
 }
 
@@ -44,7 +44,7 @@ export default async function CommunityPostsPage({ params, searchParams }: Props
   const { community, tag } = await params;
   const { before } = await searchParams;
   const basePath = `/${tag}/${community}`;
-  const cursor = ARCHIVE_FILTERS.includes(tag) ? parseArchiveCursor(before) : null;
+  const cursor = isArchivableFilter(tag) ? parseArchiveCursor(before) : null;
 
   // Cursor archive page: one O(1) fetch of the 20 posts older than the cursor,
   // fully server-rendered (no infinite scroll) with a crawlable pager.
@@ -93,7 +93,7 @@ export default async function CommunityPostsPage({ params, searchParams }: Props
   const firstPage = pageToEntries((data as InfiniteData<Page, unknown>).pages[0]);
   const lastOfFirst = firstPage[firstPage.length - 1];
   const olderCursor =
-    ARCHIVE_FILTERS.includes(tag) && firstPage.length >= ARCHIVE_PAGE_SIZE && lastOfFirst
+    isArchivableFilter(tag) && firstPage.length >= ARCHIVE_PAGE_SIZE && lastOfFirst
       ? `${lastOfFirst.author}/${lastOfFirst.permlink}`
       : null;
 
@@ -101,7 +101,7 @@ export default async function CommunityPostsPage({ params, searchParams }: Props
     <HydrationBoundary state={dehydrate(getQueryClient())}>
       {data.pages.length === 0 ? <LinearProgress /> : null}
 
-      {["hot", "created", "trending"].includes(tag) && data.pages.length > 0 && (
+      {isArchivableFilter(tag) && data.pages.length > 0 && (
         <div className="searchProfile">
           <CommunityContentSearch community={communityData} filter={tag} />
         </div>

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_helpers/generate-community-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_helpers/generate-community-metadata.ts
@@ -6,7 +6,11 @@ import { getServerAppBase } from "@/utils/server-app-base";
 import { prefetchQuery } from "@/core/react-query";
 import { getAccountFullQueryOptions } from "@ecency/sdk";
 
-export async function generateCommunityMetadata(communityName: string, tag: string) {
+export async function generateCommunityMetadata(
+  communityName: string,
+  tag: string,
+  cursor?: string
+) {
   const [community, account, base] = await Promise.all([
     prefetchQuery(getCommunityCache(communityName)),
     prefetchQuery(getAccountFullQueryOptions(communityName)),
@@ -21,19 +25,21 @@ export async function generateCommunityMetadata(communityName: string, tag: stri
     const metaCanonical = `${base}/created/${community.name}`;
 
     const metaImage = `${defaults.imageServer}/u/${community.name}/avatar/medium`;
+    // Cursor archive page: keep out of the index, let crawlers follow the pager
+    // (noindex, follow), self-canonical to the ?before URL, no RSS.
+    const isPaginated = !!cursor;
     return {
-      title,
+      title: isPaginated ? `${title} - older` : title,
       description,
+      ...(isPaginated ? { robots: "noindex, follow" } : {}),
       alternates: {
-        canonical: metaCanonical,
-        types: {
-          "application/rss+xml": metaRss,
-        },
+        canonical: isPaginated ? `${base}/${tag}/${community.name}?before=${cursor}` : metaCanonical,
+        ...(isPaginated ? {} : { types: { "application/rss+xml": metaRss } }),
       },
       openGraph: {
         title,
         description,
-        url: `/${tag}/${community.name}`,
+        url: isPaginated ? `/${tag}/${community.name}?before=${cursor}` : `/${tag}/${community.name}`,
         images: [metaImage],
       },
       twitter: {

--- a/apps/web/src/app/(dynamicPages)/feed/[...sections]/_helpers/generate-feed-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/feed/[...sections]/_helpers/generate-feed-metadata.ts
@@ -2,7 +2,7 @@ import { capitalize } from "@/utils";
 import i18next from "i18next";
 import { getServerAppBase } from "@/utils/server-app-base";
 
-export async function generateFeedMetadata(filter: string, tag: string) {
+export async function generateFeedMetadata(filter: string, tag: string, cursor?: string) {
   const fC = capitalize(filter);
   const base = await getServerAppBase();
   let title = i18next.t("entry-index.title", { f: fC });
@@ -25,17 +25,22 @@ export async function generateFeedMetadata(filter: string, tag: string) {
     rss = `${base}/${filter}/${tag}/rss.xml`;
   }
 
+  // Cursor archive page: keep it out of the index but let crawlers walk the
+  // pager chain (noindex, follow), self-canonical to the ?before URL, no RSS.
+  const isPaginated = !!cursor;
+
   return {
-    title,
+    title: isPaginated ? `${title} - older` : title,
     description,
+    ...(isPaginated ? { robots: "noindex, follow" } : {}),
     alternates: {
-      canonical,
-      ...(rss && { types: { "application/rss+xml": rss } }),
+      canonical: isPaginated ? `${canonical}?before=${cursor}` : canonical,
+      ...(rss && !isPaginated && { types: { "application/rss+xml": rss } }),
     },
     openGraph: {
       title,
       description,
-      url,
+      url: isPaginated ? `${url}?before=${cursor}` : url,
     },
     twitter: {
       card: "summary",

--- a/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
@@ -59,25 +59,31 @@ export default async function FeedPage({ params, searchParams }: Props) {
     if (entries.length === 0) {
       return redirect(basePath); // stale/invalid cursor -> clean first page
     }
+    // Static wrapper (NOT FeedLayout): an archive page must not run FeedLayout's
+    // live usePostsFeedQuery + 30s "new posts" polling, which would refetch the
+    // latest feed and prepend it onto this older-posts view. The route layout
+    // still provides the navbar/menu; we only need the list wrapper divs.
     return (
       <HydrationBoundary
         state={stripActiveVotesFromDehydratedState(dehydrate(getQueryClient()), loggedInUser)}
       >
-        <FeedLayout tag={tag} filter={filter} observer={observer}>
-          <EntryListContent
-            username=""
-            loading={false}
-            entries={stripActiveVotesFromValue(entries, loggedInUser)}
-            sectionParam={filter}
-            isPromoted={false}
-            showEmptyPlaceholder={false}
-          />
-          <EntryArchivePager
-            basePath={basePath}
-            olderCursor={nextCursor ? cursorToken(nextCursor) : null}
-            showLatest={true}
-          />
-        </FeedLayout>
+        <div className="entry-list">
+          <div className="entry-list-body">
+            <EntryListContent
+              username=""
+              loading={false}
+              entries={stripActiveVotesFromValue(entries, loggedInUser)}
+              sectionParam={filter}
+              isPromoted={false}
+              showEmptyPlaceholder={false}
+            />
+            <EntryArchivePager
+              basePath={basePath}
+              olderCursor={nextCursor ? cursorToken(nextCursor) : null}
+              showLatest={true}
+            />
+          </div>
+        </div>
       </HydrationBoundary>
     );
   }

--- a/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
@@ -8,9 +8,22 @@ import { redirect } from "next/navigation";
 import { generateFeedMetadata } from "@/app/(dynamicPages)/feed/[...sections]/_helpers";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { getQueryClient, prefetchQuery } from "@/core/react-query";
-import { stripActiveVotesFromDehydratedState } from "@/core/react-query/strip-active-votes";
+import {
+  stripActiveVotesFromDehydratedState,
+  stripActiveVotesFromValue
+} from "@/core/react-query/strip-active-votes";
 import { getPromotedPostsQuery } from "@ecency/sdk";
 import { EcencyConfigManager } from "@/config";
+import { EntryListContent } from "@/features/shared/entry-list-content";
+import { EntryArchivePager } from "@/features/shared/entry-archive-pager";
+import {
+  ARCHIVE_PAGE_SIZE,
+  cursorToken,
+  fetchRankedCursorPage,
+  isArchivableTag,
+  parseArchiveCursor
+} from "@/features/seo/ranked-archive";
+import { Entry } from "@/entities";
 
 interface Props {
   params: Promise<{ sections: string[] }>;
@@ -19,31 +32,81 @@ interface Props {
 
 export async function generateMetadata(props: Props, parent: ResolvingMetadata): Promise<Metadata> {
   const { sections } = await props.params;
-  return generateFeedMetadata(sections[0], sections[1]);
+  const { before } = await props.searchParams;
+  const [filter = "hot", rawTag = ""] = sections;
+  const tag = rawTag === "global" ? "" : rawTag;
+  const cursor = isArchivableTag(filter, tag) ? parseArchiveCursor(before) : null;
+  return generateFeedMetadata(filter, tag, cursor ? cursorToken(cursor) : undefined);
 }
 
 export default async function FeedPage({ params, searchParams }: Props) {
   const [filter = "hot", rawTag = ""] = (await params).sections;
   const tag = rawTag === "global" ? "" : rawTag;
+  const { before } = await searchParams;
 
   const cookiesStore = await cookies();
-
   // observer is for filtering muted users/content - always use logged-in user or "ecency"
   const loggedInUser = cookiesStore.get(ACTIVE_USER_COOKIE_NAME)?.value;
   const observer = loggedInUser || "ecency";
 
-  // Prefetch data on server for hydration
-  await prefetchGetPostsFeedQuery(filter, tag, 20, observer);
+  const basePath = `/${filter}/${tag}`;
+  const cursor = isArchivableTag(filter, tag) ? parseArchiveCursor(before) : null;
+
+  // Cursor archive page: one O(1) fetch of the 20 posts older than the cursor,
+  // fully server-rendered (no infinite scroll) with a crawlable pager.
+  if (cursor) {
+    const { entries, nextCursor } = await fetchRankedCursorPage(filter, tag, cursor);
+    if (entries.length === 0) {
+      return redirect(basePath); // stale/invalid cursor -> clean first page
+    }
+    return (
+      <HydrationBoundary
+        state={stripActiveVotesFromDehydratedState(dehydrate(getQueryClient()), loggedInUser)}
+      >
+        <FeedLayout tag={tag} filter={filter} observer={observer}>
+          <EntryListContent
+            username=""
+            loading={false}
+            entries={stripActiveVotesFromValue(entries, loggedInUser)}
+            sectionParam={filter}
+            isPromoted={false}
+            showEmptyPlaceholder={false}
+          />
+          <EntryArchivePager
+            basePath={basePath}
+            olderCursor={nextCursor ? cursorToken(nextCursor) : null}
+            showLatest={true}
+          />
+        </FeedLayout>
+      </HydrationBoundary>
+    );
+  }
+
+  // Default (page 1): prefetch for hydration; add a crawlable "Older" link into
+  // the cursor chain when the first page is full (infinite scroll = JS path).
+  const feed = await prefetchGetPostsFeedQuery(filter, tag, 20, observer);
 
   // Only prefetch promoted posts if promotions feature is enabled
   if (EcencyConfigManager.CONFIG.visionFeatures.promotions.enabled) {
     await prefetchQuery(getPromotedPostsQuery());
   }
 
+  const firstPage = ((feed?.pages?.[0] as Entry[] | undefined) ?? []).filter(Boolean);
+  const lastOfFirst = firstPage[firstPage.length - 1];
+  const olderCursor =
+    isArchivableTag(filter, tag) && firstPage.length >= ARCHIVE_PAGE_SIZE && lastOfFirst
+      ? `${lastOfFirst.author}/${lastOfFirst.permlink}`
+      : null;
+
   return (
-    <HydrationBoundary state={stripActiveVotesFromDehydratedState(dehydrate(getQueryClient()), loggedInUser)}>
+    <HydrationBoundary
+      state={stripActiveVotesFromDehydratedState(dehydrate(getQueryClient()), loggedInUser)}
+    >
       <FeedLayout tag={tag} filter={filter} observer={observer}>
         <FeedList filter={filter} tag={tag} observer={observer} />
+        {olderCursor && (
+          <EntryArchivePager basePath={basePath} olderCursor={olderCursor} showLatest={false} />
+        )}
       </FeedLayout>
     </HydrationBoundary>
   );

--- a/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
@@ -55,7 +55,7 @@ export default async function FeedPage({ params, searchParams }: Props) {
   // Cursor archive page: one O(1) fetch of the 20 posts older than the cursor,
   // fully server-rendered (no infinite scroll) with a crawlable pager.
   if (cursor) {
-    const { entries, nextCursor } = await fetchRankedCursorPage(filter, tag, cursor);
+    const { entries, nextCursor } = await fetchRankedCursorPage(filter, tag, cursor, observer);
     if (entries.length === 0) {
       return redirect(basePath); // stale/invalid cursor -> clean first page
     }

--- a/apps/web/src/features/seo/ranked-archive.ts
+++ b/apps/web/src/features/seo/ranked-archive.ts
@@ -1,0 +1,64 @@
+import { Entry } from "@/entities";
+import { fetchQuery } from "@/core/react-query";
+import { getPostsRankedQueryOptions } from "@ecency/sdk";
+
+// bridge.get_ranked_posts caps `limit` at 20 and its cursor
+// (start_author/start_permlink) is exclusive (verified), so tag/community
+// archives use O(1) cursor-token pagination — one 20-post fetch per page.
+export const ARCHIVE_PAGE_SIZE = 20;
+
+// Feed/community sorts that get a crawlable archive (content ordering only;
+// payout/muted/promoted are not content histories).
+export const ARCHIVE_FILTERS = ["created", "trending", "hot"];
+
+export interface ArchiveCursor {
+  author: string;
+  permlink: string;
+}
+
+export function parseArchiveCursor(before?: string): ArchiveCursor | null {
+  if (!before) {
+    return null;
+  }
+  const idx = before.indexOf("/");
+  if (idx <= 0 || idx >= before.length - 1) {
+    return null; // must be "author/permlink"
+  }
+  return { author: before.slice(0, idx), permlink: before.slice(idx + 1) };
+}
+
+export function cursorToken(c: ArchiveCursor): string {
+  return `${c.author}/${c.permlink}`;
+}
+
+/** A tag page is archivable on content sorts, for a real topic tag only. */
+export function isArchivableTag(filter: string, tag: string): boolean {
+  return (
+    ARCHIVE_FILTERS.includes(filter) &&
+    !!tag &&
+    tag !== "my" &&
+    !tag.startsWith("@") &&
+    !tag.startsWith("%40")
+  );
+}
+
+/**
+ * Fetch one ranked-feed archive page (the 20 posts older than `cursor`) for a
+ * tag or a community id. O(1) — a single bridge.get_ranked_posts call.
+ */
+export async function fetchRankedCursorPage(
+  sort: string,
+  tag: string,
+  cursor: ArchiveCursor
+): Promise<{ entries: Entry[]; nextCursor: ArchiveCursor | null }> {
+  const entries =
+    ((await fetchQuery(
+      getPostsRankedQueryOptions(sort, cursor.author, cursor.permlink, ARCHIVE_PAGE_SIZE, tag)
+    )) as unknown as Entry[] | undefined) ?? [];
+  const last = entries[entries.length - 1];
+  const nextCursor =
+    entries.length === ARCHIVE_PAGE_SIZE && last
+      ? { author: last.author, permlink: last.permlink }
+      : null;
+  return { entries, nextCursor };
+}

--- a/apps/web/src/features/seo/ranked-archive.ts
+++ b/apps/web/src/features/seo/ranked-archive.ts
@@ -31,10 +31,15 @@ export function cursorToken(c: ArchiveCursor): string {
   return `${c.author}/${c.permlink}`;
 }
 
+/** Whether a feed/community sort has a crawlable archive. */
+export function isArchivableFilter(filter: string): boolean {
+  return ARCHIVE_FILTERS.includes(filter);
+}
+
 /** A tag page is archivable on content sorts, for a real topic tag only. */
 export function isArchivableTag(filter: string, tag: string): boolean {
   return (
-    ARCHIVE_FILTERS.includes(filter) &&
+    isArchivableFilter(filter) &&
     !!tag &&
     tag !== "my" &&
     !tag.startsWith("@") &&
@@ -45,15 +50,25 @@ export function isArchivableTag(filter: string, tag: string): boolean {
 /**
  * Fetch one ranked-feed archive page (the 20 posts older than `cursor`) for a
  * tag or a community id. O(1) — a single bridge.get_ranked_posts call.
+ * `observer` mirrors the default feed so a logged-in user's muted-user/content
+ * filtering applies to archive pages too.
  */
 export async function fetchRankedCursorPage(
   sort: string,
   tag: string,
-  cursor: ArchiveCursor
+  cursor: ArchiveCursor,
+  observer = ""
 ): Promise<{ entries: Entry[]; nextCursor: ArchiveCursor | null }> {
   const entries =
     ((await fetchQuery(
-      getPostsRankedQueryOptions(sort, cursor.author, cursor.permlink, ARCHIVE_PAGE_SIZE, tag)
+      getPostsRankedQueryOptions(
+        sort,
+        cursor.author,
+        cursor.permlink,
+        ARCHIVE_PAGE_SIZE,
+        tag,
+        observer
+      )
     )) as unknown as Entry[] | undefined) ?? [];
   const last = entries[entries.length - 1];
   const nextCursor =

--- a/apps/web/src/specs/features/seo/ranked-archive.spec.ts
+++ b/apps/web/src/specs/features/seo/ranked-archive.spec.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   parseArchiveCursor,
   cursorToken,
-  isArchivableTag
+  isArchivableTag,
+  isArchivableFilter
 } from "@/features/seo/ranked-archive";
 
 describe("parseArchiveCursor", () => {
@@ -20,6 +21,17 @@ describe("parseArchiveCursor", () => {
     expect(parseArchiveCursor("enjar")).toBeNull(); // no slash
     expect(parseArchiveCursor("/my-post")).toBeNull(); // empty author
     expect(parseArchiveCursor("enjar/")).toBeNull(); // empty permlink
+  });
+});
+
+describe("isArchivableFilter", () => {
+  it("allows only content sorts", () => {
+    expect(isArchivableFilter("created")).toBe(true);
+    expect(isArchivableFilter("trending")).toBe(true);
+    expect(isArchivableFilter("hot")).toBe(true);
+    expect(isArchivableFilter("payout")).toBe(false);
+    expect(isArchivableFilter("muted")).toBe(false);
+    expect(isArchivableFilter("promoted")).toBe(false);
   });
 });
 

--- a/apps/web/src/specs/features/seo/ranked-archive.spec.ts
+++ b/apps/web/src/specs/features/seo/ranked-archive.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseArchiveCursor,
+  cursorToken,
+  isArchivableTag
+} from "@/features/seo/ranked-archive";
+
+describe("parseArchiveCursor", () => {
+  it("parses a valid author/permlink token", () => {
+    expect(parseArchiveCursor("enjar/my-post")).toEqual({ author: "enjar", permlink: "my-post" });
+  });
+
+  it("round-trips through cursorToken", () => {
+    expect(cursorToken(parseArchiveCursor("alice/a-b-c")!)).toBe("alice/a-b-c");
+  });
+
+  it("rejects missing / malformed tokens", () => {
+    expect(parseArchiveCursor(undefined)).toBeNull();
+    expect(parseArchiveCursor("")).toBeNull();
+    expect(parseArchiveCursor("enjar")).toBeNull(); // no slash
+    expect(parseArchiveCursor("/my-post")).toBeNull(); // empty author
+    expect(parseArchiveCursor("enjar/")).toBeNull(); // empty permlink
+  });
+});
+
+describe("isArchivableTag", () => {
+  it("allows content sorts on a real topic tag", () => {
+    expect(isArchivableTag("created", "photography")).toBe(true);
+    expect(isArchivableTag("trending", "art")).toBe(true);
+    expect(isArchivableTag("hot", "hive")).toBe(true);
+  });
+
+  it("rejects non-content sorts", () => {
+    expect(isArchivableTag("payout", "photography")).toBe(false);
+    expect(isArchivableTag("muted", "photography")).toBe(false);
+  });
+
+  it("rejects empty / personal / user tags", () => {
+    expect(isArchivableTag("created", "")).toBe(false); // global feed
+    expect(isArchivableTag("created", "my")).toBe(false);
+    expect(isArchivableTag("created", "@bob")).toBe(false);
+    expect(isArchivableTag("created", "%40bob")).toBe(false);
+  });
+});


### PR DESCRIPTION
Extends the archive-pagination pattern (#1054) to **tag** and **community** feeds. Both use `bridge.get_ranked_posts` (verified live: `limit` caps at 20, cursor exclusive), so the same O(1) cursor-token approach applies.

- **Tag** `/:filter/:tag` and **community** `/:filter/hive-NNNNN` gain `?before=<author>/<permlink>` cursor archive pages — one 20-post fetch each, fully server-rendered with the shared `EntryArchivePager`.
- Page 1 stays the clean, indexed URL (infinite scroll for humans) and gains a crawlable "Older →" link into the cursor chain when the first page is full.
- Cursor pages are `noindex, follow` + self-canonical (`?before`); empty/invalid cursors redirect to page 1.
- Only content sorts (`created`/`trending`/`hot`) and real topic tags are archivable (payout/muted/promoted, global, `my`, and `@user` feeds excluded).
- New shared helper `features/seo/ranked-archive.ts` (parse/fetch/eligibility) with unit tests.

**Stacked on #1054** (reuses `EntryArchivePager` + the cursor concept). Base is the author-archive branch and will auto-retarget to `develop` once #1054 merges. Full web suite green; typecheck clean for changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added archive-style browsing for community tags and feeds, including older-page navigation and a “latest” return link.
  * Improved page metadata for paginated archive views so older pages are marked appropriately and use the correct canonical URLs.
  * Expanded archive support to more topic-based views while keeping standard infinite scrolling for regular browsing.

* **Bug Fixes**
  * Redirects stale or empty archive pages back to the main view.
  * Keeps search and archive navigation hidden for unsupported content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->