### PR TITLE
perf(cwv): community-page LCP cover + modal-open CLS

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover/index.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { setProxyBase } from "@ecency/render-helper";
 import "./_index.scss";
-import defaults from "@/defaults";
+import defaults, { DEFAULT_IMAGE_SERVER } from "@/defaults";
 import i18next from "i18next";
 import { CommunityCoverEditImage } from "@/app/(dynamicPages)/community/[community]/_components/community-cover-edit-image";
 import { SubscriptionBtn } from "@/app/communities/_components";
@@ -45,13 +45,14 @@ export function CommunityCover({ community, account }: Props) {
 
   const fallbackCover =
     theme === "day" ? "/assets/cover-fallback-day.png" : "/assets/cover-fallback-night.png";
-  // Build the src from the canonical image server (a build-time constant),
-  // NOT the client image-proxy store: those differ server- vs client-side, which
-  // would make the eager high-priority <img> fetch once during SSR then re-fetch
-  // after hydration. The /u/<name>/cover endpoint is only served by i.ecency.com.
+  // Build the src from DEFAULT_IMAGE_SERVER (stable across SSR and client), NOT
+  // `defaults.imageServer` (a getter that reads the per-user image_proxy override
+  // from localStorage). Otherwise the eager high-priority <img> is fetched once
+  // during SSR then re-fetched at a different host after hydration. The
+  // /u/<name>/cover endpoint is only served by i.ecency.com anyway.
   const coverSrc =
     community && !coverError
-      ? `${defaults.imageServer}/u/${community.name}/cover`
+      ? `${DEFAULT_IMAGE_SERVER}/u/${community.name}/cover`
       : fallbackCover;
   const subscribers = useMemo(
     () => formattedNumber(community.subscribers, { fractionDigits: 0 }),

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { setProxyBase } from "@ecency/render-helper";
 import "./_index.scss";
@@ -28,7 +28,6 @@ export function CommunityCover({ community, account }: Props) {
   const { activeUser } = useActiveAccount();
   const users = useGlobalStore((state) => state.users);
   const theme = useGlobalStore((state) => state.theme);
-  const imageProxy = useGlobalStore((state) => state.imageProxy);
   const { data: channelData } = useQuery({
     queryKey: ["private-api", "get-community-channel", community.name],
     queryFn: () =>
@@ -38,15 +37,22 @@ export function CommunityCover({ community, account }: Props) {
   });
   const hasCommunityChannel = !!channelData?.channel_id;
 
-  const style = useMemo(() => {
-    let img =
-      theme === "day" ? "/assets/cover-fallback-day.png" : "/assets/cover-fallback-night.png";
-    if (community) {
-      img = `${imageProxy}/u/${community.name}/cover`;
-    }
+  // Reset the error fallback when navigating between communities — this client
+  // component is reused across community routes, so state would persist and a
+  // once-failed cover would wrongly force the fallback on the next community.
+  const [coverError, setCoverError] = useState(false);
+  useEffect(() => setCoverError(false), [community.name]);
 
-    return img ? { backgroundImage: `url('${img}')` } : {};
-  }, [theme, community, imageProxy]);
+  const fallbackCover =
+    theme === "day" ? "/assets/cover-fallback-day.png" : "/assets/cover-fallback-night.png";
+  // Build the src from the canonical image server (a build-time constant),
+  // NOT the client image-proxy store: those differ server- vs client-side, which
+  // would make the eager high-priority <img> fetch once during SSR then re-fetch
+  // after hydration. The /u/<name>/cover endpoint is only served by i.ecency.com.
+  const coverSrc =
+    community && !coverError
+      ? `${defaults.imageServer}/u/${community.name}/cover`
+      : fallbackCover;
   const subscribers = useMemo(
     () => formattedNumber(community.subscribers, { fractionDigits: 0 }),
     [community.subscribers]
@@ -66,9 +72,21 @@ export function CommunityCover({ community, account }: Props) {
 
   return (
     <div className="relative overflow-hidden rounded-2xl lg:max-h-[210px]">
-      <div
-        className="bg-cover absolute top-0 left-0 w-full h-full bg-light-300 dark:bg-dark-default"
-        style={style}
+      {/* Themed placeholder color shown until the cover paints (and if it fails). */}
+      <div className="absolute top-0 left-0 w-full h-full bg-light-300 dark:bg-dark-default" />
+      {/* Render the cover as a real <img> (not a CSS background) so the browser's
+          preload scanner discovers it in the SSR HTML and fetches it eagerly at
+          high priority. This is the community page's LCP element; as a background
+          image it was discovered late and painted seconds after load. */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        className="absolute top-0 left-0 w-full h-full object-cover object-left-top"
+        src={coverSrc}
+        alt=""
+        fetchPriority="high"
+        loading="eager"
+        decoding="async"
+        onError={() => setCoverError(true)}
       />
       <div className="grid gap-4 md:gap-6 px-4 pb-4 md:px-6 md:pb-6 pt-16 md:pt-24 grid-cols-2 lg:grid-cols-4 w-full relative">
         <CommunityStatItem value={subscribers} label={i18next.t("community.subscribers")} />

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -2,7 +2,7 @@
 
 import { rcPower } from "@ecency/sdk";
 import { EcencyConfigManager } from "@/config";
-import defaults from "@/defaults";
+import defaults, { DEFAULT_IMAGE_SERVER } from "@/defaults";
 import { Account } from "@/entities";
 import { FollowControls, HivePosh, UserAvatar } from "@/features/shared";
 import { FavoriteBtn } from "@/features/shared/favorite-btn";
@@ -77,7 +77,7 @@ export function ProfileCard({ account }: Props) {
           Render it visible from the server instead. */}
       <Image
           className="absolute top-0 left-0 w-full h-[96px] object-cover"
-          src={imageSrc ?? (data?.profile?.cover_image ? `${defaults.imageServer}/u/${data.name}/cover` : "/assets/promote-wave-bg.jpg")}
+          src={imageSrc ?? (data?.profile?.cover_image ? `${DEFAULT_IMAGE_SERVER}/u/${data.name}/cover` : "/assets/promote-wave-bg.jpg")}
           alt=""
           width={300}
           height={200}

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -82,6 +82,7 @@ export function ProfileCard({ account }: Props) {
           width={300}
           height={200}
           priority
+          fetchPriority="high"
           onError={() => setImageSrc("/assets/promote-wave-bg.jpg")}
       />
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -104,7 +104,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <script async src="/scripts/config-stub.js" />
         <link rel="dns-prefetch" href="https://i.ecency.com" />
         <link rel="dns-prefetch" href="https://ecency.com" />
-        <link rel="preconnect" href="https://i.ecency.com" crossOrigin="anonymous" />
+        {/* Non-CORS preconnect: cover/avatar <img> and next/image requests to
+            i.ecency.com are credentialed and can't reuse an anonymous (crossorigin)
+            socket, so warm the credentialed connection they actually use. */}
+        <link rel="preconnect" href="https://i.ecency.com" />
         <link rel="preconnect" href="https://ecency.com" crossOrigin="anonymous" />
         <JsonLd data={buildOrganizationJsonLd()} />
       </head>

--- a/apps/web/src/defaults.ts
+++ b/apps/web/src/defaults.ts
@@ -24,6 +24,12 @@ const resolveRuntimeBase = (): string => {
 
 const defaultImageServer = process.env.NEXT_PUBLIC_IMAGE_SERVER || baseDefaults.imageServer;
 
+// The canonical image host, stable across SSR and client (env vars inline
+// identically in both bundles). Unlike `defaults.imageServer` — a getter that
+// reads the per-user `image_proxy` localStorage override — this never diverges
+// after hydration, so it is safe for eager/preloaded above-the-fold images.
+export const DEFAULT_IMAGE_SERVER = defaultImageServer;
+
 export const ALLOWED_IMAGE_SERVERS = [
   "https://i.ecency.com",
   "https://images.ecency.com",

--- a/apps/web/src/specs/app/community-cover.spec.tsx
+++ b/apps/web/src/specs/app/community-cover.spec.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it, vi } from "vitest";
+
+// The community cover is the LCP element on community pages. It must render as a
+// real, eager, high-priority <img> — the deterministic markup emitted into the
+// SSR HTML that the preload scanner can discover — NOT as a CSS background-image
+// (which the browser finds late and paints seconds after load). These tests
+// guard against a regression back to a background-image.
+
+const store = vi.hoisted(() => ({
+  users: [] as { username: string }[],
+  theme: "day" as "day" | "night",
+  imageProxy: "https://i.ecency.com"
+}));
+vi.mock("@/core/global-store", () => ({
+  useGlobalStore: (selector: any) => selector(store)
+}));
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-query")>()),
+  useQuery: () => ({ data: undefined })
+}));
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+// Stub the heavy children so the test isolates the cover markup.
+vi.mock("@/app/communities/_components", () => ({
+  SubscriptionBtn: () => <button>subscribe</button>
+}));
+vi.mock(
+  "@/app/(dynamicPages)/community/[community]/_components/community-cover-edit-image",
+  () => ({ CommunityCoverEditImage: () => null })
+);
+
+import { CommunityCover } from "@/app/(dynamicPages)/community/[community]/_components/community-cover";
+
+const community: any = {
+  name: "hive-125125",
+  title: "Community",
+  subscribers: 10,
+  sum_pending: 5,
+  num_authors: 3,
+  lang: "en"
+};
+const account: any = { name: "hive-125125" };
+
+const coverImg = (c: HTMLElement) =>
+  Array.from(c.querySelectorAll("img")).find((i) =>
+    i.getAttribute("src")?.includes("/u/hive-125125/cover")
+  );
+
+describe("CommunityCover — SSR-discoverable LCP cover image", () => {
+  it("renders the cover as an eager, high-priority <img> (not a CSS background)", () => {
+    const { container } = render(<CommunityCover community={community} account={account} />);
+
+    const img = coverImg(container);
+    expect(img).toBeTruthy();
+    expect(img!.getAttribute("src")).toBe("https://i.ecency.com/u/hive-125125/cover");
+    expect(img!.getAttribute("fetchpriority")).toBe("high");
+    expect(img!.getAttribute("loading")).toBe("eager");
+    expect(img!.getAttribute("decoding")).toBe("async");
+
+    // Regression guard: no element paints the cover via a CSS background-image.
+    const bgWithCover = Array.from(container.querySelectorAll<HTMLElement>("[style]")).some((el) =>
+      (el.getAttribute("style") ?? "").includes("/u/hive-125125/cover")
+    );
+    expect(bgWithCover).toBe(false);
+  });
+
+  it("falls back to the themed asset when the cover image fails to load", () => {
+    const { container } = render(<CommunityCover community={community} account={account} />);
+
+    const img = coverImg(container);
+    expect(img).toBeTruthy();
+    fireEvent.error(img!);
+
+    const anyImg = container.querySelector("img");
+    expect(anyImg!.getAttribute("src")).toBe("/assets/cover-fallback-day.png");
+  });
+});

--- a/apps/web/src/styles/_base.scss
+++ b/apps/web/src/styles/_base.scss
@@ -218,6 +218,9 @@ a[target="_blank"] {
 html {
   scrollbar-width: auto;
   scrollbar-color: var(--scrollbar-thumb-color, auto) var(--scrollbar-track-color, transparent);
+  // Reserve the scrollbar gutter so opening a modal (which locks body scroll and
+  // hides the scrollbar) does not shift the page horizontally — a CLS source.
+  scrollbar-gutter: stable;
 }
 
 /* WebKit browsers */


### PR DESCRIPTION
## What

The community page's cover is its **LCP element**, but it was painted as a CSS `background-image`. Background images aren't visible to the browser's preload scanner, so the cover was discovered late and painted well after first load. This renders it as a real, eager, high-priority `<img>` that ships in the SSR HTML.

Also folds in two small adjacent wins on the same paths.

## Changes

- **community-cover**: `background-image` div → `<img fetchPriority="high" loading="eager" decoding="async">`.
  - `src` is built from the canonical image server (a build-time constant) rather than the client image-proxy store, so the SSR and post-hydration `src` match and the eager fetch isn't duplicated. The `/u/<name>/cover` endpoint is only served by that host anyway.
  - Themed placeholder color sits behind the image; `onError` falls back to the local themed asset; the error flag resets when navigating between communities (the client component is reused across community routes).
  - `object-left-top` preserves the previous crop framing.
- **profile-card**: add `fetchPriority="high"` to the cover `next/image`. In Next 15.5.18 `priority` emits the preload link but does **not** set the fetch-priority hint.
- **layout**: make the `i.ecency.com` preconnect non-CORS. Cover/avatar `<img>` and `next/image` requests are credentialed and can't reuse an anonymous (crossorigin) socket.
- **styles**: `scrollbar-gutter: stable` on `<html>`. Opening a modal locks body scroll and hides the scrollbar, which shifted the page horizontally (CLS). Reserving the gutter removes that shift.
  - Tradeoff: reserves ~15px on short desktop pages that don't otherwise scroll. No layout shift (reserved from first paint); overlay-scrollbar platforms (mobile) are unaffected.

## Testing

- New regression spec asserts the cover renders as an eager, high-priority `<img>` (not a background-image) and falls back on error.
- `tsc --noEmit`: no new errors. ESLint clean on touched files. Existing modal scroll-lock and app specs pass.