### PR TITLE
Add translate.ecency.com to report-only CSP connect-src

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -398,6 +398,8 @@ const config = {
                 "https://o4507985141956608.ingest.de.sentry.io",
                 "https://api.coingecko.com https://api.giphy.com",
                 "https://studio.3speak.tv https://embed.3speak.tv https://3speak.tv https://poll.ecency.com",
+                // Post translation (LibreTranslate: /detect, /translate, /languages):
+                "https://translate.ecency.com",
                 "https://rpc.ankr.com https://bsc-dataseed.binance.org https://explorer.solana.com https://etherscan.io https://bscscan.com",
                 "wss://enotify.ecency.com",
                 // Feature dependencies surfaced by report-only monitoring:


### PR DESCRIPTION
Post translation calls LibreTranslate at translate.ecency.com (/detect, /translate, /languages) from the browser, but the host was missing from the Report-Only CSP connect-src inventory, so every translation logged a violation report. Adds it next to the other first-party service hosts.