### PR TITLE
Attribute and reclassify stackless script-parse errors in Sentry

### DIFF
--- a/apps/web/src/core/sentry/lazy-sentry.ts
+++ b/apps/web/src/core/sentry/lazy-sentry.ts
@@ -26,14 +26,43 @@ let options: Options | null = null;
 
 // Method calls made before the SDK is initialized, replayed on init.
 const queued: { method: string; args: unknown[] }[] = [];
-// Raw errors/rejections captured by the early listeners before init.
-const earlyErrors: unknown[] = [];
+// Raw errors/rejections captured by the early listeners before init. For
+// `error` events the ErrorEvent's source location is kept alongside the error
+// and attached as `extra` on replay: a script that fails to PARSE (truncated
+// download, an old engine hitting modern syntax, an HTML error page served for
+// a JS URL) throws its SyntaxError at compile time, so it has NO stack — after
+// replay the Sentry event is frame-less and the ErrorEvent metadata is the only
+// attribution that exists (ECENCY-NEXT-13K2 grouped these unattributably
+// because this handler used to discard it).
+interface EarlyCapture {
+  error: unknown;
+  // Absent for rejections — PromiseRejectionEvent carries no source location.
+  extra?: Record<string, unknown>;
+}
+const earlyErrors: EarlyCapture[] = [];
 
 const earlyErrorHandler = (e: ErrorEvent) => {
-  earlyErrors.push(e.error);
+  // Same growth cap as `queued`: init may be pending for a while and an error
+  // loop must not grow the buffer without bound (new entries dropped — the
+  // FIRST errors on a page are the ones that explain it).
+  if (earlyErrors.length >= MAX_QUEUE) return;
+  earlyErrors.push({
+    error: e.error,
+    extra: {
+      earlySource: e.filename || "<unknown>",
+      earlyPosition: `${e.lineno}:${e.colno}`,
+      // NOTE: this metadata only ships when e.error is a real value. A
+      // cross-origin script without CORS gives error=null + "Script error." —
+      // the replay then captures null and beforeSend's empty-capture rule
+      // drops the whole event (matching Sentry's own inbound filter for the
+      // post-init twin), extras included.
+      earlyMessage: e.message
+    }
+  });
 };
 const earlyRejectionHandler = (e: PromiseRejectionEvent) => {
-  earlyErrors.push(e.reason);
+  if (earlyErrors.length >= MAX_QUEUE) return;
+  earlyErrors.push({ error: e.reason });
 };
 
 function removeEarlyListeners() {
@@ -61,8 +90,10 @@ function loadSentry(): Promise<SentryModule | null> {
 let initPromise: Promise<void> | null = null;
 let initFailures = 0;
 const MAX_INIT_FAILURES = 3;
-// Hard cap on the pre-init buffer so a persistently-failing load can never grow
-// it without bound (drops the oldest entries first).
+// Hard cap on the pre-init buffers so a persistently-failing load can never
+// grow them without bound. `queued` drops the OLDEST entries (a later capture
+// is as good as an earlier one for buffered method calls); `earlyErrors` drops
+// the NEWEST (the first errors on a page are the ones that explain it).
 const MAX_QUEUE = 100;
 
 // Reset the load/init state so a later call can retry (CDN blip, chunk fetch
@@ -116,10 +147,15 @@ function ensureInit(): Promise<void> {
           /* ignore replay errors */
         }
       }
-      // Replay raw early errors.
-      for (const err of earlyErrors.splice(0)) {
+      // Replay raw early errors, with the captured ErrorEvent source metadata
+      // where present (see EarlyCapture).
+      for (const c of earlyErrors.splice(0)) {
         try {
-          m.captureException(err);
+          if (c.extra) {
+            m.captureException(c.error, { extra: c.extra });
+          } else {
+            m.captureException(c.error);
+          }
         } catch {
           /* ignore */
         }

--- a/apps/web/src/specs/core/sentry/lazy-sentry.spec.ts
+++ b/apps/web/src/specs/core/sentry/lazy-sentry.spec.ts
@@ -47,4 +47,77 @@ describe("lazy-sentry facade", () => {
     sentry.captureException(err);
     await vi.waitFor(() => expect(sdk.captureException).toHaveBeenCalledWith(err));
   });
+
+  it("replays early window errors WITH the ErrorEvent's source metadata", async () => {
+    // A script parse failure (truncated chunk, old engine vs modern syntax)
+    // throws a STACKLESS SyntaxError; the ErrorEvent's filename/position is the
+    // only attribution, so the replay must carry it as `extra`
+    // (ECENCY-NEXT-13K2 was unattributable because it was discarded).
+    const { configureLazySentry } = await import("@/core/sentry/lazy-sentry");
+    configureLazySentry({ dsn: "x" } as never);
+    // The early listener attaches synchronously in configure; the SDK import
+    // resolves on a later microtask, so this event lands in the pre-init buffer.
+    const parseError = new SyntaxError("Unexpected end of input");
+    window.dispatchEvent(
+      new ErrorEvent("error", {
+        error: parseError,
+        filename: "https://example.com/_next/static/chunks/1234-abcdef.js",
+        lineno: 1,
+        colno: 98765,
+        message: "Uncaught SyntaxError: Unexpected end of input"
+      })
+    );
+    await vi.waitFor(() =>
+      expect(sdk.captureException).toHaveBeenCalledWith(parseError, {
+        extra: {
+          earlySource: "https://example.com/_next/static/chunks/1234-abcdef.js",
+          earlyPosition: "1:98765",
+          earlyMessage: "Uncaught SyntaxError: Unexpected end of input"
+        }
+      })
+    );
+  });
+
+  it("replays early unhandled rejections WITHOUT source metadata (none exists)", async () => {
+    const { configureLazySentry } = await import("@/core/sentry/lazy-sentry");
+    configureLazySentry({ dsn: "x" } as never);
+    // jsdom has no PromiseRejectionEvent constructor; the handler only reads
+    // `.reason`, so a plain event carrying it exercises the same path.
+    const reason = new Error("early rejection");
+    const evt = new Event("unhandledrejection");
+    (evt as unknown as { reason: unknown }).reason = reason;
+    window.dispatchEvent(evt);
+    // Exactly one argument — no fabricated extra for rejections.
+    await vi.waitFor(() => expect(sdk.captureException).toHaveBeenCalledWith(reason));
+  });
+
+  it("caps the early-error buffer, keeping the FIRST errors (drop-newest)", async () => {
+    const { configureLazySentry } = await import("@/core/sentry/lazy-sentry");
+    configureLazySentry({ dsn: "x" } as never);
+    const errors = Array.from({ length: 150 }, (_, i) => new Error(`e${i}`));
+    for (const error of errors) {
+      window.dispatchEvent(new ErrorEvent("error", { error, filename: "f.js" }));
+    }
+    await vi.waitFor(() => expect(sdk.captureException).toHaveBeenCalledTimes(100));
+    // Drop-NEWEST policy: the first errors on a page are the ones that explain
+    // it, so e0..e99 must be replayed and e100+ discarded (a drop-oldest
+    // regression would pass a size-only assertion).
+    const captured = sdk.captureException.mock.calls.map((c) => c[0]);
+    expect(captured[0]).toBe(errors[0]);
+    expect(captured).toContain(errors[99]);
+    expect(captured).not.toContain(errors[100]);
+    expect(captured).not.toContain(errors[149]);
+  });
+
+  it("caps early unhandled rejections with the same limit", async () => {
+    const { configureLazySentry } = await import("@/core/sentry/lazy-sentry");
+    configureLazySentry({ dsn: "x" } as never);
+    for (let i = 0; i < 150; i++) {
+      const evt = new Event("unhandledrejection");
+      (evt as unknown as { reason: unknown }).reason = new Error(`r${i}`);
+      window.dispatchEvent(evt);
+    }
+    await vi.waitFor(() => expect(sdk.init).toHaveBeenCalled());
+    await vi.waitFor(() => expect(sdk.captureException).toHaveBeenCalledTimes(100));
+  });
 });

--- a/apps/web/src/specs/core/sentry/lazy-sentry.spec.ts
+++ b/apps/web/src/specs/core/sentry/lazy-sentry.spec.ts
@@ -109,15 +109,22 @@ describe("lazy-sentry facade", () => {
     expect(captured).not.toContain(errors[149]);
   });
 
-  it("caps early unhandled rejections with the same limit", async () => {
+  it("caps early unhandled rejections with the same limit, keeping the FIRST (drop-newest)", async () => {
     const { configureLazySentry } = await import("@/core/sentry/lazy-sentry");
     configureLazySentry({ dsn: "x" } as never);
-    for (let i = 0; i < 150; i++) {
+    const reasons = Array.from({ length: 150 }, (_, i) => new Error(`r${i}`));
+    for (const reason of reasons) {
       const evt = new Event("unhandledrejection");
-      (evt as unknown as { reason: unknown }).reason = new Error(`r${i}`);
+      (evt as unknown as { reason: unknown }).reason = reason;
       window.dispatchEvent(evt);
     }
-    await vi.waitFor(() => expect(sdk.init).toHaveBeenCalled());
     await vi.waitFor(() => expect(sdk.captureException).toHaveBeenCalledTimes(100));
+    // The rejection handler has its own guard: pin drop-newest here too, so
+    // flipping just this path to drop-oldest can't pass on the count alone.
+    const captured = sdk.captureException.mock.calls.map((c) => c[0]);
+    expect(captured[0]).toBe(reasons[0]);
+    expect(captured).toContain(reasons[99]);
+    expect(captured).not.toContain(reasons[100]);
+    expect(captured).not.toContain(reasons[149]);
   });
 });

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -274,6 +274,147 @@ describe("beforeSend — synthetic DOM Event capture is dropped", () => {
   });
 });
 
+describe("beforeSend — frame-less script-parse SyntaxError is reclassified", () => {
+  // ECENCY-NEXT-13K2 / ECENCY-NEXT-1GFP: engines throw parse-time SyntaxErrors
+  // while COMPILING a script, so there is no JS stack — the event arrives with
+  // zero frames and the frame-gated chunk rule can't take it. Environmental
+  // (truncated download, or an old engine hitting syntax it predates), so it is
+  // reclassified (NOT dropped) to one fingerprinted warning: a spike would mean
+  // we shipped syntax our browserslist targets can't parse.
+  const parseEvent = (msg: string) => makeEvent(msg, [], { type: "SyntaxError" });
+
+  it("reclassifies the V8 truncation grammar (Unexpected end of input)", () => {
+    const out = beforeSend(parseEvent("Unexpected end of input"));
+    expect(out).not.toBeNull();
+    expect(out!.level).toBe("warning");
+    expect(out!.tags?.script_parse_failure).toBe("true");
+    expect(out!.fingerprint).toEqual(["script-parse-failure"]);
+  });
+
+  it("reclassifies the SpiderMonkey truncation grammar (missing ; after for-loop condition)", () => {
+    const out = beforeSend(parseEvent("missing ; after for-loop condition"));
+    expect(out!.level).toBe("warning");
+    expect(out!.fingerprint).toEqual(["script-parse-failure"]);
+  });
+
+  it("reclassifies the WebKit private-name grammar (old engine, modern syntax)", () => {
+    const out = beforeSend(
+      parseEvent("Unexpected private name #R. Cannot parse class method with private name.")
+    );
+    expect(out!.fingerprint).toEqual(["script-parse-failure"]);
+  });
+
+  it("reclassifies the WebKit method-parameter grammar", () => {
+    const out = beforeSend(
+      parseEvent("Unexpected token '='. Expected an opening '(' before a method's parameter list.")
+    );
+    expect(out!.fingerprint).toEqual(["script-parse-failure"]);
+  });
+
+  it("reclassifies optional chaining on a pre-chaining engine (Unexpected token '.')", () => {
+    const out = beforeSend(parseEvent("Unexpected token '.'"));
+    expect(out!.fingerprint).toEqual(["script-parse-failure"]);
+  });
+
+  it("does NOT touch a frame-less V8 JSON.parse failure ('is not valid JSON')", () => {
+    // res.json() on an HTML error page — a REAL signal about an API response,
+    // and V8 creates it with no JS frames on the stack. Must stay an error.
+    const ev = parseEvent("Unexpected token '<', \"<html>…\" is not valid JSON");
+    expect(beforeSend(ev)).toBe(ev);
+    expect(ev.level).toBeUndefined();
+    expect(ev.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch the older V8 JSON grammar (Unexpected end of JSON input)", () => {
+    const ev = parseEvent("Unexpected end of JSON input");
+    expect(beforeSend(ev)).toBe(ev);
+    expect(ev.level).toBeUndefined();
+    expect(ev.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch the SpiderMonkey JSON.parse grammar", () => {
+    // beforeSend mutates in place and returns the SAME reference, so toBe alone
+    // is vacuous — the level/fingerprint assertions are what pin "untouched".
+    const ev = parseEvent("JSON.parse: unexpected end of data at line 1 column 1 of the JSON data");
+    expect(beforeSend(ev)).toBe(ev);
+    expect(ev.level).toBeUndefined();
+    expect(ev.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch a SyntaxError WITH frames (runtime throw from app code)", () => {
+    // A constructed/thrown SyntaxError always has a stack; only compile-time
+    // parse failures are frame-less. Non-chunk filename so the frame-gated
+    // chunk rule doesn't take it either.
+    const ev = makeEvent("Unexpected token ')'", [{ filename: "app:///src/utils/template.ts" }], {
+      type: "SyntaxError"
+    });
+    expect(beforeSend(ev)).toBe(ev);
+    expect(ev.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch a frame-less SyntaxError with a NON-parse grammar", () => {
+    // e.g. an invalid-selector DOMException surfaced with name SyntaxError —
+    // not a script-parse failure, so it must stay a real error.
+    const ev = parseEvent("'##bad' is not a valid selector");
+    expect(beforeSend(ev)).toBe(ev);
+    expect(ev.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch a frame-less parse grammar under a different exception type", () => {
+    const ev = makeEvent("Unexpected end of input", [], { type: "TypeError" });
+    expect(beforeSend(ev)).toBe(ev);
+    expect(ev.level).toBeUndefined();
+    expect(ev.fingerprint).toBeUndefined();
+  });
+
+  // POST-init the same parse failures arrive through GlobalHandlers' onerror,
+  // which synthesizes exactly one placeholder frame — function "?" with the
+  // failing script URL — for a stackless error. The rule must take that shape
+  // too, and must take it BEFORE the chunk-corruption drop rule (which would
+  // otherwise silently eat the commonest grammars and blind the fingerprint).
+  const SYNTHETIC_ONERROR_FRAME = {
+    filename: "app:///_next/static/chunks/5678-fedcba.js",
+    function: "?"
+  };
+
+  it("reclassifies the post-init single-synthetic-frame shape (WebKit private name)", () => {
+    const out = beforeSend(
+      makeEvent(
+        "Unexpected private name #R. Cannot parse class method with private name.",
+        [SYNTHETIC_ONERROR_FRAME],
+        { type: "SyntaxError" }
+      )
+    );
+    expect(out).not.toBeNull();
+    expect(out!.level).toBe("warning");
+    expect(out!.fingerprint).toEqual(["script-parse-failure"]);
+  });
+
+  it("reclassifies (not drops) the post-init truncation shape despite the chunk frame", () => {
+    // Ordering guard: with one synthetic chunks/ frame and an "Unexpected end
+    // of input" message, the chunk-corruption rule would DROP this — the
+    // reclassify rule must win so the fingerprint keeps its volume visible.
+    const out = beforeSend(
+      makeEvent("Unexpected end of input", [SYNTHETIC_ONERROR_FRAME], { type: "SyntaxError" })
+    );
+    expect(out).not.toBeNull();
+    expect(out!.level).toBe("warning");
+    expect(out!.fingerprint).toEqual(["script-parse-failure"]);
+  });
+
+  it("does NOT take a single REAL frame (named function) — parse errors never have one", () => {
+    // A single NAMED frame means a runtime throw, not a compile failure. Non-
+    // chunk filename so the chunk-drop rule doesn't take it either; it must
+    // pass through untouched.
+    const ev = makeEvent("Unexpected token ')'", [
+      { filename: "app:///src/utils/template.ts", function: "renderTemplate" }
+    ], { type: "SyntaxError" });
+    expect(beforeSend(ev)).toBe(ev);
+    expect(ev.level).toBeUndefined();
+    expect(ev.fingerprint).toBeUndefined();
+  });
+});
+
 describe("beforeSend — Firefox iframe contentWindow-null teardown is reclassified", () => {
   // ECENCY-NEXT-1FGA: the iframe variant of the $RS #418 self-heal above. After a
   // Firefox hydration mismatch an iframe's contentWindow is null while downstream

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -227,7 +227,58 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
     return null;
   }
 
-  // Network issues corrupting JS chunk downloads
+  // ECENCY-NEXT-13K2 / ECENCY-NEXT-1GFP: a script that failed to PARSE. Engines
+  // throw these SyntaxErrors at COMPILE time, so there is no JS stack. They
+  // reach Sentry through exactly two shapes, matched by the frame gate below:
+  //   - pre-init: the lazy-sentry early-error replay captures the raw error —
+  //     ZERO frames (and mechanism/handled that look like an app capture);
+  //   - post-init: GlobalHandlers' onerror sees the stackless error and
+  //     synthesizes a single placeholder frame from the ErrorEvent — function
+  //     "?" with the failing script URL as filename — so exactly ONE
+  //     anonymous frame.
+  // Two real causes, both environmental, neither an app bug:
+  //   - a truncated/corrupted script download (V8 "Unexpected end of input",
+  //     SpiderMonkey "missing ; after for-loop condition" / "unterminated
+  //     string literal");
+  //   - an old engine hitting syntax it predates in a chunk it downloaded fine
+  //     (WebKit "Unexpected private name #R. Cannot parse class method with
+  //     private name.", "Unexpected token '.'" for optional chaining).
+  // An app-thrown SyntaxError always carries a real stack (JSON.parse & friends
+  // are RUNTIME throws), and every engine's JSON grammar names JSON (V8 "is not
+  // valid JSON" / "Unexpected end of JSON input", SpiderMonkey "JSON.parse: …",
+  // WebKit "JSON Parse error: …") — so the frame gate + parse grammar + non-JSON
+  // cannot swallow a real res.json()/JSON.parse failure, including the
+  // frame-less rejection res.json() produces.
+  // RECLASSIFY (not drop) to one fingerprinted warning like the skew/hydration
+  // rules above: truncation volume is network weather, but a SPIKE on this
+  // fingerprint after a build-tooling change would mean we shipped syntax our
+  // browserslist targets cannot parse — worth keeping visible. This rule sits
+  // BEFORE the chunk-corruption drop below on purpose: the drop rule would
+  // silently eat the post-init single-frame shape for the commonest grammars
+  // and blind that spike. Replayed early captures additionally carry the
+  // failing script URL in extra.earlySource (lazy-sentry.ts) for attribution.
+  const isScriptParseGrammar =
+    /Unexpected (?:end of (?:input|script)|token|identifier|string|number|keyword|private name)|Invalid or unexpected token|Cannot parse|missing .+ (?:after|before)|expected expression|unterminated (?:string|regexp)/i.test(
+      message
+    );
+  const hasNoRealFrames =
+    frames.length === 0 || (frames.length === 1 && frames[0].function === "?");
+  if (
+    exceptionType === "SyntaxError" &&
+    hasNoRealFrames &&
+    isScriptParseGrammar &&
+    !/JSON/i.test(message)
+  ) {
+    event.level = "warning";
+    event.tags = { ...event.tags, script_parse_failure: "true" };
+    event.fingerprint = ["script-parse-failure"];
+    return event;
+  }
+
+  // Network issues corrupting JS chunk downloads. After the reclassify rule
+  // above this only sees events with at least one REAL frame (or a synthetic
+  // frame under a non-parse grammar) — kept as a drop for the legacy shapes
+  // that still reach it.
   if (
     /^SyntaxError/.test(exceptionType) &&
     /Unexpected (end of input|token)/.test(message) &&

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -258,7 +258,7 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
   // and blind that spike. Replayed early captures additionally carry the
   // failing script URL in extra.earlySource (lazy-sentry.ts) for attribution.
   const isScriptParseGrammar =
-    /Unexpected (?:end of (?:input|script)|token|identifier|string|number|keyword|private name)|Invalid or unexpected token|Cannot parse|missing .+ (?:after|before)|expected expression|unterminated (?:string|regexp)/i.test(
+    /Unexpected (?:end of (?:input|script)|token|identifier|string|number|keyword|private name)|Invalid or unexpected token|Cannot parse (?:class method|function)|missing .+ (?:after|before)|expected expression|unterminated (?:string|regexp)/i.test(
       message
     );
   const hasNoRealFrames =


### PR DESCRIPTION
## What

Script parse failures throw SyntaxErrors at compile time, so they carry no JS stack. They currently reach Sentry frameless and unattributable (ECENCY-NEXT-13K2, ECENCY-NEXT-1GFP), spawning error-level noise that slips past the frame-gated chunk-corruption rule. Two environmental causes: truncated/corrupted script downloads, and old engines hitting syntax they predate (e.g. optional chaining, private class fields).

## Changes

- **lazy-sentry**: the early window-error buffer now keeps the ErrorEvent's `filename`/`lineno`/`colno`/`message` and attaches them as extras on replay, so the failing script URL is visible on the event. Both early buffers are now capped at `MAX_QUEUE` (drop-newest: the first errors on a page are the explanatory ones).
- **beforeSend**: SyntaxErrors with a parse grammar and no real frames (zero frames from the pre-init replay, or the single synthetic `"?"` frame GlobalHandlers adds post-init) are reclassified to one fingerprinted warning (`script-parse-failure`). Placed before the chunk-corruption drop rule so post-init volume stays visible on the fingerprint - a spike after a build-tooling change would mean shipping syntax the browserslist targets cannot parse. JSON grammars are explicitly excluded so real `res.json()`/`JSON.parse` failures stay error-level.

## Tests

- 8 new beforeSend specs: all production-observed grammars (V8, SpiderMonkey, WebKit), both frame shapes, rule-ordering guard against the chunk-drop rule, JSON-grammar exclusions, framed/typed negative cases.
- 4 new lazy-sentry specs: replay carries source metadata, rejections replay without fabricated extras, buffer cap pins the drop-newest policy for both handlers.

Full web suite: 1931 tests pass.