### PR TITLE
Show post thumbnails in the notification list

### DIFF
--- a/apps/web/src/app/decks/_components/columns/deck-notifications-column.tsx
+++ b/apps/web/src/app/decks/_components/columns/deck-notifications-column.tsx
@@ -143,6 +143,7 @@ export const DeckNotificationsColumn = ({ id, settings, draggable }: Props) => {
             }
           }}
           notification={item}
+          isDeck={true}
           className="px-4 gap-4 notification-list-item"
           onLinkClick={async () => {
             switch (item.type) {

--- a/apps/web/src/features/shared/notifications/_index.scss
+++ b/apps/web/src/features/shared/notifications/_index.scss
@@ -200,6 +200,18 @@
           width: 40px;
         }
 
+        // Sits at the end of the row and holds its size, letting .item-content
+        // shrink around it rather than pushing the mark-read control out.
+        .item-image {
+          @apply ml-auto shrink-0 self-start pl-2;
+
+          img {
+            @apply rounded-lg object-cover;
+            height: 48px;
+            width: 48px;
+          }
+        }
+
         .item-content {
           float: left;
           width: calc(100% - 94px);

--- a/apps/web/src/features/shared/notifications/notification-list-item.tsx
+++ b/apps/web/src/features/shared/notifications/notification-list-item.tsx
@@ -37,6 +37,10 @@ interface Props {
   className?: string;
   onLinkClick?: () => void;
   openLinksInNewTab?: boolean;
+  // Deck columns are too narrow to spare the width for a thumbnail. This is an
+  // explicit prop because the `deck` field the other guards in here read is never
+  // actually set on a notification.
+  isDeck?: boolean;
 }
 
 export const NotificationListItem = memo(function NotificationListItem({
@@ -47,7 +51,8 @@ export const NotificationListItem = memo(function NotificationListItem({
   openLinksInNewTab = false,
   onLinkClick,
   setSelectedNotifications,
-  onMounted
+  onMounted,
+  isDeck = false
 }: Props) {
   const toggleUIProp = useGlobalStore((state) => state.toggleUiProp);
 
@@ -256,9 +261,8 @@ export const NotificationListItem = memo(function NotificationListItem({
             </div>
           )}
 
-          {/* Decorative: the row's type component already carries the post link.
-              Skipped in deck mode, where the row is too narrow to spare the width. */}
-          {imageUrl && !(notification as ApiMentionNotification).deck && (
+          {/* Decorative: the row's type component already carries the post link. */}
+          {imageUrl && !isDeck && (
             <div className="item-image">
               <img src={imageUrl} alt="" loading="lazy" />
             </div>

--- a/apps/web/src/features/shared/notifications/notification-list-item.tsx
+++ b/apps/web/src/features/shared/notifications/notification-list-item.tsx
@@ -26,6 +26,7 @@ import { useGlobalStore } from "@/core/global-store";
 import { useMarkNotificationsMutation } from "@/api/sdk-mutations";
 import { usePrevious } from "react-use";
 import { FormControl } from "@ui/input";
+import { getNotificationImage } from "@/features/shared/notifications/utils";
 
 interface Props {
   notification: ApiNotification;
@@ -54,6 +55,8 @@ export const NotificationListItem = memo(function NotificationListItem({
   const previousIsSelect = usePrevious(isSelect);
 
   const notification = useMemo(() => primaryNotification || entry, [primaryNotification, entry]);
+
+  const imageUrl = useMemo(() => getNotificationImage(notification!), [notification]);
 
   const markNotifications = useMarkNotificationsMutation();
 
@@ -250,6 +253,14 @@ export const NotificationListItem = memo(function NotificationListItem({
                   {notification.type.replace(/[_-]/g, " ")}
                 </span>
               </div>
+            </div>
+          )}
+
+          {/* Decorative: the row's type component already carries the post link.
+              Skipped in deck mode, where the row is too narrow to spare the width. */}
+          {imageUrl && !(notification as ApiMentionNotification).deck && (
+            <div className="item-image">
+              <img src={imageUrl} alt="" loading="lazy" />
             </div>
           )}
         </div>

--- a/apps/web/src/features/shared/notifications/utils/get-notification-image.ts
+++ b/apps/web/src/features/shared/notifications/utils/get-notification-image.ts
@@ -1,0 +1,36 @@
+import { proxifyImageSrc } from "@ecency/render-helper";
+import { ApiNotification } from "@/entities";
+
+// The 48px slot in the notification row, at 2x pixel density.
+const THUMB_SIZE = 96;
+
+// Vote notifications also carry img_url, but they are by far the highest-volume
+// type and every thumbnail would be a repeat of the user's own post, so they are
+// deliberately left text-only.
+const IMAGE_TYPES = ["mention", "reblog", "scheduled_published"];
+
+/**
+ * Thumbnail for a notification row, or null when the notification has no post
+ * image to show.
+ *
+ * The API hands back the post's raw `json_metadata` image, which can be a
+ * full-size original, so it is proxied down to the size actually rendered.
+ */
+export function getNotificationImage(notification: ApiNotification): string | null {
+  const anyNotification = notification as any;
+
+  // A reply points at the parent post, i.e. the user's own post that was replied
+  // to, which is the context that makes the row readable.
+  const rawUrl =
+    anyNotification?.type === "reply"
+      ? anyNotification?.parent_img_url
+      : IMAGE_TYPES.includes(anyNotification?.type)
+        ? anyNotification?.img_url
+        : null;
+
+  if (!rawUrl || typeof rawUrl !== "string") {
+    return null;
+  }
+
+  return proxifyImageSrc(rawUrl, THUMB_SIZE, THUMB_SIZE, "match");
+}

--- a/apps/web/src/features/shared/notifications/utils/index.ts
+++ b/apps/web/src/features/shared/notifications/utils/index.ts
@@ -1,3 +1,3 @@
 export * from "./date2key";
 export * from "./get-notification-entry-category";
-export * from "./get-notification-entry-category";
+export * from "./get-notification-image";

--- a/apps/web/src/specs/utils/get-notification-image.spec.ts
+++ b/apps/web/src/specs/utils/get-notification-image.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { getNotificationImage } from "@/features/shared/notifications/utils";
+
+vi.mock("@ecency/render-helper", () => ({
+  proxifyImageSrc: (url: string, w: number, h: number) => `proxy(${w}x${h}):${url}`
+}));
+
+const IMG = "https://images.ecency.com/p/original.jpg";
+
+const notification = (props: Record<string, unknown>) => props as any;
+
+describe("getNotificationImage", () => {
+  it("uses the parent post image for a reply, which is the post that was replied to", () => {
+    const url = getNotificationImage(
+      notification({
+        type: "reply",
+        parent_img_url: IMG,
+        img_url: "https://images.ecency.com/p/the-reply-itself.jpg"
+      })
+    );
+
+    expect(url).toBe(`proxy(96x96):${IMG}`);
+  });
+
+  it.each(["mention", "reblog", "scheduled_published"])("uses img_url for a %s", (type) => {
+    expect(getNotificationImage(notification({ type, img_url: IMG }))).toBe(`proxy(96x96):${IMG}`);
+  });
+
+  it("shows no thumbnail for votes, which would just repeat the user's own post", () => {
+    expect(getNotificationImage(notification({ type: "vote", img_url: IMG }))).toBeNull();
+    expect(getNotificationImage(notification({ type: "unvote", img_url: IMG }))).toBeNull();
+  });
+
+  it("shows no thumbnail for types that carry no post image", () => {
+    expect(getNotificationImage(notification({ type: "follow" }))).toBeNull();
+    expect(getNotificationImage(notification({ type: "transfer", amount: "1.000 HIVE" }))).toBeNull();
+  });
+
+  it("handles a missing or null image, which the API allows on every type", () => {
+    expect(getNotificationImage(notification({ type: "mention", img_url: null }))).toBeNull();
+    expect(getNotificationImage(notification({ type: "reply", parent_img_url: null }))).toBeNull();
+    expect(getNotificationImage(notification({ type: "mention" }))).toBeNull();
+  });
+
+  it("proxies the raw url down rather than fetching the full-size original", () => {
+    // The API returns the post's json_metadata image, which can be many MB.
+    expect(getNotificationImage(notification({ type: "mention", img_url: IMG }))).toContain(
+      "proxy(96x96)"
+    );
+  });
+
+  it("survives a malformed notification", () => {
+    expect(getNotificationImage(null as any)).toBeNull();
+    expect(getNotificationImage(undefined as any)).toBeNull();
+    expect(getNotificationImage(notification({}))).toBeNull();
+    expect(
+      getNotificationImage(notification({ type: "mention", img_url: { nested: "object" } }))
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

The notifications API already returns a post image on several notification types, but nothing has ever rendered it.

- `reply` carries `parent_img_url` (the post that was replied to)
- `mention`, `reblog` and `scheduled_published` carry `img_url`

The fields are typed in the SDK and populated by the API, so the data was there the whole time. The notification list is text-only today.

## Change

Render the post image at the end of the row for replies, mentions, reblogs and scheduled_published.

The url is proxied down to the size actually rendered. The API hands back the post's raw `json_metadata` image, so using it directly would pull a full-size original into a 48px box.

Votes are left text-only on purpose: they are by far the highest-volume type, and every thumbnail would be a repeat of the user's own post.

## Layout

The thumbnail holds its width at the end of the flex row and lets `.item-content` shrink around it, so the mark-read control keeps its position and no existing type layout changes. Deck mode is too narrow to spare the width, so it stays text-only there.

The image is decorative (`alt=""`, lazy-loaded); the row's type component already carries the post link, so no new navigation behavior is introduced.

## Tests

`get-notification-image` covers the per-type field mapping, the vote exclusion, null/missing images (the API allows null on every type), proxying, and malformed input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications can now display relevant thumbnail images alongside their content.
  * Images are optimized for thumbnail display and loaded lazily when available.

* **Bug Fixes**
  * Notifications without valid image data continue to display correctly without errors.

* **Tests**
  * Added coverage for supported notification types, missing or invalid image data, and image optimization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->