### PR TITLE
self-hosted: owner-based gating and community authoring

### DIFF
--- a/apps/self-hosted/src/core/configuration-loader.ts
+++ b/apps/self-hosted/src/core/configuration-loader.ts
@@ -41,6 +41,7 @@ export interface InstanceConfig {
     instanceConfiguration: {
       type: 'blog' | 'community';
       username: string;
+      owner?: string;
       communityId: string;
       meta: {
         title: string;

--- a/apps/self-hosted/src/features/auth/auth-provider.tsx
+++ b/apps/self-hosted/src/features/auth/auth-provider.tsx
@@ -39,7 +39,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // username is the community (hive-NNNNN), so the owner must be used instead.
   const blogOwner = InstanceConfigManager.getConfigValue(
     ({ configuration }) =>
-      configuration.instanceConfiguration.owner ??
+      configuration.instanceConfiguration.owner ||
       configuration.instanceConfiguration.username
   );
 

--- a/apps/self-hosted/src/features/auth/auth-provider.tsx
+++ b/apps/self-hosted/src/features/auth/auth-provider.tsx
@@ -33,12 +33,17 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const isAuthEnabled = authConfig?.enabled ?? false;
   const availableMethods = (authConfig?.methods ?? []) as AuthMethod[];
 
-  // Get blog owner username
+  // Get the instance owner. Falls back to the showcased username for older
+  // configs that predate the `owner` field (blog instances where the owner and
+  // the showcased account are the same). In community instances the showcased
+  // username is the community (hive-NNNNN), so the owner must be used instead.
   const blogOwner = InstanceConfigManager.getConfigValue(
-    ({ configuration }) => configuration.instanceConfiguration.username
+    ({ configuration }) =>
+      configuration.instanceConfiguration.owner ??
+      configuration.instanceConfiguration.username
   );
 
-  // Check if current user is blog owner
+  // Check if current user is the instance owner
   const isBlogOwner = useMemo(() => {
     if (!user || !blogOwner) return false;
     return (

--- a/apps/self-hosted/src/features/auth/components/create-post-button.tsx
+++ b/apps/self-hosted/src/features/auth/components/create-post-button.tsx
@@ -1,20 +1,27 @@
 "use client";
 
 import { InstanceConfigManager, t } from "@/core";
+import { useInstanceConfig } from "@/features/blog/hooks/use-instance-config";
 import { UilPen } from "@tooni/iconscout-unicons-react";
-import { useIsAuthEnabled, useIsBlogOwner } from "../hooks";
+import { useIsAuthEnabled, useIsAuthenticated, useIsBlogOwner } from "../hooks";
 
 export function CreatePostButton() {
   const isBlogOwner = useIsBlogOwner();
   const isAuthEnabled = useIsAuthEnabled();
+  const isAuthenticated = useIsAuthenticated();
+  const { isCommunityMode } = useInstanceConfig();
 
   const createPostUrl = InstanceConfigManager.getConfigValue(
     ({ configuration }) =>
       configuration.general.createPostUrl || "https://ecency.com/submit",
   );
 
-  // Only show for blog owner when auth is enabled
-  if (!isAuthEnabled || !isBlogOwner) {
+  // Community instances: any authenticated user can post into the community
+  // (standard Hive community moderation still applies). Blog instances: only
+  // the instance owner can post.
+  const canCreatePost = isCommunityMode ? isAuthenticated : isBlogOwner;
+
+  if (!isAuthEnabled || !canCreatePost) {
     return null;
   }
 

--- a/apps/self-hosted/src/features/auth/components/create-post-button.tsx
+++ b/apps/self-hosted/src/features/auth/components/create-post-button.tsx
@@ -3,7 +3,11 @@
 import { InstanceConfigManager, t } from "@/core";
 import { useInstanceConfig } from "@/features/blog/hooks/use-instance-config";
 import { UilPen } from "@tooni/iconscout-unicons-react";
+import { Link } from "@tanstack/react-router";
 import { useIsAuthEnabled, useIsAuthenticated, useIsBlogOwner } from "../hooks";
+
+const BUTTON_CLASS =
+  "fixed bottom-6 right-30 z-50 px-4 py-2 flex items-center text-sm !no-underline rounded-full border border-gray-400 dark:border-gray-600 !font-serif";
 
 export function CreatePostButton() {
   const isBlogOwner = useIsBlogOwner();
@@ -13,7 +17,7 @@ export function CreatePostButton() {
 
   const createPostUrl = InstanceConfigManager.getConfigValue(
     ({ configuration }) =>
-      configuration.general.createPostUrl || "https://ecency.com/submit",
+      configuration.general.createPostUrl || "https://ecency.com/publish",
   );
 
   // Community instances: any authenticated user can post into the community
@@ -25,12 +29,24 @@ export function CreatePostButton() {
     return null;
   }
 
+  // Community: use the built-in /publish editor, which publishes INTO the community
+  // (parentPermlink = communityId). Sending members to the external composer would
+  // lose the community target and post to their own blog instead.
+  if (isCommunityMode) {
+    return (
+      <Link to="/publish" className={BUTTON_CLASS}>
+        <UilPen className="w-4 h-4" />
+        <span className="hidden sm:block">{t("create_post")}</span>
+      </Link>
+    );
+  }
+
   return (
     <a
       href={createPostUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="fixed bottom-6 right-30 z-50 px-4 py-2 flex items-center text-sm !no-underline rounded-full border border-gray-400 dark:border-gray-600 !font-serif"
+      className={BUTTON_CLASS}
     >
       <UilPen className="w-4 h-4" />
       <span className="hidden sm:block">{t("create_post")}</span>

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -342,7 +342,7 @@ export const configFieldsMap: Record<string, ConfigField> = {
           createPostUrl: {
             label: 'Create Post URL',
             type: 'string',
-            description: 'URL for creating new posts (e.g., https://ecency.com/submit)',
+            description: 'URL for creating new posts (e.g., https://ecency.com/publish)',
           },
           styles: {
             label: 'Styles',

--- a/apps/self-hosted/src/features/publish/hooks/use-publish-post.ts
+++ b/apps/self-hosted/src/features/publish/hooks/use-publish-post.ts
@@ -1,13 +1,16 @@
 import { useAuth } from "@/features/auth/hooks";
+import { useInstanceConfig } from "@/features/blog/hooks/use-instance-config";
 import { useNavigate } from "@tanstack/react-router";
 import { useComment } from "@ecency/sdk";
 import { useMutation } from "@tanstack/react-query";
 import { createPermlink } from "../utils/permlink";
+import { resolvePublishTarget } from "../utils/publish-target";
 import { createBroadcastAdapter } from "@/providers/sdk";
 
 export function usePublishPost({ beforeNavigate }: { beforeNavigate?: () => void } = {}) {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const { isCommunityMode, communityId } = useInstanceConfig();
 
   const adapter = createBroadcastAdapter();
   const commentMutation = useComment(user?.username, { adapter });
@@ -41,15 +44,24 @@ export function usePublishPost({ beforeNavigate }: { beforeNavigate?: () => void
 
       const permlink = createPermlink(title, true);
 
+      // In community mode publish into the community (parentPermlink =
+      // communityId) with the community tag first; in blog mode the first tag
+      // stays the category. The logged-in user remains the author either way.
+      const { parentPermlink, tags: metadataTags } = resolvePublishTarget({
+        tags,
+        isCommunityMode,
+        communityId,
+      });
+
       const result = await commentMutation.mutateAsync({
         author: user.username,
         permlink,
         parentAuthor: "",
-        parentPermlink: tags[0].toLowerCase().trim(),
+        parentPermlink,
         title: title.trim(),
         body: body.trim(),
         jsonMetadata: {
-          tags,
+          tags: metadataTags,
           app: "ecency-selfhost/1.0",
           format: "markdown",
         },

--- a/apps/self-hosted/src/features/publish/utils/publish-target.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/publish-target.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePublishTarget } from './publish-target';
+
+describe('resolvePublishTarget', () => {
+  it('uses the first tag as category in blog mode', () => {
+    const result = resolvePublishTarget({
+      tags: ['travel', 'photography'],
+      isCommunityMode: false,
+      communityId: '',
+    });
+    expect(result.parentPermlink).toBe('travel');
+    expect(result.tags).toEqual(['travel', 'photography']);
+  });
+
+  it('normalizes the blog category to lowercase', () => {
+    const result = resolvePublishTarget({
+      tags: ['Travel', 'Photography'],
+      isCommunityMode: false,
+      communityId: '',
+    });
+    expect(result.parentPermlink).toBe('travel');
+    // Tags themselves are preserved as entered.
+    expect(result.tags).toEqual(['Travel', 'Photography']);
+  });
+
+  it('publishes into the community with the community id as category', () => {
+    const result = resolvePublishTarget({
+      tags: ['travel', 'photography'],
+      isCommunityMode: true,
+      communityId: 'hive-12345',
+    });
+    expect(result.parentPermlink).toBe('hive-12345');
+    expect(result.tags).toEqual(['hive-12345', 'travel', 'photography']);
+  });
+
+  it('does not duplicate the community tag when already present', () => {
+    const result = resolvePublishTarget({
+      tags: ['hive-12345', 'travel'],
+      isCommunityMode: true,
+      communityId: 'hive-12345',
+    });
+    expect(result.tags).toEqual(['hive-12345', 'travel']);
+  });
+
+  it('falls back to blog behavior when community mode has no community id', () => {
+    const result = resolvePublishTarget({
+      tags: ['travel'],
+      isCommunityMode: true,
+      communityId: '',
+    });
+    expect(result.parentPermlink).toBe('travel');
+    expect(result.tags).toEqual(['travel']);
+  });
+
+  it('handles an empty tag list without throwing', () => {
+    const result = resolvePublishTarget({
+      tags: [],
+      isCommunityMode: false,
+      communityId: '',
+    });
+    expect(result.parentPermlink).toBe('');
+    expect(result.tags).toEqual([]);
+  });
+});

--- a/apps/self-hosted/src/features/publish/utils/publish-target.ts
+++ b/apps/self-hosted/src/features/publish/utils/publish-target.ts
@@ -1,0 +1,43 @@
+export interface PublishTargetInput {
+  /** User-entered tags from the editor. */
+  tags: string[];
+  /** True when the instance is a community instance with a community id. */
+  isCommunityMode: boolean;
+  /** The community id (hive-NNNNN) for community instances. */
+  communityId: string;
+}
+
+export interface PublishTarget {
+  /** Category the post is published under (the comment parent permlink). */
+  parentPermlink: string;
+  /** Tags to store in json metadata (community tag first in community mode). */
+  tags: string[];
+}
+
+/**
+ * Resolve where a post is published and how its tags are ordered.
+ *
+ * Blog mode: the first user tag is the category and the tags are kept as-is.
+ * Community mode: the community id is the category and it is placed first in
+ * the json metadata tags, matching what Hive communities expect. The logged-in
+ * user stays the author; the post is simply published into the community.
+ */
+export function resolvePublishTarget({
+  tags,
+  isCommunityMode,
+  communityId,
+}: PublishTargetInput): PublishTarget {
+  if (isCommunityMode && communityId) {
+    const community = communityId.toLowerCase().trim();
+    const rest = tags.filter((tag) => tag.toLowerCase().trim() !== community);
+    return {
+      parentPermlink: community,
+      tags: [community, ...rest],
+    };
+  }
+
+  return {
+    parentPermlink: (tags[0] ?? "").toLowerCase().trim(),
+    tags,
+  };
+}

--- a/apps/self-hosted/src/routes/publish.tsx
+++ b/apps/self-hosted/src/routes/publish.tsx
@@ -4,7 +4,8 @@ import {
   PublishEditor,
   PublishActionBar,
 } from "@/features/publish";
-import { useIsBlogOwner, useIsAuthEnabled } from "@/features/auth/hooks";
+import { useIsBlogOwner, useIsAuthEnabled, useIsAuthenticated } from "@/features/auth/hooks";
+import { useInstanceConfig } from "@/features/blog/hooks/use-instance-config";
 import { BlogSidebar } from "@/features/blog/layout/blog-sidebar";
 import { useEffect } from "react";
 
@@ -15,16 +16,21 @@ export const Route = createFileRoute("/publish")({
 function RouteComponent() {
   const isBlogOwner = useIsBlogOwner();
   const isAuthEnabled = useIsAuthEnabled();
+  const isAuthenticated = useIsAuthenticated();
+  const { isCommunityMode } = useInstanceConfig();
   const navigate = useNavigate();
 
-  // Redirect if auth is disabled or user is not blog owner
+  // Community instances: any authenticated user can compose (posts publish into the community).
+  // Blog instances: only the instance owner. Redirect anyone who does not qualify.
+  const canPublish = isAuthEnabled && (isCommunityMode ? isAuthenticated : isBlogOwner);
+
   useEffect(() => {
-    if (!isAuthEnabled || !isBlogOwner) {
+    if (!canPublish) {
       navigate({ to: "/blog", search: { filter: "posts" } });
     }
-  }, [isAuthEnabled, isBlogOwner, navigate]);
+  }, [canPublish, navigate]);
 
-  if (!isAuthEnabled || !isBlogOwner) {
+  if (!canPublish) {
     return null;
   }
 


### PR DESCRIPTION
Adds community-instance support to the self-hosted SPA, where the showcased account is a community (hive-NNNNN) and the controlling account is a separate `owner`.

## Changes
- **Ownership gate.** `isBlogOwner` now compares the active user against `configuration.instanceConfiguration.owner`, falling back to `username` when `owner` is absent (back-compat for existing blog configs). Previously community instances gated on the community account, so no real user ever matched and owner-only UI (config editor) was unreachable.
- **Community authoring.** In community mode the publish flow posts into the community: `parentPermlink` becomes the community id and the community tag is placed first in json metadata. The logged-in user stays the author. Blog mode keeps the first-tag-as-category behavior. Extracted the derivation into a small pure helper with unit tests.
- **Create post button.** In a community instance any authenticated user can post into the community (standard Hive community moderation still applies); blog instances stay owner-only.

## Tests
- `pnpm --filter @ecency/self-hosted test` passes (31 tests, 6 new).
- App typecheck clean for touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for both blog and community publishing flows, with post routing and tags now adapting automatically based on the instance mode.
  * Improved ownership handling so newer configurations can define a dedicated owner while older setups still work as expected.

* **Bug Fixes**
  * Fixed post creation visibility and publishing behavior so the correct author or community rules are applied consistently.
  * Improved tag handling to avoid duplicate community tags and to better handle empty tag lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->