### PR TITLE
Surface daily quest and streak in composers

### DIFF
--- a/apps/web/src/app/publish/_api/use-publish.ts
+++ b/apps/web/src/app/publish/_api/use-publish.ts
@@ -22,6 +22,7 @@ import {
   makeCommentOptions,
   tempEntry
 } from "@/utils";
+import { scheduleQuestsRefresh } from "@/utils/refresh-quests";
 import { postBodySummary } from "@ecency/render-helper";
 import { EcencyAnalytics } from "@ecency/sdk";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -269,6 +270,8 @@ export function usePublishApi() {
           } as unknown as Poll;
         }
       );
+
+      scheduleQuestsRefresh(queryClient, username);
     }
   });
 }

--- a/apps/web/src/app/publish/_components/publish-mode-header.tsx
+++ b/apps/web/src/app/publish/_components/publish-mode-header.tsx
@@ -1,4 +1,5 @@
 import i18next from "i18next";
+import { QuestStreakChip } from "@/features/shared/quest-streak-chip";
 
 interface Props {
   /**
@@ -22,12 +23,15 @@ export function PublishModeHeader({ label, lastSaved }: Props) {
     <div className="container max-w-[1024px] mx-auto text-xs text-gray-600 dark:text-gray-400 px-2 md:px-4 py-2 md:py-0">
       <div className="flex flex-wrap justify-between items-center">
         <span>{label}</span>
-        {lastSaved && (
-          <span className="text-gray-500 dark:text-gray-400">
-            {i18next.t("publish.auto-save")}:{" "}
-          {lastSaved.toLocaleTimeString(i18next.language || undefined)}
-          </span>
-        )}
+        <span className="flex items-center gap-3">
+          {lastSaved && (
+            <span className="text-gray-500 dark:text-gray-400">
+              {i18next.t("publish.auto-save")}:{" "}
+              {lastSaved.toLocaleTimeString(i18next.language || undefined)}
+            </span>
+          )}
+          <QuestStreakChip />
+        </span>
       </div>
     </div>
   );

--- a/apps/web/src/app/publish/_components/publish-success-state.tsx
+++ b/apps/web/src/app/publish/_components/publish-success-state.tsx
@@ -2,7 +2,10 @@ import { Button } from "@/features/ui";
 import { UilCheckCircle, UilClock } from "@tooni/iconscout-unicons-react";
 import i18next from "i18next";
 import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { getQuestsQueryOptions } from "@ecency/sdk";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { deriveQuestChipState } from "@/features/shared/quest-streak-chip/derive-quest-chip-state";
 import {
   makeShareUrlReddit,
   makeShareUrlTwitter,
@@ -10,13 +13,7 @@ import {
   makeShareUrlLinkedin,
   makeShareUrlDiscord
 } from "@/utils/url-share";
-import {
-  facebookSvg,
-  discordSvg,
-  linkedinSvg,
-  redditSvg,
-  twitterSvg
-} from "@ui/svg";
+import { facebookSvg, discordSvg, linkedinSvg, redditSvg, twitterSvg } from "@ui/svg";
 
 interface EntryInfo {
   title: string;
@@ -72,6 +69,32 @@ function ShareBar({ entryInfo }: { entryInfo: EntryInfo }) {
   );
 }
 
+/**
+ * One-line quest celebration under the success message. Waits for the quests
+ * query (refreshed via `scheduleQuestsRefresh` on publish) and only renders
+ * once it confirms the daily post quest is complete.
+ */
+function QuestCompleteLine() {
+  const { activeUser } = useActiveAccount();
+  const { data: quests } = useQuery(getQuestsQueryOptions(activeUser?.username));
+
+  const state = deriveQuestChipState(quests);
+
+  if (!state?.postedToday) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 text-sm font-semibold text-green">
+      <span aria-hidden>🔥</span>
+      <span>
+        {i18next.t("quest-chip.post-quest-complete")}
+        {state.streak > 0 && <> · {i18next.t("perks.quests.streak", { n: state.streak })}</>}
+      </span>
+    </div>
+  );
+}
+
 export function PublishSuccessState({ step, setEditStep, entryInfo }: Props) {
   const { activeUser } = useActiveAccount();
   const profileHref = activeUser ? `/@${activeUser.username}/posts` : "/";
@@ -91,6 +114,8 @@ export function PublishSuccessState({ step, setEditStep, entryInfo }: Props) {
             {step === "scheduled" && i18next.t("publish.scheduled-hint")}
           </div>
         </div>
+
+        {step === "published" && <QuestCompleteLine />}
 
         {step === "published" && entryInfo && <ShareBar entryInfo={entryInfo} />}
 

--- a/apps/web/src/app/publish/_components/publish-success-state.tsx
+++ b/apps/web/src/app/publish/_components/publish-success-state.tsx
@@ -70,9 +70,10 @@ function ShareBar({ entryInfo }: { entryInfo: EntryInfo }) {
 }
 
 /**
- * One-line quest celebration under the success message. Waits for the quests
- * query (refreshed via `scheduleQuestsRefresh` on publish) and only renders
- * once it confirms the daily post quest is complete.
+ * One-line quest celebration under the success message. Renders whenever the
+ * quests query reports the daily post quest complete: instantly from cache
+ * for a repeat post, or after the post-publish refresh for the first post of
+ * the day.
  */
 function QuestCompleteLine() {
   const { activeUser } = useActiveAccount();

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -2974,7 +2974,7 @@
   },
   "quest-chip": {
     "daily-post": "Daily post {{progress}}/{{goal}}",
-    "tooltip": "Publish a post or check in today to keep your streak",
+    "tooltip": "Check in today to keep your streak. The daily post quest earns extra Points.",
     "post-quest-complete": "Daily post quest complete"
   },
   "boost-plus": {

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -2972,6 +2972,11 @@
       }
     }
   },
+  "quest-chip": {
+    "daily-post": "Daily post {{progress}}/{{goal}}",
+    "tooltip": "Publish a post or check in today to keep your streak",
+    "post-quest-complete": "Daily post quest complete"
+  },
   "boost-plus": {
     "title": "Boost+",
     "sub-title": "Boost your account using Ecency points",

--- a/apps/web/src/features/shared/quest-streak-chip/derive-quest-chip-state.ts
+++ b/apps/web/src/features/shared/quest-streak-chip/derive-quest-chip-state.ts
@@ -1,0 +1,42 @@
+import { getQuestCatalogEntry, type QuestsResponse } from "@ecency/sdk";
+
+export interface QuestChipState {
+  /** show the chip at all — an active streak to protect or a daily post still to publish */
+  visible: boolean;
+  /** the daily post quest reached its catalog goal today */
+  postedToday: boolean;
+  postProgress: number;
+  postGoal: number;
+  /** current streak length in days */
+  streak: number;
+  /** streak is active but today has no qualifying activity yet */
+  atRisk: boolean;
+}
+
+/**
+ * Pure derivation of the composer quest chip from the `/private-api/quests`
+ * response. Returns null until data arrives so callers can distinguish
+ * "loading" from "nothing to show" (`visible: false`).
+ */
+export function deriveQuestChipState(quests: QuestsResponse | undefined): QuestChipState | null {
+  if (!quests) {
+    return null;
+  }
+
+  const postQuest = quests.daily?.find((q) => q.id === "post");
+  const postGoal = getQuestCatalogEntry("daily", "post")?.goal ?? 1;
+  const postProgress = postQuest?.progress ?? 0;
+  const postedToday = postProgress >= postGoal;
+
+  const streak = quests.streak?.current ?? 0;
+  const atRisk = (quests.streak?.at_risk ?? false) && streak > 0;
+
+  return {
+    visible: streak > 0 || !postedToday,
+    postedToday,
+    postProgress,
+    postGoal,
+    streak,
+    atRisk
+  };
+}

--- a/apps/web/src/features/shared/quest-streak-chip/index.tsx
+++ b/apps/web/src/features/shared/quest-streak-chip/index.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { Tooltip } from "@ui/tooltip";
+import { getQuestsQueryOptions } from "@ecency/sdk";
+import { useQuery } from "@tanstack/react-query";
+import clsx from "clsx";
+import i18next from "i18next";
+import Link from "next/link";
+import { deriveQuestChipState } from "./derive-quest-chip-state";
+
+interface Props {
+  className?: string;
+}
+
+/**
+ * Compact daily-quest pill for the composers: shows the unfinished daily post
+ * quest and/or the current streak flame (orange when the streak is at risk)
+ * and links to /perks. Renders nothing while the quests query loads, for
+ * logged-out users, or when there is nothing to nudge about.
+ */
+export function QuestStreakChip({ className }: Props) {
+  const { activeUser } = useActiveAccount();
+  const { data: quests } = useQuery(getQuestsQueryOptions(activeUser?.username));
+
+  const state = deriveQuestChipState(quests);
+
+  if (!activeUser || !state?.visible) {
+    return null;
+  }
+
+  return (
+    <Tooltip content={i18next.t("quest-chip.tooltip")}>
+      <Link
+        href="/perks"
+        className={clsx(
+          "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold whitespace-nowrap",
+          state.atRisk
+            ? "bg-orange-100 dark:bg-orange-900/40 text-orange-600 dark:text-orange-300"
+            : "bg-blue-duck-egg dark:bg-gray-800 text-blue-dark-sky",
+          className
+        )}
+      >
+        {!state.postedToday && (
+          <span>
+            {i18next.t("quest-chip.daily-post", {
+              progress: state.postProgress,
+              goal: state.postGoal
+            })}
+          </span>
+        )}
+        {state.streak > 0 && (
+          <span className="inline-flex items-center gap-1">
+            <span aria-hidden>🔥</span>
+            <span>{state.streak > 99 ? "99+" : state.streak}</span>
+          </span>
+        )}
+      </Link>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/features/waves/components/wave-form/index.tsx
+++ b/apps/web/src/features/waves/components/wave-form/index.tsx
@@ -7,6 +7,7 @@ import { PollsContext, PollsManager, useEntryPollExtractor } from "@/features/po
 import { useLocalStorage } from "react-use";
 import { PREFIX } from "@/utils/local-storage";
 import { ProfileLink, UserAvatar } from "@/features/shared";
+import { QuestStreakChip } from "@/features/shared/quest-streak-chip";
 import { WaveFormControl } from "./wave-form-control";
 import i18next from "i18next";
 import { Button } from "@ui/button";
@@ -337,6 +338,8 @@ const WaveFormComponent = ({
             {i18next.t("g.loading")}...
           </div>
         )}
+
+        <QuestStreakChip className="mb-1.5" />
 
         <WaveFormToolbar
           isEdit={!!entry}

--- a/apps/web/src/features/waves/hooks/use-wave-submit.ts
+++ b/apps/web/src/features/waves/hooks/use-wave-submit.ts
@@ -13,6 +13,7 @@ import i18next from "i18next";
 import { useActiveAccount } from "@/core/hooks";
 import { getQueryClient } from "@/core/react-query";
 import { getAccountFullQueryOptions } from "@ecency/sdk";
+import { scheduleQuestsRefresh } from "@/utils/refresh-quests";
 
 interface Body {
   text: string;
@@ -146,6 +147,7 @@ export function useWaveSubmit(
       }
       if (item) {
         onSuccess?.(item);
+        scheduleQuestsRefresh(getQueryClient(), username);
       }
     }
   });

--- a/apps/web/src/specs/app/publish-mode-header.spec.tsx
+++ b/apps/web/src/specs/app/publish-mode-header.spec.tsx
@@ -1,30 +1,34 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
+import { renderWithQueryClient } from "@/specs/test-utils";
 import { PublishModeHeader } from "@/app/publish/_components/publish-mode-header";
 
 // i18next is globally mocked (see setup-any-spec.ts) to echo keys, so
 // t("publish.auto-save") renders as the literal "publish.auto-save".
+// A QueryClient is required since the header renders the QuestStreakChip.
 describe("PublishModeHeader", () => {
   it("renders the provided mode label", () => {
-    render(<PublishModeHeader label="New Content" />);
+    renderWithQueryClient(<PublishModeHeader label="New Content" />);
     expect(screen.getByText("New Content")).toBeInTheDocument();
   });
 
   it("shows the auto-saved time when lastSaved is provided", () => {
-    render(<PublishModeHeader label="Draft Editing" lastSaved={new Date("2026-06-04T10:06:46Z")} />);
+    renderWithQueryClient(
+      <PublishModeHeader label="Draft Editing" lastSaved={new Date("2026-06-04T10:06:46Z")} />
+    );
     expect(screen.getByText("Draft Editing")).toBeInTheDocument();
     expect(screen.getByText(/publish\.auto-save/)).toBeInTheDocument();
   });
 
   it("omits the auto-saved time when lastSaved is null", () => {
-    render(<PublishModeHeader label="Post Editing" lastSaved={null} />);
+    renderWithQueryClient(<PublishModeHeader label="Post Editing" lastSaved={null} />);
     expect(screen.getByText("Post Editing")).toBeInTheDocument();
     expect(screen.queryByText(/publish\.auto-save/)).not.toBeInTheDocument();
   });
 
   it("omits the auto-saved time when lastSaved is omitted", () => {
-    render(<PublishModeHeader label="New Content" />);
+    renderWithQueryClient(<PublishModeHeader label="New Content" />);
     expect(screen.queryByText(/publish\.auto-save/)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/specs/features/shared/quest-streak-chip.spec.ts
+++ b/apps/web/src/specs/features/shared/quest-streak-chip.spec.ts
@@ -1,0 +1,77 @@
+import { vi } from "vitest";
+import type { QuestsResponse } from "@ecency/sdk";
+
+vi.mock("@ecency/sdk", () => ({
+  // Minimal mirror of the SDK quest catalog — only the entry the helper reads.
+  getQuestCatalogEntry: (tier: string, id: string) =>
+    tier === "daily" && id === "post"
+      ? { id: "post", tier: "daily", goal: 1, i18nKey: "post", icon: "pencil" }
+      : undefined
+}));
+
+import { deriveQuestChipState } from "@/features/shared/quest-streak-chip/derive-quest-chip-state";
+
+function makeQuests(overrides: {
+  postProgress?: number;
+  includePostQuest?: boolean;
+  streak?: Partial<QuestsResponse["streak"]>;
+}): QuestsResponse {
+  const { postProgress = 0, includePostQuest = true, streak } = overrides;
+  return {
+    period: { day: "2026-07-06", week: "2026-W28", month: "2026-07", day_resets_in_secs: 3600 },
+    daily: includePostQuest ? [{ id: "post", progress: postProgress, cap: 3 }] : [],
+    weekly: [],
+    monthly: [],
+    streak: { current: 0, best: 0, at_risk: false, ...streak }
+  };
+}
+
+describe("deriveQuestChipState", () => {
+  it("returns null while the quests query has no data yet", () => {
+    expect(deriveQuestChipState(undefined)).toBeNull();
+  });
+
+  it("is visible with post progress when the daily post is incomplete and no streak exists", () => {
+    const state = deriveQuestChipState(makeQuests({ postProgress: 0 }));
+    expect(state).toEqual({
+      visible: true,
+      postedToday: false,
+      postProgress: 0,
+      postGoal: 1,
+      streak: 0,
+      atRisk: false
+    });
+  });
+
+  it("stays visible for the streak flame once the daily post is complete", () => {
+    const state = deriveQuestChipState(
+      makeQuests({ postProgress: 1, streak: { current: 5, best: 9 } })
+    );
+    expect(state).toMatchObject({ visible: true, postedToday: true, streak: 5 });
+  });
+
+  it("hides entirely when the daily post is done and there is no streak to show", () => {
+    const state = deriveQuestChipState(makeQuests({ postProgress: 1 }));
+    expect(state).toMatchObject({ visible: false, postedToday: true, streak: 0 });
+  });
+
+  it("treats progress beyond the catalog goal as complete", () => {
+    const state = deriveQuestChipState(makeQuests({ postProgress: 3 }));
+    expect(state).toMatchObject({ postedToday: true, postProgress: 3, postGoal: 1 });
+  });
+
+  it("treats a missing daily post quest as zero progress", () => {
+    const state = deriveQuestChipState(makeQuests({ includePostQuest: false }));
+    expect(state).toMatchObject({ visible: true, postedToday: false, postProgress: 0 });
+  });
+
+  it("flags at-risk only while a streak is actually active", () => {
+    const active = deriveQuestChipState(
+      makeQuests({ streak: { current: 3, best: 3, at_risk: true } })
+    );
+    expect(active).toMatchObject({ atRisk: true });
+
+    const inactive = deriveQuestChipState(makeQuests({ streak: { at_risk: true } }));
+    expect(inactive).toMatchObject({ atRisk: false });
+  });
+});

--- a/apps/web/src/specs/setup-any-spec.ts
+++ b/apps/web/src/specs/setup-any-spec.ts
@@ -81,6 +81,16 @@ vi.mock("@ecency/sdk", () => ({
   })),
   getBoostPlusPricesQueryOptions: vi.fn(() => ({ queryKey: ["boost-prices"], queryFn: vi.fn() })),
   getPointsQueryOptions: vi.fn(() => ({ queryKey: ["points"], queryFn: vi.fn() })),
+  getQuestsQueryOptions: vi.fn((username?: string) => ({
+    queryKey: ["quests", "status", username],
+    queryFn: vi.fn(),
+    enabled: !!username
+  })),
+  getQuestCatalogEntry: vi.fn((tier: string, id: string) =>
+    tier === "daily" && id === "post"
+      ? { id: "post", tier: "daily", goal: 1, i18nKey: "post", icon: "pencil" }
+      : undefined
+  ),
   getSpotlightsQueryOptions: vi.fn(() => ({
     queryKey: ["notifications", "spotlights"],
     queryFn: vi.fn()


### PR DESCRIPTION
Phase 1 of quest surfacing: the publish editor and Waves composer show a compact pill with the daily post quest progress and check-in streak, so the habit loop is visible at the moment of creation instead of only under Perks.

## What
- New shared QuestStreakChip (reads the existing quests query; no new endpoints): "Daily post 0/1" while incomplete, flame + streak count when a streak is active (orange when at risk), tooltip explains how to keep the streak, links to /perks. Renders nothing while loading, logged out, or when there is nothing to nudge.
- Mounted in the publish mode header (next to the autosave time) and above the Waves composer toolbar.
- `scheduleQuestsRefresh` is now wired into publish success and wave submit success (it previously covered replies/reblogs/follows only), so quest state updates right after posting.
- The publish success screen shows a one-line celebration ("Daily post quest complete" + streak) once the refreshed query confirms the quest is done.

## Notes
- Pure `deriveQuestChipState` helper with unit tests; global SDK spec mock extended for the two new exports and the publish-mode-header spec updated accordingly (the header now contains a query component).
- No new icons (fire emoji as text, same as perks/navbar); unicons coverage spec passes.
- Full suite green (201 files / 2042 tests); zero new type errors vs develop.
- The chip also appears in wave reply forms; it is a generic nudge and self-hides once the daily post is done, so this is deliberate for v1.