### PR TITLE
Surface Translate CTA when reader and post languages differ

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -91,6 +91,7 @@
     "dompurify": "^3.4.11",
     "emoji-mart": "^5.5.2",
     "formidable": "^3.5.4",
+    "franc-min": "^6.2.0",
     "heic2any": "^0.0.4",
     "highcharts": "^12.1.2",
     "highcharts-react-official": "^3.2.1",

--- a/apps/web/src/api/translation.ts
+++ b/apps/web/src/api/translation.ts
@@ -9,6 +9,15 @@ const translationApi = axios.create({
 
 interface TranslationResponse {
   translatedText: string;
+  // Present when source === "auto": LibreTranslate reports what it detected.
+  // Used to relabel the CTA ("Translated from X") and to self-correct a wrong
+  // client-side guess without a separate /detect call.
+  detectedLanguage?: { confidence: number; language: string };
+}
+
+export interface DetectedLanguage {
+  confidence: number;
+  language: string;
 }
 
 interface LanguagesMap {
@@ -100,4 +109,76 @@ export const getLanguages = async (): Promise<Language[]> => {
       targets,
     }))
     .filter((lang) => typeof lang.code === 'string' && lang.code.length > 0);
+};
+
+/**
+ * Ask LibreTranslate to detect the language of a text. Returns confidence-ranked
+ * ISO-639-1 candidates (e.g. [{ confidence: 92.4, language: "es" }]). Used only
+ * on the full-post view to confirm/refine the instant client-side guess (never
+ * per feed item). Callers must handle the empty array / rejection (fail closed).
+ */
+export const detectLanguage = async (text: string): Promise<DetectedLanguage[]> => {
+  const { clean } = stripEmojis(text);
+  if (!clean) {
+    return [];
+  }
+  const { data } = await translationApi.post<DetectedLanguage[]>("/detect", {
+    // A short sample is plenty for detection and keeps the request small.
+    q: clean.slice(0, 800),
+    api_key: ""
+  });
+  return Array.isArray(data) ? data : [];
+};
+
+// LibreTranslate can reject or truncate very long requests. Split the body into
+// chunks on sentence/word boundaries and translate each, so a full-length post
+// translates reliably instead of silently failing.
+const MAX_TRANSLATE_CHARS = 1800;
+
+const chunkText = (text: string, max: number): string[] => {
+  if (text.length <= max) {
+    return [text];
+  }
+  // Greedy word-accumulation. No regex lookbehind — the body is already plain
+  // text joined with spaces, so word boundaries are a safe, engine-portable
+  // split point (older iOS Safari can't parse lookbehind).
+  const chunks: string[] = [];
+  let buf = "";
+  for (const word of text.split(/\s+/)) {
+    if (buf && (buf.length + 1 + word.length) > max) {
+      chunks.push(buf);
+      buf = word;
+    } else {
+      buf = buf ? `${buf} ${word}` : word;
+    }
+  }
+  if (buf) {
+    chunks.push(buf);
+  }
+  return chunks.filter(Boolean);
+};
+
+/**
+ * Translate a full (possibly long) plain-text body, chunking as needed. Returns
+ * the joined translation plus the language LibreTranslate auto-detected on the
+ * first chunk (authoritative — used to relabel and cache).
+ */
+export const translateLongText = async (
+  text: string,
+  source: string,
+  target: string
+): Promise<TranslationResponse> => {
+  const chunks = chunkText(text, MAX_TRANSLATE_CHARS);
+  const parts: string[] = [];
+  let detectedLanguage: DetectedLanguage | undefined;
+  for (const chunk of chunks) {
+    // Sequential on purpose: a deliberate, spinner-backed user action, and it
+    // keeps us well under the translate endpoint's per-IP rate limit.
+    const res = await getTranslation(chunk, source, target);
+    parts.push(res.translatedText);
+    if (!detectedLanguage && res.detectedLanguage) {
+      detectedLanguage = res.detectedLanguage;
+    }
+  }
+  return { translatedText: parts.join(" "), detectedLanguage };
 };

--- a/apps/web/src/api/translation.ts
+++ b/apps/web/src/api/translation.ts
@@ -135,7 +135,7 @@ export const detectLanguage = async (text: string): Promise<DetectedLanguage[]> 
 // translates reliably instead of silently failing.
 const MAX_TRANSLATE_CHARS = 1800;
 
-const chunkText = (text: string, max: number): string[] => {
+export const chunkText = (text: string, max: number): string[] => {
   if (text.length <= max) {
     return [text];
   }
@@ -144,17 +144,29 @@ const chunkText = (text: string, max: number): string[] => {
   // split point (older iOS Safari can't parse lookbehind).
   const chunks: string[] = [];
   let buf = "";
-  for (const word of text.split(/\s+/)) {
-    if (buf && (buf.length + 1 + word.length) > max) {
+  const flush = () => {
+    if (buf) {
       chunks.push(buf);
+      buf = "";
+    }
+  };
+  for (const word of text.split(/\s+/)) {
+    // A single "word" longer than the limit — e.g. space-less CJK text, where
+    // the whole body is one token — must be hard-split by character, or it would
+    // be sent as one over-limit request and truncated/rejected.
+    if (word.length > max) {
+      flush();
+      for (let i = 0; i < word.length; i += max) {
+        chunks.push(word.slice(i, i + max));
+      }
+    } else if (buf && buf.length + 1 + word.length > max) {
+      flush();
       buf = word;
     } else {
       buf = buf ? `${buf} ${word}` : word;
     }
   }
-  if (buf) {
-    chunks.push(buf);
-  }
+  flush();
   return chunks.filter(Boolean);
 };
 

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-ssr.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-ssr.tsx
@@ -11,6 +11,7 @@ import { EntryPageStaticBody } from "./entry-page-static-body";
 import { EntryPageWarnings } from "./entry-page-warnings";
 import { EntryTags } from "./entry-tags";
 import { EntryPageNsfwBodyWrapper } from "./entry-page-nsfw-body-wrapper";
+import { EntryTranslateInline } from "@/features/shared/entry-translate/entry-translate-inline";
 
 interface Props {
   entry: Entry;
@@ -31,6 +32,7 @@ export function EntryPageContentSSR({ entry, isRawContent }: Props) {
       <EntryPageNsfwBodyWrapper entry={entry}>
         {!isRawContent && (
           <div className="bg-white/80 dark:bg-dark-200/90 rounded-xl p-2 md:p-4">
+            <EntryTranslateInline entry={entry} />
             <EntryPageStaticBody entry={entry} />
             {postPoll && <PollWidget entry={entry} poll={postPoll} isReadOnly={false} />}
           </div>

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -582,7 +582,15 @@
     "edit-classic": "Classic Edit"
   },
   "entry-translate": {
-    "target-language": "Target language"
+    "target-language": "Target language",
+    "banner-detected": "This post is in {{lang}}. Translate to {{target}}?",
+    "translate-to": "Translate to {{lang}}",
+    "show-original": "Show original",
+    "translated-from": "Translated from {{lang}}",
+    "change-language": "Change language",
+    "translating": "Translating…",
+    "dismiss": "Dismiss",
+    "plain-text-note": "Plain-text translation. Images and formatting are shown in the original."
   },
   "cross-post": {
     "title": "Cross Post",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -590,7 +590,8 @@
     "change-language": "Change language",
     "translating": "Translating…",
     "dismiss": "Dismiss",
-    "plain-text-note": "Plain-text translation. Images and formatting are shown in the original."
+    "plain-text-note": "Plain-text translation. Images and formatting are shown in the original.",
+    "error": "Translation failed. Please try again."
   },
   "cross-post": {
     "title": "Cross Post",

--- a/apps/web/src/features/shared/entry-list-item/index.tsx
+++ b/apps/web/src/features/shared/entry-list-item/index.tsx
@@ -31,6 +31,7 @@ import { EntryListItemNsfwContent } from "@/features/shared/entry-list-item/entr
 import { EntryListItemClientInit } from "@/features/shared/entry-list-item/entry-list-item-client-init";
 import { EntryListItemPollIcon } from "@/features/shared/entry-list-item/entry-list-item-poll-icon";
 import { HydrateOnVisible } from "@/features/shared/hydrate-on-visible";
+import { TranslateChip } from "@/features/shared/entry-translate/translate-chip";
 import { UilComment } from "@tooni/iconscout-unicons-react";
 
 setProxyBase(defaults.imageServer);
@@ -189,6 +190,9 @@ export function EntryListItemComponent({
           )}
           <EntryReblogBtn entry={entry} />
           <EntryTipBtn entry={entry} />
+          {/* Detection runs only here — inside the near-viewport action island —
+              so off-screen cards never load franc or run detection. */}
+          <TranslateChip entry={entry} />
           <div className="border-r border-[--border-color] w-[1px] h-4" />
           <EntryMenu alignBottom={order >= 1} entry={entry} />
         </div>

--- a/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
+++ b/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
@@ -176,8 +176,13 @@ export function useMenuItemsGenerator(
           icon: !!entry.stats?.gray ? <UilVolumeOff /> : <UilVolume />
         })
       ),
+      // Fallback translate entry: every top-level post AND waves (waves are
+      // technically comments — parent_author "ecency.waves" — so `!isComment`
+      // alone would strip it from the one place it works today). Ordinary reply
+      // comments stay excluded. The prominent inline banner / chip handles the
+      // language-mismatch case; this is the always-available manual option.
       ...safeSpread(
-        () => isWave,
+        () => !isComment || isWave,
         () => ({
           label: i18next.t("entry-menu.translate"),
           onClick: () => setTranslate(true),

--- a/apps/web/src/features/shared/entry-translate/entry-translate-inline.tsx
+++ b/apps/web/src/features/shared/entry-translate/entry-translate-inline.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
+import i18next from "i18next";
+import { postBodySummary } from "@ecency/render-helper";
+import { UilLanguage, UilTimes } from "@tooni/iconscout-unicons-react";
+import { Entry } from "@/entities";
+import { translateLongText } from "@/api/translation";
+import { Spinner } from "@ui/spinner";
+import * as ls from "@/utils/local-storage";
+import { useContentLanguageGate } from "./use-content-language-gate";
+import { isRtlLang, languageDisplayName, normLang } from "./iso639";
+
+// The full language-picker modal is only needed if the reader wants a language
+// other than their own — lazy-load it so it stays off the post read path.
+const EntryTranslate = dynamic(
+  () => import("./index").then((m) => ({ default: m.EntryTranslate })),
+  { ssr: false }
+);
+
+const DISMISS_PREFIX = "translate-dismissed";
+
+interface Props {
+  entry: Entry;
+}
+
+/**
+ * Prominent, inline "Translate to <your language>" banner shown directly above
+ * the post body when the detected content language differs from the reader's.
+ * One tap translates the FULL body in place (plain text) with a Show-original
+ * toggle; the hidden 3-dot Translate item remains as a fallback.
+ *
+ * Renders nothing on the server and on the first client render (the gate hook
+ * resolves only in an effect), so it can live inside the server-rendered post
+ * card without a hydration mismatch.
+ */
+export function EntryTranslateInline({ entry }: Props) {
+  const dismissKey = `${DISMISS_PREFIX}:${entry.author}/${entry.permlink}`;
+
+  const [dismissed, setDismissed] = useState(false);
+  const [status, setStatus] = useState<"idle" | "loading" | "done">("idle");
+  const [translated, setTranslated] = useState("");
+  const [fromLang, setFromLang] = useState("");
+  const [changeLang, setChangeLang] = useState(false);
+
+  // Guards the in-flight translation so Show-original / dismiss / unmount abort it.
+  const requestRef = useRef<{ canceled: boolean } | null>(null);
+  // Whether we currently have #post-body hidden (so we only restore what we hid).
+  const hidBodyRef = useRef(false);
+
+  const decision = useContentLanguageGate(entry, { serverConfirm: true });
+
+  // Read the persisted per-post dismissal on the client only (avoids SSR/render
+  // divergence). Keyed on author+permlink because permlinks repeat across authors.
+  useEffect(() => {
+    setDismissed(!!ls.get(dismissKey));
+  }, [dismissKey]);
+
+  const setBodyHidden = (hidden: boolean) => {
+    const el = typeof document !== "undefined" ? document.getElementById("post-body") : null;
+    if (!el) {
+      return;
+    }
+    if (hidden) {
+      el.setAttribute("hidden", "");
+      hidBodyRef.current = true;
+    } else {
+      el.removeAttribute("hidden");
+      hidBodyRef.current = false;
+    }
+  };
+
+  // On unmount (e.g. navigating away, entering edit mode) abort any request and
+  // restore the original body so it never stays hidden behind a stale panel.
+  useEffect(
+    () => () => {
+      if (requestRef.current) {
+        requestRef.current.canceled = true;
+      }
+      if (hidBodyRef.current) {
+        setBodyHidden(false);
+      }
+    },
+    []
+  );
+
+  if (dismissed || !decision?.show) {
+    return null;
+  }
+
+  const { source, target } = decision;
+  const targetName = languageDisplayName(target, i18next.language);
+  const sourceName = languageDisplayName(source, i18next.language);
+
+  const handleTranslate = async () => {
+    setStatus("loading");
+    const token = { canceled: false };
+    requestRef.current = token;
+    try {
+      const text = postBodySummary(entry.body, 0);
+      const res = await translateLongText(text, "auto", target);
+      if (token.canceled) {
+        return;
+      }
+      const detected = res.detectedLanguage?.language
+        ? normLang(res.detectedLanguage.language)
+        : source;
+      // The instant guess was wrong and the body is actually the reader's
+      // language — abort, keep the original, and dismiss so we don't re-nag.
+      if (detected && detected === target) {
+        ls.set(dismissKey, 1);
+        setDismissed(true);
+        return;
+      }
+      setTranslated(res.translatedText);
+      setFromLang(detected || source);
+      setBodyHidden(true);
+      setStatus("done");
+    } catch {
+      if (!token.canceled) {
+        setStatus("idle"); // keep the original body; allow retry
+      }
+    }
+  };
+
+  const handleShowOriginal = () => {
+    if (requestRef.current) {
+      requestRef.current.canceled = true;
+    }
+    setBodyHidden(false);
+    setTranslated("");
+    setStatus("idle");
+  };
+
+  const handleDismiss = () => {
+    if (requestRef.current) {
+      requestRef.current.canceled = true;
+    }
+    setBodyHidden(false);
+    ls.set(dismissKey, 1);
+    setDismissed(true);
+  };
+
+  const rtl = isRtlLang(status === "done" ? fromLang || target : target);
+
+  return (
+    <div className="entry-translate-inline mb-3">
+      <div className="flex items-center flex-wrap gap-x-3 gap-y-1 rounded-lg border border-[--border-color] bg-blue-duck-egg dark:bg-dark-200 px-3 py-2 text-sm">
+        <UilLanguage className="w-4 h-4 text-blue-dark-sky shrink-0" />
+        {status === "done" ? (
+          <span className="text-gray-600 dark:text-gray-400">
+            {i18next.t("entry-translate.translated-from", {
+              lang: languageDisplayName(fromLang || source, i18next.language)
+            })}
+          </span>
+        ) : (
+          <span className="text-gray-charcoal dark:text-white-075">
+            {i18next.t("entry-translate.banner-detected", {
+              lang: sourceName,
+              target: targetName
+            })}
+          </span>
+        )}
+
+        <span className="flex-grow" />
+
+        {status === "idle" && (
+          <button
+            type="button"
+            className="font-semibold text-blue-dark-sky hover:underline"
+            onClick={handleTranslate}
+          >
+            {i18next.t("entry-translate.translate-to", { lang: targetName })}
+          </button>
+        )}
+        {status === "loading" && (
+          <span className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
+            <Spinner className="w-3.5 h-3.5" /> {i18next.t("entry-translate.translating")}
+          </span>
+        )}
+        {status === "done" && (
+          <button
+            type="button"
+            className="font-semibold text-blue-dark-sky hover:underline"
+            onClick={handleShowOriginal}
+          >
+            {i18next.t("entry-translate.show-original")}
+          </button>
+        )}
+
+        <button
+          type="button"
+          className="font-semibold text-blue-dark-sky hover:underline"
+          onClick={() => setChangeLang(true)}
+        >
+          {i18next.t("entry-translate.change-language")}
+        </button>
+
+        {status !== "loading" && (
+          <button
+            type="button"
+            className="text-gray-600 hover:text-gray-charcoal dark:text-gray-400 shrink-0"
+            aria-label={i18next.t("entry-translate.dismiss")}
+            title={i18next.t("entry-translate.dismiss")}
+            onClick={handleDismiss}
+          >
+            <UilTimes className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {status === "done" && (
+        <div className="mt-3">
+          <div
+            className="entry-body markdown-view user-selectable whitespace-pre-line"
+            dir={rtl ? "rtl" : "ltr"}
+          >
+            {translated}
+          </div>
+          <div className="mt-2 text-xs text-gray-600 dark:text-gray-400">
+            {i18next.t("entry-translate.plain-text-note")}
+          </div>
+        </div>
+      )}
+
+      {changeLang && (
+        <EntryTranslate
+          entry={entry}
+          initialTarget={target}
+          onHide={() => setChangeLang(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/shared/entry-translate/entry-translate-inline.tsx
+++ b/apps/web/src/features/shared/entry-translate/entry-translate-inline.tsx
@@ -142,7 +142,9 @@ export function EntryTranslateInline({ entry }: Props) {
     setDismissed(true);
   };
 
-  const rtl = isRtlLang(status === "done" ? fromLang || target : target);
+  // The translated body is always in the TARGET language, so its direction must
+  // follow the target — not the detected source (e.g. Arabic -> English must be LTR).
+  const rtl = isRtlLang(target);
 
   return (
     <div className="entry-translate-inline mb-3">

--- a/apps/web/src/features/shared/entry-translate/index.tsx
+++ b/apps/web/src/features/shared/entry-translate/index.tsx
@@ -23,6 +23,7 @@ export function EntryTranslate({ entry, onHide, initialTarget, initialSource }: 
   const [loading, setLoading] = useState(true);
   const [languages, setLanguages] = useState<Language[]>([]);
   const [detectedFrom, setDetectedFrom] = useState<string>("");
+  const [error, setError] = useState(false);
   const [target, setTarget] = useState<string>(
     normLang(initialTarget || i18next.language) || "en"
   );
@@ -36,6 +37,7 @@ export function EntryTranslate({ entry, onHide, initialTarget, initialSource }: 
     setLoading(true);
     setTranslated("");
     setDetectedFrom("");
+    setError(false);
     const body = postBodySummary(entry.body);
     getTranslation(body, initialSource ?? "auto", target)
       .then((r) => {
@@ -44,6 +46,13 @@ export function EntryTranslate({ entry, onHide, initialTarget, initialSource }: 
           if (r.detectedLanguage?.language) {
             setDetectedFrom(r.detectedLanguage.language);
           }
+        }
+      })
+      .catch(() => {
+        // Surface the failure instead of leaving the modal blank (and swallow
+        // the rejection so it isn't unhandled).
+        if (!canceled) {
+          setError(true);
         }
       })
       .finally(() => {
@@ -86,6 +95,8 @@ export function EntryTranslate({ entry, onHide, initialTarget, initialSource }: 
           <div className="flex justify-center p-3">
             <Spinner className="w-4 h-4" />
           </div>
+        ) : error ? (
+          <p className="text-sm text-red-500">{i18next.t("entry-translate.error")}</p>
         ) : (
           <>
             {detectedFrom && (

--- a/apps/web/src/features/shared/entry-translate/index.tsx
+++ b/apps/web/src/features/shared/entry-translate/index.tsx
@@ -6,18 +6,25 @@ import i18next from "i18next";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import { Spinner } from "@ui/spinner";
 import { Select } from "@ui/input/form-controls/select";
+import { isRtlLang, languageDisplayName, normLang } from "./iso639";
 
 interface Props {
   entry: Entry;
   onHide: () => void;
+  // Pre-select the target language (e.g. from the inline banner's "Change
+  // language" action or a feed/wave chip). Defaults to the UI language.
+  initialTarget?: string;
+  // Source language for the request. Defaults to "auto" (LibreTranslate detects).
+  initialSource?: string;
 }
 
-export function EntryTranslate({ entry, onHide }: Props) {
+export function EntryTranslate({ entry, onHide, initialTarget, initialSource }: Props) {
   const [translated, setTranslated] = useState<string>("");
   const [loading, setLoading] = useState(true);
   const [languages, setLanguages] = useState<Language[]>([]);
+  const [detectedFrom, setDetectedFrom] = useState<string>("");
   const [target, setTarget] = useState<string>(
-    i18next.language.split("-")[0]
+    normLang(initialTarget || i18next.language) || "en"
   );
 
   useEffect(() => {
@@ -28,11 +35,15 @@ export function EntryTranslate({ entry, onHide }: Props) {
     let canceled = false;
     setLoading(true);
     setTranslated("");
+    setDetectedFrom("");
     const body = postBodySummary(entry.body);
-    getTranslation(body, "auto", target)
+    getTranslation(body, initialSource ?? "auto", target)
       .then((r) => {
         if (!canceled) {
           setTranslated(r.translatedText);
+          if (r.detectedLanguage?.language) {
+            setDetectedFrom(r.detectedLanguage.language);
+          }
         }
       })
       .finally(() => {
@@ -43,7 +54,7 @@ export function EntryTranslate({ entry, onHide }: Props) {
     return () => {
       canceled = true;
     };
-  }, [entry, target]);
+  }, [entry, target, initialSource]);
 
   return (
     <Modal
@@ -76,10 +87,20 @@ export function EntryTranslate({ entry, onHide }: Props) {
             <Spinner className="w-4 h-4" />
           </div>
         ) : (
-          <p className="whitespace-pre-line text-sm">{translated}</p>
+          <>
+            {detectedFrom && (
+              <div className="text-xs text-gray-600 dark:text-gray-400 mb-1">
+                {i18next.t("entry-translate.translated-from", {
+                  lang: languageDisplayName(detectedFrom, i18next.language)
+                })}
+              </div>
+            )}
+            <p className="whitespace-pre-line text-sm" dir={isRtlLang(target) ? "rtl" : "ltr"}>
+              {translated}
+            </p>
+          </>
         )}
       </ModalBody>
     </Modal>
   );
 }
-

--- a/apps/web/src/features/shared/entry-translate/iso639.ts
+++ b/apps/web/src/features/shared/entry-translate/iso639.ts
@@ -1,0 +1,189 @@
+/**
+ * Pure, framework-free language helpers for the "translate when the reader's
+ * language differs from the content" feature. No React, no network, no DOM —
+ * unit-testable in isolation.
+ *
+ * Two code systems meet here:
+ *  - franc-min (the client-side detector) emits ISO-639-3 codes ("spa", "pes").
+ *  - LibreTranslate (translate.ecency.com) speaks ISO-639-1 codes ("es", "fa").
+ *
+ * Our LibreTranslate instance exposes 43 languages and — verified against
+ * /languages — every source can translate to every target (all-to-all), so a
+ * per-pair check is unnecessary: a CTA is valid whenever both the detected
+ * source and the reader target are in the supported set and they differ.
+ */
+
+// The 43 languages our LibreTranslate instance supports (source === target set).
+// Keep in sync with translate.ecency.com/languages. Used only as an offline
+// gate; the modal's language picker still fetches the live list.
+export const LIBRETRANSLATE_CODES = [
+  "ar", "az", "bg", "bn", "ca", "cs", "da", "de", "el", "en", "eo", "es",
+  "et", "fa", "fi", "fr", "ga", "he", "hi", "hu", "id", "it", "ja", "ko",
+  "lt", "lv", "ms", "nb", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sq",
+  "sv", "th", "tl", "tr", "uk", "zh", "zt"
+] as const;
+
+export const LIBRETRANSLATE_SOURCES = new Set<string>(LIBRETRANSLATE_CODES);
+export const LIBRETRANSLATE_TARGETS = new Set<string>(LIBRETRANSLATE_CODES);
+
+/**
+ * ISO-639-3 (franc-min output) -> ISO-639-1 (LibreTranslate), restricted to the
+ * languages BOTH franc-min can emit AND our LibreTranslate supports.
+ *
+ * Codes verified empirically against the installed franc-min@6 data/expressions
+ * (not assumed): franc emits "pes" for Persian (NOT "fas"), "arb" for Arabic,
+ * "cmn" for Chinese, "zlm" for Malay, "azj" for Azerbaijani, "nb"->"nob" absent
+ * (franc-min lacks Norwegian), etc.
+ *
+ * franc-min does NOT cover 14 of LibreTranslate's languages
+ * (ca, da, eo, et, fi, ga, he, lt, lv, nb, sk, sl, sq, zt). Content in those
+ * languages is caught by the server /detect escalation on the full-post view;
+ * in feed/wave chips (franc-only) it simply yields no chip. This is intentional.
+ */
+export const ISO_639_3_TO_1: Record<string, string> = {
+  arb: "ar", // Arabic
+  azj: "az", // North Azerbaijani
+  bul: "bg", // Bulgarian
+  ben: "bn", // Bengali
+  cmn: "zh", // Mandarin Chinese
+  ces: "cs", // Czech
+  deu: "de", // German
+  ell: "el", // Greek
+  eng: "en", // English
+  spa: "es", // Spanish
+  pes: "fa", // Western Persian (franc emits "pes", not "fas")
+  fra: "fr", // French
+  hin: "hi", // Hindi
+  hun: "hu", // Hungarian
+  ind: "id", // Indonesian
+  ita: "it", // Italian
+  jpn: "ja", // Japanese
+  kor: "ko", // Korean
+  nld: "nl", // Dutch
+  pol: "pl", // Polish
+  por: "pt", // Portuguese
+  ron: "ro", // Romanian
+  rus: "ru", // Russian
+  swe: "sv", // Swedish
+  tgl: "tl", // Tagalog
+  tha: "th", // Thai
+  tur: "tr", // Turkish
+  ukr: "uk", // Ukrainian
+  zlm: "ms" // Malay
+};
+
+/** Map a franc-min ISO-639-3 code to a LibreTranslate ISO-639-1 code, or null. */
+export function francToIso1(code3: string | null | undefined): string | null {
+  if (!code3 || code3 === "und") {
+    return null;
+  }
+  return ISO_639_3_TO_1[code3] ?? null;
+}
+
+/**
+ * Normalize a locale/language tag ("en-US", "pt_BR", "zh-Hant") to a single
+ * LibreTranslate code. Traditional-Chinese variants map to LibreTranslate's
+ * dedicated "zt" so Traditional readers aren't silently served Simplified.
+ */
+export function normLang(input: string | null | undefined): string {
+  if (!input) {
+    return "";
+  }
+  const lower = input.toLowerCase().replace(/_/g, "-");
+  if (
+    lower === "zh-hant" ||
+    lower.startsWith("zh-hant-") ||
+    lower === "zh-tw" ||
+    lower === "zh-hk" ||
+    lower === "zh-mo"
+  ) {
+    return "zt";
+  }
+  return lower.split("-")[0];
+}
+
+/** Right-to-left languages among LibreTranslate's set (+ a couple of extras). */
+const RTL_LANGS = new Set(["ar", "he", "fa", "ur", "ps", "dv", "yi"]);
+
+export function isRtlLang(code: string | null | undefined): boolean {
+  return RTL_LANGS.has(normLang(code));
+}
+
+/** Minimum plain-text length before we bother detecting / offering a CTA. */
+export const MIN_DETECT_CHARS = 40;
+
+export interface TranslateCtaDecision {
+  show: boolean;
+  /** Detected content language (ISO-639-1), best available guess. */
+  source: string;
+  /** Reader's target language (ISO-639-1), always a supported target. */
+  target: string;
+}
+
+/**
+ * The single gate: should we offer a prominent "Translate to <reader>" CTA?
+ *
+ * @param detected content language (ISO-639-1) or null/"und" when unknown
+ * @param reader   reader's resolved language (ISO-639-1)
+ * @param textLength plain-text length of the sample used for detection
+ */
+export function resolveTranslateCta({
+  detected,
+  reader,
+  textLength
+}: {
+  detected: string | null | undefined;
+  reader: string;
+  textLength: number;
+}): TranslateCtaDecision {
+  const normDetected = detected ? normLang(detected) : null;
+  const target = LIBRETRANSLATE_TARGETS.has(reader) ? reader : "en";
+
+  const show =
+    textLength >= MIN_DETECT_CHARS &&
+    !!normDetected &&
+    normDetected !== "und" &&
+    LIBRETRANSLATE_SOURCES.has(normDetected) &&
+    LIBRETRANSLATE_TARGETS.has(target) &&
+    normDetected !== target;
+
+  return { show, source: normDetected ?? "", target };
+}
+
+// Codes that Intl.DisplayNames may not resolve on its own, or that we prefer to
+// render with a specific label. "zt" is not a standard BCP-47 code.
+const DISPLAY_NAME_FALLBACK: Record<string, string> = {
+  ar: "Arabic", az: "Azerbaijani", bg: "Bulgarian", bn: "Bengali",
+  ca: "Catalan", cs: "Czech", da: "Danish", de: "German", el: "Greek",
+  en: "English", eo: "Esperanto", es: "Spanish", et: "Estonian",
+  fa: "Persian", fi: "Finnish", fr: "French", ga: "Irish", he: "Hebrew",
+  hi: "Hindi", hu: "Hungarian", id: "Indonesian", it: "Italian",
+  ja: "Japanese", ko: "Korean", lt: "Lithuanian", lv: "Latvian",
+  ms: "Malay", nb: "Norwegian", nl: "Dutch", pl: "Polish",
+  pt: "Portuguese", ro: "Romanian", ru: "Russian", sk: "Slovak",
+  sl: "Slovenian", sq: "Albanian", sv: "Swedish", th: "Thai",
+  tl: "Tagalog", tr: "Turkish", uk: "Ukrainian", zh: "Chinese",
+  zt: "Chinese (Traditional)"
+};
+
+/**
+ * Human-readable language name for a LibreTranslate code, localized to the UI
+ * language when the platform can, falling back to an English label.
+ */
+export function languageDisplayName(code: string, uiLang?: string): string {
+  const norm = normLang(code);
+  // "zt" isn't a real BCP-47 tag; render it via zh-Hant.
+  const bcp47 = norm === "zt" ? "zh-Hant" : norm;
+  try {
+    if (typeof Intl !== "undefined" && typeof Intl.DisplayNames === "function") {
+      const dn = new Intl.DisplayNames([uiLang || "en", "en"], { type: "language" });
+      const name = dn.of(bcp47);
+      if (name && name.toLowerCase() !== bcp47.toLowerCase()) {
+        return norm === "zt" ? `${name} (Traditional)` : name;
+      }
+    }
+  } catch {
+    // Intl.DisplayNames unavailable / invalid tag — fall through.
+  }
+  return DISPLAY_NAME_FALLBACK[norm] ?? code;
+}

--- a/apps/web/src/features/shared/entry-translate/translate-chip.tsx
+++ b/apps/web/src/features/shared/entry-translate/translate-chip.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React, { useState } from "react";
+import dynamic from "next/dynamic";
+import i18next from "i18next";
+import { UilLanguage } from "@tooni/iconscout-unicons-react";
+import { Entry } from "@/entities";
+import { useContentLanguageGate } from "./use-content-language-gate";
+import { languageDisplayName } from "./iso639";
+
+const EntryTranslate = dynamic(
+  () => import("./index").then((m) => ({ default: m.EntryTranslate })),
+  { ssr: false }
+);
+
+interface Props {
+  entry: Entry;
+  className?: string;
+}
+
+/**
+ * Compact "Translate" chip for feed list items and waves, shown only when the
+ * detected content language differs from the reader's. Feed-safe by design:
+ *  - detection is franc-only (NO server /detect), so no per-item network;
+ *  - the gate is idle-scheduled and memoized per-permlink at module scope;
+ *  - it must be placed inside a near-viewport-hydrated island so off-screen
+ *    cards never run detection at all.
+ *
+ * Tapping opens the existing translate modal pre-targeted to the reader's
+ * language (source stays "auto" so LibreTranslate — not the coarse franc guess
+ * — decides the real source language). The 3-dot Translate item stays as a
+ * fallback for everything else.
+ */
+export function TranslateChip({ entry, className = "" }: Props) {
+  const [open, setOpen] = useState(false);
+  const decision = useContentLanguageGate(entry, { serverConfirm: false });
+
+  if (!decision?.show) {
+    return null;
+  }
+
+  const targetName = languageDisplayName(decision.target, i18next.language);
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`flex items-center gap-1 text-gray-steel hover:text-blue-dark-sky ${className}`}
+        onClick={() => setOpen(true)}
+        title={i18next.t("entry-translate.translate-to", { lang: targetName })}
+        aria-label={i18next.t("entry-translate.translate-to", { lang: targetName })}
+      >
+        <UilLanguage className="w-3.5 h-3.5" />
+        <span>{i18next.t("entry-menu.translate")}</span>
+      </button>
+      {open && (
+        <EntryTranslate
+          entry={entry}
+          initialTarget={decision.target}
+          onHide={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
+++ b/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
@@ -1,0 +1,193 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import i18next from "i18next";
+import { postBodySummary } from "@ecency/render-helper";
+import { detectLanguage } from "@/api/translation";
+import {
+  francToIso1,
+  LIBRETRANSLATE_TARGETS,
+  MIN_DETECT_CHARS,
+  normLang,
+  resolveTranslateCta,
+  TranslateCtaDecision
+} from "./iso639";
+
+// How much plain text to feed the detector. franc is accurate well below this.
+const SAMPLE_CHARS = 600;
+// Only render markdown for the first slice of raw body — detection needs a few
+// hundred clean chars, so rendering a whole long article would be wasted work
+// (especially across many feed cards).
+const RAW_SAMPLE_CHARS = 2000;
+
+interface CacheEntry {
+  // Detected content language (ISO-639-1), null when undetermined/unsupported.
+  lang: string | null;
+  // true once the server /detect confirmed it (full-post path). A franc-only
+  // (feed) result can later be upgraded by the full-post path.
+  confirmed: boolean;
+}
+
+// Module-scoped, keyed by `${author}/${permlink}` so the reader-independent
+// content language is computed at most once per post for the whole session.
+// Crucially this survives component REMOUNTS (feed scroll/refetch, FlashList-
+// style header churn), so nothing re-runs detection or re-hits the network.
+const contentLangCache = new Map<string, CacheEntry>();
+
+/** Read the reader's preferred language. MUST be called client-side only. */
+function resolveReaderLang(): string {
+  const candidates = [
+    i18next.language,
+    typeof navigator !== "undefined" ? navigator.language : "",
+    typeof navigator !== "undefined" && navigator.languages?.length ? navigator.languages[0] : ""
+  ];
+  for (const candidate of candidates) {
+    const norm = normLang(candidate);
+    if (norm && LIBRETRANSLATE_TARGETS.has(norm)) {
+      return norm;
+    }
+  }
+  return "en";
+}
+
+function scheduleIdle(cb: () => void): void {
+  const ric = (typeof window !== "undefined" && (window as any).requestIdleCallback) as
+    | ((c: () => void, o?: { timeout: number }) => number)
+    | undefined;
+  if (ric) {
+    ric(cb, { timeout: 2000 });
+  } else {
+    setTimeout(cb, 200);
+  }
+}
+
+interface GateEntry {
+  author: string;
+  permlink: string;
+  body: string;
+}
+
+interface GateOptions {
+  // Full-post view: confirm/refine the franc guess with the server /detect
+  // endpoint (accurate source-language name, catches franc-unsupported langs,
+  // corrects confident misdetections). NEVER enable for feed/wave chips — it
+  // would fan out one network call per rendered item.
+  serverConfirm?: boolean;
+  // Skip detection entirely (e.g. raw/edit view, NSFW not yet revealed).
+  disabled?: boolean;
+}
+
+/**
+ * Decide whether to offer a "Translate to <reader>" CTA for an entry, by
+ * comparing the reader's language to the detected content language.
+ *
+ * Contract: returns `null` until resolved on the client (never during SSR or the
+ * first client render) so it cannot cause a hydration mismatch — callers render
+ * nothing while it is null. Fails closed (null) on any error.
+ *
+ * Feed-safe: the only synchronous work per mount is a raw string-length check
+ * and a Map lookup. The expensive markdown render + detection happen once per
+ * permlink, at idle, and only on a cache miss.
+ */
+export function useContentLanguageGate(
+  entry: GateEntry | null | undefined,
+  { serverConfirm = false, disabled = false }: GateOptions = {}
+): TranslateCtaDecision | null {
+  const [decision, setDecision] = useState<TranslateCtaDecision | null>(null);
+
+  const author = entry?.author;
+  const permlink = entry?.permlink;
+  const body = entry?.body;
+
+  useEffect(() => {
+    setDecision(null);
+
+    if (disabled || !author || !permlink || !body) {
+      return;
+    }
+
+    // Cheap raw pre-check — never render a summary for a trivially short body.
+    if (body.trim().length < MIN_DETECT_CHARS) {
+      return;
+    }
+
+    let cancelled = false;
+    const key = `${author}/${permlink}`;
+    const reader = resolveReaderLang();
+
+    const cached = contentLangCache.get(key);
+    if (cached && (cached.confirmed || !serverConfirm)) {
+      // A cached lang implies the body was already long enough when detected.
+      setDecision(
+        resolveTranslateCta({ detected: cached.lang, reader, textLength: MIN_DETECT_CHARS })
+      );
+      return;
+    }
+
+    scheduleIdle(async () => {
+      if (cancelled) {
+        return;
+      }
+      try {
+        // Bound markdown work regardless of article length.
+        const sample = postBodySummary(body.slice(0, RAW_SAMPLE_CHARS), 0).slice(0, SAMPLE_CHARS);
+        const textLength = sample.trim().length;
+
+        if (textLength < MIN_DETECT_CHARS) {
+          contentLangCache.set(key, { lang: null, confirmed: true });
+          return; // decision stays null → no CTA
+        }
+
+        let lang: string | null = cached?.lang ?? null;
+        let confirmed = cached?.confirmed ?? false;
+
+        if (!cached) {
+          const { franc } = await import("franc-min");
+          if (cancelled) {
+            return;
+          }
+          lang = francToIso1(franc(sample));
+        }
+
+        if (lang && lang === reader) {
+          // franc is confident it's the reader's own language — no CTA, and no
+          // need to spend a /detect call. Safe to treat as confirmed.
+          confirmed = true;
+        } else if (serverConfirm) {
+          // Full-post: get the authoritative source language. Covers franc
+          // 'und'/unsupported langs and corrects confident misdetections
+          // (e.g. Danish reported as Dutch) so the banner names the real one.
+          try {
+            const detected = await detectLanguage(sample);
+            if (cancelled) {
+              return;
+            }
+            const top = detected[0];
+            if (top && typeof top.language === "string") {
+              lang = normLang(top.language);
+              confirmed = true;
+            }
+          } catch {
+            // /detect unreachable — keep the franc guess (fail open to franc).
+          }
+        }
+
+        contentLangCache.set(key, { lang, confirmed });
+        if (!cancelled) {
+          setDecision(resolveTranslateCta({ detected: lang, reader, textLength }));
+        }
+      } catch {
+        // Detector chunk failed to load or threw — fail closed, keep original.
+        if (!cancelled) {
+          setDecision(null);
+        }
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [author, permlink, body, serverConfirm, disabled]);
+
+  return decision;
+}

--- a/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
+++ b/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
@@ -32,7 +32,19 @@ interface CacheEntry {
 // content language is computed at most once per post for the whole session.
 // Crucially this survives component REMOUNTS (feed scroll/refetch, FlashList-
 // style header churn), so nothing re-runs detection or re-hits the network.
+const MAX_CACHE_ENTRIES = 500;
 const contentLangCache = new Map<string, CacheEntry>();
+
+// Bound memory over long infinite-scroll sessions with simple FIFO eviction.
+function cacheDetection(key: string, entry: CacheEntry): void {
+  if (!contentLangCache.has(key) && contentLangCache.size >= MAX_CACHE_ENTRIES) {
+    const oldest = contentLangCache.keys().next().value;
+    if (oldest !== undefined) {
+      contentLangCache.delete(oldest);
+    }
+  }
+  contentLangCache.set(key, entry);
+}
 
 /** Read the reader's preferred language. MUST be called client-side only. */
 function resolveReaderLang(): string {
@@ -134,7 +146,7 @@ export function useContentLanguageGate(
         const textLength = sample.trim().length;
 
         if (textLength < MIN_DETECT_CHARS) {
-          contentLangCache.set(key, { lang: null, confirmed: true });
+          cacheDetection(key, { lang: null, confirmed: true });
           return; // decision stays null → no CTA
         }
 
@@ -172,7 +184,7 @@ export function useContentLanguageGate(
           }
         }
 
-        contentLangCache.set(key, { lang, confirmed });
+        cacheDetection(key, { lang, confirmed });
         if (!cancelled) {
           setDecision(resolveTranslateCta({ detected: lang, reader, textLength }));
         }

--- a/apps/web/src/features/waves/components/wave-actions.tsx
+++ b/apps/web/src/features/waves/components/wave-actions.tsx
@@ -7,6 +7,7 @@ import {
   EntryVotes,
   UserAvatar
 } from "@/features/shared";
+import { TranslateChip } from "@/features/shared/entry-translate/translate-chip";
 import { commentSvg, voteSvg } from "@/app/decks/_components/icons";
 import { Button } from "@ui/button";
 import i18next from "i18next";
@@ -82,6 +83,7 @@ export function WaveActions({
             />
           </div>
           <div>
+            <TranslateChip entry={entry!} />
             <EntryMenu entry={entry!} />
             {activeUser?.username === entry?.author && (
               <Button className="edit-btn" appearance="link" onClick={() => onEdit(entry!)}>

--- a/apps/web/src/specs/api/translation.spec.ts
+++ b/apps/web/src/specs/api/translation.spec.ts
@@ -5,7 +5,30 @@ vi.mock("axios", () => ({
   default: { create: () => ({ post, get: vi.fn() }) }
 }));
 
-import { getTranslation, stripEmojis } from "@/api/translation";
+import { chunkText, getTranslation, stripEmojis } from "@/api/translation";
+
+describe("chunkText", () => {
+  it("returns the whole text when within the limit", () => {
+    expect(chunkText("short text", 100)).toEqual(["short text"]);
+  });
+
+  it("splits long spaced text into chunks that respect the limit", () => {
+    const text = Array.from({ length: 50 }, (_, i) => `word${i}`).join(" ");
+    const chunks = chunkText(text, 30);
+    expect(chunks.length).toBeGreaterThan(1);
+    chunks.forEach((c) => expect(c.length).toBeLessThanOrEqual(30));
+    expect(chunks.join(" ")).toBe(text);
+  });
+
+  it("hard-splits a space-less run longer than the limit (CJK)", () => {
+    // A 250-char CJK paragraph with no spaces must not become one over-limit chunk.
+    const cjk = "中".repeat(250);
+    const chunks = chunkText(cjk, 100);
+    expect(chunks.length).toBe(3);
+    chunks.forEach((c) => expect(c.length).toBeLessThanOrEqual(100));
+    expect(chunks.join("")).toBe(cjk);
+  });
+});
 
 describe("stripEmojis", () => {
   it("removes trailing emoji and returns them separately", () => {

--- a/apps/web/src/specs/features/entry-translate-iso639.spec.ts
+++ b/apps/web/src/specs/features/entry-translate-iso639.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  francToIso1,
+  isRtlLang,
+  ISO_639_3_TO_1,
+  languageDisplayName,
+  LIBRETRANSLATE_SOURCES,
+  normLang,
+  resolveTranslateCta
+} from "@/features/shared/entry-translate/iso639";
+
+describe("normLang", () => {
+  it("reduces locale tags to a 2-letter code", () => {
+    expect(normLang("en-US")).toBe("en");
+    expect(normLang("pt_BR")).toBe("pt");
+    expect(normLang("ES")).toBe("es");
+  });
+
+  it("maps Traditional Chinese variants to LibreTranslate 'zt'", () => {
+    expect(normLang("zh-Hant")).toBe("zt");
+    expect(normLang("zh-TW")).toBe("zt");
+    expect(normLang("zh-HK")).toBe("zt");
+    expect(normLang("zh-Hant-TW")).toBe("zt");
+  });
+
+  it("keeps Simplified Chinese as 'zh'", () => {
+    expect(normLang("zh")).toBe("zh");
+    expect(normLang("zh-CN")).toBe("zh");
+    expect(normLang("zh-Hans")).toBe("zh");
+  });
+
+  it("returns empty string for missing input", () => {
+    expect(normLang("")).toBe("");
+    expect(normLang(null)).toBe("");
+    expect(normLang(undefined)).toBe("");
+  });
+});
+
+describe("francToIso1", () => {
+  it("maps franc's actual ISO-639-3 codes to LibreTranslate ISO-639-1", () => {
+    // Regression guards for the codes the design critique flagged.
+    expect(francToIso1("pes")).toBe("fa"); // franc emits pes, NOT fas
+    expect(francToIso1("arb")).toBe("ar");
+    expect(francToIso1("cmn")).toBe("zh");
+    expect(francToIso1("zlm")).toBe("ms");
+    expect(francToIso1("azj")).toBe("az");
+    expect(francToIso1("spa")).toBe("es");
+    expect(francToIso1("eng")).toBe("en");
+  });
+
+  it("returns null for 'und' and unknown/unsupported codes", () => {
+    expect(francToIso1("und")).toBeNull();
+    expect(francToIso1("")).toBeNull();
+    expect(francToIso1(null)).toBeNull();
+    // 'dan' (Danish) is a real franc code but franc-min can't emit it and we
+    // don't map it — full-post falls back to server /detect.
+    expect(francToIso1("dan")).toBeNull();
+  });
+
+  it("every mapped target is a supported LibreTranslate source", () => {
+    for (const code1 of Object.values(ISO_639_3_TO_1)) {
+      expect(LIBRETRANSLATE_SOURCES.has(code1)).toBe(true);
+    }
+  });
+});
+
+describe("resolveTranslateCta", () => {
+  const long = 200;
+
+  it("shows the CTA when content and reader languages differ", () => {
+    expect(resolveTranslateCta({ detected: "es", reader: "en", textLength: long })).toEqual({
+      show: true,
+      source: "es",
+      target: "en"
+    });
+  });
+
+  it("hides the CTA when content is already the reader's language", () => {
+    expect(resolveTranslateCta({ detected: "en", reader: "en", textLength: long }).show).toBe(false);
+  });
+
+  it("hides the CTA for text below the minimum length", () => {
+    expect(resolveTranslateCta({ detected: "es", reader: "en", textLength: 10 }).show).toBe(false);
+  });
+
+  it("hides the CTA for undetected / unsupported source languages", () => {
+    expect(resolveTranslateCta({ detected: null, reader: "en", textLength: long }).show).toBe(false);
+    expect(resolveTranslateCta({ detected: "und", reader: "en", textLength: long }).show).toBe(false);
+    // 'xx' is not a LibreTranslate language.
+    expect(resolveTranslateCta({ detected: "xx", reader: "en", textLength: long }).show).toBe(false);
+  });
+
+  it("falls back to English target when the reader language is unsupported", () => {
+    const d = resolveTranslateCta({ detected: "es", reader: "xx", textLength: long });
+    expect(d.target).toBe("en");
+    expect(d.show).toBe(true);
+  });
+
+  it("routes Traditional-Chinese readers to 'zt' target, not 'zh'", () => {
+    const d = resolveTranslateCta({ detected: "en", reader: normLang("zh-TW"), textLength: long });
+    expect(d.target).toBe("zt");
+    expect(d.show).toBe(true);
+  });
+});
+
+describe("isRtlLang", () => {
+  it("flags RTL languages", () => {
+    expect(isRtlLang("ar")).toBe(true);
+    expect(isRtlLang("he")).toBe(true);
+    expect(isRtlLang("fa")).toBe(true);
+    expect(isRtlLang("en")).toBe(false);
+    expect(isRtlLang("es")).toBe(false);
+  });
+});
+
+describe("languageDisplayName", () => {
+  it("produces readable names, including Traditional Chinese", () => {
+    expect(languageDisplayName("es", "en").toLowerCase()).toContain("spanish");
+    expect(languageDisplayName("zt", "en").toLowerCase()).toContain("traditional");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,9 @@ importers:
       formidable:
         specifier: ^3.5.4
         version: 3.5.4
+      franc-min:
+        specifier: ^6.2.0
+        version: 6.2.0
       heic2any:
         specifier: ^0.0.4
         version: 0.0.4
@@ -4952,6 +4955,9 @@ packages:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
 
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -5685,6 +5691,9 @@ packages:
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+
+  franc-min@6.2.0:
+    resolution: {integrity: sha512-1uDIEUSlUZgvJa2AKYR/dmJC66v/PvGQ9mWfI9nOr/kPpMFyvswK0gPXOwpYJYiYD008PpHLkGfG58SPjQJFxw==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -6723,6 +6732,9 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  n-gram@2.0.2:
+    resolution: {integrity: sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==}
 
   nano-css@5.6.2:
     resolution: {integrity: sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==}
@@ -8255,6 +8267,9 @@ packages:
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+
+  trigram-utils@2.0.1:
+    resolution: {integrity: sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -13196,7 +13211,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.27.7)(jiti@1.21.7)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -13266,7 +13281,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.27.7)(jiti@1.21.7)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/utils@4.1.8':
     dependencies:
@@ -13863,6 +13878,8 @@ snapshots:
   clsx@2.1.1: {}
 
   cluster-key-slot@1.1.2: {}
+
+  collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -14765,6 +14782,10 @@ snapshots:
   forwarded-parse@2.1.2: {}
 
   fraction.js@4.3.7: {}
+
+  franc-min@6.2.0:
+    dependencies:
+      trigram-utils: 2.0.1
 
   fs-extra@7.0.1:
     dependencies:
@@ -15787,6 +15808,8 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  n-gram@2.0.2: {}
 
   nano-css@5.6.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -17407,6 +17430,11 @@ snapshots:
       punycode: 2.3.1
 
   tree-kill@1.2.2: {}
+
+  trigram-utils@2.0.1:
+    dependencies:
+      collapse-white-space: 2.1.0
+      n-gram: 2.0.2
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## What

Surfaces the existing post translation feature prominently when the reader's language differs from the language a post is written in, instead of hiding it in the 3-dot menu.

When a post's detected language differs from the reader's language, a one-line **"This post is in X. Translate to Y?"** banner appears directly above the post body. One tap translates the full body in place (plain text) with a **Show original** toggle and a **Change language** option. On feed items and waves, a compact **Translate** chip appears in the action row for the same mismatch case. The 3-dot Translate item stays as an always-available fallback and now shows on all top-level posts and waves (previously waves-only).

## How

- **Reader language** resolves from the UI language, falling back to the browser language (read only in an effect, so SSR stays deterministic).
- **Content language** is detected client-side and network-free with `franc-min` (dynamically imported, so it stays off the post read-path chunk). On the full-post view, an ambiguous or franc-unsupported result is confirmed with the translation service's `/detect` endpoint; the actual translation call (`source: "auto"`) also returns the authoritative source language for free, which relabels the banner to "Translated from X" and self-corrects a wrong guess.
- **Gate** (`resolveTranslateCta`): show only when the detected source and reader target are both supported and differ. Our backend is all-to-all across its 43 languages, so no per-pair validation is needed.
- **Feed-safe:** detection never runs on off-screen cards. It is idle-scheduled, bounded to the first ~2k chars of the body, memoized per `author/permlink` at module scope (survives remounts), and — in feeds/waves — franc-only with no server calls. It lives inside the existing near-viewport hydration island in feed items.
- **Correctness details:** franc emits ISO-639-3 (`pes`≠`fas`, `arb`, `cmn`, `zlm`, …) — the map was verified empirically against the installed data. Traditional-Chinese readers route to the dedicated `zt` code. RTL targets (ar/he/fa) render `dir="rtl"`. Full-body translations are chunked to stay under request limits. Dismissal is remembered per post. The whole path fails closed (original body intact) on any error.

## Files

- New: `features/shared/entry-translate/iso639.ts` (pure, unit-tested), `use-content-language-gate.ts`, `entry-translate-inline.tsx`, `translate-chip.tsx`
- `api/translation.ts`: `detectLanguage()`, chunked `translateLongText()`, `detectedLanguage` typing
- `entry-translate/index.tsx`: optional `initialTarget`/`initialSource`, "Translated from" label, RTL
- Wired into `entry-page-content-ssr.tsx` (full post), `entry-list-item/index.tsx` (feed), `waves/components/wave-actions.tsx` (waves); un-gated `entry-menu/menu-items-generator.tsx`; new `entry-translate.*` strings in `en-US.json`

## Testing

- 15 unit tests for the language mapping / gate logic (`entry-translate-iso639.spec.ts`)
- `tsc --noEmit` clean for all changed files; production build passes
- Note: the translation backend is not reachable from CI, so the live translate/detect round-trip needs a real-browser check.

## Notes / follow-ups

- v1 is full-body plain-text (images/formatting stay in the original view; paragraph breaks are collapsed) — a follow-up can preserve paragraph structure.
- franc-min does not cover ~14 of the backend's languages (e.g. Danish, Finnish, Hebrew); those are caught by the `/detect` confirmation on the full-post view and simply show no chip in feeds.
- An optional global "auto-translate on mismatch" preference (default off) is a natural follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline translation prompts and a compact Translate button on posts and feed items.
  * Translation now supports longer content, language detection, and clearer “show original” / “change language” actions.
  * Added improved language labeling, including right-to-left display handling and translated-from indicators.

* **Bug Fixes**
  * Translation options now appear more consistently across top-level entries.
  * Better handling for short, unsupported, or already-matching languages to avoid unnecessary translation prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->