### PR TITLE
hosting: community-instance hosting (decouple owner from showcased account)

### DIFF
--- a/apps/self-hosted/hosting/api/src/routes/domains.ts
+++ b/apps/self-hosted/hosting/api/src/routes/domains.ts
@@ -32,6 +32,11 @@ domainRoutes.post('/', authMiddleware, zValidator('json', addDomainSchema), asyn
     return c.json({ error: 'Tenant not found' }, 404);
   }
 
+  // Authorize the controlling owner, not the showcased account.
+  if (authUser.username !== tenant.owner) {
+    return c.json({ error: 'Unauthorized' }, 403);
+  }
+
   // Check if Pro plan
   if (tenant.subscriptionPlan !== 'pro') {
     return c.json({ error: 'Custom domains require Pro plan' }, 402);
@@ -79,6 +84,11 @@ domainRoutes.post('/verify', authMiddleware, async (c) => {
     return c.json({ error: 'Tenant not found' }, 404);
   }
 
+  // Authorize the controlling owner, not the showcased account.
+  if (authUser.username !== tenant.owner) {
+    return c.json({ error: 'Unauthorized' }, 403);
+  }
+
   if (!tenant.customDomain) {
     return c.json({ error: 'No custom domain configured' }, 400);
   }
@@ -120,6 +130,15 @@ domainRoutes.delete('/', authMiddleware, async (c) => {
 
   try {
     const tenant = await TenantService.getByUsername(username);
+    if (!tenant) {
+      return c.json({ error: 'Tenant not found' }, 404);
+    }
+
+    // Authorize the controlling owner, not the showcased account.
+    if (authUser.username !== tenant.owner) {
+      return c.json({ error: 'Unauthorized' }, 403);
+    }
+
     await TenantService.removeCustomDomain(username);
 
     void AuditService.log({

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -82,12 +82,52 @@ tenantRoutes.get('/:username/config', async (c) => {
 });
 
 // POST /v1/tenants - Create new tenant (requires payment)
+// Validate a tenant-create request (shared by POST / and /subscribe). Enforces that the showcased
+// and owner accounts exist; that a PERSONAL blog is controlled by its own account (owner === the
+// username) so a direct API call cannot assign someone else as controller of a blog; and that a
+// COMMUNITY has a real, separate owner account plus a valid, existing community id equal to the
+// subdomain. Returns the resolved owner or a client error.
+async function resolveAndValidateTenant(
+  body: any
+): Promise<{ ok: true; owner: string } | { ok: false; status: 400; error: string }> {
+  const username = body.username.toLowerCase();
+  const owner = (body.owner || body.username).toLowerCase();
+  const isCommunity = body.config?.type === 'community';
+
+  if (!(await TenantService.verifyHiveAccount(username))) {
+    return { ok: false, status: 400, error: 'Hive account not found' };
+  }
+  if (!(await TenantService.verifyHiveAccount(owner))) {
+    return { ok: false, status: 400, error: 'Owner account not found' };
+  }
+
+  if (isCommunity) {
+    const communityId = (body.config.communityId || '').toLowerCase();
+    if (!/^hive-\d+$/.test(communityId)) {
+      return { ok: false, status: 400, error: 'Community id must look like hive-NNNN' };
+    }
+    if (username !== communityId) {
+      return { ok: false, status: 400, error: 'Subdomain must equal the community id' };
+    }
+    // A community account holds no user's keys, so it can never be the controller: require an
+    // explicit, different owner or the instance would be unmanageable.
+    if (!body.owner || owner === communityId) {
+      return { ok: false, status: 400, error: 'A community instance requires a separate owner account' };
+    }
+    if (!(await TenantService.verifyCommunity(communityId))) {
+      return { ok: false, status: 400, error: 'Community not found' };
+    }
+  } else if (owner !== username) {
+    // A personal blog is always controlled by its own account; reject an attempt to assign a
+    // different owner, which would let a direct API call hijack management of someone's blog.
+    return { ok: false, status: 400, error: 'A personal blog must be owned by its own account' };
+  }
+
+  return { ok: true, owner };
+}
+
 tenantRoutes.post('/', zValidator('json', createTenantSchema), async (c) => {
   const body = c.req.valid('json');
-
-  // Resolve the controlling account. A personal blog owns itself; a community is owned by its
-  // creator. Every later mutating op (PATCH / DELETE / domains / upgrade) authorizes on this.
-  const owner = (body.owner || body.username).toLowerCase();
 
   // Check if username already exists
   const existing = await TenantService.getByUsername(body.username);
@@ -95,32 +135,12 @@ tenantRoutes.post('/', zValidator('json', createTenantSchema), async (c) => {
     return c.json({ error: 'Username already registered' }, 409);
   }
 
-  // Verify the showcased Hive account exists
-  const hiveAccountExists = await TenantService.verifyHiveAccount(body.username);
-  if (!hiveAccountExists) {
-    return c.json({ error: 'Hive account not found' }, 400);
+  // Validate accounts + community + ownership rules (shared with /subscribe).
+  const validation = await resolveAndValidateTenant(body);
+  if (!validation.ok) {
+    return c.json({ error: validation.error }, validation.status);
   }
-
-  // Verify the owner Hive account exists
-  const ownerExists = await TenantService.verifyHiveAccount(owner);
-  if (!ownerExists) {
-    return c.json({ error: 'Owner account not found' }, 400);
-  }
-
-  // Community instances: the subdomain IS the community, and the community must exist.
-  if (body.config?.type === 'community') {
-    const communityId = (body.config.communityId || '').toLowerCase();
-    if (!/^hive-\d+$/.test(communityId)) {
-      return c.json({ error: 'Community id must look like hive-NNNN' }, 400);
-    }
-    if (body.username.toLowerCase() !== communityId) {
-      return c.json({ error: 'Subdomain must equal the community id' }, 400);
-    }
-    const communityExists = await TenantService.verifyCommunity(communityId);
-    if (!communityExists) {
-      return c.json({ error: 'Community not found' }, 400);
-    }
-  }
+  const { owner } = validation;
 
   // Create tenant (inactive until payment)
   const tenant = await TenantService.create(body.username, owner, body.config);
@@ -165,9 +185,11 @@ tenantRoutes.post('/subscribe',
     if (existing) {
       return c.json({ error: 'Username already registered' }, 409);
     }
-    const hiveAccountExists = await TenantService.verifyHiveAccount(body.username);
-    if (!hiveAccountExists) {
-      return c.json({ error: 'Hive account not found' }, 400);
+    // Same account + community + ownership validation as POST /, BEFORE the paywall so a payment is
+    // never settled for a request the create route would reject (unverified owner, invalid community).
+    const validation = await resolveAndValidateTenant(body);
+    if (!validation.ok) {
+      return c.json({ error: validation.error }, validation.status);
     }
     await next();
   },

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -18,6 +18,7 @@ export const tenantRoutes = new Hono();
 // Validation schemas
 const createTenantSchema = z.object({
   username: z.string().min(3).max(16).regex(/^[a-z][a-z0-9.-]*$/),
+  owner: z.string().min(3).max(16).regex(/^[a-z][a-z0-9.-]*$/).optional(),
   config: z.object({
     theme: z.enum(['light', 'dark', 'system']).optional(),
     styleTemplate: z.enum(['medium', 'minimal', 'magazine', 'developer', 'modern-gradient']).optional(),
@@ -82,21 +83,46 @@ tenantRoutes.get('/:username/config', async (c) => {
 // POST /v1/tenants - Create new tenant (requires payment)
 tenantRoutes.post('/', zValidator('json', createTenantSchema), async (c) => {
   const body = c.req.valid('json');
-  
+
+  // Resolve the controlling account. A personal blog owns itself; a community is owned by its
+  // creator. Every later mutating op (PATCH / DELETE / domains / upgrade) authorizes on this.
+  const owner = (body.owner || body.username).toLowerCase();
+
   // Check if username already exists
   const existing = await TenantService.getByUsername(body.username);
   if (existing) {
     return c.json({ error: 'Username already registered' }, 409);
   }
-  
-  // Verify the Hive account exists
+
+  // Verify the showcased Hive account exists
   const hiveAccountExists = await TenantService.verifyHiveAccount(body.username);
   if (!hiveAccountExists) {
     return c.json({ error: 'Hive account not found' }, 400);
   }
-  
+
+  // Verify the owner Hive account exists
+  const ownerExists = await TenantService.verifyHiveAccount(owner);
+  if (!ownerExists) {
+    return c.json({ error: 'Owner account not found' }, 400);
+  }
+
+  // Community instances: the subdomain IS the community, and the community must exist.
+  if (body.config?.type === 'community') {
+    const communityId = (body.config.communityId || '').toLowerCase();
+    if (!/^hive-\d+$/.test(communityId)) {
+      return c.json({ error: 'Community id must look like hive-NNNN' }, 400);
+    }
+    if (body.username.toLowerCase() !== communityId) {
+      return c.json({ error: 'Subdomain must equal the community id' }, 400);
+    }
+    const communityExists = await TenantService.verifyCommunity(communityId);
+    if (!communityExists) {
+      return c.json({ error: 'Community not found' }, 400);
+    }
+  }
+
   // Create tenant (inactive until payment)
-  const tenant = await TenantService.create(body.username, body.config);
+  const tenant = await TenantService.create(body.username, owner, body.config);
   
   // Generate config file (will be served after payment)
   await ConfigService.generateConfigFile(tenant);
@@ -108,7 +134,7 @@ tenantRoutes.post('/', zValidator('json', createTenantSchema), async (c) => {
   void AuditService.log({
     tenantId: tenant.id,
     eventType: 'tenant.created',
-    eventData: { username: body.username },
+    eventData: { username: body.username, owner },
     ipAddress: parseClientIp(c.req.header('x-forwarded-for')),
     userAgent: c.req.header('user-agent'),
   });
@@ -154,8 +180,11 @@ tenantRoutes.post('/subscribe',
       return c.json({ error: 'Missing or invalid payer/txId from payment settlement' }, 502);
     }
 
+    // Resolve owner (defaults to the showcased account for a self-serve personal blog).
+    const owner = (body.owner || body.username).toLowerCase();
+
     // Prepare config before entering the DB transaction (pure, no I/O)
-    const tenantConfig = await TenantService.buildConfig(body.username, body.config);
+    const tenantConfig = await TenantService.buildConfig(body.username, body.config, owner);
     const blockNum = c.get('blockNum');
     if (!Number.isInteger(blockNum) || blockNum <= 0) {
       return c.json({ error: 'Missing or invalid block number from payment settlement' }, 502);
@@ -165,11 +194,11 @@ tenantRoutes.post('/subscribe',
     const result = await db.transaction(async (client) => {
       // Create tenant — ON CONFLICT handles race with concurrent requests
       const tenantRow = await client.query(
-        `INSERT INTO tenants (username, config, subscription_status, subscription_plan)
-         VALUES ($1, $2, 'inactive', 'standard')
+        `INSERT INTO tenants (username, owner, config, subscription_status, subscription_plan)
+         VALUES ($1, $2, $3, 'inactive', 'standard')
          ON CONFLICT (username) DO NOTHING
          RETURNING *`,
-        [body.username.toLowerCase(), JSON.stringify(tenantConfig)]
+        [body.username.toLowerCase(), owner, JSON.stringify(tenantConfig)]
       );
       if (tenantRow.rowCount === 0) {
         throw Object.assign(new Error('Username already registered'), { isConflict: true });
@@ -253,11 +282,17 @@ tenantRoutes.post('/subscribe',
 // POST /v1/tenants/:username/upgrade - Upgrade to Pro via x402 payment
 // Validation runs before paywall so we don't settle payment for invalid requests
 tenantRoutes.post('/:username/upgrade',
+  authMiddleware,
   async (c, next) => {
     const username = c.req.param('username')!;
+    const authUser = c.get('user');
     const tenant = await TenantService.getByUsername(username);
     if (!tenant) {
       return c.json({ error: 'Tenant not found' }, 404);
+    }
+    // Only the controlling owner may pin a Pro plan onto the tenant, not any wallet that can pay.
+    if (authUser.username !== tenant.owner) {
+      return c.json({ error: 'Unauthorized' }, 403);
     }
     if (tenant.subscriptionStatus !== 'active') {
       return c.json({ error: 'Subscription must be active to upgrade' }, 400);
@@ -378,17 +413,18 @@ tenantRoutes.patch('/:username', authMiddleware, zValidator('json', updateTenant
   const username = c.req.param('username');
   const body = c.req.valid('json');
   const authUser = c.get('user');
-  
-  // Verify user owns this tenant
-  if (authUser.username !== username) {
-    return c.json({ error: 'Unauthorized' }, 403);
-  }
-  
+
   const tenant = await TenantService.getByUsername(username);
   if (!tenant) {
     return c.json({ error: 'Tenant not found' }, 404);
   }
-  
+
+  // Authorize the controlling owner, not the showcased account (a community's keys are held
+  // by no one). For a personal blog owner === username, so this stays equivalent.
+  if (authUser.username !== tenant.owner) {
+    return c.json({ error: 'Unauthorized' }, 403);
+  }
+
   // Update config
   const updatedTenant = await TenantService.updateConfig(username, body.config);
   
@@ -440,18 +476,18 @@ tenantRoutes.get('/:username/status', async (c) => {
 
 // DELETE /v1/tenants/:username - Delete tenant (requires auth)
 tenantRoutes.delete('/:username', authMiddleware, async (c) => {
-  const username = c.req.param('username');
+  const username = c.req.param('username')!;
   const authUser = c.get('user');
 
-  // Verify user owns this tenant
-  if (authUser.username !== username) {
-    return c.json({ error: 'Unauthorized' }, 403);
-  }
-
-  // Capture tenant ID before deletion for audit trail
+  // Capture tenant before deletion (for the owner check and the audit trail)
   const tenant = await TenantService.getByUsername(username);
   if (!tenant) {
     return c.json({ error: 'Tenant not found' }, 404);
+  }
+
+  // Authorize the controlling owner, not the showcased account.
+  if (authUser.username !== tenant.owner) {
+    return c.json({ error: 'Unauthorized' }, 403);
   }
 
   await TenantService.delete(username);

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -52,6 +52,7 @@ tenantRoutes.get('/:username', async (c) => {
   
   return c.json({
     username: tenant.username,
+    owner: tenant.owner,
     subscriptionStatus: tenant.subscriptionStatus,
     subscriptionPlan: tenant.subscriptionPlan,
     subscriptionExpiresAt: tenant.subscriptionExpiresAt,

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { TenantService } from './tenant-service';
+
+// These exercise the pure config builders only (no DB / no RPC), which is where the
+// owner (controlling account) is resolved and written into the stored config.
+
+describe('TenantService.getDefaultConfig owner', () => {
+  it('defaults owner to the showcased username when no owner is given', async () => {
+    const config = await TenantService.getDefaultConfig('alice');
+    expect(config.configuration.instanceConfiguration.owner).toBe('alice');
+    expect(config.configuration.instanceConfiguration.username).toBe('alice');
+  });
+
+  it('uses the given owner and lowercases it', async () => {
+    const config = await TenantService.getDefaultConfig('hive-125125', 'Alice');
+    expect(config.configuration.instanceConfiguration.owner).toBe('alice');
+    expect(config.configuration.instanceConfiguration.username).toBe('hive-125125');
+  });
+});
+
+describe('TenantService.buildConfig owner + community', () => {
+  it('keeps owner defaulted to username with no overrides', async () => {
+    const config = await TenantService.buildConfig('bob');
+    expect(config.configuration.instanceConfiguration.owner).toBe('bob');
+    expect(config.configuration.instanceConfiguration.type).toBe('blog');
+  });
+
+  it('sets owner alongside a community override (owner decoupled from showcased account)', async () => {
+    const config = await TenantService.buildConfig(
+      'hive-125125',
+      { type: 'community', communityId: 'hive-125125', title: 'My Community' },
+      'alice'
+    );
+    const instance = config.configuration.instanceConfiguration;
+    expect(instance.owner).toBe('alice');
+    expect(instance.username).toBe('hive-125125');
+    expect(instance.type).toBe('community');
+    expect(instance.communityId).toBe('hive-125125');
+    expect(instance.meta.title).toBe('My Community');
+  });
+
+  it('never lets a client override the server-resolved owner via configOverrides', async () => {
+    const config = await TenantService.buildConfig(
+      'bob',
+      { owner: 'attacker' } as any,
+      'bob'
+    );
+    expect(config.configuration.instanceConfiguration.owner).toBe('bob');
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -37,20 +37,27 @@ export const TenantService = {
   },
   
   /**
-   * Create new tenant
+   * Create new tenant.
+   *
+   * `owner` is the Hive account that controls the instance and every mutating op is later
+   * authorized against it. It defaults to `username` (a personal blog, where the showcased
+   * account is also the owner). For a community the caller passes their own account as `owner`
+   * while `username` is the community account (hive-NNNNN).
    */
-  async create(username: string, configOverrides?: any): Promise<Tenant> {
+  async create(username: string, owner?: string, configOverrides?: any): Promise<Tenant> {
+    const ownerName = (owner || username).toLowerCase();
+
     // buildConfig normalizes flat API overrides (title, description, theme, styleTemplate, type,
     // communityId) into the nested shape the SPA actually reads. Merging the flat keys directly kept
     // them at the config root, where the SPA ignores them, so a signup's chosen title/theme/style
     // were silently dropped (and any community override too). Route both paths through buildConfig.
-    const config = await this.buildConfig(username, configOverrides);
+    const config = await this.buildConfig(username, configOverrides, ownerName);
 
     const row = await db.queryOne<TenantRow>(
-      `INSERT INTO tenants (username, config, subscription_status, subscription_plan)
-       VALUES ($1, $2, 'inactive', 'standard')
+      `INSERT INTO tenants (username, owner, config, subscription_status, subscription_plan)
+       VALUES ($1, $2, $3, 'inactive', 'standard')
        RETURNING *`,
-      [username.toLowerCase(), JSON.stringify(config)]
+      [username.toLowerCase(), ownerName, JSON.stringify(config)]
     );
 
     return mapTenantFromDb(row!);
@@ -241,6 +248,18 @@ export const TenantService = {
       return false;
     }
   },
+
+  /**
+   * Verify a Hive community exists (not merely an account named hive-NNNNN).
+   */
+  async verifyCommunity(communityId: string): Promise<boolean> {
+    try {
+      const community = await callRPC('bridge.get_community', { name: communityId, observer: '' }) as any;
+      return !!community && community.name === communityId;
+    } catch {
+      return false;
+    }
+  },
   
   /**
    * Get blog URL for tenant
@@ -257,8 +276,8 @@ export const TenantService = {
    * Normalizes flat API overrides into the nested stored config shape.
    * Pure function, safe to call outside a DB transaction.
    */
-  async buildConfig(username: string, configOverrides?: any): Promise<any> {
-    const defaults = await this.getDefaultConfig(username);
+  async buildConfig(username: string, configOverrides?: any, owner?: string): Promise<any> {
+    const defaults = await this.getDefaultConfig(username, owner);
     if (!configOverrides) return defaults;
 
     // Map flat API keys to nested config paths
@@ -267,6 +286,7 @@ export const TenantService = {
     if (configOverrides.styleTemplate) normalized.configuration.general.styleTemplate = configOverrides.styleTemplate;
     if (configOverrides.type) normalized.configuration.instanceConfiguration.type = configOverrides.type;
     if (configOverrides.communityId) normalized.configuration.instanceConfiguration.communityId = configOverrides.communityId;
+    // Owner is server-resolved, not client-supplied, so it is never taken from configOverrides.
     if (configOverrides.title) normalized.configuration.instanceConfiguration.meta.title = configOverrides.title;
     if (configOverrides.description) normalized.configuration.instanceConfiguration.meta.description = configOverrides.description;
 
@@ -274,9 +294,10 @@ export const TenantService = {
   },
 
   /**
-   * Get default config for a new tenant
+   * Get default config for a new tenant.
+   * `owner` is written into instanceConfiguration.owner, which the SPA reads for its ownership gate.
    */
-  async getDefaultConfig(username: string): Promise<any> {
+  async getDefaultConfig(username: string, owner?: string): Promise<any> {
     return {
       version: 1,
       configuration: {
@@ -298,6 +319,7 @@ export const TenantService = {
         instanceConfiguration: {
           type: 'blog',
           username: username,
+          owner: (owner || username).toLowerCase(),
           communityId: '',
           meta: {
             title: `${username}'s Blog`,

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -311,7 +311,7 @@ export const TenantService = {
           dateTimeFormat: 'YYYY-MM-DD HH:mm:ss',
           imageProxy: 'https://i.ecency.com',
           profileBaseUrl: 'https://ecency.com/@',
-          createPostUrl: 'https://ecency.com/submit',
+          createPostUrl: 'https://ecency.com/publish',
           styles: {
             background: 'bg-gradient-to-br from-[#f8fafc] to-[#e2e8f0]',
           },

--- a/apps/self-hosted/hosting/api/src/types.test.ts
+++ b/apps/self-hosted/hosting/api/src/types.test.ts
@@ -91,6 +91,7 @@ describe('mapTenantFromDb', () => {
   const baseRow: TenantRow = {
     id: '123',
     username: 'alice',
+    owner: 'alice',
     subscription_status: 'active',
     subscription_plan: 'standard',
     subscription_started_at: '2025-01-01T00:00:00Z',
@@ -107,6 +108,7 @@ describe('mapTenantFromDb', () => {
     const tenant = mapTenantFromDb(baseRow);
     expect(tenant.id).toBe('123');
     expect(tenant.username).toBe('alice');
+    expect(tenant.owner).toBe('alice');
     expect(tenant.subscriptionStatus).toBe('active');
     expect(tenant.subscriptionPlan).toBe('standard');
     expect(tenant.customDomain).toBe('alice.blog');
@@ -152,12 +154,14 @@ describe('mapTenantToDb', () => {
   it('maps camelCase to snake_case for all fields', () => {
     const partial: Partial<Tenant> = {
       username: 'bob',
+      owner: 'bob',
       subscriptionStatus: 'active',
       subscriptionPlan: 'pro',
     };
     const dbFields = mapTenantToDb(partial);
     expect(dbFields).toEqual({
       username: 'bob',
+      owner: 'bob',
       subscription_status: 'active',
       subscription_plan: 'pro',
     });

--- a/apps/self-hosted/hosting/api/src/types.ts
+++ b/apps/self-hosted/hosting/api/src/types.ts
@@ -8,8 +8,9 @@
 
 export interface Tenant {
   id: string;
-  username: string; // Hive username, also used as subdomain
-  
+  username: string; // Showcased Hive account, also used as subdomain (hive-NNNNN for a community)
+  owner: string; // Hive account that created and controls this instance (equals username for a personal blog)
+
   // Subscription
   subscriptionStatus: 'inactive' | 'active' | 'expired' | 'suspended';
   subscriptionPlan: 'standard' | 'pro';
@@ -80,6 +81,7 @@ export interface BlogConfig {
 export interface TenantRow {
   id: string;
   username: string;
+  owner: string;
   subscription_status: 'inactive' | 'active' | 'expired' | 'suspended';
   subscription_plan: 'standard' | 'pro';
   subscription_started_at: string | null;
@@ -99,6 +101,7 @@ export function mapTenantFromDb(row: TenantRow): Tenant {
   return {
     id: row.id,
     username: row.username,
+    owner: row.owner,
     subscriptionStatus: row.subscription_status,
     subscriptionPlan: row.subscription_plan,
     subscriptionStartedAt: row.subscription_started_at ? new Date(row.subscription_started_at) : null,
@@ -120,6 +123,7 @@ export function mapTenantToDb(tenant: Partial<Tenant>): Record<string, any> {
   const result: Record<string, any> = {};
 
   if (tenant.username !== undefined) result.username = tenant.username;
+  if (tenant.owner !== undefined) result.owner = tenant.owner;
   if (tenant.subscriptionStatus !== undefined) result.subscription_status = tenant.subscriptionStatus;
   if (tenant.subscriptionPlan !== undefined) result.subscription_plan = tenant.subscriptionPlan;
   if (tenant.subscriptionStartedAt !== undefined) result.subscription_started_at = tenant.subscriptionStartedAt;

--- a/apps/self-hosted/hosting/db/init.sql
+++ b/apps/self-hosted/hosting/db/init.sql
@@ -6,8 +6,9 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 -- Tenants table - stores blog instance configurations
 CREATE TABLE tenants (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    username VARCHAR(255) NOT NULL UNIQUE,  -- Hive username (also subdomain)
-    
+    username VARCHAR(255) NOT NULL UNIQUE,  -- Showcased Hive account (also subdomain). For a community this is hive-NNNNN.
+    owner VARCHAR(255) NOT NULL,            -- Hive account that created and controls this instance. Equals username for a personal blog; the creator for a community.
+
     -- Subscription
     subscription_status VARCHAR(50) NOT NULL DEFAULT 'inactive', -- active, inactive, expired, suspended
     subscription_plan VARCHAR(50) NOT NULL DEFAULT 'standard',   -- standard, pro
@@ -29,6 +30,7 @@ CREATE TABLE tenants (
 
 -- Index for fast lookups
 CREATE INDEX idx_tenants_username ON tenants(username);
+CREATE INDEX idx_tenants_owner ON tenants(owner);
 CREATE INDEX idx_tenants_custom_domain ON tenants(custom_domain) WHERE custom_domain IS NOT NULL;
 CREATE INDEX idx_tenants_subscription_status ON tenants(subscription_status);
 CREATE INDEX idx_tenants_expires ON tenants(subscription_expires_at) WHERE subscription_status = 'active';

--- a/apps/self-hosted/hosting/db/migrations/002_add_owner.sql
+++ b/apps/self-hosted/hosting/db/migrations/002_add_owner.sql
@@ -1,0 +1,13 @@
+-- Add tenant owner (idempotent).
+-- Decouples the controlling Hive account (owner) from the showcased account (username).
+-- For a personal blog owner equals username; for a community the owner is the creating
+-- user and username is the community account (hive-NNNNN).
+--
+-- init.sql only runs on a fresh Postgres volume, so apply this to the existing deployed
+-- `hosting` database before this release ships:
+--   docker exec -i ecency-hosting-postgres psql -U postgres -d hosting < db/migrations/002_add_owner.sql
+
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS owner VARCHAR(255);
+UPDATE tenants SET owner = username WHERE owner IS NULL;
+ALTER TABLE tenants ALTER COLUMN owner SET NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_tenants_owner ON tenants(owner);


### PR DESCRIPTION
## Community-instance hosting: decouple `owner` from `username`

Today a hosted instance is keyed only by `username` (the Hive account = subdomain = showcased account), and every mutating op authorizes `authUser.username === tenant.username`. That cannot work for a community, whose creator does not hold the community account's keys.

This introduces an **`owner`** (the Hive account that created and controls the instance), decoupled from `username` (the showcased account):

- Personal blog: `owner === username`.
- Community: `owner =` the creating user, `username = hive-NNNNN` (the community being showcased).

### Changes

- **Schema:** add `tenants.owner` (`NOT NULL`, indexed) to `db/init.sql`; new `db/migrations/002_add_owner.sql` adds the column, backfills `owner = username` for existing rows, sets `NOT NULL`, and indexes it.
- **Types:** `owner` added to `Tenant` / `TenantRow` and both mappers.
- **Service:** `create(username, owner, config?)` stores `owner` (defaults to `username`); `buildConfig` / `getDefaultConfig` write `instanceConfiguration.owner` (server-resolved, never taken from client config) for the SPA ownership gate; new `verifyCommunity` (bridge get_community).
- **Create (`POST /v1/tenants`):** resolves `owner = (body.owner || body.username)`, verifies the owner account exists, and for `type: community` requires `communityId` matching `hive-NNNN`, `username === communityId`, and that the community exists.
- **Authorization moved from `username` to `owner`** on every mutating op (see below). The JWT/auth middleware is unchanged; only the comparison moves.
- **Auto-create paths preserved:** the HBD payment listener and x402 subscribe default `owner = username`.

### Routes now authorizing on `tenant.owner`

- `PATCH /v1/tenants/:username` (update config)
- `DELETE /v1/tenants/:username`
- `POST /v1/tenants/:username/upgrade` (Pro upgrade) — now also requires a JWT so only the owner, not any paying wallet, can pin Pro
- `POST /v1/domains` (add custom domain)
- `POST /v1/domains/verify`
- `DELETE /v1/domains`

### Deploy note

The `002_add_owner.sql` migration must run against the existing hosting database before this deploys (`init.sql` only runs on a fresh volume). It is idempotent and backfills `owner = username` for existing tenants, so current personal blogs keep working unchanged.

### Tests

`npm test` green (27 tests). Added focused coverage for owner defaulting to `username`, owner staying decoupled for a community config, and the config builder rejecting a client-supplied owner. Typecheck (`tsc --noEmit`) clean.