### PR TITLE
Hosting: default to live API + lazy-load Stripe

### DIFF
--- a/apps/web/src/features/hosting-signup/hosting-api.ts
+++ b/apps/web/src/features/hosting-signup/hosting-api.ts
@@ -2,7 +2,12 @@
 // that service already allows ecency.com. The base URL is configured per-environment; the
 // signup page is hidden when it is unset.
 
-const HOSTING_API = (process.env.NEXT_PUBLIC_HOSTING_API ?? "").replace(/\/$/, "");
+// The managed-hosting API is a stable public service; default to it so /hosting works without
+// a build-time env. Override with NEXT_PUBLIC_HOSTING_API (e.g. "" to force the coming-soon gate).
+const HOSTING_API = (process.env.NEXT_PUBLIC_HOSTING_API ?? "https://api.blogs.ecency.com").replace(
+  /\/$/,
+  ""
+);
 
 export interface HostingPaymentMethods {
   hbd: { enabled: boolean; monthly: string; account: string };

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -7,8 +7,22 @@ import { Button } from "@ui/button";
 import { FormControl } from "@ui/input";
 import i18next from "i18next";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { HostingCardCheckout } from "./hosting-card-checkout";
 import { hostingApi, hostingSkuForMonths, type HostingPaymentMethods } from "./hosting-api";
+import dynamic from "next/dynamic";
+
+// Lazy-load the card checkout so /hosting doesn't pull @stripe/stripe-js (which injects the
+// js.stripe.com script on import) into its bundle until the user actually picks "card".
+const HostingCardCheckout = dynamic(
+  () => import("./hosting-card-checkout").then((m) => m.HostingCardCheckout),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="py-6 text-center text-sm opacity-75">
+        {i18next.t("hosting.preparing-checkout")}
+      </div>
+    )
+  }
+);
 
 type Step = "username" | "configure" | "payment" | "success";
 type Method = "hbd" | "card";


### PR DESCRIPTION
Two small follow-ups to the merged hosting signup:

- **Default `NEXT_PUBLIC_HOSTING_API` to `https://api.blogs.ecency.com`** (the running, publicly-exposed hosting service — verified 200 with the $2 pricing). `/hosting` now shows the real signup form instead of 'coming soon', with **HBD + x402 working immediately**. Still overridable via the env (set to empty to force the coming-soon gate). Card stays gated server-side (`/methods` `card.enabled:false`) until `HOSTING_INTERNAL_SECRET` is configured on the hosting-api + ePoints.
- **Lazy-load the card checkout** via `next/dynamic({ ssr:false })` so `/hosting` doesn't pull `@stripe/stripe-js` (which injects the js.stripe.com script on import) into its bundle until the user picks card.

tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The hosting signup checkout now loads on demand and shows a loading state while it initializes.
  * Hosting signup is now available by default without requiring extra configuration in most cases.

* **Bug Fixes**
  * Improved the default hosting API handling so the signup flow works even when no custom API setting is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->