### PR TITLE
Pro: unlock any creator's Insights for Pro members

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-menu/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-menu/index.tsx
@@ -12,9 +12,6 @@ import { Button } from "@ui/button";
 import { PageMenu, PageMenuItems, PageMenuLink, PageMenuMobileDropdown } from "@ui/index";
 import { EcencyConfigManager } from "@/config";
 import { usePathname } from "next/navigation";
-import { isProMember } from "@/features/pro";
-import { getProMembersQueryOptions } from "@ecency/sdk";
-import { useQuery } from "@tanstack/react-query";
 
 interface Props {
   username: string;
@@ -24,9 +21,6 @@ export function ProfileMenu({ username }: Props) {
   const { activeUser } = useActiveAccount();
   const pathname = usePathname();
   const section = useMemo(() => pathname?.split("/")[2] ?? "posts", [pathname]);
-  // Pro members can open anyone's Insights; everyone can still see their own.
-  const { data: proMembers } = useQuery(getProMembersQueryOptions());
-  const isPro = isProMember(proMembers?.members, activeUser?.username);
 
   const kebabMenuItemsAll = [
     ...["trail", "replies", "followers", "following"].map((x) => ({
@@ -65,7 +59,7 @@ export function ProfileMenu({ username }: Props) {
       href: `/@${username}/wallet`,
       id: "wallet"
     },
-    ...(activeUser && (activeUser.username === username || isPro)
+    ...(activeUser
       ? [
           {
             label: i18next.t(`profile.section-insights`, { defaultValue: "Insights" }),

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-menu/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-menu/index.tsx
@@ -12,6 +12,9 @@ import { Button } from "@ui/button";
 import { PageMenu, PageMenuItems, PageMenuLink, PageMenuMobileDropdown } from "@ui/index";
 import { EcencyConfigManager } from "@/config";
 import { usePathname } from "next/navigation";
+import { isProMember } from "@/features/pro";
+import { getProMembersQueryOptions } from "@ecency/sdk";
+import { useQuery } from "@tanstack/react-query";
 
 interface Props {
   username: string;
@@ -21,6 +24,9 @@ export function ProfileMenu({ username }: Props) {
   const { activeUser } = useActiveAccount();
   const pathname = usePathname();
   const section = useMemo(() => pathname?.split("/")[2] ?? "posts", [pathname]);
+  // Pro members can open anyone's Insights; everyone can still see their own.
+  const { data: proMembers } = useQuery(getProMembersQueryOptions());
+  const isPro = isProMember(proMembers?.members, activeUser?.username);
 
   const kebabMenuItemsAll = [
     ...["trail", "replies", "followers", "following"].map((x) => ({
@@ -59,7 +65,7 @@ export function ProfileMenu({ username }: Props) {
       href: `/@${username}/wallet`,
       id: "wallet"
     },
-    ...(activeUser && activeUser.username === username
+    ...(activeUser && (activeUser.username === username || isPro)
       ? [
           {
             label: i18next.t(`profile.section-insights`, { defaultValue: "Insights" }),

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/insights/_insights-pro-gate.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/insights/_insights-pro-gate.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import i18next from "i18next";
+import Link from "next/link";
+import { Button } from "@/features/ui";
+
+interface Props {
+  username: string;
+}
+
+/**
+ * Shown when a non-Pro viewer opens someone else's Insights. Own insights stay free; viewing
+ * any other creator's traffic is an Ecency Pro perk, so this is the upsell in place of the data.
+ */
+export function InsightsProGate({ username }: Props) {
+  return (
+    <div className="max-w-lg mx-auto my-10 flex flex-col items-center gap-4 text-center">
+      <div className="text-xl md:text-2xl font-bold">
+        {i18next.t("profile-insights.pro-gate-title", {
+          defaultValue: "Insights is an Ecency Pro feature"
+        })}
+      </div>
+      <p className="opacity-75">
+        {i18next.t("profile-insights.pro-gate-body", {
+          username,
+          defaultValue:
+            "Go Pro to explore traffic insights for @{{username}} and any other creator on Ecency."
+        })}
+      </p>
+      <Link href="/perks">
+        <Button size="lg">
+          {i18next.t("profile-insights.pro-gate-cta", { defaultValue: "Go Pro" })}
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/insights/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/insights/page.tsx
@@ -29,8 +29,9 @@ export default async function InsightsPage({ params }: Props) {
 
   // Own insights stay free; viewing anyone else's is an Ecency Pro perk. Non-Pro viewers get a
   // Go-Pro upsell instead of the data (previously this was a hard owner-only redirect).
-  const activeUser = get("active_user")?.value;
-  let canView = !!activeUser && account.name === activeUser;
+  // Hive usernames are lowercase; normalize the cookie so a non-canonical case never denies an owner.
+  const activeUser = get("active_user")?.value?.toLowerCase();
+  let canView = !!activeUser && account.name.toLowerCase() === activeUser;
   if (!canView && activeUser) {
     try {
       const proMembers = await prefetchQuery(getProMembersQueryOptions());

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/insights/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/insights/page.tsx
@@ -1,10 +1,12 @@
 import { generateProfileMetadata } from "../_helpers";
 import { Metadata, ResolvingMetadata } from "next";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { cookies } from "next/headers";
 import { prefetchQuery } from "@/core/react-query";
-import { getAccountFullQueryOptions } from "@ecency/sdk";
+import { getAccountFullQueryOptions, getProMembersQueryOptions } from "@ecency/sdk";
+import { isProMember } from "@/features/pro/pro-config";
 import { ProfileInsights } from "./_page";
+import { InsightsProGate } from "./_insights-pro-gate";
 
 interface Props {
   params: Promise<{ username: string }>;
@@ -25,8 +27,21 @@ export default async function InsightsPage({ params }: Props) {
     return notFound();
   }
 
-  if (account.name !== get("active_user")?.value) {
-    return redirect(`/@${username.replace(/%40/g, "")}`);
+  // Own insights stay free; viewing anyone else's is an Ecency Pro perk. Non-Pro viewers get a
+  // Go-Pro upsell instead of the data (previously this was a hard owner-only redirect).
+  const activeUser = get("active_user")?.value;
+  let canView = !!activeUser && account.name === activeUser;
+  if (!canView && activeUser) {
+    try {
+      const proMembers = await prefetchQuery(getProMembersQueryOptions());
+      canView = isProMember(proMembers?.members, activeUser);
+    } catch {
+      canView = false;
+    }
+  }
+
+  if (!canView) {
+    return <InsightsProGate username={account.name} />;
   }
 
   return <ProfileInsights username={account.name} />;

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/insights/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/insights/page.tsx
@@ -29,6 +29,13 @@ export default async function InsightsPage({ params }: Props) {
 
   // Own insights stay free; viewing anyone else's is an Ecency Pro perk. Non-Pro viewers get a
   // Go-Pro upsell instead of the data (previously this was a hard owner-only redirect).
+  //
+  // SECURITY NOTE: this SSR check is a UX optimization only (render the data view vs the upsell)
+  // and reads the client-writable `active_user` cookie, so it is deliberately NOT the security
+  // boundary. The Insights numbers are served by `/api/profile-insights`, which verifies the
+  // viewer's real signed HiveSigner identity (own OR Pro) and 403s otherwise. A forged cookie can
+  // only render an empty shell here; it can never fetch another creator's traffic data.
+  //
   // Hive usernames are lowercase; normalize the cookie so a non-canonical case never denies an owner.
   const activeUser = get("active_user")?.value?.toLowerCase();
   let canView = !!activeUser && account.name.toLowerCase() === activeUser;

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1316,6 +1316,9 @@
   },
   "profile-insights": {
     "description": "See which of your posts resonate most with readers.",
+    "pro-gate-title": "Insights is an Ecency Pro feature",
+    "pro-gate-body": "Go Pro to explore traffic insights for @{{username}} and any other creator on Ecency.",
+    "pro-gate-cta": "Go Pro",
     "today": "Today",
     "yesterday": "Yesterday",
     "last-7": "Last 7 days",


### PR DESCRIPTION
Turns the profile **Insights** page into an Ecency Pro perk.

Today Insights (Plausible traffic: views / unique views / minutes) is strictly **owner-only** (server-side redirect + a tab that only shows on your own profile). This makes it a Pro benefit:

- **Own insights stay free** (unchanged).
- **Pro members can open any creator's Insights** — the tab now appears on any profile for Pro members, and the page renders for them.
- **Non-Pro** who land on someone else's insights get a **Go-Pro upsell** instead of the previous hard redirect (a conversion driver).

No data/pipeline work: the Plausible query already works for any username; this only adds the `getProMembersQueryOptions`/`isProMember` gate (same one the perks page + badge use). Richer creator metrics (engagement/earnings via nightly rollups) are a planned Phase 2 on the same page.

Typecheck clean. Best eyeballed on staging.