### PR TITLE
fix(creator-economy): layout wrapper, svg titles, chart a11y

### DIFF
--- a/apps/web/src/app/(staticPages)/creator-economy/_components/charts.tsx
+++ b/apps/web/src/app/(staticPages)/creator-economy/_components/charts.tsx
@@ -78,16 +78,12 @@ export function ColumnChart({
                 const yTop = H - padBottom - h;
                 return (
                   <g key={s.name}>
-                    {/* aria-label instead of an svg <title> child: the page's real
-                        <title> streams late (async metadata, site-wide pattern), so
-                        naive first-title parsers would otherwise read a tooltip as
-                        the document title. Values stay visible via direct labels. */}
-                    <path
-                      d={columnPath(x, yTop, barW, h)}
-                      fill={seriesColor(si)}
-                      role="img"
-                      aria-label={`${label}${series.length > 1 ? ` ${s.name}` : ""}: ${v.toLocaleString("en-US")}`}
-                    />
+                    {/* Bare mark: no svg <title> (naive first-title parsers would
+                        read a tooltip as the document title, which streams late)
+                        and no per-mark aria (the outer svg role="img" is atomic,
+                        so children are pruned from the a11y tree). Values live in
+                        the visible cap labels and the table views. */}
+                    <path d={columnPath(x, yTop, barW, h)} fill={seriesColor(si)} aria-hidden="true" />
                     {/* direct label on the cap; text token, not series color */}
                     <text
                       x={x + barW / 2}
@@ -150,12 +146,7 @@ export function HBarChart({
             >
               {item.label.length > 26 ? `${item.label.slice(0, 25)}…` : item.label}
             </text>
-            <path
-              d={hbarPath(labelW, y, w, barH)}
-              fill="var(--ce-s1)"
-              role="img"
-              aria-label={`${item.label}: ${item.value.toLocaleString("en-US")}`}
-            />
+            <path d={hbarPath(labelW, y, w, barH)} fill="var(--ce-s1)" aria-hidden="true" />
             <text x={labelW + w + 8} y={y + barH - 3} fontSize={12} fill="var(--ce-text2)">
               {item.value.toLocaleString("en-US")}
             </text>

--- a/apps/web/src/app/(staticPages)/creator-economy/_components/charts.tsx
+++ b/apps/web/src/app/(staticPages)/creator-economy/_components/charts.tsx
@@ -78,9 +78,16 @@ export function ColumnChart({
                 const yTop = H - padBottom - h;
                 return (
                   <g key={s.name}>
-                    <path d={columnPath(x, yTop, barW, h)} fill={seriesColor(si)}>
-                      <title>{`${label}${series.length > 1 ? ` ${s.name}` : ""}: ${v.toLocaleString("en-US")}`}</title>
-                    </path>
+                    {/* aria-label instead of an svg <title> child: the page's real
+                        <title> streams late (async metadata, site-wide pattern), so
+                        naive first-title parsers would otherwise read a tooltip as
+                        the document title. Values stay visible via direct labels. */}
+                    <path
+                      d={columnPath(x, yTop, barW, h)}
+                      fill={seriesColor(si)}
+                      role="img"
+                      aria-label={`${label}${series.length > 1 ? ` ${s.name}` : ""}: ${v.toLocaleString("en-US")}`}
+                    />
                     {/* direct label on the cap; text token, not series color */}
                     <text
                       x={x + barW / 2}
@@ -143,9 +150,12 @@ export function HBarChart({
             >
               {item.label.length > 26 ? `${item.label.slice(0, 25)}…` : item.label}
             </text>
-            <path d={hbarPath(labelW, y, w, barH)} fill="var(--ce-s1)">
-              <title>{`${item.label}: ${item.value.toLocaleString("en-US")}`}</title>
-            </path>
+            <path
+              d={hbarPath(labelW, y, w, barH)}
+              fill="var(--ce-s1)"
+              role="img"
+              aria-label={`${item.label}: ${item.value.toLocaleString("en-US")}`}
+            />
             <text x={labelW + w + 8} y={y + barH - 3} fontSize={12} fill="var(--ce-text2)">
               {item.value.toLocaleString("en-US")}
             </text>

--- a/apps/web/src/app/(staticPages)/creator-economy/page.tsx
+++ b/apps/web/src/app/(staticPages)/creator-economy/page.tsx
@@ -42,9 +42,7 @@ export default async function CreatorEconomyPage() {
 
   const labels = quarters.map((q) => q.display);
   const hiveSide = (q: (typeof quarters)[number]) => q.rewards.hive + q.rewards.hp;
-  const communities = [...latest.topCommunities]
-    .sort((a, b) => b.authors - a.authors)
-    .slice(0, 8);
+  const communities = [...latest.topCommunities].sort((a, b) => b.authors - a.authors).slice(0, 8);
 
   const jsonLd = [
     buildDatasetJsonLd({
@@ -67,178 +65,183 @@ export default async function CreatorEconomyPage() {
       <JsonLd data={jsonLd} />
       <style dangerouslySetInnerHTML={{ __html: VIZ_VARS }} />
 
-      <div className="app-content static-page ce-viz max-w-[860px] mx-auto px-4 pb-16">
-        <h1 className="text-3xl md:text-4xl font-bold mt-8">{t("title")}</h1>
-        <p className="mt-3 text-gray-600 dark:text-gray-400">{t("intro")}</p>
-        <p className="mt-1 text-sm text-gray-500">{t("updated", { q: latest.display })}</p>
+      {/* .app-content is display:flex (site-wide); static pages render their
+          content inside a single .static-content child (margin:auto, 800px),
+          exactly like /faq — otherwise every section becomes a flex column. */}
+      <div className="app-content static-page ce-viz">
+        <div className="static-content pb-16">
+          <h1 className="text-3xl md:text-4xl font-bold mt-8">{t("title")}</h1>
+          <p className="mt-3 text-gray-600 dark:text-gray-400">{t("intro")}</p>
+          <p className="mt-1 text-sm text-gray-500">{t("updated", { q: latest.display })}</p>
 
-        {/* KPI row, latest quarter */}
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mt-6">
-          <StatTile
-            label={t("tile-authors")}
-            value={formatFull(latest.rewards.authors)}
-            delta={deltaPct(latest.rewards.authors, prev?.rewards.authors)}
-          />
-          <StatTile
-            label={t("tile-rewards")}
-            value={`${formatCompact(hiveSide(latest))} HIVE`}
-            delta={deltaPct(hiveSide(latest), prev ? hiveSide(prev) : null)}
-          />
-          <StatTile
-            label={t("tile-usd")}
-            value={latest.rewards.usd ? `$${formatFull(latest.rewards.usd)}` : "n/a"}
-            delta={deltaPct(latest.rewards.usd ?? 0, prev?.rewards.usd)}
-          />
-          <StatTile
-            label={t("tile-posts")}
-            value={formatFull(latest.content.posts)}
-            delta={deltaPct(latest.content.posts, prev?.content.posts)}
-          />
-        </div>
+          {/* KPI row, latest quarter */}
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mt-6">
+            <StatTile
+              label={t("tile-authors")}
+              value={formatFull(latest.rewards.authors)}
+              delta={deltaPct(latest.rewards.authors, prev?.rewards.authors)}
+            />
+            <StatTile
+              label={t("tile-rewards")}
+              value={`${formatCompact(hiveSide(latest))} HIVE`}
+              delta={deltaPct(hiveSide(latest), prev ? hiveSide(prev) : null)}
+            />
+            <StatTile
+              label={t("tile-usd")}
+              value={latest.rewards.usd ? `$${formatFull(latest.rewards.usd)}` : "n/a"}
+              delta={deltaPct(latest.rewards.usd ?? 0, prev?.rewards.usd)}
+            />
+            <StatTile
+              label={t("tile-posts")}
+              value={formatFull(latest.content.posts)}
+              delta={deltaPct(latest.content.posts, prev?.content.posts)}
+            />
+          </div>
 
-        <section className="mt-10">
-          <h2 className="text-xl font-semibold mb-3">{t("chart-usd")}</h2>
-          <ColumnChart
-            labels={labels}
-            series={[{ name: "USD", values: quarters.map((q) => q.rewards.usd ?? 0) }]}
-            ariaLabel={t("chart-usd")}
-            valueFormatter={(n) => `$${formatCompact(n)}`}
-          />
-        </section>
+          <section className="mt-10">
+            <h2 className="text-xl font-semibold mb-3">{t("chart-usd")}</h2>
+            <ColumnChart
+              labels={labels}
+              series={[{ name: "USD", values: quarters.map((q) => q.rewards.usd ?? 0) }]}
+              ariaLabel={t("chart-usd")}
+              valueFormatter={(n) => `$${formatCompact(n)}`}
+            />
+          </section>
 
-        <section className="mt-10">
-          <h2 className="text-xl font-semibold mb-3">{t("chart-authors")}</h2>
-          <ColumnChart
-            labels={labels}
-            series={[{ name: t("tile-authors"), values: quarters.map((q) => q.rewards.authors) }]}
-            ariaLabel={t("chart-authors")}
-          />
-        </section>
+          <section className="mt-10">
+            <h2 className="text-xl font-semibold mb-3">{t("chart-authors")}</h2>
+            <ColumnChart
+              labels={labels}
+              series={[{ name: t("tile-authors"), values: quarters.map((q) => q.rewards.authors) }]}
+              ariaLabel={t("chart-authors")}
+            />
+          </section>
 
-        <section className="mt-10">
-          <h2 className="text-xl font-semibold mb-3">{t("chart-content")}</h2>
-          <ColumnChart
-            labels={labels}
-            series={[
-              { name: t("series-posts"), values: quarters.map((q) => q.content.posts) },
-              { name: t("series-comments"), values: quarters.map((q) => q.content.comments) }
-            ]}
-            ariaLabel={t("chart-content")}
-          />
-        </section>
+          <section className="mt-10">
+            <h2 className="text-xl font-semibold mb-3">{t("chart-content")}</h2>
+            <ColumnChart
+              labels={labels}
+              series={[
+                { name: t("series-posts"), values: quarters.map((q) => q.content.posts) },
+                { name: t("series-comments"), values: quarters.map((q) => q.content.comments) }
+              ]}
+              ariaLabel={t("chart-content")}
+            />
+          </section>
 
-        <section className="mt-10">
-          <h2 className="text-xl font-semibold mb-1">
-            {t("communities-title", { q: latest.display })}
-          </h2>
-          <p className="text-sm text-gray-500 mb-3">{t("communities-note")}</p>
-          <HBarChart
-            items={communities.map((c) => ({ label: c.title, value: c.authors }))}
-            ariaLabel={t("communities-title", { q: latest.display })}
-          />
-          {/* Table view for the chart (accessibility relief), full top-12 list */}
-          <table className="w-full text-sm mt-4">
-            <thead>
-              <tr className="text-left border-b border-[--border-color] text-gray-500">
-                <th className="py-2 pr-3">{t("th-community")}</th>
-                <th className="py-2 pr-3 text-right">{t("th-authors-count")}</th>
-                <th className="py-2 text-right">{t("th-posts-count")}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {[...latest.topCommunities]
-                .sort((a, b) => b.authors - a.authors)
-                .map((c) => (
-                  <tr key={c.id} className="border-b border-[--border-color]">
-                    <td className="py-2 pr-3">{c.title}</td>
-                    <td className="py-2 pr-3 text-right">{formatFull(c.authors)}</td>
-                    <td className="py-2 text-right">{formatFull(c.posts)}</td>
+          <section className="mt-10">
+            <h2 className="text-xl font-semibold mb-1">
+              {t("communities-title", { q: latest.display })}
+            </h2>
+            <p className="text-sm text-gray-500 mb-3">{t("communities-note")}</p>
+            <HBarChart
+              items={communities.map((c) => ({ label: c.title, value: c.authors }))}
+              ariaLabel={t("communities-title", { q: latest.display })}
+            />
+            {/* Table view for the chart (accessibility relief), full top-12 list */}
+            <table className="w-full text-sm mt-4">
+              <thead>
+                <tr className="text-left border-b border-[--border-color] text-gray-500">
+                  <th className="py-2 pr-3">{t("th-community")}</th>
+                  <th className="py-2 pr-3 text-right">{t("th-authors-count")}</th>
+                  <th className="py-2 text-right">{t("th-posts-count")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[...latest.topCommunities]
+                  .sort((a, b) => b.authors - a.authors)
+                  .map((c) => (
+                    <tr key={c.id} className="border-b border-[--border-color]">
+                      <td className="py-2 pr-3">{c.title}</td>
+                      <td className="py-2 pr-3 text-right">{formatFull(c.authors)}</td>
+                      <td className="py-2 text-right">{formatFull(c.posts)}</td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </section>
+
+          <section className="mt-10">
+            <h2 className="text-xl font-semibold mb-1">
+              {t("distribution-title", { q: latest.display })}
+            </h2>
+            <p className="text-sm text-gray-500 mb-3">{t("distribution-note")}</p>
+            <table className="w-full text-sm">
+              <tbody>
+                <tr className="border-b border-[--border-color]">
+                  <td className="py-2">{t("dist-median")}</td>
+                  <td className="py-2 text-right font-medium">
+                    {formatFull(Math.round(latest.perAuthorHp.median))} HP
+                  </td>
+                </tr>
+                <tr className="border-b border-[--border-color]">
+                  <td className="py-2">{t("dist-p90")}</td>
+                  <td className="py-2 text-right font-medium">
+                    {formatFull(Math.round(latest.perAuthorHp.p90))} HP
+                  </td>
+                </tr>
+                <tr className="border-b border-[--border-color]">
+                  <td className="py-2">{t("dist-p99")}</td>
+                  <td className="py-2 text-right font-medium">
+                    {formatFull(Math.round(latest.perAuthorHp.p99))} HP
+                  </td>
+                </tr>
+                <tr>
+                  <td className="py-2">{t("dist-max")}</td>
+                  <td className="py-2 text-right font-medium">
+                    {formatFull(Math.round(latest.perAuthorHp.max))} HP
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          {/* Full-precision table: the accessible/table view for every chart above */}
+          <section className="mt-10 overflow-x-auto">
+            <h2 className="text-xl font-semibold mb-3">{t("quarters-title")}</h2>
+            <table className="w-full text-sm whitespace-nowrap">
+              <thead>
+                <tr className="text-left border-b border-[--border-color] text-gray-500">
+                  <th className="py-2 pr-3">{t("th-quarter")}</th>
+                  <th className="py-2 pr-3 text-right">{t("th-authors")}</th>
+                  <th className="py-2 pr-3 text-right">{t("th-hbd")}</th>
+                  <th className="py-2 pr-3 text-right">{t("th-hive")}</th>
+                  <th className="py-2 pr-3 text-right">{t("th-hp")}</th>
+                  <th className="py-2 pr-3 text-right">{t("th-usd")}</th>
+                  <th className="py-2 pr-3 text-right">{t("th-posts")}</th>
+                  <th className="py-2 text-right">{t("th-comments")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {quarters.map((q) => (
+                  <tr key={q.label} className="border-b border-[--border-color]">
+                    <td className="py-2 pr-3">{q.display}</td>
+                    <td className="py-2 pr-3 text-right">{formatFull(q.rewards.authors)}</td>
+                    <td className="py-2 pr-3 text-right">{formatFull(q.rewards.hbd)}</td>
+                    <td className="py-2 pr-3 text-right">{formatFull(q.rewards.hive)}</td>
+                    <td className="py-2 pr-3 text-right">{formatFull(q.rewards.hp)}</td>
+                    <td className="py-2 pr-3 text-right">
+                      {q.rewards.usd ? `$${formatFull(q.rewards.usd)}` : "n/a"}
+                    </td>
+                    <td className="py-2 pr-3 text-right">{formatFull(q.content.posts)}</td>
+                    <td className="py-2 text-right">{formatFull(q.content.comments)}</td>
                   </tr>
                 ))}
-            </tbody>
-          </table>
-        </section>
+              </tbody>
+            </table>
+          </section>
 
-        <section className="mt-10">
-          <h2 className="text-xl font-semibold mb-1">
-            {t("distribution-title", { q: latest.display })}
-          </h2>
-          <p className="text-sm text-gray-500 mb-3">{t("distribution-note")}</p>
-          <table className="w-full text-sm">
-            <tbody>
-              <tr className="border-b border-[--border-color]">
-                <td className="py-2">{t("dist-median")}</td>
-                <td className="py-2 text-right font-medium">
-                  {formatFull(Math.round(latest.perAuthorHp.median))} HP
-                </td>
-              </tr>
-              <tr className="border-b border-[--border-color]">
-                <td className="py-2">{t("dist-p90")}</td>
-                <td className="py-2 text-right font-medium">
-                  {formatFull(Math.round(latest.perAuthorHp.p90))} HP
-                </td>
-              </tr>
-              <tr className="border-b border-[--border-color]">
-                <td className="py-2">{t("dist-p99")}</td>
-                <td className="py-2 text-right font-medium">
-                  {formatFull(Math.round(latest.perAuthorHp.p99))} HP
-                </td>
-              </tr>
-              <tr>
-                <td className="py-2">{t("dist-max")}</td>
-                <td className="py-2 text-right font-medium">
-                  {formatFull(Math.round(latest.perAuthorHp.max))} HP
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </section>
-
-        {/* Full-precision table: the accessible/table view for every chart above */}
-        <section className="mt-10 overflow-x-auto">
-          <h2 className="text-xl font-semibold mb-3">{t("quarters-title")}</h2>
-          <table className="w-full text-sm whitespace-nowrap">
-            <thead>
-              <tr className="text-left border-b border-[--border-color] text-gray-500">
-                <th className="py-2 pr-3">{t("th-quarter")}</th>
-                <th className="py-2 pr-3 text-right">{t("th-authors")}</th>
-                <th className="py-2 pr-3 text-right">{t("th-hbd")}</th>
-                <th className="py-2 pr-3 text-right">{t("th-hive")}</th>
-                <th className="py-2 pr-3 text-right">{t("th-hp")}</th>
-                <th className="py-2 pr-3 text-right">{t("th-usd")}</th>
-                <th className="py-2 pr-3 text-right">{t("th-posts")}</th>
-                <th className="py-2 text-right">{t("th-comments")}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {quarters.map((q) => (
-                <tr key={q.label} className="border-b border-[--border-color]">
-                  <td className="py-2 pr-3">{q.display}</td>
-                  <td className="py-2 pr-3 text-right">{formatFull(q.rewards.authors)}</td>
-                  <td className="py-2 pr-3 text-right">{formatFull(q.rewards.hbd)}</td>
-                  <td className="py-2 pr-3 text-right">{formatFull(q.rewards.hive)}</td>
-                  <td className="py-2 pr-3 text-right">{formatFull(q.rewards.hp)}</td>
-                  <td className="py-2 pr-3 text-right">
-                    {q.rewards.usd ? `$${formatFull(q.rewards.usd)}` : "n/a"}
-                  </td>
-                  <td className="py-2 pr-3 text-right">{formatFull(q.content.posts)}</td>
-                  <td className="py-2 text-right">{formatFull(q.content.comments)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </section>
-
-        <section className="mt-10">
-          <h2 className="text-xl font-semibold mb-3">{t("methodology-title")}</h2>
-          <ul className="list-disc pl-5 space-y-2 text-sm text-gray-600 dark:text-gray-400">
-            <li>{t("methodology-1")}</li>
-            <li>{t("methodology-2")}</li>
-            <li>{t("methodology-3")}</li>
-            <li>{t("methodology-4")}</li>
-            <li>{t("methodology-5")}</li>
-          </ul>
-        </section>
+          <section className="mt-10">
+            <h2 className="text-xl font-semibold mb-3">{t("methodology-title")}</h2>
+            <ul className="list-disc pl-5 space-y-2 text-sm text-gray-600 dark:text-gray-400">
+              <li>{t("methodology-1")}</li>
+              <li>{t("methodology-2")}</li>
+              <li>{t("methodology-3")}</li>
+              <li>{t("methodology-4")}</li>
+              <li>{t("methodology-5")}</li>
+            </ul>
+          </section>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
Post-launch fixes for /creator-economy, found on staging:

- **Broken layout (main fix)**: .app-content is display:flex site-wide, so the page's sections rendered as horizontal columns. Static pages put their content inside a single .static-content child (like /faq); adopted the same wrapper. Verified against the deployed compiled CSS via headless render, light and dark.
- svg title tooltips were the first title tags in raw HTML (the document title streams late); naive first-title parsers could read a tooltip as the page title. Replaced with bare aria-hidden marks inside the atomic role=img svg (also resolves the nested-role and label-format review findings). Values remain via direct labels and table views.