### PR TITLE
Show thumbnails on bookmark and favorite notifications

### DIFF
--- a/apps/web/src/entities/ws-notifications.ts
+++ b/apps/web/src/entities/ws-notifications.ts
@@ -257,6 +257,9 @@ export interface ApiFavoriteNotification extends BaseAPiNotification {
   permlink: string;
   post: boolean;
   title: string | null;
+  // Image of the newly published post. Optional so this stays structurally
+  // compatible with the published @ecency/sdk types, which do not declare it yet.
+  img_url?: string | null;
 }
 
 export interface ApiBookmarkNotification extends BaseAPiNotification {
@@ -266,6 +269,10 @@ export interface ApiBookmarkNotification extends BaseAPiNotification {
   permlink: string;
   post: boolean;
   title: string | null;
+  // Image of the bookmarked post that was commented on, not of the comment.
+  // Optional so this stays structurally compatible with the published
+  // @ecency/sdk types, which do not declare it yet.
+  parent_img_url?: string | null;
 }
 
 export interface ApiSpinNotification extends BaseAPiNotification {

--- a/apps/web/src/features/shared/notifications/utils/get-notification-image.ts
+++ b/apps/web/src/features/shared/notifications/utils/get-notification-image.ts
@@ -4,10 +4,18 @@ import { ApiNotification } from "@/entities";
 // The 48px slot in the notification row, at 2x pixel density.
 const THUMB_SIZE = 96;
 
+// Types whose image is the post the notification is about: the post you were
+// mentioned in, the one that was reblogged, the one that just went live.
+//
 // Vote notifications also carry img_url, but they are by far the highest-volume
 // type and every thumbnail would be a repeat of the user's own post, so they are
 // deliberately left text-only.
-const IMAGE_TYPES = ["mention", "reblog", "scheduled_published"];
+const IMAGE_TYPES = ["mention", "reblog", "scheduled_published", "favorites"];
+
+// Types whose image hangs off the PARENT post, because the notification itself is
+// about a comment: your post that was replied to, or the post you bookmarked that
+// someone has now commented on. Either way the parent is the useful context.
+const PARENT_IMAGE_TYPES = ["reply", "bookmarks"];
 
 /**
  * Thumbnail for a notification row, or null when the notification has no post
@@ -19,14 +27,11 @@ const IMAGE_TYPES = ["mention", "reblog", "scheduled_published"];
 export function getNotificationImage(notification: ApiNotification): string | null {
   const anyNotification = notification as any;
 
-  // A reply points at the parent post, i.e. the user's own post that was replied
-  // to, which is the context that makes the row readable.
-  const rawUrl =
-    anyNotification?.type === "reply"
-      ? anyNotification?.parent_img_url
-      : IMAGE_TYPES.includes(anyNotification?.type)
-        ? anyNotification?.img_url
-        : null;
+  const rawUrl = PARENT_IMAGE_TYPES.includes(anyNotification?.type)
+    ? anyNotification?.parent_img_url
+    : IMAGE_TYPES.includes(anyNotification?.type)
+      ? anyNotification?.img_url
+      : null;
 
   if (!rawUrl || typeof rawUrl !== "string") {
     return null;

--- a/apps/web/src/specs/utils/get-notification-image.spec.ts
+++ b/apps/web/src/specs/utils/get-notification-image.spec.ts
@@ -22,8 +22,25 @@ describe("getNotificationImage", () => {
     expect(url).toBe(`proxy(96x96):${IMG}`);
   });
 
-  it.each(["mention", "reblog", "scheduled_published"])("uses img_url for a %s", (type) => {
-    expect(getNotificationImage(notification({ type, img_url: IMG }))).toBe(`proxy(96x96):${IMG}`);
+  it.each(["mention", "reblog", "scheduled_published", "favorites"])(
+    "uses img_url for a %s",
+    (type) => {
+      expect(getNotificationImage(notification({ type, img_url: IMG }))).toBe(`proxy(96x96):${IMG}`);
+    }
+  );
+
+  it("uses the parent post image for a bookmark, i.e. the post that was bookmarked", () => {
+    // A bookmarks notification fires when someone comments on a post you saved,
+    // so the useful image is the saved post's, not the comment's.
+    const url = getNotificationImage(
+      notification({
+        type: "bookmarks",
+        parent_img_url: IMG,
+        img_url: "https://images.ecency.com/p/the-comment.jpg"
+      })
+    );
+
+    expect(url).toBe(`proxy(96x96):${IMG}`);
   });
 
   it("shows no thumbnail for votes, which would just repeat the user's own post", () => {


### PR DESCRIPTION
## Problem

Two notification types that should show a post thumbnail do not.

**Bookmarks** — the data is already flowing and we were dropping it. enotify populates `parent_img_url` (the bookmarked post that someone has now commented on) and `endpoints.py` serializes it, but the image mapper only knew about `reply`. No backend change needed.

**Favorites** — the backend genuinely never sent it. `convert_source_row_favorites` never put `img_url` into `extra`, so the API always serialized `img_url: null`. Fixed in ecency/enotify-py#16.

## Change

`getNotificationImage` now splits the types by *where the image lives*:

- `img_url` (the post the notification is about): mention, reblog, scheduled_published, **favorites**
- `parent_img_url` (the parent post, because the notification is about a comment): reply, **bookmarks**

Votes stay text-only, as before: highest-volume type, and every thumbnail would repeat the user's own post.

## Sequencing

Bookmarks light up as soon as this ships. Favorites stay text-only until enotify-py#16 deploys — the field is simply absent, the mapper returns null, and the row renders exactly as it does today. No coupling, no broken intermediate state.

## Types

The two entity fields are **optional**, so the entity stays structurally compatible with the published `@ecency/sdk` types, which do not declare them yet. Updating those is a separate release, since `packages/sdk/dist` is committed and I am not rebuilding dist in a feature PR.

## Tests

Extended `get-notification-image` to cover favorites (`img_url`) and bookmarks (`parent_img_url`, asserting it prefers the parent over the comment's own image).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification thumbnails for favorites and bookmarks.
  * Bookmark notifications now display the saved post’s image when available.
  * Notifications continue to handle missing image URLs gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->