### PR TITLE
docs(sdk): correct module list in README

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.43
+
+### Patch Changes
+
+- docs(sdk): correct module list in README (#1121)
+
 ## 2.3.42
 
 ### Patch Changes

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -352,8 +352,10 @@ src/hive-tx/            built-in transaction engine (signing, serialization, RPC
 
 src/modules/
   accounts/           account data, relationships, mutations
+  ai/                 AI helpers (queries and mutations)
   analytics/          activity tracking and stats
   auth/               login, tokens, and auth helpers
+  bad-actors/         bad-actor list queries
   bridge/             bridge API helpers
   communities/        community queries and utils
   core/               config, client, query manager, helpers
@@ -364,13 +366,15 @@ src/modules/
   notifications/      notification queries and enums
   operations/         operation signing helpers
   points/             points queries and mutations
+  polls/              poll queries and mutations
   posts/              post queries, mutations, utils
   private-api/         private API helpers
   promotions/         promotion queries
   proposals/          proposal queries and mutations
+  quests/             quest queries and mutations
   resource-credits/   RC stats helpers
   search/             search queries
-  spk/                SPK data helpers
+  support/            support queries and mutations
   wallet/             wallet-related queries and types
   witnesses/          witness queries and votes
 ```

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -9,7 +9,7 @@ Built and maintained by [Ecency](https://ecency.com), an open-source social plat
 - **Built-in transaction engine** — create, sign, and broadcast Hive transactions with ECDSA secp256k1 cryptography, memo encryption, and full serialization for all 50 operation types (built on an improved version of [hive-tx](https://github.com/mahdiyari/hive-tx) by Mahdi Yari)
 - **Multi-node RPC with health tracking** — automatic failover across Hive API nodes with per-node failure tracking, rate-limit detection, stale-head awareness, and quorum-based consensus calls
 - **Query and mutation option builders** powered by [@tanstack/react-query](https://tanstack.com/query)
-- **24 domain modules**: accounts, posts, communities, market, wallet, notifications, analytics, integrations, core, auth, bridge, games, hive-engine, operations, points, private-api, promotions, proposals, resource-credits, search, spk, witnesses
+- **26 domain modules**: accounts, ai, analytics, auth, bad-actors, bridge, communities, core, games, hive-engine, integrations, market, notifications, operations, points, polls, posts, private-api, promotions, proposals, quests, resource-credits, search, support, wallet, witnesses
 - Central configuration via `CONFIG` / `ConfigManager` (RPC nodes, QueryClient, DMCA filtering)
 
 ## Why React Query?

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ecency/sdk",
   "private": false,
-  "version": "2.3.42",
+  "version": "2.3.43",
   "description": "Ecency SDK",
   "repository": {
     "type": "git",

--- a/packages/wallets/CHANGELOG.md
+++ b/packages/wallets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ecency/wallets
 
+## 5.0.42
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @ecency/sdk@2.3.43
+
 ## 5.0.41
 
 ### Patch Changes

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ecency/wallets",
   "private": false,
-  "version": "5.0.41",
+  "version": "5.0.42",
   "description": "Ecency wallets",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes a stale list in the SDK README: removes the decommissioned `spk` module and refreshes the list to the 26 modules that actually ship (adds `ai`, `bad-actors`, `polls`, `quests`, `support`), correcting the count.

Doc-only. Label to bump @ecency/sdk so the pending publish goes out on the now-pinned npm@11 (fixes the 2.3.42 that was stranded by the npm 12.0.0 sigstore regression).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the SDK README to show the current module list and directory layout.
  * Added release notes for the latest SDK and Wallets versions.
* **Chores**
  * Bumped the SDK package to **2.3.43** and Wallets to **5.0.42**.
  * Updated Wallets to use the newer SDK release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->