### PR TITLE
Blog hosting signup page (card + HBD)

### DIFF
--- a/apps/web/src/app/hosting/_page.tsx
+++ b/apps/web/src/app/hosting/_page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { HostingSignup } from "@/features/hosting-signup";
+import { hostingApi } from "@/features/hosting-signup/hosting-api";
+import i18next from "i18next";
+
+export function HostingPage() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      {hostingApi.isConfigured() ? (
+        <HostingSignup />
+      ) : (
+        <div className="max-w-lg mx-auto text-center opacity-75 py-12">
+          {i18next.t("hosting.coming-soon")}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/hosting/page.tsx
+++ b/apps/web/src/app/hosting/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from "next";
+import { HostingPage } from "./_page";
+
+export const metadata: Metadata = {
+  title: "Blog Hosting | Ecency",
+  description: "Host your Hive blog on your own branded site at yourname.blogs.ecency.com."
+};
+
+export default function Page() {
+  return <HostingPage />;
+}

--- a/apps/web/src/features/hosting-signup/hosting-api.ts
+++ b/apps/web/src/features/hosting-signup/hosting-api.ts
@@ -1,0 +1,88 @@
+// Thin client for the managed blog-hosting API (a separate service from vapi). CORS on
+// that service already allows ecency.com. The base URL is configured per-environment; the
+// signup page is hidden when it is unset.
+
+const HOSTING_API = (process.env.NEXT_PUBLIC_HOSTING_API ?? "").replace(/\/$/, "");
+
+export interface HostingPaymentMethods {
+  hbd: { enabled: boolean; monthly: string; account: string };
+  x402: { enabled: boolean; monthly: string };
+  card: { enabled: boolean; monthlyUsdCents: number };
+}
+
+export interface HostingConfigInput {
+  theme?: "light" | "dark" | "system";
+  styleTemplate?: string;
+  title?: string;
+  description?: string;
+}
+
+export interface CreateTenantResult {
+  tenant: { username: string; subscriptionStatus: string; blogUrl: string };
+  paymentInstructions: { to: string; amount: string; memo: string; note?: string };
+}
+
+export interface TenantInfo {
+  username: string;
+  subscriptionStatus: "active" | "inactive" | "expired" | "suspended";
+  subscriptionExpiresAt?: string | null;
+  blogUrl?: string;
+}
+
+async function parseError(r: Response): Promise<string> {
+  try {
+    const data = await r.json();
+    return (data && (data.error || data.message)) || `HTTP ${r.status}`;
+  } catch {
+    return `HTTP ${r.status}`;
+  }
+}
+
+async function get<T>(path: string): Promise<T> {
+  const r = await fetch(`${HOSTING_API}${path}`, { headers: { Accept: "application/json" } });
+  if (!r.ok) throw new Error(await parseError(r));
+  return r.json() as Promise<T>;
+}
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const r = await fetch(`${HOSTING_API}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body)
+  });
+  if (!r.ok) throw new Error(await parseError(r));
+  return r.json() as Promise<T>;
+}
+
+export const hostingApi = {
+  /** The signup page only renders when the service URL is configured. */
+  isConfigured: () => HOSTING_API.length > 0,
+
+  paymentMethods: () => get<HostingPaymentMethods>("/v1/payments/methods"),
+
+  /** Create the (inactive) tenant. Payment then activates it. */
+  createTenant: (username: string, config?: HostingConfigInput) =>
+    post<CreateTenantResult>("/v1/tenants", { username, config }),
+
+  tenant: (username: string) => get<TenantInfo>(`/v1/tenants/${encodeURIComponent(username)}`),
+
+  /** HBD payment instructions for a given term. */
+  paymentInstructions: (username: string, months: number) =>
+    get<{ to: string; amount: string; memo: string; totalAmount: string; instructions: string[] }>(
+      `/v1/payments/instructions/${encodeURIComponent(username)}?months=${months}`
+    )
+};
+
+/** SKU the ePoints Stripe rail expects for a hosting term (leading number = price in cents). */
+export function hostingSkuForMonths(months: number): string {
+  switch (months) {
+    case 3:
+      return "600hosting";
+    case 6:
+      return "1200hosting";
+    case 12:
+      return "2400hosting";
+    default:
+      return "200hosting";
+  }
+}

--- a/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { getStripePromise } from "@/features/shared/purchase-stripe";
+import { StripeCheckoutForm } from "@/features/shared/purchase-stripe/stripe-checkout-form";
+import {
+  fetchStripeOrderStatus,
+  useCreateStripeIntent
+} from "@/features/shared/purchase-stripe/use-stripe-points-purchase";
+import { Elements } from "@stripe/react-stripe-js";
+import { Alert } from "@ui/alert";
+import i18next from "i18next";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const isDarkMode = () =>
+  typeof document !== "undefined" && document.documentElement.classList.contains("dark");
+
+// Fresh per-checkout nonce (guarded for insecure-origin / older WebViews).
+const genNonce = (): string =>
+  typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+interface Props {
+  /** The buyer / blog owner (authenticated). ePoints binds the order to this user. */
+  username: string;
+  /** The hosting SKU for the chosen term (e.g. "200hosting"). */
+  sku: string;
+  payLabel: string;
+  returnUrl: string;
+  onActivated: () => void;
+}
+
+/**
+ * Card payment for hosting, riding the shared ePoints Stripe rail: create a PaymentIntent for
+ * a hosting SKU via vapi, confirm with the Payment Element, then poll the order status. For a
+ * hosting SKU the order reaching "success" means ePoints has already called the hosting
+ * service's activate endpoint, so the blog is live. The tenant must already exist (the signup
+ * flow creates it before this renders).
+ */
+export function HostingCardCheckout({ username, sku, payLabel, returnUrl, onActivated }: Props) {
+  const [nonce] = useState(genNonce);
+  const [clientSecret, setClientSecret] = useState("");
+  const [error, setError] = useState("");
+  const [activating, setActivating] = useState(false);
+  const pollingRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const createIntent = useCreateStripeIntent(username);
+  const stripePromise = getStripePromise();
+
+  // Mint the PaymentIntent once for this checkout.
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const { client_secret } = await createIntent.mutateAsync({ sku, nonce });
+        if (alive) setClientSecret(client_secret);
+      } catch (e) {
+        if (alive) setError((e as Error).message || i18next.t("hosting.card-unavailable"));
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sku, nonce]);
+
+  // Stop polling on unmount.
+  useEffect(
+    () => () => {
+      pollingRef.current = false;
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    []
+  );
+
+  const paymentIntentId = clientSecret ? clientSecret.split("_secret_")[0] : "";
+
+  const startPoll = useCallback(() => {
+    if (!paymentIntentId || pollingRef.current) return;
+    pollingRef.current = true;
+    setActivating(true);
+    const poll = async () => {
+      if (!pollingRef.current) return;
+      try {
+        const st = await fetchStripeOrderStatus(username, paymentIntentId);
+        if (!pollingRef.current) return;
+        if (st.status === "success") {
+          pollingRef.current = false;
+          onActivated();
+          return;
+        }
+        if (st.status === "failed") {
+          pollingRef.current = false;
+          setActivating(false);
+          setError(i18next.t("hosting.card-failed"));
+          return;
+        }
+      } catch {
+        // transient (network / not-yet-recorded) -> keep polling
+      }
+      timerRef.current = setTimeout(poll, 2000);
+    };
+    poll();
+  }, [paymentIntentId, username, onActivated]);
+
+  if (!stripePromise) {
+    return <Alert appearance="danger">{i18next.t("hosting.card-unavailable")}</Alert>;
+  }
+  if (error) {
+    return <Alert appearance="danger">{error}</Alert>;
+  }
+  if (activating) {
+    return <div className="py-6 text-center text-sm opacity-75">{i18next.t("hosting.activating")}</div>;
+  }
+  if (!clientSecret) {
+    return (
+      <div className="py-6 text-center text-sm opacity-75">{i18next.t("hosting.preparing-checkout")}</div>
+    );
+  }
+
+  return (
+    <Elements
+      stripe={stripePromise}
+      options={{ clientSecret, appearance: { theme: isDarkMode() ? "night" : "stripe" } }}
+    >
+      <StripeCheckoutForm
+        returnUrl={returnUrl}
+        payLabel={payLabel}
+        onPaid={startPoll}
+        onError={setError}
+      />
+    </Elements>
+  );
+}

--- a/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
@@ -80,6 +80,8 @@ export function HostingCardCheckout({ username, sku, payLabel, returnUrl, onActi
     if (!paymentIntentId || pollingRef.current) return;
     pollingRef.current = true;
     setActivating(true);
+    let attempts = 0;
+    const MAX_ATTEMPTS = 45; // ~90s
     const poll = async () => {
       if (!pollingRef.current) return;
       try {
@@ -98,6 +100,15 @@ export function HostingCardCheckout({ username, sku, payLabel, returnUrl, onActi
         }
       } catch {
         // transient (network / not-yet-recorded) -> keep polling
+      }
+      attempts += 1;
+      if (attempts >= MAX_ATTEMPTS) {
+        // Payment succeeded; ePoints keeps retrying activation with backoff, so this is not a
+        // hard failure -- stop the spinner and reassure rather than loop forever.
+        pollingRef.current = false;
+        setActivating(false);
+        setError(i18next.t("hosting.activation-pending"));
+        return;
       }
       timerRef.current = setTimeout(poll, 2000);
     };

--- a/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
@@ -28,6 +28,9 @@ interface Props {
   payLabel: string;
   returnUrl: string;
   onActivated: () => void;
+  /** Fired once the card is confirmed (payment taken); the parent locks the term selector so
+   *  a remount can't cancel the poll for an already-paid intent. */
+  onConfirmed?: () => void;
 }
 
 /**
@@ -37,7 +40,14 @@ interface Props {
  * service's activate endpoint, so the blog is live. The tenant must already exist (the signup
  * flow creates it before this renders).
  */
-export function HostingCardCheckout({ username, sku, payLabel, returnUrl, onActivated }: Props) {
+export function HostingCardCheckout({
+  username,
+  sku,
+  payLabel,
+  returnUrl,
+  onActivated,
+  onConfirmed
+}: Props) {
   const [nonce] = useState(genNonce);
   const [clientSecret, setClientSecret] = useState("");
   const [error, setError] = useState("");
@@ -80,6 +90,9 @@ export function HostingCardCheckout({ username, sku, payLabel, returnUrl, onActi
     if (!paymentIntentId || pollingRef.current) return;
     pollingRef.current = true;
     setActivating(true);
+    // Payment is confirmed at this point -- lock the term selector in the parent so a remount
+    // cannot cancel this poll and strand a paid user.
+    onConfirmed?.();
     let attempts = 0;
     const MAX_ATTEMPTS = 45; // ~90s
     const poll = async () => {
@@ -113,7 +126,7 @@ export function HostingCardCheckout({ username, sku, payLabel, returnUrl, onActi
       timerRef.current = setTimeout(poll, 2000);
     };
     poll();
-  }, [paymentIntentId, username, onActivated]);
+  }, [paymentIntentId, username, onActivated, onConfirmed]);
 
   if (!stripePromise) {
     return <Alert appearance="danger">{i18next.t("hosting.card-unavailable")}</Alert>;

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -35,6 +35,8 @@ export function HostingSignup() {
   const [blogUrl, setBlogUrl] = useState("");
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
+  // Card confirmed -> the term/method are locked so a remount can't cancel the activation poll.
+  const [paying, setPaying] = useState(false);
   // The username we actually created a tenant for; if the user goes back and changes it,
   // we must create the new one before payment (a stale guard would let them pay for a blog
   // that was never created and never activates).
@@ -93,6 +95,8 @@ export function HostingSignup() {
   useEffect(() => {
     if (step !== "payment" || method !== "hbd") return;
     let stale = false;
+    // Clear immediately so the previous term's amount/memo isn't copyable while the new one loads.
+    setInstructions(null);
     hostingApi
       .paymentInstructions(username.trim().toLowerCase(), months)
       .then((r) => {
@@ -187,9 +191,10 @@ export function HostingSignup() {
               <button
                 key={m}
                 onClick={() => setMonths(m)}
+                disabled={paying}
                 className={`px-3 py-2 rounded-lg border text-sm ${
                   months === m ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
-                }`}
+                } ${paying ? "opacity-50 cursor-not-allowed" : ""}`}
               >
                 {i18next.t("hosting.term-months", { n: m })}
               </button>
@@ -201,18 +206,20 @@ export function HostingSignup() {
             {cardEnabled && (
               <button
                 onClick={() => setMethod("card")}
+                disabled={paying}
                 className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
                   method === "card" ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
-                }`}
+                } ${paying ? "opacity-50 cursor-not-allowed" : ""}`}
               >
                 {i18next.t("hosting.pay-card", { amount: (usdPer * months).toFixed(2) })}
               </button>
             )}
             <button
               onClick={() => setMethod("hbd")}
+              disabled={paying}
               className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
                 method === "hbd" ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
-              }`}
+              } ${paying ? "opacity-50 cursor-not-allowed" : ""}`}
             >
               {i18next.t("hosting.pay-hbd", { amount: (hbdPer * months).toFixed(3) })}
             </button>
@@ -225,6 +232,7 @@ export function HostingSignup() {
               sku={hostingSkuForMonths(months)}
               payLabel={i18next.t("hosting.pay-now")}
               returnUrl={typeof window !== "undefined" ? window.location.href : ""}
+              onConfirmed={() => setPaying(true)}
               onActivated={() => setStep("success")}
             />
           )}

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { Alert } from "@ui/alert";
+import { Button } from "@ui/button";
+import { FormControl } from "@ui/input";
+import i18next from "i18next";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { HostingCardCheckout } from "./hosting-card-checkout";
+import { hostingApi, hostingSkuForMonths, type HostingPaymentMethods } from "./hosting-api";
+
+type Step = "username" | "configure" | "payment" | "success";
+type Method = "hbd" | "card";
+
+const TERMS = [1, 3, 6, 12];
+const USERNAME_RE = /^[a-z][a-z0-9.-]{2,15}$/;
+
+interface Instructions {
+  to: string;
+  amount: string;
+  memo: string;
+}
+
+export function HostingSignup() {
+  const { activeUser } = useActiveAccount();
+
+  const [step, setStep] = useState<Step>("username");
+  const [username, setUsername] = useState(activeUser?.username ?? "");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [months, setMonths] = useState(1);
+  const [method, setMethod] = useState<Method>("card");
+  const [methods, setMethods] = useState<HostingPaymentMethods | null>(null);
+  const [instructions, setInstructions] = useState<Instructions | null>(null);
+  const [blogUrl, setBlogUrl] = useState("");
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const tenantCreatedRef = useRef(false);
+
+  const baseDomain = "blogs.ecency.com";
+  const cardEnabled = !!methods?.card.enabled && !!activeUser && username === activeUser.username;
+
+  useEffect(() => {
+    hostingApi.paymentMethods().then(setMethods).catch(() => setMethods(null));
+  }, []);
+
+  // Default the payment method to whichever is available (card needs login).
+  useEffect(() => {
+    if (methods && !methods.card.enabled) setMethod("hbd");
+  }, [methods]);
+
+  const goConfigure = () => {
+    setError("");
+    if (!USERNAME_RE.test(username.trim().toLowerCase())) {
+      setError(i18next.t("hosting.invalid-username"));
+      return;
+    }
+    setStep("configure");
+  };
+
+  // Create the (inactive) tenant, then move to payment. Payment activates it.
+  const goPayment = useCallback(async () => {
+    setError("");
+    setBusy(true);
+    try {
+      if (!tenantCreatedRef.current) {
+        const res = await hostingApi.createTenant(username.trim().toLowerCase(), {
+          theme: "system",
+          title: title.trim() || undefined,
+          description: description.trim() || undefined
+        });
+        tenantCreatedRef.current = true;
+        setBlogUrl(res.tenant.blogUrl);
+      }
+      setStep("payment");
+    } catch (e) {
+      const msg = (e as Error).message;
+      setError(msg === "Username already registered" ? i18next.t("hosting.already-registered") : msg);
+    } finally {
+      setBusy(false);
+    }
+  }, [username, title, description]);
+
+  // HBD: refresh instructions for the selected term whenever it changes on the HBD tab.
+  useEffect(() => {
+    if (step !== "payment" || method !== "hbd") return;
+    hostingApi
+      .paymentInstructions(username.trim().toLowerCase(), months)
+      .then((r) => setInstructions({ to: r.to, amount: r.amount, memo: r.memo }))
+      .catch(() => setInstructions(null));
+  }, [step, method, months, username]);
+
+  const checkActivation = useCallback(async () => {
+    setError("");
+    setBusy(true);
+    try {
+      const t = await hostingApi.tenant(username.trim().toLowerCase());
+      if (t.subscriptionStatus === "active") {
+        setStep("success");
+      } else {
+        setError(i18next.t("hosting.not-yet-active"));
+      }
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }, [username]);
+
+  const usdPer = (methods?.card.monthlyUsdCents ?? 200) / 100;
+  const hbdPer = parseFloat(methods?.hbd.monthly ?? "2");
+
+  return (
+    <div className="max-w-lg mx-auto flex flex-col gap-4">
+      <h1 className="text-2xl font-bold">{i18next.t("hosting.title")}</h1>
+      <p className="opacity-75">{i18next.t("hosting.subtitle")}</p>
+
+      {error && <Alert appearance="danger">{error}</Alert>}
+
+      {step === "username" && (
+        <div className="flex flex-col gap-3">
+          <label className="text-sm font-semibold">{i18next.t("hosting.username-label")}</label>
+          <FormControl
+            type="text"
+            value={username}
+            onChange={(e: any) => setUsername(e.target.value)}
+            placeholder="yourname"
+            autoFocus={true}
+          />
+          <p className="text-sm opacity-60">
+            {i18next.t("hosting.subdomain-preview", { url: `${username || "yourname"}.${baseDomain}` })}
+          </p>
+          <Button onClick={goConfigure} full={true}>
+            {i18next.t("g.continue")}
+          </Button>
+        </div>
+      )}
+
+      {step === "configure" && (
+        <div className="flex flex-col gap-3">
+          <label className="text-sm font-semibold">{i18next.t("hosting.blog-title-label")}</label>
+          <FormControl
+            type="text"
+            value={title}
+            onChange={(e: any) => setTitle(e.target.value)}
+            placeholder={i18next.t("hosting.blog-title-placeholder")}
+          />
+          <label className="text-sm font-semibold">{i18next.t("hosting.blog-desc-label")}</label>
+          <FormControl
+            type="text"
+            value={description}
+            onChange={(e: any) => setDescription(e.target.value)}
+            placeholder={i18next.t("hosting.blog-desc-placeholder")}
+          />
+          <div className="flex gap-2">
+            <Button appearance="secondary" onClick={() => setStep("username")}>
+              {i18next.t("g.back")}
+            </Button>
+            <Button onClick={goPayment} disabled={busy} isLoading={busy} full={true}>
+              {i18next.t("g.continue")}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {step === "payment" && (
+        <div className="flex flex-col gap-4">
+          {/* Term */}
+          <div className="flex gap-2 flex-wrap">
+            {TERMS.map((m) => (
+              <button
+                key={m}
+                onClick={() => setMonths(m)}
+                className={`px-3 py-2 rounded-lg border text-sm ${
+                  months === m ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
+                }`}
+              >
+                {i18next.t("hosting.term-months", { n: m })}
+              </button>
+            ))}
+          </div>
+
+          {/* Method toggle */}
+          <div className="flex gap-2">
+            {cardEnabled && (
+              <button
+                onClick={() => setMethod("card")}
+                className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
+                  method === "card" ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
+                }`}
+              >
+                {i18next.t("hosting.pay-card", { amount: (usdPer * months).toFixed(2) })}
+              </button>
+            )}
+            <button
+              onClick={() => setMethod("hbd")}
+              className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
+                method === "hbd" ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
+              }`}
+            >
+              {i18next.t("hosting.pay-hbd", { amount: (hbdPer * months).toFixed(3) })}
+            </button>
+          </div>
+
+          {method === "card" && cardEnabled && (
+            <HostingCardCheckout
+              username={username.trim().toLowerCase()}
+              sku={hostingSkuForMonths(months)}
+              payLabel={i18next.t("hosting.pay-now")}
+              returnUrl={typeof window !== "undefined" ? window.location.href : ""}
+              onActivated={() => setStep("success")}
+            />
+          )}
+
+          {method === "hbd" && (
+            <div className="flex flex-col gap-2 text-sm">
+              <p>{i18next.t("hosting.hbd-instructions")}</p>
+              {instructions && (
+                <div className="rounded-lg border border-[--border-color] p-3 flex flex-col gap-1 font-mono">
+                  <div>{i18next.t("hosting.send-to")}: @{instructions.to}</div>
+                  <div>{i18next.t("hosting.amount")}: {instructions.amount}</div>
+                  <div>{i18next.t("hosting.memo")}: {instructions.memo}</div>
+                </div>
+              )}
+              <Button onClick={checkActivation} disabled={busy} isLoading={busy} full={true}>
+                {i18next.t("hosting.ive-paid")}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {step === "success" && (
+        <Alert appearance="success">
+          <div className="flex flex-col gap-2">
+            <strong>{i18next.t("hosting.success-title")}</strong>
+            {blogUrl && (
+              <a href={blogUrl} target="_blank" rel="noreferrer" className="text-blue-dark-sky underline">
+                {blogUrl}
+              </a>
+            )}
+          </div>
+        </Alert>
+      )}
+    </div>
+  );
+}
+
+export default HostingSignup;

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { getUsernameError } from "@/utils/username-validation";
 import { Alert } from "@ui/alert";
 import { Button } from "@ui/button";
 import { FormControl } from "@ui/input";
@@ -13,7 +14,6 @@ type Step = "username" | "configure" | "payment" | "success";
 type Method = "hbd" | "card";
 
 const TERMS = [1, 3, 6, 12];
-const USERNAME_RE = /^[a-z][a-z0-9.-]{2,15}$/;
 
 interface Instructions {
   to: string;
@@ -35,7 +35,10 @@ export function HostingSignup() {
   const [blogUrl, setBlogUrl] = useState("");
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
-  const tenantCreatedRef = useRef(false);
+  // The username we actually created a tenant for; if the user goes back and changes it,
+  // we must create the new one before payment (a stale guard would let them pay for a blog
+  // that was never created and never activates).
+  const createdForRef = useRef("");
 
   const baseDomain = "blogs.ecency.com";
   const cardEnabled = !!methods?.card.enabled && !!activeUser && username === activeUser.username;
@@ -44,32 +47,36 @@ export function HostingSignup() {
     hostingApi.paymentMethods().then(setMethods).catch(() => setMethods(null));
   }, []);
 
-  // Default the payment method to whichever is available (card needs login).
+  // Default to HBD whenever card is not actually available to this visitor (logged out, or
+  // the name is not their own), so the payment step never renders with no method shown.
   useEffect(() => {
-    if (methods && !methods.card.enabled) setMethod("hbd");
-  }, [methods]);
+    if (!cardEnabled) setMethod("hbd");
+  }, [cardEnabled]);
 
   const goConfigure = () => {
     setError("");
-    if (!USERNAME_RE.test(username.trim().toLowerCase())) {
-      setError(i18next.t("hosting.invalid-username"));
+    const err = getUsernameError(username.trim().toLowerCase());
+    if (err) {
+      setError(err);
       return;
     }
     setStep("configure");
   };
 
-  // Create the (inactive) tenant, then move to payment. Payment activates it.
+  // Create the (inactive) tenant for the CURRENT username, then move to payment. Payment
+  // activates it. Re-creates when the username changed since the last creation.
   const goPayment = useCallback(async () => {
     setError("");
     setBusy(true);
+    const uname = username.trim().toLowerCase();
     try {
-      if (!tenantCreatedRef.current) {
-        const res = await hostingApi.createTenant(username.trim().toLowerCase(), {
+      if (createdForRef.current !== uname) {
+        const res = await hostingApi.createTenant(uname, {
           theme: "system",
           title: title.trim() || undefined,
           description: description.trim() || undefined
         });
-        tenantCreatedRef.current = true;
+        createdForRef.current = uname;
         setBlogUrl(res.tenant.blogUrl);
       }
       setStep("payment");
@@ -81,13 +88,22 @@ export function HostingSignup() {
     }
   }, [username, title, description]);
 
-  // HBD: refresh instructions for the selected term whenever it changes on the HBD tab.
+  // HBD: refresh instructions for the selected term. Guard against a slow earlier response
+  // (a different term) landing after a newer one and showing a mismatched amount/memo.
   useEffect(() => {
     if (step !== "payment" || method !== "hbd") return;
+    let stale = false;
     hostingApi
       .paymentInstructions(username.trim().toLowerCase(), months)
-      .then((r) => setInstructions({ to: r.to, amount: r.amount, memo: r.memo }))
-      .catch(() => setInstructions(null));
+      .then((r) => {
+        if (!stale) setInstructions({ to: r.to, amount: r.amount, memo: r.memo });
+      })
+      .catch(() => {
+        if (!stale) setInstructions(null);
+      });
+    return () => {
+      stale = true;
+    };
   }, [step, method, months, username]);
 
   const checkActivation = useCallback(async () => {
@@ -204,6 +220,7 @@ export function HostingSignup() {
 
           {method === "card" && cardEnabled && (
             <HostingCardCheckout
+              key={hostingSkuForMonths(months)}
               username={username.trim().toLowerCase()}
               sku={hostingSkuForMonths(months)}
               payLabel={i18next.t("hosting.pay-now")}

--- a/apps/web/src/features/hosting-signup/index.ts
+++ b/apps/web/src/features/hosting-signup/index.ts
@@ -1,0 +1,3 @@
+export * from "./hosting-signup";
+export * from "./hosting-api";
+export * from "./hosting-card-checkout";

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -24,6 +24,7 @@
     "card-unavailable": "Card payment is unavailable right now.",
     "card-failed": "The payment could not be completed.",
     "activating": "Payment received. Activating your blog.",
+    "activation-pending": "Payment received. Your blog is being set up and will be live shortly. You can safely close this page.",
     "preparing-checkout": "Preparing secure checkout.",
     "coming-soon": "Blog hosting is coming soon."
   },

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1,4 +1,32 @@
 {
+  "hosting": {
+    "title": "Blog hosting",
+    "subtitle": "Host your Hive blog on your own branded site at yourname.blogs.ecency.com.",
+    "username-label": "Your Hive username",
+    "subdomain-preview": "Your blog: {{url}}",
+    "blog-title-label": "Blog title (optional)",
+    "blog-title-placeholder": "My Hive Blog",
+    "blog-desc-label": "Description (optional)",
+    "blog-desc-placeholder": "Powered by Ecency",
+    "term-months": "{{n}} mo",
+    "pay-card": "Card ${{amount}}",
+    "pay-hbd": "{{amount}} HBD",
+    "pay-now": "Pay now",
+    "hbd-instructions": "Send the exact amount with the exact memo from any Hive wallet, then check activation.",
+    "send-to": "Send to",
+    "amount": "Amount",
+    "memo": "Memo",
+    "ive-paid": "I've sent the payment",
+    "not-yet-active": "Payment not detected yet. It can take a few seconds after confirmation.",
+    "success-title": "Your blog is live",
+    "invalid-username": "Enter a valid Hive username.",
+    "already-registered": "This blog is already registered.",
+    "card-unavailable": "Card payment is unavailable right now.",
+    "card-failed": "The payment could not be completed.",
+    "activating": "Payment received. Activating your blog.",
+    "preparing-checkout": "Preparing secure checkout.",
+    "coming-soon": "Blog hosting is coming soon."
+  },
   "tweet": {
     "load-failed": "Couldn't load this X post.",
     "view-on-x": "View on X"

--- a/apps/web/src/specs/features/hosting-signup/hosting-api.spec.ts
+++ b/apps/web/src/specs/features/hosting-signup/hosting-api.spec.ts
@@ -1,0 +1,16 @@
+import { hostingSkuForMonths } from "@/features/hosting-signup/hosting-api";
+import { describe, expect, it } from "vitest";
+
+describe("hostingSkuForMonths", () => {
+  it("maps each term to its priced SKU (leading number = price in cents)", () => {
+    expect(hostingSkuForMonths(1)).toBe("200hosting");
+    expect(hostingSkuForMonths(3)).toBe("600hosting");
+    expect(hostingSkuForMonths(6)).toBe("1200hosting");
+    expect(hostingSkuForMonths(12)).toBe("2400hosting");
+  });
+
+  it("falls back to the 1-month SKU for an unknown term", () => {
+    expect(hostingSkuForMonths(2)).toBe("200hosting");
+    expect(hostingSkuForMonths(0)).toBe("200hosting");
+  });
+});


### PR DESCRIPTION
The public `/hosting` signup page for managed blog hosting — the last piece of the launch (backend already merged: hosting-api #1085, ePoints #26).

## Flow
username → configure → pay → live. The tenant is created (inactive) before payment; paying activates it.

## Card (reuses the existing Stripe rail — no new wiring)
`HostingCardCheckout` reuses `purchase-stripe`'s Elements + `useCreateStripeIntent` with a hosting SKU (`200/600/1200/2400hosting` for 1/3/6/12 months), then polls the order status. For a hosting SKU, the order reaching `success` means ePoints has already called the hosting service's activate endpoint, so the blog is live. Offered only to the logged-in owner, and only when the service reports card available.

## HBD
Copyable pay-to / amount / memo for the chosen term + an activation check (the on-chain listener activates the blog).

## Config
Talks to the managed-hosting API (`NEXT_PUBLIC_HOSTING_API`) for create-tenant / status / methods / instructions. The page renders "coming soon" until that env is set, so this is **safe to merge ahead of the infra**.

## Tests
`hosting-api.spec.ts` locks the term → SKU mapping (wrong SKU = wrong charge). tsc clean.

## Follow-ups
One-click Keychain HBD transfer, an x402 option (Ecency's own rail), richer blog config.
