### PR TITLE
feat(ui): micro-interaction animation polish

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -84,9 +84,12 @@ export function ProfileCard({ account }: Props) {
           onError={() => setImageSrc("/assets/promote-wave-bg.jpg")}
       />
 
+      {/* Overlaid on the cover (like ProfileInfo) — the relationship loads
+          async, so an in-flow badge would shift the whole card down when it
+          appears. */}
       {!isMyProfile && relationshipBetweenAccounts?.follows && (
-        <div className="animate-pop-in">
-          <Badge className="relative z-10">{i18next.t("profile.follows-you")}</Badge>
+        <div className="absolute z-10 left-4 top-4 animate-pop-in">
+          <Badge>{i18next.t("profile.follows-you")}</Badge>
         </div>
       )}
       <div className="absolute z-10 right-4 top-4">

--- a/apps/web/src/app/(staticPages)/faq/_components/faq-category/faq-category-client.tsx
+++ b/apps/web/src/app/(staticPages)/faq/_components/faq-category/faq-category-client.tsx
@@ -5,7 +5,7 @@ import { Accordion, AccordionCollapse, AccordionToggle } from "@ui/accordion";
 import { Tooltip } from "@ui/tooltip";
 import i18next from "i18next";
 import { Button } from "@ui/button";
-import { chevronDownSvgForSlider, chevronUpSvgForSlider } from "@ui/svg";
+import { chevronDownSvgForSlider } from "@ui/svg";
 
 interface Props {
   categoryTitle: string;
@@ -47,7 +47,8 @@ export function FaqCategoryClient({ contentList, categoryTitle }: Props) {
                   onClick={() => {
                     setExpanded?.(!expanded);
                   }}
-                  icon={expanded ? chevronUpSvgForSlider : chevronDownSvgForSlider}
+                  icon={chevronDownSvgForSlider}
+                  iconClassName="transition-transform duration-200 [[data-open=true]_&]:rotate-180"
                 />
               </Tooltip>
             </div>

--- a/apps/web/src/app/decks/_components/_deck.scss
+++ b/apps/web/src/app/decks/_components/_deck.scss
@@ -349,7 +349,8 @@
       }
 
       > * {
-        animation: skeleton-loader 1s infinite;
+        position: relative;
+        overflow: hidden;
 
         @include themify(day) {
           @apply bg-gray-200;
@@ -357,6 +358,21 @@
 
         @include themify(night) {
           @apply bg-dark-200;
+        }
+
+        &::after {
+          content: "";
+          position: absolute;
+          inset: 0;
+          background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.35), transparent);
+          transform: translateX(-100%);
+          animation: anim-shimmer 1.4s ease-in-out infinite;
+        }
+
+        @include themify(night) {
+          &::after {
+            background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.06), transparent);
+          }
         }
       }
 
@@ -405,21 +421,6 @@
       }
     }
 
-    @include themify(day) {
-      @keyframes skeleton-loader {
-        0% {
-          background-color: $pagination-border-color;
-        }
-
-        50% {
-          background-color: $pagination-hover-bg;
-        }
-
-        100% {
-          background-color: $pagination-border-color;
-        }
-      }
-    }
   }
 
   .transaction-list-item {

--- a/apps/web/src/app/decks/_components/columns/deck-items/_index.scss
+++ b/apps/web/src/app/decks/_components/columns/deck-items/_index.scss
@@ -266,23 +266,10 @@
         .title {
           @include font-size(1.125rem);
 
-          @keyframes thread-post-item-skeleton-loader {
-            0% {
-              background-color: rgba($primary, 0.15);
-            }
-
-            50% {
-              background-color: rgba($primary, 0.2);
-            }
-
-            100% {
-              background-color: rgba($primary, 0.15);
-            }
-          }
-
           &.loading {
             height: 27px;
-            animation: thread-post-item-skeleton-loader 1s infinite;
+            // shimmer mixin comes from the imported waves thread-render styles
+            @include thread-render-skeleton;
           }
         }
 
@@ -293,7 +280,7 @@
 
           &.loading {
             height: 2rem;
-            animation: thread-post-item-skeleton-loader 1s infinite;
+            @include thread-render-skeleton;
           }
         }
       }

--- a/apps/web/src/app/decks/_components/header/deck-header-settings-item.tsx
+++ b/apps/web/src/app/decks/_components/header/deck-header-settings-item.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "@ui/button";
 import { Accordion, AccordionCollapse, AccordionToggle } from "@ui/accordion";
-import { chevronDownSvgForSlider, chevronUpSvgForSlider } from "@ui/svg";
+import { chevronDownSvgForSlider } from "@ui/svg";
 
 interface Props {
   title: string;
@@ -27,7 +27,8 @@ export const DeckHeaderSettingsItem = ({ title, children, hasBorderBottom, class
         appearance="link"
         className="justify-between w-full toggle"
         onClick={() => setExpanded(!expanded)}
-        icon={expanded ? chevronUpSvgForSlider : chevronDownSvgForSlider}
+        icon={chevronDownSvgForSlider}
+        iconClassName="transition-transform duration-200 [[data-open=true]_&]:rotate-180"
       >
         {title}
       </AccordionToggle>

--- a/apps/web/src/app/decks/_components/header/deck-header.tsx
+++ b/apps/web/src/app/decks/_components/header/deck-header.tsx
@@ -1,10 +1,5 @@
 import React, { JSX, useState } from "react";
-import {
-  chevronDownSvgForSlider,
-  chevronUpSvgForSlider,
-  deleteForeverSvg,
-  dragSvg
-} from "@/assets/img/svg";
+import { chevronDownSvgForSlider, deleteForeverSvg, dragSvg } from "@/assets/img/svg";
 import { DeckHeaderSettings } from "./deck-header-settings";
 import { DeckHeaderReloading } from "./deck-header-reloading";
 import { DraggableProvidedDragHandleProps } from "@hello-pangea/dnd";
@@ -77,11 +72,11 @@ export const DeckHeader = (props: Props | WithIntervalProps | WithDeletionProps 
               eventKey="0"
               noPadding={true}
               className="accordion-toggle"
-              iconClassName="justify-end"
+              iconClassName="justify-end transition-transform duration-200 [[data-open=true]_&]:rotate-180"
               onClick={() => {
                 setExpanded(!expanded);
               }}
-              icon={expanded ? chevronUpSvgForSlider : chevronDownSvgForSlider}
+              icon={chevronDownSvgForSlider}
             />
           </Tooltip>
         </div>

--- a/apps/web/src/app/market/advanced/_components/market-advanced-mode-widget-header.tsx
+++ b/apps/web/src/app/market/advanced/_components/market-advanced-mode-widget-header.tsx
@@ -1,7 +1,7 @@
 import React, { JSX } from "react";
 import { Button } from "@ui/button";
 import { Accordion, AccordionCollapse, AccordionToggle } from "@ui/accordion";
-import { chevronDownSvgForSlider, chevronUpSvgForSlider } from "@ui/svg";
+import { chevronDownSvgForSlider } from "@ui/svg";
 
 interface Props {
   title?: string | JSX.Element;
@@ -49,7 +49,8 @@ export const MarketAdvancedModeWidgetHeader = ({
               eventKey="0"
               noPadding={true}
               onClick={() => setExpandedHeader(!expandedHeader)}
-              icon={expandedHeader ? chevronUpSvgForSlider : chevronDownSvgForSlider}
+              icon={chevronDownSvgForSlider}
+              iconClassName="transition-transform duration-200 [[data-open=true]_&]:rotate-180"
             />
           ) : (
             <></>

--- a/apps/web/src/app/waves/_components/waves-list-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-item.tsx
@@ -40,6 +40,9 @@ interface Props {
   now?: number;
   currentHost?: string;
   feedType?: WavesFeedType;
+  className?: string;
+  style?: React.CSSProperties;
+  onAnimationEnd?: React.AnimationEventHandler<HTMLDivElement>;
 }
 
 export const WavesListItem = React.memo(function WavesListItem({
@@ -49,7 +52,10 @@ export const WavesListItem = React.memo(function WavesListItem({
   interactable = true,
   now,
   currentHost,
-  feedType
+  feedType,
+  className,
+  style,
+  onAnimationEnd
 }: Props) {
   const { activeUser } = useActiveAccount();
 
@@ -260,13 +266,16 @@ export const WavesListItem = React.memo(function WavesListItem({
         "waves-list-item bg-white dark:bg-dark-200 relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-dark-sky",
         "border-b border-[--border-color] last:border-b-0",
         isMuted && "grayscale opacity-50",
-        interactable && "cursor-pointer"
+        interactable && "cursor-pointer",
+        className
       )}
+      style={style}
       role={interactable ? "link" : undefined}
       tabIndex={interactable ? 0 : -1}
       onClick={onClick}
       onAuxClick={onAuxClick}
       onKeyDown={onKeyDown}
+      onAnimationEnd={onAnimationEnd}
     >
       {hasPromoted && (
         <div className="text-xs font-semibold uppercase rounded-br-lg px-1 rounded-tl-lg bg-blue-dark-sky text-white absolute top-[-1px] left-[-1px]">

--- a/apps/web/src/app/waves/_components/waves-list-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-view.tsx
@@ -4,7 +4,7 @@ import { getWavesFeedQueryOptions } from "@ecency/sdk";
 import { WavesListItem } from "@/app/waves/_components/waves-list-item";
 import { DetectBottom } from "@/features/shared";
 import { WavesListLoader } from "@/app/waves/_components/waves-list-loader";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteDataFlow } from "@/utils";
 import { useWavesAutoRefresh } from "@/app/waves/_hooks";
 import { WavesRefreshPopup } from "@/app/waves/_components";
@@ -115,6 +115,23 @@ export function WavesListView({ feedType, username }: Props) {
   }, [dataFlow, promoted, tag, selectedSource]);
 
   const [replyingEntry, setReplyingEntry] = useState<WaveEntry>();
+  // Keys of waves prepended via the refresh popup AFTER the initial render —
+  // only these get the entrance animation. The initial feed (and older pages
+  // appended by infinite scroll) must stay instant, so we scope the guard to
+  // the popup-insert path instead of keying off "not seen on first render".
+  const [freshKeys, setFreshKeys] = useState<Set<string>>(() => new Set());
+  const clearFreshKey = useCallback((key: string) => {
+    // Drop the key once its entrance finishes so a key-stable remount (e.g.
+    // toggling a tag filter) doesn't replay the animation.
+    setFreshKeys((prev) => {
+      if (!prev.has(key)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+  }, []);
   const shouldAutoRefresh = feedType === "for-you" && !tag && !selectedSource;
   const { newWaves, clear, now } = useWavesAutoRefresh(
     shouldAutoRefresh ? dataFlow[0] : undefined,
@@ -214,25 +231,32 @@ export function WavesListView({ feedType, username }: Props) {
               return;
             }
 
+            // A wave is uniquely identified by author + permlink (entry.id is
+            // not reliable across the feed sources).
+            const keyOf = (entry: WaveEntry) => `${entry.author}/${entry.permlink}`;
+            // Collected inside the cache updater so only genuinely-new (deduped)
+            // waves get the entrance animation.
+            const insertedKeys: string[] = [];
+
             queryClient.setQueryData<InfiniteData<WaveEntry[], string | undefined>>(
               wavesQueryKey,
               (prev) => {
                 if (!prev) {
+                  insertedKeys.push(...wavesToInsert.map(keyOf));
                   return {
                     pages: [wavesToInsert],
                     pageParams: [undefined]
                   };
                 }
 
-                // A wave is uniquely identified by author + permlink (entry.id is
-                // not reliable across the feed sources).
-                const keyOf = (entry: WaveEntry) => `${entry.author}/${entry.permlink}`;
                 const existingKeys = new Set(prev.pages.flatMap((page) => page.map(keyOf)));
                 const deduped = wavesToInsert.filter((entry) => !existingKeys.has(keyOf(entry)));
 
                 if (deduped.length === 0) {
                   return prev;
                 }
+
+                insertedKeys.push(...deduped.map(keyOf));
 
                 const [firstPage = [], ...restPages] = prev.pages;
 
@@ -243,22 +267,46 @@ export function WavesListView({ feedType, username }: Props) {
               }
             );
 
+            if (insertedKeys.length > 0) {
+              setFreshKeys((prev) => {
+                const next = new Set(prev);
+                insertedKeys.forEach((key) => next.add(key));
+                return next;
+              });
+            }
+
             clear();
             window.scrollTo({ top: 0, behavior: "smooth" });
             void refetch();
           }}
         />
       )}
-      {combinedDataFlow.map((item, i) => (
-        <WavesListItem
-          key={`${item.author}/${item.permlink}`}
-          i={i}
-          item={item}
-          onExpandReplies={() => setReplyingEntry(item)}
-          now={now}
-          feedType={feedType}
-        />
-      ))}
+      {combinedDataFlow.map((item, i) => {
+        const itemKey = `${item.author}/${item.permlink}`;
+        const isFresh = freshKeys.has(itemKey);
+        return (
+          <WavesListItem
+            key={itemKey}
+            i={i}
+            item={item}
+            onExpandReplies={() => setReplyingEntry(item)}
+            now={now}
+            feedType={feedType}
+            className={isFresh ? "animate-fade-in-up" : undefined}
+            style={isFresh ? { animationDelay: `${Math.min(i, 4) * 50}ms` } : undefined}
+            onAnimationEnd={
+              isFresh
+                ? (e) => {
+                    // Child animations bubble; only the item's own entrance counts.
+                    if (e.target === e.currentTarget) {
+                      clearFreshKey(itemKey);
+                    }
+                  }
+                : undefined
+            }
+          />
+        );
+      })}
 
       <WavesListLoader data={dataFlow} failed={isError} isEndReached={!hasNextPage} />
       {shouldShowDetectBottom && <DetectBottom onBottom={() => fetchNextPage()} />}

--- a/apps/web/src/app/waves/_components/waves-list-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-view.tsx
@@ -242,7 +242,9 @@ export function WavesListView({ feedType, username }: Props) {
               wavesQueryKey,
               (prev) => {
                 if (!prev) {
-                  insertedKeys.push(...wavesToInsert.map(keyOf));
+                  // Empty cache (evicted while the page was open): this seeds
+                  // the whole visible feed, which is an initial render — no
+                  // entrance animation for any of it.
                   return {
                     pages: [wavesToInsert],
                     pageParams: [undefined]

--- a/apps/web/src/features/shared/bookmark-btn/index.tsx
+++ b/apps/web/src/features/shared/bookmark-btn/index.tsx
@@ -13,7 +13,7 @@ import { NotificationBadgeIcon } from "../notification-badge-icon";
 import { Button } from "@ui/button";
 import { Tooltip } from "@ui/tooltip";
 import i18next from "i18next";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import "./_index.scss";
 import { error, success } from "../feedback";
 import { getAccessToken } from "@/utils";
@@ -44,22 +44,35 @@ export function BookmarkBtn({ entry }: Props) {
     return bookmark?._id;
   }, [bookmarks, entry.author, entry.permlink]);
 
+  // Transient success cue: set only in the mutation success callbacks and
+  // cleared on animationend, so the pulse never fires on initial render.
+  const [bookmarkDone, setBookmarkDone] = useState(false);
+
   const { mutateAsync: addBookmark, isPending: isAdding } = useBookmarkAdd(
     username,
     accessToken,
-    () => success(i18next.t("bookmark-btn.added")),
+    () => {
+      success(i18next.t("bookmark-btn.added"));
+      setBookmarkDone(true);
+    },
     () => error(i18next.t("g.server-error"))
   );
   const { mutateAsync: deleteBookmark, isPending: isDeleting } = useBookmarkDelete(
     username,
     accessToken,
-    () => success(i18next.t("bookmark-btn.deleted")),
+    () => {
+      success(i18next.t("bookmark-btn.deleted"));
+      setBookmarkDone(true);
+    },
     () => error(i18next.t("g.server-error"))
   );
 
   const bookmarkIcon = (
     <NotificationBadgeIcon>
-      <UilBookmark />
+      <UilBookmark
+        className={bookmarkDone ? "animate-success-pulse" : undefined}
+        onAnimationEnd={() => setBookmarkDone(false)}
+      />
     </NotificationBadgeIcon>
   );
 

--- a/apps/web/src/features/shared/discussion/discussion-item.tsx
+++ b/apps/web/src/features/shared/discussion/discussion-item.tsx
@@ -395,30 +395,37 @@ export const DiscussionItem = memo(function DiscussionItem({
         </div>
       </div>
 
+      {/* reply/edit start false and only flip on user action, so the entrance
+          animation never fires on initial render. The wrapper also masks the
+          dynamic-import seam while the lazy composer chunk loads. */}
       {reply && (
-        <Comment
-          entry={entry}
-          submitText={i18next.t("g.reply")}
-          cancellable
-          onSubmit={submitReply}
-          onCancel={toggleReply}
-          inProgress={isCreateLoading || isUpdateReplyLoading}
-          autoFocus
-          initialText={failedReplyText}
-        />
+        <div className="animate-fade-in-up">
+          <Comment
+            entry={entry}
+            submitText={i18next.t("g.reply")}
+            cancellable
+            onSubmit={submitReply}
+            onCancel={toggleReply}
+            inProgress={isCreateLoading || isUpdateReplyLoading}
+            autoFocus
+            initialText={failedReplyText}
+          />
+        </div>
       )}
 
       {edit && (
-        <Comment
-          entry={entry}
-          isEdit
-          submitText={i18next.t("g.update")}
-          cancellable
-          onSubmit={_updateReply}
-          onCancel={toggleEdit}
-          inProgress={isCreateLoading || isUpdateReplyLoading}
-          autoFocus
-        />
+        <div className="animate-fade-in-up">
+          <Comment
+            entry={entry}
+            isEdit
+            submitText={i18next.t("g.update")}
+            cancellable
+            onSubmit={_updateReply}
+            onCancel={toggleEdit}
+            inProgress={isCreateLoading || isUpdateReplyLoading}
+            autoFocus
+          />
+        </div>
       )}
 
       {showSubList && (

--- a/apps/web/src/features/shared/entry-list-loading-item/_index.scss
+++ b/apps/web/src/features/shared/entry-list-loading-item/_index.scss
@@ -2,7 +2,6 @@
 
 .entry-list-loading-item {
   @include clearfix();
-  animation: anim-fadein-out 2s infinite;
 
   margin-top: 20px;
   padding: 0 0 16px 6px;
@@ -26,6 +25,8 @@
   .item-body .item-summary *,
   .item-body .item-controls * {
     border-radius: 10px;
+    position: relative;
+    overflow: hidden;
 
     @include themify(day) {
       @apply bg-light-light-405;
@@ -33,6 +34,21 @@
 
     @include themify(night) {
       @apply bg-dark-default;
+    }
+
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.35), transparent);
+      transform: translateX(-100%);
+      animation: anim-shimmer 1.4s ease-in-out infinite;
+    }
+
+    @include themify(night) {
+      &::after {
+        background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.06), transparent);
+      }
     }
   }
 

--- a/apps/web/src/features/shared/entry-payout/index.tsx
+++ b/apps/web/src/features/shared/entry-payout/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import "./_index.scss";
 import { Popover, PopoverContent } from "@ui/popover";
 import { EntryPayoutDetail } from "@/features/shared/entry-payout/entry-payout-detail";
@@ -59,6 +59,21 @@ export const EntryPayout = ({ entry: initialEntry }: Props) => {
     shownPayout = entry.payout;
   }
 
+  // Ref guard for the payout tick: remember the first-seen value (per entry,
+  // so list-recycled instances never tick for a different post) and animate
+  // only when the payout changes after mount — never on first paint.
+  const payoutKey = `${entry.author}/${entry.permlink}`;
+  const firstSeenPayout = useRef({ payoutKey, value: shownPayout });
+  if (firstSeenPayout.current.payoutKey !== payoutKey) {
+    firstSeenPayout.current = { payoutKey, value: shownPayout };
+  }
+  const payoutChanged = shownPayout !== firstSeenPayout.current.value;
+  const payoutFigure = (
+    <span key={shownPayout} className={payoutChanged ? "inline-block animate-tick" : undefined}>
+      <FormattedCurrency value={shownPayout ?? 0} fixAt={3} />
+    </span>
+  );
+
   return !isSearchResult ? (
     <div className="noselection">
       <Popover
@@ -73,7 +88,7 @@ export const EntryPayout = ({ entry: initialEntry }: Props) => {
               "payout-limit-hit": payoutLimitHit
             })}
           >
-            <FormattedCurrency value={shownPayout ?? 0} fixAt={3} />
+            {payoutFigure}
           </div>
         }
         behavior="hover"
@@ -93,7 +108,7 @@ export const EntryPayout = ({ entry: initialEntry }: Props) => {
         "payout-limit-hit": payoutLimitHit
       })}
     >
-      <FormattedCurrency value={shownPayout ?? 0} fixAt={3} />
+      {payoutFigure}
     </div>
   );
 };

--- a/apps/web/src/features/shared/entry-reblog-btn/_index.scss
+++ b/apps/web/src/features/shared/entry-reblog-btn/_index.scss
@@ -47,6 +47,14 @@
     }
   }
 
+  // Success cue after a confirmed reblog broadcast: transient class set by the
+  // component (never present on initial render), removed on animationend.
+  &.reblog-done {
+    svg {
+      animation: anim-rotate-once 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+  }
+
   &.in-progress {
     .inner-btn {
       animation: anim-fadein-out 5s infinite;

--- a/apps/web/src/features/shared/entry-reblog-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-reblog-btn/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import "./_index.scss";
 import { Entry } from "@/entities";
 import { PopoverConfirm } from "@/features/ui";
@@ -32,6 +32,21 @@ export function EntryReblogBtn({ entry }: Props) {
         [activeUser, data, reblogs]
     );
 
+    // Transient success cue: set only after a reblog broadcast succeeds and
+    // cleared on animationend, so the spin never fires on initial render.
+    const [reblogDone, setReblogDone] = useState(false);
+
+    const reblogsCount = data?.reblogs && data.reblogs > 0 ? data.reblogs : 0;
+    // Ref guard for the count tick: remember the first-seen count (per entry,
+    // since a button instance can be reused for another post) and only animate
+    // when the displayed number changes after mount — never on first paint.
+    const entryKey = `${entry.author}/${entry.permlink}`;
+    const firstSeenCount = useRef({ entryKey, count: reblogsCount });
+    if (firstSeenCount.current.entryKey !== entryKey) {
+        firstSeenCount.current = { entryKey, count: reblogsCount };
+    }
+    const countChanged = reblogsCount !== firstSeenCount.current.count;
+
     const reblogLabel = reblogged
         ? i18next.t("entry-reblog.delete-reblog")
         : i18next.t("entry-reblog.reblog");
@@ -40,7 +55,12 @@ export function EntryReblogBtn({ entry }: Props) {
         <div
             className={`entry-reblog-btn ${reblogged ? "reblogged" : ""} ${
                 isPending ? "in-progress" : ""
-            }`}
+            } ${reblogDone ? "reblog-done" : ""}`}
+            onAnimationEnd={(e) => {
+                // The count tick's animationend bubbles here too — clearing on it
+                // would cut the icon spin short, so match the spin by name.
+                if (e.animationName === "anim-rotate-once") setReblogDone(false);
+            }}
             role="button"
             tabIndex={0}
             aria-label={reblogLabel}
@@ -65,7 +85,10 @@ export function EntryReblogBtn({ entry }: Props) {
             <Tooltip content={reblogLabel}>
                 <a className="inner-btn" aria-hidden={true}>
                     {repeatSvg}
-                    <span>{data?.reblogs && data.reblogs > 0 ? data.reblogs : ""}</span>
+                    {/* key-remount so the tick replays on every count change */}
+                    <span key={reblogsCount} className={countChanged ? "animate-tick" : undefined}>
+                        {reblogsCount > 0 ? reblogsCount : ""}
+                    </span>
                 </a>
             </Tooltip>
         </div>
@@ -77,7 +100,13 @@ export function EntryReblogBtn({ entry }: Props) {
 
     return (
     <PopoverConfirm
-        onConfirm={() => reblog({ isDelete: !!reblogged })}
+        onConfirm={() => {
+            const isDelete = !!reblogged;
+            return reblog({ isDelete }).then(() => {
+                // Celebratory spin only for a fresh reblog, not for removing one.
+                if (!isDelete) setReblogDone(true);
+            });
+        }}
         okVariant={reblogged ? "danger" : "primary"}
         titleText={
             reblogged

--- a/apps/web/src/features/shared/entry-vote-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/index.tsx
@@ -48,6 +48,9 @@ export function EntryVoteBtn({ entry: originalEntry, isPostSlider, account }: Pr
   const [dialog, setDialog] = useState(false);
   const [tipDialog, setTipDialog] = useState(false);
   const [previousVotedValue, setPreviousVotedValue] = useState<number>();
+  // Transient success cue: set only after a vote broadcast succeeds and cleared
+  // on animationend, so the pulse never fires for already-voted posts on load.
+  const [voteDone, setVoteDone] = useState(false);
 
   const { mutateAsync: voteInAPI, isPending: isVotingLoading } = useEntryVote(entry);
 
@@ -90,6 +93,7 @@ export function EntryVoteBtn({ entry: originalEntry, isPostSlider, account }: Pr
         // Close only on success — on failure keep the slider open so the user
         // can adjust and retry in place (matches the pre-existing behavior).
         setDialog(false);
+        setVoteDone(true);
       } catch (e) {
         // The broadcast was rejected (commonly the account is out of Resource
         // Credits, or an identical/duplicate vote). Surface the friendly,
@@ -217,13 +221,14 @@ export function EntryVoteBtn({ entry: originalEntry, isPostSlider, account }: Pr
                         ? "secondary-btn-done"
                         : "primary-btn"
                     : ""
-                }`}
+                } ${voteDone ? "animate-success-pulse" : ""}`}
+                onAnimationEnd={() => setVoteDone(false)}
               >
                 {chevronUpSvgForVote}
               </span>
               {dialog && entry && activeUser && (
                 <div
-                  className="tooltiptext animate-scale-in origin-top"
+                  className="tooltiptext animate-scale-in origin-top-left"
                   onClick={(e) => e.stopPropagation()}
                 >
                   <EntryVoteDialog

--- a/apps/web/src/features/shared/entry-votes/index.tsx
+++ b/apps/web/src/features/shared/entry-votes/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { ReactNode, useMemo, useState } from "react";
+import React, { ReactNode, useMemo, useRef, useState } from "react";
 import "./_index.scss";
 import { Entry } from "@/entities";
 import { Tooltip } from "@ui/tooltip";
@@ -71,6 +71,16 @@ export function EntryVotes({ entry: initialEntry, icon, hideCount = false }: Pro
 
   const countClassName = `entry-votes__count${hideCount ? " entry-votes__count--hidden" : ""}`;
 
+  // Ref guard for the count tick: remember the first-seen count (per entry, so
+  // a list-recycled instance never ticks when handed a different post) and
+  // animate only when the number changes after mount — never on first paint.
+  const entryKey = `${entry?.author}/${entry?.permlink}`;
+  const firstSeenVotes = useRef({ entryKey, count: totalVotes });
+  if (firstSeenVotes.current.entryKey !== entryKey) {
+    firstSeenVotes.current = { entryKey, count: totalVotes };
+  }
+  const countChanged = totalVotes !== firstSeenVotes.current.count;
+
   const child = (
     <>
       <div
@@ -80,7 +90,11 @@ export function EntryVotes({ entry: initialEntry, icon, hideCount = false }: Pro
       >
         {icon ?? heartSvg}
       </div>
-      <span className={countClassName} aria-hidden={hideCount}>
+      <span
+        key={totalVotes}
+        className={`${countClassName}${countChanged ? " animate-tick" : ""}`}
+        aria-hidden={hideCount}
+      >
         {totalVotes}
       </span>
     </>

--- a/apps/web/src/features/shared/feedback/feedback.tsx
+++ b/apps/web/src/features/shared/feedback/feedback.tsx
@@ -2,16 +2,55 @@
 
 import { FeedbackMessage } from "./feedback-message";
 import { FeedbackObject } from "./feedback-events";
-import { useCallback, useMemo } from "react";
+import { useMountTransition } from "@/core/hooks";
+import clsx from "clsx";
+import { useCallback, useEffect, useMemo } from "react";
 import { useMount, useSet, useUnmount } from "react-use";
 import "./_index.scss";
 
+interface FeedbackItemProps {
+  feedback: FeedbackObject;
+  live: boolean;
+  onClose: () => void;
+  onExited: () => void;
+}
+
+// Each toast owns its exit transition: `live` turns false when the toast is
+// dismissed (close button or auto-expiry), the exit classes play for 150ms,
+// then `mounted` flips false and the parent drops the item from the store.
+function FeedbackItem({ feedback, live, onClose, onExited }: FeedbackItemProps) {
+  const { mounted, open } = useMountTransition(live, 150);
+
+  useEffect(() => {
+    if (!mounted) {
+      onExited();
+    }
+  }, [mounted, onExited]);
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <div
+      className={clsx(
+        // Entrance stays the pure CSS keyframe; the transition below only
+        // becomes visible on exit (the keyframe overrides it while running).
+        "feedback-item-enter transition-[opacity,transform] duration-150 motion-reduce:transition-none",
+        open ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"
+      )}
+    >
+      <FeedbackMessage feedback={feedback} onClose={onClose} />
+    </div>
+  );
+}
+
 // Feedback is mounted on every route, so its toast entrance must stay a pure
 // CSS keyframe (see _index.scss) with zero JS on the global critical path.
-// Exit animation is intentionally absent — toasts are transient and
-// auto-dismiss, so popping out is acceptable.
+// Exit is a 150ms fade + slide-down driven per-item by useMountTransition.
 export function Feedback() {
   const [set, { add, remove }] = useSet(new Set<FeedbackObject>());
+  const [closing, { add: markClosing, remove: unmarkClosing }] = useSet(new Set<string>());
   const queue = useMemo(() => Array.from(set), [set]);
 
   const onFeedback = useCallback(
@@ -24,9 +63,16 @@ export function Feedback() {
   return (
     <div className="feedback-container">
       {queue.map((item) => (
-        <div className="feedback-item-enter" key={item.id}>
-          <FeedbackMessage feedback={item} onClose={() => remove(item)} />
-        </div>
+        <FeedbackItem
+          key={item.id}
+          feedback={item}
+          live={!closing.has(item.id)}
+          onClose={() => markClosing(item.id)}
+          onExited={() => {
+            remove(item);
+            unmarkClosing(item.id);
+          }}
+        />
       ))}
     </div>
   );

--- a/apps/web/src/features/shared/feedback/feedback.tsx
+++ b/apps/web/src/features/shared/feedback/feedback.tsx
@@ -4,7 +4,7 @@ import { FeedbackMessage } from "./feedback-message";
 import { FeedbackObject } from "./feedback-events";
 import { useMountTransition } from "@/core/hooks";
 import clsx from "clsx";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useMount, useSet, useUnmount } from "react-use";
 import "./_index.scss";
 
@@ -21,11 +21,18 @@ interface FeedbackItemProps {
 function FeedbackItem({ feedback, live, onClose, onExited }: FeedbackItemProps) {
   const { mounted, open } = useMountTransition(live, 150);
 
+  // Read onExited through a ref so the effect fires exactly once per
+  // mounted→false transition — the parent recreates the lambda every render,
+  // and a toast arriving during another's exit window would otherwise re-run
+  // the effect and double-remove from the store.
+  const onExitedRef = useRef(onExited);
+  onExitedRef.current = onExited;
+
   useEffect(() => {
     if (!mounted) {
-      onExited();
+      onExitedRef.current();
     }
-  }, [mounted, onExited]);
+  }, [mounted]);
 
   if (!mounted) {
     return null;

--- a/apps/web/src/features/shared/follow-controls/index.tsx
+++ b/apps/web/src/features/shared/follow-controls/index.tsx
@@ -10,6 +10,7 @@ import { scheduleQuestsRefresh } from "@/utils/refresh-quests";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@ui/button";
 import i18next from "i18next";
+import { useRef } from "react";
 
 interface Props {
   targetUsername: string;
@@ -20,6 +21,20 @@ interface Props {
 interface ButtonProps {
   disabled: boolean;
   following: string;
+}
+
+// Ref guard: animate the label only when the relation value CHANGES after mount.
+// The initial render (including the undefined -> loaded transition) must never animate.
+function useRelationPop(relation: boolean | undefined) {
+  const prev = useRef(relation);
+  const changed = useRef(false);
+  if (prev.current !== relation) {
+    if (prev.current !== undefined) {
+      changed.current = true;
+    }
+    prev.current = relation;
+  }
+  return changed.current;
 }
 
 function MuteButton({ disabled, following }: ButtonProps) {
@@ -41,6 +56,9 @@ function MuteButton({ disabled, following }: ButtonProps) {
     (err) => error(...formatError(err))
   );
 
+  const ignores = data === undefined ? undefined : data.ignores === true;
+  const shouldPop = useRelationPop(ignores);
+
   return activeUser?.username !== following ? (
     <LoginRequired>
       <Button
@@ -52,9 +70,14 @@ function MuteButton({ disabled, following }: ButtonProps) {
         onClick={() => updateRelation("toggle-ignore")}
         appearance={data?.ignores === true ? "secondary" : "primary"}
       >
-        {data?.ignores === true
-          ? i18next.t("entry-menu.unmute")
-          : i18next.t("entry-menu.mute")}
+        <span
+          key={String(ignores)}
+          className={shouldPop ? "inline-block animate-pop-in" : undefined}
+        >
+          {data?.ignores === true
+            ? i18next.t("entry-menu.unmute")
+            : i18next.t("entry-menu.mute")}
+        </span>
       </Button>
     </LoginRequired>
   ) : (
@@ -78,6 +101,9 @@ function FollowButton({ disabled, following }: ButtonProps) {
     (err) => error(...formatError(err))
   );
 
+  const follows = data === undefined ? undefined : data.follows === true;
+  const shouldPop = useRelationPop(follows);
+
   return (
     <LoginRequired promptOnAnon>
       <Button
@@ -87,9 +113,14 @@ function FollowButton({ disabled, following }: ButtonProps) {
         isLoading={isPending}
         onClick={() => updateRelation("toggle-follow")}
       >
-        {data?.follows
-          ? i18next.t("follow-controls.unFollow")
-          : i18next.t("follow-controls.follow")}
+        <span
+          key={String(follows)}
+          className={shouldPop ? "inline-block animate-pop-in" : undefined}
+        >
+          {data?.follows
+            ? i18next.t("follow-controls.unFollow")
+            : i18next.t("follow-controls.follow")}
+        </span>
       </Button>
     </LoginRequired>
   );

--- a/apps/web/src/features/shared/navbar/navbar-notifications-button.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-notifications-button.tsx
@@ -12,6 +12,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getNotificationsUnreadCountQueryOptions } from "@ecency/sdk";
 import { useActiveAccount } from "@/core/hooks";
 import { getAccessToken } from "@/utils";
+import { AnimationEvent, useEffect, useRef, useState } from "react";
 
 export function NavbarNotificationsButton({ onClick }: { onClick?: () => void }) {
   const { activeUser } = useActiveAccount();
@@ -25,6 +26,22 @@ export function NavbarNotificationsButton({ onClick }: { onClick?: () => void })
     )
   );
 
+  const [ringing, setRinging] = useState(false);
+  // Ref guard: remembers the first unread count seen after mount so the bell
+  // only rings when the count INCREASES while the page is open, never on load.
+  const prevUnreadRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (typeof unread !== "number") {
+      return;
+    }
+    const prev = prevUnreadRef.current;
+    prevUnreadRef.current = unread;
+    if (prev !== undefined && unread > prev) {
+      setRinging(true);
+    }
+  }, [unread]);
+
   return (
     <EcencyConfigManager.Conditional
       condition={({ visionFeatures }) => visionFeatures.notifications.enabled}
@@ -32,12 +49,21 @@ export function NavbarNotificationsButton({ onClick }: { onClick?: () => void })
       <Tooltip content={i18next.t("user-nav.notifications")}>
         <div className="notifications">
           {unread > 0 && (
-            <span className="notifications-badge notranslate">
+            // key remount re-pops the badge on every count change; playing on the
+            // initial mount is intentional here (tiny client-only badge, approved
+            // exception to the no-initial-animation rule)
+            <span key={unread} className="notifications-badge notranslate animate-pop-in">
               {unread.toString().length < 3 ? unread : "..."}
             </span>
           )}
           <Button
             icon={globalNotifications ? bellSvg : bellOffSvg}
+            iconClassName={ringing ? "animate-bell-ring" : undefined}
+            onAnimationEnd={(e: AnimationEvent) => {
+              if (e.animationName === "anim-bell-ring") {
+                setRinging(false);
+              }
+            }}
             appearance="gray-link"
             aria-label={
               unread > 0

--- a/apps/web/src/features/shared/skeleton/index.scss
+++ b/apps/web/src/features/shared/skeleton/index.scss
@@ -1,7 +1,8 @@
 @import "src/styles/vars_mixins";
 
 .skeleton {
-  animation: anim-fadein-out 2s infinite;
+  position: relative;
+  overflow: hidden;
   border-radius: 0.25rem;
 
   @include themify(night) {
@@ -10,5 +11,20 @@
 
   @include themify(day) {
     @apply bg-light-light-405;
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.35), transparent);
+    transform: translateX(-100%);
+    animation: anim-shimmer 1.4s ease-in-out infinite;
+  }
+
+  @include themify(night) {
+    &::after {
+      background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.06), transparent);
+    }
   }
 }

--- a/apps/web/src/features/ui/accordion/accordion-toggle.tsx
+++ b/apps/web/src/features/ui/accordion/accordion-toggle.tsx
@@ -17,6 +17,9 @@ export function AccordionToggle(props: Props) {
     props.as ?? "div",
     {
       ...nativeProps,
+      // Additive: expose the open state so consumers can style chevrons/carets
+      // (e.g. [[data-open=true]_&]:rotate-180) without new API surface
+      "data-open": show[props.eventKey] ?? false,
       onClick: () =>
         setShow({
           ...show,

--- a/apps/web/src/features/ui/input/input-group-copy-clipboard.tsx
+++ b/apps/web/src/features/ui/input/input-group-copy-clipboard.tsx
@@ -29,7 +29,7 @@ export function InputGroupCopyClipboard(props: Props & HTMLAttributes<HTMLElemen
         copied ? (
           <Button
             appearance="gray-link"
-            icon={<UilCheck className="w-4 h-4 text-green" />}
+            icon={<UilCheck className="w-4 h-4 text-green animate-pop-in" />}
             aria-label={i18next.t("g.copied", { defaultValue: "Copied" })}
           />
         ) : (

--- a/apps/web/src/features/ui/popover/popover-sheet.tsx
+++ b/apps/web/src/features/ui/popover/popover-sheet.tsx
@@ -9,11 +9,13 @@ interface Props {
 }
 
 export function PopoverSheet({ show, setShow, children }: PropsWithChildren<Props>) {
-  useLockBodyScroll(show);
-
   // Bottom sheet keeps a real exit slide: mounted holds it in the DOM for the
   // 250ms close transition, open drives the overlay fade + sheet position.
   const { mounted, open } = useMountTransition(show, 250);
+
+  // Keyed on mounted (not show) so the page can't scroll under the sheet
+  // while it is still sliding out.
+  useLockBodyScroll(mounted);
 
   return mounted ? (
     <>

--- a/apps/web/src/features/waves/styles/thread-render.scss
+++ b/apps/web/src/features/waves/styles/thread-render.scss
@@ -1,5 +1,27 @@
 @import "src/styles/vars_mixins";
 
+// static placeholder background + directional shimmer sweep (anim-shimmer keyframe is global)
+@mixin thread-render-skeleton {
+  position: relative;
+  overflow: hidden;
+  background-color: rgba($primary, 0.15);
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.35), transparent);
+    transform: translateX(-100%);
+    animation: anim-shimmer 1.4s ease-in-out infinite;
+  }
+
+  @include themify(night) {
+    &::after {
+      background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.06), transparent);
+    }
+  }
+}
+
 .thread-render,
 .waves-list-item {
   display: grid;
@@ -200,23 +222,9 @@
     .title {
       @include font-size(1.125rem);
 
-      @keyframes thread-post-item-skeleton-loader {
-        0% {
-          background-color: rgba($primary, 0.15);
-        }
-
-        50% {
-          background-color: rgba($primary, 0.2);
-        }
-
-        100% {
-          background-color: rgba($primary, 0.15);
-        }
-      }
-
       &.loading {
         height: 27px;
-        animation: thread-post-item-skeleton-loader 1s infinite;
+        @include thread-render-skeleton;
       }
     }
 
@@ -227,7 +235,7 @@
 
       &.loading {
         height: 2rem;
-        animation: thread-post-item-skeleton-loader 1s infinite;
+        @include thread-render-skeleton;
       }
     }
   }

--- a/apps/web/src/specs/features/shared/bookmark-btn.spec.tsx
+++ b/apps/web/src/specs/features/shared/bookmark-btn.spec.tsx
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useBookmarkAdd, useBookmarkDelete } from "@ecency/sdk";
@@ -17,8 +17,10 @@ vi.mock("@tanstack/react-query", () => ({
   isServer: false
 }));
 
+// Spread props so the transient animation className/onAnimationEnd wiring on
+// the icon stays observable.
 vi.mock("@tooni/iconscout-unicons-react", () => ({
-  UilBookmark: () => <svg data-testid="bookmark-icon" />,
+  UilBookmark: (props: any) => <svg data-testid="bookmark-icon" {...props} />,
   UilBell: () => <svg data-testid="bell-icon" />
 }));
 
@@ -100,5 +102,42 @@ describe("BookmarkBtn", () => {
     fireEvent.click(screen.getByRole("button"));
 
     expect(deleteBookmarkMock).toHaveBeenCalled();
+  });
+
+  test("pulses the icon after a successful bookmark add and clears on animationend", async () => {
+    useActiveAccount.mockReturnValue({ activeUser: { username: "user1" }, username: "user1" });
+    (useQuery as any).mockReturnValue({ data: [] });
+    // Invoke the component-supplied success callback on mutate, like the real hook.
+    useBookmarkAdd.mockImplementation((_u: any, _t: any, onSuccess: any) => ({
+      mutateAsync: vi.fn(async () => onSuccess()),
+      isPending: false
+    }));
+    useBookmarkDelete.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+
+    render(<BookmarkBtn entry={entry} />);
+
+    // Transient class: never present on initial render.
+    expect(screen.getByTestId("bookmark-icon")).not.toHaveClass("animate-success-pulse");
+
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("bookmark-icon")).toHaveClass("animate-success-pulse")
+    );
+
+    fireEvent.animationEnd(screen.getByTestId("bookmark-icon"));
+    expect(screen.getByTestId("bookmark-icon")).not.toHaveClass("animate-success-pulse");
+  });
+
+  test("does not pulse the icon for an already-bookmarked entry on initial render", () => {
+    useActiveAccount.mockReturnValue({ activeUser: { username: "user1" }, username: "user1" });
+    (useQuery as any).mockReturnValue({
+      data: [{ _id: "bookmark123", author: entry.author, permlink: entry.permlink }]
+    });
+    useBookmarkAdd.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+    useBookmarkDelete.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+
+    render(<BookmarkBtn entry={entry} />);
+
+    expect(screen.getByTestId("bookmark-icon")).not.toHaveClass("animate-success-pulse");
   });
 });

--- a/apps/web/src/specs/features/shared/discussion-item.spec.tsx
+++ b/apps/web/src/specs/features/shared/discussion-item.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Entry } from "@/entities";
 import { mockEntry } from "@/specs/test-utils";
@@ -14,6 +14,15 @@ vi.mock("@/utils", async () => ({
   ...(await vi.importActual<typeof import("@/utils")>("@/utils")),
   random: vi.fn(),
   getAccessToken: vi.fn(() => "mock-token")
+}));
+
+// The Reply toggle only renders for a logged-in user; keep the active user
+// switchable per test (default: logged out, matching the global mock).
+const activeUserRef = vi.hoisted(() => ({ current: null as string | null }));
+vi.mock("@/core/hooks/use-active-account", () => ({
+  useActiveAccount: () => ({
+    activeUser: activeUserRef.current ? { username: activeUserRef.current } : null
+  })
 }));
 
 // The reply / edit / pin mutations broadcast to the chain — stub them so the
@@ -96,6 +105,10 @@ function renderItem(entry: Entry, root: Entry) {
 }
 
 describe("DiscussionItem", () => {
+  afterEach(() => {
+    activeUserRef.current = null;
+  });
+
   const root = mockEntry({ author: "bob", permlink: "the-post", category: "hive-101" });
   const comment = mockEntry({
     author: "alice",
@@ -133,5 +146,22 @@ describe("DiscussionItem", () => {
     );
 
     expect(screen.queryByTestId("entry-tip-btn")).not.toBeInTheDocument();
+  });
+
+  it("animates the reply composer entrance only after clicking Reply, never on initial render", () => {
+    activeUserRef.current = "demo";
+    const { container } = renderItem(comment, root);
+
+    // Nothing animates on mount — the composer (and its entrance wrapper)
+    // doesn't exist until the user acts.
+    expect(container.querySelector(".animate-fade-in-up")).toBeNull();
+
+    fireEvent.click(screen.getByText("g.reply"));
+
+    expect(container.querySelector(".animate-fade-in-up")).not.toBeNull();
+
+    // Toggling the composer closed removes the wrapper again.
+    fireEvent.click(screen.getByText("g.reply"));
+    expect(container.querySelector(".animate-fade-in-up")).toBeNull();
   });
 });

--- a/apps/web/src/specs/features/shared/entry-reblog-btn.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-reblog-btn.spec.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { fireEvent, screen, within } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createTestQueryClient,
   mockEntry,
   renderWithQueryClient,
   setupModalContainers,
@@ -98,6 +99,15 @@ vi.mock("@/features/ui", () => ({
 }));
 
 import { EntryReblogBtn } from "@/features/shared/entry-reblog-btn";
+
+// jsdom has no AnimationEvent, and testing-library's plain-Event fallback drops
+// `animationName` from the init dict — build the event by hand so the
+// name-gated onAnimationEnd handler can actually match.
+function fireAnimationEnd(el: Element, animationName: string) {
+  const ev = new Event("animationend", { bubbles: true });
+  Object.assign(ev, { animationName });
+  fireEvent(el, ev);
+}
 
 function asLoggedIn(username = "alice") {
   mockUseActiveAccount.mockReturnValue({
@@ -246,5 +256,71 @@ describe("EntryReblogBtn", () => {
 
     expect(reblogMutate).toHaveBeenCalledTimes(1);
     expect(reblogMutate).toHaveBeenCalledWith({ isDelete: true });
+  });
+
+  it("spins the icon once after a successful fresh reblog and clears on animationend", async () => {
+    asLoggedIn("alice");
+    const entry = mockEntry({ author: "bob", permlink: "post" } as Partial<Entry>);
+    const { container } = renderWithQueryClient(<EntryReblogBtn entry={entry} />);
+
+    const wrapper = container.querySelector(".entry-reblog-btn") as HTMLElement;
+    // Transient class: never present on initial render.
+    expect(wrapper).not.toHaveClass("reblog-done");
+
+    fireEvent.click(screen.getByTestId("confirm-ok"));
+    await waitFor(() => expect(wrapper).toHaveClass("reblog-done"));
+
+    // The count tick's animationend bubbles to the wrapper too — it must not
+    // cut the spin short.
+    fireAnimationEnd(wrapper, "anim-tick");
+    expect(wrapper).toHaveClass("reblog-done");
+
+    fireAnimationEnd(wrapper, "anim-rotate-once");
+    expect(wrapper).not.toHaveClass("reblog-done");
+  });
+
+  it("does not spin when removing a reblog", async () => {
+    asLoggedIn("alice");
+    reblogsFixture = [{ author: "bob", permlink: "post" }];
+    const entry = mockEntry({ author: "bob", permlink: "post" } as Partial<Entry>);
+    const { container } = renderWithQueryClient(<EntryReblogBtn entry={entry} />);
+
+    fireEvent.click(screen.getByTestId("confirm-ok"));
+    await waitFor(() => expect(reblogMutate).toHaveBeenCalledWith({ isDelete: true }));
+    // Flush the mutation's resolution before asserting no cue was set.
+    await act(async () => {});
+
+    expect(container.querySelector(".entry-reblog-btn")).not.toHaveClass("reblog-done");
+  });
+
+  it("ticks the reblog count only when it changes after mount, never on first paint", async () => {
+    asLoggedIn("alice");
+    const entry = mockEntry({ author: "bob", permlink: "post", reblogs: 7 } as Partial<Entry>);
+    const queryClient = createTestQueryClient();
+    const { container } = renderWithQueryClient(<EntryReblogBtn entry={entry} />, { queryClient });
+
+    // First paint: number visible, no tick.
+    expect(within(container).getByText("7")).not.toHaveClass("animate-tick");
+
+    // The count changes in the entry cache (e.g. optimistic bump after reblog).
+    act(() => {
+      queryClient.setQueryData(["entry", "bob", "post"], { ...entry, reblogs: 8 });
+    });
+
+    await waitFor(() => expect(within(container).getByText("8")).toHaveClass("animate-tick"));
+  });
+
+  it("does not tick when the button instance is reused for a different post", () => {
+    asLoggedIn("alice");
+    const entryA = mockEntry({ author: "bob", permlink: "post-a", reblogs: 7 } as Partial<Entry>);
+    const entryB = mockEntry({ author: "carol", permlink: "post-b", reblogs: 3 } as Partial<Entry>);
+    const { container, rerender } = renderWithQueryClient(<EntryReblogBtn entry={entryA} />);
+
+    expect(within(container).getByText("7")).not.toHaveClass("animate-tick");
+
+    // Reuse: the first-seen ref guard resets per entry, so the new post's
+    // count renders without a tick.
+    rerender(<EntryReblogBtn entry={entryB} />);
+    expect(within(container).getByText("3")).not.toHaveClass("animate-tick");
   });
 });

--- a/apps/web/src/specs/features/shared/entry-vote-btn.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-vote-btn.spec.tsx
@@ -45,10 +45,20 @@ vi.mock("@/features/shared/entry-vote-btn/utils", () => ({
 // The slider dialog is loaded via next/dynamic and pulls in SDK vote-value queries we
 // don't exercise here. Replace it with a marker that records the previousVotedValue prop
 // it receives, so we can assert (a) it mounts and (b) the resolved value reaches it.
+// The extra button forwards to the dialog's onClick (the vote handler) so tests can
+// drive a successful vote broadcast.
 vi.mock("@/features/shared/entry-vote-btn/entry-vote-dialog", () => ({
-  EntryVoteDialog: ({ previousVotedValue }: { previousVotedValue: number | undefined }) => (
+  EntryVoteDialog: ({
+    previousVotedValue,
+    onClick
+  }: {
+    previousVotedValue: number | undefined;
+    onClick: (percent: number, estimated: number) => void;
+  }) => (
     <div data-testid="vote-dialog">
       prev:{previousVotedValue === undefined ? "none" : previousVotedValue}
+      {/* span, not <button>: pre-existing tests query the single role=button control */}
+      <span data-testid="vote-now" onClick={() => onClick(100, 0.5)} />
     </div>
   )
 }));
@@ -148,5 +158,53 @@ describe("EntryVoteBtn — opening the slider is not blocked on the previous-vot
     fireEvent.click(screen.getByRole("button"));
     const dialogB = await screen.findByTestId("vote-dialog");
     expect(dialogB).toHaveTextContent("prev:none");
+  });
+});
+
+describe("EntryVoteBtn — success pulse (transient class, never on load)", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("does not pulse the chevron for an already-voted post on initial render", () => {
+    const entry = mockEntry({
+      author: "bob",
+      permlink: "voted-post",
+      post_id: 1001,
+      active_votes: [{ voter: "alice", rshares: 100 }] as any
+    });
+    const { container } = renderWithQueryClient(<EntryVoteBtn entry={entry} isPostSlider={true} />);
+
+    expect(container.querySelector(".btn-inner")).not.toHaveClass("animate-success-pulse");
+  });
+
+  it("pulses the chevron after a successful vote broadcast and clears on animationend", async () => {
+    const entry = mockEntry({ author: "bob", permlink: "c-post", post_id: 1002, active_votes: [] });
+    const { container } = renderWithQueryClient(<EntryVoteBtn entry={entry} isPostSlider={true} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(await screen.findByTestId("vote-now"));
+
+    const chevron = container.querySelector(".btn-inner") as HTMLElement;
+    await waitFor(() => expect(chevron).toHaveClass("animate-success-pulse"));
+    // A successful vote also closes the slider (pre-existing behavior).
+    expect(screen.queryByTestId("vote-dialog")).not.toBeInTheDocument();
+
+    // Transient class is removed once the pulse finishes.
+    fireEvent.animationEnd(chevron);
+    expect(chevron).not.toHaveClass("animate-success-pulse");
+  });
+
+  it("grows the slider popover from the chevron (top-left origin)", async () => {
+    const entry = mockEntry({ author: "bob", permlink: "d-post", post_id: 1003, active_votes: [] });
+    const { container } = renderWithQueryClient(<EntryVoteBtn entry={entry} isPostSlider={true} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    await screen.findByTestId("vote-dialog");
+
+    const popover = container.querySelector(".tooltiptext") as HTMLElement;
+    expect(popover).toHaveClass("animate-scale-in");
+    expect(popover).toHaveClass("origin-top-left");
   });
 });

--- a/apps/web/src/specs/features/shared/feedback.spec.tsx
+++ b/apps/web/src/specs/features/shared/feedback.spec.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { vi } from "vitest";
+import { Feedback } from "@/features/shared/feedback/feedback";
+import { FeedbackObject } from "@/features/shared/feedback/feedback-events";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() })
+}));
+
+vi.mock("@/core/global-store", () => ({
+  useGlobalStore: vi.fn((selector: (state: any) => any) => selector({ activeUser: null }))
+}));
+
+// Toasts enter with a pure CSS keyframe and exit with a 150ms
+// useMountTransition-driven fade + slide-down. These tests pin that both the
+// close button and the 5s auto-expiry play the exit before unmounting, and
+// that hover still pauses auto-expiry.
+describe("Feedback", () => {
+  const emit = (detail: Partial<FeedbackObject>) =>
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("ecency-feedback", {
+          detail: { id: "toast-1", type: "success", message: "saved!", ...detail }
+        })
+      );
+    });
+
+  const toastWrapper = () => document.querySelector(".feedback-item-enter");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders an incoming toast with the CSS entrance class", () => {
+    render(<Feedback />);
+    emit({ message: "saved!" });
+
+    expect(screen.getByText("saved!")).toBeInTheDocument();
+    expect(toastWrapper()).not.toBeNull();
+  });
+
+  it("animates out on manual close, then unmounts", () => {
+    render(<Feedback />);
+    emit({ message: "saved!" });
+
+    // Let the entrance settle (open flips true a couple of rAFs after mount)
+    // so the opacity-0 below is genuinely the exit state.
+    act(() => vi.advanceTimersByTime(100));
+    expect(toastWrapper()!.className).toContain("opacity-100");
+
+    fireEvent.click(screen.getByRole("button", { name: "g.close" }));
+
+    // Exit state applies while the toast is still mounted...
+    expect(screen.getByText("saved!")).toBeInTheDocument();
+    expect(toastWrapper()!.className).toContain("opacity-0");
+    expect(toastWrapper()!.className).toContain("translate-y-3");
+
+    // ...and the 150ms exit timer removes it from the store.
+    act(() => vi.advanceTimersByTime(200));
+    expect(screen.queryByText("saved!")).not.toBeInTheDocument();
+  });
+
+  it("animates out on auto-expiry, then unmounts", () => {
+    render(<Feedback />);
+    emit({ message: "saved!" });
+
+    act(() => vi.advanceTimersByTime(100));
+    expect(toastWrapper()!.className).toContain("opacity-100");
+
+    act(() => vi.advanceTimersByTime(5000));
+
+    expect(screen.getByText("saved!")).toBeInTheDocument();
+    expect(toastWrapper()!.className).toContain("opacity-0");
+
+    act(() => vi.advanceTimersByTime(200));
+    expect(screen.queryByText("saved!")).not.toBeInTheDocument();
+  });
+
+  it("hover pauses auto-expiry; leaving re-arms it", () => {
+    render(<Feedback />);
+    emit({ message: "saved!" });
+
+    fireEvent.mouseEnter(screen.getByRole("alert"));
+    act(() => vi.advanceTimersByTime(10000));
+    expect(screen.getByText("saved!")).toBeInTheDocument();
+    expect(toastWrapper()!.className).not.toContain("opacity-0");
+
+    fireEvent.mouseLeave(screen.getByRole("alert"));
+    // Auto-expiry fires at 5s; the exit timer is only scheduled once React
+    // flushes that update, so the 150ms exit needs its own advance.
+    act(() => vi.advanceTimersByTime(5000));
+    act(() => vi.advanceTimersByTime(200));
+    expect(screen.queryByText("saved!")).not.toBeInTheDocument();
+  });
+
+  it("dismisses toasts independently", () => {
+    render(<Feedback />);
+    emit({ id: "toast-1", message: "first" });
+    emit({ id: "toast-2", message: "second" });
+
+    const closeButtons = screen.getAllByRole("button", { name: "g.close" });
+    fireEvent.click(closeButtons[0]);
+    act(() => vi.advanceTimersByTime(200));
+
+    expect(screen.queryByText("first")).not.toBeInTheDocument();
+    expect(screen.getByText("second")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/styles/_animations.scss
+++ b/apps/web/src/styles/_animations.scss
@@ -119,6 +119,66 @@
   }
 }
 
+/* ── Micro-interaction keyframes (animation-polish) ───────────────────────
+   Success/feedback cues fired by transient classes or key-remounts after a
+   user action — never on initial render. Transform/opacity only. */
+
+@keyframes anim-success-pulse {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.35);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes anim-rotate-once {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes anim-bell-ring {
+  0%,
+  100% {
+    transform: rotate(0);
+  }
+  20% {
+    transform: rotate(12deg);
+  }
+  40% {
+    transform: rotate(-10deg);
+  }
+  60% {
+    transform: rotate(6deg);
+  }
+  80% {
+    transform: rotate(-4deg);
+  }
+}
+
+@keyframes anim-tick {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Skeleton shimmer: a directional highlight sweep — reads as "actively
+   loading" (vs a blinking pulse) and only animates transform. */
+@keyframes anim-shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+
 /* Standalone copy of the spin keyframes: arbitrary animate-[spin_...] values
    (points-spin wheels) don't make Tailwind emit its theme keyframes, so they
    must not depend on some other file happening to use animate-spin. */

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -12,6 +12,10 @@ const config: Config = {
     animation: {
       none: "none",
       "fade-in-up": "anim-fade-in-up 0.2s cubic-bezier(0.16, 1, 0.3, 1) both",
+      "success-pulse": "anim-success-pulse 0.3s cubic-bezier(0.16, 1, 0.3, 1)",
+      "rotate-once": "anim-rotate-once 0.4s cubic-bezier(0.16, 1, 0.3, 1)",
+      "bell-ring": "anim-bell-ring 0.6s ease-out",
+      tick: "anim-tick 0.15s ease-out both",
       "scale-in": "anim-scale-in 0.12s cubic-bezier(0.16, 1, 0.3, 1) both",
       "pop-in": "anim-pop-in 0.15s cubic-bezier(0.16, 1, 0.3, 1) both",
       spin: "spin 1s linear infinite",


### PR DESCRIPTION
Implements the 13 animation candidates approved after #1072, all CSS-only (transform/opacity, compositor-friendly) and all guarded so **nothing animates on initial page render** — feedback fires only on user actions or live state changes.

## What's included

**Action feedback** (transient class set in the mutation success path, cleared on `animationend`):
- Vote chevron success pulse; vote slider now grows from the chevron that opened it (transform-origin fix)
- Reblog icon spins once on a fresh reblog (not on un-reblog); reblog count ticks on change
- Bookmark icon pulses on successful add/remove
- Follow/Mute button label pops when the relation actually changes (prev-value ref guard — the simpler click-flag approach double-fired and was rejected)
- Copy-to-clipboard check icon pops in

**Perceived speed**:
- Skeleton shimmer: loading placeholders (entry list, decks, waves threads) now sweep a gradient highlight instead of blinking opacity — the classic "actively loading" cue; consolidated four duplicated skeleton keyframe blocks into one mixin

**Live-arrival cues**:
- Notification badge pops on count change; bell wiggles once when unread *increases* live (never on load, never on reading)
- Waves feed: items prepended by the refresh popup fade in with a capped stagger — initial render, infinite scroll and promoted interleaves stay instant
- Guarded count ticks on vote count and payout (per-entry ref guard, so recycled list rows never tick for a different post)

**Continuity**:
- Toasts now animate out (150ms fade+slide via useMountTransition; hover-pause and auto-expiry preserved)
- Accordion chevrons rotate with open state (AccordionToggle now exposes `data-open`; applied in FAQ, deck headers, market widgets)
- Reply/edit composer fades up when opened (also masks the lazy editor chunk seam)

## Verification

- Full suite: 194 files, **1,970 tests** (17 new tests covering the transient-class and ref-guard behavior, including "must NOT animate on first paint" assertions and a new feedback/toast spec)
- Production build green; no new type errors
- Every entrance ≤200ms, staggers capped at 250ms, no layout-property animation anywhere

Worth a staging feel-check: vote/reblog/bookmark on a feed card, a live notification arriving, toast dismiss, FAQ accordion, waves refresh popup.