### PR TITLE
Stub SVGAnimatedString for browsers with SVG interfaces disabled

### DIFF
--- a/apps/web/src/polyfills.ts
+++ b/apps/web/src/polyfills.ts
@@ -9,3 +9,13 @@ if (typeof BigInt === "undefined") {
       "Please upgrade to a modern browser for the best experience."
   );
 }
+
+// SVGAnimatedString fallback
+// Firefox with svg.disabled=true removes all SVG DOM interfaces. @bprogress/core
+// checks `prop instanceof SVGAnimatedString` (to unwrap SVG anchor hrefs) without
+// guarding the global, throwing ReferenceError on every DOM mutation in such
+// browsers. With SVG disabled no property can be an SVGAnimatedString, so a stub
+// that makes the instanceof check return false restores the intended behavior.
+if (typeof window !== "undefined" && typeof window.SVGAnimatedString === "undefined") {
+  (window as any).SVGAnimatedString = class SVGAnimatedString {};
+}

--- a/apps/web/src/specs/core/polyfills.spec.ts
+++ b/apps/web/src/specs/core/polyfills.spec.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("polyfills — SVGAnimatedString fallback", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("defines a stub when the browser lacks SVGAnimatedString", async () => {
+    const original = (window as any).SVGAnimatedString;
+    delete (window as any).SVGAnimatedString;
+    try {
+      await import("@/polyfills");
+      expect((window as any).SVGAnimatedString).toBeDefined();
+      // instanceof must be safe to call and reject non-SVG values,
+      // matching how @bprogress/core probes anchor properties
+      expect("https://example.com" instanceof (window as any).SVGAnimatedString).toBe(false);
+      expect(document.createElement("a") instanceof (window as any).SVGAnimatedString).toBe(false);
+    } finally {
+      (window as any).SVGAnimatedString = original;
+    }
+  });
+
+  it("keeps the native implementation when present", async () => {
+    const sentinel = class {};
+    const original = (window as any).SVGAnimatedString;
+    (window as any).SVGAnimatedString = sentinel;
+    try {
+      await import("@/polyfills");
+      expect((window as any).SVGAnimatedString).toBe(sentinel);
+    } finally {
+      (window as any).SVGAnimatedString = original;
+    }
+  });
+});


### PR DESCRIPTION
Firefox with `svg.disabled=true` removes all SVG DOM interfaces, including the `SVGAnimatedString` global. `@bprogress/core` probes anchor properties with a bare `prop instanceof SVGAnimatedString`, which throws an unhandled `ReferenceError` on every DOM mutation in such browsers (Sentry ECENCY-NEXT-1GGR).

We are already on the latest `@bprogress/core` (1.3.4), so there is no upstream fix to pull in. This adds a stub class in `polyfills.ts` (loaded first in `client-providers.tsx`, before the progress bar mounts) so the `instanceof` check safely returns `false` — the correct result in a browser where no value can be an `SVGAnimatedString`. Native implementations are left untouched.

Includes regression tests covering both the stubbed and native paths.