### PR TITLE
fix(rss): suppress crawler-induced upstream errors on feed routes

### DIFF
--- a/apps/web/src/features/rss/community-rss-handler.ts
+++ b/apps/web/src/features/rss/community-rss-handler.ts
@@ -1,8 +1,7 @@
 import { EntriesRssHandler } from "@/features/rss/entries-rss-handler";
+import { resolvePostSort } from "@/features/rss/valid-sorts";
 import { getPostsRankedInfiniteQueryOptions } from "@ecency/sdk";
 import { getQueryClient } from "@/core/react-query";
-
-const VALID_SORTS = ["trending", "hot", "created", "payout", "payout_comments", "muted"] as const;
 
 export class CommunityRssHandler extends EntriesRssHandler {
   private community = "";
@@ -13,7 +12,9 @@ export class CommunityRssHandler extends EntriesRssHandler {
     super();
     this.pathname = pathname;
     this.community = community;
-    this.tag = VALID_SORTS.includes(tag as (typeof VALID_SORTS)[number]) ? tag : "created";
+    // `tag` is the sort key here; clamp unknown crawler-supplied sorts to a
+    // bridge-accepted value to avoid an "Unsupported sort" RPCError.
+    this.tag = resolvePostSort(tag);
   }
 
   protected async fetchData() {

--- a/apps/web/src/features/rss/feed-rss-handler.ts
+++ b/apps/web/src/features/rss/feed-rss-handler.ts
@@ -1,4 +1,5 @@
 import { EntriesRssHandler } from "@/features/rss/entries-rss-handler";
+import { resolvePostSort } from "@/features/rss/valid-sorts";
 import { getPostsRankedInfiniteQueryOptions } from "@ecency/sdk";
 import { getQueryClient } from "@/core/react-query";
 
@@ -10,7 +11,10 @@ export class FeedRssHandler extends EntriesRssHandler {
   constructor(pathname: string, filter: string, tag = "created") {
     super();
     this.pathname = pathname;
-    this.filter = filter;
+    // `filter` is the sort key; crawlers hit /:filter/:tag/rss.xml with
+    // arbitrary segments, so clamp to a bridge-accepted sort to avoid an
+    // "Unsupported sort" RPCError (mirrors the community handler).
+    this.filter = resolvePostSort(filter);
     this.tag = tag;
   }
 

--- a/apps/web/src/features/rss/index.ts
+++ b/apps/web/src/features/rss/index.ts
@@ -3,3 +3,4 @@ export * from "./entries-rss-handler";
 export * from "./community-rss-handler";
 export * from "./feed-rss-handler";
 export * from "./rss-response";
+export * from "./valid-sorts";

--- a/apps/web/src/features/rss/rss-handler.ts
+++ b/apps/web/src/features/rss/rss-handler.ts
@@ -52,7 +52,10 @@ export function isTransientUpstreamError(e: unknown): boolean {
   const msg = String(err.message ?? "");
   return (
     /Unable to parse endpoint data/i.test(msg) ||
-    /HTTP 5\d\d/.test(msg) ||
+    // Upstream 5xx, and 429 rate-limits: a crawler fanning out across many feed
+    // paths trips the bridge/API rate limiter, which is a transient upstream
+    // condition (not an app bug), so treat it like the other upstream failures.
+    /HTTP (?:429|5\d\d)/.test(msg) ||
     /fetch failed/i.test(msg) ||
     // Hive's bridge rejects a bad tag/category two different ways depending on
     // the input: "...Tag does not exist" for a valid-but-missing one, and

--- a/apps/web/src/features/rss/valid-sorts.ts
+++ b/apps/web/src/features/rss/valid-sorts.ts
@@ -1,0 +1,29 @@
+/**
+ * The sort keys the Hive bridge accepts for a ranked-posts feed
+ * (`getPostsRankedInfiniteQueryOptions`). Any other value makes the bridge
+ * reject the request with `Assert Exception:Unsupported sort, valid sorts: ...`.
+ *
+ * Crawlers fan out across our RSS routes with arbitrary first path segments
+ * (e.g. `/subscribers/hive-116509/rss.xml`), so both the feed and community RSS
+ * handlers must clamp the caller-supplied sort to this set before querying —
+ * otherwise the bad sort surfaces as an error-level Sentry issue on every hit.
+ */
+export const VALID_POST_SORTS = [
+  "trending",
+  "hot",
+  "created",
+  "payout",
+  "payout_comments",
+  "muted"
+] as const;
+
+export type PostSort = (typeof VALID_POST_SORTS)[number];
+
+/**
+ * Return `sort` when it is a bridge-accepted sort, otherwise fall back to
+ * `created` — the safe default that always returns real content, matching the
+ * feed/community handler defaults.
+ */
+export function resolvePostSort(sort: string): string {
+  return (VALID_POST_SORTS as readonly string[]).includes(sort) ? sort : "created";
+}

--- a/apps/web/src/specs/features/rss-handler.spec.ts
+++ b/apps/web/src/specs/features/rss-handler.spec.ts
@@ -33,6 +33,15 @@ describe("isTransientUpstreamError", () => {
     expect(isTransientUpstreamError(new Error("fetch failed"))).toBe(true);
   });
 
+  it("treats an upstream 429 rate-limit as transient (crawler fanout trips the bridge limiter)", () => {
+    // ECENCY-NEXT-1E3Z: crawlers hammering /@user/rss get `HTTP 429 Rate
+    // Limited` from the bridge; that is upstream throttling, not an app bug.
+    expect(isTransientUpstreamError(new Error("HTTP 429 Rate Limited"))).toBe(true);
+    // A non-429/5xx client error must still surface as a real error.
+    expect(isTransientUpstreamError(new Error("HTTP 400 Bad Request"))).toBe(false);
+    expect(isTransientUpstreamError(new Error("HTTP 404 Not Found"))).toBe(false);
+  });
+
   it("does NOT suppress genuine application errors", () => {
     expect(isTransientUpstreamError(new Error("Cannot read properties of undefined"))).toBe(false);
     expect(isTransientUpstreamError(new Error("Assert Exception:something unrelated"))).toBe(false);

--- a/apps/web/src/specs/features/rss-valid-sorts.spec.ts
+++ b/apps/web/src/specs/features/rss-valid-sorts.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { VALID_POST_SORTS, resolvePostSort } from "@/features/rss/valid-sorts";
+
+describe("resolvePostSort", () => {
+  it("passes through every bridge-accepted sort unchanged", () => {
+    for (const sort of VALID_POST_SORTS) {
+      expect(resolvePostSort(sort)).toBe(sort);
+    }
+  });
+
+  it("falls back to `created` for crawler-supplied non-sort segments", () => {
+    // e.g. /subscribers/hive-116509/rss.xml — `subscribers` is a UI filter,
+    // not a ranked-posts sort, and the bridge rejects it with "Unsupported
+    // sort" (ECENCY-NEXT-1E0W). Clamp it instead of throwing.
+    expect(resolvePostSort("subscribers")).toBe("created");
+    expect(resolvePostSort("")).toBe("created");
+    expect(resolvePostSort("Trending")).toBe("created"); // case-sensitive; bridge is lowercase-only
+    expect(resolvePostSort("../../etc")).toBe("created");
+  });
+});


### PR DESCRIPTION
## Summary

Two crawler-driven, error-level issues on the RSS feed routes are environmental (upstream conditions), not app bugs. They add error-level noise without any user impact. This hardens the RSS handlers so both stop surfacing as errors.

### 1. `Unsupported sort` RPCError
Crawlers request `/:filter/:tag/rss.xml` (and the community equivalent) with arbitrary first path segments such as `/subscribers/...`. That segment is used as the ranked-posts sort, and the bridge rejects anything outside its accepted set with `Assert Exception:Unsupported sort, valid sorts: ...`.

The community handler already clamped its sort to a valid value, but the feed handler did not. This extracts the valid-sort list and a `resolvePostSort()` helper into a shared `valid-sorts.ts` and uses it in **both** handlers, so an unknown sort falls back to `created` (returns real content) instead of throwing.

### 2. `HTTP 429 Rate Limited`
A crawler fanning out across many feed paths trips the bridge/API rate limiter. This is a transient upstream condition, exactly like the 5xx / connection errors `isTransientUpstreamError()` already swallows. The matcher now treats `429` the same as `5xx`. Non-429/4xx client errors (400/404) still surface as real errors.

## Changes
- New `features/rss/valid-sorts.ts` with `VALID_POST_SORTS` + `resolvePostSort()`.
- `FeedRssHandler` and `CommunityRssHandler` both use the shared resolver (dedups the previously inline list).
- `isTransientUpstreamError()` matches `HTTP 429` in addition to `HTTP 5xx`.

## Tests
- `resolvePostSort` passes valid sorts through and clamps unknown segments to `created`.
- `isTransientUpstreamError` classifies a 429 as transient while keeping 400/404 as real errors.
- Existing RSS handler tests remain green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - RSS feeds now safely handle unsupported sorting values by falling back to a valid default.
  - Rate-limit responses are treated as temporary upstream issues, improving retry and recovery behavior.
  - Non-sort or malformed RSS inputs no longer reach downstream services.

- **Tests**
  - Added coverage for sort validation, fallback behavior, rate limiting, and preservation of valid sorting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->