### PR TITLE
fix(waves): onboarding checklist review fixes

### DIFF
--- a/apps/web/src/app/waves/_components/waves-list-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-view.tsx
@@ -325,7 +325,9 @@ export function WavesListView({ feedType, username }: Props) {
         );
       })}
 
-      <WavesListLoader data={dataFlow} failed={isError} isEndReached={!hasNextPage} />
+      {/* A disabled/not-yet-fetched query (e.g. Following before the active
+          user hydrates) must read as loading, not as an exhausted feed. */}
+      <WavesListLoader data={dataFlow} failed={isError} isEndReached={isFetched && !hasNextPage} />
       {shouldShowDetectBottom && <DetectBottom onBottom={() => fetchNextPage()} />}
 
       <WavesFastReplyDialog

--- a/apps/web/src/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state.ts
+++ b/apps/web/src/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state.ts
@@ -1,19 +1,74 @@
 import type { QuestsResponse } from "@ecency/sdk";
 
+import { PREFIX } from "@/utils/local-storage";
+
 export type WavesOnboardingItemId = "wave" | "vote" | "reply" | "checkin";
 
 /**
- * Window event fired on wave submit success. On chain a wave is a reply into
- * the waves container, so the quests endpoint counts it as comment activity,
- * not post: the only reliable "posted a wave" signal is the submit path itself.
- * The mounted checklist listens and latches the item.
+ * Window event fired when the submit path latches an onboarding item. On chain a
+ * wave — and a reply to a wave — is comment activity, so the quests endpoint
+ * cannot tell a posted wave from a reply: the submit path is the only reliable
+ * signal for the `wave` and `reply` items. The event carries the submitting
+ * `username` so a checklist mounted for a different account (e.g. after an
+ * account switch) ignores it; the submitting account is persisted directly
+ * regardless (see latchWavesOnboardingItem).
  */
 export const WAVES_ONBOARDING_LATCH_EVENT = "ecency-waves-onboarding-latch";
 
-export function dispatchWavesOnboardingLatch(id: WavesOnboardingItemId) {
-  if (typeof window !== "undefined") {
-    window.dispatchEvent(new CustomEvent(WAVES_ONBOARDING_LATCH_EVENT, { detail: id }));
+export interface WavesOnboardingLatchDetail {
+  username: string;
+  id: WavesOnboardingItemId;
+}
+
+/** localStorage key the checklist latches per-user completions under. Must stay
+ * in sync with the key used by the checklist component's useSynchronizedLocalStorage. */
+function onboardingDoneStorageKey(username: string): string {
+  return `${PREFIX}_waves_onboarding_done_${username}`;
+}
+
+/**
+ * Complete an onboarding item for a specific account from the submit path.
+ *
+ * The completion is persisted straight to the *submitting* account's localStorage
+ * key — passed in by the caller, not read from whatever account is active when an
+ * async submit resolves. This makes the latch reliable in the two cases the old
+ * fire-and-forget window event dropped: a wave posted from a page where the
+ * checklist is not mounted (no listener to catch the event), and a submit that
+ * resolves after the user switches accounts (the event would have marked the new
+ * account). A scoped event still lets a checklist mounted for that same user tick
+ * the item live.
+ */
+export function latchWavesOnboardingItem(username: string, id: WavesOnboardingItemId) {
+  if (typeof window === "undefined" || !username) {
+    return;
   }
+
+  const key = onboardingDoneStorageKey(username);
+  let current: WavesOnboardingItemId[] = [];
+  try {
+    const raw = window.localStorage.getItem(key);
+    const parsed = raw ? JSON.parse(raw) : [];
+    if (Array.isArray(parsed)) {
+      current = parsed;
+    }
+  } catch {
+    current = [];
+  }
+
+  if (!current.includes(id)) {
+    try {
+      window.localStorage.setItem(key, JSON.stringify([...current, id]));
+    } catch {
+      // Ignore storage quota/availability failures; a mounted checklist still
+      // ticks via the event below, and re-derivation re-latches on the next load.
+    }
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<WavesOnboardingLatchDetail>(WAVES_ONBOARDING_LATCH_EVENT, {
+      detail: { username, id }
+    })
+  );
 }
 
 export interface WavesOnboardingItem {
@@ -75,11 +130,14 @@ export function deriveWavesOnboardingState(
 
   const streak = quests.streak?.current ?? 0;
   const items = [
-    // No live quest signal: a wave advances the comment quest (it is a reply
-    // on chain), so this item completes only via the submit-path latch.
+    // No live quest signal for either item: on chain a wave and a reply are both
+    // comment activity, so the `comment` daily quest cannot tell them apart — a
+    // user's very first wave would otherwise also complete "reply" without them
+    // ever replying. Both complete only via the submit-path latch (see
+    // latchWavesOnboardingItem).
     item("wave", false),
     item("vote", dailyProgress(quests, "vote") > 0),
-    item("reply", dailyProgress(quests, "comment") > 0),
+    item("reply", false),
     item("checkin", dailyProgress(quests, "checkin") > 0 || streak >= 1)
   ];
 

--- a/apps/web/src/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state.ts
+++ b/apps/web/src/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state.ts
@@ -63,7 +63,8 @@ export function deriveWavesOnboardingState(
   persistedCompleted: WavesOnboardingItemId[] = [],
   now = Date.now()
 ): WavesOnboardingState | null {
-  if (!quests || !account) {
+  // Tolerate a truthy-but-partial account object; treat it as still loading.
+  if (!quests || typeof account?.created !== "string" || typeof account?.post_count !== "number") {
     return null;
   }
 

--- a/apps/web/src/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state.ts
+++ b/apps/web/src/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state.ts
@@ -2,6 +2,20 @@ import type { QuestsResponse } from "@ecency/sdk";
 
 export type WavesOnboardingItemId = "wave" | "vote" | "reply" | "checkin";
 
+/**
+ * Window event fired on wave submit success. On chain a wave is a reply into
+ * the waves container, so the quests endpoint counts it as comment activity,
+ * not post: the only reliable "posted a wave" signal is the submit path itself.
+ * The mounted checklist listens and latches the item.
+ */
+export const WAVES_ONBOARDING_LATCH_EVENT = "ecency-waves-onboarding-latch";
+
+export function dispatchWavesOnboardingLatch(id: WavesOnboardingItemId) {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent(WAVES_ONBOARDING_LATCH_EVENT, { detail: id }));
+  }
+}
+
 export interface WavesOnboardingItem {
   id: WavesOnboardingItemId;
   completed: boolean;
@@ -60,7 +74,9 @@ export function deriveWavesOnboardingState(
 
   const streak = quests.streak?.current ?? 0;
   const items = [
-    item("wave", dailyProgress(quests, "post") > 0),
+    // No live quest signal: a wave advances the comment quest (it is a reply
+    // on chain), so this item completes only via the submit-path latch.
+    item("wave", false),
     item("vote", dailyProgress(quests, "vote") > 0),
     item("reply", dailyProgress(quests, "comment") > 0),
     item("checkin", dailyProgress(quests, "checkin") > 0 || streak >= 1)

--- a/apps/web/src/features/waves/components/waves-onboarding-checklist/index.tsx
+++ b/apps/web/src/features/waves/components/waves-onboarding-checklist/index.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import {
   deriveWavesOnboardingState,
+  WAVES_ONBOARDING_LATCH_EVENT,
   WavesOnboardingItem,
   WavesOnboardingItemId
 } from "./derive-waves-onboarding-state";
@@ -84,6 +85,20 @@ function ChecklistContent({ username }: { username: string }) {
       setLatched(done);
     }
   }, [state, latched, setLatched]);
+
+  // Latch items completed by the submit path (a wave has no live quest signal,
+  // see WAVES_ONBOARDING_LATCH_EVENT in derive-waves-onboarding-state).
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const id = (e as CustomEvent<WavesOnboardingItemId>).detail;
+      const prev = latched ?? [];
+      if (!prev.includes(id)) {
+        setLatched([...prev, id]);
+      }
+    };
+    window.addEventListener(WAVES_ONBOARDING_LATCH_EVENT, handler);
+    return () => window.removeEventListener(WAVES_ONBOARDING_LATCH_EVENT, handler);
+  }, [latched, setLatched]);
 
   useEffect(() => {
     if (state?.allComplete && !celebrated) {

--- a/apps/web/src/features/waves/components/waves-onboarding-checklist/index.tsx
+++ b/apps/web/src/features/waves/components/waves-onboarding-checklist/index.tsx
@@ -15,7 +15,8 @@ import {
   deriveWavesOnboardingState,
   WAVES_ONBOARDING_LATCH_EVENT,
   WavesOnboardingItem,
-  WavesOnboardingItemId
+  WavesOnboardingItemId,
+  WavesOnboardingLatchDetail
 } from "./derive-waves-onboarding-state";
 
 /**
@@ -86,19 +87,25 @@ function ChecklistContent({ username }: { username: string }) {
     }
   }, [state, latched, setLatched]);
 
-  // Latch items completed by the submit path (a wave has no live quest signal,
-  // see WAVES_ONBOARDING_LATCH_EVENT in derive-waves-onboarding-state).
+  // Tick items the submit path completes live (a wave and a reply have no live
+  // quest signal, see WAVES_ONBOARDING_LATCH_EVENT in derive-waves-onboarding-state).
+  // Ignore latches for a different account: an async submit can resolve after the
+  // user switches accounts, and the submit path already persisted the submitting
+  // account's completion directly.
   useEffect(() => {
     const handler = (e: Event) => {
-      const id = (e as CustomEvent<WavesOnboardingItemId>).detail;
+      const detail = (e as CustomEvent<WavesOnboardingLatchDetail>).detail;
+      if (!detail || detail.username !== username) {
+        return;
+      }
       const prev = latched ?? [];
-      if (!prev.includes(id)) {
-        setLatched([...prev, id]);
+      if (!prev.includes(detail.id)) {
+        setLatched([...prev, detail.id]);
       }
     };
     window.addEventListener(WAVES_ONBOARDING_LATCH_EVENT, handler);
     return () => window.removeEventListener(WAVES_ONBOARDING_LATCH_EVENT, handler);
-  }, [latched, setLatched]);
+  }, [username, latched, setLatched]);
 
   useEffect(() => {
     if (state?.allComplete && !celebrated) {

--- a/apps/web/src/features/waves/hooks/use-wave-submit.ts
+++ b/apps/web/src/features/waves/hooks/use-wave-submit.ts
@@ -14,7 +14,7 @@ import { useActiveAccount } from "@/core/hooks";
 import { getQueryClient } from "@/core/react-query";
 import { getAccountFullQueryOptions } from "@ecency/sdk";
 import { scheduleQuestsRefresh } from "@/utils/refresh-quests";
-import { dispatchWavesOnboardingLatch } from "@/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state";
+import { latchWavesOnboardingItem } from "@/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state";
 
 interface Body {
   text: string;
@@ -149,10 +149,13 @@ export function useWaveSubmit(
       if (item) {
         onSuccess?.(item);
         scheduleQuestsRefresh(getQueryClient(), username);
-        // A brand-new top-level wave (not an edit, not a reply) completes the
-        // onboarding checklist's wave item; the quests API cannot signal it.
-        if (!editingEntry && !replySource) {
-          dispatchWavesOnboardingLatch("wave");
+        // A wave or a reply to a wave completes an onboarding checklist item the
+        // quests API cannot signal (both are comment activity on chain). Latch it
+        // scoped to the wave's actual author — not the active account, which may
+        // have changed while this async submit was in flight — so the correct
+        // user is credited. Edits complete nothing.
+        if (!editingEntry && item.author) {
+          latchWavesOnboardingItem(item.author, replySource ? "reply" : "wave");
         }
       }
     }

--- a/apps/web/src/features/waves/hooks/use-wave-submit.ts
+++ b/apps/web/src/features/waves/hooks/use-wave-submit.ts
@@ -14,6 +14,7 @@ import { useActiveAccount } from "@/core/hooks";
 import { getQueryClient } from "@/core/react-query";
 import { getAccountFullQueryOptions } from "@ecency/sdk";
 import { scheduleQuestsRefresh } from "@/utils/refresh-quests";
+import { dispatchWavesOnboardingLatch } from "@/features/waves/components/waves-onboarding-checklist/derive-waves-onboarding-state";
 
 interface Body {
   text: string;
@@ -148,6 +149,11 @@ export function useWaveSubmit(
       if (item) {
         onSuccess?.(item);
         scheduleQuestsRefresh(getQueryClient(), username);
+        // A brand-new top-level wave (not an edit, not a reply) completes the
+        // onboarding checklist's wave item; the quests API cannot signal it.
+        if (!editingEntry && !replySource) {
+          dispatchWavesOnboardingLatch("wave");
+        }
       }
     }
   });

--- a/apps/web/src/specs/features/waves/derive-waves-onboarding-state.spec.ts
+++ b/apps/web/src/specs/features/waves/derive-waves-onboarding-state.spec.ts
@@ -104,6 +104,13 @@ describe("deriveWavesOnboardingState", () => {
     });
   });
 
+  it("returns null for a truthy but partial account object", () => {
+    expect(deriveWavesOnboardingState(makeQuests({}), {} as any, [], NOW)).toBeNull();
+    expect(
+      deriveWavesOnboardingState(makeQuests({}), { created: "2026-07-01T00:00:00" } as any, [], NOW)
+    ).toBeNull();
+  });
+
   it("completes check-in via an active streak even without a check-in today", () => {
     const state = deriveWavesOnboardingState(
       makeQuests({ streak: { current: 2, best: 4 } }),

--- a/apps/web/src/specs/features/waves/derive-waves-onboarding-state.spec.ts
+++ b/apps/web/src/specs/features/waves/derive-waves-onboarding-state.spec.ts
@@ -85,7 +85,7 @@ describe("deriveWavesOnboardingState", () => {
 
   it("marks items complete from daily quest progress", () => {
     const state = deriveWavesOnboardingState(
-      makeQuests({ post: 1, comment: 2 }),
+      makeQuests({ post: 1, vote: 4, checkin: 1 }),
       makeAccount(),
       [],
       NOW
@@ -95,13 +95,33 @@ describe("deriveWavesOnboardingState", () => {
         // A wave counts as comment activity on chain, so the wave item has no
         // live quest signal; it completes only via the submit-path latch.
         { id: "wave", completed: false },
-        { id: "vote", completed: false },
-        { id: "reply", completed: true },
-        { id: "checkin", completed: false }
+        { id: "vote", completed: true },
+        // Reply is likewise latch-only (see below); comment progress here comes
+        // from the wave, not a reply, so it must not complete.
+        { id: "reply", completed: false },
+        { id: "checkin", completed: true }
       ],
-      completedCount: 1,
+      completedCount: 2,
       allComplete: false
     });
+  });
+
+  it("does not complete the reply item from comment quest progress", () => {
+    // A brand-new top-level wave advances the daily `comment` quest (a wave is a
+    // comment on chain). The reply item must stay incomplete until the user
+    // actually replies, which the submit path latches separately.
+    const state = deriveWavesOnboardingState(
+      makeQuests({ comment: 5 }),
+      makeAccount(),
+      [],
+      NOW
+    );
+    expect(state?.items.find((i) => i.id === "reply")).toEqual({ id: "reply", completed: false });
+  });
+
+  it("keeps the reply item complete once the submit path has latched it", () => {
+    const state = deriveWavesOnboardingState(makeQuests({}), makeAccount(), ["reply"], NOW);
+    expect(state?.items.find((i) => i.id === "reply")).toEqual({ id: "reply", completed: true });
   });
 
   it("returns null for a truthy but partial account object", () => {

--- a/apps/web/src/specs/features/waves/derive-waves-onboarding-state.spec.ts
+++ b/apps/web/src/specs/features/waves/derive-waves-onboarding-state.spec.ts
@@ -92,12 +92,14 @@ describe("deriveWavesOnboardingState", () => {
     );
     expect(state).toMatchObject({
       items: [
-        { id: "wave", completed: true },
+        // A wave counts as comment activity on chain, so the wave item has no
+        // live quest signal; it completes only via the submit-path latch.
+        { id: "wave", completed: false },
         { id: "vote", completed: false },
         { id: "reply", completed: true },
         { id: "checkin", completed: false }
       ],
-      completedCount: 2,
+      completedCount: 1,
       allComplete: false
     });
   });
@@ -139,7 +141,7 @@ describe("deriveWavesOnboardingState", () => {
     const state = deriveWavesOnboardingState(
       makeQuests({ post: 1 }),
       makeAccount({ created: "2020-01-01T00:00:00", post_count: 1200 }),
-      [],
+      ["wave"],
       NOW
     );
     expect(state).toMatchObject({ eligible: false });


### PR DESCRIPTION
Follow-up to #1116, which merged before these two review fixes landed on the branch:

- Latch the "Post your first Wave" item from the wave submit path instead of the daily post quest: on chain a wave is a reply into the waves container, so the quests endpoint counts it as comment activity and the item never completed from the intended flow. New top-level waves (not edits, not replies) dispatch a window event; the checklist listens and latches.
- Guard the derivation against a truthy-but-partial account object (treated as still loading).
- Gate the waves list end-reached state on isFetched so a disabled Following query (before the active user hydrates) reads as loading instead of an exhausted feed.

28/28 waves specs pass; typecheck unchanged vs develop baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wave onboarding checklist progress now updates immediately after successfully submitting a wave or reply.
  * Completed wave and reply tasks persist across sessions and are tracked separately for each account.
* **Bug Fixes**
  * Following feeds remain in a loading state until data is available, instead of appearing exhausted prematurely.
  * Onboarding progress no longer advances incorrectly from unrelated daily quest activity.
  * Partial account data is handled safely while account details load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->