### PR TITLE
Hosting card checkout: optional target tenant

### DIFF
--- a/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
@@ -66,9 +66,12 @@ export function HostingCardCheckout({
   const createIntent = useCreateStripeIntent(username);
   const stripePromise = getStripePromise();
 
-  // Mint the PaymentIntent once for this checkout.
+  // Mint the PaymentIntent for this checkout. Re-mint when the SKU or the target tenant changes so
+  // the active clientSecret always matches what the UI shows: paying with a stale intent would
+  // charge for the previously minted (sku, hostingTarget) rather than the current one.
   useEffect(() => {
     let alive = true;
+    setClientSecret("");
     (async () => {
       try {
         const { client_secret } = await createIntent.mutateAsync({ sku, nonce, hosting_target: hostingTarget });
@@ -81,7 +84,7 @@ export function HostingCardCheckout({
       alive = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sku, nonce]);
+  }, [sku, nonce, hostingTarget]);
 
   // Stop polling on unmount.
   useEffect(

--- a/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
@@ -21,10 +21,16 @@ const genNonce = (): string =>
     : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
 interface Props {
-  /** The buyer / blog owner (authenticated). ePoints binds the order to this user. */
+  /** The buyer / payer (authenticated). ePoints binds the Stripe order to this user; the token
+   *  binds to the payer regardless of which tenant is activated. */
   username: string;
   /** The hosting SKU for the chosen term (e.g. "200hosting"). */
   sku: string;
+  /** Optional: activate a DIFFERENT tenant than the payer -- e.g. a community (hive-NNNNN) whose
+   *  owner (the `username` above) pays. Omit for a personal blog (the payer's own account is
+   *  activated). The parent MUST include this in the component `key` so a target change remounts
+   *  with a fresh nonce (the intent is minted once per mount). */
+  hostingTarget?: string;
   payLabel: string;
   returnUrl: string;
   onActivated: () => void;
@@ -37,12 +43,14 @@ interface Props {
  * Card payment for hosting, riding the shared ePoints Stripe rail: create a PaymentIntent for
  * a hosting SKU via vapi, confirm with the Payment Element, then poll the order status. For a
  * hosting SKU the order reaching "success" means ePoints has already called the hosting
- * service's activate endpoint, so the blog is live. The tenant must already exist (the signup
- * flow creates it before this renders).
+ * service's activate endpoint, so the blog is live. The activated tenant is `hostingTarget` when
+ * supplied (e.g. a community), otherwise the payer's own account. The tenant must already exist
+ * (the signup flow creates it before this renders).
  */
 export function HostingCardCheckout({
   username,
   sku,
+  hostingTarget,
   payLabel,
   returnUrl,
   onActivated,
@@ -63,7 +71,7 @@ export function HostingCardCheckout({
     let alive = true;
     (async () => {
       try {
-        const { client_secret } = await createIntent.mutateAsync({ sku, nonce });
+        const { client_secret } = await createIntent.mutateAsync({ sku, nonce, hosting_target: hostingTarget });
         if (alive) setClientSecret(client_secret);
       } catch (e) {
         if (alive) setError((e as Error).message || i18next.t("hosting.card-unavailable"));

--- a/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
@@ -9,7 +9,7 @@ import {
 import { Elements } from "@stripe/react-stripe-js";
 import { Alert } from "@ui/alert";
 import i18next from "i18next";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const isDarkMode = () =>
   typeof document !== "undefined" && document.documentElement.classList.contains("dark");
@@ -56,7 +56,10 @@ export function HostingCardCheckout({
   onActivated,
   onConfirmed
 }: Props) {
-  const [nonce] = useState(genNonce);
+  // The nonce is the create-intent idempotency key, so it must change when the checkout identity
+  // (sku or target tenant) changes; otherwise a re-mint for a new target would return the
+  // PaymentIntent already created for the previous one. Fresh nonce per (sku, hostingTarget).
+  const nonce = useMemo(genNonce, [sku, hostingTarget]);
   const [clientSecret, setClientSecret] = useState("");
   const [error, setError] = useState("");
   const [activating, setActivating] = useState(false);

--- a/apps/web/src/features/shared/purchase-stripe/use-stripe-points-purchase.ts
+++ b/apps/web/src/features/shared/purchase-stripe/use-stripe-points-purchase.ts
@@ -21,11 +21,24 @@ export interface StripeOrderStatus {
  * Points are all decided server-side; we only send the SKU and a stable per-checkout
  * nonce (so a double-submit returns the same intent instead of charging twice). Credits
  * the authenticated user.
+ *
+ * `hosting_target` is optional and only meaningful on the hosting rail: it activates a
+ * DIFFERENT tenant than the buyer (e.g. a community hive-NNNNN whose owner pays). The order
+ * still binds to the authenticated `username` (the payer); only the activated tenant differs.
+ * ePoints validates it and ignores it on every non-hosting rail.
  */
 export function useCreateStripeIntent(username?: string) {
   return useMutation({
     mutationKey: ["stripe-create-intent", username],
-    mutationFn: async ({ sku, nonce }: { sku: string; nonce: string }) => {
+    mutationFn: async ({
+      sku,
+      nonce,
+      hosting_target
+    }: {
+      sku: string;
+      nonce: string;
+      hosting_target?: string;
+    }) => {
       // Await the background token refresh first (a long-lived session can hold a stale
       // token that getAccessToken would return as-is, failing this first call).
       const code = await ensureValidToken(username ?? "");
@@ -34,7 +47,7 @@ export function useCreateStripeIntent(username?: string) {
       }
       const resp = await appAxios.post<CreateIntentResult>(
         apiBase("/private-api/stripe-create-intent"),
-        { code, sku, nonce }
+        { code, sku, nonce, hosting_target }
       );
       return resp.data;
     }


### PR DESCRIPTION
Adds the reusable client rail for paying hosting by card for a tenant that is not the buyer (needed for community instances, where the owner pays but the tenant to activate is the community `hive-NNNNN`). Pairs with ePoints and vision-api PRs of the same name.

## Changes
- `useCreateStripeIntent`: the mutation input accepts an optional `hosting_target`, forwarded to the create-intent request. Only meaningful on the hosting rail; ignored elsewhere server-side.
- `HostingCardCheckout`: new optional `hostingTarget` prop. When set, the Stripe order still binds to the payer (`username`, so the token binds to who pays) and `hosting_target` is forwarded so the activated tenant differs. Omit for a personal blog (unchanged). The parent must include the target in the component `key` so a target change remounts with a fresh nonce (the intent is minted once per mount).

Personal blog checkout is unchanged (no target sent).

## Coordination with community signup (#1105)
#1105 adds the community signup UI and currently keeps card gated to the payer's own account (`!isCommunity`). To enable card for a community it consumes this prop:
- `cardEnabled`: allow the community case when the owner is logged in (drop the `!isCommunity` gate for the target-carrying path).
- Render: `<HostingCardCheckout username={activeUser.username} hostingTarget={tenantUsername} ... key={`${cardSku}:${tenantUsername}`} />` for a community, so the payer is the owner and the activated tenant is the community id.

This PR is intentionally scoped to the reusable checkout/hook so it can merge to develop independently of #1105 (it does not touch `hosting-signup.tsx` / `hosting-api.ts`).

## Typecheck
`npx tsc --noEmit` in apps/web: 212 errors, unchanged from the develop baseline (212). Zero new errors in the touched files.
