### PR TITLE
fix(chat): keep unread DMs visible so the badge stays clearable

### DIFF
--- a/apps/web/src/app/api/mattermost/channels/helpers.ts
+++ b/apps/web/src/app/api/mattermost/channels/helpers.ts
@@ -27,6 +27,53 @@ interface MattermostChannelMemberCounts {
   last_update_at?: number;
 }
 
+/** A channel is muted when the member opted out of unread marking (mobile parity). */
+export function isChannelMuted(member?: { notify_props?: { mark_unread?: string } }): boolean {
+  return member?.notify_props?.mark_unread === "mention";
+}
+
+/**
+ * A channel has never been viewed when the member has no meaningful
+ * `last_viewed_at`. Mattermost represents "never viewed" as either a missing
+ * value or the int64 zero (`0`), so both must count — otherwise a never-viewed
+ * DM slips through and floods the badge with historical messages. Such channels
+ * are excluded from the unread badge on purpose.
+ */
+export function isChannelNeverViewed(member?: { last_viewed_at?: number | null }): boolean {
+  return member?.last_viewed_at == null || member.last_viewed_at === 0;
+}
+
+/** Unread messages = total posts in the channel minus what the member has read. */
+export function channelUnreadMessageCount(
+  channel: { total_msg_count?: number },
+  member?: { msg_count?: number }
+): number {
+  return Math.max((channel.total_msg_count || 0) - (member?.msg_count || 0), 0);
+}
+
+/**
+ * Whether a DM contributes to the unread badge. This is the SINGLE source of
+ * truth shared by two routes that must agree:
+ *  - `channels/unreads` COUNTS such DMs into the badge, and
+ *  - `channels` force-SHOWS them in the list.
+ * If the two ever drift, a closed DM can show a badge count with no row to open
+ * and clear it — the "phantom unread" bug. A DM contributes when it is not
+ * muted, has been viewed at least once, and has unread messages.
+ */
+export function dmContributesToUnreadBadge(
+  channel: { total_msg_count?: number },
+  member?: {
+    msg_count?: number;
+    last_viewed_at?: number | null;
+    notify_props?: { mark_unread?: string };
+  }
+): boolean {
+  if (!member) return false;
+  if (isChannelMuted(member)) return false;
+  if (isChannelNeverViewed(member)) return false;
+  return channelUnreadMessageCount(channel, member) > 0;
+}
+
 // `/users/me/channels` returns the user's full channel list as a single
 // streamed response when no `page`/`per_page` are supplied. This matches
 // Client4.getAllTeamsChannels in the official Mattermost webapp and avoids

--- a/apps/web/src/app/api/mattermost/channels/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/route.ts
@@ -112,12 +112,38 @@ export async function GET() {
     // the team. Hide them since no Hive user intentionally joined these.
     const MATTERMOST_DEFAULT_CHANNELS = new Set(["town-square", "off-topic"]);
 
+    const channelMembersById = channelMembers.reduce<Record<string, MattermostChannelMemberCounts>>(
+      (acc, member) => {
+        acc[member.channel_id] = member;
+        return acc;
+      },
+      {}
+    );
+
+    // A DM contributes to the unread badge (see channels/unreads/route.ts) whenever
+    // it has unread messages and is neither muted nor never-viewed. Such a DM must
+    // stay visible in the list, otherwise the badge shows a count the user has no
+    // row to open and clear — the "phantom unread" bug for a closed (or
+    // uncategorized) DM that later receives a message.
+    const dmContributesToBadge = (channel: MattermostChannel) => {
+      const member = channelMembersById[channel.id];
+      if (!member) return false;
+      if (member.notify_props?.mark_unread === "mention") return false; // muted
+      if (member.last_viewed_at == null) return false; // never viewed
+      return (channel.total_msg_count || 0) > (member.msg_count || 0);
+    };
+
     const hasCategories = (categoriesResponse.categories || []).length > 0;
     const filteredChannels = channels.filter((channel) => {
       // Filter out Mattermost team default channels
       if (MATTERMOST_DEFAULT_CHANNELS.has(channel.name)) return false;
 
       if (channel.type !== "D") return true;
+
+      // Never hide a DM that contributes to the unread badge, regardless of the
+      // direct_channel_show preference or category membership. This keeps the
+      // badge clearable (the user always has a row to open and read).
+      if (dmContributesToBadge(channel)) return true;
 
       // Extract the other user ID from channel name first
       const parts = channel.name?.split("__") ?? [];
@@ -143,14 +169,6 @@ export async function GET() {
 
       return true;
     });
-
-    const channelMembersById = channelMembers.reduce<Record<string, MattermostChannelMemberCounts>>(
-      (acc, member) => {
-        acc[member.channel_id] = member;
-        return acc;
-      },
-      {}
-    );
 
     const directChannels = filteredChannels.filter((channel) => channel.type === "D");
     const usersById: Record<string, MattermostUser> = {};

--- a/apps/web/src/app/api/mattermost/channels/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/route.ts
@@ -5,7 +5,11 @@ import {
   handleMattermostError,
   mmUserFetch
 } from "@/server/mattermost";
-import { fetchAllChannelPages, fetchAllChannelMemberPages } from "./helpers";
+import {
+  fetchAllChannelPages,
+  fetchAllChannelMemberPages,
+  dmContributesToUnreadBadge
+} from "./helpers";
 
 interface MattermostChannel {
   id: string;
@@ -120,18 +124,13 @@ export async function GET() {
       {}
     );
 
-    // A DM contributes to the unread badge (see channels/unreads/route.ts) whenever
-    // it has unread messages and is neither muted nor never-viewed. Such a DM must
-    // stay visible in the list, otherwise the badge shows a count the user has no
-    // row to open and clear — the "phantom unread" bug for a closed (or
-    // uncategorized) DM that later receives a message.
-    const dmContributesToBadge = (channel: MattermostChannel) => {
-      const member = channelMembersById[channel.id];
-      if (!member) return false;
-      if (member.notify_props?.mark_unread === "mention") return false; // muted
-      if (member.last_viewed_at == null) return false; // never viewed
-      return (channel.total_msg_count || 0) > (member.msg_count || 0);
-    };
+    // A DM that contributes to the unread badge must stay visible in the list,
+    // otherwise the badge shows a count the user has no row to open and clear —
+    // the "phantom unread" bug for a closed (or uncategorized) DM that later
+    // receives a message. The rule lives in ./helpers so it stays identical to
+    // the unread-badge computation in channels/unreads/route.ts.
+    const dmContributesToBadge = (channel: MattermostChannel) =>
+      dmContributesToUnreadBadge(channel, channelMembersById[channel.id]);
 
     const hasCategories = (categoriesResponse.categories || []).length > 0;
     const filteredChannels = channels.filter((channel) => {

--- a/apps/web/src/app/api/mattermost/channels/unreads/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/unreads/route.ts
@@ -6,7 +6,13 @@ import {
   mmUserFetch
 } from "@/server/mattermost";
 import * as Sentry from "@sentry/nextjs";
-import { fetchAllChannelPages, fetchAllChannelMemberPages } from "../helpers";
+import {
+  fetchAllChannelPages,
+  fetchAllChannelMemberPages,
+  isChannelMuted,
+  isChannelNeverViewed,
+  channelUnreadMessageCount
+} from "../helpers";
 
 interface MattermostChannel {
   id: string;
@@ -179,11 +185,11 @@ export async function GET() {
     const channelsWithCounts = filteredChannels.map((channel) => {
       const member = memberByChannelId[channel.id];
 
-      // Muted channels: zero out all counts (mobile parity).
-      // Muted channels are hidden from the channel list so showing their
-      // unreads in the badge would be misleading.
-      const isMuted = member?.notify_props?.mark_unread === "mention";
-      if (isMuted) {
+      // Zero out muted channels (hidden from the list, so their unreads would
+      // mislead) and never-viewed channels (skipped to prevent a historical
+      // message flood). Both rules are shared with the channel-list route via
+      // ./helpers so the two stay in lockstep — see dmContributesToUnreadBadge.
+      if (isChannelMuted(member) || isChannelNeverViewed(member)) {
         return {
           channelId: channel.id,
           type: channel.type,
@@ -193,23 +199,11 @@ export async function GET() {
         };
       }
 
-      // Skip never-viewed channels to prevent historical message flood (mobile parity)
-      if (member?.last_viewed_at == null) {
-        return {
-          channelId: channel.id,
-          type: channel.type,
-          mention_count: 0,
-          message_count: 0,
-          thread_unread: 0
-        };
-      }
-
-      const unreadMessages = Math.max((channel.total_msg_count || 0) - (member?.msg_count || 0), 0);
       return {
         channelId: channel.id,
         type: channel.type,
         mention_count: member?.mention_count || 0,
-        message_count: unreadMessages,
+        message_count: channelUnreadMessageCount(channel, member),
         thread_unread: threadUnreadByChannel[channel.id] || 0
       };
     });

--- a/apps/web/src/specs/api/mattermost-dm-unread-visibility.spec.ts
+++ b/apps/web/src/specs/api/mattermost-dm-unread-visibility.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 /**
@@ -22,12 +23,15 @@ vi.mock("@/server/mattermost", () => ({
   mmUserFetch: (...args: unknown[]) => mockMmUserFetch(...args)
 }));
 
-vi.mock("@/app/api/mattermost/channels/helpers", () => ({
+// Keep the real badge/never-viewed predicates (the route now imports
+// dmContributesToUnreadBadge from here); only the network fetchers are stubbed.
+vi.mock("@/app/api/mattermost/channels/helpers", async () => ({
+  ...(await vi.importActual("@/app/api/mattermost/channels/helpers")),
   fetchAllChannelPages: (...args: unknown[]) => mockFetchAllChannelPages(...args),
   fetchAllChannelMemberPages: (...args: unknown[]) => mockFetchAllChannelMemberPages(...args)
 }));
 
-// Four closed DMs (direct_channel_show=false), each exercising one branch of the
+// Five closed DMs (direct_channel_show=false), each exercising one branch of the
 // "contributes to badge" rule.
 const CHANNELS = [
   // unread + viewed + not muted -> contributes -> must stay visible
@@ -36,8 +40,10 @@ const CHANNELS = [
   { id: "dm-read", name: "u-self__u-read", display_name: "", type: "D", total_msg_count: 3 },
   // muted with unread -> badge zeroes muted -> stays hidden
   { id: "dm-muted", name: "u-self__u-muted", display_name: "", type: "D", total_msg_count: 4 },
-  // never viewed -> badge skips never-viewed -> stays hidden
-  { id: "dm-neverviewed", name: "u-self__u-new", display_name: "", type: "D", total_msg_count: 2 }
+  // never viewed (last_viewed_at null) -> badge skips never-viewed -> stays hidden
+  { id: "dm-neverviewed", name: "u-self__u-new", display_name: "", type: "D", total_msg_count: 2 },
+  // never viewed (last_viewed_at 0, Mattermost's other "never" value) -> stays hidden
+  { id: "dm-neverviewed-zero", name: "u-self__u-zero", display_name: "", type: "D", total_msg_count: 2 }
 ];
 
 const MEMBERS = [
@@ -51,21 +57,24 @@ const MEMBERS = [
     last_viewed_at: 3000,
     notify_props: { mark_unread: "mention" }
   },
-  { user_id: "u-self", channel_id: "dm-neverviewed", mention_count: 0, msg_count: 0, last_viewed_at: null }
+  { user_id: "u-self", channel_id: "dm-neverviewed", mention_count: 0, msg_count: 0, last_viewed_at: null },
+  { user_id: "u-self", channel_id: "dm-neverviewed-zero", mention_count: 0, msg_count: 0, last_viewed_at: 0 }
 ];
 
 const PREFERENCES = [
   { user_id: "u-self", category: "direct_channel_show", name: "u-other", value: "false" },
   { user_id: "u-self", category: "direct_channel_show", name: "u-read", value: "false" },
   { user_id: "u-self", category: "direct_channel_show", name: "u-muted", value: "false" },
-  { user_id: "u-self", category: "direct_channel_show", name: "u-new", value: "false" }
+  { user_id: "u-self", category: "direct_channel_show", name: "u-new", value: "false" },
+  { user_id: "u-self", category: "direct_channel_show", name: "u-zero", value: "false" }
 ];
 
 const DM_USERS = [
   { id: "u-other", username: "other", delete_at: 0 },
   { id: "u-read", username: "readpartner", delete_at: 0 },
   { id: "u-muted", username: "mutedpartner", delete_at: 0 },
-  { id: "u-new", username: "newpartner", delete_at: 0 }
+  { id: "u-new", username: "newpartner", delete_at: 0 },
+  { id: "u-zero", username: "zeropartner", delete_at: 0 }
 ];
 
 describe("channels route — DM unread visibility", () => {
@@ -107,5 +116,10 @@ describe("channels route — DM unread visibility", () => {
   it("does not force-show a never-viewed DM (excluded from the badge)", async () => {
     const ids = await getChannelIds();
     expect(ids).not.toContain("dm-neverviewed");
+  });
+
+  it("treats last_viewed_at of 0 as never-viewed and keeps it hidden", async () => {
+    const ids = await getChannelIds();
+    expect(ids).not.toContain("dm-neverviewed-zero");
   });
 });

--- a/apps/web/src/specs/api/mattermost-dm-unread-visibility.spec.ts
+++ b/apps/web/src/specs/api/mattermost-dm-unread-visibility.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Regression test: a DM that contributes to the unread badge must stay visible
+ * in the channel list.
+ *
+ * The unread badge (channels/unreads/route.ts) counts a DM's unread messages
+ * regardless of the `direct_channel_show` preference. The channel list route
+ * used to hide any DM with `direct_channel_show=false`, so a closed DM that
+ * later received a message produced a "phantom" badge: a count with no row to
+ * open and clear. The list route now keeps such a DM visible.
+ */
+
+const mockMmUserFetch = vi.fn();
+const mockFetchAllChannelPages = vi.fn();
+const mockFetchAllChannelMemberPages = vi.fn();
+
+vi.mock("@/server/mattermost", () => ({
+  getMattermostTeamId: () => "team-123",
+  getMattermostTokenFromCookies: () => Promise.resolve("test-token"),
+  handleMattermostError: (err: unknown) => ({ error: String(err) }),
+  mmUserFetch: (...args: unknown[]) => mockMmUserFetch(...args)
+}));
+
+vi.mock("@/app/api/mattermost/channels/helpers", () => ({
+  fetchAllChannelPages: (...args: unknown[]) => mockFetchAllChannelPages(...args),
+  fetchAllChannelMemberPages: (...args: unknown[]) => mockFetchAllChannelMemberPages(...args)
+}));
+
+// Four closed DMs (direct_channel_show=false), each exercising one branch of the
+// "contributes to badge" rule.
+const CHANNELS = [
+  // unread + viewed + not muted -> contributes -> must stay visible
+  { id: "dm-unread", name: "u-self__u-other", display_name: "", type: "D", total_msg_count: 5 },
+  // read (msg_count == total) -> no unread -> stays hidden
+  { id: "dm-read", name: "u-self__u-read", display_name: "", type: "D", total_msg_count: 3 },
+  // muted with unread -> badge zeroes muted -> stays hidden
+  { id: "dm-muted", name: "u-self__u-muted", display_name: "", type: "D", total_msg_count: 4 },
+  // never viewed -> badge skips never-viewed -> stays hidden
+  { id: "dm-neverviewed", name: "u-self__u-new", display_name: "", type: "D", total_msg_count: 2 }
+];
+
+const MEMBERS = [
+  { user_id: "u-self", channel_id: "dm-unread", mention_count: 4, msg_count: 1, last_viewed_at: 1000 },
+  { user_id: "u-self", channel_id: "dm-read", mention_count: 0, msg_count: 3, last_viewed_at: 2000 },
+  {
+    user_id: "u-self",
+    channel_id: "dm-muted",
+    mention_count: 2,
+    msg_count: 0,
+    last_viewed_at: 3000,
+    notify_props: { mark_unread: "mention" }
+  },
+  { user_id: "u-self", channel_id: "dm-neverviewed", mention_count: 0, msg_count: 0, last_viewed_at: null }
+];
+
+const PREFERENCES = [
+  { user_id: "u-self", category: "direct_channel_show", name: "u-other", value: "false" },
+  { user_id: "u-self", category: "direct_channel_show", name: "u-read", value: "false" },
+  { user_id: "u-self", category: "direct_channel_show", name: "u-muted", value: "false" },
+  { user_id: "u-self", category: "direct_channel_show", name: "u-new", value: "false" }
+];
+
+const DM_USERS = [
+  { id: "u-other", username: "other", delete_at: 0 },
+  { id: "u-read", username: "readpartner", delete_at: 0 },
+  { id: "u-muted", username: "mutedpartner", delete_at: 0 },
+  { id: "u-new", username: "newpartner", delete_at: 0 }
+];
+
+describe("channels route — DM unread visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchAllChannelPages.mockResolvedValue(CHANNELS);
+    mockFetchAllChannelMemberPages.mockResolvedValue(MEMBERS);
+    mockMmUserFetch.mockImplementation((path: string) => {
+      if (path === "/users/me") return Promise.resolve({ id: "u-self", username: "self" });
+      if (path.includes("/channels/categories")) return Promise.resolve({ categories: [], order: [] });
+      if (path === "/users/me/preferences") return Promise.resolve(PREFERENCES);
+      if (path === "/users/ids") return Promise.resolve(DM_USERS);
+      return Promise.resolve([]);
+    });
+  });
+
+  async function getChannelIds() {
+    const { GET } = await import("@/app/api/mattermost/channels/route");
+    const res = await GET();
+    const body = await res.json();
+    return (body.channels as { id: string }[]).map((c) => c.id);
+  }
+
+  it("keeps a closed DM visible when it has unread messages", async () => {
+    const ids = await getChannelIds();
+    expect(ids).toContain("dm-unread");
+  });
+
+  it("still hides a closed DM that has been read", async () => {
+    const ids = await getChannelIds();
+    expect(ids).not.toContain("dm-read");
+  });
+
+  it("does not force-show a muted DM (excluded from the badge)", async () => {
+    const ids = await getChannelIds();
+    expect(ids).not.toContain("dm-muted");
+  });
+
+  it("does not force-show a never-viewed DM (excluded from the badge)", async () => {
+    const ids = await getChannelIds();
+    expect(ids).not.toContain("dm-neverviewed");
+  });
+});


### PR DESCRIPTION
### Problem

The chat unread badge and the DM list disagreed about closed DMs:

- **Badge** (`channels/unreads`): counts a DM's unread messages regardless of the `direct_channel_show` preference.
- **DM list** (`channels`): hid any DM with `direct_channel_show=false` (or, when categories exist, any DM not in a category).

So a DM that was closed in the sidebar and *later received a message* showed an unread count with **no row in the list to open and clear it** — a phantom unread that the user cannot dismiss from the UI. Native Mattermost re-opens a closed DM when a new message arrives; our custom list did not.

### Fix

In the channel-list route, never hide a DM that contributes to the unread badge. A DM is kept visible when it has unread messages and is neither muted nor never-viewed (mirroring exactly how `channels/unreads` decides a DM counts). Read, muted, and never-viewed closed DMs stay hidden as before, so no extra clutter.

### Tests

Adds `mattermost-dm-unread-visibility.spec.ts` driving the real route:

- closed DM with unread messages -> visible
- closed DM already read -> hidden
- muted DM with unread -> hidden
- never-viewed DM -> hidden


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed channel visibility so unread direct messages can stay visible even when they would normally be hidden.
  * Improved handling of direct message lists to better respect unread status while preserving existing visibility preferences for other channels.
  * Added coverage to prevent regressions in direct message unread visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->