### PR TITLE
feat(waves): onboarding checklist card for new users + empty-feed state

### DIFF
--- a/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
@@ -27,6 +27,7 @@ import { Entry } from "@/entities";
 import { JsonLd, buildBreadcrumbJsonLd } from "@/features/structured-data";
 import { getServerAppBase } from "@/utils/server-app-base";
 import defaults from "@/defaults";
+import { WavesOnboardingChecklist } from "@/features/waves/components/waves-onboarding-checklist";
 
 interface Props {
   params: Promise<{ sections: string[] }>;
@@ -127,6 +128,9 @@ export default async function FeedPage({ params, searchParams }: Props) {
     >
       {breadcrumbJsonLd && <JsonLd data={breadcrumbJsonLd} />}
       <FeedLayout tag={tag} filter={filter} observer={observer}>
+        {/* Personal feed (/@user/feed) is where new users land after login;
+            the card self-gates to fresh accounts and renders nothing otherwise. */}
+        {filter === "feed" && <WavesOnboardingChecklist />}
         <FeedList filter={filter} tag={tag} observer={observer} />
         {olderCursor && (
           <EntryArchivePager basePath={basePath} olderCursor={olderCursor} showLatest={false} />

--- a/apps/web/src/app/waves/_components/waves-list-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-view.tsx
@@ -56,10 +56,12 @@ export function WavesListView({ feedType, username }: Props) {
   // The Following feed needs a username; without one `following` drops and the
   // query would silently become the unfiltered combined feed, so gate it until
   // the active user is known.
-  const { data, fetchNextPage, isError, error, hasNextPage, refetch } = useInfiniteQuery({
-    ...queryOptions,
-    enabled: feedType !== "following" || !!username
-  });
+  const { data, fetchNextPage, isError, error, hasNextPage, isFetched, refetch } = useInfiniteQuery(
+    {
+      ...queryOptions,
+      enabled: feedType !== "following" || !!username
+    }
+  );
   const previousErrorMessage = useRef<string | undefined>(undefined);
 
   useEffect(() => {
@@ -211,6 +213,19 @@ export function WavesListView({ feedType, username }: Props) {
               {i18next.t("g.retry", { defaultValue: "Retry" })}
             </Button>
           </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Genuinely-empty feed (first page fetched fine, nothing to show and nothing
+  // left to paginate) — e.g. a tag/source with no waves or a fresh Following feed.
+  if (isFetched && !isError && combinedDataFlow.length === 0 && !hasNextPage) {
+    return (
+      <div className="rounded-2xl bg-white dark:bg-dark-200 p-4 text-sm text-gray-700 dark:text-gray-300">
+        <div className="font-semibold">{i18next.t("waves.feed.empty-title")}</div>
+        <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+          {i18next.t("waves.feed.empty-subtitle")}
         </div>
       </div>
     );

--- a/apps/web/src/app/waves/_page.tsx
+++ b/apps/web/src/app/waves/_page.tsx
@@ -17,6 +17,7 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useGlobalStore } from "@/core/global-store";
 import { useWavesCustomFeeds, normalizeWaveTag } from "@/app/waves/_hooks";
 import { SHORTS_SOURCE, WAVE_HOST_LABELS } from "@/features/waves/consts/host-labels";
+import { WavesOnboardingChecklist } from "@/features/waves/components/waves-onboarding-checklist";
 import { WavesFeedType } from "@/app/waves/_constants";
 
 export function WavesPage() {
@@ -103,6 +104,7 @@ export function WavesPage() {
         onSelectSource={selectSource}
         onAdd={() => setShowCustomFeeds(true)}
       />
+      {!isShorts && <WavesOnboardingChecklist />}
       {!isShorts && <WavesCreateCard />}
       {showTagChip && (
         <div className="rounded-2xl bg-white dark:bg-dark-200 p-4 mb-4 flex flex-wrap items-center gap-3 text-sm">

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -3228,7 +3228,21 @@
   "waves": {
     "feed": {
       "for-you": "For you",
-      "following": "Following"
+      "following": "Following",
+      "empty-title": "No waves yet",
+      "empty-subtitle": "Be the first to say hello!"
+    },
+    "onboarding": {
+      "title": "Getting started",
+      "subtitle": "New here? Waves are short posts and the easiest way to jump in.",
+      "progress": "{{completed}}/{{total}}",
+      "dismiss": "Dismiss",
+      "item-wave": "Post your first Wave",
+      "item-vote": "Vote on a Wave you like",
+      "item-reply": "Reply to someone",
+      "item-checkin": "Check in to start your streak",
+      "all-done-title": "All done 🎉",
+      "all-done-subtitle": "You're all set. Keep the waves coming!"
     },
     "sources": "Sources",
     "reply-form-title": "Replying to",

--- a/apps/web/src/features/waves/components/index.ts
+++ b/apps/web/src/features/waves/components/index.ts
@@ -2,3 +2,4 @@ export * from "./wave-actions";
 export * from "./wave-form";
 export * from "./render";
 export * from "./wave-actions-loading";
+export * from "./waves-onboarding-checklist";

--- a/apps/web/src/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state.ts
+++ b/apps/web/src/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state.ts
@@ -1,0 +1,78 @@
+import type { QuestsResponse } from "@ecency/sdk";
+
+export type WavesOnboardingItemId = "wave" | "vote" | "reply" | "checkin";
+
+export interface WavesOnboardingItem {
+  id: WavesOnboardingItemId;
+  completed: boolean;
+}
+
+export interface WavesOnboardingState {
+  /** the account is fresh enough (or quiet enough) to be nudged */
+  eligible: boolean;
+  items: WavesOnboardingItem[];
+  completedCount: number;
+  totalCount: number;
+  allComplete: boolean;
+}
+
+const NEW_ACCOUNT_WINDOW_DAYS = 30;
+const NEW_ACCOUNT_MAX_POSTS = 10;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function dailyProgress(quests: QuestsResponse, id: string): number {
+  return quests.daily?.find((q) => q.id === id)?.progress ?? 0;
+}
+
+export function isNewAccount(
+  account: { created: string; post_count: number },
+  now = Date.now()
+): boolean {
+  // Hive timestamps come without a timezone marker but are UTC.
+  const created = account.created;
+  const createdAt = Date.parse(created.indexOf("Z") === -1 ? `${created}Z` : created);
+  const withinWindow =
+    Number.isFinite(createdAt) && now - createdAt <= NEW_ACCOUNT_WINDOW_DAYS * DAY_MS;
+  return withinWindow || account.post_count < NEW_ACCOUNT_MAX_POSTS;
+}
+
+/**
+ * Pure derivation of the waves onboarding checklist from the `/private-api/quests`
+ * response + account freshness. Daily quest progress resets at 00:00 UTC, so the
+ * caller passes completions it already latched to localStorage — a checklist item
+ * must never un-check itself the next day. Returns null until both inputs arrive
+ * so callers can distinguish "loading" from "nothing to show".
+ */
+export function deriveWavesOnboardingState(
+  quests: QuestsResponse | undefined,
+  account: { created: string; post_count: number } | null | undefined,
+  persistedCompleted: WavesOnboardingItemId[] = [],
+  now = Date.now()
+): WavesOnboardingState | null {
+  if (!quests || !account) {
+    return null;
+  }
+
+  const item = (id: WavesOnboardingItemId, liveComplete: boolean): WavesOnboardingItem => ({
+    id,
+    completed: liveComplete || persistedCompleted.includes(id)
+  });
+
+  const streak = quests.streak?.current ?? 0;
+  const items = [
+    item("wave", dailyProgress(quests, "post") > 0),
+    item("vote", dailyProgress(quests, "vote") > 0),
+    item("reply", dailyProgress(quests, "comment") > 0),
+    item("checkin", dailyProgress(quests, "checkin") > 0 || streak >= 1)
+  ];
+
+  const completedCount = items.filter((i) => i.completed).length;
+
+  return {
+    eligible: isNewAccount(account, now),
+    items,
+    completedCount,
+    totalCount: items.length,
+    allComplete: completedCount === items.length
+  };
+}

--- a/apps/web/src/features/waves/components/waves-onboarding-checklist/index.tsx
+++ b/apps/web/src/features/waves/components/waves-onboarding-checklist/index.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { useSynchronizedLocalStorage } from "@/utils";
+import { PREFIX } from "@/utils/local-storage";
+import { getQuestsQueryOptions } from "@ecency/sdk";
+import { useQuery } from "@tanstack/react-query";
+import { UilCheckCircle, UilTimes } from "@tooni/iconscout-unicons-react";
+import clsx from "clsx";
+import i18next from "i18next";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import {
+  deriveWavesOnboardingState,
+  WavesOnboardingItem,
+  WavesOnboardingItemId
+} from "./derive-waves-onboarding-state";
+
+/**
+ * Dismissible "Getting started" checklist for new accounts, nudging the first
+ * Wave as the entry action. Completion is derived from the daily quests API and
+ * latched per-user in localStorage so items never un-check when the daily
+ * window resets. Once every item is done it celebrates once, then hides for good.
+ */
+export function WavesOnboardingChecklist() {
+  const { activeUser } = useActiveAccount();
+
+  if (!activeUser) {
+    return null;
+  }
+
+  // Keyed by username so the per-user localStorage keys re-read on account switch.
+  return <ChecklistContent key={activeUser.username} username={activeUser.username} />;
+}
+
+function focusWaveComposer() {
+  const form = document.getElementById("wave-form");
+  if (!form) {
+    return;
+  }
+  form.scrollIntoView({ behavior: "smooth", block: "center" });
+  const textarea = form.querySelector("textarea");
+  textarea?.focus({ preventScroll: true });
+}
+
+function ChecklistContent({ username }: { username: string }) {
+  const { account } = useActiveAccount();
+  const { data: quests } = useQuery(getQuestsQueryOptions(username));
+
+  const [dismissed, setDismissed] = useSynchronizedLocalStorage<boolean>(
+    PREFIX + "_waves_onboarding_dismissed_" + username,
+    false
+  );
+  // Daily quest progress resets at 00:00 UTC; latch completions so a finished
+  // item stays checked on later days.
+  const [latched, setLatched] = useSynchronizedLocalStorage<WavesOnboardingItemId[]>(
+    PREFIX + "_waves_onboarding_done_" + username,
+    []
+  );
+  const [celebrated, setCelebrated] = useSynchronizedLocalStorage<boolean>(
+    PREFIX + "_waves_onboarding_celebrated_" + username,
+    false
+  );
+  // Latched for this mount only: the completion state renders once, then the
+  // persisted flag hides the card on the next mount.
+  const [celebrating, setCelebrating] = useState(false);
+
+  const state = useMemo(
+    () => deriveWavesOnboardingState(quests, account, latched ?? []),
+    [quests, account, latched]
+  );
+
+  useEffect(() => {
+    if (!state) {
+      return;
+    }
+    const done = state.items.filter((i) => i.completed).map((i) => i.id);
+    const prev = latched ?? [];
+    if (done.some((id) => !prev.includes(id))) {
+      setLatched(done);
+    }
+  }, [state, latched, setLatched]);
+
+  useEffect(() => {
+    if (state?.allComplete && !celebrated) {
+      setCelebrating(true);
+      setCelebrated(true);
+    }
+  }, [state?.allComplete, celebrated, setCelebrated]);
+
+  if (!state || !state.eligible || dismissed || (state.allComplete && !celebrating)) {
+    return null;
+  }
+
+  const pct = Math.round((state.completedCount / state.totalCount) * 100);
+
+  return (
+    <div className="rounded-2xl bg-white dark:bg-dark-200 p-4 mb-4 relative">
+      <button
+        type="button"
+        aria-label={i18next.t("waves.onboarding.dismiss")}
+        className="absolute top-3 right-3 p-1 rounded-full text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+        onClick={() => setDismissed(true)}
+      >
+        <UilTimes className="w-4 h-4" />
+      </button>
+      {state.allComplete ? (
+        <div className="flex flex-col gap-1 pr-8">
+          <div className="font-semibold">{i18next.t("waves.onboarding.all-done-title")}</div>
+          <div className="text-sm text-gray-600 dark:text-gray-400">
+            {i18next.t("waves.onboarding.all-done-subtitle")}
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-2 pr-8">
+            <div className="font-semibold">{i18next.t("waves.onboarding.title")}</div>
+            <span className="text-xs text-gray-600 dark:text-gray-400 tabular-nums shrink-0">
+              {i18next.t("waves.onboarding.progress", {
+                completed: state.completedCount,
+                total: state.totalCount
+              })}
+            </span>
+          </div>
+          <div className="text-sm text-gray-600 dark:text-gray-400">
+            {i18next.t("waves.onboarding.subtitle")}
+          </div>
+          <div className="h-1.5 w-full rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+            <div
+              style={{ width: `${pct}%` }}
+              className="h-full rounded-full bg-blue-dark-sky duration-300"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            {state.items.map((item) => (
+              <ChecklistRow key={item.id} item={item} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChecklistRow({ item }: { item: WavesOnboardingItem }) {
+  const label = i18next.t(`waves.onboarding.item-${item.id}`);
+  const content = (
+    <>
+      {item.completed ? (
+        <UilCheckCircle className="w-5 h-5 shrink-0 text-green-500" />
+      ) : (
+        <span className="w-5 h-5 shrink-0 rounded-full border-2 border-gray-300 dark:border-gray-600" />
+      )}
+      <span className={clsx("text-sm", item.completed && "line-through opacity-50")}>{label}</span>
+    </>
+  );
+  const rowClassName = "flex items-center gap-2.5 rounded-lg p-1.5 -mx-1.5";
+
+  if (!item.completed && item.id === "wave") {
+    return (
+      <button
+        type="button"
+        className={clsx(
+          rowClassName,
+          "text-left hover:bg-gray-100 dark:hover:bg-gray-800 text-blue-dark-sky font-semibold"
+        )}
+        onClick={focusWaveComposer}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  if (!item.completed && item.id === "checkin") {
+    return (
+      <Link
+        href="/perks"
+        className={clsx(
+          rowClassName,
+          "hover:bg-gray-100 dark:hover:bg-gray-800 text-blue-dark-sky font-semibold"
+        )}
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return <div className={rowClassName}>{content}</div>;
+}

--- a/apps/web/src/features/waves/components/waves-onboarding-checklist/index.tsx
+++ b/apps/web/src/features/waves/components/waves-onboarding-checklist/index.tsx
@@ -9,6 +9,7 @@ import { UilCheckCircle, UilTimes } from "@tooni/iconscout-unicons-react";
 import clsx from "clsx";
 import i18next from "i18next";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import {
   deriveWavesOnboardingState,
@@ -33,9 +34,12 @@ export function WavesOnboardingChecklist() {
   return <ChecklistContent key={activeUser.username} username={activeUser.username} />;
 }
 
-function focusWaveComposer() {
+// On /waves the composer is on the page; elsewhere (e.g. the personal feed,
+// where new users land after login) fall back to navigating there.
+function focusWaveComposer(navigateToWaves: () => void) {
   const form = document.getElementById("wave-form");
   if (!form) {
+    navigateToWaves();
     return;
   }
   form.scrollIntoView({ behavior: "smooth", block: "center" });
@@ -143,6 +147,7 @@ function ChecklistContent({ username }: { username: string }) {
 }
 
 function ChecklistRow({ item }: { item: WavesOnboardingItem }) {
+  const router = useRouter();
   const label = i18next.t(`waves.onboarding.item-${item.id}`);
   const content = (
     <>
@@ -164,7 +169,7 @@ function ChecklistRow({ item }: { item: WavesOnboardingItem }) {
           rowClassName,
           "text-left hover:bg-gray-100 dark:hover:bg-gray-800 text-blue-dark-sky font-semibold"
         )}
-        onClick={focusWaveComposer}
+        onClick={() => focusWaveComposer(() => router.push("/waves"))}
       >
         {content}
       </button>

--- a/apps/web/src/specs/features/waves/derive-waves-onboarding-state.spec.ts
+++ b/apps/web/src/specs/features/waves/derive-waves-onboarding-state.spec.ts
@@ -1,0 +1,148 @@
+import type { QuestsResponse } from "@ecency/sdk";
+
+import {
+  deriveWavesOnboardingState,
+  isNewAccount
+} from "@/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state";
+
+const NOW = Date.parse("2026-07-07T12:00:00Z");
+
+function makeQuests(overrides: {
+  post?: number;
+  vote?: number;
+  comment?: number;
+  checkin?: number;
+  streak?: Partial<QuestsResponse["streak"]>;
+}): QuestsResponse {
+  const { post = 0, vote = 0, comment = 0, checkin = 0, streak } = overrides;
+  return {
+    period: { day: "2026-07-07", week: "2026-W28", month: "2026-07", day_resets_in_secs: 3600 },
+    daily: [
+      {
+        id: "checkin",
+        progress: checkin,
+        reward_each: 1,
+        milestone: { progress: 0, at: 48, reward: 100 }
+      },
+      { id: "post", progress: post, cap: 3 },
+      { id: "comment", progress: comment, cap: 10 },
+      { id: "vote", progress: vote, cap: 30 }
+    ],
+    weekly: [],
+    monthly: [],
+    streak: { current: 0, best: 0, at_risk: false, ...streak }
+  };
+}
+
+function makeAccount(overrides: { created?: string; post_count?: number } = {}) {
+  return { created: "2026-07-01T00:00:00", post_count: 0, ...overrides };
+}
+
+describe("isNewAccount", () => {
+  it("treats an account created within the last 30 days as new", () => {
+    expect(isNewAccount({ created: "2026-06-20T00:00:00", post_count: 500 }, NOW)).toBe(true);
+  });
+
+  it("treats an older account with few posts as new", () => {
+    expect(isNewAccount({ created: "2020-01-01T00:00:00", post_count: 9 }, NOW)).toBe(true);
+  });
+
+  it("rejects an older, active account", () => {
+    expect(isNewAccount({ created: "2020-01-01T00:00:00", post_count: 10 }, NOW)).toBe(false);
+  });
+
+  it("falls back to post_count when the created date is malformed", () => {
+    expect(isNewAccount({ created: "not-a-date", post_count: 3 }, NOW)).toBe(true);
+    expect(isNewAccount({ created: "not-a-date", post_count: 300 }, NOW)).toBe(false);
+  });
+});
+
+describe("deriveWavesOnboardingState", () => {
+  it("returns null while the quests query has no data yet", () => {
+    expect(deriveWavesOnboardingState(undefined, makeAccount(), [], NOW)).toBeNull();
+  });
+
+  it("returns null while the account has not loaded", () => {
+    expect(deriveWavesOnboardingState(makeQuests({}), undefined, [], NOW)).toBeNull();
+    expect(deriveWavesOnboardingState(makeQuests({}), null, [], NOW)).toBeNull();
+  });
+
+  it("starts with every item incomplete for a fresh account", () => {
+    const state = deriveWavesOnboardingState(makeQuests({}), makeAccount(), [], NOW);
+    expect(state).toEqual({
+      eligible: true,
+      items: [
+        { id: "wave", completed: false },
+        { id: "vote", completed: false },
+        { id: "reply", completed: false },
+        { id: "checkin", completed: false }
+      ],
+      completedCount: 0,
+      totalCount: 4,
+      allComplete: false
+    });
+  });
+
+  it("marks items complete from daily quest progress", () => {
+    const state = deriveWavesOnboardingState(
+      makeQuests({ post: 1, comment: 2 }),
+      makeAccount(),
+      [],
+      NOW
+    );
+    expect(state).toMatchObject({
+      items: [
+        { id: "wave", completed: true },
+        { id: "vote", completed: false },
+        { id: "reply", completed: true },
+        { id: "checkin", completed: false }
+      ],
+      completedCount: 2,
+      allComplete: false
+    });
+  });
+
+  it("completes check-in via an active streak even without a check-in today", () => {
+    const state = deriveWavesOnboardingState(
+      makeQuests({ streak: { current: 2, best: 4 } }),
+      makeAccount(),
+      [],
+      NOW
+    );
+    expect(state?.items[3]).toEqual({ id: "checkin", completed: true });
+  });
+
+  it("keeps previously latched items complete after the daily window resets", () => {
+    const state = deriveWavesOnboardingState(makeQuests({}), makeAccount(), ["wave", "vote"], NOW);
+    expect(state).toMatchObject({
+      items: [
+        { id: "wave", completed: true },
+        { id: "vote", completed: true },
+        { id: "reply", completed: false },
+        { id: "checkin", completed: false }
+      ],
+      completedCount: 2
+    });
+  });
+
+  it("reports allComplete when live progress and latched items cover the list", () => {
+    const state = deriveWavesOnboardingState(
+      makeQuests({ vote: 3, checkin: 1 }),
+      makeAccount(),
+      ["wave", "reply"],
+      NOW
+    );
+    expect(state).toMatchObject({ completedCount: 4, totalCount: 4, allComplete: true });
+  });
+
+  it("flags established accounts as ineligible while still deriving items", () => {
+    const state = deriveWavesOnboardingState(
+      makeQuests({ post: 1 }),
+      makeAccount({ created: "2020-01-01T00:00:00", post_count: 1200 }),
+      [],
+      NOW
+    );
+    expect(state).toMatchObject({ eligible: false });
+    expect(state?.items[0]).toEqual({ id: "wave", completed: true });
+  });
+});


### PR DESCRIPTION
Adds a dismissible "Getting started" checklist card at the top of the Waves feed for new accounts (account younger than 30 days or fewer than 10 posts), nudging the first wave as the first action.

- Four items derived from the daily quests API and streak state: post your first wave, vote on a wave, reply to someone, check in to start your streak. Item 1 scrolls to and focuses the wave composer; item 4 links to /perks.
- Completion latches per user in synchronized localStorage so the daily quest reset at 00:00 UTC never un-checks an item.
- One-time "All done" celebration state, then the card stays hidden. Dismissible at any point.
- Pure derivation function with 11 specs, mirroring the quest-chip pattern.
- Adds a genuine empty state to the waves list view (previously only the error case rendered a message).

Typecheck clean vs develop baseline (no new errors); 52/52 specs pass across waves, quest-chip, and publish suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Waves onboarding checklist to guide new or eligible users through key actions.
  - Added a new empty-state view when a feed has no content.
  - Expanded in-app text for the Waves feed, onboarding steps, and completion messaging.

- **Bug Fixes**
  - Improved handling of truly empty feeds so users see a clear message instead of a blank or loading state.
  - Kept onboarding progress visible across daily resets, so completed steps stay checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->