### PR TITLE
chore(packages): link ecency.com from package homepages and READMEs

### DIFF
--- a/packages/render-helper/README.md
+++ b/packages/render-helper/README.md
@@ -1,5 +1,7 @@
 # Ecency render helper
 
+Built and maintained by [Ecency](https://ecency.com), an open-source social platform on the Hive blockchain.
+
 ## Project Overview
 
 `@ecency/render-helper` is a TypeScript library for rendering and sanitizing markdown+HTML content for the Ecency social platform (built on Hive blockchain). It provides security-focused content rendering with XSS protection, image proxification, and embedded media filtering.

--- a/packages/render-helper/package.json
+++ b/packages/render-helper/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/ecency/vision-next.git",
     "directory": "packages/render-helper"
   },
-  "homepage": "https://github.com/ecency/vision-next/tree/develop/packages/render-helper",
+  "homepage": "https://ecency.com",
   "bugs": {
     "url": "https://github.com/ecency/vision-next/issues"
   },

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,6 +2,8 @@
 
 Full-featured Hive blockchain SDK with built-in transaction signing, RPC failover, and first-class React Query support.
 
+Built and maintained by [Ecency](https://ecency.com), an open-source social platform on the Hive blockchain.
+
 ## What's Inside
 
 - **Built-in transaction engine** — create, sign, and broadcast Hive transactions with ECDSA secp256k1 cryptography, memo encryption, and full serialization for all 50 operation types (built on an improved version of [hive-tx](https://github.com/mahdiyari/hive-tx) by Mahdi Yari)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/ecency/vision-next.git",
     "directory": "packages/sdk"
   },
-  "homepage": "https://github.com/ecency/vision-next/tree/develop/packages/sdk",
+  "homepage": "https://ecency.com",
   "bugs": {
     "url": "https://github.com/ecency/vision-next/issues"
   },

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -2,6 +2,8 @@
 
 Shared UI components for Ecency applications. These components are designed to work with both the main Ecency web application and the self-hosted blog application.
 
+Built and maintained by [Ecency](https://ecency.com), an open-source social platform on the Hive blockchain.
+
 ## Installation
 
 ```bash

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/ecency/vision-next.git",
     "directory": "packages/ui"
   },
-  "homepage": "https://github.com/ecency/vision-next/tree/develop/packages/ui",
+  "homepage": "https://ecency.com",
   "bugs": {
     "url": "https://github.com/ecency/vision-next/issues"
   },

--- a/packages/wallets/README.md
+++ b/packages/wallets/README.md
@@ -2,6 +2,8 @@
 
 Utilities for managing Hive blockchain wallets and external cryptocurrency wallets within the Ecency ecosystem.
 
+Built and maintained by [Ecency](https://ecency.com), an open-source social platform on the Hive blockchain.
+
 ## Features
 
 - Create wallets from BIP39 seed phrases

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/ecency/vision-next.git",
     "directory": "packages/wallets"
   },
-  "homepage": "https://github.com/ecency/vision-next/tree/develop/packages/wallets",
+  "homepage": "https://ecency.com",
   "bugs": {
     "url": "https://github.com/ecency/vision-next/issues"
   },


### PR DESCRIPTION
Sets `homepage: https://ecency.com` on the four published packages (the `repository` field already carries the GitHub link, so npm keeps both) and adds a one-line maintainer link to each package README. Brand/discovery for npm and GitHub visitors; no code changes. Ships to npm with each package's next release.