### PR TITLE
fix(ui): comment delete silently failing (confirm popover unmounted by dropdown click-away)

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-main-info-menu.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-main-info-menu.tsx
@@ -4,11 +4,9 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 
 import { Entry } from "@/entities";
 import i18next from "i18next";
-import { EntryDeleteBtn, EntryMenu } from "@/features/shared";
-import { useContext, useMemo } from "react";
-import { deleteForeverSvg, pencilOutlineSvg } from "@ui/svg";
-import { EntryPageContext } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/context";
-import * as ls from "@/utils/local-storage";
+import { EntryMenu } from "@/features/shared";
+import { useMemo } from "react";
+import { pencilOutlineSvg } from "@ui/svg";
 import { useRouter } from "next/navigation";
 import { makeEntryPath } from "@/utils";
 
@@ -20,56 +18,26 @@ export function EntryPageMainInfoMenu({ entry }: Props) {
   const { activeUser } = useActiveAccount();
 
   const router = useRouter();
-  const { setLoading } = useContext(EntryPageContext);
 
   const isComment = useMemo(() => !!entry.parent_author, [entry]);
   const isOwnEntry = useMemo(
     () => activeUser?.username === entry.author,
     [activeUser?.username, entry.author]
   );
-  const extraItems = useMemo(
-    () => {
-      const path = makeEntryPath(entry.category, entry.author, entry.permlink);
-      return [
-        ...(isOwnEntry && isComment && path !== "#"
-          ? [
-              {
-                label: i18next.t("g.edit"),
-                onClick: () => router.push(`${path}/edit`),
-                icon: pencilOutlineSvg
-              }
-            ]
-          : []),
-      ...(!(entry.children > 0 || entry.net_rshares > 0 || entry.is_paidout) &&
-      isOwnEntry &&
-      isComment
-        ? [
-            {
-              label: "",
-              onClick: () => {},
-              icon: (
-                <EntryDeleteBtn
-                  entry={entry}
-                  setDeleteInProgress={(value) => () => setLoading(true)}
-                  onSuccess={deleted}
-                >
-                  <a title={i18next.t("g.delete")} className="edit-btn">
-                    {deleteForeverSvg} {i18next.t("g.delete")}
-                  </a>
-                </EntryDeleteBtn>
-              )
-            }
-          ]
-        : [])
-      ];
-    },
-    [entry, isOwnEntry, isComment, router, setLoading]
-  );
-
-  const deleted = () => {
-    ls.set(`deletedComment`, entry?.post_id);
-    router.back();
-  };
+  // Delete is intentionally absent here: EntryMenu already generates its own
+  // delete item (modal confirm) for any deletable entry, comments included.
+  const extraItems = useMemo(() => {
+    const path = makeEntryPath(entry.category, entry.author, entry.permlink);
+    return isOwnEntry && isComment && path !== "#"
+      ? [
+          {
+            label: i18next.t("g.edit"),
+            onClick: () => router.push(`${path}/edit`),
+            icon: pencilOutlineSvg
+          }
+        ]
+      : [];
+  }, [entry, isOwnEntry, isComment, router]);
 
   return <EntryMenu entry={entry} separatedSharing={true} extraMenuItems={extraItems} />;
 }

--- a/apps/web/src/features/shared/entry-delete-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-delete-btn/index.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import React, { cloneElement, ReactElement } from "react";
+import React, { cloneElement, ReactElement, useEffect } from "react";
 import { Entry } from "@/entities";
 import { PopoverConfirm } from "@/features/ui";
 import { useDeleteComment } from "@/api/mutations";
-import { useRouter } from "next/navigation";
 
 interface Props {
   children: ReactElement & { className?: string };
@@ -12,15 +11,26 @@ interface Props {
   parent?: Entry;
   onSuccess?: () => void;
   setDeleteInProgress?: (value: boolean) => void;
-  isComment?: boolean;
 }
-export function EntryDeleteBtn({ children, entry, parent }: Props) {
-  const router = useRouter();
+export function EntryDeleteBtn({
+  children,
+  entry,
+  parent,
+  onSuccess,
+  setDeleteInProgress
+}: Props) {
+  // Navigation after delete is the caller's decision (via onSuccess): in a
+  // discussion thread the entry simply disappears from the cached list, so
+  // forcing a redirect here would yank the user off the page they're reading.
   const { mutateAsync: deleteAction, isPending } = useDeleteComment(
     entry,
-    () => router.push("/"),
+    () => onSuccess?.(),
     parent
   );
+
+  useEffect(() => {
+    setDeleteInProgress?.(isPending);
+  }, [isPending, setDeleteInProgress]);
 
   // Read the caller's class from children.props (ReactElement.props is typed
   // `unknown` under React 19, hence the cast). The previous code read

--- a/apps/web/src/features/shared/entry-delete-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-delete-btn/index.tsx
@@ -30,6 +30,9 @@ export function EntryDeleteBtn({
 
   useEffect(() => {
     setDeleteInProgress?.(isPending);
+    // Don't leave the caller stuck in a loading state if the button unmounts
+    // mid-flight (navigation, list invalidation after a successful delete).
+    return () => setDeleteInProgress?.(false);
   }, [isPending, setDeleteInProgress]);
 
   // Read the caller's class from children.props (ReactElement.props is typed

--- a/apps/web/src/features/shared/entry-menu/index.tsx
+++ b/apps/web/src/features/shared/entry-menu/index.tsx
@@ -9,7 +9,7 @@ import { getCommunityCache, useCommunityPin } from "@/core/caches";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useGlobalStore } from "@/core/global-store";
 import { useDeleteComment, usePinToBlog } from "@/api/mutations";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { dotsHorizontal } from "@ui/svg";
 import i18next from "i18next";
 import { Dropdown, DropdownItemWithIcon, DropdownMenu, DropdownToggle } from "@ui/dropdown";
@@ -65,6 +65,7 @@ export const EntryMenu = ({
 }: Props) => {
   const { activeUser } = useActiveAccount();
   const router = useRouter();
+  const pathname = usePathname();
 
   const menuRef = useRef<HTMLDivElement>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -88,7 +89,15 @@ export const EntryMenu = ({
   const { data: community } = useQuery(getCommunityCache(entry.category));
   const { mutateAsync: pinToBlog } = usePinToBlog(entry, () => pinEntry?.(pin ? entry : null));
   const { mutateAsync: pinToCommunity } = useCommunityPin(entry, community);
-  const { mutateAsync: deleteAction } = useDeleteComment(entry, () => router.push("/"));
+  // Navigate away only when the user is on the deleted entry's own page —
+  // there the page's content just vanished. Deleting from a feed, waves or
+  // deck list must keep the user where they are (the item disappears from the
+  // list via cache invalidation, plus a success toast).
+  const { mutateAsync: deleteAction } = useDeleteComment(entry, () => {
+    if (pathname?.endsWith(`/@${entry.author}/${entry.permlink}`)) {
+      router.push("/");
+    }
+  });
 
   const {
     menuItems,

--- a/apps/web/src/features/ui/core/index.tsx
+++ b/apps/web/src/features/ui/core/index.tsx
@@ -5,10 +5,13 @@ import { useSet } from "react-use";
 
 export * from "./intro-step.interface";
 
+// Anchor elements of currently open click-popovers. Registered by Popover,
+// consumed by Dropdown to decide whether an outside mousedown belongs to a
+// popover it hosts (whose content portals outside the dropdown's DOM).
 export const UIContext = createContext<{
-  openPopovers: Set<string>;
-  addOpenPopover: (v: string) => void;
-  removeOpenPopover: (v: string) => void;
+  openPopovers: Set<HTMLElement>;
+  addOpenPopover: (v: HTMLElement) => void;
+  removeOpenPopover: (v: HTMLElement) => void;
 }>({
   openPopovers: new Set(),
   addOpenPopover: () => {},
@@ -17,7 +20,7 @@ export const UIContext = createContext<{
 
 export function UIManager({ children }: PropsWithChildren<unknown>) {
   const [openPopovers, { add: addOpenPopover, remove: removeOpenPopover }] = useSet(
-    new Set<string>()
+    new Set<HTMLElement>()
   );
 
   const contextValue = useMemo(

--- a/apps/web/src/features/ui/dropdown/index.tsx
+++ b/apps/web/src/features/ui/dropdown/index.tsx
@@ -22,11 +22,19 @@ export function Dropdown(props: HTMLProps<HTMLDivElement> & Props) {
   const { openPopovers } = useContext(UIContext);
 
   useClickAway(ref, (e) => {
-    if (openPopovers.size === 0) {
-      setShow(false);
-    } else {
+    // An open click-popover anchored inside THIS dropdown (e.g. a confirm
+    // popover whose buttons render in a portal outside our DOM) — keep the
+    // menu mounted until the popover is answered; closing now would unmount
+    // the popover before its buttons' click handlers can fire. Popovers open
+    // elsewhere on the page don't block dismissal.
+    const hostsOpenPopover = Array.from(openPopovers).some((anchor) =>
+      ref.current?.contains(anchor)
+    );
+    if (hostsOpenPopover) {
       return;
     }
+
+    setShow(false);
 
     if (!isInsideDropdown(e) && (props.closeOnClickOutside ?? true)) {
       setShow(false);

--- a/apps/web/src/features/ui/popover/index.tsx
+++ b/apps/web/src/features/ui/popover/index.tsx
@@ -5,12 +5,15 @@ import {
   HTMLProps,
   PropsWithChildren,
   ReactNode,
+  useContext,
   useEffect,
+  useId,
   useMemo,
   useState
 } from "react";
 import { createPortal } from "react-dom";
 import { useFilteredProps } from "../util";
+import { UIContext } from "../core";
 import { useClickAway, useMountedState, useWindowSize } from "react-use";
 import { PopoverSheet } from "@ui/popover/popover-sheet";
 import { flip, Placement, shift } from "@floating-ui/dom";
@@ -66,6 +69,22 @@ export function Popover(
   const [show, setShow] = useState(
     (props as ShowProps).show ?? (props as Props).defaultShow ?? false
   );
+
+  // Register open click-popovers in the shared UI context. Dropdown's
+  // click-away guard (`openPopovers.size === 0`) relies on this to keep the
+  // menu mounted while a popover portaled outside the dropdown DOM (e.g. a
+  // PopoverConfirm) is awaiting the user's answer — otherwise the mousedown
+  // on the popover's buttons closes the dropdown and unmounts the popover
+  // before its click handler can fire. Hover popovers (tooltips) stay
+  // unregistered so they never pin a dropdown open.
+  const popoverId = useId();
+  const { addOpenPopover, removeOpenPopover } = useContext(UIContext);
+  useEffect(() => {
+    if (props.behavior === "click" && show) {
+      addOpenPopover(popoverId);
+      return () => removeOpenPopover(popoverId);
+    }
+  }, [props.behavior, show, popoverId, addOpenPopover, removeOpenPopover]);
 
   const isMounted = useMountedState();
   const windowSize = useWindowSize();

--- a/apps/web/src/features/ui/popover/index.tsx
+++ b/apps/web/src/features/ui/popover/index.tsx
@@ -7,7 +7,6 @@ import {
   ReactNode,
   useContext,
   useEffect,
-  useId,
   useMemo,
   useState
 } from "react";
@@ -70,21 +69,22 @@ export function Popover(
     (props as ShowProps).show ?? (props as Props).defaultShow ?? false
   );
 
-  // Register open click-popovers in the shared UI context. Dropdown's
-  // click-away guard (`openPopovers.size === 0`) relies on this to keep the
-  // menu mounted while a popover portaled outside the dropdown DOM (e.g. a
-  // PopoverConfirm) is awaiting the user's answer — otherwise the mousedown
-  // on the popover's buttons closes the dropdown and unmounts the popover
-  // before its click handler can fire. Hover popovers (tooltips) stay
-  // unregistered so they never pin a dropdown open.
-  const popoverId = useId();
+  // Register the anchor of an open click-popover in the shared UI context.
+  // Dropdown's click-away guard uses this to keep the menu mounted while a
+  // popover IT HOSTS is awaiting the user's answer — the popover's content
+  // portals outside the dropdown DOM, so the mousedown on its buttons would
+  // otherwise close the dropdown and unmount the popover before its click
+  // handler can fire. Registering the anchor element (not a global flag)
+  // lets each dropdown ignore popovers opened elsewhere on the page. Hover
+  // popovers (tooltips) stay unregistered so they never pin a dropdown open.
   const { addOpenPopover, removeOpenPopover } = useContext(UIContext);
   useEffect(() => {
-    if (props.behavior === "click" && show) {
-      addOpenPopover(popoverId);
-      return () => removeOpenPopover(popoverId);
+    const anchor = refs.reference.current;
+    if (props.behavior === "click" && show && anchor instanceof HTMLElement) {
+      addOpenPopover(anchor);
+      return () => removeOpenPopover(anchor);
     }
-  }, [props.behavior, show, popoverId, addOpenPopover, removeOpenPopover]);
+  }, [props.behavior, show, refs.reference, addOpenPopover, removeOpenPopover]);
 
   const isMounted = useMountedState();
   const windowSize = useWindowSize();

--- a/apps/web/src/specs/features/shared/entry-delete-btn.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-delete-btn.spec.tsx
@@ -3,12 +3,6 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-// next/navigation: EntryDeleteBtn calls useRouter() and pushes "/" on success.
-const push = vi.fn();
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push })
-}));
-
 // useDeleteComment is the data hook that owns the actual broadcast. We mock it
 // so the test is deterministic: we control isPending and inspect mutateAsync.
 const mutateAsync = vi.fn();
@@ -52,7 +46,6 @@ const entry = {
 
 describe("EntryDeleteBtn", () => {
   beforeEach(() => {
-    push.mockReset();
     mutateAsync.mockReset();
     useDeleteComment.mockReset();
     useDeleteComment.mockReturnValue({ mutateAsync, isPending: false });
@@ -118,6 +111,39 @@ describe("EntryDeleteBtn", () => {
     fireEvent.click(screen.getByText("Delete"));
     fireEvent.click(screen.getByText("confirm.cancel"));
     expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("runs the caller's onSuccess through the mutation's success callback", () => {
+    const onSuccess = vi.fn();
+
+    render(
+      <EntryDeleteBtn entry={entry} onSuccess={onSuccess}>
+        <button type="button">Delete</button>
+      </EntryDeleteBtn>
+    );
+
+    // Second arg to useDeleteComment is the success callback the mutation
+    // fires after a confirmed broadcast; it must invoke the caller's handler.
+    const [, successCallback] = useDeleteComment.mock.calls[0] as unknown as [
+      Entry,
+      () => void
+    ];
+    expect(onSuccess).not.toHaveBeenCalled();
+    successCallback();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports pending state changes through setDeleteInProgress", () => {
+    const setDeleteInProgress = vi.fn();
+    useDeleteComment.mockReturnValue({ mutateAsync, isPending: true });
+
+    render(
+      <EntryDeleteBtn entry={entry} setDeleteInProgress={setDeleteInProgress}>
+        <button type="button">Delete</button>
+      </EntryDeleteBtn>
+    );
+
+    expect(setDeleteInProgress).toHaveBeenCalledWith(true);
   });
 
   it("marks the child with the 'in-progress' class while the delete is pending", () => {

--- a/apps/web/src/specs/features/shared/entry-delete-btn.spec.tsx
+++ b/apps/web/src/specs/features/shared/entry-delete-btn.spec.tsx
@@ -133,17 +133,21 @@ describe("EntryDeleteBtn", () => {
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 
-  it("reports pending state changes through setDeleteInProgress", () => {
+  it("reports pending state changes through setDeleteInProgress and resets it on unmount", () => {
     const setDeleteInProgress = vi.fn();
     useDeleteComment.mockReturnValue({ mutateAsync, isPending: true });
 
-    render(
+    const { unmount } = render(
       <EntryDeleteBtn entry={entry} setDeleteInProgress={setDeleteInProgress}>
         <button type="button">Delete</button>
       </EntryDeleteBtn>
     );
 
     expect(setDeleteInProgress).toHaveBeenCalledWith(true);
+
+    // Unmounting mid-flight must not leave the caller stuck in loading state.
+    unmount();
+    expect(setDeleteInProgress).toHaveBeenLastCalledWith(false);
   });
 
   it("marks the child with the 'in-progress' class while the delete is pending", () => {

--- a/apps/web/src/specs/features/ui/dropdown-popover-confirm.spec.tsx
+++ b/apps/web/src/specs/features/ui/dropdown-popover-confirm.spec.tsx
@@ -77,4 +77,34 @@ describe("Dropdown + PopoverConfirm", () => {
     fireEvent.mouseDown(document.body);
     expect(screen.queryByText("Delete")).not.toBeInTheDocument();
   });
+
+  it("still closes on outside mousedown while an unrelated click popover is open elsewhere", async () => {
+    // The guard is scoped by anchor containment: only a popover hosted INSIDE
+    // the dropdown may keep it open. A popover open anywhere else on the page
+    // must not pin unrelated dropdowns.
+    render(
+      <UIManager>
+        <PopoverConfirm onConfirm={vi.fn()}>
+          <div>Unrelated</div>
+        </PopoverConfirm>
+        <Dropdown>
+          <DropdownToggle>
+            <button type="button">menu</button>
+          </DropdownToggle>
+          <DropdownMenu>
+            <DropdownItemWithIcon label="item" />
+          </DropdownMenu>
+        </Dropdown>
+      </UIManager>
+    );
+
+    fireEvent.click(screen.getByText("menu"));
+    expect(screen.getByText("item")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Unrelated"));
+    await screen.findByText("confirm.ok");
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText("item")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/specs/features/ui/dropdown-popover-confirm.spec.tsx
+++ b/apps/web/src/specs/features/ui/dropdown-popover-confirm.spec.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { UIManager } from "@ui/core";
+import { Dropdown, DropdownItemWithIcon, DropdownMenu, DropdownToggle } from "@ui/dropdown";
+import { PopoverConfirm } from "@/features/ui/popover-confirm";
+
+// Regression for the "silent comment delete" bug. PopoverConfirm renders its
+// confirm buttons through a portal OUTSIDE the dropdown's DOM, while Dropdown
+// closes itself on document mousedown via useClickAway (guarded by
+// UIContext.openPopovers). Before Popover registered itself in openPopovers,
+// pressing the confirm button tore down the dropdown — and the popover with
+// it — on mousedown, before the click could reach onConfirm: the action never
+// ran and no feedback was shown. This mirrors the comment-delete menu in
+// discussion-item.tsx (real Dropdown, real Popover, real portal).
+function renderMenuWithConfirm(onConfirm: () => void) {
+  return render(
+    <UIManager>
+      <Dropdown>
+        <DropdownToggle>
+          <button type="button">menu</button>
+        </DropdownToggle>
+        <DropdownMenu>
+          <DropdownItemWithIcon
+            label={
+              <PopoverConfirm onConfirm={onConfirm}>
+                <div>Delete</div>
+              </PopoverConfirm>
+            }
+          />
+        </DropdownMenu>
+      </Dropdown>
+    </UIManager>
+  );
+}
+
+describe("Dropdown + PopoverConfirm", () => {
+  it("keeps the menu mounted on mousedown over the portaled confirm button and fires onConfirm on click", async () => {
+    const onConfirm = vi.fn();
+    renderMenuWithConfirm(onConfirm);
+
+    fireEvent.click(screen.getByText("menu"));
+    fireEvent.click(screen.getByText("Delete"));
+    const ok = await screen.findByText("confirm.ok");
+
+    // mousedown lands outside the dropdown's DOM (portal) and triggers its
+    // click-away handler; the open popover must keep the menu alive.
+    fireEvent.mouseDown(ok);
+    expect(screen.getByText("Delete")).toBeInTheDocument();
+    expect(screen.getByText("confirm.ok")).toBeInTheDocument();
+
+    fireEvent.click(ok);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores normal outside-mousedown dismissal once the confirm popover is cancelled", async () => {
+    const onConfirm = vi.fn();
+    renderMenuWithConfirm(onConfirm);
+
+    fireEvent.click(screen.getByText("menu"));
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(await screen.findByText("confirm.cancel"));
+
+    // The popover unregistered itself, so the guard no longer applies.
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("closes on outside mousedown while no popover is open", () => {
+    renderMenuWithConfirm(vi.fn());
+
+    fireEvent.click(screen.getByText("menu"));
+    expect(screen.getByText("Delete")).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Users could not delete their comments: pressing OK in the delete confirmation did nothing, with no success or error toast.

The confirm popover renders through a portal outside the dropdown's DOM, and `Dropdown` closes itself on document `mousedown` via `useClickAway`. Its guard for this case (`openPopovers.size === 0`) never worked because nothing ever called `addOpenPopover`. So the mousedown on the confirm button closed the dropdown and unmounted the popover before the click could reach `onConfirm`: the broadcast never ran and no feedback was shown. Post delete was unaffected (it uses `ModalConfirm` rendered outside the dropdown).

## Changes

- `Popover` now registers open click-behavior popovers in `UIContext.openPopovers` while shown, activating the existing dropdown guard. Hover popovers (tooltips) stay unregistered.
- `EntryDeleteBtn` honors its `onSuccess` / `setDeleteInProgress` props (previously ignored) and no longer force-redirects to the homepage; deleting a comment from a discussion thread keeps the reader on the page.
- `EntryMenu` redirects after delete only when the user is on the deleted entry's own page; deleting from feeds, waves or decks stays in place.
- Removed the duplicate delete item on the comment page menu; `EntryMenu` already generates a working modal-confirm delete item for deletable entries. This also removes a latent render crash (`onSuccess={deleted}` referenced the const before initialization).

## Tests

- New integration spec (`dropdown-popover-confirm.spec.tsx`) with real `Dropdown` + `Popover` + portal reproduces the bug: it fails without the `Popover` registration and passes with it.
- Updated `entry-delete-btn.spec.tsx` for the callback wiring.
- Full web suite passes (2129 tests); lint clean; no new type errors in touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment deletion behavior so users remain on the current page when appropriate.
  * Added deletion progress handling for more responsive feedback.
  * Improved dropdown and confirmation popover interactions, including cancel and outside-click behavior.
  * Click-opened popovers now integrate correctly with shared interface state.

* **Tests**
  * Expanded coverage for deletion callbacks, progress states, and popover confirmation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->