### PR TITLE
Require GFM adjacency for translate table detection

### DIFF
--- a/apps/web/src/api/translation.ts
+++ b/apps/web/src/api/translation.ts
@@ -263,13 +263,17 @@ const isSkippableBlock = (block: string): boolean => {
   ) {
     return true;
   }
-  // Tables: a pipe row plus a |---| separator row. Cell-safe translation is
-  // out of scope, so the whole block is passed through.
-  return (
-    lines.some((line) => line.includes("|")) &&
-    lines.some(
-      (line) => line.includes("|") && line.includes("-") && TABLE_SEPARATOR_LINE.test(line)
-    )
+  // Tables: a |---| separator row directly below a pipe row (the GFM shape).
+  // Cell-safe translation is out of scope, so the whole block is passed
+  // through; requiring adjacency keeps prose that merely contains pipe
+  // characters translatable.
+  return lines.some(
+    (line, i) =>
+      i > 0 &&
+      line.includes("|") &&
+      line.includes("-") &&
+      TABLE_SEPARATOR_LINE.test(line) &&
+      lines[i - 1].includes("|")
   );
 };
 

--- a/apps/web/src/specs/api/translate-markdown.spec.ts
+++ b/apps/web/src/specs/api/translate-markdown.spec.ts
@@ -277,4 +277,18 @@ it("preserves leading indentation on marker-less continuation lines", async () =
     ).rejects.toThrow("translate-cancelled");
     expect(calls).toBe(1);
   });
+it("still skips a real GFM table (separator directly under the header row)", async () => {
+    const table = "| a | b |\n|---|---|\n| 1 | 2 |";
+    const result = await translateMarkdown(`Intro.\n\n${table}`, "es", "en");
+
+    expect(result).toBe(`\u00abIntro.\u00bb\n\n${table}`);
+  });
+
+  it("translates prose containing pipes and a stray separator-like line", async () => {
+    const block = "El valor |x| es absoluto\nnota al margen\n|---|";
+    const result = await translateMarkdown(block, "es", "en");
+
+    expect(result).toContain("\u00ab");
+    expect(post).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Parity port of the tightening that shipped in the mobile compose-translation review (ecency/ecency-mobile#3325): `translateMarkdown` classified a block as a table when any line had a pipe and any other line looked like a `|---|` separator, so prose containing pipe characters near a separator-like line was silently skipped by translation. The separator row must now sit directly below a pipe-containing row (the GFM shape).

Two regression tests added (real table still skipped; pipes-in-prose now translates); suite 30/30.