### PR TITLE
Show a thumbnail on payout notifications

### DIFF
--- a/apps/web/src/entities/ws-notifications.ts
+++ b/apps/web/src/entities/ws-notifications.ts
@@ -111,6 +111,8 @@ export interface WsPayoutsNotification extends BaseWsNotification {
     amount_usd?: string;
     title?: string | null;
     permlink?: string;
+    // Image of the post that paid out.
+    img_url?: string | null;
   };
 }
 
@@ -307,9 +309,12 @@ export interface ApiPayoutsNotification extends BaseAPiNotification {
   type: "payouts";
   amount?: string;
   amount_usd?: string;
+  payout_at?: string;
   title?: string | null;
   author: string;
   permlink: string;
+  // Image of the post that paid out.
+  img_url?: string | null;
 }
 
 export interface ApiMonthlyPostsNotification extends BaseAPiNotification {

--- a/apps/web/src/entities/ws-notifications.ts
+++ b/apps/web/src/entities/ws-notifications.ts
@@ -307,9 +307,10 @@ export interface ApiCheckinNotification extends BaseAPiNotification {
 
 export interface ApiPayoutsNotification extends BaseAPiNotification {
   type: "payouts";
-  amount?: string;
-  amount_usd?: string;
-  payout_at?: string;
+  // The api builds these with .get(), so they can come back null, not just absent.
+  amount?: string | null;
+  amount_usd?: string | null;
+  payout_at?: string | null;
   title?: string | null;
   author: string;
   permlink: string;

--- a/apps/web/src/features/shared/notifications/utils/get-notification-image.ts
+++ b/apps/web/src/features/shared/notifications/utils/get-notification-image.ts
@@ -10,7 +10,7 @@ const THUMB_SIZE = 96;
 // Vote notifications also carry img_url, but they are by far the highest-volume
 // type and every thumbnail would be a repeat of the user's own post, so they are
 // deliberately left text-only.
-const IMAGE_TYPES = ["mention", "reblog", "scheduled_published", "favorites"];
+const IMAGE_TYPES = ["mention", "reblog", "scheduled_published", "favorites", "payouts"];
 
 // Types whose image hangs off the PARENT post, because the notification itself is
 // about a comment: your post that was replied to, or the post you bookmarked that

--- a/apps/web/src/specs/utils/get-notification-image.spec.ts
+++ b/apps/web/src/specs/utils/get-notification-image.spec.ts
@@ -22,7 +22,7 @@ describe("getNotificationImage", () => {
     expect(url).toBe(`proxy(96x96):${IMG}`);
   });
 
-  it.each(["mention", "reblog", "scheduled_published", "favorites"])(
+  it.each(["mention", "reblog", "scheduled_published", "favorites", "payouts"])(
     "uses img_url for a %s",
     (type) => {
       expect(getNotificationImage(notification({ type, img_url: IMG }))).toBe(`proxy(96x96):${IMG}`);


### PR DESCRIPTION
## Problem

`payouts` ("your post paid out") carries `img_url` and the api has always sent it, but the type was missing from the image mapper, so those rows render text-only.

It is live and not rare: roughly **1,500 rows a day, about half of them with an image**.

## Why it was missed

I derived the original type list from the sdk types, and **the sdk has no payouts type at all** — even though the api emits `payouts` and both clients already render the row. An incomplete source produced an incomplete list. The sdk gap is fixed in #1143.

Verified against the backend this time: `endpoints.py` has an `ACTIVITY_TYPE_PAYOUT` branch that serializes `img_url`, `convert_source_row_payouts` populates it via `get_post()`, and the live table confirms the rows carry real image urls.

## Change

- adds `payouts` to `IMAGE_TYPES` (the `img_url` group)
- declares `img_url` on `ApiPayoutsNotification` and `WsPayoutsNotification`, which never had it, plus `payout_at`, which the api also sends
- widens `amount` / `amount_usd` / `payout_at` to allow `null`: the api builds them with `.get()`, so they come back null rather than absent. Without this the sdk/entity boundary would break once #1143 is published. The payouts row already truthiness-checks them, so nothing changes at runtime.

Votes remain the only image-carrying type left text-only, as agreed: highest-volume, and every thumbnail would repeat the user own post.

## Tests

12 pass. Typecheck at the 214 baseline, lint clean.