### PR TITLE
Bound vapi container logs in the vision stack files

### DIFF
--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -20,9 +20,13 @@ services:
       - STRIPE_INTERNAL_SECRET
       - BLOCKSTREAM_CLIENT_ID
       - BLOCKSTREAM_CLIENT_SECRET
-      # Explicit default so the rendered stack spec is deterministic even when
-      # the deploy environment doesn't set it (compose v1 renders bare
-      # passthroughs of unset vars as null).
+      # Pinned to Warning at deploy time (the CI deploy env does not forward
+      # this variable, and compose v1 would render an unset bare passthrough as
+      # null). To enable per-request logs temporarily, set it directly on the
+      # running service:
+      #   docker service update --env-add Logging__LogLevel__Default=Information vision_vapi
+      # The next stack deploy resets it to Warning, so debug logging cannot be
+      # left on by accident.
       - Logging__LogLevel__Default=${Logging__LogLevel__Default:-Warning}
     restart: always
     # Bound container logs so vapi can never grow the host's json-file logs

--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -20,7 +20,19 @@ services:
       - STRIPE_INTERNAL_SECRET
       - BLOCKSTREAM_CLIENT_ID
       - BLOCKSTREAM_CLIENT_SECRET
+      # Explicit default so the rendered stack spec is deterministic even when
+      # the deploy environment doesn't set it (compose v1 renders bare
+      # passthroughs of unset vars as null).
+      - Logging__LogLevel__Default=${Logging__LogLevel__Default:-Warning}
     restart: always
+    # Bound container logs so vapi can never grow the host's json-file logs
+    # unchecked (the service itself defaults to Warning-level logging; set
+    # Logging__LogLevel__Default=Information for per-request logs).
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
     ports:
       - "4000:4000"
     hostname: vapi

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -19,9 +19,13 @@ services:
       - TURNSTILE_SECRET
       - BLOCKSTREAM_CLIENT_ID
       - BLOCKSTREAM_CLIENT_SECRET
-      # Explicit default so the rendered stack spec is deterministic even when
-      # the deploy environment doesn't set it (compose v1 renders bare
-      # passthroughs of unset vars as null).
+      # Pinned to Warning at deploy time (the CI deploy env does not forward
+      # this variable, and compose v1 would render an unset bare passthrough as
+      # null). To enable per-request logs temporarily, set it directly on the
+      # running service:
+      #   docker service update --env-add Logging__LogLevel__Default=Information vision_vapi
+      # The next stack deploy resets it to Warning, so debug logging cannot be
+      # left on by accident.
       - Logging__LogLevel__Default=${Logging__LogLevel__Default:-Warning}
     restart: always
     # Bound container logs so vapi can never grow the host's json-file logs

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -19,7 +19,19 @@ services:
       - TURNSTILE_SECRET
       - BLOCKSTREAM_CLIENT_ID
       - BLOCKSTREAM_CLIENT_SECRET
+      # Explicit default so the rendered stack spec is deterministic even when
+      # the deploy environment doesn't set it (compose v1 renders bare
+      # passthroughs of unset vars as null).
+      - Logging__LogLevel__Default=${Logging__LogLevel__Default:-Warning}
     restart: always
+    # Bound container logs so vapi can never grow the host's json-file logs
+    # unchecked (the service itself defaults to Warning-level logging; set
+    # Logging__LogLevel__Default=Information for per-request logs).
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
     ports:
       - "4000:4000"
     hostname: vapi


### PR DESCRIPTION
The vapi service spec in the stack files has no logging limits, so its json-file container logs can grow unchecked on the origin hosts — and any limits applied out-of-band with `docker service update` are reset by the next `docker stack deploy` from these files.

- Cap vapi logs at `max-size: 20m` / `max-file: 3` in both `docker-compose.yml` (staging) and `docker-compose.production.yml` (prod).
- Forward `Logging__LogLevel__Default` to the vapi container with an explicit `Warning` default, so the rendered spec is deterministic even when the deploy environment doesn't set the variable (compose v1 renders bare passthroughs of unset vars as null). The API service itself also defaults to Warning; setting the variable to `Information` in the deploy environment re-enables per-request logs when needed.

Verified by rendering both files with `docker-compose config` with the variable unset (renders `Warning`) and set (renders the override).