### PR TITLE
Hosting: apply signup config overrides (title/theme/style) to new tenants

### DIFF
--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -40,10 +40,11 @@ export const TenantService = {
    * Create new tenant
    */
   async create(username: string, configOverrides?: any): Promise<Tenant> {
-    const defaultConfig = await this.getDefaultConfig(username);
-    const config = configOverrides
-      ? this.mergeConfig(defaultConfig, configOverrides)
-      : defaultConfig;
+    // buildConfig normalizes flat API overrides (title, description, theme, styleTemplate, type,
+    // communityId) into the nested shape the SPA actually reads. Merging the flat keys directly kept
+    // them at the config root, where the SPA ignores them, so a signup's chosen title/theme/style
+    // were silently dropped (and any community override too). Route both paths through buildConfig.
+    const config = await this.buildConfig(username, configOverrides);
 
     const row = await db.queryOne<TenantRow>(
       `INSERT INTO tenants (username, config, subscription_status, subscription_plan)


### PR DESCRIPTION
`POST /v1/tenants` (the primary path the web signup + HBD use) routed through `TenantService.create`, which merged the flat API overrides (title, description, theme, styleTemplate, and community type/communityId) at the **config root**, where the self-hosted SPA never reads them. So a new blog rendered with default title/theme and silently ignored what the user picked at signup. Only the x402 `/subscribe` path used the correct `buildConfig` normalizer.

Fix: route `create()` through `buildConfig` so both paths map flat overrides into the nested config shape the SPA reads. This repairs personal-blog customization and is also the first prerequisite for community instances (whose `type`/`communityId` overrides were dropped the same way).