### PR TITLE
Fix the dead deck flag on notification rows

### DIFF
--- a/apps/web/src/entities/ws-notifications.ts
+++ b/apps/web/src/entities/ws-notifications.ts
@@ -211,7 +211,6 @@ export interface ApiMentionNotification extends BaseAPiNotification {
   post: boolean;
   title: string | null;
   img_url: string | null;
-  deck?: boolean;
 }
 
 export interface ApiFollowNotification extends BaseAPiNotification {

--- a/apps/web/src/features/shared/notifications/notification-list-item.tsx
+++ b/apps/web/src/features/shared/notifications/notification-list-item.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect, useMemo, useRef, useState } from "react";
-import { ApiMentionNotification, ApiNotification } from "@/entities";
+import { ApiNotification } from "@/entities";
 import { NotificationReferralType } from "@/features/shared/notifications/notification-types/notification-referral-type";
 import { NotificationInactiveType } from "@/features/shared/notifications/notification-types/notification-inactive-type";
 import { NotificationSpinType } from "@/features/shared/notifications/notification-types/notification-spin-type";
@@ -37,9 +37,8 @@ interface Props {
   className?: string;
   onLinkClick?: () => void;
   openLinksInNewTab?: boolean;
-  // Deck columns are too narrow to spare the width for a thumbnail. This is an
-  // explicit prop because the `deck` field the other guards in here read is never
-  // actually set on a notification.
+  // True when this row is rendered inside a deck column, which is narrow and has
+  // no notifications dropdown to toggle.
   isDeck?: boolean;
 }
 
@@ -79,13 +78,18 @@ export const NotificationListItem = memo(function NotificationListItem({
   }, [isSelect, previousIsSelect]);
 
   const markAsRead = () => {
-    if (notification!.read === 0 && !(notification as ApiMentionNotification).deck) {
+    if (notification!.read === 0) {
       markNotifications.mutateAsync({ id: notification!.id });
     }
   };
 
   const afterClick = () => {
-    !(entry && (entry as any).toggleNotNeeded) && toggleUIProp("notifications");
+    // A deck column has no notifications dropdown to close, and opening the
+    // navbar one on top of the deck is not what the click asked for. The other
+    // deck columns already opt out of this via entry.toggleNotNeeded.
+    if (!isDeck && !(entry && (entry as any).toggleNotNeeded)) {
+      toggleUIProp("notifications");
+    }
     markAsRead();
   };
 
@@ -120,7 +124,7 @@ export const NotificationListItem = memo(function NotificationListItem({
       title={notification.timestamp}
       className={classNameObject({
         "list-item": true,
-        "not-read": notification.read === 0 && !(notification as ApiMentionNotification).deck,
+        "not-read": notification.read === 0,
         [className ?? ""]: !!className
       })}
       role="button"
@@ -134,9 +138,7 @@ export const NotificationListItem = memo(function NotificationListItem({
       }}
       key={notification.id}
     >
-      <div
-        className={`item-inner ${(notification as ApiMentionNotification).deck ? "p-2 m-0" : ""}`}
-      >
+      <div className={`item-inner ${isDeck ? "p-2 m-0" : ""}`}>
         <div className="flex w-full">
           <div className="source pt-0.5">{sourceLinkMain}</div>
 
@@ -274,12 +276,8 @@ export const NotificationListItem = memo(function NotificationListItem({
             <FormControl type="checkbox" checked={isChecked} onChange={() => {}} />
           </div>
         ) : (
-          <div
-            className={`item-control ${
-              (notification as ApiMentionNotification).deck ? "item-control-deck" : ""
-            }`}
-          >
-            {!(notification as ApiMentionNotification).deck && notification.read === 0 && (
+          <div className={`item-control ${isDeck ? "item-control-deck" : ""}`}>
+            {notification.read === 0 && (
               <Tooltip content={i18next.t("notifications.mark-read")}>
                 <span
                   role="button"

--- a/apps/web/src/specs/features/notification-list-item-deck.spec.tsx
+++ b/apps/web/src/specs/features/notification-list-item-deck.spec.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiNotification } from "@/entities";
+
+// The row previously gated five behaviors on a `deck` field that nothing ever
+// set, so deck columns silently got the wrong ones. These lock in what a deck
+// row actually does, so the flag cannot rot back into a no-op.
+
+const toggleUiProp = vi.fn();
+const mutateAsync = vi.fn();
+
+vi.mock("@/core/global-store", () => ({
+  useGlobalStore: (selector: any) => selector({ toggleUiProp })
+}));
+
+vi.mock("@/api/sdk-mutations", () => ({
+  useMarkNotificationsMutation: () => ({ mutateAsync })
+}));
+
+vi.mock("@/features/shared", () => ({
+  // Stand in for the real link so a click drives the row's afterClick handler.
+  ProfileLink: ({ children, afterClick }: any) => (
+    <button type="button" onClick={afterClick}>
+      {children}
+    </button>
+  ),
+  UserAvatar: () => <span />,
+  // Pulled in by the per-type row components (e.g. NotificationReplyType).
+  EntryLink: ({ children }: any) => <span>{children}</span>
+}));
+
+vi.mock("@ecency/render-helper", async () => ({
+  ...(await vi.importActual("@ecency/render-helper")),
+  proxifyImageSrc: (url: string) => url
+}));
+
+// The global @/utils mock only exports random/getAccessToken; the per-type row
+// components reach for more than that.
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+
+// eslint-disable-next-line import/first
+import { NotificationListItem } from "@/features/shared/notifications/notification-list-item";
+
+const reply = {
+  id: "rr-1",
+  type: "reply",
+  source: "alice",
+  read: 0,
+  timestamp: "2026-07-13T10:00:00+00:00",
+  ts: 1,
+  gk: "today",
+  gkf: false,
+  author: "alice",
+  permlink: "re-post",
+  title: "",
+  body: "nice post",
+  json_metadata: "{}",
+  metadata: {},
+  parent_author: "bob",
+  parent_permlink: "post",
+  parent_title: "The post",
+  parent_img_url: "https://images.ecency.com/p/cover.jpg"
+} as unknown as ApiNotification;
+
+const renderRow = (isDeck: boolean) =>
+  render(<NotificationListItem notification={reply} isDeck={isDeck} />);
+
+describe("NotificationListItem in a deck column", () => {
+  beforeEach(() => {
+    toggleUiProp.mockClear();
+    mutateAsync.mockClear();
+  });
+
+  it("drops the thumbnail, which the narrow column cannot spare the width for", () => {
+    expect(renderRow(true).container.querySelector(".item-image")).toBeNull();
+    expect(renderRow(false).container.querySelector(".item-image")).not.toBeNull();
+  });
+
+  it("uses compact padding and a narrow control column", () => {
+    const deck = renderRow(true).container;
+    expect(deck.querySelector(".item-inner")?.className).toContain("p-2");
+    expect(deck.querySelector(".item-control")?.className).toContain("item-control-deck");
+
+    const normal = renderRow(false).container;
+    expect(normal.querySelector(".item-inner")?.className).not.toContain("p-2");
+    expect(normal.querySelector(".item-control")?.className).not.toContain("item-control-deck");
+  });
+
+  it("still highlights an unread row, which the old dead flag would have removed", () => {
+    expect(renderRow(true).container.querySelector(".list-item")?.className).toContain("not-read");
+  });
+
+  it("still offers the mark-read dot, which the old dead flag would have removed", () => {
+    const dot = renderRow(true).container.querySelector(".mark-read");
+    expect(dot).not.toBeNull();
+
+    fireEvent.click(dot!);
+    expect(mutateAsync).toHaveBeenCalledWith({ id: "rr-1" });
+  });
+
+  // The row's outer div carries role="button" for the select checkbox, so reach
+  // for the real <button> the mocked ProfileLink renders.
+  const clickSourceLink = (container: HTMLElement) =>
+    fireEvent.click(container.querySelectorAll("button")[0]);
+
+  it("still marks the notification read on click, which the old dead flag would have stopped", () => {
+    clickSourceLink(renderRow(true).container);
+    expect(mutateAsync).toHaveBeenCalledWith({ id: "rr-1" });
+  });
+
+  it("does not pop the navbar notifications dropdown open on top of the deck", () => {
+    clickSourceLink(renderRow(true).container);
+    expect(toggleUiProp).not.toHaveBeenCalled();
+  });
+
+  it("still toggles the dropdown outside a deck, where the row lives inside it", () => {
+    clickSourceLink(renderRow(false).container);
+    expect(toggleUiProp).toHaveBeenCalledWith("notifications");
+  });
+});


### PR DESCRIPTION
Follow-up to #1140, where this surfaced.

## Problem

`NotificationListItem` gated five behaviors on `(notification as ApiMentionNotification).deck`. **Nothing has ever set that field** — `deck: true` does not appear anywhere in the repo's history, and the deck column passes the raw API notification straight through. So all five guards were inert.

## Why this isn't just "turn the flag on"

Enabling the guards as written would have *removed* working functionality from deck columns:

| guard | today | if enabled as written |
|---|---|---|
| unread highlight | shows | disappears |
| mark-as-read on click | works | stops working |
| manual mark-read dot | shows | disappears |
| compact padding | off | on |
| narrow control column | off | on |

Only the last two are worth having in a narrow column. So those two now key off the real `isDeck` prop (already threaded in #1140), and the unread highlight, mark-read dot and mark-as-read keep working in decks exactly as they do today.

The `deck` field is removed from the entity so it cannot mislead again.

## Second bug, same cause

Clicking a notification inside a deck column called `toggleUIProp("notifications")`, popping the navbar notifications dropdown open on top of the deck. The other five deck columns already opt out of this via `entry.toggleNotNeeded`; the notifications column never passed anything. `isDeck` now covers it.

## Behavior change

Deck notification rows get tighter padding and a narrower control column. Nothing else about them changes.

## Tests

`notification-list-item-deck.spec.tsx` pins what a deck row does: no thumbnail, compact padding, narrow control, and — the parts the dead flag would have broken — unread highlight, mark-read dot, and mark-as-read all still working, plus no dropdown toggle.