### PR TITLE
Add post templates to publish flow

### DIFF
--- a/apps/web/src/app/publish/_api/index.ts
+++ b/apps/web/src/app/publish/_api/index.ts
@@ -1,3 +1,4 @@
 export * from "./use-publish";
 export * from "./use-schedule";
 export * from "./use-save-draft";
+export * from "./use-save-template";

--- a/apps/web/src/app/publish/_api/use-save-template.ts
+++ b/apps/web/src/app/publish/_api/use-save-template.ts
@@ -38,7 +38,7 @@ export function useSaveTemplateApi() {
 
       const username = activeUser.username;
 
-      const tagJ = tags?.join(" ");
+      const tagJ = tags?.join(" ") ?? "";
 
       const metaBuilder = await EntryMetadataManagement.EntryMetadataManager.shared
         .builder()
@@ -67,7 +67,7 @@ export function useSaveTemplateApi() {
         token,
         title!,
         content!,
-        tagJ!,
+        tagJ,
         draftMeta
       );
       success(i18next.t("post-templates.saved-toast"));

--- a/apps/web/src/app/publish/_api/use-save-template.ts
+++ b/apps/web/src/app/publish/_api/use-save-template.ts
@@ -1,0 +1,80 @@
+import { addDraft, QueryKeys } from "@ecency/sdk";
+import { DraftMetadata, RewardType } from "@/entities";
+import { EntryMetadataManagement } from "@/features/entry-management";
+import { error, success } from "@/features/shared";
+import { postBodySummary } from "@ecency/render-helper";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import i18next from "i18next";
+import { usePublishState } from "../_hooks";
+import { formatError } from "@/api/format-error";
+import { SUBMIT_DESCRIPTION_MAX_LENGTH } from "@/app/submit/_consts";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { ensureValidToken } from "@/utils";
+
+export function useSaveTemplateApi() {
+  const { activeUser } = useActiveAccount();
+
+  const queryClient = useQueryClient();
+
+  const {
+    title,
+    content,
+    tags,
+    beneficiaries,
+    reward,
+    metaDescription,
+    selectedThumbnail,
+    poll,
+    postLinks,
+    location
+  } = usePublishState();
+
+  return useMutation({
+    mutationKey: ["saveTemplate"],
+    mutationFn: async ({ name }: { name: string }) => {
+      if (!activeUser?.username) {
+        throw new Error("[Template] No active user");
+      }
+
+      const username = activeUser.username;
+
+      const tagJ = tags?.join(" ");
+
+      const metaBuilder = await EntryMetadataManagement.EntryMetadataManager.shared
+        .builder()
+        .default()
+        .extractFromBody(content!)
+        .withTags(tags)
+        // It should select filled description or if its empty or null/undefined then get auto summary
+        .withSummary(metaDescription! || postBodySummary(content!, SUBMIT_DESCRIPTION_MAX_LENGTH))
+        .withPostLinks(postLinks)
+        .withLocation(location)
+        .withSelectedThumbnail(selectedThumbnail);
+
+      const meta = metaBuilder.build();
+      const draftMeta: DraftMetadata = {
+        ...meta,
+        beneficiaries: beneficiaries ?? [],
+        rewardType: (reward as RewardType) ?? "default",
+        poll,
+        postTemplate: true,
+        templateName: name
+      };
+
+      const token = await ensureValidToken(username);
+
+      const resp = await addDraft(
+        token,
+        title!,
+        content!,
+        tagJ!,
+        draftMeta
+      );
+      success(i18next.t("post-templates.saved-toast"));
+
+      queryClient.setQueryData(QueryKeys.posts.drafts(username), resp.drafts);
+      queryClient.invalidateQueries({ queryKey: QueryKeys.posts.draftsInfinite(username) });
+    },
+    onError: (err) => error(...formatError(err))
+  });
+}

--- a/apps/web/src/app/publish/_components/publish-action-bar.tsx
+++ b/apps/web/src/app/publish/_components/publish-action-bar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { EcencyConfigManager } from "@/config";
 import { LoginRequired } from "@/features/shared";
 import dynamic from "next/dynamic";
 
@@ -37,6 +38,13 @@ const PublishImportDialog = dynamic(
   })),
   { ssr: false }
 );
+
+const PostTemplatesDialog = dynamic(
+  () => import("@/features/shared/post-templates").then((m) => ({
+    default: m.PostTemplatesDialog
+  })),
+  { ssr: false }
+);
 import { StyledTooltip } from "@/features/ui";
 import { useSynchronizedLocalStorage } from "@/utils";
 import { PREFIX } from "@/utils/local-storage";
@@ -44,6 +52,7 @@ import {
   UilClock,
   UilDocumentInfo,
   UilEllipsisV,
+  UilFileBookmarkAlt,
   UilFileImport,
   UilMoneybag,
   UilQuestionCircle,
@@ -55,8 +64,8 @@ import { Dropdown, DropdownItemWithIcon, DropdownMenu, DropdownToggle } from "@u
 import i18next from "i18next";
 import { usePathname } from "next/navigation";
 import { PropsWithChildren, useState } from "react";
-import { useSaveDraftApi } from "../_api";
-import { useDefaultBeneficiary, usePublishState } from "../_hooks";
+import { useSaveDraftApi, useSaveTemplateApi } from "../_api";
+import { useApplyTemplate, useDefaultBeneficiary, usePublishState } from "../_hooks";
 import { useOptionalUploadTracker } from "../_hooks/use-upload-tracker";
 import { PublishActionBarCommunity } from "./publish-action-bar-community";
 import { hasPublishContent } from "../_utils/content";
@@ -67,6 +76,7 @@ interface Props {
   onPublish: () => void;
   onBackToClassic: () => void;
   onImport?: (result: ImportResult) => void;
+  setEditorContent?: (content: string | undefined) => void;
   draftId?: string;
 }
 
@@ -75,6 +85,7 @@ export function PublishActionBar({
   children,
   onBackToClassic,
   onImport,
+  setEditorContent,
   draftId
 }: PropsWithChildren<Props>) {
   const { schedule: scheduleDate, clearAll, title, content } = usePublishState();
@@ -84,6 +95,7 @@ export function PublishActionBar({
   const [showMetaInfo, setShowMetaInfo] = useState(false);
   const [schedule, setSchedule] = useState(false);
   const [showImport, setShowImport] = useState(false);
+  const [showTemplates, setShowTemplates] = useState(false);
 
   const pathname = usePathname();
 
@@ -92,6 +104,8 @@ export function PublishActionBar({
   const canContinue = !!title?.trim() && hasPublishContent(content);
 
   const { mutateAsync: saveToDraft, isPending: isDraftPending } = useSaveDraftApi(draftId);
+  const { mutateAsync: saveTemplate, isPending: isTemplatePending } = useSaveTemplateApi();
+  const applyTemplate = useApplyTemplate(setEditorContent);
   const uploadTracker = useOptionalUploadTracker();
   const [_, setShowGuide] = useSynchronizedLocalStorage(PREFIX + "_pub_onboarding_passed", true);
 
@@ -174,6 +188,17 @@ export function PublishActionBar({
               icon={<UilDocumentInfo />}
               label={i18next.t("publish.meta-information")}
             />
+            <EcencyConfigManager.Conditional
+              condition={({ visionFeatures }) => visionFeatures.postTemplates.enabled}
+            >
+              <LoginRequired>
+                <DropdownItemWithIcon
+                  onClick={() => setShowTemplates(true)}
+                  icon={<UilFileBookmarkAlt />}
+                  label={i18next.t("post-templates.title")}
+                />
+              </LoginRequired>
+            </EcencyConfigManager.Conditional>
             <div className="border-b border-[--border-color] h-[1px] w-full" />
             <DropdownItemWithIcon
               selected={!!scheduleDate}
@@ -207,6 +232,18 @@ export function PublishActionBar({
       {onImport && (
         <PublishImportDialog show={showImport} setShow={setShowImport} onImport={onImport} />
       )}
+      <EcencyConfigManager.Conditional
+        condition={({ visionFeatures }) => visionFeatures.postTemplates.enabled}
+      >
+        <PostTemplatesDialog
+          show={showTemplates}
+          setShow={setShowTemplates}
+          onApply={applyTemplate}
+          onSaveCurrent={(name) => saveTemplate({ name })}
+          isSaving={isTemplatePending}
+          confirmApply={!!title?.trim() || hasPublishContent(content)}
+        />
+      </EcencyConfigManager.Conditional>
     </div>
   );
 }

--- a/apps/web/src/app/publish/_components/publish-validate-post.tsx
+++ b/apps/web/src/app/publish/_components/publish-validate-post.tsx
@@ -16,7 +16,10 @@ import { PublishScheduleDialog } from "./publish-schedule-dialog";
 import { PublishValidatePostMeta } from "./publish-validate-post-meta";
 import { PublishValidatePostThumbnailPicker } from "./publish-validate-post-thumbnail-picker";
 import { isCommunity } from "@/utils";
+import { wordOverlapSimilarity } from "@/utils/text-similarity";
 import { hasPublishContent } from "../_utils/content";
+
+const TEMPLATE_SIMILARITY_THRESHOLD = 0.9;
 
 interface Props {
   onClose: () => void;
@@ -35,7 +38,8 @@ export function PublishValidatePost({ onClose, onSuccess }: Props) {
     isReblogToCommunity,
     setIsReblogToCommunity,
     beneficiaries,
-    title
+    title,
+    appliedTemplateBody
   } = usePublishState();
 
   const [showSchedule, setShowSchedule] = useState(false);
@@ -46,6 +50,13 @@ export function PublishValidatePost({ onClose, onSuccess }: Props) {
         ? beneficiaries?.find((ben) => ben.account === tags?.[0])?.weight
         : undefined,
     [beneficiaries, tags]
+  );
+
+  const isMostlyTemplate = useMemo(
+    () =>
+      !!appliedTemplateBody &&
+      wordOverlapSimilarity(content ?? "", appliedTemplateBody) >= TEMPLATE_SIMILARITY_THRESHOLD,
+    [appliedTemplateBody, content]
   );
 
   const { mutateAsync: publishNow, isPending: isPublishPending } = usePublishApi();
@@ -194,6 +205,12 @@ export function PublishValidatePost({ onClose, onSuccess }: Props) {
           {(beneficiaryReward ?? 0) / 100 > 25 && (
             <Alert className="w-full" appearance="warning">
               {i18next.t("publish.community-beneficiary.hint")}
+            </Alert>
+          )}
+
+          {isMostlyTemplate && (
+            <Alert className="w-full" appearance="warning">
+              {i18next.t("post-templates.similarity-warning")}
             </Alert>
           )}
 

--- a/apps/web/src/app/publish/_hooks/index.ts
+++ b/apps/web/src/app/publish/_hooks/index.ts
@@ -1,5 +1,6 @@
 export * from "./use-publish-state";
 export * from "./use-publish-editor";
+export * from "./use-apply-template";
 export * from "./use-publish-links-attach";
 export * from "./use-auto-save-draft";
 export * from "./use-default-beneficiary";

--- a/apps/web/src/app/publish/_hooks/use-apply-template.ts
+++ b/apps/web/src/app/publish/_hooks/use-apply-template.ts
@@ -1,0 +1,55 @@
+import { Draft } from "@ecency/sdk";
+import { useCallback } from "react";
+import { normalizePollSnapshot } from "../_utils/poll";
+import { usePublishState } from "./use-publish-state";
+
+export function useApplyTemplate(setEditorContent?: (content: string | undefined) => void) {
+  const {
+    clearAll,
+    setTitle,
+    setContent,
+    setTags,
+    setLocation,
+    setReward,
+    setBeneficiaries,
+    setMetaDescription,
+    setSelectedThumbnail,
+    setEntryImages,
+    setPoll,
+    setAppliedTemplateBody
+  } = usePublishState();
+
+  return useCallback(
+    (draft: Draft) => {
+      clearAll();
+      setTitle(draft.title);
+      setContent(draft.body);
+      setTags(draft.tags_arr ?? []);
+
+      setEditorContent?.(draft.body);
+      setLocation(draft.meta?.location);
+      setReward(draft.meta?.rewardType ?? "default");
+      setBeneficiaries(draft.meta?.beneficiaries ?? []);
+      setMetaDescription(draft.meta?.description ?? "");
+      setSelectedThumbnail(draft.meta?.image?.[0] ?? "");
+      setEntryImages(draft.meta?.image ?? []);
+      setPoll(normalizePollSnapshot(draft.meta?.poll));
+      setAppliedTemplateBody(draft.body);
+    },
+    [
+      clearAll,
+      setTitle,
+      setContent,
+      setTags,
+      setEditorContent,
+      setLocation,
+      setReward,
+      setBeneficiaries,
+      setMetaDescription,
+      setSelectedThumbnail,
+      setEntryImages,
+      setPoll,
+      setAppliedTemplateBody
+    ]
+  );
+}

--- a/apps/web/src/app/publish/_hooks/use-publish-state.tsx
+++ b/apps/web/src/app/publish/_hooks/use-publish-state.tsx
@@ -73,6 +73,8 @@ interface PublishStateContextValue {
   addDecentMemesResult: (entry: DecentMemesEntry) => void;
   setDecentMemes: (entries: DecentMemesEntry[]) => void;
   clearDecentMemes: () => void;
+  appliedTemplateBody: string | null;
+  setAppliedTemplateBody: (value: string | null) => void;
 }
 
 const PublishStateContext = createContext<PublishStateContextValue | undefined>(undefined);
@@ -100,6 +102,7 @@ export function PublishStateProvider({ children }: { children: React.ReactNode }
   const hasThreeSpeakVideo = useMemo(() => hasThreeSpeakEmbed(content), [content]);
   const [poll, setPoll] = usePublishPollState(false);
   const [decentMemes, setDecentMemes] = useState<DecentMemesEntry[]>([]);
+  const [appliedTemplateBody, setAppliedTemplateBody] = useState<string | null>(null);
 
   const clearDecentMemes = useCallback(() => setDecentMemes([]), []);
 
@@ -228,6 +231,7 @@ export function PublishStateProvider({ children }: { children: React.ReactNode }
     clearEntryImages();
     clearLocation();
     clearDecentMemes();
+    setAppliedTemplateBody(null);
     setIsReblogToCommunity(false);
   }, [
     setBeneficiaries,
@@ -244,6 +248,7 @@ export function PublishStateProvider({ children }: { children: React.ReactNode }
     clearEntryImages,
     clearLocation,
     clearDecentMemes,
+    setAppliedTemplateBody,
     setIsReblogToCommunity
   ]);
 
@@ -286,7 +291,9 @@ export function PublishStateProvider({ children }: { children: React.ReactNode }
         decentMemes,
         addDecentMemesResult,
         setDecentMemes,
-        clearDecentMemes
+        clearDecentMemes,
+        appliedTemplateBody,
+        setAppliedTemplateBody
       }}
     >
       {children}

--- a/apps/web/src/app/publish/_page.tsx
+++ b/apps/web/src/app/publish/_page.tsx
@@ -100,6 +100,7 @@ export default function Publish() {
             onPublish={() => setStep("validation")}
             onBackToClassic={() => router.push(routes.SUBMIT)}
             onImport={handleImport}
+            setEditorContent={setEditorContent}
             draftId={draftId}
           />
           <PublishEditor editor={editor} />

--- a/apps/web/src/app/publish/drafts/[id]/_page.tsx
+++ b/apps/web/src/app/publish/drafts/[id]/_page.tsx
@@ -77,6 +77,7 @@ export default function PublishPage() {
           <PublishActionBar
             onPublish={() => setStep("validation")}
             onBackToClassic={() => router.push(`/draft/${params?.id}`)}
+            setEditorContent={setEditorContent}
             draftId={draftId}
           />
           <PublishEditor editor={editor} />

--- a/apps/web/src/config/config.template.ts
+++ b/apps/web/src/config/config.template.ts
@@ -78,6 +78,9 @@ const CONFIG = {
       fragments: {
         enabled: true
       },
+      postTemplates: {
+        enabled: true
+      },
       discover: {
         leaderboard: {
           enabled: true

--- a/apps/web/src/config/config.ts
+++ b/apps/web/src/config/config.ts
@@ -77,6 +77,9 @@ const CONFIG = {
       fragments: {
         enabled: true
       },
+      postTemplates: {
+        enabled: true
+      },
       discover: {
         leaderboard: {
           enabled: true

--- a/apps/web/src/entities/private-api/drafts.ts
+++ b/apps/web/src/entities/private-api/drafts.ts
@@ -6,6 +6,8 @@ export interface DraftMetadata extends MetaData {
   rewardType: RewardType;
   poll?: PollSnapshot;
   decentMemes?: DecentMemesEntry[];
+  postTemplate?: boolean;
+  templateName?: string;
 }
 
 export interface Draft {

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -2201,6 +2201,24 @@
     "validation-body": "Body is required.",
     "form-body": "Body"
   },
+  "post-templates": {
+    "title": "Templates",
+    "save-current": "Save as template",
+    "name-label": "Template name",
+    "name-placeholder": "e.g. Weekly update",
+    "validation-name": "Name is required.",
+    "save": "Save",
+    "cancel": "Cancel",
+    "apply": "Apply",
+    "apply-confirm": "Replace your current draft content?",
+    "delete-confirm": "Delete this template?",
+    "untitled": "Untitled template",
+    "empty-list-hint": "Save your current post as a template to reuse its title, tags and settings later.",
+    "filter": "Search by name",
+    "saved-toast": "Template saved",
+    "similarity-warning": "This post is still mostly your template. Add your own content before publishing.",
+    "load-more": "Load More"
+  },
   "password-update": {
     "title": "Create new keys",
     "account": "Account",

--- a/apps/web/src/features/shared/drafts/drafts-list.tsx
+++ b/apps/web/src/features/shared/drafts/drafts-list.tsx
@@ -12,6 +12,9 @@ import useMount from "react-use/lib/useMount";
 import { getAccessToken } from "@/utils";
 import { Button } from "@ui/button";
 
+// Bounds the automatic page waterfall that skips template-only pages.
+const AUTO_FETCH_PAGE_BUDGET = 5;
+
 interface Props {
   onHide: () => void;
   onPick?: (url: string) => void;
@@ -74,13 +77,22 @@ export function DraftsList({ onHide, onPick }: Props) {
     }
   }, [allDrafts]);
 
+  const pagesLoaded = data?.pages.length ?? 0;
+
   // A fetched page can consist entirely of templates; keep fetching so the
-  // empty state never hides non-template drafts living on later pages.
+  // empty state never hides non-template drafts living on later pages. The
+  // page budget bounds the waterfall for users whose drafts are all
+  // templates; past it, loading continues on demand below.
   useEffect(() => {
-    if (hasNextPage && !isFetchingNextPage && allDrafts.length === 0) {
+    if (
+      hasNextPage &&
+      !isFetchingNextPage &&
+      allDrafts.length === 0 &&
+      pagesLoaded < AUTO_FETCH_PAGE_BUDGET
+    ) {
       fetchNextPage();
     }
-  }, [allDrafts.length, fetchNextPage, hasNextPage, isFetchingNextPage]);
+  }, [allDrafts.length, fetchNextPage, hasNextPage, isFetchingNextPage, pagesLoaded]);
 
   if (isPending) {
     return <LinearProgress />;
@@ -88,7 +100,14 @@ export function DraftsList({ onHide, onPick }: Props) {
 
   if (allDrafts.length === 0) {
     if (hasNextPage) {
-      return <LinearProgress />;
+      if (isFetchingNextPage || pagesLoaded < AUTO_FETCH_PAGE_BUDGET) {
+        return <LinearProgress />;
+      }
+      return (
+        <div className="flex justify-center my-4">
+          <Button onClick={() => fetchNextPage()}>{i18next.t("g.load-more")}</Button>
+        </div>
+      );
     }
     return <div className="drafts-list">{i18next.t("g.empty-list")}</div>;
   }

--- a/apps/web/src/features/shared/drafts/drafts-list.tsx
+++ b/apps/web/src/features/shared/drafts/drafts-list.tsx
@@ -74,11 +74,22 @@ export function DraftsList({ onHide, onPick }: Props) {
     }
   }, [allDrafts]);
 
+  // A fetched page can consist entirely of templates; keep fetching so the
+  // empty state never hides non-template drafts living on later pages.
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage && allDrafts.length === 0) {
+      fetchNextPage();
+    }
+  }, [allDrafts.length, fetchNextPage, hasNextPage, isFetchingNextPage]);
+
   if (isPending) {
     return <LinearProgress />;
   }
 
   if (allDrafts.length === 0) {
+    if (hasNextPage) {
+      return <LinearProgress />;
+    }
     return <div className="drafts-list">{i18next.t("g.empty-list")}</div>;
   }
 

--- a/apps/web/src/features/shared/drafts/drafts-list.tsx
+++ b/apps/web/src/features/shared/drafts/drafts-list.tsx
@@ -41,7 +41,8 @@ export function DraftsList({ onHide, onPick }: Props) {
   );
 
   const allDrafts = useMemo(
-    () => data?.pages.flatMap((page) => page.data) ?? [],
+    () =>
+      (data?.pages.flatMap((page) => page.data) ?? []).filter((d) => !d.meta?.postTemplate),
     [data]
   );
 

--- a/apps/web/src/features/shared/post-templates/index.tsx
+++ b/apps/web/src/features/shared/post-templates/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import { Button, FormControl } from "@/features/ui";
 import { Form } from "@/features/ui/form";
@@ -28,6 +28,15 @@ export function PostTemplatesDialog({
   const [name, setName] = useState("");
 
   const form = useRef<HTMLFormElement>(null);
+
+  // The dialog stays mounted between opens; a dismissed save form must not
+  // reappear the next time it is shown.
+  useEffect(() => {
+    if (!show) {
+      setMode("list");
+      setName("");
+    }
+  }, [show]);
 
   return (
     <Modal show={show} centered={true} onHide={() => setShow(false)} size="lg">

--- a/apps/web/src/features/shared/post-templates/index.tsx
+++ b/apps/web/src/features/shared/post-templates/index.tsx
@@ -1,0 +1,93 @@
+import React, { useRef, useState } from "react";
+import { Modal, ModalBody, ModalHeader } from "@ui/modal";
+import { Button, FormControl } from "@/features/ui";
+import { Form } from "@/features/ui/form";
+import { handleInvalid, handleOnInput } from "@/utils";
+import i18next from "i18next";
+import { Draft } from "@ecency/sdk";
+import { PostTemplatesList } from "./post-templates-list";
+
+interface Props {
+  show: boolean;
+  setShow: (v: boolean) => void;
+  onApply: (draft: Draft) => void;
+  onSaveCurrent: (name: string) => Promise<unknown>;
+  isSaving: boolean;
+  confirmApply: boolean;
+}
+
+export function PostTemplatesDialog({
+  show,
+  setShow,
+  onApply,
+  onSaveCurrent,
+  isSaving,
+  confirmApply
+}: Props) {
+  const [mode, setMode] = useState<"list" | "save">("list");
+  const [name, setName] = useState("");
+
+  const form = useRef<HTMLFormElement>(null);
+
+  return (
+    <Modal show={show} centered={true} onHide={() => setShow(false)} size="lg">
+      <ModalHeader closeButton={true}>{i18next.t("post-templates.title")}</ModalHeader>
+      <ModalBody>
+        {mode === "list" && (
+          <PostTemplatesList
+            confirmApply={confirmApply}
+            onApply={(draft) => {
+              onApply(draft);
+              setShow(false);
+            }}
+            onSave={() => setMode("save")}
+          />
+        )}
+        {mode === "save" && (
+          <Form
+            ref={form}
+            onSubmit={async (e: React.FormEvent) => {
+              e.preventDefault();
+              e.stopPropagation();
+
+              if (!form.current?.checkValidity() || !name.trim()) {
+                return;
+              }
+
+              try {
+                await onSaveCurrent(name.trim());
+                setName("");
+                setMode("list");
+              } catch (e) {
+                // error feedback comes from the save mutation
+              }
+            }}
+          >
+            <div className="mb-4">
+              <label>{i18next.t("post-templates.name-label")}</label>
+              <FormControl
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required={true}
+                type="text"
+                maxLength={255}
+                autoFocus={true}
+                placeholder={i18next.t("post-templates.name-placeholder")}
+                onInvalid={(e: any) => handleInvalid(e, "post-templates.", "validation-name")}
+                onInput={handleOnInput}
+              />
+            </div>
+            <div className="flex justify-end gap-3">
+              <Button appearance="gray" disabled={isSaving} onClick={() => setMode("list")}>
+                {i18next.t("post-templates.cancel")}
+              </Button>
+              <Button type="submit" disabled={isSaving} isLoading={isSaving}>
+                {i18next.t("post-templates.save")}
+              </Button>
+            </div>
+          </Form>
+        )}
+      </ModalBody>
+    </Modal>
+  );
+}

--- a/apps/web/src/features/shared/post-templates/post-templates-list-item.tsx
+++ b/apps/web/src/features/shared/post-templates/post-templates-list-item.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from "react";
+import { PopoverConfirm } from "@ui/popover-confirm";
+import { Badge } from "@ui/badge";
+import { Button } from "@ui/button";
+import { Draft } from "@ecency/sdk";
+import { getCommunityCache } from "@/core/caches";
+import { dateToFormatted, dateToFullRelative } from "@/utils";
+import i18next from "i18next";
+import { UilTrash } from "@tooni/iconscout-unicons-react";
+import { useQuery } from "@tanstack/react-query";
+import { useDeleteDraft } from "@/api/mutations";
+
+interface Props {
+  item: Draft;
+  confirmApply: boolean;
+  onApply: () => void;
+}
+
+export function PostTemplatesListItem({ item, confirmApply, onApply }: Props) {
+  const tag = item.tags_arr?.[0] ?? "";
+
+  const { data: community } = useQuery(getCommunityCache(tag));
+
+  const dateRelative = useMemo(() => dateToFullRelative(item.modified), [item]);
+  const dateFormatted = useMemo(() => dateToFormatted(item.modified), [item]);
+
+  const { mutateAsync: deleteDraft } = useDeleteDraft(() => {});
+
+  return (
+    <div className="flex flex-col border dark:border-dark-400 rounded-xl overflow-hidden">
+      <div className="flex items-center justify-between border-b dark:border-dark-300 px-3 py-2 bg-gray-100 dark:bg-dark-500">
+        <div className="flex items-center gap-3">
+          {tag && <Badge>{community?.title ?? tag}</Badge>}
+          <div className="text-sm text-gray-600" title={dateFormatted}>
+            {dateRelative}
+          </div>
+        </div>
+        <PopoverConfirm
+          titleText={i18next.t("post-templates.delete-confirm")}
+          onConfirm={() => deleteDraft({ id: item._id })}
+        >
+          <Button
+            size="xs"
+            appearance="gray-link"
+            icon={<UilTrash />}
+            title={i18next.t("g.delete")}
+          />
+        </PopoverConfirm>
+      </div>
+      <div className="flex items-center justify-between gap-4 px-3 py-2">
+        <div>
+          <div className="text-gray-charcoal dark:text-white font-semibold">
+            {item.meta?.templateName || item.title || i18next.t("post-templates.untitled")}
+          </div>
+          {item.title && (
+            <div className="text-sm text-gray-steel dark:text-white-075">{item.title}</div>
+          )}
+        </div>
+        {confirmApply ? (
+          <PopoverConfirm
+            titleText={i18next.t("post-templates.apply-confirm")}
+            onConfirm={onApply}
+          >
+            <Button size="sm">{i18next.t("post-templates.apply")}</Button>
+          </PopoverConfirm>
+        ) : (
+          <Button size="sm" onClick={onApply}>
+            {i18next.t("post-templates.apply")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/shared/post-templates/post-templates-list.tsx
+++ b/apps/web/src/features/shared/post-templates/post-templates-list.tsx
@@ -1,0 +1,124 @@
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { LinearProgress } from "@/features/shared";
+import { Draft, getDraftsInfiniteQueryOptions } from "@ecency/sdk";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { UilMinusCircle } from "@tooni/iconscout-unicons-react";
+import { Button } from "@ui/button";
+import { FormControl } from "@ui/input";
+import i18next from "i18next";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { PostTemplatesListItem } from "./post-templates-list-item";
+import { getAccessToken } from "@/utils";
+
+// Templates are sparse among ordinary drafts, so pages are chain-fetched
+// until at least this many templates have been accumulated.
+const TEMPLATES_AUTO_FETCH_TARGET = 30;
+
+interface Props {
+  onApply: (draft: Draft) => void;
+  onSave: () => void;
+  confirmApply: boolean;
+}
+
+export function PostTemplatesList({ onApply, onSave, confirmApply }: Props) {
+  const innerRef = useRef<HTMLInputElement | null>(null);
+
+  const { activeUser } = useActiveAccount();
+  const username = activeUser?.username;
+  const accessToken = username ? getAccessToken(username) : undefined;
+
+  const [filter, setFilter] = useState("");
+
+  const {
+    data,
+    isPending,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery(
+    getDraftsInfiniteQueryOptions(username, accessToken, 10)
+  );
+
+  const templates = useMemo(
+    () =>
+      (data?.pages.flatMap((page) => page.data) ?? []).filter((item) => item.meta?.postTemplate),
+    [data]
+  );
+
+  const items = useMemo(
+    () =>
+      templates
+        .filter((x) =>
+          (x.meta?.templateName ?? x.title ?? "").toLowerCase().includes(filter.toLowerCase())
+        )
+        .sort((a, b) => (new Date(b.modified).getTime() > new Date(a.modified).getTime() ? 1 : -1)),
+    [templates, filter]
+  );
+
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage && templates.length < TEMPLATES_AUTO_FETCH_TARGET) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, templates.length]);
+
+  useEffect(() => {
+    if (items && items.length > 0) {
+      innerRef.current && innerRef.current.focus();
+    }
+  }, [items]);
+
+  return (
+    <div>
+      <div className="flex gap-4">
+        <FormControl
+          ref={innerRef}
+          type="text"
+          placeholder={i18next.t("post-templates.filter")}
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          style={{ marginRight: "6px" }}
+        />
+        <div>
+          <Button className="h-full whitespace-nowrap" onClick={onSave}>
+            {i18next.t("post-templates.save-current")}
+          </Button>
+        </div>
+      </div>
+
+      {isPending && <LinearProgress />}
+      {!isPending && items.length === 0 && (
+        <div className="flex items-center flex-col gap-4 pt-16">
+          <UilMinusCircle className="w-10 h-10 text-gray-400 dark:text-gray-600" />
+          <div className="text-gray-600 dark:text-gray-400 text-lg">
+            {i18next.t("g.empty-list")}
+          </div>
+          <div className="text-sm text-gray-600 dark:text-gray-400 text-center">
+            {i18next.t("post-templates.empty-list-hint")}
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-3 my-4">
+        {items.map((item) => (
+          <PostTemplatesListItem
+            item={item}
+            confirmApply={confirmApply}
+            onApply={() => onApply(item)}
+            key={item._id}
+          />
+        ))}
+        {hasNextPage && (
+          <div className="flex justify-center my-4">
+            <Button
+              onClick={() => fetchNextPage()}
+              disabled={isFetchingNextPage}
+              isLoading={isFetchingNextPage}
+            >
+              {isFetchingNextPage ? i18next.t("g.loading") : i18next.t("post-templates.load-more")}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/shared/post-templates/post-templates-list.tsx
+++ b/apps/web/src/features/shared/post-templates/post-templates-list.tsx
@@ -62,10 +62,8 @@ export function PostTemplatesList({ onApply, onSave, confirmApply }: Props) {
   }, [fetchNextPage, hasNextPage, isFetchingNextPage, templates.length]);
 
   useEffect(() => {
-    if (items && items.length > 0) {
-      innerRef.current && innerRef.current.focus();
-    }
-  }, [items]);
+    innerRef.current && innerRef.current.focus();
+  }, []);
 
   return (
     <div>

--- a/apps/web/src/features/shared/post-templates/post-templates-list.tsx
+++ b/apps/web/src/features/shared/post-templates/post-templates-list.tsx
@@ -83,8 +83,10 @@ export function PostTemplatesList({ onApply, onSave, confirmApply }: Props) {
         </div>
       </div>
 
-      {isPending && <LinearProgress />}
-      {!isPending && items.length === 0 && (
+      {(isPending || (items.length === 0 && (hasNextPage || isFetchingNextPage))) && (
+        <LinearProgress />
+      )}
+      {!isPending && items.length === 0 && !hasNextPage && !isFetchingNextPage && (
         <div className="flex items-center flex-col gap-4 pt-16">
           <UilMinusCircle className="w-10 h-10 text-gray-400 dark:text-gray-600" />
           <div className="text-gray-600 dark:text-gray-400 text-lg">

--- a/apps/web/src/features/shared/post-templates/post-templates-list.tsx
+++ b/apps/web/src/features/shared/post-templates/post-templates-list.tsx
@@ -83,10 +83,10 @@ export function PostTemplatesList({ onApply, onSave, confirmApply }: Props) {
         </div>
       </div>
 
-      {(isPending || (items.length === 0 && (hasNextPage || isFetchingNextPage))) && (
+      {(isPending || (templates.length === 0 && (hasNextPage || isFetchingNextPage))) && (
         <LinearProgress />
       )}
-      {!isPending && items.length === 0 && !hasNextPage && !isFetchingNextPage && (
+      {!isPending && templates.length === 0 && !hasNextPage && !isFetchingNextPage && (
         <div className="flex items-center flex-col gap-4 pt-16">
           <UilMinusCircle className="w-10 h-10 text-gray-400 dark:text-gray-600" />
           <div className="text-gray-600 dark:text-gray-400 text-lg">

--- a/apps/web/src/features/shared/post-templates/post-templates-list.tsx
+++ b/apps/web/src/features/shared/post-templates/post-templates-list.tsx
@@ -11,8 +11,10 @@ import { PostTemplatesListItem } from "./post-templates-list-item";
 import { getAccessToken } from "@/utils";
 
 // Templates are sparse among ordinary drafts, so pages are chain-fetched
-// until at least this many templates have been accumulated.
+// until at least this many templates have been accumulated, bounded by a
+// page budget so a large draft library is never walked end to end.
 const TEMPLATES_AUTO_FETCH_TARGET = 30;
+const AUTO_FETCH_PAGE_BUDGET = 5;
 
 interface Props {
   onApply: (draft: Draft) => void;
@@ -55,11 +57,18 @@ export function PostTemplatesList({ onApply, onSave, confirmApply }: Props) {
     [templates, filter]
   );
 
+  const pagesLoaded = data?.pages.length ?? 0;
+
   useEffect(() => {
-    if (hasNextPage && !isFetchingNextPage && templates.length < TEMPLATES_AUTO_FETCH_TARGET) {
+    if (
+      hasNextPage &&
+      !isFetchingNextPage &&
+      templates.length < TEMPLATES_AUTO_FETCH_TARGET &&
+      pagesLoaded < AUTO_FETCH_PAGE_BUDGET
+    ) {
       fetchNextPage();
     }
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage, templates.length]);
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, pagesLoaded, templates.length]);
 
   useEffect(() => {
     innerRef.current && innerRef.current.focus();
@@ -83,7 +92,9 @@ export function PostTemplatesList({ onApply, onSave, confirmApply }: Props) {
         </div>
       </div>
 
-      {(isPending || (templates.length === 0 && (hasNextPage || isFetchingNextPage))) && (
+      {(isPending ||
+        (templates.length === 0 &&
+          (isFetchingNextPage || (hasNextPage && pagesLoaded < AUTO_FETCH_PAGE_BUDGET)))) && (
         <LinearProgress />
       )}
       {!isPending && templates.length === 0 && !hasNextPage && !isFetchingNextPage && (

--- a/apps/web/src/specs/utils/text-similarity.spec.ts
+++ b/apps/web/src/specs/utils/text-similarity.spec.ts
@@ -1,0 +1,49 @@
+import { wordOverlapSimilarity } from "../../utils/text-similarity";
+
+describe("wordOverlapSimilarity", () => {
+  it("should return 1 for identical texts", () => {
+    const text = "My weekly report about the Hive ecosystem";
+    expect(wordOverlapSimilarity(text, text)).toBe(1);
+  });
+
+  it("should ignore case and punctuation", () => {
+    expect(wordOverlapSimilarity("Hello, World!", "hello world")).toBe(1);
+  });
+
+  it("should return 0 for fully disjoint texts", () => {
+    expect(wordOverlapSimilarity("alpha beta gamma", "delta epsilon zeta")).toBe(0);
+  });
+
+  it("should return 0 when either side has no tokens", () => {
+    expect(wordOverlapSimilarity("", "some words here")).toBe(0);
+    expect(wordOverlapSimilarity("some words here", "")).toBe(0);
+    expect(wordOverlapSimilarity("", "")).toBe(0);
+    expect(wordOverlapSimilarity("...!!!", "some words here")).toBe(0);
+  });
+
+  it("should score a subset against its superset proportionally", () => {
+    expect(wordOverlapSimilarity("hola mundo", "hola mundo feliz dia")).toBeCloseTo(2 / 3);
+  });
+
+  it("should count repeated words by their minimum frequency", () => {
+    expect(wordOverlapSimilarity("foo foo bar", "foo bar bar")).toBeCloseTo(2 / 3);
+  });
+
+  it("should handle unicode text", () => {
+    const spanish = "¿Cómo estás? ¡Muy bien, gracias! Nos vemos mañana.";
+    expect(wordOverlapSimilarity(spanish, spanish)).toBe(1);
+    expect(wordOverlapSimilarity(spanish, "completely unrelated english words")).toBe(0);
+  });
+
+  it("should stay above 0.9 for near-identical text with small additions", () => {
+    const template = Array.from({ length: 50 }, (_, i) => `word${i}`).join(" ");
+    const withSmallAdditions = `${template} plus three more`;
+    expect(wordOverlapSimilarity(withSmallAdditions, template)).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it("should drop below 0.9 once substantial new content is added", () => {
+    const template = Array.from({ length: 20 }, (_, i) => `word${i}`).join(" ");
+    const rewritten = `${template} ${Array.from({ length: 20 }, (_, i) => `fresh${i}`).join(" ")}`;
+    expect(wordOverlapSimilarity(rewritten, template)).toBeLessThan(0.9);
+  });
+});

--- a/apps/web/src/utils/text-similarity.ts
+++ b/apps/web/src/utils/text-similarity.ts
@@ -1,0 +1,42 @@
+// Built via the constructor because the es5 compile target rejects the
+// literal's unicode-property escapes; every supported runtime handles them.
+const WORD_TOKEN_PATTERN = "[\\p{L}\\p{N}]+";
+
+function tokenize(text: string): string[] {
+  return text.toLowerCase().match(new RegExp(WORD_TOKEN_PATTERN, "gu")) ?? [];
+}
+
+function buildFrequencyMap(tokens: string[]): Map<string, number> {
+  const frequencies = new Map<string, number>();
+  for (const token of tokens) {
+    frequencies.set(token, (frequencies.get(token) ?? 0) + 1);
+  }
+  return frequencies;
+}
+
+/**
+ * Word-frequency overlap between two texts (Sorensen-Dice over word
+ * multisets): 2 * sum(min(freqA, freqB)) / (lenA + lenB). Returns a value in
+ * [0, 1]; 0 when either side has no word tokens.
+ */
+export function wordOverlapSimilarity(a: string, b: string): number {
+  const tokensA = tokenize(a);
+  const tokensB = tokenize(b);
+
+  if (tokensA.length === 0 || tokensB.length === 0) {
+    return 0;
+  }
+
+  const freqA = buildFrequencyMap(tokensA);
+  const freqB = buildFrequencyMap(tokensB);
+
+  let overlap = 0;
+  freqA.forEach((count, token) => {
+    const other = freqB.get(token);
+    if (other) {
+      overlap += Math.min(count, other);
+    }
+  });
+
+  return (2 * overlap) / (tokensA.length + tokensB.length);
+}


### PR DESCRIPTION
Adds reusable post templates to the publish flow: save the current post (title, body, tags, community, beneficiaries, reward type, poll) as a named template, apply it into the editor, and delete templates.

## How it works
- Templates are stored as regular private-api drafts carrying `meta.postTemplate: true` and `meta.templateName`, so no backend changes are needed. The drafts dialog filters them out of the normal drafts list.
- New `Templates` entry in the publish action bar dropdown opens a dialog (list/apply/delete plus a save-as-template form), gated behind a new `visionFeatures.postTemplates` flag and login.
- Applying a template hydrates publish state the same way draft loading does; if the editor already has content, apply asks for confirmation first.
- Validate step shows a warning when the post body is still nearly identical to the applied template (word-overlap similarity >= 0.9), nudging authors to add their own content before publishing.

## Notes
- Templates ride the drafts pagination; the list chain-fetches pages until enough templates are collected.
- The mobile app will show template drafts in its drafts screen until it ships the same meta filter (follow-up there).
- New util `wordOverlapSimilarity` with unit tests; no new type errors vs develop baseline.