### PR TITLE
fix(chat): keep realtime unread badge in lockstep with the route's eligibility

### DIFF
--- a/apps/web/src/app/api/mattermost/channels/unreads/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/unreads/route.ts
@@ -189,13 +189,17 @@ export async function GET() {
       // mislead) and never-viewed channels (skipped to prevent a historical
       // message flood). Both rules are shared with the channel-list route via
       // ./helpers so the two stay in lockstep — see dmContributesToUnreadBadge.
+      // `unread_eligible: false` tells the realtime updater not to grow the
+      // badge for these on a websocket post, otherwise the badge could count a
+      // channel the list route never shows (a phantom unread).
       if (isChannelMuted(member) || isChannelNeverViewed(member)) {
         return {
           channelId: channel.id,
           type: channel.type,
           mention_count: 0,
           message_count: 0,
-          thread_unread: 0
+          thread_unread: 0,
+          unread_eligible: false
         };
       }
 
@@ -204,7 +208,8 @@ export async function GET() {
         type: channel.type,
         mention_count: member?.mention_count || 0,
         message_count: channelUnreadMessageCount(channel, member),
-        thread_unread: threadUnreadByChannel[channel.id] || 0
+        thread_unread: threadUnreadByChannel[channel.id] || 0,
+        unread_eligible: true
       };
     });
 

--- a/apps/web/src/features/chat/mattermost-api.ts
+++ b/apps/web/src/features/chat/mattermost-api.ts
@@ -208,10 +208,16 @@ export function useMattermostMuteChannel() {
       return (await safeJson(res)) as { ok: boolean };
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: ["mattermost-channels"],
-        exact: false
-      });
+      // Refresh both caches: the channel list (mute state hides/shows the row)
+      // and the unread summary. The summary carries `unread_eligible`, which the
+      // realtime updater trusts; a mute toggle changes it, so the cached flag
+      // must be refetched or the badge would keep using the stale value until the
+      // periodic refetch (missing an unread after unmute, or over-counting after
+      // mute).
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["mattermost-channels"], exact: false }),
+        queryClient.invalidateQueries({ queryKey: ["mattermost-unread"], exact: false })
+      ]);
     }
   });
 }

--- a/apps/web/src/features/chat/mattermost-api.ts
+++ b/apps/web/src/features/chat/mattermost-api.ts
@@ -604,6 +604,11 @@ export interface MattermostUnreadChannel {
   mention_count: number;
   message_count: number;
   thread_unread: number;
+  // Whether the channel may contribute to the unread badge. The unreads route
+  // sets this to false for muted and never-viewed channels (which it keeps out
+  // of the badge); the realtime updater must not grow the badge for them.
+  // Optional so cached responses from an older route are treated as eligible.
+  unread_eligible?: boolean;
 }
 
 export interface MattermostUnreadSummary {

--- a/apps/web/src/features/chat/mattermost-websocket.ts
+++ b/apps/web/src/features/chat/mattermost-websocket.ts
@@ -722,7 +722,7 @@ export class MattermostWebSocket {
     if (channelId === this.channelId) return;
 
     this.queryClient.setQueriesData<{
-      channels: Array<{ channelId: string; type: string; mention_count: number; message_count: number; thread_unread?: number }>;
+      channels: Array<{ channelId: string; type: string; mention_count: number; message_count: number; thread_unread?: number; unread_eligible?: boolean }>;
       totalMentions: number;
       totalDMs: number;
       totalThreads?: number;
@@ -734,6 +734,12 @@ export class MattermostWebSocket {
 
       const target = data.channels.find((channel) => channel.channelId === channelId);
       if (!target) return data;
+
+      // Muted and never-viewed channels are deliberately kept out of the badge by
+      // the unreads route (unread_eligible === false). Growing the badge here would
+      // count a channel the list route never shows — a phantom unread. Skip them.
+      // (undefined means an older cached response: treat as eligible, no regression.)
+      if (target.unread_eligible === false) return data;
 
       const isDm = target.type === "D";
       // Compute effective unread before and after to get the delta

--- a/apps/web/src/specs/api/mattermost-unreads-eligibility.spec.ts
+++ b/apps/web/src/specs/api/mattermost-unreads-eligibility.spec.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * The unreads route must tag each channel with `unread_eligible`, mirroring the
+ * muted / never-viewed guard it applies to the badge counts. The realtime
+ * updater relies on this flag to avoid growing the badge for channels the
+ * channel-list route keeps hidden (the phantom-unread bug).
+ */
+
+const mockMmUserFetch = vi.fn();
+const mockFetchAllChannelPages = vi.fn();
+const mockFetchAllChannelMemberPages = vi.fn();
+
+vi.mock("@/server/mattermost", () => ({
+  getMattermostTeamId: () => "team-123",
+  getMattermostTokenFromCookies: () => Promise.resolve("test-token"),
+  handleMattermostError: (err: unknown) => ({ error: String(err) }),
+  mmUserFetch: (...args: unknown[]) => mockMmUserFetch(...args)
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  withScope: vi.fn(),
+  captureMessage: vi.fn()
+}));
+
+// Keep the real muted / never-viewed / unread-count helpers; stub only fetchers.
+vi.mock("@/app/api/mattermost/channels/helpers", async () => ({
+  ...(await vi.importActual("@/app/api/mattermost/channels/helpers")),
+  fetchAllChannelPages: (...args: unknown[]) => mockFetchAllChannelPages(...args),
+  fetchAllChannelMemberPages: (...args: unknown[]) => mockFetchAllChannelMemberPages(...args)
+}));
+
+const CHANNELS = [
+  { id: "c-normal", type: "O", name: "normal", total_msg_count: 5 },
+  { id: "c-read", type: "O", name: "read", total_msg_count: 3 },
+  { id: "c-muted", type: "O", name: "muted", total_msg_count: 4 },
+  { id: "c-neverviewed", type: "O", name: "nv", total_msg_count: 2 },
+  { id: "c-neverviewed-zero", type: "O", name: "nvz", total_msg_count: 2 }
+];
+
+const MEMBERS = [
+  { channel_id: "c-normal", mention_count: 1, msg_count: 1, last_viewed_at: 1000 },
+  { channel_id: "c-read", mention_count: 0, msg_count: 3, last_viewed_at: 2000 },
+  {
+    channel_id: "c-muted",
+    mention_count: 2,
+    msg_count: 0,
+    last_viewed_at: 3000,
+    notify_props: { mark_unread: "mention" }
+  },
+  { channel_id: "c-neverviewed", mention_count: 0, msg_count: 0, last_viewed_at: null },
+  { channel_id: "c-neverviewed-zero", mention_count: 0, msg_count: 0, last_viewed_at: 0 }
+];
+
+describe("channels/unreads route — unread_eligible flag", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchAllChannelPages.mockResolvedValue(CHANNELS);
+    mockFetchAllChannelMemberPages.mockResolvedValue(MEMBERS);
+    mockMmUserFetch.mockImplementation((path: string) => {
+      if (path === "/users/me") return Promise.resolve({ id: "u-self" });
+      if (path.includes("/threads")) return Promise.resolve({ threads: [] });
+      if (path === "/users/ids") return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
+  });
+
+  async function getChannels() {
+    const { GET } = await import("@/app/api/mattermost/channels/unreads/route");
+    const res = await GET();
+    const body = await res.json();
+    const byId: Record<string, { unread_eligible?: boolean; message_count: number }> = {};
+    for (const c of body.channels as Array<{
+      channelId: string;
+      unread_eligible?: boolean;
+      message_count: number;
+    }>) {
+      byId[c.channelId] = { unread_eligible: c.unread_eligible, message_count: c.message_count };
+    }
+    return byId;
+  }
+
+  it("marks a viewed channel with unread messages as eligible", async () => {
+    const byId = await getChannels();
+    expect(byId["c-normal"]).toEqual({ unread_eligible: true, message_count: 4 });
+  });
+
+  it("marks a fully-read channel as eligible with no unread", async () => {
+    const byId = await getChannels();
+    expect(byId["c-read"]).toEqual({ unread_eligible: true, message_count: 0 });
+  });
+
+  it("marks a muted channel ineligible and zeroed", async () => {
+    const byId = await getChannels();
+    expect(byId["c-muted"]).toEqual({ unread_eligible: false, message_count: 0 });
+  });
+
+  it("marks never-viewed channels ineligible (last_viewed_at null and 0)", async () => {
+    const byId = await getChannels();
+    expect(byId["c-neverviewed"]).toEqual({ unread_eligible: false, message_count: 0 });
+    expect(byId["c-neverviewed-zero"]).toEqual({ unread_eligible: false, message_count: 0 });
+  });
+});

--- a/apps/web/src/specs/features/chat/mattermost-mute-invalidation.spec.tsx
+++ b/apps/web/src/specs/features/chat/mattermost-mute-invalidation.spec.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useMattermostMuteChannel } from "@/features/chat/mattermost-api";
+
+/**
+ * Regression: toggling a channel's mute state must refresh the unread summary,
+ * not only the channel list. The summary carries `unread_eligible`, which the
+ * realtime updater trusts; without this invalidation the badge would keep using
+ * the stale flag until the periodic refetch (missing an unread after unmute, or
+ * over-counting after mute).
+ */
+describe("useMattermostMuteChannel", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ ok: true }))
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("invalidates both the channel list and the unread summary on success", async () => {
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useMattermostMuteChannel(), { wrapper });
+    await result.current.mutateAsync({ channelId: "c1", mute: true });
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map((call) => (call[0] as any)?.queryKey?.[0]);
+    expect(invalidatedKeys).toContain("mattermost-channels");
+    expect(invalidatedKeys).toContain("mattermost-unread");
+  });
+});

--- a/apps/web/src/specs/features/chat/mattermost-unread-increment.spec.ts
+++ b/apps/web/src/specs/features/chat/mattermost-unread-increment.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { MattermostWebSocket } from "@/features/chat/mattermost-websocket";
+
+/**
+ * Regression: the realtime unread updater must not grow the badge for channels
+ * the unreads route marks ineligible (muted / never-viewed). Otherwise a
+ * websocket post to such a channel raises a badge count the channel-list route
+ * never shows a row for — a phantom unread the user cannot clear.
+ */
+
+const UNREAD_KEY = ["mattermost-unread", "self"];
+
+type UnreadChannel = {
+  channelId: string;
+  type: string;
+  mention_count: number;
+  message_count: number;
+  thread_unread: number;
+  unread_eligible?: boolean;
+};
+
+function seed(qc: QueryClient, channels: UnreadChannel[]) {
+  qc.setQueryData(UNREAD_KEY, {
+    channels,
+    totalMentions: 0,
+    totalDMs: 0,
+    totalThreads: 0,
+    totalUnread: 0,
+    truncated: false
+  });
+}
+
+function increment(qc: QueryClient, channelId: string) {
+  const ws = new MattermostWebSocket().withQueryClient(qc);
+  (ws as unknown as { incrementUnreadCount: (id: string) => void }).incrementUnreadCount(channelId);
+  return qc.getQueryData<{ channels: UnreadChannel[]; totalDMs: number; totalUnread: number }>(
+    UNREAD_KEY
+  )!;
+}
+
+describe("MattermostWebSocket.incrementUnreadCount — badge eligibility", () => {
+  let qc: QueryClient;
+  beforeEach(() => {
+    qc = new QueryClient();
+  });
+
+  it("grows the badge for an eligible DM", () => {
+    seed(qc, [
+      { channelId: "dm-1", type: "D", mention_count: 0, message_count: 0, thread_unread: 0, unread_eligible: true }
+    ]);
+    const data = increment(qc, "dm-1");
+    expect(data.channels[0].message_count).toBe(1);
+    expect(data.totalDMs).toBe(1);
+    expect(data.totalUnread).toBe(1);
+  });
+
+  it("does not grow the badge for an ineligible (muted/never-viewed) DM", () => {
+    seed(qc, [
+      { channelId: "dm-x", type: "D", mention_count: 0, message_count: 0, thread_unread: 0, unread_eligible: false }
+    ]);
+    const data = increment(qc, "dm-x");
+    expect(data.channels[0].message_count).toBe(0);
+    expect(data.totalDMs).toBe(0);
+    expect(data.totalUnread).toBe(0);
+  });
+
+  it("treats a missing unread_eligible flag as eligible (older cached response)", () => {
+    seed(qc, [
+      { channelId: "dm-legacy", type: "D", mention_count: 0, message_count: 2, thread_unread: 0 }
+    ]);
+    const data = increment(qc, "dm-legacy");
+    expect(data.channels[0].message_count).toBe(3);
+    expect(data.totalDMs).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Follow-up to #1122 (DM unread visibility). That PR made the `channels/unreads` route and the channel-list route agree on which DMs contribute to the unread badge — but only on the **initial fetch**. The client's realtime updater diverges:

`incrementUnreadCount` (in `mattermost-websocket.ts`) grows the cached badge on **every** `posted` websocket event, with no muted/never-viewed guard. The unreads cache still contains muted and never-viewed channels at `message_count: 0`, so a websocket post to one of them raises the badge — while the channel-list route still hides the row. The result is a phantom unread reachable via the realtime path (raised by review on #1122).

## Fix

Make the optimistic realtime update match exactly what the route would compute on a refetch:

- The unreads route now tags every channel with **`unread_eligible`** — `false` for muted / never-viewed (the same guard it already uses to zero their counts), `true` otherwise.
- `incrementUnreadCount` **skips growing the badge when `unread_eligible === false`**.
- A missing flag (a response cached by the older route during rollout) is treated as eligible, so there is no regression.

No product behavior changes for normal (viewed, unmuted) channels; this only stops the badge from counting channels the list intentionally hides.

## Tests

- `mattermost-unreads-eligibility.spec.ts` (node env) — the route emits `unread_eligible` correctly for viewed/read/muted/never-viewed(null and 0) channels.
- `mattermost-unread-increment.spec.ts` — the updater grows the badge for eligible channels, leaves ineligible ones untouched, and treats a missing flag as eligible.

Full web suite green (2120), typecheck and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unread badges from increasing for muted or never-viewed channels.
  * Ensured eligible channels continue receiving accurate unread count updates.
  * Preserved existing behavior for cached data without eligibility information.

* **Tests**
  * Added coverage for channel eligibility, unread count handling, and realtime badge updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->