### PR TITLE
Surface save-as-template in the publish action menu

### DIFF
--- a/apps/web/src/app/publish/_components/publish-action-bar.tsx
+++ b/apps/web/src/app/publish/_components/publish-action-bar.tsx
@@ -103,6 +103,7 @@ export function PublishActionBar({
   useDefaultBeneficiary();
 
   const canContinue = !!title?.trim() && hasPublishContent(content);
+  const hasEditorContent = !!title?.trim() || hasPublishContent(content);
 
   const { mutateAsync: saveToDraft, isPending: isDraftPending } = useSaveDraftApi(draftId);
   const { mutateAsync: saveTemplate, isPending: isTemplatePending } = useSaveTemplateApi();
@@ -255,9 +256,9 @@ export function PublishActionBar({
           onApply={applyTemplate}
           onSaveCurrent={(name) => saveTemplate({ name })}
           isSaving={isTemplatePending}
-          confirmApply={!!title?.trim() || hasPublishContent(content)}
+          confirmApply={hasEditorContent}
           initialMode={templatesMode}
-          canSaveCurrent={!!title?.trim() || hasPublishContent(content)}
+          canSaveCurrent={hasEditorContent}
         />
       </EcencyConfigManager.Conditional>
     </div>

--- a/apps/web/src/app/publish/_components/publish-action-bar.tsx
+++ b/apps/web/src/app/publish/_components/publish-action-bar.tsx
@@ -96,6 +96,7 @@ export function PublishActionBar({
   const [schedule, setSchedule] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const [showTemplates, setShowTemplates] = useState(false);
+  const [templatesMode, setTemplatesMode] = useState<"list" | "save">("list");
 
   const pathname = usePathname();
 
@@ -193,9 +194,22 @@ export function PublishActionBar({
             >
               <LoginRequired>
                 <DropdownItemWithIcon
-                  onClick={() => setShowTemplates(true)}
+                  onClick={() => {
+                    setTemplatesMode("list");
+                    setShowTemplates(true);
+                  }}
                   icon={<UilFileBookmarkAlt />}
                   label={i18next.t("post-templates.title")}
+                />
+              </LoginRequired>
+              <LoginRequired>
+                <DropdownItemWithIcon
+                  onClick={() => {
+                    setTemplatesMode("save");
+                    setShowTemplates(true);
+                  }}
+                  icon={<UilFileBookmarkAlt />}
+                  label={i18next.t("post-templates.save-current")}
                 />
               </LoginRequired>
             </EcencyConfigManager.Conditional>
@@ -242,6 +256,8 @@ export function PublishActionBar({
           onSaveCurrent={(name) => saveTemplate({ name })}
           isSaving={isTemplatePending}
           confirmApply={!!title?.trim() || hasPublishContent(content)}
+          initialMode={templatesMode}
+          canSaveCurrent={!!title?.trim() || hasPublishContent(content)}
         />
       </EcencyConfigManager.Conditional>
     </div>

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -2205,6 +2205,7 @@
   "post-templates": {
     "title": "Templates",
     "save-current": "Save as template",
+    "empty-editor-hint": "Write your post first, then save it as a template.",
     "name-label": "Template name",
     "name-placeholder": "e.g. Weekly update",
     "validation-name": "Name is required.",

--- a/apps/web/src/features/shared/post-templates/index.tsx
+++ b/apps/web/src/features/shared/post-templates/index.tsx
@@ -14,6 +14,8 @@ interface Props {
   onSaveCurrent: (name: string) => Promise<unknown>;
   isSaving: boolean;
   confirmApply: boolean;
+  initialMode?: "list" | "save";
+  canSaveCurrent?: boolean;
 }
 
 export function PostTemplatesDialog({
@@ -22,21 +24,24 @@ export function PostTemplatesDialog({
   onApply,
   onSaveCurrent,
   isSaving,
-  confirmApply
+  confirmApply,
+  initialMode = "list",
+  canSaveCurrent = true
 }: Props) {
-  const [mode, setMode] = useState<"list" | "save">("list");
+  const [mode, setMode] = useState<"list" | "save">(initialMode);
   const [name, setName] = useState("");
 
   const form = useRef<HTMLFormElement>(null);
 
-  // The dialog stays mounted between opens; a dismissed save form must not
-  // reappear the next time it is shown.
+  // The dialog stays mounted between opens; each open starts at the caller's
+  // requested mode and a dismissed save form must not reappear.
   useEffect(() => {
-    if (!show) {
-      setMode("list");
+    if (show) {
+      setMode(initialMode);
+    } else {
       setName("");
     }
-  }, [show]);
+  }, [show, initialMode]);
 
   return (
     <Modal show={show} centered={true} onHide={() => setShow(false)} size="lg">
@@ -50,9 +55,20 @@ export function PostTemplatesDialog({
               setShow(false);
             }}
             onSave={() => setMode("save")}
+            canSave={canSaveCurrent}
           />
         )}
-        {mode === "save" && (
+        {mode === "save" && !canSaveCurrent && (
+          <div className="flex flex-col items-start gap-4">
+            <div className="text-sm opacity-75">
+              {i18next.t("post-templates.empty-editor-hint")}
+            </div>
+            <Button appearance="gray" size="sm" onClick={() => setMode("list")}>
+              {i18next.t("post-templates.cancel")}
+            </Button>
+          </div>
+        )}
+        {mode === "save" && canSaveCurrent && (
           <Form
             ref={form}
             onSubmit={async (e: React.FormEvent) => {

--- a/apps/web/src/features/shared/post-templates/index.tsx
+++ b/apps/web/src/features/shared/post-templates/index.tsx
@@ -34,14 +34,18 @@ export function PostTemplatesDialog({
   const form = useRef<HTMLFormElement>(null);
 
   // The dialog stays mounted between opens; each open starts at the caller's
-  // requested mode and a dismissed save form must not reappear.
+  // requested mode and a dismissed save form must not reappear. The mode is
+  // read through a ref so the effect only fires on open/close and can never
+  // clobber navigation done inside the dialog.
+  const initialModeRef = useRef(initialMode);
+  initialModeRef.current = initialMode;
   useEffect(() => {
     if (show) {
-      setMode(initialMode);
+      setMode(initialModeRef.current);
     } else {
       setName("");
     }
-  }, [show, initialMode]);
+  }, [show]);
 
   return (
     <Modal show={show} centered={true} onHide={() => setShow(false)} size="lg">

--- a/apps/web/src/features/shared/post-templates/post-templates-list.tsx
+++ b/apps/web/src/features/shared/post-templates/post-templates-list.tsx
@@ -19,10 +19,11 @@ const AUTO_FETCH_PAGE_BUDGET = 5;
 interface Props {
   onApply: (draft: Draft) => void;
   onSave: () => void;
+  canSave: boolean;
   confirmApply: boolean;
 }
 
-export function PostTemplatesList({ onApply, onSave, confirmApply }: Props) {
+export function PostTemplatesList({ onApply, onSave, confirmApply, canSave }: Props) {
   const innerRef = useRef<HTMLInputElement | null>(null);
 
   const { activeUser } = useActiveAccount();
@@ -86,7 +87,12 @@ export function PostTemplatesList({ onApply, onSave, confirmApply }: Props) {
           style={{ marginRight: "6px" }}
         />
         <div>
-          <Button className="h-full whitespace-nowrap" onClick={onSave}>
+          <Button
+            className="h-full whitespace-nowrap"
+            onClick={onSave}
+            disabled={!canSave}
+            title={canSave ? undefined : i18next.t("post-templates.empty-editor-hint")}
+          >
             {i18next.t("post-templates.save-current")}
           </Button>
         </div>

--- a/apps/web/src/features/shared/post-templates/post-templates-list.tsx
+++ b/apps/web/src/features/shared/post-templates/post-templates-list.tsx
@@ -33,12 +33,6 @@ export function PostTemplatesList({ onApply, onSave, confirmApply, canSave }: Pr
 
   const [filter, setFilter] = useState("");
 
-  // refetchOnMount is disabled app-wide; a template saved while this list was
-  // unmounted (the dialog shows the save form then) must appear on return.
-  useMount(() => {
-    refetch();
-  });
-
   const {
     data,
     isPending,
@@ -49,6 +43,12 @@ export function PostTemplatesList({ onApply, onSave, confirmApply, canSave }: Pr
   } = useInfiniteQuery(
     getDraftsInfiniteQueryOptions(username, accessToken, 10)
   );
+
+  // refetchOnMount is disabled app-wide; a template saved while this list was
+  // unmounted (the dialog shows the save form then) must appear on return.
+  useMount(() => {
+    refetch();
+  });
 
   const templates = useMemo(
     () =>

--- a/apps/web/src/features/shared/post-templates/post-templates-list.tsx
+++ b/apps/web/src/features/shared/post-templates/post-templates-list.tsx
@@ -7,6 +7,7 @@ import { Button } from "@ui/button";
 import { FormControl } from "@ui/input";
 import i18next from "i18next";
 import { useEffect, useMemo, useRef, useState } from "react";
+import useMount from "react-use/lib/useMount";
 import { PostTemplatesListItem } from "./post-templates-list-item";
 import { getAccessToken } from "@/utils";
 
@@ -32,9 +33,16 @@ export function PostTemplatesList({ onApply, onSave, confirmApply, canSave }: Pr
 
   const [filter, setFilter] = useState("");
 
+  // refetchOnMount is disabled app-wide; a template saved while this list was
+  // unmounted (the dialog shows the save form then) must appear on return.
+  useMount(() => {
+    refetch();
+  });
+
   const {
     data,
     isPending,
+    refetch,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,


### PR DESCRIPTION
Creating a template was only reachable through the Templates dialog's header button, which is hard to discover. This makes creation a first-class action and prevents empty templates.

## What
- The publish 3-dot menu gains a dedicated "Save as template" entry next to "Templates"; it opens the templates dialog directly on the name form.
- The dialog accepts an initial mode, so "Templates" still opens the browse list while the new entry jumps straight to saving.
- Saving is guarded by the same content check the Continue button uses: with an empty editor the list's save button is disabled with a hint, and the save form is replaced by an explanation ("Write your post first, then save it as a template."), so an empty template can no longer be created.

## Notes
- No new icons (reuses the existing bookmark icon for both entries); unicons coverage spec passes.
- No new type errors vs develop; related specs green.