### PR TITLE
Add Community option to hosting signup

### DIFF
--- a/apps/web/src/features/hosting-signup/hosting-api.ts
+++ b/apps/web/src/features/hosting-signup/hosting-api.ts
@@ -33,6 +33,7 @@ export interface CreateTenantResult {
 
 export interface TenantInfo {
   username: string;
+  owner?: string;
   subscriptionStatus: "active" | "inactive" | "expired" | "suspended";
   subscriptionExpiresAt?: string | null;
   blogUrl?: string;

--- a/apps/web/src/features/hosting-signup/hosting-api.ts
+++ b/apps/web/src/features/hosting-signup/hosting-api.ts
@@ -20,6 +20,10 @@ export interface HostingConfigInput {
   styleTemplate?: string;
   title?: string;
   description?: string;
+  /** Instance kind. Omit (or "blog") for a personal blog; "community" hosts a Hive community. */
+  type?: "blog" | "community";
+  /** The Hive community id (hive-NNNNN) when type is "community". */
+  communityId?: string;
 }
 
 export interface CreateTenantResult {
@@ -65,9 +69,14 @@ export const hostingApi = {
 
   paymentMethods: () => get<HostingPaymentMethods>("/v1/payments/methods"),
 
-  /** Create the (inactive) tenant. Payment then activates it. */
-  createTenant: (username: string, config?: HostingConfigInput) =>
-    post<CreateTenantResult>("/v1/tenants", { username, config }),
+  /**
+   * Create the (inactive) tenant. Payment then activates it. `username` is the tenant subdomain
+   * (the Hive user for a personal blog, or the community id for a community). `owner` is the Hive
+   * account that controls and pays for the instance; it defaults to `username` for a personal blog
+   * where the showcased account and the owner are the same.
+   */
+  createTenant: (username: string, owner?: string, config?: HostingConfigInput) =>
+    post<CreateTenantResult>("/v1/tenants", { username, owner: owner ?? username, config }),
 
   tenant: (username: string) => get<TenantInfo>(`/v1/tenants/${encodeURIComponent(username)}`),
 
@@ -114,3 +123,11 @@ export function hostingProSkuForMonths(months: number): string {
 export const HOSTING_MONTHLY_USD = 2;
 /** Custom domain plan monthly price in USD (standard + your own domain, +$1/mo). */
 export const HOSTING_CUSTOM_DOMAIN_MONTHLY_USD = 3;
+
+/** A Hive community id is the literal "hive-" followed by digits (e.g. "hive-125125"). */
+export const COMMUNITY_ID_PATTERN = /^hive-\d+$/;
+
+/** True when `id` is a well-formed Hive community id (hive-NNNNN). */
+export function isValidCommunityId(id: string): boolean {
+  return COMMUNITY_ID_PATTERN.test(id.trim().toLowerCase());
+}

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -153,9 +153,6 @@ export function HostingSignup() {
       setStep("payment");
     } catch (e) {
       const msg = (e as Error).message;
-      // The tenant already existing is not an error for the owner: a member who claimed a free
-      // blog can come back to add a custom domain / renew. Card is gated to the owner and the
-      // checkout only needs the tenant to exist, so proceed straight to payment for own account.
       // The tenant already existing is not an error: only its OWNER may resume to payment or renew.
       // For a blog the owner is the account itself. For a community the owner is fixed at creation
       // (and is not the community account), so confirm the logged-in user owns the existing tenant

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -156,12 +156,20 @@ export function HostingSignup() {
       // The tenant already existing is not an error for the owner: a member who claimed a free
       // blog can come back to add a custom domain / renew. Card is gated to the owner and the
       // checkout only needs the tenant to exist, so proceed straight to payment for own account.
-      // The tenant already existing is not an error: a personal-blog owner, or a community whose
-      // tenant was created on a prior attempt, can come back to pay or renew. For a blog we require
-      // the caller to be the owner; a community tenant's owner is fixed at creation, so proceeding
-      // just pays (via HBD) to activate it.
-      const canResume =
-        msg === "Username already registered" && (isCommunity || activeUser?.username === uname);
+      // The tenant already existing is not an error: only its OWNER may resume to payment or renew.
+      // For a blog the owner is the account itself. For a community the owner is fixed at creation
+      // (and is not the community account), so confirm the logged-in user owns the existing tenant
+      // before letting them reach the payment/activation step.
+      let canResume =
+        msg === "Username already registered" && !isCommunity && activeUser?.username === uname;
+      if (msg === "Username already registered" && isCommunity && activeUser) {
+        try {
+          const existing = await hostingApi.tenant(uname);
+          canResume = existing.owner === activeUser.username;
+        } catch {
+          canResume = false;
+        }
+      }
       if (canResume) {
         createdForRef.current = uname;
         setBlogUrl(`https://${uname}.${baseDomain}`);
@@ -218,6 +226,18 @@ export function HostingSignup() {
   const usdPer = customDomain ? HOSTING_CUSTOM_DOMAIN_MONTHLY_USD : usdPerBase;
   const hbdPer = customDomain ? hbdPerBase + 1 : hbdPerBase;
   const cardSku = customDomain ? hostingProSkuForMonths(months) : hostingSkuForMonths(months);
+
+  // Only surface a well-formed https URL as a link so a validated subdomain or API-returned blog URL
+  // cannot carry an unexpected scheme into the href (guards CodeQL js/xss-through-dom).
+  let safeBlogUrl = "";
+  try {
+    if (blogUrl) {
+      const parsed = new URL(blogUrl);
+      if (parsed.protocol === "https:") safeBlogUrl = parsed.toString();
+    }
+  } catch {
+    safeBlogUrl = "";
+  }
 
   return (
     <div className="max-w-lg mx-auto flex flex-col gap-4">
@@ -441,14 +461,14 @@ export function HostingSignup() {
           <Alert appearance="success">
             <div className="flex flex-col gap-2">
               <strong>{i18next.t("hosting.success-title")}</strong>
-              {blogUrl && (
+              {safeBlogUrl && (
                 <a
-                  href={blogUrl}
+                  href={safeBlogUrl}
                   target="_blank"
                   rel="noreferrer"
                   className="text-blue-dark-sky underline"
                 >
-                  {blogUrl}
+                  {safeBlogUrl}
                 </a>
               )}
             </div>

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { useGlobalStore } from "@/core/global-store";
 import { getUsernameError } from "@/utils/username-validation";
 import { Alert } from "@ui/alert";
 import { Button } from "@ui/button";
@@ -12,6 +13,7 @@ import {
   hostingApi,
   hostingSkuForMonths,
   hostingProSkuForMonths,
+  isValidCommunityId,
   HOSTING_CUSTOM_DOMAIN_MONTHLY_USD,
   type HostingPaymentMethods
 } from "./hosting-api";
@@ -34,6 +36,7 @@ const HostingCardCheckout = dynamic(
 
 type Step = "username" | "configure" | "payment" | "success";
 type Method = "hbd" | "card";
+type InstanceType = "blog" | "community";
 
 const TERMS = [1, 3, 6, 12];
 
@@ -45,9 +48,13 @@ interface Instructions {
 
 export function HostingSignup() {
   const { activeUser } = useActiveAccount();
+  const toggleUIProp = useGlobalStore((s) => s.toggleUiProp);
 
   const [step, setStep] = useState<Step>("username");
+  // Personal blog (default) vs a Hive community hosted as its own site.
+  const [instanceType, setInstanceType] = useState<InstanceType>("blog");
   const [username, setUsername] = useState(activeUser?.username ?? "");
+  const [communityId, setCommunityId] = useState("");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [months, setMonths] = useState(1);
@@ -68,7 +75,16 @@ export function HostingSignup() {
   const createdForRef = useRef("");
 
   const baseDomain = "blogs.ecency.com";
-  const cardEnabled = !!methods?.card.enabled && !!activeUser && username === activeUser.username;
+  const isCommunity = instanceType === "community";
+  // The tenant subdomain/name: the Hive user for a personal blog, the community id for a community.
+  // The owner (payer/controller) is always the logged-in account.
+  const tenantUsername = (isCommunity ? communityId : username).trim().toLowerCase();
+  // Card can only activate the payer's own tenant: ePoints binds the Stripe order to the
+  // authenticated buyer, and activation targets that account. A community is keyed by its id, not
+  // by the buyer, so the on-chain HBD memo is the only rail that can target it. Keep card to a
+  // personal blog owned by the buyer.
+  const cardEnabled =
+    !!methods?.card.enabled && !!activeUser && !isCommunity && tenantUsername === activeUser.username;
 
   useEffect(() => {
     hostingApi.paymentMethods().then(setMethods).catch(() => setMethods(null));
@@ -88,10 +104,22 @@ export function HostingSignup() {
 
   const goConfigure = () => {
     setError("");
-    const err = getUsernameError(username.trim().toLowerCase());
-    if (err) {
-      setError(err);
-      return;
+    if (isCommunity) {
+      // The owner (creator) must be logged in: the owner comes from the active account.
+      if (!activeUser) {
+        toggleUIProp("login");
+        return;
+      }
+      if (!isValidCommunityId(communityId)) {
+        setError(i18next.t("hosting.invalid-community-id"));
+        return;
+      }
+    } else {
+      const err = getUsernameError(tenantUsername);
+      if (err) {
+        setError(err);
+        return;
+      }
     }
     setStep("configure");
   };
@@ -101,13 +129,17 @@ export function HostingSignup() {
   const goPayment = useCallback(async () => {
     setError("");
     setBusy(true);
-    const uname = username.trim().toLowerCase();
+    const uname = tenantUsername;
+    // A community is owned and paid for by the logged-in account; a personal blog is owned by the
+    // blog account itself (which may pay by HBD while logged out).
+    const owner = isCommunity ? (activeUser?.username ?? "") : uname;
     try {
       if (createdForRef.current !== uname) {
-        const res = await hostingApi.createTenant(uname, {
+        const res = await hostingApi.createTenant(uname, owner, {
           theme: "system",
           title: title.trim() || undefined,
-          description: description.trim() || undefined
+          description: description.trim() || undefined,
+          ...(isCommunity ? { type: "community", communityId: uname } : {})
         });
         createdForRef.current = uname;
         setBlogUrl(res.tenant.blogUrl);
@@ -118,7 +150,7 @@ export function HostingSignup() {
       // The tenant already existing is not an error for the owner: a member who claimed a free
       // blog can come back to add a custom domain / renew. Card is gated to the owner and the
       // checkout only needs the tenant to exist, so proceed straight to payment for own account.
-      if (msg === "Username already registered" && activeUser?.username === uname) {
+      if (msg === "Username already registered" && !isCommunity && activeUser?.username === uname) {
         createdForRef.current = uname;
         setBlogUrl(`https://${uname}.${baseDomain}`);
         setStep("payment");
@@ -128,7 +160,7 @@ export function HostingSignup() {
     } finally {
       setBusy(false);
     }
-  }, [username, title, description, activeUser]);
+  }, [tenantUsername, isCommunity, title, description, activeUser]);
 
   // HBD: refresh instructions for the selected term. Guard against a slow earlier response
   // (a different term) landing after a newer one and showing a mismatched amount/memo. Skipped
@@ -139,7 +171,7 @@ export function HostingSignup() {
     // Clear immediately so the previous term's amount/memo isn't copyable while the new one loads.
     setInstructions(null);
     hostingApi
-      .paymentInstructions(username.trim().toLowerCase(), months)
+      .paymentInstructions(tenantUsername, months)
       .then((r) => {
         if (!stale) setInstructions({ to: r.to, amount: r.amount, memo: r.memo });
       })
@@ -149,13 +181,13 @@ export function HostingSignup() {
     return () => {
       stale = true;
     };
-  }, [step, method, months, username, customDomain]);
+  }, [step, method, months, tenantUsername, customDomain]);
 
   const checkActivation = useCallback(async () => {
     setError("");
     setBusy(true);
     try {
-      const t = await hostingApi.tenant(username.trim().toLowerCase());
+      const t = await hostingApi.tenant(tenantUsername);
       if (t.subscriptionStatus === "active") {
         setStep("success");
       } else {
@@ -166,7 +198,7 @@ export function HostingSignup() {
     } finally {
       setBusy(false);
     }
-  }, [username]);
+  }, [tenantUsername]);
 
   const usdPerBase = (methods?.card.monthlyUsdCents ?? 200) / 100;
   const hbdPerBase = parseFloat(methods?.hbd.monthly ?? "2");
@@ -189,17 +221,65 @@ export function HostingSignup() {
 
       {step === "username" && (
         <div className="flex flex-col gap-3">
-          <label className="text-sm font-semibold">{i18next.t("hosting.username-label")}</label>
-          <FormControl
-            type="text"
-            value={username}
-            onChange={(e: any) => setUsername(e.target.value)}
-            placeholder="yourname"
-            autoFocus={true}
-          />
-          <p className="text-sm opacity-60">
-            {i18next.t("hosting.subdomain-preview", { url: `${username || "yourname"}.${baseDomain}` })}
-          </p>
+          {/* Instance type: personal blog (default) or a Hive community as its own site. */}
+          <div className="flex gap-2">
+            <button
+              onClick={() => setInstanceType("blog")}
+              className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
+                !isCommunity ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
+              }`}
+            >
+              {i18next.t("hosting.type-blog")}
+            </button>
+            <button
+              onClick={() => setInstanceType("community")}
+              className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
+                isCommunity ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
+              }`}
+            >
+              {i18next.t("hosting.type-community")}
+            </button>
+          </div>
+
+          {isCommunity ? (
+            <>
+              <label className="text-sm font-semibold">
+                {i18next.t("hosting.community-id-label")}
+              </label>
+              <FormControl
+                type="text"
+                value={communityId}
+                onChange={(e: any) => setCommunityId(e.target.value)}
+                placeholder="hive-125125"
+                autoFocus={true}
+              />
+              <p className="text-sm opacity-75">{i18next.t("hosting.community-explainer")}</p>
+              <p className="text-sm opacity-60">
+                {i18next.t("hosting.subdomain-preview", {
+                  url: `${communityId.trim().toLowerCase() || "hive-125125"}.${baseDomain}`
+                })}
+              </p>
+              {!activeUser && (
+                <Alert appearance="primary">{i18next.t("hosting.community-login-required")}</Alert>
+              )}
+            </>
+          ) : (
+            <>
+              <label className="text-sm font-semibold">{i18next.t("hosting.username-label")}</label>
+              <FormControl
+                type="text"
+                value={username}
+                onChange={(e: any) => setUsername(e.target.value)}
+                placeholder="yourname"
+                autoFocus={true}
+              />
+              <p className="text-sm opacity-60">
+                {i18next.t("hosting.subdomain-preview", {
+                  url: `${username || "yourname"}.${baseDomain}`
+                })}
+              </p>
+            </>
+          )}
           <Button onClick={goConfigure} full={true}>
             {i18next.t("g.continue")}
           </Button>
@@ -251,22 +331,25 @@ export function HostingSignup() {
             ))}
           </div>
 
-          {/* Custom domain add-on */}
-          <button
-            onClick={() => setCustomDomain((v) => !v)}
-            disabled={paying}
-            className={`text-left px-4 py-3 rounded-lg border ${
-              customDomain ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
-            } ${paying ? "opacity-50 cursor-not-allowed" : ""}`}
-          >
-            <div className="flex items-center justify-between gap-2">
-              <span className="font-semibold">{i18next.t("hosting.custom-domain-option")}</span>
-              <span className="text-sm text-blue-dark-sky">
-                {customDomain ? i18next.t("hosting.custom-domain-added") : i18next.t("hosting.custom-domain-price")}
-              </span>
-            </div>
-            <p className="text-sm opacity-75 mt-1">{i18next.t("hosting.custom-domain-explainer")}</p>
-          </button>
+          {/* Custom domain add-on. It is a card-only one-step checkout, and card is unavailable for
+              a community (see cardEnabled), so the add-on is offered for personal blogs only. */}
+          {!isCommunity && (
+            <button
+              onClick={() => setCustomDomain((v) => !v)}
+              disabled={paying}
+              className={`text-left px-4 py-3 rounded-lg border ${
+                customDomain ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
+              } ${paying ? "opacity-50 cursor-not-allowed" : ""}`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-semibold">{i18next.t("hosting.custom-domain-option")}</span>
+                <span className="text-sm text-blue-dark-sky">
+                  {customDomain ? i18next.t("hosting.custom-domain-added") : i18next.t("hosting.custom-domain-price")}
+                </span>
+              </div>
+              <p className="text-sm opacity-75 mt-1">{i18next.t("hosting.custom-domain-explainer")}</p>
+            </button>
+          )}
 
           {/* Method toggle */}
           <div className="flex gap-2">
@@ -299,7 +382,7 @@ export function HostingSignup() {
           {method === "card" && cardEnabled && (
             <HostingCardCheckout
               key={cardSku}
-              username={username.trim().toLowerCase()}
+              username={tenantUsername}
               sku={cardSku}
               payLabel={i18next.t("hosting.pay-now")}
               returnUrl={typeof window !== "undefined" ? window.location.href : ""}
@@ -359,8 +442,9 @@ export function HostingSignup() {
             </div>
           </Alert>
 
-          {/* Custom domain plan -> let the owner attach and verify their domain now. */}
-          {customDomain && activeUser && username === activeUser.username && (
+          {/* Custom domain plan -> let the owner attach and verify their domain now. Personal blog
+              only; the add-on is not offered for a community. */}
+          {!isCommunity && customDomain && activeUser && username === activeUser.username && (
             <CustomDomainManager username={activeUser.username} />
           )}
         </div>

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -102,6 +102,12 @@ export function HostingSignup() {
     if (customDomain && cardEnabled) setMethod("card");
   }, [customDomain, cardEnabled]);
 
+  // Community has no custom-domain add-on; clear a stale selection carried over from the blog flow,
+  // otherwise the HBD instructions effect (which skips when customDomain is set) never runs.
+  useEffect(() => {
+    if (isCommunity && customDomain) setCustomDomain(false);
+  }, [isCommunity, customDomain]);
+
   const goConfigure = () => {
     setError("");
     if (isCommunity) {
@@ -150,7 +156,13 @@ export function HostingSignup() {
       // The tenant already existing is not an error for the owner: a member who claimed a free
       // blog can come back to add a custom domain / renew. Card is gated to the owner and the
       // checkout only needs the tenant to exist, so proceed straight to payment for own account.
-      if (msg === "Username already registered" && !isCommunity && activeUser?.username === uname) {
+      // The tenant already existing is not an error: a personal-blog owner, or a community whose
+      // tenant was created on a prior attempt, can come back to pay or renew. For a blog we require
+      // the caller to be the owner; a community tenant's owner is fixed at creation, so proceeding
+      // just pays (via HBD) to activate it.
+      const canResume =
+        msg === "Username already registered" && (isCommunity || activeUser?.username === uname);
+      if (canResume) {
         createdForRef.current = uname;
         setBlogUrl(`https://${uname}.${baseDomain}`);
         setStep("payment");

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -2,6 +2,12 @@
   "hosting": {
     "title": "Blog hosting",
     "subtitle": "Host your Hive blog on your own branded site at yourname.blogs.ecency.com.",
+    "type-blog": "Personal blog",
+    "type-community": "Community",
+    "community-id-label": "Community ID",
+    "community-explainer": "Host a Hive community you belong to as its own site, on your own domain.",
+    "community-login-required": "Sign in with the Hive account that will own and manage this community site.",
+    "invalid-community-id": "Enter a community ID in the form hive-00000.",
     "username-label": "Your Hive username",
     "subdomain-preview": "Your blog: {{url}}",
     "blog-title-label": "Blog title (optional)",

--- a/apps/web/src/specs/features/hosting-signup/hosting-api.spec.ts
+++ b/apps/web/src/specs/features/hosting-signup/hosting-api.spec.ts
@@ -2,7 +2,8 @@ import {
   HOSTING_CUSTOM_DOMAIN_MONTHLY_USD,
   HOSTING_MONTHLY_USD,
   hostingProSkuForMonths,
-  hostingSkuForMonths
+  hostingSkuForMonths,
+  isValidCommunityId
 } from "@/features/hosting-signup/hosting-api";
 import { describe, expect, it } from "vitest";
 
@@ -37,5 +38,25 @@ describe("hostingProSkuForMonths", () => {
     expect(HOSTING_MONTHLY_USD).toBe(2);
     expect(HOSTING_CUSTOM_DOMAIN_MONTHLY_USD).toBe(3);
     expect(HOSTING_CUSTOM_DOMAIN_MONTHLY_USD - HOSTING_MONTHLY_USD).toBe(1);
+  });
+});
+
+describe("isValidCommunityId", () => {
+  it("accepts a well-formed Hive community id", () => {
+    expect(isValidCommunityId("hive-125125")).toBe(true);
+    expect(isValidCommunityId("hive-1")).toBe(true);
+  });
+
+  it("trims and lowercases before validating", () => {
+    expect(isValidCommunityId("  HIVE-125125  ")).toBe(true);
+  });
+
+  it("rejects anything that is not hive-<digits>", () => {
+    expect(isValidCommunityId("hive-")).toBe(false);
+    expect(isValidCommunityId("hive-12a")).toBe(false);
+    expect(isValidCommunityId("hive125125")).toBe(false);
+    expect(isValidCommunityId("alice")).toBe(false);
+    expect(isValidCommunityId("hive-125125-extra")).toBe(false);
+    expect(isValidCommunityId("")).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Adds a Community option to the web hosting signup so a logged-in user can create and host a Hive community as its own site, alongside the existing personal blog flow.

## Changes

- Instance type selector at the top of signup: Personal blog (default) or Community.
- Community: a Community ID input (`hive-NNNNN`) with client-side shape validation, a short explainer, and a login prompt (the owner comes from the active account).
- Personal blog flow is unchanged.
- Tenant is created with `username = communityId`, `owner = the logged-in account`, and `config: { type: "community", communityId, title, description, theme }`.
- `createTenant` now sends an `owner` (defaults to the username for a personal blog). `HostingConfigInput` gains `type` and `communityId`.
- Subdomain preview stays accurate for both types.
- A community activates via the HBD memo rail (the memo encodes the community id, and the owner pays). The card rail stays scoped to a personal blog the buyer owns, so the custom domain add-on is offered for personal blogs only.
- Adds tests for the community-id validation helper.

## Notes

The card rail binds the order to the authenticated buyer and activates that buyer's own tenant, so it cannot target a separate community id. Community checkout therefore uses HBD, whose memo carries the community id. This is intentional and reflected in the UI.