### PR TITLE
Points top-up CTA at insufficient-balance moments

### DIFF
--- a/apps/web/src/app/perks/points/_page.tsx
+++ b/apps/web/src/app/perks/points/_page.tsx
@@ -6,15 +6,15 @@ import { error, success } from "@/features/shared/feedback";
 import { LoginRequired } from "@/features/shared/login-required";
 import { PurchaseQrDialog, PurchaseTypes } from "@/features/shared/purchase-qr";
 import {
-  STRIPE_POINTS_TIERS,
   StripePointsDialog,
+  isKnownTierSku,
   isStripeEnabled
 } from "@/features/shared/purchase-stripe";
-import { getPointsQueryOptions, useClaimPoints } from "@ecency/sdk";
+import { QueryKeys, getPointsQueryOptions, useClaimPoints } from "@ecency/sdk";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import i18next from "i18next";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { PointsActionCard, PointsBasicInfo } from "./_components";
 import { formatError } from "@/api/format-error";
 import { getAccessToken } from "@/utils";
@@ -26,49 +26,59 @@ export function PointsPage() {
   const [showPurchaseQr, setShowPurchaseQr] = useState(false);
   const [showStripe, setShowStripe] = useState(false);
   const [resumePi, setResumePi] = useState<string | undefined>(undefined);
-  const [deepLinkSku, setDeepLinkSku] = useState<string | undefined>(undefined);
-  const [pendingBuy, setPendingBuy] = useState(false);
+  // Non-null once a ?buy=card deep link is seen; carries the preselected tier and
+  // keeps it available to the dialog until the dialog is closed.
+  const [deepLinkBuy, setDeepLinkBuy] = useState<{ sku?: string } | null>(null);
   const router = useRouter();
   const queryClient = useQueryClient();
 
-  // Upsell deep-link (?buy=card&sku=...): open the card dialog with the tier that
-  // covers the caller's deficit preselected. Params are stripped from the address
-  // bar either way; an unknown sku falls back to the dialog default.
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
+  // Remove only our own params, preserving any unrelated query (utm/ref), the hash,
+  // and the App Router's history state.
+  const clearSearchParams = useCallback((keys: string[]) => {
+    const url = new URL(window.location.href);
+    let changed = false;
+    for (const key of keys) {
+      if (url.searchParams.has(key)) {
+        url.searchParams.delete(key);
+        changed = true;
+      }
     }
+    if (changed) {
+      window.history.replaceState(
+        window.history.state,
+        "",
+        `${url.pathname}${url.search}${url.hash}`
+      );
+    }
+  }, []);
+
+  // Upsell deep-link (?buy=card&sku=...): arm the card dialog with the tier that
+  // covers the caller's deficit preselected. The params stay in the URL until the
+  // dialog actually opens (below), so a redirect-based login round-trip doesn't
+  // lose the intent. An unknown/absent sku falls back to the dialog default.
+  useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    if (params.get("buy") !== "card") {
+    if (params.get("buy") !== "card" || !isStripeEnabled()) {
       return;
     }
     const sku = params.get("sku") ?? undefined;
-    window.history.replaceState({}, "", window.location.pathname);
-    if (!isStripeEnabled()) {
-      return;
-    }
-    if (sku && STRIPE_POINTS_TIERS.some((tier) => tier.sku === sku)) {
-      setDeepLinkSku(sku);
-    }
-    setPendingBuy(true);
+    setDeepLinkBuy({ sku: sku && isKnownTierSku(sku) ? sku : undefined });
   }, []);
 
-  // The dialog needs an authenticated user to create the intent, so wait for the
-  // active user (covers login completing after landing on the deep link).
+  // The dialog needs an authenticated user to create the intent, so open once the
+  // active user is available (covers login completing after landing on the link).
+  // Strip the params only now that the intent has been consumed.
   useEffect(() => {
-    if (pendingBuy && activeUser) {
+    if (deepLinkBuy && activeUser && !showStripe) {
       setShowStripe(true);
-      setPendingBuy(false);
+      clearSearchParams(["buy", "sku"]);
     }
-  }, [pendingBuy, activeUser]);
+  }, [deepLinkBuy, activeUser, showStripe, clearSearchParams]);
 
   // Resume the card flow after a redirect-based payment method returns here (Stripe
   // appends payment_intent + redirect_status to the URL). Card payments resolve
   // in-place and never hit this; it covers wallet/redirect methods if enabled.
   useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
     const params = new URLSearchParams(window.location.search);
     const pi = params.get("payment_intent");
     if (!pi) {
@@ -76,7 +86,7 @@ export function PointsPage() {
     }
     const status = params.get("redirect_status");
     // Clear Stripe's params from the address bar regardless of outcome.
-    window.history.replaceState({}, "", window.location.pathname);
+    clearSearchParams(["payment_intent", "redirect_status"]);
     if (status === "succeeded" || status === "processing") {
       // still in flight -> resume into the delivery poll
       setResumePi(pi);
@@ -85,7 +95,14 @@ export function PointsPage() {
       // failed / requires_payment_method / canceled -> tell the user
       error(i18next.t("stripe-points.pay-failed"));
     }
-  }, []);
+  }, [clearSearchParams]);
+
+  const onPointsDelivered = useCallback(() => {
+    const username = activeUser?.username;
+    if (username) {
+      queryClient.invalidateQueries({ queryKey: QueryKeys.points._prefix(username) });
+    }
+  }, [queryClient, activeUser?.username]);
 
   const canClaim = useMemo(
     () => activeUserPoints?.uPoints && parseInt(activeUserPoints?.uPoints) !== 0,
@@ -177,16 +194,12 @@ export function PointsPage() {
             setShowStripe(v);
             if (!v) {
               setResumePi(undefined);
-              setDeepLinkSku(undefined);
+              setDeepLinkBuy(null);
             }
           }}
-          defaultSku={deepLinkSku}
+          defaultSku={deepLinkBuy?.sku}
           resumePaymentIntent={resumePi}
-          onDelivered={() =>
-            queryClient.invalidateQueries({
-              queryKey: getPointsQueryOptions(activeUser?.username).queryKey
-            })
-          }
+          onDelivered={onPointsDelivered}
         />
       )}
     </div>

--- a/apps/web/src/app/perks/points/_page.tsx
+++ b/apps/web/src/app/perks/points/_page.tsx
@@ -5,9 +5,13 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { error, success } from "@/features/shared/feedback";
 import { LoginRequired } from "@/features/shared/login-required";
 import { PurchaseQrDialog, PurchaseTypes } from "@/features/shared/purchase-qr";
-import { StripePointsDialog, isStripeEnabled } from "@/features/shared/purchase-stripe";
+import {
+  STRIPE_POINTS_TIERS,
+  StripePointsDialog,
+  isStripeEnabled
+} from "@/features/shared/purchase-stripe";
 import { getPointsQueryOptions, useClaimPoints } from "@ecency/sdk";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import i18next from "i18next";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
@@ -22,7 +26,41 @@ export function PointsPage() {
   const [showPurchaseQr, setShowPurchaseQr] = useState(false);
   const [showStripe, setShowStripe] = useState(false);
   const [resumePi, setResumePi] = useState<string | undefined>(undefined);
+  const [deepLinkSku, setDeepLinkSku] = useState<string | undefined>(undefined);
+  const [pendingBuy, setPendingBuy] = useState(false);
   const router = useRouter();
+  const queryClient = useQueryClient();
+
+  // Upsell deep-link (?buy=card&sku=...): open the card dialog with the tier that
+  // covers the caller's deficit preselected. Params are stripped from the address
+  // bar either way; an unknown sku falls back to the dialog default.
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("buy") !== "card") {
+      return;
+    }
+    const sku = params.get("sku") ?? undefined;
+    window.history.replaceState({}, "", window.location.pathname);
+    if (!isStripeEnabled()) {
+      return;
+    }
+    if (sku && STRIPE_POINTS_TIERS.some((tier) => tier.sku === sku)) {
+      setDeepLinkSku(sku);
+    }
+    setPendingBuy(true);
+  }, []);
+
+  // The dialog needs an authenticated user to create the intent, so wait for the
+  // active user (covers login completing after landing on the deep link).
+  useEffect(() => {
+    if (pendingBuy && activeUser) {
+      setShowStripe(true);
+      setPendingBuy(false);
+    }
+  }, [pendingBuy, activeUser]);
 
   // Resume the card flow after a redirect-based payment method returns here (Stripe
   // appends payment_intent + redirect_status to the URL). Card payments resolve
@@ -139,9 +177,16 @@ export function PointsPage() {
             setShowStripe(v);
             if (!v) {
               setResumePi(undefined);
+              setDeepLinkSku(undefined);
             }
           }}
+          defaultSku={deepLinkSku}
           resumePaymentIntent={resumePi}
+          onDelivered={() =>
+            queryClient.invalidateQueries({
+              queryKey: getPointsQueryOptions(activeUser?.username).queryKey
+            })
+          }
         />
       )}
     </div>

--- a/apps/web/src/app/perks/promote-post/_components/promote-post-setup.tsx
+++ b/apps/web/src/app/perks/promote-post/_components/promote-post-setup.tsx
@@ -4,6 +4,7 @@ import { getAccessToken } from "@/utils";
 import { useQuery } from "@tanstack/react-query";
 import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { EntryListItem, SuggestionList } from "@/features/shared";
+import { PointsTopupCta } from "@/features/shared/points-topup-cta";
 import { Button, FormControl } from "@/features/ui";
 import { UilTrashAlt } from "@tooni/iconscout-unicons-react";
 import clsx from "clsx";
@@ -109,9 +110,16 @@ export function PromotePostSetup({ onSuccess, isPending }: Props) {
         </div>
         <div>
           {isAmountMoreThanBalance && (
-            <small className="usd-balance bold block text-red mt-3">
-              {i18next.t("market.more-than-balance")}
-            </small>
+            <div className="mt-3">
+              <small className="usd-balance bold block text-red">
+                {i18next.t("market.more-than-balance")}
+              </small>
+              <PointsTopupCta
+                className="mt-2 inline-block"
+                required={prices?.find((p) => p.duration === selectedDuration)?.price}
+                available={+(activeUserPoints?.points ?? 0)}
+              />
+            </div>
           )}
         </div>
         <div className="flex md:col-span-2 justify-end">

--- a/apps/web/src/app/perks/promote-post/_components/promote-post-setup.tsx
+++ b/apps/web/src/app/perks/promote-post/_components/promote-post-setup.tsx
@@ -46,13 +46,17 @@ export function PromotePostSetup({ onSuccess, isPending }: Props) {
     permlink
   ));
 
+  const selectedPrice = useMemo(
+    () => prices?.find((p) => p.duration === selectedDuration)?.price,
+    [prices, selectedDuration]
+  );
+
   const isAmountMoreThanBalance = useMemo(() => {
-    const price = prices?.find((p) => p.duration === selectedDuration);
-    if (activeUserPoints && price) {
-      return +activeUserPoints?.points < price.price;
+    if (activeUserPoints && selectedPrice != null) {
+      return +activeUserPoints?.points < selectedPrice;
     }
     return false;
-  }, [activeUserPoints, prices, selectedDuration]);
+  }, [activeUserPoints, selectedPrice]);
 
   useDebounce(() => setPathQuery(path), 500, [path]);
   useDebounce(() => setDebouncedPathQuery(pathQuery), 500, [pathQuery]);
@@ -116,7 +120,7 @@ export function PromotePostSetup({ onSuccess, isPending }: Props) {
               </small>
               <PointsTopupCta
                 className="mt-2 inline-block"
-                required={prices?.find((p) => p.duration === selectedDuration)?.price}
+                required={selectedPrice}
                 available={+(activeUserPoints?.points ?? 0)}
               />
             </div>

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1439,6 +1439,7 @@
   },
   "points": {
     "get": "BUY POINTS",
+    "get-more": "Get more Points",
     "unclaimed-points": "Unclaimed points",
     "claim-reward-points": "Collect points",
     "main-description": "Points can be used for in-app services, like Promote, Boost, Gifting. Earn them just by using Ecency apps and improve your experience.",

--- a/apps/web/src/features/shared/ai-assist/ai-assist.tsx
+++ b/apps/web/src/features/shared/ai-assist/ai-assist.tsx
@@ -3,6 +3,7 @@
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { withFeatureFlag } from "@/core/react-query";
 import { error, success } from "@/features/shared";
+import { PointsTopupCta } from "@/features/shared/points-topup-cta";
 import { Button, FormControl } from "@/features/ui";
 import { getAccessToken, ensureValidToken } from "@/utils";
 import {
@@ -438,12 +439,19 @@ export function AiAssist({ onApply, initialText = "" }: Props) {
       )}
 
       {isInsufficientBalance && (
-        <small className="text-red block">
-          {i18next.t("ai-assist.error-insufficient-points", {
-            required: selectedPrice?.cost ?? 0,
-            available: activeUserPoints?.points ?? "0",
-          })}
-        </small>
+        <div className="flex items-center flex-wrap gap-3">
+          <small className="text-red block">
+            {i18next.t("ai-assist.error-insufficient-points", {
+              required: selectedPrice?.cost ?? 0,
+              available: activeUserPoints?.points ?? "0",
+            })}
+          </small>
+          <PointsTopupCta
+            required={selectedPrice?.cost}
+            available={+(activeUserPoints?.points ?? 0)}
+            newTab={true}
+          />
+        </div>
       )}
 
       <div className="flex justify-end">

--- a/apps/web/src/features/shared/ai-assist/ai-assist.tsx
+++ b/apps/web/src/features/shared/ai-assist/ai-assist.tsx
@@ -449,7 +449,6 @@ export function AiAssist({ onApply, initialText = "" }: Props) {
           <PointsTopupCta
             required={selectedPrice?.cost}
             available={+(activeUserPoints?.points ?? 0)}
-            newTab={true}
           />
         </div>
       )}

--- a/apps/web/src/features/shared/ai-image-generator/ai-image-generator.tsx
+++ b/apps/web/src/features/shared/ai-image-generator/ai-image-generator.tsx
@@ -3,6 +3,7 @@
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { withFeatureFlag } from "@/core/react-query";
 import { error, success } from "@/features/shared";
+import { PointsTopupCta } from "@/features/shared/points-topup-cta";
 import { Button, FormControl } from "@/features/ui";
 import { getAccessToken, ensureValidToken } from "@/utils";
 import {
@@ -291,9 +292,16 @@ export function AiImageGenerator({ onInsert, showInsertAction = true, suggestedP
       )}
 
       {isInsufficientBalance && (
-        <small className="text-red block">
-          {i18next.t("market.more-than-balance")}
-        </small>
+        <div className="flex items-center flex-wrap gap-3">
+          <small className="text-red block">
+            {i18next.t("market.more-than-balance")}
+          </small>
+          <PointsTopupCta
+            required={cost}
+            available={+(activeUserPoints?.points ?? 0)}
+            newTab={true}
+          />
+        </div>
       )}
 
       <div className="flex justify-end">

--- a/apps/web/src/features/shared/ai-image-generator/ai-image-generator.tsx
+++ b/apps/web/src/features/shared/ai-image-generator/ai-image-generator.tsx
@@ -299,7 +299,6 @@ export function AiImageGenerator({ onInsert, showInsertAction = true, suggestedP
           <PointsTopupCta
             required={cost}
             available={+(activeUserPoints?.points ?? 0)}
-            newTab={true}
           />
         </div>
       )}

--- a/apps/web/src/features/shared/boost/index.tsx
+++ b/apps/web/src/features/shared/boost/index.tsx
@@ -13,6 +13,7 @@ import { getBoostPlusPricesQueryOptions, getPointsQueryOptions, getBoostPlusAcco
 import { getAccessToken } from "@/utils";
 import i18next from "i18next";
 import { LinearProgress } from "@/features/shared";
+import { PointsTopupCta } from "@/features/shared/points-topup-cta";
 import { checkAllSvg } from "@ui/svg";
 import { useQuery } from "@tanstack/react-query";
 import { withFeatureFlag } from "@/core/react-query";
@@ -121,7 +122,15 @@ export function BoostDialog({ onHide }: Props) {
                       readOnly={true}
                       value={`${activeUserPoints?.points ?? "0.000"} POINTS`}
                     />
-                    {balanceError && <small className="pl-3 text-red">{balanceError}</small>}
+                    {balanceError && (
+                      <div className="flex items-center flex-wrap gap-3 mt-1">
+                        <small className="pl-3 text-red">{balanceError}</small>
+                        <PointsTopupCta
+                          required={price}
+                          available={parseFloat(activeUserPoints?.points ?? "0")}
+                        />
+                      </div>
+                    )}
                     {isAlreadyBoosted && (
                       <div>
                         <small className="pl-3 text-red">

--- a/apps/web/src/features/shared/boost/index.tsx
+++ b/apps/web/src/features/shared/boost/index.tsx
@@ -58,7 +58,7 @@ export function BoostDialog({ onHide }: Props) {
       parseFloat(activeUserPoints?.points ?? "0") < price
         ? i18next.t("trx-common.insufficient-funds")
         : "",
-    [activeUser, price]
+    [activeUserPoints?.points, price]
   );
   const isAlreadyBoosted = useMemo(
     () =>

--- a/apps/web/src/features/shared/points-topup-cta/index.tsx
+++ b/apps/web/src/features/shared/points-topup-cta/index.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import {
+  DEFAULT_STRIPE_TIER_SKU,
+  STRIPE_POINTS_TIERS,
+  isStripeEnabled
+} from "@/features/shared/purchase-stripe/stripe-config";
+import { Button } from "@ui/button";
+import i18next from "i18next";
+import { useMemo } from "react";
+
+interface Props {
+  /** Points the intended action costs. Together with `available` it picks a tier covering the gap. */
+  required?: number;
+  /** The user's current Points balance. */
+  available?: number;
+  className?: string;
+  /** Open the top-up page in a new tab (use inside the editor so a draft in progress isn't lost). */
+  newTab?: boolean;
+}
+
+/**
+ * Smallest card tier whose Points cover the deficit; largest tier when even that
+ * falls short. Undefined when there is no deficit to cover.
+ */
+export function suggestPointsSkuForDeficit(deficit: number): string | undefined {
+  if (!Number.isFinite(deficit) || deficit <= 0) {
+    return undefined;
+  }
+  return (
+    STRIPE_POINTS_TIERS.find((tier) => tier.points >= deficit) ??
+    STRIPE_POINTS_TIERS[STRIPE_POINTS_TIERS.length - 1]
+  ).sku;
+}
+
+/**
+ * "Get more Points" call-to-action for insufficient-balance states. Deep-links into
+ * the card checkout on /perks/points with a tier preselected to cover the deficit;
+ * when card payment is unavailable it still lands on the top-up hub (QR/HIVE rails).
+ */
+export function PointsTopupCta({ required, available, className, newTab }: Props) {
+  const href = useMemo(() => {
+    if (!isStripeEnabled()) {
+      return "/perks/points";
+    }
+    const deficit = (required ?? 0) - (available ?? 0);
+    const sku = suggestPointsSkuForDeficit(deficit) ?? DEFAULT_STRIPE_TIER_SKU;
+    return `/perks/points?buy=card&sku=${sku}`;
+  }, [required, available]);
+
+  return (
+    <Button
+      href={href}
+      target={newTab ? "_blank" : undefined}
+      size="sm"
+      outline={true}
+      className={className}
+    >
+      {i18next.t("points.get-more")}
+    </Button>
+  );
+}

--- a/apps/web/src/features/shared/points-topup-cta/index.tsx
+++ b/apps/web/src/features/shared/points-topup-cta/index.tsx
@@ -2,12 +2,11 @@
 
 import {
   DEFAULT_STRIPE_TIER_SKU,
-  STRIPE_POINTS_TIERS,
-  isStripeEnabled
-} from "@/features/shared/purchase-stripe/stripe-config";
+  isStripeEnabled,
+  suggestPointsSkuForDeficit
+} from "@/features/shared/purchase-stripe/stripe-tiers";
 import { Button } from "@ui/button";
 import i18next from "i18next";
-import { useMemo } from "react";
 
 interface Props {
   /** Points the intended action costs. Together with `available` it picks a tier covering the gap. */
@@ -15,43 +14,30 @@ interface Props {
   /** The user's current Points balance. */
   available?: number;
   className?: string;
-  /** Open the top-up page in a new tab (use inside the editor so a draft in progress isn't lost). */
-  newTab?: boolean;
-}
-
-/**
- * Smallest card tier whose Points cover the deficit; largest tier when even that
- * falls short. Undefined when there is no deficit to cover.
- */
-export function suggestPointsSkuForDeficit(deficit: number): string | undefined {
-  if (!Number.isFinite(deficit) || deficit <= 0) {
-    return undefined;
-  }
-  return (
-    STRIPE_POINTS_TIERS.find((tier) => tier.points >= deficit) ??
-    STRIPE_POINTS_TIERS[STRIPE_POINTS_TIERS.length - 1]
-  ).sku;
 }
 
 /**
  * "Get more Points" call-to-action for insufficient-balance states. Deep-links into
  * the card checkout on /perks/points with a tier preselected to cover the deficit;
  * when card payment is unavailable it still lands on the top-up hub (QR/HIVE rails).
+ *
+ * Always opens in a new tab so an in-progress flow (a draft in the editor, a filled
+ * Boost/Promote form) is never discarded, and so the checkout page mounts fresh and
+ * consumes the deep-link params reliably.
  */
-export function PointsTopupCta({ required, available, className, newTab }: Props) {
-  const href = useMemo(() => {
-    if (!isStripeEnabled()) {
-      return "/perks/points";
-    }
+export function PointsTopupCta({ required, available, className }: Props) {
+  let href = "/perks/points";
+  if (isStripeEnabled()) {
     const deficit = (required ?? 0) - (available ?? 0);
     const sku = suggestPointsSkuForDeficit(deficit) ?? DEFAULT_STRIPE_TIER_SKU;
-    return `/perks/points?buy=card&sku=${sku}`;
-  }, [required, available]);
+    href = `/perks/points?buy=card&sku=${sku}`;
+  }
 
   return (
     <Button
       href={href}
-      target={newTab ? "_blank" : undefined}
+      target="_blank"
+      rel="noopener noreferrer"
       size="sm"
       outline={true}
       className={className}

--- a/apps/web/src/features/shared/promote/index.tsx
+++ b/apps/web/src/features/shared/promote/index.tsx
@@ -9,6 +9,7 @@ import { FormControl } from "@ui/input";
 import { Button } from "@ui/button";
 import i18next from "i18next";
 import { LinearProgress, SuggestionList } from "@/features/shared";
+import { PointsTopupCta } from "@/features/shared/points-topup-cta";
 import { checkAllSvg } from "@ui/svg";
 import { usePromoteMutation } from "@/api/sdk-mutations";
 import { usePreCheckPromote } from "@/api/mutations";
@@ -94,14 +95,18 @@ export function Promote({ onHide, entry }: Props) {
     }
   }, [prices]);
 
+  const price = useMemo(
+    () => prices?.find((x) => x.duration === duration)?.price ?? 0.0,
+    [prices, duration]
+  );
+
   useEffect(() => {
-    const { price } = prices?.find((x) => x.duration === duration) ?? { price: 0.0 };
     setBalanceError(
       parseFloat(activeUserPoints?.points ?? "0.0") < price
         ? i18next.t("trx-common.insufficient-funds")
         : ""
     );
-  }, [activeUser, activeUserPoints?.points, duration, prices]);
+  }, [activeUser, activeUserPoints?.points, price]);
 
   const pathChanged = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const path = e.target.value;
@@ -163,7 +168,15 @@ export function Promote({ onHide, entry }: Props) {
                       readOnly={true}
                       value={isPointsPending ? "..." : `${activeUserPoints?.points ?? "0"} POINTS`}
                     />
-                    {balanceError && <small className="pl-3 text-red">{balanceError}</small>}
+                    {balanceError && (
+                      <div className="flex items-center flex-wrap gap-3 mt-1">
+                        <small className="pl-3 text-red">{balanceError}</small>
+                        <PointsTopupCta
+                          required={price}
+                          available={parseFloat(activeUserPoints?.points ?? "0")}
+                        />
+                      </div>
+                    )}
                   </div>
                 </div>
                 <div className="grid grid-cols-12 mb-4">

--- a/apps/web/src/features/shared/promote/index.tsx
+++ b/apps/web/src/features/shared/promote/index.tsx
@@ -95,10 +95,7 @@ export function Promote({ onHide, entry }: Props) {
     }
   }, [prices]);
 
-  const price = useMemo(
-    () => prices?.find((x) => x.duration === duration)?.price ?? 0.0,
-    [prices, duration]
-  );
+  const price = prices?.find((x) => x.duration === duration)?.price ?? 0.0;
 
   useEffect(() => {
     setBalanceError(

--- a/apps/web/src/features/shared/purchase-stripe/stripe-config.ts
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-config.ts
@@ -1,12 +1,20 @@
 import { loadStripe, Stripe } from "@stripe/stripe-js";
 
-// The publishable key is public (safe in the browser) but environment-specific
-// (test vs live). It is baked at build time as a NEXT_PUBLIC_ var. When it is not
-// configured, card payment is disabled (the entry point hides itself) so we never
-// render a broken Payment Element.
-const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "";
+// Tier catalog + isStripeEnabled live in a dependency-free module so consumers that
+// only need tier data don't pull in @stripe/stripe-js (its main entry injects the
+// js.stripe.com script on import). Re-exported here for existing import sites.
+export {
+  DEFAULT_STRIPE_TIER_SKU,
+  STRIPE_POINTS_TIERS,
+  isKnownTierSku,
+  isStripeEnabled,
+  suggestPointsSkuForDeficit,
+  type StripePointsTier
+} from "./stripe-tiers";
 
-export const isStripeEnabled = (): boolean => PUBLISHABLE_KEY.trim().length > 0;
+import { isStripeEnabled } from "./stripe-tiers";
+
+const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "";
 
 let stripePromise: Promise<Stripe | null> | undefined;
 
@@ -23,25 +31,3 @@ export const getStripePromise = (): Promise<Stripe | null> | undefined => {
   }
   return stripePromise;
 };
-
-export interface StripePointsTier {
-  /** SKU forwarded to ePoints; the amount + Points are derived there server-side. */
-  sku: string;
-  /** USD price (the SKU's leading number IS the price in cents). */
-  usd: number;
-  /** Points delivered. MUST mirror ePoints STRIPE_PRODUCT_MAP (server is the truth). */
-  points: number;
-}
-
-// Mirrors ePoints constants.py STRIPE_PRODUCT_MAP. The smallest IAP tiers (099/199)
-// are intentionally not offered on the card rail. The Points figures are display-only;
-// the actual credit is computed server-side from the SKU, so a drift here only affects
-// the label, never the delivered amount.
-export const STRIPE_POINTS_TIERS: StripePointsTier[] = [
-  { sku: "499points", usd: 4.99, points: 2800 },
-  { sku: "999points", usd: 9.99, points: 6000 },
-  { sku: "4999points", usd: 49.99, points: 31500 },
-  { sku: "9999points", usd: 99.99, points: 70000 }
-];
-
-export const DEFAULT_STRIPE_TIER_SKU = "999points";

--- a/apps/web/src/features/shared/purchase-stripe/stripe-tiers.ts
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-tiers.ts
@@ -1,0 +1,54 @@
+// Dependency-free tier catalog + helpers. Kept separate from stripe-config.ts so
+// consumers that only need tier data (e.g. the top-up CTA rendered across the app)
+// do NOT pull in @stripe/stripe-js, whose main entry injects the js.stripe.com
+// script as a module-eval side effect.
+
+// The publishable key is public (safe in the browser) but environment-specific
+// (test vs live), baked at build time as a NEXT_PUBLIC_ var. When unset, card
+// payment is disabled and the entry points hide themselves.
+const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "";
+
+export const isStripeEnabled = (): boolean => PUBLISHABLE_KEY.trim().length > 0;
+
+export interface StripePointsTier {
+  /** SKU forwarded to ePoints; the amount + Points are derived there server-side. */
+  sku: string;
+  /** USD price (the SKU's leading number IS the price in cents). */
+  usd: number;
+  /** Points delivered. MUST mirror ePoints STRIPE_PRODUCT_MAP (server is the truth). */
+  points: number;
+}
+
+// Mirrors ePoints constants.py STRIPE_PRODUCT_MAP. The smallest IAP tiers (099/199)
+// are intentionally not offered on the card rail. Kept sorted ascending by points;
+// suggestPointsSkuForDeficit relies on that order.
+//
+// The Points figures drive the display label AND the deficit->tier suggestion, so
+// keep them in sync with the server map: a drift no longer only mislabels a tile,
+// it can preselect a tier that fails to cover the user's deficit.
+export const STRIPE_POINTS_TIERS: StripePointsTier[] = [
+  { sku: "499points", usd: 4.99, points: 2800 },
+  { sku: "999points", usd: 9.99, points: 6000 },
+  { sku: "4999points", usd: 49.99, points: 31500 },
+  { sku: "9999points", usd: 99.99, points: 70000 }
+];
+
+export const DEFAULT_STRIPE_TIER_SKU = "999points";
+
+/** Whether a sku string is one of the known card-rail tiers. */
+export const isKnownTierSku = (sku: string): boolean =>
+  STRIPE_POINTS_TIERS.some((tier) => tier.sku === sku);
+
+/**
+ * Smallest card tier whose Points cover the deficit; largest tier when even that
+ * falls short. Undefined when there is no deficit to cover.
+ */
+export function suggestPointsSkuForDeficit(deficit: number): string | undefined {
+  if (!Number.isFinite(deficit) || deficit <= 0) {
+    return undefined;
+  }
+  return (
+    STRIPE_POINTS_TIERS.find((tier) => tier.points >= deficit) ??
+    STRIPE_POINTS_TIERS[STRIPE_POINTS_TIERS.length - 1]
+  ).sku;
+}

--- a/apps/web/src/specs/features/points-topup-cta.spec.tsx
+++ b/apps/web/src/specs/features/points-topup-cta.spec.tsx
@@ -1,0 +1,50 @@
+import { PointsTopupCta, suggestPointsSkuForDeficit } from "@/features/shared/points-topup-cta";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/features/shared/purchase-stripe/stripe-config", async () => ({
+  ...(await vi.importActual("@/features/shared/purchase-stripe/stripe-config")),
+  isStripeEnabled: () => true
+}));
+
+describe("suggestPointsSkuForDeficit", () => {
+  it("returns undefined when there is no deficit", () => {
+    expect(suggestPointsSkuForDeficit(0)).toBeUndefined();
+    expect(suggestPointsSkuForDeficit(-150)).toBeUndefined();
+    expect(suggestPointsSkuForDeficit(NaN)).toBeUndefined();
+  });
+
+  it("picks the smallest tier covering the deficit", () => {
+    expect(suggestPointsSkuForDeficit(100)).toBe("499points");
+    expect(suggestPointsSkuForDeficit(2800)).toBe("499points");
+    expect(suggestPointsSkuForDeficit(2801)).toBe("999points");
+    expect(suggestPointsSkuForDeficit(31500)).toBe("4999points");
+  });
+
+  it("falls back to the largest tier for oversized deficits", () => {
+    expect(suggestPointsSkuForDeficit(1_000_000)).toBe("9999points");
+  });
+});
+
+describe("PointsTopupCta", () => {
+  it("deep-links into card checkout with the tier covering the deficit", () => {
+    render(<PointsTopupCta required={500} available={100} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/perks/points?buy=card&sku=499points");
+    expect(link).not.toHaveAttribute("target");
+  });
+
+  it("falls back to the default tier when the deficit is unknown", () => {
+    render(<PointsTopupCta />);
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/perks/points?buy=card&sku=999points"
+    );
+  });
+
+  it("opens in a new tab when requested", () => {
+    render(<PointsTopupCta required={500} available={0} newTab={true} />);
+    expect(screen.getByRole("link")).toHaveAttribute("target", "_blank");
+  });
+});

--- a/apps/web/src/specs/features/points-topup-cta.spec.tsx
+++ b/apps/web/src/specs/features/points-topup-cta.spec.tsx
@@ -1,10 +1,14 @@
-import { PointsTopupCta, suggestPointsSkuForDeficit } from "@/features/shared/points-topup-cta";
+import { PointsTopupCta } from "@/features/shared/points-topup-cta";
+import {
+  isKnownTierSku,
+  suggestPointsSkuForDeficit
+} from "@/features/shared/purchase-stripe/stripe-tiers";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@/features/shared/purchase-stripe/stripe-config", async () => ({
-  ...(await vi.importActual("@/features/shared/purchase-stripe/stripe-config")),
+vi.mock("@/features/shared/purchase-stripe/stripe-tiers", async () => ({
+  ...(await vi.importActual("@/features/shared/purchase-stripe/stripe-tiers")),
   isStripeEnabled: () => true
 }));
 
@@ -27,12 +31,22 @@ describe("suggestPointsSkuForDeficit", () => {
   });
 });
 
+describe("isKnownTierSku", () => {
+  it("accepts known card-rail tiers and rejects others", () => {
+    expect(isKnownTierSku("999points")).toBe(true);
+    expect(isKnownTierSku("099points")).toBe(false);
+    expect(isKnownTierSku("garbage")).toBe(false);
+    expect(isKnownTierSku("")).toBe(false);
+  });
+});
+
 describe("PointsTopupCta", () => {
-  it("deep-links into card checkout with the tier covering the deficit", () => {
+  it("deep-links into card checkout with the tier covering the deficit, in a new tab", () => {
     render(<PointsTopupCta required={500} available={100} />);
     const link = screen.getByRole("link");
     expect(link).toHaveAttribute("href", "/perks/points?buy=card&sku=499points");
-    expect(link).not.toHaveAttribute("target");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
   it("falls back to the default tier when the deficit is unknown", () => {
@@ -41,10 +55,5 @@ describe("PointsTopupCta", () => {
       "href",
       "/perks/points?buy=card&sku=999points"
     );
-  });
-
-  it("opens in a new tab when requested", () => {
-    render(<PointsTopupCta required={500} available={0} newTab={true} />);
-    expect(screen.getByRole("link")).toHaveAttribute("target", "_blank");
   });
 });


### PR DESCRIPTION
Every Points-gated action (Boost+, Promote dialog, Promote setup page, AI image generator, AI assist) currently dead-ends with a red error and a disabled button when balance is insufficient. This adds an actionable path to top up.

## What
- New shared `PointsTopupCta` component: deep-links into the card checkout on `/perks/points` with the tier that covers the user's deficit preselected (smallest tier covering the gap, largest as fallback). When the card rail is disabled it links to the top-up hub (QR/HIVE rails).
- Wired into all five insufficient-balance sites. Editor surfaces (AI assist, AI image generator) open in a new tab so a draft in progress is never lost.
- `/perks/points` supports the `?buy=card&sku=...` deep link: opens the Stripe dialog with the tier preselected, strips params from the address bar, and waits for login when the user lands unauthenticated (dialog opens after login completes).
- Points balance now refreshes right after card delivery (`onDelivered` invalidates the points query; previously the new balance appeared only after remount/staleTime).

## Tests
- New spec: tier suggestion helper + CTA render (6 tests).
- Full web suite passes (197 files / 1997 tests). `tsc --noEmit` introduces no new errors vs develop baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Get more Points” links to low-balance flows, making it easier to top up directly from purchase, promotion, AI assist, and image generation screens.
  * Enabled a direct Stripe checkout flow that can open with a preselected points package from a link.

* **Bug Fixes**
  * Improved points balance updates after successful checkout so the latest balance appears sooner.
  * Refined low-balance prompts to show a clearer call to action instead of only an error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->