### PR TITLE
feat(seo): snippet quality, hub breadcrumbs, archive-gate pin fix

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/page.tsx
@@ -13,12 +13,15 @@ import { ProfileEntriesLayout } from "@/app/(dynamicPages)/profile/[username]/_c
 import { CommunityContentInfiniteList } from "../_components/community-content-infinite-list";
 import { Entry, SearchResponse } from "@/entities";
 import {
-  ARCHIVE_PAGE_SIZE,
   cursorToken,
   fetchRankedCursorPage,
   isArchivableFilter,
+  olderCursorToken,
   parseArchiveCursor
 } from "@/features/seo/ranked-archive";
+import { JsonLd, buildBreadcrumbJsonLd } from "@/features/structured-data";
+import { getServerAppBase } from "@/utils/server-app-base";
+import defaults from "@/defaults";
 
 type Page = Entry[] | SearchResponse;
 
@@ -77,9 +80,10 @@ export default async function CommunityPostsPage({ params, searchParams }: Props
     );
   }
 
-  const [communityData, data] = await Promise.all([
+  const [communityData, data, base] = await Promise.all([
     prefetchQuery(getCommunityCache(community)),
-    prefetchGetPostsFeedQuery(tag, community)
+    prefetchGetPostsFeedQuery(tag, community),
+    getServerAppBase()
   ]);
 
   if (!communityData) return notFound();
@@ -89,16 +93,29 @@ export default async function CommunityPostsPage({ params, searchParams }: Props
   }
 
   const flatEntries = data.pages.flatMap(pageToEntries);
-  // Crawlable "Older" entry into the cursor chain when page 1 is full.
+  // Crawlable "Older" entry into the cursor chain — `created` only (the SDK
+  // re-sorts processed pages by date, so trending/hot cursors would not match
+  // bridge rank order, and the created chain already reaches every post).
+  // allowPinShrink: the SDK's pinned-entry dedupe can shrink a full raw page.
   const firstPage = pageToEntries((data as InfiniteData<Page, unknown>).pages[0]);
-  const lastOfFirst = firstPage[firstPage.length - 1];
-  const olderCursor =
-    isArchivableFilter(tag) && firstPage.length >= ARCHIVE_PAGE_SIZE && lastOfFirst
-      ? `${lastOfFirst.author}/${lastOfFirst.permlink}`
-      : null;
+  const olderCursor = tag === "created" ? olderCursorToken(firstPage, true) : null;
+
+  // Desktop SERPs replace the URL-derived trail ("ecency.com > created >
+  // hive-NNNNN") with this breadcrumb ("Home > Community Title"). Skipped when
+  // the community has no human title — a trail must never surface the raw
+  // hive-NNNNN machine id (same policy as buildEntryBreadcrumbs).
+  const cleanBase = base.replace(/\/+$/, "");
+  const communityTitle = communityData.title?.trim();
+  const breadcrumbJsonLd = communityTitle
+    ? buildBreadcrumbJsonLd([
+        { name: defaults.name, url: cleanBase },
+        { name: communityTitle, url: `${cleanBase}/created/${community}` }
+      ])
+    : null;
 
   return (
     <HydrationBoundary state={dehydrate(getQueryClient())}>
+      {breadcrumbJsonLd && <JsonLd data={breadcrumbJsonLd} />}
       {data.pages.length === 0 ? <LinearProgress /> : null}
 
       {isArchivableFilter(tag) && data.pages.length > 0 && (

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_helpers/generate-community-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_helpers/generate-community-metadata.ts
@@ -32,11 +32,13 @@ export async function generateCommunityMetadata(
     const rawAbout = community.about;
     const communityAbout =
       typeof rawAbout === "string" ? rawAbout.replace(/\s+/g, " ").trim() : "";
+    // Non-feed sections (subscribers/roles/activities) must not claim "posts
+    // and discussions" — they get the section-neutral fallback.
     const description = communityAbout
       ? truncate(communityAbout, 160)
-      : i18next.t("community.page-description", {
-          f: isFeedTag ? `${feedLabel} ${communityTitle}` : communityTitle
-        });
+      : isFeedTag
+        ? i18next.t("community.page-description", { f: `${feedLabel} ${communityTitle}` })
+        : i18next.t("community.page-description-generic", { f: communityTitle });
     const metaRss = `${base}/${tag}/${community.name}/rss.xml`;
     const metaCanonical = `${base}/created/${community.name}`;
 

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_helpers/generate-community-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_helpers/generate-community-metadata.ts
@@ -1,6 +1,6 @@
 import { getCommunityCache } from "@/core/caches";
 import i18next from "i18next";
-import { capitalize } from "@/utils";
+import { capitalize, truncate } from "@/utils";
 import defaults from "@/defaults";
 import { getServerAppBase } from "@/utils/server-app-base";
 import { prefetchQuery } from "@/core/react-query";
@@ -17,10 +17,26 @@ export async function generateCommunityMetadata(
     getServerAppBase()
   ]);
   if (community && account) {
-    const title = `${community.title.trim()} community ${tag} list`;
-    const description = i18next.t("community.page-description", {
-      f: `${capitalize(tag)} ${community.title.trim()}`
-    });
+    // This helper also serves non-feed sections (subscribers/activities/roles),
+    // where a "posts" suffix would be wrong — keep the old generic "list" there.
+    const communityTitle = community.title.trim();
+    const isFeedTag = ["created", "trending", "hot"].includes(tag);
+    const feedLabel = tag === "created" ? "Latest" : capitalize(tag);
+    // Bare titles; the root title.template appends "| Ecency".
+    const title = isFeedTag
+      ? `${communityTitle} community${tag === "created" ? "" : ` ${tag}`} posts`
+      : `${communityTitle} community ${tag} list`;
+    // The community's own about text is the most distinctive snippet we have
+    // (about only: `description` is free-form markdown — rules/links — that
+    // would leak raw syntax into a truncated meta description).
+    const rawAbout = community.about;
+    const communityAbout =
+      typeof rawAbout === "string" ? rawAbout.replace(/\s+/g, " ").trim() : "";
+    const description = communityAbout
+      ? truncate(communityAbout, 160)
+      : i18next.t("community.page-description", {
+          f: isFeedTag ? `${feedLabel} ${communityTitle}` : communityTitle
+        });
     const metaRss = `${base}/${tag}/${community.name}/rss.xml`;
     const metaCanonical = `${base}/created/${community.name}`;
 

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-card-fields.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-card-fields.ts
@@ -5,8 +5,18 @@ import type { Entry } from "@/entities";
 export interface EntryCardFields {
   /** ≤67-char title; for a comment, "@author: <body summary>". */
   title: string;
-  /** ≤160-char summary (author-set description wins). */
+  /**
+   * ≤160-char summary (author-set description wins). MAY BE EMPTY for
+   * media-only posts — the SERP meta description deliberately stays empty so
+   * Google auto-snippets from page content instead of sitewide boilerplate.
+   */
   summary: string;
+  /**
+   * `summary`, or a minimal descriptive fallback when it is empty. For card
+   * surfaces (og/twitter/oEmbed) that have no auto-snippet and must not render
+   * an empty description.
+   */
+  cardSummary: string;
   /** 1200×630 cover image, or null when the post has none. */
   image: string | null;
   isComment: boolean;
@@ -30,11 +40,36 @@ export function buildEntryCardFields(entry: Entry): EntryCardFields {
   }
 
   // Cap at 160 chars to match Google's desktop snippet width; consumers may
-  // truncate further. An author-set json_metadata.description wins.
+  // truncate further. An author-set json_metadata.description wins (guarded:
+  // json_metadata is untrusted on-chain data, a non-string value would leak
+  // "[object Object]" into cards).
+  const declared = entry.json_metadata?.description;
   const summary =
-    entry.json_metadata?.description || truncate(postBodySummary(entry.body, 210), 160);
+    (typeof declared === "string" ? declared : "") ||
+    truncate(postBodySummary(entry.body, 210), 160);
+
+  // Media-only posts (image/video, no prose) summarize to "". Card surfaces
+  // (og/twitter/oEmbed) must not render an empty description, so give THEM a
+  // minimal descriptive line — while `summary` stays empty so the SERP meta
+  // description keeps Google's (usually better) auto-snippet. Built lazily:
+  // the common non-empty case never pays for it.
+  let cardSummary = summary;
+  if (!cardSummary) {
+    const rawTags = entry.json_metadata?.tags;
+    const tags = (Array.isArray(rawTags) ? rawTags : []).filter(
+      (t): t is string => typeof t === "string" && t.length > 0
+    );
+    cardSummary = truncate(
+      isComment
+        ? `A reply by @${entry.author} on Ecency`
+        : `A post by @${entry.author}${entry.community_title ? ` in ${entry.community_title}` : ""} on Ecency${
+            tags.length ? `. Tags: ${tags.slice(0, 3).join(", ")}` : ""
+          }`,
+      160
+    );
+  }
 
   const image = catchPostImage(entry, 1200, 630, "match");
 
-  return { title, summary, image, isComment };
+  return { title, summary, cardSummary, image, isComment };
 }

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/generate-entry-metadata.ts
@@ -54,7 +54,7 @@ export async function generateEntryMetadata(
 
     // Shared with the oEmbed provider so the meta-tag card and the oEmbed
     // card can never drift (title/summary/image rules live in one place).
-    const { title, summary, image, isComment } = buildEntryCardFields(entry as Entry);
+    const { title, summary, cardSummary, image, isComment } = buildEntryCardFields(entry as Entry);
 
     // Bare /@author/permlink form for this exact page.
     const fullUrl = `${base}/@${entry.author}/${entry.permlink}`;
@@ -102,7 +102,9 @@ export async function generateEntryMetadata(
       robots,
       openGraph: {
         title,
-        description: summary,
+        // Cards use cardSummary (never empty); the SERP meta description above
+        // stays the bare summary so media-only posts keep Google's auto-snippet.
+        description: cardSummary,
         url: ogUrl,
         // Add alt only. catchPostImage uses aspect-fit (mode=match), so the
         // proxied asset is rarely exactly 1200x630 (and GIF covers may be served
@@ -120,7 +122,7 @@ export async function generateEntryMetadata(
         // per segment, so without this the root layout's twitter:site is dropped.
         site: defaults.twitterHandle,
         title,
-        description: summary,
+        description: cardSummary,
         images: image ? [{ url: image, alt: title }] : [],
       },
       other: {

--- a/apps/web/src/app/(dynamicPages)/feed/[...sections]/_helpers/generate-feed-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/feed/[...sections]/_helpers/generate-feed-metadata.ts
@@ -20,7 +20,9 @@ export async function generateFeedMetadata(filter: string, tag: string, cursor?:
     });
   } else if (tag) {
     title = `latest #${tag} ${filter} topics`;
-    description = i18next.t("entry-index.description-tag", { f: fC, t: tag });
+    // "Created #tag posts..." reads oddly in a snippet; label that sort "Latest".
+    const fLabel = filter === "created" ? "Latest" : fC;
+    description = i18next.t("entry-index.description-tag", { f: fLabel, t: tag });
 
     url = `/${filter}/${tag}`;
     canonical = `${base}/${filter}/${tag}`;

--- a/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
@@ -93,7 +93,10 @@ export default async function FeedPage({ params, searchParams }: Props) {
 
   // Default (page 1): prefetch for hydration; add a crawlable "Older" link into
   // the cursor chain when the first page is full (infinite scroll = JS path).
-  const feed = await prefetchGetPostsFeedQuery(filter, tag, 20, observer);
+  const [feed, appBase] = await Promise.all([
+    prefetchGetPostsFeedQuery(filter, tag, 20, observer),
+    getServerAppBase()
+  ]);
 
   // Only prefetch promoted posts if promotions feature is enabled
   if (EcencyConfigManager.CONFIG.visionFeatures.promotions.enabled) {
@@ -111,7 +114,7 @@ export default async function FeedPage({ params, searchParams }: Props) {
   // Tag hubs get a BreadcrumbList (desktop SERPs show it in place of the raw URL trail).
   let breadcrumbJsonLd = null;
   if (isTagHub) {
-    const base = (await getServerAppBase()).replace(/\/+$/, "");
+    const base = appBase.replace(/\/+$/, "");
     breadcrumbJsonLd = buildBreadcrumbJsonLd([
       { name: defaults.name, url: base },
       { name: `#${tag}`, url: `${base}${basePath}` }

--- a/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
@@ -17,13 +17,16 @@ import { EcencyConfigManager } from "@/config";
 import { EntryListContent } from "@/features/shared/entry-list-content";
 import { EntryArchivePager } from "@/features/shared/entry-archive-pager";
 import {
-  ARCHIVE_PAGE_SIZE,
   cursorToken,
   fetchRankedCursorPage,
   isArchivableTag,
+  olderCursorToken,
   parseArchiveCursor
 } from "@/features/seo/ranked-archive";
 import { Entry } from "@/entities";
+import { JsonLd, buildBreadcrumbJsonLd } from "@/features/structured-data";
+import { getServerAppBase } from "@/utils/server-app-base";
+import defaults from "@/defaults";
 
 interface Props {
   params: Promise<{ sections: string[] }>;
@@ -98,16 +101,28 @@ export default async function FeedPage({ params, searchParams }: Props) {
   }
 
   const firstPage = ((feed?.pages?.[0] as Entry[] | undefined) ?? []).filter(Boolean);
-  const lastOfFirst = firstPage[firstPage.length - 1];
-  const olderCursor =
-    isArchivableTag(filter, tag) && firstPage.length >= ARCHIVE_PAGE_SIZE && lastOfFirst
-      ? `${lastOfFirst.author}/${lastOfFirst.permlink}`
-      : null;
+  const isTagHub = isArchivableTag(filter, tag);
+  // "Older" chain entry for `created` tag hubs only — see olderCursorToken (the
+  // SDK re-sorts pages by date, so trending/hot cursors would overlap; the
+  // created chain already reaches every post). No pin-shrink here: tag feeds
+  // have no pin-at-top semantics, so a short page means the tag really ended.
+  const olderCursor = isTagHub && filter === "created" ? olderCursorToken(firstPage) : null;
+
+  // Tag hubs get a BreadcrumbList (desktop SERPs show it in place of the raw URL trail).
+  let breadcrumbJsonLd = null;
+  if (isTagHub) {
+    const base = (await getServerAppBase()).replace(/\/+$/, "");
+    breadcrumbJsonLd = buildBreadcrumbJsonLd([
+      { name: defaults.name, url: base },
+      { name: `#${tag}`, url: `${base}${basePath}` }
+    ]);
+  }
 
   return (
     <HydrationBoundary
       state={stripActiveVotesFromDehydratedState(dehydrate(getQueryClient()), loggedInUser)}
     >
+      {breadcrumbJsonLd && <JsonLd data={breadcrumbJsonLd} />}
       <FeedLayout tag={tag} filter={filter} observer={observer}>
         <FeedList filter={filter} tag={tag} observer={observer} />
         {olderCursor && (

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/generate-profile-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/generate-profile-metadata.ts
@@ -3,7 +3,7 @@ import defaults from "@/defaults";
 import { getServerAppBase } from "@/utils/server-app-base";
 import { prefetchQuery } from "@/core/react-query";
 import { getAccountFullQueryOptions } from "@ecency/sdk";
-import { accountReputation } from "@/utils";
+import { accountReputation, truncate } from "@/utils";
 
 const NOINDEX_REPUTATION_THRESHOLD = 40;
 
@@ -24,11 +24,20 @@ export async function generateProfileMetadata(
     }`
       .replace(/\s{2,}/g, " ")
       .trim();
-    const metaDescription = `${
-      account.profile?.about
-        ? `${account.profile?.about} ${section ? `${section}` : ""}`
-        : `${account.profile?.name || account.name} ${section ? `${section}` : ""}`
-    }`;
+    // Bio-first: the user's own about text is the most distinctive snippet we
+    // have (feeds meta description + og/twitter cards verbatim); the section
+    // prefix keeps each section's description unique. Fallback is section-aware
+    // so wallet/followers/settings pages don't claim "posts". typeof guard:
+    // profile is untrusted on-chain JSON, about can be a non-string.
+    const displayName = account.profile?.name || account.name;
+    const rawAbout = account.profile?.about;
+    const about = typeof rawAbout === "string" ? rawAbout.replace(/\s+/g, " ").trim() : "";
+    const contentSections = ["posts", "blog", "comments", "replies"];
+    const metaDescription = about
+      ? truncate(`${displayName}'s ${sectionLabel}: ${about}`, 160)
+      : contentSections.includes(section)
+        ? `Latest ${section} by ${displayName} (@${cleanUsername}) on Ecency.`
+        : `${displayName}'s ${sectionLabel} on Ecency (@${cleanUsername}).`;
     const isPaginated = !!cursor;
     const baseUrl = `/@${cleanUsername}${section ? `/${section}` : ""}`;
     const metaUrl = isPaginated ? `${baseUrl}?before=${cursor}` : baseUrl;

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/generate-profile-metadata.ts
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/generate-profile-metadata.ts
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import i18next from "i18next";
 import defaults from "@/defaults";
 import { getServerAppBase } from "@/utils/server-app-base";
 import { prefetchQuery } from "@/core/react-query";
@@ -36,8 +37,12 @@ export async function generateProfileMetadata(
     const metaDescription = about
       ? truncate(`${displayName}'s ${sectionLabel}: ${about}`, 160)
       : contentSections.includes(section)
-        ? `Latest ${section} by ${displayName} (@${cleanUsername}) on Ecency.`
-        : `${displayName}'s ${sectionLabel} on Ecency (@${cleanUsername}).`;
+        ? i18next.t("profile.page-description", { s: section, n: displayName, u: cleanUsername })
+        : i18next.t("profile.page-description-generic", {
+            n: displayName,
+            s: sectionLabel,
+            u: cleanUsername
+          });
     const isPaginated = !!cursor;
     const baseUrl = `/@${cleanUsername}${section ? `/${section}` : ""}`;
     const metaUrl = isPaginated ? `${baseUrl}?before=${cursor}` : baseUrl;

--- a/apps/web/src/app/api/oembed/route.ts
+++ b/apps/web/src/app/api/oembed/route.ts
@@ -50,7 +50,8 @@ export async function GET(request: Request): Promise<Response> {
     if (!loaded) return errorResponse(404);
 
     const base = await getServerAppBase();
-    const { title, summary, image } = buildEntryCardFields(loaded.entry);
+    // cardSummary: never empty (media-only posts get a descriptive fallback).
+    const { title, cardSummary, image } = buildEntryCardFields(loaded.entry);
 
     const payload: Record<string, unknown> = {
       version: "1.0",
@@ -63,7 +64,7 @@ export async function GET(request: Request): Promise<Response> {
       cache_age: 300,
       // Non-standard extension: standard consumers ignore unknown fields;
       // Ecency's own in-post link enhancer reads it for the card description.
-      description: summary
+      description: cardSummary
     };
 
     if (image) {

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1207,6 +1207,8 @@
     "note-placeholder-unmute": "Provide a note regarding your decision to unmute this content."
   },
   "profile": {
+    "page-description": "Latest {{s}} by {{n}} (@{{u}}) on Ecency.",
+    "page-description-generic": "{{n}}'s {{s}} on Ecency (@{{u}}).",
     "voting-power": "Voting Power",
     "followers": "Followers",
     "following": "Following",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1075,6 +1075,7 @@
   },
   "community": {
     "page-description": "{{f}} posts and discussions. Join the community on Ecency to read, share and earn rewards.",
+    "page-description-generic": "{{f}} community on Ecency. Join to read, share and earn rewards.",
     "subscribe": "Join",
     "subscribed": "Joined",
     "unsubscribe": "Leave",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -610,7 +610,7 @@
     "tags": "Popular",
     "title": "{{f}} topics",
     "description": "{{f}} topics on a social network owned and operated by its users.",
-    "description-tag": "{{f}} #{{t}} topics",
+    "description-tag": "{{f}} #{{t}} posts and discussions on Ecency. Read the community's latest stories and earn rewards for sharing your own.",
     "description-user-feed": "{{u}}'s feed",
     "faq": "FAQ",
     "tos": "Terms of service",
@@ -1074,7 +1074,7 @@
     "load-error": "Failed to load comments. Tap to retry"
   },
   "community": {
-    "page-description": "{{f}} topics",
+    "page-description": "{{f}} posts and discussions. Join the community on Ecency to read, share and earn rewards.",
     "subscribe": "Join",
     "subscribed": "Joined",
     "unsubscribe": "Leave",

--- a/apps/web/src/features/seo/ranked-archive.ts
+++ b/apps/web/src/features/seo/ranked-archive.ts
@@ -49,6 +49,15 @@ export const PIN_DEDUPE_ALLOWANCE = 4;
  * immediately redirects back would be a crawl trap). `allowPinShrink` is for
  * COMMUNITY feeds, where the SDK's pinned-entry dedupe shrinks a full raw page.
  *
+ * Known residual with allowPinShrink: a community whose TOTAL post count is
+ * 16-19 with a pinned post is indistinguishable from a pin-shrunk full page
+ * (the processed page carries no raw count), so it emits one link whose target
+ * redirects back. Accepted: the state is transient for active communities,
+ * costs a crawler a single redirect hop, and the only exact signal would be an
+ * extra raw fetch per render. Becomes exact once the SDK ranked-feed select
+ * stops dropping all-but-one pinned entry (tracked follow-up) — processed
+ * length then always equals raw length.
+ *
  * Callers should only emit the link for the `created` sort: the SDK re-sorts
  * processed pages by created date, so a cursor taken from a processed
  * trending/hot page would not match the bridge's rank order (overlapping

--- a/apps/web/src/features/seo/ranked-archive.ts
+++ b/apps/web/src/features/seo/ranked-archive.ts
@@ -36,6 +36,41 @@ export function isArchivableFilter(filter: string): boolean {
   return ARCHIVE_FILTERS.includes(filter);
 }
 
+// The SDK's ranked-feed select keeps ONE pinned entry and drops the rest, so a
+// community whose raw page was full can surface as 16-19 entries. Pin presence
+// alone does NOT imply fullness (a 5-post community with one pin also shows a
+// pin), so additionally require the page to be within plausible dedupe loss of
+// a full page. Communities pinning >5 posts fall back to no link (conservative).
+export const PIN_DEDUPE_ALLOWANCE = 4;
+
+/**
+ * Cursor token for the page-1 "Older" archive link, or null when page 1 gives
+ * no evidence that older content exists (emitting a link whose target
+ * immediately redirects back would be a crawl trap). `allowPinShrink` is for
+ * COMMUNITY feeds, where the SDK's pinned-entry dedupe shrinks a full raw page.
+ *
+ * Callers should only emit the link for the `created` sort: the SDK re-sorts
+ * processed pages by created date, so a cursor taken from a processed
+ * trending/hot page would not match the bridge's rank order (overlapping
+ * chain), and the created chain already reaches every post.
+ */
+export function olderCursorToken(
+  entries: (Entry | null | undefined)[],
+  allowPinShrink = false
+): string | null {
+  const page = entries.filter((e): e is Entry => !!e);
+  const last = page[page.length - 1];
+  if (!last) return null;
+  const full = page.length >= ARCHIVE_PAGE_SIZE;
+  const pinShrunk =
+    allowPinShrink &&
+    page.length >= ARCHIVE_PAGE_SIZE - PIN_DEDUPE_ALLOWANCE &&
+    page.some((e) => e.stats?.is_pinned);
+  return full || pinShrunk
+    ? cursorToken({ author: last.author, permlink: last.permlink })
+    : null;
+}
+
 /** A tag page is archivable on content sorts, for a real topic tag only. */
 export function isArchivableTag(filter: string, tag: string): boolean {
   return (

--- a/apps/web/src/specs/api/oembed-route.spec.ts
+++ b/apps/web/src/specs/api/oembed-route.spec.ts
@@ -62,6 +62,7 @@ describe("GET /api/oembed", () => {
     vi.mocked(buildEntryCardFields).mockReturnValue({
       title: "My Title",
       summary: "My summary",
+      cardSummary: "My summary",
       image: "https://img/cover.png",
       isComment: false
     });
@@ -96,6 +97,7 @@ describe("GET /api/oembed", () => {
     vi.mocked(buildEntryCardFields).mockReturnValue({
       title: "T",
       summary: "S",
+      cardSummary: "S",
       image: null,
       isComment: false
     });

--- a/apps/web/src/specs/app/entry-card-fields.spec.ts
+++ b/apps/web/src/specs/app/entry-card-fields.spec.ts
@@ -28,11 +28,13 @@ function entry(overrides: Record<string, unknown> = {}) {
 describe("buildEntryCardFields", () => {
   it("matches the inline title/summary/image rules for a post (parity lock)", () => {
     const e = entry({ json_metadata: { image: ["https://example.com/cover.png"] } });
+    const expectedSummary =
+      (e.json_metadata as any).description || truncate(postBodySummary(e.body, 210), 160);
     expect(buildEntryCardFields(e as any)).toEqual({
       isComment: false,
       title: truncate(e.title, 67),
-      summary:
-        (e.json_metadata as any).description || truncate(postBodySummary(e.body, 210), 160),
+      summary: expectedSummary,
+      cardSummary: expectedSummary, // non-empty summary => identical
       image: catchPostImage(e as any, 1200, 630, "match")
     });
   });
@@ -54,5 +56,38 @@ describe("buildEntryCardFields", () => {
     expect(buildEntryCardFields(e as any).image).toBe(
       catchPostImage(e as any, 1200, 630, "match")
     );
+  });
+
+  // Media-only posts summarize to "": `summary` (the SERP meta description)
+  // stays EMPTY so Google auto-snippets from page content, while `cardSummary`
+  // (og/twitter/oEmbed, which have no auto-snippet) gets a descriptive fallback.
+  it("keeps summary empty but fills cardSummary for an image-only post body", () => {
+    const e = entry({
+      body: "![shot](https://example.com/a.jpg)",
+      community_title: "Photography Lovers",
+      json_metadata: { tags: ["photo", "art", "hive", "extra"] }
+    });
+    expect(postBodySummary(e.body as string, 210)).toBe(""); // premise: media-only => empty
+    const fields = buildEntryCardFields(e as any);
+    expect(fields.summary).toBe("");
+    expect(fields.cardSummary).toBe(
+      "A post by @alice in Photography Lovers on Ecency. Tags: photo, art, hive"
+    );
+  });
+
+  it("card fallback works without community/tags and guards non-array tags", () => {
+    const e = entry({ body: "![x](https://example.com/a.jpg)", json_metadata: { tags: "photo" } });
+    expect(buildEntryCardFields(e as any).cardSummary).toBe("A post by @alice on Ecency");
+  });
+
+  it("uses the reply card fallback for a media-only comment", () => {
+    const e = entry({ parent_author: "bob", body: "![x](https://example.com/a.jpg)" });
+    expect(buildEntryCardFields(e as any).cardSummary).toBe("A reply by @alice on Ecency");
+  });
+
+  it("ignores a non-string json_metadata.description (untrusted on-chain data)", () => {
+    const e = entry({ json_metadata: { description: { evil: true } } });
+    const fields = buildEntryCardFields(e as any);
+    expect(fields.summary).toBe(truncate(postBodySummary(e.body, 210), 160));
   });
 });

--- a/apps/web/src/specs/features/seo/ranked-archive.spec.ts
+++ b/apps/web/src/specs/features/seo/ranked-archive.spec.ts
@@ -3,8 +3,21 @@ import {
   parseArchiveCursor,
   cursorToken,
   isArchivableTag,
-  isArchivableFilter
+  isArchivableFilter,
+  olderCursorToken,
+  ARCHIVE_PAGE_SIZE,
+  PIN_DEDUPE_ALLOWANCE
 } from "@/features/seo/ranked-archive";
+
+const post = (i: number, pinned = false) =>
+  ({
+    author: `author${i}`,
+    permlink: `post-${i}`,
+    ...(pinned ? { stats: { is_pinned: true } } : {})
+  }) as any;
+
+const page = (n: number, pinnedCount = 0) =>
+  Array.from({ length: n }, (_, i) => post(i, i < pinnedCount));
 
 describe("parseArchiveCursor", () => {
   it("parses a valid author/permlink token", () => {
@@ -32,6 +45,41 @@ describe("isArchivableFilter", () => {
     expect(isArchivableFilter("payout")).toBe(false);
     expect(isArchivableFilter("muted")).toBe(false);
     expect(isArchivableFilter("promoted")).toBe(false);
+  });
+});
+
+describe("olderCursorToken", () => {
+  it("full page -> cursor of the last entry", () => {
+    expect(olderCursorToken(page(ARCHIVE_PAGE_SIZE))).toBe("author19/post-19");
+  });
+
+  it("short page -> null (no evidence older content exists)", () => {
+    expect(olderCursorToken(page(5))).toBeNull();
+    expect(olderCursorToken([])).toBeNull();
+    expect(olderCursorToken([null, undefined])).toBeNull();
+  });
+
+  // The SDK keeps one pinned entry and DROPS the rest, so a full raw community
+  // page can surface as 16-19 entries with a pin present.
+  it("pin-shrunk community page (17 entries, pin present) -> cursor", () => {
+    expect(olderCursorToken(page(17, 1), true)).toBe("author16/post-16");
+  });
+
+  it("small pinned community (5 posts, 1 pin) -> null — NOT a full-page signal", () => {
+    expect(olderCursorToken(page(5, 1), true)).toBeNull();
+  });
+
+  it("pin-shrink lower bound: exactly PAGE_SIZE - ALLOWANCE passes, one below fails", () => {
+    expect(olderCursorToken(page(ARCHIVE_PAGE_SIZE - PIN_DEDUPE_ALLOWANCE, 1), true)).not.toBeNull();
+    expect(olderCursorToken(page(ARCHIVE_PAGE_SIZE - PIN_DEDUPE_ALLOWANCE - 1, 1), true)).toBeNull();
+  });
+
+  it("short page with pin but allowPinShrink=false (tag feeds) -> null", () => {
+    expect(olderCursorToken(page(17, 1))).toBeNull();
+  });
+
+  it("17 entries without any pin -> null even with allowPinShrink", () => {
+    expect(olderCursorToken(page(17), true)).toBeNull();
   });
 });
 


### PR DESCRIPTION
Snippet-quality and structured-data follow-up to #1057, plus a fix for the archive "Older" link gate.

**Meta descriptions**
- Profile pages: use the user's bio, prefixed with the section ("Name's posts: <bio>") so each section page keeps a unique description; section-aware fallbacks when the bio is empty. Non-string `profile.about` (untrusted on-chain JSON) is guarded - it previously crashed `.trim()`.
- Community pages: prefer the community's own `about` text (plain-text field only; `description` is free-form markdown that would leak raw syntax). The "posts" phrasing applies to feed tags only - subscribers/activities/roles keep the generic "list" title.
- Tag/community i18n templates replaced with descriptive copy (en-US.json).

**Card vs snippet split**
`buildEntryCardFields` now returns `summary` (may be empty for media-only posts, so Google keeps auto-snippeting from page content) and `cardSummary` (never empty - og/twitter/oEmbed cards have no auto-snippet fallback). Also guards a non-string `json_metadata.description` that could render `[object Object]` in cards.

**Hub breadcrumbs**
BreadcrumbList JSON-LD on community and tag hub pages (page 1 only). The community crumb requires a human title so the raw `hive-NNNNN` id never surfaces in a trail; base URL normalized to match the entry-page breadcrumb builder.

**Archive "Older" gate**
New shared `olderCursorToken()` in `features/seo/ranked-archive` replaces the duplicated inline gates:
- Handles the SDK's pinned-entry dedupe (a full raw community page can surface as 16-19 entries when several posts are pinned) with a bounded allowance, without emitting a self-redirecting link for small communities that merely have a pin.
- Links emit for the `created` sort only: the SDK re-sorts processed pages by date, so a cursor from a trending/hot page would not match the bridge's rank order, and the created chain already reaches every post.

**Tests**: 7 new `olderCursorToken` cases, 4 card summary/fallback cases, oEmbed fixtures updated. Full web suite green (1924).

Known follow-up (separate issue): the SDK's ranked-feed select keeps only one pinned entry and silently drops the rest - multi-pin communities never display their other pins on any consumer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added crawlable breadcrumb structured data to community and feed pages.
  * Improved social preview and oEmbed descriptions with fuller fallback text.
* **Bug Fixes**
  * Refined “Older” pagination so archive links are generated more reliably.
  * Improved metadata titles and descriptions for communities, feeds, and profiles.
* **Documentation**
  * Updated visible page copy for community and feed descriptions.
* **Tests**
  * Expanded coverage for archive cursor behavior and card summary fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->