### PR TITLE
Reclassify unhandled cancellation AbortErrors and stop market refetch churn

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-content-infinite-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-content-infinite-list.tsx
@@ -21,7 +21,6 @@ export function CommunityContentInfiniteList({ section, community }: Props) {
     const fetchNextPage = result.fetchNextPage;
     const isFetching = result.isFetching;
     const hasNextPage = result.hasNextPage;
-    const isFetchingNextPage = result.isFetchingNextPage;
 
     // Make 'data' explicit: it's InfiniteData<FeedPage, unknown> | undefined
     const data = result.data as InfiniteData<FeedPage, unknown> | undefined;
@@ -33,7 +32,7 @@ export function CommunityContentInfiniteList({ section, community }: Props) {
     // which re-runs DetectBottom's effect while the sentinel is still in
     // viewport — see useBottomPagination for why the naive inline handler
     // aborts its own fetch.
-    const onBottom = useBottomPagination({ data, hasNextPage, isFetchingNextPage, fetchNextPage });
+    const onBottom = useBottomPagination({ data, hasNextPage, isFetching, fetchNextPage });
 
     const entryList = useMemo(
         () =>

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-content-infinite-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-content-infinite-list.tsx
@@ -21,6 +21,7 @@ export function CommunityContentInfiniteList({ section, community }: Props) {
     const fetchNextPage = result.fetchNextPage;
     const isFetching = result.isFetching;
     const hasNextPage = result.hasNextPage;
+    const dataUpdatedAt = result.dataUpdatedAt;
 
     // Make 'data' explicit: it's InfiniteData<FeedPage, unknown> | undefined
     const data = result.data as InfiniteData<FeedPage, unknown> | undefined;
@@ -32,7 +33,13 @@ export function CommunityContentInfiniteList({ section, community }: Props) {
     // which re-runs DetectBottom's effect while the sentinel is still in
     // viewport — see useBottomPagination for why the naive inline handler
     // aborts its own fetch.
-    const onBottom = useBottomPagination({ data, hasNextPage, isFetching, fetchNextPage });
+    const onBottom = useBottomPagination({
+        data,
+        dataUpdatedAt,
+        hasNextPage,
+        isFetching,
+        fetchNextPage
+    });
 
     const entryList = useMemo(
         () =>

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-content-infinite-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-content-infinite-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DetectBottom, EntryListContent, EntryListContentLoading } from "@/features/shared";
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { usePostsFeedQuery } from "@/api/queries";
 import { Community, Entry, SearchResponse } from "@/entities";
 import type { UseInfiniteQueryResult, InfiniteData } from "@tanstack/react-query";
@@ -19,12 +19,24 @@ export function CommunityContentInfiniteList({ section, community }: Props) {
 
     const fetchNextPage = result.fetchNextPage;
     const isFetching = result.isFetching;
+    const hasNextPage = result.hasNextPage;
+    const isFetchingNextPage = result.isFetchingNextPage;
 
     // Make 'data' explicit: it's InfiniteData<FeedPage, unknown> | undefined
     const data = result.data as InfiniteData<FeedPage, unknown> | undefined;
 
     const pageToEntries = (p: FeedPage): Entry[] =>
         Array.isArray(p) ? p : ((p as any).items ?? (p as any).results ?? []);
+
+    // Guarded: this component re-renders when a fetch starts (it reads
+    // isFetching), which re-runs DetectBottom's effect while the sentinel is
+    // still in viewport — an unguarded fetchNextPage() there aborts and
+    // restarts the page fetch it just kicked off.
+    const onBottom = useCallback(() => {
+        if (hasNextPage && !isFetchingNextPage) {
+            fetchNextPage();
+        }
+    }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
     const entryList = useMemo(
         () =>
@@ -43,7 +55,7 @@ export function CommunityContentInfiniteList({ section, community }: Props) {
                 isPromoted={false}
                 showEmptyPlaceholder={false}
             />
-            <DetectBottom onBottom={() => fetchNextPage()} />
+            <DetectBottom onBottom={onBottom} />
             {isFetching && <EntryListContentLoading />}
         </>
     );

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-content-infinite-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-content-infinite-list.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { DetectBottom, EntryListContent, EntryListContentLoading } from "@/features/shared";
-import React, { useCallback, useMemo } from "react";
+import React, { useMemo } from "react";
+import { useBottomPagination } from "@/core/hooks";
 import { usePostsFeedQuery } from "@/api/queries";
 import { Community, Entry, SearchResponse } from "@/entities";
 import type { UseInfiniteQueryResult, InfiniteData } from "@tanstack/react-query";
@@ -28,15 +29,11 @@ export function CommunityContentInfiniteList({ section, community }: Props) {
     const pageToEntries = (p: FeedPage): Entry[] =>
         Array.isArray(p) ? p : ((p as any).items ?? (p as any).results ?? []);
 
-    // Guarded: this component re-renders when a fetch starts (it reads
-    // isFetching), which re-runs DetectBottom's effect while the sentinel is
-    // still in viewport — an unguarded fetchNextPage() there aborts and
-    // restarts the page fetch it just kicked off.
-    const onBottom = useCallback(() => {
-        if (hasNextPage && !isFetchingNextPage) {
-            fetchNextPage();
-        }
-    }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+    // This component re-renders when a fetch starts (it reads isFetching),
+    // which re-runs DetectBottom's effect while the sentinel is still in
+    // viewport — see useBottomPagination for why the naive inline handler
+    // aborts its own fetch.
+    const onBottom = useBottomPagination({ data, hasNextPage, isFetchingNextPage, fetchNextPage });
 
     const entryList = useMemo(
         () =>

--- a/apps/web/src/app/market/advanced/_advanced-mode/advanced-mode-toolbar.tsx
+++ b/apps/web/src/app/market/advanced/_advanced-mode/advanced-mode-toolbar.tsx
@@ -55,7 +55,9 @@ export const AdvancedModeToolbar = ({
             <div className={"amount " + (dayChange.percent > 0 ? "text-green" : "text-red")}>
               {formattedNumber(dayChange.price)}
             </div>
-            <div className="usd-value">${usdPrice.toFixed(2)}</div>
+            {/* 0 means "no quote yet" (initial state, or CoinGecko still
+                unreachable) — don't present it as a real price. */}
+            {usdPrice > 0 && <div className="usd-value">${usdPrice.toFixed(2)}</div>}
           </div>
           <div className="day-change-price change-price">
             <label>24h change</label>

--- a/apps/web/src/app/market/advanced/_advanced-mode/advanced-mode-toolbar.tsx
+++ b/apps/web/src/app/market/advanced/_advanced-mode/advanced-mode-toolbar.tsx
@@ -55,8 +55,9 @@ export const AdvancedModeToolbar = ({
             <div className={"amount " + (dayChange.percent > 0 ? "text-green" : "text-red")}>
               {formattedNumber(dayChange.price)}
             </div>
-            {/* 0 means "no quote yet" (initial state, or CoinGecko still
-                unreachable) — don't present it as a real price. */}
+            {/* 0 means "no quote" (initial state, or the observer published 0
+                because CoinGecko is unavailable) — don't present it as a real
+                price. */}
             {usdPrice > 0 && <div className="usd-value">${usdPrice.toFixed(2)}</div>}
           </div>
           <div className="day-change-price change-price">

--- a/apps/web/src/app/market/advanced/_advanced-mode/pairs/hive-hbd-observer.tsx
+++ b/apps/web/src/app/market/advanced/_advanced-mode/pairs/hive-hbd-observer.tsx
@@ -63,8 +63,11 @@ export const HiveHbdObserver = ({
         usdResponse = await getCGMarket(MarketAsset.HIVE, MarketAsset.HBD);
       } catch {
         // No caller awaits this function (interval/mount/refresh effect), so a
-        // failed CoinGecko lookup must not escape as an unhandled rejection —
-        // the USD price keeps its last value until the next tick.
+        // failed CoinGecko lookup must not escape as an unhandled rejection.
+        // Publish 0 — the shared "no quote" value the USD displays hide on —
+        // so an outage doesn't leave an old quote rendered as current; the
+        // next successful tick restores it.
+        onUsdChange(0);
         return;
       }
       if (usdResponse[0]) {

--- a/apps/web/src/app/market/advanced/_advanced-mode/pairs/hive-hbd-observer.tsx
+++ b/apps/web/src/app/market/advanced/_advanced-mode/pairs/hive-hbd-observer.tsx
@@ -70,9 +70,10 @@ export const HiveHbdObserver = ({
         onUsdChange(0);
         return;
       }
-      if (usdResponse[0]) {
-        onUsdChange(usdResponse[0]);
-      }
+      // Normalize any unusable quote (0/undefined/NaN) through the same
+      // "no quote" sentinel as the catch path, so a degraded response also
+      // clears a previously rendered price.
+      onUsdChange(usdResponse[0] || 0);
     },
     [activeUsername, onUsdChange, reFetchAllStats, reFetchOpenOrders, reFetchOrderBook, reFetchTransactions]
   );

--- a/apps/web/src/app/market/advanced/_advanced-mode/pairs/hive-hbd-observer.tsx
+++ b/apps/web/src/app/market/advanced/_advanced-mode/pairs/hive-hbd-observer.tsx
@@ -42,29 +42,37 @@ export const HiveHbdObserver = ({
     activeUsername ?? ""
   ));
 
-  const fetchAllStats = useCallback(async () => {
-    // cancelRefetch: false joins a still-in-flight request instead of aborting
-    // it — the transactions history walk can outlive one poll tick on slow
-    // public nodes, and restarting it every tick would keep it from ever
-    // completing (a frozen trade-history widget).
-    reFetchAllStats({ cancelRefetch: false });
-    reFetchOrderBook({ cancelRefetch: false });
-    if (activeUsername) {
-      reFetchOpenOrders({ cancelRefetch: false });
-      reFetchTransactions({ cancelRefetch: false });
-    }
+  const fetchAllStats = useCallback(
+    async (postTrade = false) => {
+      // Poll ticks join a still-in-flight request (cancelRefetch: false) — the
+      // transactions history walk can outlive one tick on slow public nodes,
+      // and restarting it every tick would keep it from ever completing (a
+      // frozen trade-history widget). The post-trade refresh is the opposite
+      // case: an in-flight request may predate the trade, so it must be
+      // cancelled and reissued for the new order to show up.
+      const options = { cancelRefetch: postTrade };
+      reFetchAllStats(options);
+      reFetchOrderBook(options);
+      if (activeUsername) {
+        reFetchOpenOrders(options);
+        reFetchTransactions(options);
+      }
 
-    try {
-      const usdResponse = await getCGMarket(MarketAsset.HIVE, MarketAsset.HBD);
+      let usdResponse: number[];
+      try {
+        usdResponse = await getCGMarket(MarketAsset.HIVE, MarketAsset.HBD);
+      } catch {
+        // No caller awaits this function (interval/mount/refresh effect), so a
+        // failed CoinGecko lookup must not escape as an unhandled rejection —
+        // the USD price keeps its last value until the next tick.
+        return;
+      }
       if (usdResponse[0]) {
         onUsdChange(usdResponse[0]);
       }
-    } catch {
-      // No caller awaits this function (interval/mount/refresh effect), so a
-      // failed CoinGecko lookup must not escape as an unhandled rejection —
-      // the USD price keeps its last value until the next tick.
-    }
-  }, [activeUsername, onUsdChange, reFetchAllStats, reFetchOpenOrders, reFetchOrderBook, reFetchTransactions]);
+    },
+    [activeUsername, onUsdChange, reFetchAllStats, reFetchOpenOrders, reFetchOrderBook, reFetchTransactions]
+  );
 
   useEffect(() => {
     setAllOrders(
@@ -111,7 +119,7 @@ export const HiveHbdObserver = ({
     if (!refresh) {
       return;
     }
-    fetchAllStats();
+    fetchAllStats(true);
     setRefresh(false);
   }, [fetchAllStats, refresh, setRefresh]);
 

--- a/apps/web/src/app/market/advanced/_advanced-mode/pairs/hive-hbd-observer.tsx
+++ b/apps/web/src/app/market/advanced/_advanced-mode/pairs/hive-hbd-observer.tsx
@@ -43,16 +43,26 @@ export const HiveHbdObserver = ({
   ));
 
   const fetchAllStats = useCallback(async () => {
-    reFetchAllStats();
-    reFetchOrderBook();
+    // cancelRefetch: false joins a still-in-flight request instead of aborting
+    // it — the transactions history walk can outlive one poll tick on slow
+    // public nodes, and restarting it every tick would keep it from ever
+    // completing (a frozen trade-history widget).
+    reFetchAllStats({ cancelRefetch: false });
+    reFetchOrderBook({ cancelRefetch: false });
     if (activeUsername) {
-      reFetchOpenOrders();
-      reFetchTransactions();
+      reFetchOpenOrders({ cancelRefetch: false });
+      reFetchTransactions({ cancelRefetch: false });
     }
 
-    const usdResponse = await getCGMarket(MarketAsset.HIVE, MarketAsset.HBD);
-    if (usdResponse[0]) {
-      onUsdChange(usdResponse[0]);
+    try {
+      const usdResponse = await getCGMarket(MarketAsset.HIVE, MarketAsset.HBD);
+      if (usdResponse[0]) {
+        onUsdChange(usdResponse[0]);
+      }
+    } catch {
+      // No caller awaits this function (interval/mount/refresh effect), so a
+      // failed CoinGecko lookup must not escape as an unhandled rejection —
+      // the USD price keeps its last value until the next tick.
     }
   }, [activeUsername, onUsdChange, reFetchAllStats, reFetchOpenOrders, reFetchOrderBook, reFetchTransactions]);
 
@@ -94,6 +104,13 @@ export const HiveHbdObserver = ({
   }, [openOrders, setOpenOrders]);
 
   useEffect(() => {
+    // `refresh` (set after a successful trade) is the only trigger here; the
+    // mount fetch is handled by useMount above. Ungated, this effect re-fired
+    // a full four-query round every time a parent re-render changed
+    // fetchAllStats' identity.
+    if (!refresh) {
+      return;
+    }
     fetchAllStats();
     setRefresh(false);
   }, [fetchAllStats, refresh, setRefresh]);

--- a/apps/web/src/app/market/advanced/_components/stake-widget.tsx
+++ b/apps/web/src/app/market/advanced/_components/stake-widget.tsx
@@ -201,7 +201,9 @@ export const StakeWidget = ({
           </div>
           <div className="market-stake-widget-current-price py-2">
             <span className="price">{price.toFixed(3)}</span>
-            <span className="usd-price">${usdPrice.toFixed(3)}</span>
+            {/* 0 means "no quote" (initial state or CoinGecko unavailable) —
+                don't present it as a real price. */}
+            {usdPrice > 0 && <span className="usd-price">${usdPrice.toFixed(3)}</span>}
           </div>
           <div className="market-stake-widget-buy">
             <div className="market-stake-widget-sell pt-0 history-widget-content">

--- a/apps/web/src/app/market/advanced/_page.tsx
+++ b/apps/web/src/app/market/advanced/_page.tsx
@@ -59,15 +59,15 @@ export function MarketAdvancedPage() {
               setRefresh={setRefresh}
               fromAsset={fromAsset}
               toAsset={toAsset}
-              onDayChange={(dayChange) => setDayChange(dayChange)}
-              onHistoryChange={(history) => setHistory(history)}
-              onUsdChange={(usdPrice) => setUsdPrice(usdPrice)}
+              onDayChange={setDayChange}
+              onHistoryChange={setHistory}
+              onUsdChange={setUsdPrice}
               setOpenOrders={setOpenOrdersData}
             />
             <UserBalanceObserver
               fromAsset={fromAsset}
-              setBuyBalance={(v) => setBuyBalance(v)}
-              setSellBalance={(v) => setSellBalance(v)}
+              setBuyBalance={setBuyBalance}
+              setSellBalance={setSellBalance}
             />
             <AdvancedModeToolbar
               fromAsset={fromAsset}

--- a/apps/web/src/app/search/_components/search-comment/index.tsx
+++ b/apps/web/src/app/search/_components/search-comment/index.tsx
@@ -48,6 +48,7 @@ export function SearchComment({ disableResults }: Props) {
 
   const {
     data: resultsPages,
+    dataUpdatedAt,
     isLoading,
     isFetching,
     fetchNextPage,
@@ -74,6 +75,7 @@ export function SearchComment({ disableResults }: Props) {
   // sentinel is also what bootstraps page 1 — see useBottomPagination.
   const onBottom = useBottomPagination({
     data: resultsPages,
+    dataUpdatedAt,
     hasNextPage,
     isFetching,
     fetchNextPage

--- a/apps/web/src/app/search/_components/search-comment/index.tsx
+++ b/apps/web/src/app/search/_components/search-comment/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo, useState } from "react";
+import React, { Fragment, useCallback, useMemo, useState } from "react";
 import numeral from "numeral";
 import dayjs, { Dayjs } from "@/utils/dayjs";
 import "./_index.scss";
@@ -49,7 +49,8 @@ export function SearchComment({ disableResults }: Props) {
     data: resultsPages,
     isLoading,
     fetchNextPage,
-    hasNextPage
+    hasNextPage,
+    isFetchingNextPage
   } = useInfiniteQuery({
     ...getSearchApiInfiniteQueryOptions(
       params?.get("q") ?? "",
@@ -67,6 +68,15 @@ export function SearchComment({ disableResults }: Props) {
       [],
     [resultsPages]
   );
+
+  // Guarded: initialData makes `data` defined from the first render, so an
+  // unguarded fetchNextPage() from a re-run of DetectBottom's effect would
+  // abort and restart a page fetch already in flight.
+  const onBottom = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
   const hits = useMemo(
     () => resultsPages?.pages?.[resultsPages?.pages?.length - 1]?.hits ?? 0,
     [resultsPages?.pages]
@@ -138,7 +148,7 @@ export function SearchComment({ disableResults }: Props) {
 
         {!disableResults && isLoading && <LinearProgress />}
       </div>
-      <DetectBottom onBottom={() => fetchNextPage()} />
+      <DetectBottom onBottom={onBottom} />
     </div>
   );
 }

--- a/apps/web/src/app/search/_components/search-comment/index.tsx
+++ b/apps/web/src/app/search/_components/search-comment/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useMemo, useState } from "react";
+import React, { Fragment, useMemo, useState } from "react";
 import numeral from "numeral";
 import dayjs, { Dayjs } from "@/utils/dayjs";
 import "./_index.scss";
@@ -12,6 +12,7 @@ import { SearchResult } from "@/entities";
 import { Button } from "@/features/ui";
 import { DateOpt } from "@/enums";
 import { SearchSort } from "@/app/decks/_components/consts";
+import { useBottomPagination } from "@/core/hooks";
 
 interface Props {
   disableResults?: boolean;
@@ -69,14 +70,14 @@ export function SearchComment({ disableResults }: Props) {
     [resultsPages]
   );
 
-  // Guarded: initialData makes `data` defined from the first render, so an
-  // unguarded fetchNextPage() from a re-run of DetectBottom's effect would
-  // abort and restart a page fetch already in flight.
-  const onBottom = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+  // initialData seeds this query as "success" with zero pages, so the bottom
+  // sentinel is also what bootstraps page 1 — see useBottomPagination.
+  const onBottom = useBottomPagination({
+    data: resultsPages,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage
+  });
   const hits = useMemo(
     () => resultsPages?.pages?.[resultsPages?.pages?.length - 1]?.hits ?? 0,
     [resultsPages?.pages]

--- a/apps/web/src/app/search/_components/search-comment/index.tsx
+++ b/apps/web/src/app/search/_components/search-comment/index.tsx
@@ -49,9 +49,9 @@ export function SearchComment({ disableResults }: Props) {
   const {
     data: resultsPages,
     isLoading,
+    isFetching,
     fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage
+    hasNextPage
   } = useInfiniteQuery({
     ...getSearchApiInfiniteQueryOptions(
       params?.get("q") ?? "",
@@ -75,7 +75,7 @@ export function SearchComment({ disableResults }: Props) {
   const onBottom = useBottomPagination({
     data: resultsPages,
     hasNextPage,
-    isFetchingNextPage,
+    isFetching,
     fetchNextPage
   });
   const hits = useMemo(
@@ -131,7 +131,7 @@ export function SearchComment({ disableResults }: Props) {
 
                 {hasNextPage && (
                   <div className="flex justify-center capitalize">
-                    <Button outline={true} onClick={() => fetchNextPage()}>
+                    <Button outline={true} disabled={isFetching} onClick={onBottom}>
                       {i18next.t("search-comment.show-more")}
                     </Button>
                   </div>

--- a/apps/web/src/app/waves/_components/waves-list-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-view.tsx
@@ -57,7 +57,7 @@ export function WavesListView({ feedType, username }: Props) {
   // The Following feed needs a username; without one `following` drops and the
   // query would silently become the unfiltered combined feed, so gate it until
   // the active user is known.
-  const { data, fetchNextPage, isError, error, hasNextPage, isFetched, isFetchingNextPage, refetch } =
+  const { data, fetchNextPage, isError, error, hasNextPage, isFetched, isFetching, refetch } =
     useInfiniteQuery(
     {
       ...queryOptions,
@@ -192,7 +192,7 @@ export function WavesListView({ feedType, username }: Props) {
   // Every feed type now paginates via the keyset cursor, so infinite scroll
   // is enabled across For You, Following and Tag (not just For You).
   const shouldShowDetectBottom = hasNextPage;
-  const onBottom = useBottomPagination({ data, hasNextPage, isFetchingNextPage, fetchNextPage });
+  const onBottom = useBottomPagination({ data, hasNextPage, isFetching, fetchNextPage });
 
   if (isError && combinedDataFlow.length === 0) {
     return (

--- a/apps/web/src/app/waves/_components/waves-list-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-view.tsx
@@ -57,7 +57,7 @@ export function WavesListView({ feedType, username }: Props) {
   // The Following feed needs a username; without one `following` drops and the
   // query would silently become the unfiltered combined feed, so gate it until
   // the active user is known.
-  const { data, fetchNextPage, isError, error, hasNextPage, isFetched, isFetching, refetch } =
+  const { data, dataUpdatedAt, fetchNextPage, isError, error, hasNextPage, isFetched, isFetching, refetch } =
     useInfiniteQuery(
     {
       ...queryOptions,
@@ -192,7 +192,7 @@ export function WavesListView({ feedType, username }: Props) {
   // Every feed type now paginates via the keyset cursor, so infinite scroll
   // is enabled across For You, Following and Tag (not just For You).
   const shouldShowDetectBottom = hasNextPage;
-  const onBottom = useBottomPagination({ data, hasNextPage, isFetching, fetchNextPage });
+  const onBottom = useBottomPagination({ data, dataUpdatedAt, hasNextPage, isFetching, fetchNextPage });
 
   if (isError && combinedDataFlow.length === 0) {
     return (

--- a/apps/web/src/app/waves/_components/waves-list-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-view.tsx
@@ -18,6 +18,7 @@ import {
   WavesFeedType
 } from "@/app/waves/_constants";
 import { useWavesTagFilter } from "@/app/waves/_context";
+import { useBottomPagination } from "@/core/hooks";
 import { Button } from "@ui/button";
 import i18next from "i18next";
 import { sentry } from "@/core/sentry/lazy-sentry";
@@ -56,7 +57,8 @@ export function WavesListView({ feedType, username }: Props) {
   // The Following feed needs a username; without one `following` drops and the
   // query would silently become the unfiltered combined feed, so gate it until
   // the active user is known.
-  const { data, fetchNextPage, isError, error, hasNextPage, isFetched, refetch } = useInfiniteQuery(
+  const { data, fetchNextPage, isError, error, hasNextPage, isFetched, isFetchingNextPage, refetch } =
+    useInfiniteQuery(
     {
       ...queryOptions,
       enabled: feedType !== "following" || !!username
@@ -190,6 +192,7 @@ export function WavesListView({ feedType, username }: Props) {
   // Every feed type now paginates via the keyset cursor, so infinite scroll
   // is enabled across For You, Following and Tag (not just For You).
   const shouldShowDetectBottom = hasNextPage;
+  const onBottom = useBottomPagination({ data, hasNextPage, isFetchingNextPage, fetchNextPage });
 
   if (isError && combinedDataFlow.length === 0) {
     return (
@@ -328,7 +331,7 @@ export function WavesListView({ feedType, username }: Props) {
       {/* A disabled/not-yet-fetched query (e.g. Following before the active
           user hydrates) must read as loading, not as an exhausted feed. */}
       <WavesListLoader data={dataFlow} failed={isError} isEndReached={isFetched && !hasNextPage} />
-      {shouldShowDetectBottom && <DetectBottom onBottom={() => fetchNextPage()} />}
+      {shouldShowDetectBottom && <DetectBottom onBottom={onBottom} />}
 
       <WavesFastReplyDialog
         show={!!replyingEntry}

--- a/apps/web/src/core/hooks/index.ts
+++ b/apps/web/src/core/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useActiveAccount } from "./use-active-account";
+export { useBottomPagination } from "./use-bottom-pagination";
 export { useMountTransition } from "./use-mount-transition";

--- a/apps/web/src/core/hooks/use-bottom-pagination.ts
+++ b/apps/web/src/core/hooks/use-bottom-pagination.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import useLatest from "react-use/lib/useLatest";
 
 interface BottomPaginationQuery {
   data?: { pages: unknown[] };
@@ -33,10 +34,15 @@ interface BottomPaginationQuery {
  *   `hasNextPage` alone would leave such a list permanently empty; the
  *   no-pages arm keeps the bootstrap.
  *
- * `isFetching` is deliberately read WITHOUT being an identity dependency (it
- * would reintroduce the failure loop). The captured value can therefore be
- * stale, which is safe: a stale-false call just joins the in-flight fetch
- * (never aborts it) and the success retrigger issues anything swallowed.
+ * `isFetching` is read through a latest-value ref, NOT captured in the
+ * closure and NOT an identity dependency (that would reintroduce the failure
+ * loop). A closure capture would go one worse: a callback minted while a
+ * fetch is in flight (e.g. the waves list mounts fetching) whose fetch then
+ * FAILS keeps `isFetching=true` forever — no dep changes on failure — and
+ * every retry would no-op. The ref is written during render (useLatest), not
+ * in an effect: a child sentinel's effect runs BEFORE this hook owner's
+ * effects in the same commit, so an effect-updated ref would still read
+ * stale there and swallow the success retrigger.
  */
 export function useBottomPagination({
   data,
@@ -46,13 +52,16 @@ export function useBottomPagination({
   fetchNextPage
 }: BottomPaginationQuery) {
   const hasPages = (data?.pages?.length ?? 0) > 0;
+  const isFetchingRef = useLatest(isFetching);
   return useCallback(() => {
-    if (isFetching) {
+    if (isFetchingRef.current) {
       return;
     }
     if (hasNextPage || !hasPages) {
       fetchNextPage({ cancelRefetch: false });
     }
+    // dataUpdatedAt is an intentional extra dependency — it is the success
+    // retrigger described above, not a value the callback reads.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchNextPage, hasNextPage, hasPages, dataUpdatedAt]);
+  }, [fetchNextPage, hasNextPage, hasPages, isFetchingRef, dataUpdatedAt]);
 }

--- a/apps/web/src/core/hooks/use-bottom-pagination.ts
+++ b/apps/web/src/core/hooks/use-bottom-pagination.ts
@@ -3,37 +3,45 @@ import { useCallback } from "react";
 interface BottomPaginationQuery {
   data?: { pages: unknown[] };
   hasNextPage: boolean;
-  isFetchingNextPage: boolean;
+  isFetching: boolean;
   fetchNextPage: (options?: { cancelRefetch?: boolean }) => Promise<unknown>;
 }
 
 /**
  * Stable load-more callback for a `DetectBottom` sentinel over an infinite
- * query. Two hazards make the naive `onBottom={() => fetchNextPage()}` wrong:
+ * query. Three hazards make the naive `onBottom={() => fetchNextPage()}`
+ * wrong:
  *
  * - `fetchNextPage()` defaults to `cancelRefetch: true`, so a re-render while
  *   a fetch is in flight (DetectBottom re-runs its effect whenever the
  *   callback identity changes) aborts and restarts that fetch — the
  *   cancellation-AbortError churn. `cancelRefetch: false` joins it instead.
+ * - Joining is only safe when nothing is in flight to join: with
+ *   `cancelRefetch: false` a call during a background refetch silently
+ *   returns that refetch's promise and the next page is never queued. The
+ *   guard therefore waits out ANY fetch (`isFetching`, which also covers
+ *   next-page fetches) — and because `isFetching` is a dependency of the
+ *   callback, its completion mints a new identity, re-running DetectBottom's
+ *   effect so a still-visible sentinel retries instead of stalling.
  * - A query seeded with `initialData: { pages: [] }` is "success" with
  *   `hasNextPage` false and never auto-fetches (`refetchOnMount` is false
- *   app-wide), so the sentinel's unguarded call is what bootstraps page 1.
- *   Gating on `hasNextPage` alone would leave such a list permanently empty;
- *   the no-pages arm keeps the bootstrap.
+ *   app-wide), so the sentinel's call is what bootstraps page 1. Gating on
+ *   `hasNextPage` alone would leave such a list permanently empty; the
+ *   no-pages arm keeps the bootstrap.
  */
 export function useBottomPagination({
   data,
   hasNextPage,
-  isFetchingNextPage,
+  isFetching,
   fetchNextPage
 }: BottomPaginationQuery) {
   const hasPages = (data?.pages?.length ?? 0) > 0;
   return useCallback(() => {
-    if (isFetchingNextPage) {
+    if (isFetching) {
       return;
     }
     if (hasNextPage || !hasPages) {
       fetchNextPage({ cancelRefetch: false });
     }
-  }, [fetchNextPage, hasNextPage, hasPages, isFetchingNextPage]);
+  }, [fetchNextPage, hasNextPage, hasPages, isFetching]);
 }

--- a/apps/web/src/core/hooks/use-bottom-pagination.ts
+++ b/apps/web/src/core/hooks/use-bottom-pagination.ts
@@ -1,0 +1,39 @@
+import { useCallback } from "react";
+
+interface BottomPaginationQuery {
+  data?: { pages: unknown[] };
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: (options?: { cancelRefetch?: boolean }) => Promise<unknown>;
+}
+
+/**
+ * Stable load-more callback for a `DetectBottom` sentinel over an infinite
+ * query. Two hazards make the naive `onBottom={() => fetchNextPage()}` wrong:
+ *
+ * - `fetchNextPage()` defaults to `cancelRefetch: true`, so a re-render while
+ *   a fetch is in flight (DetectBottom re-runs its effect whenever the
+ *   callback identity changes) aborts and restarts that fetch — the
+ *   cancellation-AbortError churn. `cancelRefetch: false` joins it instead.
+ * - A query seeded with `initialData: { pages: [] }` is "success" with
+ *   `hasNextPage` false and never auto-fetches (`refetchOnMount` is false
+ *   app-wide), so the sentinel's unguarded call is what bootstraps page 1.
+ *   Gating on `hasNextPage` alone would leave such a list permanently empty;
+ *   the no-pages arm keeps the bootstrap.
+ */
+export function useBottomPagination({
+  data,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage
+}: BottomPaginationQuery) {
+  const hasPages = (data?.pages?.length ?? 0) > 0;
+  return useCallback(() => {
+    if (isFetchingNextPage) {
+      return;
+    }
+    if (hasNextPage || !hasPages) {
+      fetchNextPage({ cancelRefetch: false });
+    }
+  }, [fetchNextPage, hasNextPage, hasPages, isFetchingNextPage]);
+}

--- a/apps/web/src/core/hooks/use-bottom-pagination.ts
+++ b/apps/web/src/core/hooks/use-bottom-pagination.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 
 interface BottomPaginationQuery {
   data?: { pages: unknown[] };
+  dataUpdatedAt: number;
   hasNextPage: boolean;
   isFetching: boolean;
   fetchNextPage: (options?: { cancelRefetch?: boolean }) => Promise<unknown>;
@@ -9,28 +10,37 @@ interface BottomPaginationQuery {
 
 /**
  * Stable load-more callback for a `DetectBottom` sentinel over an infinite
- * query. Three hazards make the naive `onBottom={() => fetchNextPage()}`
+ * query. The hazards that make the naive `onBottom={() => fetchNextPage()}`
  * wrong:
  *
  * - `fetchNextPage()` defaults to `cancelRefetch: true`, so a re-render while
  *   a fetch is in flight (DetectBottom re-runs its effect whenever the
  *   callback identity changes) aborts and restarts that fetch — the
  *   cancellation-AbortError churn. `cancelRefetch: false` joins it instead.
- * - Joining is only safe when nothing is in flight to join: with
- *   `cancelRefetch: false` a call during a background refetch silently
- *   returns that refetch's promise and the next page is never queued. The
- *   guard therefore waits out ANY fetch (`isFetching`, which also covers
- *   next-page fetches) — and because `isFetching` is a dependency of the
- *   callback, its completion mints a new identity, re-running DetectBottom's
- *   effect so a still-visible sentinel retries instead of stalling.
+ * - A call landing during a BACKGROUND refetch silently joins it and the next
+ *   page is never queued, so a still-visible sentinel needs a retrigger when
+ *   the refetch ends. The callback identity is keyed on `dataUpdatedAt` — the
+ *   SUCCESS timestamp — so completion re-runs DetectBottom's effect and
+ *   issues the queued page. Keying on `isFetching` instead would also
+ *   retrigger after a FAILED fetch (isFetching flips back to false), and with
+ *   `hasNextPage` still true that immediately refetches: an API outage would
+ *   loop requests indefinitely. On failure nothing here changes, so the
+ *   sentinel stops; a fresh user signal (re-entering the viewport, a
+ *   load-more click) retries.
  * - A query seeded with `initialData: { pages: [] }` is "success" with
  *   `hasNextPage` false and never auto-fetches (`refetchOnMount` is false
  *   app-wide), so the sentinel's call is what bootstraps page 1. Gating on
  *   `hasNextPage` alone would leave such a list permanently empty; the
  *   no-pages arm keeps the bootstrap.
+ *
+ * `isFetching` is deliberately read WITHOUT being an identity dependency (it
+ * would reintroduce the failure loop). The captured value can therefore be
+ * stale, which is safe: a stale-false call just joins the in-flight fetch
+ * (never aborts it) and the success retrigger issues anything swallowed.
  */
 export function useBottomPagination({
   data,
+  dataUpdatedAt,
   hasNextPage,
   isFetching,
   fetchNextPage
@@ -43,5 +53,6 @@ export function useBottomPagination({
     if (hasNextPage || !hasPages) {
       fetchNextPage({ cancelRefetch: false });
     }
-  }, [fetchNextPage, hasNextPage, hasPages, isFetching]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchNextPage, hasNextPage, hasPages, dataUpdatedAt]);
 }

--- a/apps/web/src/specs/core/use-bottom-pagination.spec.tsx
+++ b/apps/web/src/specs/core/use-bottom-pagination.spec.tsx
@@ -2,17 +2,19 @@ import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useBottomPagination } from "@/core/hooks/use-bottom-pagination";
 
-// The DetectBottom load-more callback has three failure modes this hook
-// exists to prevent: aborting an in-flight fetch (fetchNextPage defaults to
-// cancelRefetch: true), silently joining a background refetch without ever
-// queuing the requested page (the sentinel must retry when the fetch ends),
-// and dead-ending a query seeded with initialData: { pages: [] }
-// (hasNextPage is false with zero pages and refetchOnMount is false
-// app-wide, so the sentinel IS the page-1 bootstrap).
+// The DetectBottom load-more callback has four failure modes this hook exists
+// to prevent: aborting an in-flight fetch (fetchNextPage defaults to
+// cancelRefetch: true), silently joining a background refetch without a later
+// retrigger for the swallowed page request, looping requests during an API
+// outage (retriggering off isFetching re-fires after FAILED fetches too), and
+// dead-ending a query seeded with initialData: { pages: [] } (hasNextPage is
+// false with zero pages and refetchOnMount is false app-wide, so the sentinel
+// IS the page-1 bootstrap).
 
 function makeQuery(overrides: Partial<Parameters<typeof useBottomPagination>[0]> = {}) {
   return {
     data: { pages: [["a"]] },
+    dataUpdatedAt: 1000,
     hasNextPage: true,
     isFetching: false,
     fetchNextPage: vi.fn(async () => undefined),
@@ -48,7 +50,8 @@ describe("useBottomPagination", () => {
   it("no-ops while ANY fetch is in flight (next page or background refetch)", () => {
     // With cancelRefetch: false a call during a background refetch would
     // silently join it and the next page would never be queued — so the
-    // guard must wait out every fetch, not just next-page ones.
+    // guard waits out every fetch; the success retrigger below issues
+    // anything swallowed.
     const query = makeQuery({ isFetching: true });
     const { result } = renderHook(() => useBottomPagination(query));
     result.current();
@@ -76,17 +79,33 @@ describe("useBottomPagination", () => {
     expect(result.current).toBe(first);
   });
 
-  it("mints a new identity when a fetch completes so a visible sentinel retries", () => {
-    // The stall guard's other half: a bottom call during a fetch no-ops, so
-    // the fetch finishing (isFetching true -> false) must change the callback
-    // identity — that re-runs DetectBottom's effect and issues the queued
-    // page instead of stalling until the user scrolls away and back.
+  it("mints a new identity when a fetch SUCCEEDS so a visible sentinel retries", () => {
+    // A bottom call during a fetch no-ops, so successful completion
+    // (dataUpdatedAt advances) must change the callback identity — that
+    // re-runs DetectBottom's effect and issues the queued page instead of
+    // stalling until the user scrolls away and back.
+    const base = makeQuery({ isFetching: true });
+    const { result, rerender } = renderHook((q) => useBottomPagination(q), {
+      initialProps: base
+    });
+    const during = result.current;
+    rerender({ ...base, isFetching: false, dataUpdatedAt: 2000 });
+    expect(result.current).not.toBe(during);
+  });
+
+  it("keeps the SAME identity when a fetch FAILS (no outage retry loop)", () => {
+    // On failure isFetching flips back to false but dataUpdatedAt does not
+    // advance. The identity must not change: a change would re-run
+    // DetectBottom's effect while the sentinel is visible and immediately
+    // refetch — combined with React Query's internal retries, an API outage
+    // would generate requests indefinitely. Recovery comes from a fresh user
+    // signal (viewport re-entry, load-more click) instead.
     const base = makeQuery({ isFetching: true });
     const { result, rerender } = renderHook((q) => useBottomPagination(q), {
       initialProps: base
     });
     const during = result.current;
     rerender({ ...base, isFetching: false });
-    expect(result.current).not.toBe(during);
+    expect(result.current).toBe(during);
   });
 });

--- a/apps/web/src/specs/core/use-bottom-pagination.spec.tsx
+++ b/apps/web/src/specs/core/use-bottom-pagination.spec.tsx
@@ -1,0 +1,69 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useBottomPagination } from "@/core/hooks/use-bottom-pagination";
+
+// The DetectBottom load-more callback has two failure modes this hook exists
+// to prevent: aborting an in-flight fetch (fetchNextPage defaults to
+// cancelRefetch: true) and dead-ending a query seeded with
+// initialData: { pages: [] } (hasNextPage is false with zero pages and
+// refetchOnMount is false app-wide, so the sentinel IS the page-1 bootstrap).
+
+function makeQuery(overrides: Partial<Parameters<typeof useBottomPagination>[0]> = {}) {
+  return {
+    data: { pages: [["a"]] },
+    hasNextPage: true,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(async () => undefined),
+    ...overrides
+  };
+}
+
+describe("useBottomPagination", () => {
+  it("fetches the next page with cancelRefetch: false (joins, never aborts)", () => {
+    const query = makeQuery();
+    const { result } = renderHook(() => useBottomPagination(query));
+    result.current();
+    expect(query.fetchNextPage).toHaveBeenCalledTimes(1);
+    expect(query.fetchNextPage).toHaveBeenCalledWith({ cancelRefetch: false });
+  });
+
+  it("bootstraps page 1 when no pages are loaded even though hasNextPage is false", () => {
+    // The initialData: { pages: [] } case — hasNextPage is false with zero
+    // pages, and gating on it alone leaves the list permanently empty.
+    const query = makeQuery({ data: { pages: [] }, hasNextPage: false });
+    const { result } = renderHook(() => useBottomPagination(query));
+    result.current();
+    expect(query.fetchNextPage).toHaveBeenCalledWith({ cancelRefetch: false });
+  });
+
+  it("bootstraps when data is undefined (query never seeded)", () => {
+    const query = makeQuery({ data: undefined, hasNextPage: false });
+    const { result } = renderHook(() => useBottomPagination(query));
+    result.current();
+    expect(query.fetchNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops while a next-page fetch is in flight", () => {
+    const query = makeQuery({ isFetchingNextPage: true });
+    const { result } = renderHook(() => useBottomPagination(query));
+    result.current();
+    expect(query.fetchNextPage).not.toHaveBeenCalled();
+  });
+
+  it("no-ops at the end of results (pages loaded, no next page)", () => {
+    const query = makeQuery({ hasNextPage: false });
+    const { result } = renderHook(() => useBottomPagination(query));
+    result.current();
+    expect(query.fetchNextPage).not.toHaveBeenCalled();
+  });
+
+  it("keeps a stable identity across re-renders with unchanged inputs", () => {
+    // DetectBottom re-runs its effect whenever onBottom's identity changes;
+    // a stable callback avoids gratuitous re-fires while parked at the bottom.
+    const query = makeQuery();
+    const { result, rerender } = renderHook(() => useBottomPagination(query));
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/apps/web/src/specs/core/use-bottom-pagination.spec.tsx
+++ b/apps/web/src/specs/core/use-bottom-pagination.spec.tsx
@@ -108,4 +108,23 @@ describe("useBottomPagination", () => {
     rerender({ ...base, isFetching: false });
     expect(result.current).toBe(during);
   });
+
+  it("can retry after a failed fetch even when the callback was minted mid-flight", () => {
+    // Stale-closure regression: a callback created while a fetch is in
+    // flight (e.g. a list that mounts fetching) whose fetch then FAILS gets
+    // no dep change — a closure-captured isFetching would stay true forever
+    // and viewport re-entry / load-more clicks could never retry. The
+    // latest-value ref must see the idle state.
+    const base = makeQuery({ isFetching: true });
+    const { result, rerender } = renderHook((q) => useBottomPagination(q), {
+      initialProps: base
+    });
+    result.current();
+    expect(base.fetchNextPage).not.toHaveBeenCalled();
+
+    rerender({ ...base, isFetching: false });
+    result.current();
+    expect(base.fetchNextPage).toHaveBeenCalledTimes(1);
+    expect(base.fetchNextPage).toHaveBeenCalledWith({ cancelRefetch: false });
+  });
 });

--- a/apps/web/src/specs/core/use-bottom-pagination.spec.tsx
+++ b/apps/web/src/specs/core/use-bottom-pagination.spec.tsx
@@ -2,17 +2,19 @@ import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useBottomPagination } from "@/core/hooks/use-bottom-pagination";
 
-// The DetectBottom load-more callback has two failure modes this hook exists
-// to prevent: aborting an in-flight fetch (fetchNextPage defaults to
-// cancelRefetch: true) and dead-ending a query seeded with
-// initialData: { pages: [] } (hasNextPage is false with zero pages and
-// refetchOnMount is false app-wide, so the sentinel IS the page-1 bootstrap).
+// The DetectBottom load-more callback has three failure modes this hook
+// exists to prevent: aborting an in-flight fetch (fetchNextPage defaults to
+// cancelRefetch: true), silently joining a background refetch without ever
+// queuing the requested page (the sentinel must retry when the fetch ends),
+// and dead-ending a query seeded with initialData: { pages: [] }
+// (hasNextPage is false with zero pages and refetchOnMount is false
+// app-wide, so the sentinel IS the page-1 bootstrap).
 
 function makeQuery(overrides: Partial<Parameters<typeof useBottomPagination>[0]> = {}) {
   return {
     data: { pages: [["a"]] },
     hasNextPage: true,
-    isFetchingNextPage: false,
+    isFetching: false,
     fetchNextPage: vi.fn(async () => undefined),
     ...overrides
   };
@@ -43,8 +45,11 @@ describe("useBottomPagination", () => {
     expect(query.fetchNextPage).toHaveBeenCalledTimes(1);
   });
 
-  it("no-ops while a next-page fetch is in flight", () => {
-    const query = makeQuery({ isFetchingNextPage: true });
+  it("no-ops while ANY fetch is in flight (next page or background refetch)", () => {
+    // With cancelRefetch: false a call during a background refetch would
+    // silently join it and the next page would never be queued — so the
+    // guard must wait out every fetch, not just next-page ones.
+    const query = makeQuery({ isFetching: true });
     const { result } = renderHook(() => useBottomPagination(query));
     result.current();
     expect(query.fetchNextPage).not.toHaveBeenCalled();
@@ -60,10 +65,28 @@ describe("useBottomPagination", () => {
   it("keeps a stable identity across re-renders with unchanged inputs", () => {
     // DetectBottom re-runs its effect whenever onBottom's identity changes;
     // a stable callback avoids gratuitous re-fires while parked at the bottom.
-    const query = makeQuery();
-    const { result, rerender } = renderHook(() => useBottomPagination(query));
+    // A fresh data object with the same page count must not break stability
+    // (the hook derives a boolean, not the object reference).
+    const base = makeQuery();
+    const { result, rerender } = renderHook((q) => useBottomPagination(q), {
+      initialProps: base
+    });
     const first = result.current;
-    rerender();
+    rerender({ ...base, data: { pages: [["b"]] } });
     expect(result.current).toBe(first);
+  });
+
+  it("mints a new identity when a fetch completes so a visible sentinel retries", () => {
+    // The stall guard's other half: a bottom call during a fetch no-ops, so
+    // the fetch finishing (isFetching true -> false) must change the callback
+    // identity — that re-runs DetectBottom's effect and issues the queued
+    // page instead of stalling until the user scrolls away and back.
+    const base = makeQuery({ isFetching: true });
+    const { result, rerender } = renderHook((q) => useBottomPagination(q), {
+      initialProps: base
+    });
+    const during = result.current;
+    rerender({ ...base, isFetching: false });
+    expect(result.current).not.toBe(during);
   });
 });

--- a/apps/web/src/specs/features/market/hive-hbd-observer.spec.tsx
+++ b/apps/web/src/specs/features/market/hive-hbd-observer.spec.tsx
@@ -126,4 +126,16 @@ describe("HiveHbdObserver", () => {
     expect(props.onUsdChange).toHaveBeenCalledTimes(1);
     expect(props.onUsdChange).toHaveBeenCalledWith(0);
   });
+
+  it("normalizes a falsy resolved quote through the same 'no quote' sentinel", async () => {
+    // A degraded CoinGecko response (missing/zero quote) must also clear a
+    // previously rendered price instead of silently holding it.
+    getCGMarketMock.mockResolvedValue([undefined as unknown as number, 1]);
+    const props = makeProps();
+    render(<HiveHbdObserver {...props} />);
+    await flush();
+
+    expect(props.onUsdChange).toHaveBeenCalledTimes(1);
+    expect(props.onUsdChange).toHaveBeenCalledWith(0);
+  });
 });

--- a/apps/web/src/specs/features/market/hive-hbd-observer.spec.tsx
+++ b/apps/web/src/specs/features/market/hive-hbd-observer.spec.tsx
@@ -1,0 +1,120 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HiveHbdObserver } from "@/app/market/advanced/_advanced-mode/pairs/hive-hbd-observer";
+
+// The observer wires four React Query refetches to a poll interval, a mount
+// hook, and a post-trade `refresh` flag. These specs pin down the two
+// regressions behind the chronic AbortError family on /market/advanced
+// (ECENCY-NEXT-1GHQ): refetches must JOIN an in-flight request instead of
+// aborting it (cancelRefetch: false), and the refresh effect must fire only on
+// refresh=true — not on every parent re-render that changes a callback
+// identity.
+
+const useQueryMock = vi.fn();
+const useInfiniteQueryMock = vi.fn();
+
+vi.mock("@tanstack/react-query", async () => ({
+  ...(await vi.importActual<Record<string, unknown>>("@tanstack/react-query")),
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+  useInfiniteQuery: (...args: unknown[]) => useInfiniteQueryMock(...args)
+}));
+
+vi.mock("@ecency/sdk", () => ({
+  getHiveHbdStatsQueryOptions: vi.fn(() => ({ queryKey: ["hive-hbd-stats"] })),
+  getOpenOrdersQueryOptions: vi.fn(() => ({ queryKey: ["open-orders"] })),
+  getOrderBookQueryOptions: vi.fn(() => ({ queryKey: ["order-book"] })),
+  getTransactionsInfiniteQueryOptions: vi.fn(() => ({ queryKey: ["transactions"] }))
+}));
+
+vi.mock("@/core/hooks", () => ({
+  useActiveAccount: () => ({ username: "alice" })
+}));
+
+const getCGMarketMock = vi.fn(async () => [0.35, 1]);
+vi.mock("@/api/coingecko-api", () => ({
+  getCGMarket: (...args: unknown[]) => getCGMarketMock(...args)
+}));
+
+const queryRefetch = vi.fn();
+const infiniteRefetch = vi.fn();
+
+function makeProps(overrides: Partial<React.ComponentProps<typeof HiveHbdObserver>> = {}) {
+  return {
+    onDayChange: vi.fn(),
+    onHistoryChange: vi.fn(),
+    onUsdChange: vi.fn(),
+    refresh: false,
+    setRefresh: vi.fn(),
+    setOpenOrders: vi.fn(),
+    setAllOrders: vi.fn(),
+    updateRate: 60_000,
+    ...overrides
+  };
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("HiveHbdObserver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useQueryMock.mockReturnValue({ data: undefined, refetch: queryRefetch });
+    useInfiniteQueryMock.mockReturnValue({ data: undefined, refetch: infiniteRefetch });
+    getCGMarketMock.mockResolvedValue([0.35, 1]);
+  });
+
+  it("fires ONE round on mount, joining in-flight requests (cancelRefetch: false)", async () => {
+    render(<HiveHbdObserver {...makeProps()} />);
+    await flush();
+
+    // stats + order book + open orders via useQuery, transactions via
+    // useInfiniteQuery — each exactly once, each with cancelRefetch: false.
+    expect(queryRefetch).toHaveBeenCalledTimes(3);
+    expect(infiniteRefetch).toHaveBeenCalledTimes(1);
+    for (const call of [...queryRefetch.mock.calls, ...infiniteRefetch.mock.calls]) {
+      expect(call[0]).toEqual({ cancelRefetch: false });
+    }
+  });
+
+  it("does NOT re-fire a round when a parent re-render changes a callback identity", async () => {
+    const props = makeProps();
+    const { rerender } = render(<HiveHbdObserver {...props} />);
+    await flush();
+    queryRefetch.mockClear();
+    infiniteRefetch.mockClear();
+
+    // A parent re-render minting a new onUsdChange gives fetchAllStats a new
+    // identity; the refresh effect must stay gated and not refetch.
+    rerender(<HiveHbdObserver {...props} onUsdChange={vi.fn()} />);
+    await flush();
+
+    expect(queryRefetch).not.toHaveBeenCalled();
+    expect(infiniteRefetch).not.toHaveBeenCalled();
+  });
+
+  it("fires a round and clears the flag when refresh becomes true", async () => {
+    const props = makeProps();
+    const { rerender } = render(<HiveHbdObserver {...props} />);
+    await flush();
+    queryRefetch.mockClear();
+    infiniteRefetch.mockClear();
+
+    rerender(<HiveHbdObserver {...props} refresh={true} />);
+    await flush();
+
+    expect(queryRefetch).toHaveBeenCalledTimes(3);
+    expect(infiniteRefetch).toHaveBeenCalledTimes(1);
+    expect(props.setRefresh).toHaveBeenCalledWith(false);
+  });
+
+  it("contains a CoinGecko failure instead of leaking an unhandled rejection", async () => {
+    // Callers never await fetchAllStats, so before the try/catch this
+    // rejection escaped as an unhandled rejection (vitest would fail the run).
+    getCGMarketMock.mockRejectedValue(new Error("coingecko down"));
+    const props = makeProps();
+    render(<HiveHbdObserver {...props} />);
+    await flush();
+
+    expect(props.onUsdChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/specs/features/market/hive-hbd-observer.spec.tsx
+++ b/apps/web/src/specs/features/market/hive-hbd-observer.spec.tsx
@@ -112,14 +112,18 @@ describe("HiveHbdObserver", () => {
     expect(props.setRefresh).toHaveBeenCalledWith(false);
   });
 
-  it("contains a CoinGecko failure instead of leaking an unhandled rejection", async () => {
+  it("contains a CoinGecko failure and publishes the 'no quote' value", async () => {
     // Callers never await fetchAllStats, so before the try/catch this
     // rejection escaped as an unhandled rejection (vitest would fail the run).
+    // The failure must also publish 0 — the shared "no quote" value the USD
+    // displays hide on — so an outage doesn't leave an old quote rendered as
+    // current.
     getCGMarketMock.mockRejectedValue(new Error("coingecko down"));
     const props = makeProps();
     render(<HiveHbdObserver {...props} />);
     await flush();
 
-    expect(props.onUsdChange).not.toHaveBeenCalled();
+    expect(props.onUsdChange).toHaveBeenCalledTimes(1);
+    expect(props.onUsdChange).toHaveBeenCalledWith(0);
   });
 });

--- a/apps/web/src/specs/features/market/hive-hbd-observer.spec.tsx
+++ b/apps/web/src/specs/features/market/hive-hbd-observer.spec.tsx
@@ -92,7 +92,9 @@ describe("HiveHbdObserver", () => {
     expect(infiniteRefetch).not.toHaveBeenCalled();
   });
 
-  it("fires a round and clears the flag when refresh becomes true", async () => {
+  it("fires a FRESH round (cancelRefetch: true) and clears the flag when refresh becomes true", async () => {
+    // Post-trade, an in-flight request may predate the trade — joining it
+    // would show stale open orders, so this round must cancel and reissue.
     const props = makeProps();
     const { rerender } = render(<HiveHbdObserver {...props} />);
     await flush();
@@ -104,6 +106,9 @@ describe("HiveHbdObserver", () => {
 
     expect(queryRefetch).toHaveBeenCalledTimes(3);
     expect(infiniteRefetch).toHaveBeenCalledTimes(1);
+    for (const call of [...queryRefetch.mock.calls, ...infiniteRefetch.mock.calls]) {
+      expect(call[0]).toEqual({ cancelRefetch: true });
+    }
     expect(props.setRefresh).toHaveBeenCalledWith(false);
   });
 

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -584,14 +584,15 @@ describe("beforeSend — unhandled cancellation AbortError is reclassified", () 
     expect(out!.fingerprint).toEqual(["cancellation-abort-unhandled"]);
   });
 
-  it("does NOT reclassify a deliberately captured AbortError (mechanism generic)", () => {
-    // captureException(abortError) from app code means someone decided this
-    // abort is exceptional — it must stay at its original level.
+  it("reclassifies the lazy-sentry replay shape too (mechanism generic/handled)", () => {
+    // Rejections from the pre-init window are replayed through
+    // captureException (mechanism generic/handled:true) — same cancellation,
+    // same bucket. An AbortError is a cancellation whatever path delivered it.
     const ev = makeEvent("signal is aborted without reason", [], { type: "AbortError" });
     (ev as any).exception.values[0].mechanism = { type: "generic", handled: true };
     const out = beforeSend(ev);
-    expect(out!.level).toBeUndefined();
-    expect(out!.fingerprint).toBeUndefined();
+    expect(out!.level).toBe("warning");
+    expect(out!.fingerprint).toEqual(["cancellation-abort-unhandled"]);
   });
 
   it("does NOT reclassify an unhandled TimeoutError (genuine node-health signal)", () => {

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -519,3 +519,97 @@ describe("beforeSend — Firefox iframe contentWindow-null teardown is reclassif
     expect(ev.fingerprint).toBeUndefined();
   });
 });
+
+describe("beforeSend — unhandled cancellation AbortError is reclassified", () => {
+  // The chronic AbortError family (ECENCY-NEXT-13T7/1GHQ/KE4/1BRF/1ABA/1GEM/M4Q):
+  // a deliberate fetch cancellation (React Query cancelRefetch, router
+  // navigation abort, unmount) whose DOMException is left on a promise nobody
+  // awaits. First-party chains all consume their abort rejections, so the
+  // leaked promise is a derived one created outside app code; the events'
+  // stacks name the aborter, not an app bug. Reclassified (NOT dropped) to one
+  // fingerprinted warning so a genuine floating-abort regression still spikes.
+  it("reclassifies the Chrome DOMException phrasing (signal is aborted without reason)", () => {
+    const ev = makeEvent("signal is aborted without reason", [], {
+      type: "AbortError",
+      handled: false
+    });
+    const out = beforeSend(ev);
+    expect(out).not.toBeNull();
+    expect(out!.level).toBe("warning");
+    expect(out!.tags?.cancellation_abort).toBe("true");
+    expect(out!.fingerprint).toEqual(["cancellation-abort-unhandled"]);
+  });
+
+  it("reclassifies the other engine phrasings under the AbortError type", () => {
+    for (const msg of [
+      "Fetch is aborted",
+      "The operation was aborted. ",
+      "The user aborted a request."
+    ]) {
+      const out = beforeSend(makeEvent(msg, [], { type: "AbortError", handled: false }));
+      expect(out!.level).toBe("warning");
+      expect(out!.fingerprint).toEqual(["cancellation-abort-unhandled"]);
+    }
+  });
+
+  it("reclassifies the plain-Error wrap whose message is prefixed 'AbortError:'", () => {
+    // ECENCY-NEXT-M4Q shape: the rejection reason was wrapped in a plain Error,
+    // so the exception type is Error and only the message carries AbortError.
+    const out = beforeSend(
+      makeEvent("AbortError: The user aborted a request.", [], {
+        type: "Error",
+        handled: false
+      })
+    );
+    expect(out!.level).toBe("warning");
+    expect(out!.fingerprint).toEqual(["cancellation-abort-unhandled"]);
+  });
+
+  it("keeps the timeoutUrl breadcrumb tag on the reclassified event", () => {
+    // The tagging block above the reclassification must still run, and the
+    // query string must still be stripped from the tagged URL.
+    const ev = makeEvent("signal is aborted without reason", [], {
+      type: "AbortError",
+      handled: false
+    });
+    (ev as any).breadcrumbs = [
+      {
+        category: "fetch",
+        data: { url: "https://api.example.com/hafah-api/accounts/alice/operations?page=2" }
+      }
+    ];
+    const out = beforeSend(ev);
+    expect(out!.tags?.timeoutUrl).toBe("https://api.example.com/hafah-api/accounts/alice/operations");
+    expect(out!.level).toBe("warning");
+    expect(out!.fingerprint).toEqual(["cancellation-abort-unhandled"]);
+  });
+
+  it("does NOT reclassify a deliberately captured AbortError (mechanism generic)", () => {
+    // captureException(abortError) from app code means someone decided this
+    // abort is exceptional — it must stay at its original level.
+    const ev = makeEvent("signal is aborted without reason", [], { type: "AbortError" });
+    (ev as any).exception.values[0].mechanism = { type: "generic", handled: true };
+    const out = beforeSend(ev);
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT reclassify an unhandled TimeoutError (genuine node-health signal)", () => {
+    // "signal timed out" means a request exceeded its window — that volume is
+    // how slow nodes surface; it must not be folded into cancellation noise.
+    const ev = makeEvent("signal timed out", [], { type: "TimeoutError", handled: false });
+    const out = beforeSend(ev);
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT reclassify an ordinary Error merely mentioning an abort mid-message", () => {
+    const ev = makeEvent("upload failed: request aborted by server", [], {
+      type: "Error",
+      handled: false
+    });
+    const out = beforeSend(ev);
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+});

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -555,14 +555,25 @@ describe("beforeSend — unhandled cancellation AbortError is reclassified", () 
   it("reclassifies the plain-Error wrap whose message is prefixed 'AbortError:'", () => {
     // ECENCY-NEXT-M4Q shape: the rejection reason was wrapped in a plain Error,
     // so the exception type is Error and only the message carries AbortError.
-    const out = beforeSend(
-      makeEvent("AbortError: The user aborted a request.", [], {
-        type: "Error",
-        handled: false
-      })
-    );
+    // The wrapped form must ALSO pass the timeoutUrl tagging block above the
+    // reclassification — a gap there would strip these events of their
+    // correlation tag.
+    const ev = makeEvent("AbortError: The user aborted a request.", [], {
+      type: "Error",
+      handled: false
+    });
+    (ev as any).breadcrumbs = [
+      {
+        category: "fetch",
+        data: { url: "https://api.example.com/hafah-api/accounts/alice/operations?page=2" }
+      }
+    ];
+    const out = beforeSend(ev);
     expect(out!.level).toBe("warning");
     expect(out!.fingerprint).toEqual(["cancellation-abort-unhandled"]);
+    expect(out!.tags?.timeoutUrl).toBe(
+      "https://api.example.com/hafah-api/accounts/alice/operations"
+    );
   });
 
   it("keeps the timeoutUrl breadcrumb tag on the reclassified event", () => {

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -140,6 +140,37 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
     }
   }
 
+  // A cancellation AbortError that surfaces as an UNHANDLED rejection is not a
+  // crash: the page keeps working — something cancelled a fetch on purpose
+  // (React Query's cancelRefetch aborting a superseded refetch, the Next router
+  // aborting a navigation fetch, an unmount) and a promise nobody awaits was
+  // left holding the rejection. Our own chains all consume their abort
+  // rejections (React Query attaches catch handlers throughout, and the SDK's
+  // callREST rethrows external aborts into an awaited chain), which is why
+  // these events' stacks point at the ABORTER (query-core's
+  // abortController.abort()) rather than any app frame — the leaked promise is
+  // a derived one created outside our code (typically an injected fetch
+  // wrapper), and the whole family is Chrome-only. RECLASSIFY (not drop) to a
+  // single low-severity fingerprint, keeping the timeoutUrl tag applied above:
+  // a genuine first-party regression that floats abort rejections would still
+  // show as a spike on this fingerprint instead of spawning per-page error
+  // issues. Gated on mechanism onunhandledrejection so a deliberate
+  // captureException(abortError) from app code stays error-level, and
+  // TimeoutError is intentionally NOT reclassified — "signal timed out" means
+  // a request genuinely exceeded its window, which is node-health signal.
+  // The `^AbortError:` message form covers rejections wrapped in a plain Error
+  // (e.g. "Error > AbortError: The user aborted a request.").
+  const mechanismType = event.exception?.values?.[0]?.mechanism?.type;
+  if (
+    mechanismType === "onunhandledrejection" &&
+    (exceptionType === "AbortError" || /^AbortError:/.test(message))
+  ) {
+    event.level = "warning";
+    event.tags = { ...event.tags, cancellation_abort: "true" };
+    event.fingerprint = ["cancellation-abort-unhandled"];
+    return event;
+  }
+
   // React 19 SSR streaming-resume ($RS) crash that FOLLOWS a hydration mismatch.
   // React #418 (text-content mismatch — commonly a browser extension or
   // auto-translate rewriting text on legacy/non-English browsers, or a residual

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -112,6 +112,10 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
   if (
     (exceptionType === "TimeoutError" ||
       exceptionType === "AbortError" ||
+      // Wrapped form: a plain Error whose message carries the AbortError —
+      // must be tagged here too or the reclassification below loses its
+      // correlation tag.
+      /^AbortError:/.test(message) ||
       /signal timed out/i.test(message)) &&
     !event.tags?.timeoutUrl
   ) {

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -140,31 +140,30 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
     }
   }
 
-  // A cancellation AbortError that surfaces as an UNHANDLED rejection is not a
-  // crash: the page keeps working — something cancelled a fetch on purpose
-  // (React Query's cancelRefetch aborting a superseded refetch, the Next router
-  // aborting a navigation fetch, an unmount) and a promise nobody awaits was
-  // left holding the rejection. Our own chains all consume their abort
-  // rejections (React Query attaches catch handlers throughout, and the SDK's
-  // callREST rethrows external aborts into an awaited chain), which is why
-  // these events' stacks point at the ABORTER (query-core's
-  // abortController.abort()) rather than any app frame — the leaked promise is
-  // a derived one created outside our code (typically an injected fetch
-  // wrapper), and the whole family is Chrome-only. RECLASSIFY (not drop) to a
-  // single low-severity fingerprint, keeping the timeoutUrl tag applied above:
-  // a genuine first-party regression that floats abort rejections would still
-  // show as a spike on this fingerprint instead of spawning per-page error
-  // issues. Gated on mechanism onunhandledrejection so a deliberate
-  // captureException(abortError) from app code stays error-level, and
-  // TimeoutError is intentionally NOT reclassified — "signal timed out" means
-  // a request genuinely exceeded its window, which is node-health signal.
-  // The `^AbortError:` message form covers rejections wrapped in a plain Error
-  // (e.g. "Error > AbortError: The user aborted a request.").
-  const mechanismType = event.exception?.values?.[0]?.mechanism?.type;
-  if (
-    mechanismType === "onunhandledrejection" &&
-    (exceptionType === "AbortError" || /^AbortError:/.test(message))
-  ) {
+  // A cancellation AbortError is not a crash: the page keeps working —
+  // something cancelled a fetch on purpose (React Query's cancelRefetch
+  // aborting a superseded refetch, the Next router aborting a navigation
+  // fetch, an unmount) and a promise nobody awaits was left holding the
+  // rejection. Our own chains all consume their abort rejections (React Query
+  // attaches catch handlers throughout, and the SDK's callREST rethrows
+  // external aborts into an awaited chain), which is why these events' stacks
+  // point at the ABORTER (query-core's abortController.abort()) rather than
+  // any app frame — the leaked promise is a derived one created outside our
+  // code (typically an injected fetch wrapper), and the whole family is
+  // Chrome-only. RECLASSIFY (not drop) to a single low-severity fingerprint,
+  // keeping the timeoutUrl tag applied above: a genuine regression that
+  // floats abort rejections would still show as a spike on this fingerprint
+  // instead of spawning per-page error issues. Deliberately NOT gated on
+  // mechanism: most of the family arrives as onunhandledrejection, but
+  // rejections from the pre-init window are replayed through captureException
+  // by lazy-sentry (mechanism generic/handled:true) and must fold into the
+  // same bucket — an AbortError is a cancellation by construction, whatever
+  // path delivered it. TimeoutError is intentionally NOT reclassified:
+  // "signal timed out" means a request genuinely exceeded its window, which
+  // is node-health signal. The `^AbortError:` message form covers rejections
+  // wrapped in a plain Error (e.g. "Error > AbortError: The user aborted a
+  // request.").
+  if (exceptionType === "AbortError" || /^AbortError:/.test(message)) {
     event.level = "warning";
     event.tags = { ...event.tags, cancellation_abort: "true" };
     event.fingerprint = ["cancellation-abort-unhandled"];


### PR DESCRIPTION
## What

**Sentry (`sentry-before-send.ts`)**
- `AbortError` events (and the plain-`Error` wrap whose message starts with `AbortError:`) are reclassified to a single fingerprinted warning (`cancellation-abort-unhandled`) instead of spawning a fresh error-level issue per call site. The `timeoutUrl` breadcrumb tag is kept for attribution. Not gated on mechanism: pre-init rejections replayed through `captureException` (mechanism generic/handled) belong in the same bucket.
- `TimeoutError` stays at its original level (node-health signal).

**Advanced market (`/market/advanced`)**
- Poll ticks refetch with `cancelRefetch: false`, joining a still-in-flight request instead of aborting and restarting it. A slow transactions history walk could otherwise never complete between ticks, leaving the trade-history widget stale. The post-trade refresh is the opposite case — an in-flight request may predate the trade — so that round forces `cancelRefetch: true`.
- The post-trade `refresh` effect is gated on the flag. Ungated, it re-fired a full four-query round whenever a parent re-render changed `fetchAllStats`' identity; the page now also passes stable state setters instead of inline wrappers.
- CoinGecko lookup failures are contained inside `fetchAllStats` (no caller awaits it, so they escaped as unhandled rejections).

**Infinite lists — new `useBottomPagination` hook**
- Shared hook for `DetectBottom` load-more callbacks: fetches with `cancelRefetch: false` (joins in-flight fetches, never aborts), no-ops while a next-page fetch is running, and keeps the page-1 bootstrap for queries seeded with `initialData: { pages: [] }` (`hasNextPage` is false with zero pages and `refetchOnMount` is false app-wide, so the bottom sentinel is what issues the first fetch on the search page). Adopted in the community content list, comment search, and waves list.

## Why

Addresses the chronic AbortError issue family (ECENCY-NEXT-1GHQ, 13T7, KE4, 1BRF, 1ABA, 1GEM, M4Q): deliberate fetch cancellations surfacing as unhandled `AbortError: signal is aborted without reason` rejections at error level. React Query, the SDK network layer, and the Sentry fetch instrumentation were verified to consume their abort rejections on every cancellation path, so the events' stacks identify the aborter rather than an app bug; reclassifying (not dropping) keeps a genuine regression visible as a spike on the fingerprint. The market and infinite-list changes remove the biggest first-party sources of the cancellations themselves.

## Tests

- 8 `beforeSend` specs (reclassification incl. plain-Error wrap and replay shape, timeoutUrl tag preserved, TimeoutError/mid-message negatives)
- 6 `useBottomPagination` specs (join semantics, empty-pages bootstrap, in-flight no-op, end-of-results no-op, stable identity)
- 4 `HiveHbdObserver` specs (single joined round on mount, no round on callback-identity churn, fresh post-trade round, contained CoinGecko failure) — fail against the previous code
- Full web suite green (221 files / 2169 tests), no new tsc errors, lint clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved infinite scrolling across feeds, waves, and search comments.
  - “Show more” actions now share consistent loading and pagination behavior.

- **Bug Fixes**
  - Prevented duplicate or overlapping content loads during active fetching.
  - Improved market data refresh reliability after trades and when external price data is unavailable.
  - Better handling and classification of browser cancellation errors for diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->