### PR TITLE
test: drop hapi.ecency.com from web read-node pool (hapi-decommission canary)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -391,7 +391,7 @@ const config = {
               [
                 "connect-src 'self'",
                 "https://ecency.com https://hapi.ecency.com https://i.ecency.com https://img.ecency.com https://images.ecency.com",
-                "https://api.hive.blog https://api.deathwing.me https://api.openhive.network https://techcoderx.com https://rpc.mahdiyari.info https://api.c0ff33a.uk https://api.syncad.com",
+                "https://api.hive.blog https://api.deathwing.me https://api.openhive.network https://techcoderx.com https://rpc.mahdiyari.info https://api.c0ff33a.uk https://api.syncad.com https://hive.atexoras.com:2096",
                 "https://hivesigner.com https://hivesearcher.com https://api.hivesearcher.com",
                 "https://pl.ecency.com https://chat.ecency.com",
                 "https://o4507985141956608.ingest.de.sentry.io",

--- a/apps/web/public/public-nodes.json
+++ b/apps/web/public/public-nodes.json
@@ -1,9 +1,10 @@
 [
-  "https://rpc.mahdiyari.info",
-  "https://techcoderx.com",
-  "https://api.openhive.network",
-  "https://api.c0ff33a.uk",
   "https://api.hive.blog",
-  "https://api.syncad.com",
-  "https://api.deathwing.me"
+  "https://api.deathwing.me",
+  "https://api.openhive.network",
+  "https://techcoderx.com",
+  "https://rpc.mahdiyari.info",
+  "https://hiveapi.actifit.io",
+  "https://hive.atexoras.com:2096",
+  "https://api.c0ff33a.uk"
 ]

--- a/apps/web/public/public-nodes.json
+++ b/apps/web/public/public-nodes.json
@@ -1,5 +1,4 @@
 [
-  "https://hapi.ecency.com",
   "https://rpc.mahdiyari.info",
   "https://techcoderx.com",
   "https://api.openhive.network",


### PR DESCRIPTION
## What
Swaps hapi out of `apps/web/public/public-nodes.json` for a **beacon.peakd.com-vetted public node pool**, so SSR/client Hive reads no longer use our own node — a data-gathering canary before deciding whether to decommission the hapi HAF box.

New read pool (8): api.hive.blog, api.deathwing.me, api.openhive.network, techcoderx.com, rpc.mahdiyari.info, **hiveapi.actifit.io (new)**, **hive.atexoras.com:2096 (new)**, api.c0ff33a.uk.

## Changes vs the old list
- **Removed `hapi.ecency.com`** (the decommission candidate).
- **Dropped `api.syncad.com`** — beacon score 51 (11 fails); verified to 500 "Unable to parse endpoint data" on all `bridge.*` calls (our dominant read methods).
- **Added `hiveapi.actifit.io`** (beacon 100; already in the SDK restNodes + CSP) and **`hive.atexoras.com:2096`** (beacon 100). Both verified live to serve `bridge.get_ranked_posts`/`get_account_posts` + `condenser_api.get_accounts`/`get_dynamic_global_properties`.
- `next.config.js`: added `hive.atexoras.com:2096` to the (report-only) CSP `connect-src`.

## Safety
hapi stays fully alive — it remains in the SDK `restNodes` pool and CSP, so re-adding the one line + redeploying is an instant rollback. Only the read pool changes. The escalating 429 backoff + per-node health tracking + per-API failover (#1056) handle c0ff33a's concurrency throttling gracefully.

## Watch during the canary (a few days)
SSR 5xx rate, Sentry RPCError/NodeError spikes, read p50/p95 latency, public-node 429 churn, and hapi's own drone/varnish req/s falling toward zero.
