### PR TITLE
Fix import from URL fetching

### DIFF
--- a/apps/web/src/app/api/import/pinned-lookup.ts
+++ b/apps/web/src/app/api/import/pinned-lookup.ts
@@ -11,7 +11,7 @@ import type { LookupFunction } from "node:net";
  */
 export function createPinnedLookup(ip: string, family: 4 | 6): LookupFunction {
   return (_hostname, options, callback) => {
-    if (options.all) {
+    if (options?.all) {
       callback(null, [{ address: ip, family }]);
       return;
     }

--- a/apps/web/src/app/api/import/pinned-lookup.ts
+++ b/apps/web/src/app/api/import/pinned-lookup.ts
@@ -1,0 +1,21 @@
+import type { LookupFunction } from "node:net";
+
+/**
+ * Build a DNS lookup function that always returns the IP address that was
+ * resolved and validated before the request started.
+ *
+ * Node asks custom lookup functions for either one address or all addresses,
+ * depending on its automatic address-family selection settings. Returning the
+ * scalar form for an `all` request makes Node read `.address` from a string and
+ * fail with ERR_INVALID_IP_ADDRESS.
+ */
+export function createPinnedLookup(ip: string, family: 4 | 6): LookupFunction {
+  return (_hostname, options, callback) => {
+    if (options.all) {
+      callback(null, [{ address: ip, family }]);
+      return;
+    }
+
+    callback(null, ip, family);
+  };
+}

--- a/apps/web/src/app/api/import/route.ts
+++ b/apps/web/src/app/api/import/route.ts
@@ -7,6 +7,7 @@ import { isIP } from "node:net";
 import { Agent } from "undici";
 import { getPost } from "@ecency/sdk";
 import { ACTIVE_USER_COOKIE_NAME } from "@/consts/cookies";
+import { createPinnedLookup } from "./pinned-lookup";
 
 // Undici dispatcher accepts a custom lookup. We pre-resolve and validate
 // every hop's IP via Node's DNS resolver, then pin the TCP connection to
@@ -14,11 +15,6 @@ import { ACTIVE_USER_COOKIE_NAME } from "@/consts/cookies";
 // resolution and connect. The original hostname rides on the request so
 // TLS SNI and certificate validation continue to verify against the
 // legitimate host.
-type LookupCallback = (
-  err: NodeJS.ErrnoException | null,
-  address: string,
-  family: number
-) => void;
 
 interface ArticleData {
   title: string;
@@ -260,12 +256,7 @@ async function fetchPage(url: string, redirectCount = 0): Promise<string> {
   // returns the pinned IP for every connect attempt this dispatcher makes.
   const dispatcher = new Agent({
     connect: {
-      // Undici passes a ConnectOptions object (port, servername, timeout)
-      // here; we don't need any of it but typing as Record<string, unknown>
-      // documents what's available rather than erasing the parameter shape.
-      lookup: (_hostname: string, _options: Record<string, unknown>, callback: LookupCallback) => {
-        callback(null, ip, family);
-      }
+      lookup: createPinnedLookup(ip, family)
     }
   });
 

--- a/apps/web/src/app/publish/_components/publish-import-dialog.tsx
+++ b/apps/web/src/app/publish/_components/publish-import-dialog.tsx
@@ -20,7 +20,14 @@ export async function fetchImport(url: string): Promise<ImportResult> {
     body: JSON.stringify({ url: url.trim() })
   });
 
-  const data = await response.json();
+  let data: ImportResult & { error?: string };
+  try {
+    data = await response.json();
+  } catch {
+    // Gateways and reverse proxies may return plain text or HTML. Keep those
+    // implementation details out of the modal and show the normal import error.
+    throw new Error(i18next.t("publish.import-failed"));
+  }
 
   if (!response.ok) {
     const key = data.error ? `publish.${data.error}` : "publish.import-failed";

--- a/apps/web/src/specs/api/import-pinned-lookup.spec.ts
+++ b/apps/web/src/specs/api/import-pinned-lookup.spec.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import { createPinnedLookup } from "@/app/api/import/pinned-lookup";
+
+describe("createPinnedLookup", () => {
+  it("returns a scalar address when Node requests one result", () => {
+    const callback = vi.fn();
+
+    createPinnedLookup("203.0.113.10", 4)("example.com", {}, callback);
+
+    expect(callback).toHaveBeenCalledWith(null, "203.0.113.10", 4);
+  });
+
+  it("returns an address array when Node requests all results", () => {
+    const callback = vi.fn();
+
+    createPinnedLookup("2001:db8::10", 6)(
+      "example.com",
+      { all: true },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, [
+      { address: "2001:db8::10", family: 6 }
+    ]);
+  });
+});

--- a/apps/web/src/specs/api/import-pinned-lookup.spec.ts
+++ b/apps/web/src/specs/api/import-pinned-lookup.spec.ts
@@ -11,6 +11,18 @@ describe("createPinnedLookup", () => {
     expect(callback).toHaveBeenCalledWith(null, "203.0.113.10", 4);
   });
 
+  it("returns a scalar address when lookup options are missing", () => {
+    const callback = vi.fn();
+
+    createPinnedLookup("203.0.113.10", 4)(
+      "example.com",
+      undefined as never,
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, "203.0.113.10", 4);
+  });
+
   it("returns an address array when Node requests all results", () => {
     const callback = vi.fn();
 

--- a/apps/web/src/specs/features/publish/import-dialog.spec.ts
+++ b/apps/web/src/specs/features/publish/import-dialog.spec.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/features/ui", () => ({
+  Button: "button",
+  FormControl: "input",
+  Modal: "div",
+  ModalBody: "div",
+  ModalFooter: "div",
+  ModalHeader: "div"
+}));
+
+vi.mock("@ui/spinner", () => ({ Spinner: "span" }));
+
+vi.mock("i18next", () => ({
+  default: { t: (key: string) => key }
+}));
+
+import { fetchImport } from "@/app/publish/_components/publish-import-dialog";
+
+describe("fetchImport", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows the generic import error when a gateway returns non-JSON", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response("All origin servers are unavailable", { status: 502 })
+    ));
+
+    await expect(fetchImport("https://example.com/post")).rejects.toThrow(
+      "publish.import-failed"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- fix external article imports under Node's automatic address-family selection
- preserve DNS-rebinding protection by continuing to pin connections to the validated IP
- show the normal import failure message when an edge or gateway returns a non-JSON response
- add regression coverage for both Node DNS callback forms and plain-text gateway errors

## Root cause

The import route's custom Undici DNS lookup always returned a scalar address. Node requests an array when `options.all` is enabled, so it attempted to read `.address` from the scalar value and failed with `ERR_INVALID_IP_ADDRESS`. The route returned a JSON 500, which the Cloudflare geo-router replaced with the plain-text `502 All origin servers are unavailable`; the modal then exposed a JSON parsing error.

## Impact

External blog posts can be imported from URL again. Hive post imports are unchanged, and the SSRF/DNS-rebinding protection remains in place.

## Validation

- `pnpm --filter @ecency/web test --run src/specs/api/import-pinned-lookup.spec.ts src/specs/api/import-route.spec.ts src/specs/features/publish/import-dialog.spec.ts` — 20 tests passed
- `pnpm --filter @ecency/web exec tsc --noEmit --pretty false`
- end-to-end local request using the reported Jennifer Navarrete URL returned HTTP 200 with the extracted title and article content


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publishing imports when a gateway or proxy returns invalid or non-JSON data.
  * Import failures now show a clear, localized error instead of an unexpected parsing message.
  * Improved reliability and security when retrieving imported content by maintaining validated network connection details.

* **Tests**
  * Added coverage for import error handling and validated network lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->