### PR TITLE
Hosting: enable card payment for community instances

### DIFF
--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -83,8 +83,11 @@ export function HostingSignup() {
   // authenticated buyer, and activation targets that account. A community is keyed by its id, not
   // by the buyer, so the on-chain HBD memo is the only rail that can target it. Keep card to a
   // personal blog owned by the buyer.
+  // Card is available when the logged-in account is the payer: for a personal blog that must be the
+  // blog account itself; for a community the owner (any logged-in account) pays and the community is
+  // activated via hostingTarget, so it does not need to equal the tenant.
   const cardEnabled =
-    !!methods?.card.enabled && !!activeUser && !isCommunity && tenantUsername === activeUser.username;
+    !!methods?.card.enabled && !!activeUser && (isCommunity || tenantUsername === activeUser.username);
 
   useEffect(() => {
     hostingApi.paymentMethods().then(setMethods).catch(() => setMethods(null));
@@ -410,8 +413,9 @@ export function HostingSignup() {
 
           {method === "card" && cardEnabled && (
             <HostingCardCheckout
-              key={cardSku}
-              username={tenantUsername}
+              key={`${cardSku}:${tenantUsername}`}
+              username={activeUser?.username ?? tenantUsername}
+              hostingTarget={isCommunity ? tenantUsername : undefined}
               sku={cardSku}
               payLabel={i18next.t("hosting.pay-now")}
               returnUrl={typeof window !== "undefined" ? window.location.href : ""}

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -413,7 +413,7 @@ export function HostingSignup() {
 
           {method === "card" && cardEnabled && (
             <HostingCardCheckout
-              key={`${cardSku}:${tenantUsername}`}
+              key={`${cardSku}:${tenantUsername}:${activeUser?.username ?? ""}`}
               username={activeUser?.username ?? tenantUsername}
               hostingTarget={isCommunity ? tenantUsername : undefined}
               sku={cardSku}


### PR DESCRIPTION
Completes the community card path. With the card rail now carrying an optional `hostingTarget` (merged), the signup enables card for a community: the logged-in owner is the payer and the community (`hostingTarget = communityId`) is the activated tenant. `cardEnabled` no longer excludes community, and the checkout keys on the target so changing it re-mounts. Personal blogs are unchanged (no target, payer equals tenant, HBD + card as before). Community keeps HBD too.