### PR TITLE
Perks: Support Ecency discovery card

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/settings/_support-ecency.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/settings/_support-ecency.tsx
@@ -50,7 +50,9 @@ export function SupportEcencySettings() {
   );
 
   return (
-    <div className="bg-white rounded-xl p-3 flex flex-col gap-4">
+    // The id lets discovery entry points (e.g. the Perks page card) deep-link
+    // straight to this card; scroll-mt keeps it clear of the fixed navbar.
+    <div id="support-ecency" className="bg-white rounded-xl p-3 flex flex-col gap-4 scroll-mt-20">
       <div className="text-gray-600 dark:text-gray-400 text-sm flex items-center gap-2">
         <UilHeart className="w-4 h-4" />
         {i18next.t("support-ecency.title")}

--- a/apps/web/src/app/perks/_page.tsx
+++ b/apps/web/src/app/perks/_page.tsx
@@ -11,7 +11,7 @@ import { isProMember } from "@/features/pro";
 import { getProMembersQueryOptions } from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
 import i18next from "i18next";
-import { UilGift, UilGlobe, UilImages, UilStar } from "@tooni/iconscout-unicons-react";
+import { UilGift, UilGlobe, UilHeart, UilImages, UilStar } from "@tooni/iconscout-unicons-react";
 import Image from "next/image";
 import Link from "next/link";
 import dynamic from "next/dynamic";
@@ -199,6 +199,24 @@ export function PerksPage() {
             </Link>
           </div>
         )}
+
+        <div className="col-span-6 row-span-2 md:col-span-3">
+          <LoginRequired>
+            <Link href={`/@${username}/settings#support-ecency`}>
+              <PerksBasicCard className="min-h-[13rem] cursor-pointer p-4">
+                <div className="relative z-10">
+                  <div className="md:text-lg font-bold text-blue-dark-sky">
+                    {i18next.t("support-ecency.perk-card-title")}
+                  </div>
+                  <div className="text-sm md:text-base text-gray-600 dark:text-gray-400">
+                    {i18next.t("support-ecency.perk-card-description")}
+                  </div>
+                </div>
+                <UilHeart className="absolute -bottom-5 -right-3 w-28 h-28 text-blue-dark-sky opacity-10 pointer-events-none" />
+              </PerksBasicCard>
+            </Link>
+          </LoginRequired>
+        </div>
 
         <div id="perks-spin" className="col-span-12 md:col-span-6 row-span-2">
           <LoginRequired>

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1902,7 +1902,9 @@
     "curation-hint": "Ecency pays a daily curation reward share to its Hive Power delegators. Choose what percent of that daily payout you want Ecency to keep as support.",
     "delegate-link": "Want to support with a Hive Power delegation to @ecency? Open your Hive Power wallet.",
     "add-chip": "Add 5% beneficiary to support Ecency",
-    "limits-reached": "Could not add the Ecency beneficiary because this post already uses all beneficiary slots or rewards."
+    "limits-reached": "Could not add the Ecency beneficiary because this post already uses all beneficiary slots or rewards.",
+    "perk-card-title": "Support Ecency",
+    "perk-card-description": "Add a small percent of your post rewards for @ecency as a beneficiary. Delegators can also leave part of their daily curation share as support."
   },
   "gif-picker": {
     "filter-placeholder": "Filter",


### PR DESCRIPTION
- Adds a Support Ecency card to the Perks grid following the existing perk card pattern; it links to the active user's settings at /@username/settings#support-ecency and, like sibling login-gated cards, is hidden for logged-out visitors
- Adds id="support-ecency" with a scroll margin to the Support Ecency settings card so the deep link lands below the fixed navbar
- New strings live under the existing support-ecency block in en-US.json