### PR TITLE
DecentMemes merge: match existing beneficiary accounts case-insensitively

### DIFF
--- a/apps/web/src/api/decentmemes/beneficiary.ts
+++ b/apps/web/src/api/decentmemes/beneficiary.ts
@@ -109,7 +109,8 @@ export function enforceDecentMemesBeneficiary(
     // Hive rejects any comment_options where a beneficiary equals the author,
     // so a widget that lists the author is silently filtered out rather than
     // failing the whole broadcast.
-    meme = meme.filter((b) => b.account !== author);
+    const authorLower = author.toLowerCase();
+    meme = meme.filter((b) => b.account.toLowerCase() !== authorLower);
   }
   const postCapped = scaleToCap(meme, maxMemeWeight);
   if (totalWeight(postCapped) < totalWeight(meme)) {
@@ -127,9 +128,12 @@ export function enforceDecentMemesBeneficiary(
   meme = headroomCapped;
 
   // 3. The slot limit only constrains brand-new accounts (bumps reuse a slot).
-  const existingAccounts = new Set(existing.map((b) => b.account));
-  const bumps = meme.filter((b) => existingAccounts.has(b.account));
-  let additions = meme.filter((b) => !existingAccounts.has(b.account));
+  // Existing rows can come from restored editor state with arbitrary casing;
+  // Hive treats account names case-insensitively, so match them that way to
+  // never emit two rows for the same account.
+  const existingAccounts = new Set(existing.map((b) => b.account.toLowerCase()));
+  const bumps = meme.filter((b) => existingAccounts.has(b.account.toLowerCase()));
+  let additions = meme.filter((b) => !existingAccounts.has(b.account.toLowerCase()));
 
   const slotHeadroom = Math.max(0, HIVE_MAX_BENEFICIARIES - existing.length);
   if (additions.length > slotHeadroom) {
@@ -138,9 +142,11 @@ export function enforceDecentMemesBeneficiary(
   }
 
   // 4. Apply bumps to existing entries, then append surviving new additions.
-  const bumpByAccount = new Map(bumps.map((b) => [b.account, b.weight]));
+  const bumpByAccount = new Map(bumps.map((b) => [b.account.toLowerCase(), b.weight]));
   const merged: BeneficiaryRoute[] = existing.map((b) =>
-    bumpByAccount.has(b.account) ? { ...b, weight: b.weight + bumpByAccount.get(b.account)! } : b
+    bumpByAccount.has(b.account.toLowerCase())
+      ? { ...b, weight: b.weight + bumpByAccount.get(b.account.toLowerCase())! }
+      : b
   );
   additions.forEach((b) => merged.push({ account: b.account, weight: b.weight }));
 

--- a/apps/web/src/api/decentmemes/beneficiary.ts
+++ b/apps/web/src/api/decentmemes/beneficiary.ts
@@ -102,6 +102,19 @@ export function enforceDecentMemesBeneficiary(
 ): EnforceResult {
   let dropped = false;
 
+  // 0. Canonicalize the existing rows: restored editor state can carry
+  //    arbitrary casing, but Hive account names are lowercase and the
+  //    broadcast rejects both invalid names and duplicate accounts. Lowercase
+  //    every account and merge case-variant duplicates by summing weights, so
+  //    every comparison below can be exact and every output row is valid.
+  const canonical = new Map<string, BeneficiaryRoute>();
+  for (const b of existing) {
+    const account = b.account.toLowerCase();
+    const prev = canonical.get(account);
+    canonical.set(account, prev ? { ...prev, weight: prev.weight + b.weight } : { ...b, account });
+  }
+  const normalizedExisting = Array.from(canonical.values());
+
   // 1. Clean the widget input (invalid account names / weights are dropped) and
   //    cap the meme contribution to the per-context maximum (10% post / 30% comment).
   let meme = aggregateMemeBeneficiaries(memeBeneficiaries);
@@ -119,7 +132,7 @@ export function enforceDecentMemesBeneficiary(
   meme = postCapped;
 
   // 2. Scale the whole meme contribution down to the remaining weight headroom.
-  const existingTotal = totalWeight(existing);
+  const existingTotal = totalWeight(normalizedExisting);
   const headroom = Math.max(0, HIVE_MAX_TOTAL_WEIGHT - existingTotal);
   const headroomCapped = scaleToCap(meme, headroom);
   if (totalWeight(headroomCapped) < totalWeight(meme)) {
@@ -128,31 +141,20 @@ export function enforceDecentMemesBeneficiary(
   meme = headroomCapped;
 
   // 3. The slot limit only constrains brand-new accounts (bumps reuse a slot).
-  // Existing rows can come from restored editor state with arbitrary casing;
-  // Hive treats account names case-insensitively, so match them that way to
-  // never emit two rows for the same account.
-  const existingAccounts = new Set(existing.map((b) => b.account.toLowerCase()));
-  const bumps = meme.filter((b) => existingAccounts.has(b.account.toLowerCase()));
-  let additions = meme.filter((b) => !existingAccounts.has(b.account.toLowerCase()));
+  const existingAccounts = new Set(normalizedExisting.map((b) => b.account));
+  const bumps = meme.filter((b) => existingAccounts.has(b.account));
+  let additions = meme.filter((b) => !existingAccounts.has(b.account));
 
-  const slotHeadroom = Math.max(0, HIVE_MAX_BENEFICIARIES - existing.length);
+  const slotHeadroom = Math.max(0, HIVE_MAX_BENEFICIARIES - normalizedExisting.length);
   if (additions.length > slotHeadroom) {
     additions = [...additions].sort((a, b) => b.weight - a.weight).slice(0, slotHeadroom);
     dropped = true;
   }
 
   // 4. Apply bumps to existing entries, then append surviving new additions.
-  const bumpByAccount = new Map(bumps.map((b) => [b.account.toLowerCase(), b.weight]));
-  const merged: BeneficiaryRoute[] = existing.map((b) =>
-    bumpByAccount.has(b.account.toLowerCase())
-      ? // normalize the merged row: Hive account names are lowercase, so a
-        // mixed-case restored row would fail the broadcast as an invalid name
-        {
-          ...b,
-          account: b.account.toLowerCase(),
-          weight: b.weight + bumpByAccount.get(b.account.toLowerCase())!
-        }
-      : b
+  const bumpByAccount = new Map(bumps.map((b) => [b.account, b.weight]));
+  const merged: BeneficiaryRoute[] = normalizedExisting.map((b) =>
+    bumpByAccount.has(b.account) ? { ...b, weight: b.weight + bumpByAccount.get(b.account)! } : b
   );
   additions.forEach((b) => merged.push({ account: b.account, weight: b.weight }));
 

--- a/apps/web/src/api/decentmemes/beneficiary.ts
+++ b/apps/web/src/api/decentmemes/beneficiary.ts
@@ -145,7 +145,13 @@ export function enforceDecentMemesBeneficiary(
   const bumpByAccount = new Map(bumps.map((b) => [b.account.toLowerCase(), b.weight]));
   const merged: BeneficiaryRoute[] = existing.map((b) =>
     bumpByAccount.has(b.account.toLowerCase())
-      ? { ...b, weight: b.weight + bumpByAccount.get(b.account.toLowerCase())! }
+      ? // normalize the merged row: Hive account names are lowercase, so a
+        // mixed-case restored row would fail the broadcast as an invalid name
+        {
+          ...b,
+          account: b.account.toLowerCase(),
+          weight: b.weight + bumpByAccount.get(b.account.toLowerCase())!
+        }
       : b
   );
   additions.forEach((b) => merged.push({ account: b.account, weight: b.weight }));

--- a/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
+++ b/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
@@ -190,12 +190,14 @@ describe("DecentMemes beneficiaries", () => {
     it("merges into a mixed-case existing row instead of adding a duplicate account", () => {
       // Restored editor state can carry arbitrary casing; Hive compares
       // account names case-insensitively, so "Ecency" and "ecency" are the
-      // same beneficiary and must never both appear.
+      // same beneficiary and must never both appear. The merged row is also
+      // normalized to lowercase, otherwise the broadcast would reject the
+      // invalid mixed-case account name.
       const existing: BeneficiaryRoute[] = [{ account: "Ecency", weight: 500 }];
       const { beneficiaries, dropped } = enforceDecentMemesBeneficiary(existing, [
         { account: "ecency", weight: 100, role: "frontend" } as any
       ]);
-      expect(beneficiaries).toEqual([{ account: "Ecency", weight: 600 }]);
+      expect(beneficiaries).toEqual([{ account: "ecency", weight: 600 }]);
       expect(dropped).toBe(false);
     });
 

--- a/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
+++ b/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
@@ -187,6 +187,18 @@ describe("DecentMemes beneficiaries", () => {
       expect(dropped).toBe(false);
     });
 
+    it("merges into a mixed-case existing row instead of adding a duplicate account", () => {
+      // Restored editor state can carry arbitrary casing; Hive compares
+      // account names case-insensitively, so "Ecency" and "ecency" are the
+      // same beneficiary and must never both appear.
+      const existing: BeneficiaryRoute[] = [{ account: "Ecency", weight: 500 }];
+      const { beneficiaries, dropped } = enforceDecentMemesBeneficiary(existing, [
+        { account: "ecency", weight: 100, role: "frontend" } as any
+      ]);
+      expect(beneficiaries).toEqual([{ account: "Ecency", weight: 600 }]);
+      expect(dropped).toBe(false);
+    });
+
     it("produces a list that always satisfies Hive limits", () => {
       const existing: BeneficiaryRoute[] = [
         { account: "a", weight: 4000 },

--- a/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
+++ b/apps/web/src/specs/api/decentmemes/beneficiary.spec.ts
@@ -201,6 +201,28 @@ describe("DecentMemes beneficiaries", () => {
       expect(dropped).toBe(false);
     });
 
+    it("normalizes a mixed-case existing row even when it receives no bump", () => {
+      const existing: BeneficiaryRoute[] = [{ account: "Ecency", weight: 500 }];
+      const { beneficiaries, dropped } = enforceDecentMemesBeneficiary(existing, [
+        { account: "alice", weight: 100, role: "creator" } as any
+      ]);
+      expect(beneficiaries).toContainEqual({ account: "ecency", weight: 500 });
+      expect(beneficiaries).toContainEqual({ account: "alice", weight: 100 });
+      expect(beneficiaries.length).toBe(2);
+      expect(dropped).toBe(false);
+    });
+
+    it("merges case-variant duplicates in the existing list by summing weights", () => {
+      const existing: BeneficiaryRoute[] = [
+        { account: "Ecency", weight: 300 },
+        { account: "ecency", weight: 200 }
+      ];
+      const { beneficiaries } = enforceDecentMemesBeneficiary(existing, [
+        { account: "ecency", weight: 100, role: "frontend" } as any
+      ]);
+      expect(beneficiaries).toEqual([{ account: "ecency", weight: 600 }]);
+    });
+
     it("produces a list that always satisfies Hive limits", () => {
       const existing: BeneficiaryRoute[] = [
         { account: "a", weight: 4000 },


### PR DESCRIPTION
- enforceDecentMemesBeneficiary matched existing rows and the author by exact string, so restored editor state carrying a mixed-case account (for example Ecency) could produce two rows for the same Hive account and fail the broadcast as a duplicate beneficiary.
- All merge comparisons (author filter, bump detection, slot additions) now compare lowercased account names; output keeps the original row casing.
- Spec covers the mixed-case existing-row merge.