### PR TITLE
feat(hosting): add /hosting entry points on perks and home

### DIFF
--- a/apps/web/src/app/_components/landing-page/index.tsx
+++ b/apps/web/src/app/_components/landing-page/index.tsx
@@ -9,6 +9,7 @@ import { LandingDownloadLinks } from "./landing-download-links";
 import { Suspense } from "react";
 import { LandingTrending, LandingTrendingSkeleton } from "./landing-trending";
 import { LandingExplore } from "./landing-explore";
+import { hostingApi } from "@/features/hosting-signup/hosting-api";
 
 /**
  * Anonymous landing page — conversion-first, mobile-first.
@@ -146,6 +147,42 @@ export async function LandingPage() {
       {/* Topic hubs — crawl entry points into deep content */}
       <LandingExplore />
 
+      {/* Managed blog hosting promo. Subtle single-row card matching the site's
+          card vocabulary, gated on the same check the /hosting page uses so it
+          only shows when hosting is configured. Inline SVG keeps the @ui/svg
+          barrel off this path. */}
+      {hostingApi.isConfigured() && (
+        <section className="relative z-[2] w-full" aria-labelledby="hosting-promo-heading">
+          <div className="inner max-w-[1200px] mx-auto w-full px-4 py-4">
+            <Link
+              href="/hosting"
+              className="group flex flex-col sm:flex-row sm:items-center gap-4 sm:gap-5 rounded-2xl border border-[--border-color] bg-white dark:bg-dark-200 px-5 py-5 transition-shadow hover:shadow-md"
+            >
+              <span className="inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg bg-blue-dark-sky-040 dark:bg-dark-default text-blue-dark-sky">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path d="M4 4h16a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm1 5v9h14V9H5Zm1.5-3a1 1 0 1 0 0 2 1 1 0 0 0 0-2Zm3 0a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z" />
+                </svg>
+              </span>
+              <div className="min-w-0 flex-1">
+                <h2 id="hosting-promo-heading" className="text-lg font-semibold">
+                  {t("hosting.landing-title")}
+                </h2>
+                <p className="mt-1 opacity-70">{t("hosting.landing-description")}</p>
+              </div>
+              <span className="shrink-0 font-semibold text-blue-dark-sky group-hover:underline">
+                {t("hosting.landing-action")}
+              </span>
+            </Link>
+          </div>
+        </section>
+      )}
+
       {/* Why Ecency — compact value prop replacing the old illustrated sections */}
       <section className="relative z-[2] w-full" aria-labelledby="why-heading">
         <div className="inner max-w-[1200px] mx-auto w-full px-4 py-10">
@@ -272,7 +309,13 @@ export async function LandingPage() {
           </div>
 
           <div className="mt-8 flex items-center gap-3 border-t border-[--border-color] pt-6">
-            <img src={defaults.logo} alt={defaults.name} width={36} height={36} className="h-9 w-9" />
+            <img
+              src={defaults.logo}
+              alt={defaults.name}
+              width={36}
+              height={36}
+              className="h-9 w-9"
+            />
             <p className="m-0 text-sm opacity-60">
               {t("landing-page.copy-rights", { year: new Date().getFullYear() })}
             </p>

--- a/apps/web/src/app/perks/_page.tsx
+++ b/apps/web/src/app/perks/_page.tsx
@@ -4,12 +4,13 @@ import { BoostDialog } from "@/features/shared/boost";
 import { LoginRequired } from "@/features/shared/login-required";
 import { PurchaseQrDialog } from "@/features/shared/purchase-qr";
 import { EcencyConfigManager } from "@/config";
+import { hostingApi } from "@/features/hosting-signup/hosting-api";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { isProMember } from "@/features/pro";
 import { getProMembersQueryOptions } from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
 import i18next from "i18next";
-import { UilImages, UilStar } from "@tooni/iconscout-unicons-react";
+import { UilGlobe, UilImages, UilStar } from "@tooni/iconscout-unicons-react";
 import Image from "next/image";
 import Link from "next/link";
 import dynamic from "next/dynamic";
@@ -161,6 +162,24 @@ export function PerksPage() {
             </LoginRequired>
           </div>
         </EcencyConfigManager.Conditional>
+
+        {hostingApi.isConfigured() && (
+          <div className="col-span-6 row-span-2 md:col-span-3">
+            <Link href="/hosting">
+              <PerksBasicCard className="min-h-[13rem] cursor-pointer p-4">
+                <div className="relative z-10">
+                  <div className="md:text-lg font-bold text-blue-dark-sky">
+                    {i18next.t("hosting.perk-card-title")}
+                  </div>
+                  <div className="text-sm md:text-base text-gray-600 dark:text-gray-400">
+                    {i18next.t("hosting.perk-card-description")}
+                  </div>
+                </div>
+                <UilGlobe className="absolute -bottom-5 -right-3 w-28 h-28 text-blue-dark-sky opacity-10 pointer-events-none" />
+              </PerksBasicCard>
+            </Link>
+          </div>
+        )}
 
         <div id="perks-spin" className="col-span-12 md:col-span-6 row-span-2">
           <LoginRequired>

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -34,7 +34,12 @@
     "custom-domain-explainer": "Use your own domain like blog.yoursite.com. $3/mo total, billed with your hosting.",
     "custom-domain-included-note": "Custom domain is included on the $3/mo plan. Add and verify your domain right after checkout.",
     "custom-domain-hbd-note": "One step custom domain setup is available with card checkout. Pay by card to activate your custom domain in one go.",
-    "custom-domain-use-card": "Pay by card"
+    "custom-domain-use-card": "Pay by card",
+    "perk-card-title": "Your own blog",
+    "perk-card-description": "Host your Hive blog on your own space at yourname.blogs.ecency.com, or your own domain.",
+    "landing-title": "Host your own blog",
+    "landing-description": "Host your Hive blog on your own space at yourname.blogs.ecency.com, or your own domain.",
+    "landing-action": "Get started"
   },
   "custom-domain": {
     "title": "Add your custom domain",


### PR DESCRIPTION
Adds two discovery entry points to the existing `/hosting` signup page.

**Where**
- **Perks page** (`apps/web/src/app/perks/_page.tsx`): a hosting card in the same style as the other perk cards (Link + `PerksBasicCard` + background icon), placed alongside the AI generator card.
- **Home landing page** (`apps/web/src/app/_components/landing-page/index.tsx`): a subtle single-row promo card after the topic hubs, matching the page card vocabulary. Inline SVG, no icon barrel pulled onto the LCP path.

**Gating**
Both are gated on `hostingApi.isConfigured()`, the same check `/hosting` uses, so neither surfaces a link to a disabled page.

**Copy**
New strings in `en-US.json` under `hosting.*` (`perk-card-*`, `landing-*`).

Typecheck: no new errors vs baseline.