### PR TITLE
fix(chat): failure-aware backoff and rate-limit pause for chat polling

### DIFF
--- a/apps/web/src/features/chat/chat-api-guard.ts
+++ b/apps/web/src/features/chat/chat-api-guard.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared guard for chat polling requests.
+ *
+ * Two protections:
+ * 1. `chatApiFetch` opens a module-wide pause when the edge answers 429, so
+ *    every chat poller stops calling the API for the rate-limit window instead
+ *    of hammering into it.
+ * 2. `chatPollInterval` computes a failure-aware refetch interval: normal
+ *    cadence while healthy, exponential backoff while the endpoint errors.
+ *    A broken chat session or an origin incident must never turn the pollers
+ *    into a request storm.
+ */
+
+const DEFAULT_PAUSE_MS = 10 * 60_000; // matches the edge rate-limit block window
+const MAX_PAUSE_MS = 15 * 60_000;
+const MAX_POLL_MS = 10 * 60_000;
+
+let pausedUntil = 0;
+
+export function chatApiPauseRemaining(now = Date.now()): number {
+  return Math.max(0, pausedUntil - now);
+}
+
+/** Test-only helper. */
+export function resetChatApiGuard(): void {
+  pausedUntil = 0;
+}
+
+export async function chatApiFetch(input: string, init?: RequestInit): Promise<Response> {
+  const remaining = chatApiPauseRemaining();
+  if (remaining > 0) {
+    throw new Error(`Chat API paused for ${Math.ceil(remaining / 1000)}s after rate limiting`);
+  }
+
+  const res = await fetch(input, init);
+
+  if (res.status === 429) {
+    const retryAfter = Number(res.headers.get("Retry-After"));
+    const pauseMs =
+      Number.isFinite(retryAfter) && retryAfter > 0
+        ? Math.min(retryAfter * 1000, MAX_PAUSE_MS)
+        : DEFAULT_PAUSE_MS;
+    pausedUntil = Date.now() + pauseMs;
+  }
+
+  return res;
+}
+
+export interface ChatPollQuery {
+  state: {
+    status: string;
+    fetchFailureCount: number;
+  };
+}
+
+/**
+ * Failure-aware polling interval for React Query `refetchInterval` callbacks.
+ * Healthy query -> `baseMs`. Erroring query -> `baseMs * 2^failures`, capped
+ * at 10 minutes. While the guard pause is open, waits at least the remaining
+ * pause so the next poll lands after the rate-limit window.
+ */
+export function chatPollInterval(baseMs: number, query: ChatPollQuery): number {
+  const paused = chatApiPauseRemaining();
+  if (paused > 0) {
+    return Math.max(baseMs, paused);
+  }
+
+  if (query.state.status !== "error") {
+    return baseMs;
+  }
+
+  const failures = Math.max(query.state.fetchFailureCount, 1);
+  return Math.min(baseMs * Math.pow(2, failures), MAX_POLL_MS);
+}

--- a/apps/web/src/features/chat/chat-api-guard.ts
+++ b/apps/web/src/features/chat/chat-api-guard.ts
@@ -17,6 +17,14 @@ const MAX_POLL_MS = 10 * 60_000;
 
 let pausedUntil = 0;
 
+/**
+ * `errorUpdateCount` at the last successful fetch, per query hash. Consecutive
+ * failures = current `errorUpdateCount` minus this baseline. Needed because
+ * `fetchFailureCount` resets to 0 whenever a new fetch starts, so with low/no
+ * retry it can never grow across poll cycles.
+ */
+const errorBaselines = new Map<string, number>();
+
 export function chatApiPauseRemaining(now = Date.now()): number {
   return Math.max(0, pausedUntil - now);
 }
@@ -24,6 +32,22 @@ export function chatApiPauseRemaining(now = Date.now()): number {
 /** Test-only helper. */
 export function resetChatApiGuard(): void {
   pausedUntil = 0;
+  errorBaselines.clear();
+}
+
+function parseRetryAfterMs(header: string | null): number {
+  if (header) {
+    const seconds = Number(header);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return seconds * 1000;
+    }
+    // Retry-After may also be an HTTP date
+    const at = Date.parse(header);
+    if (!Number.isNaN(at) && at > Date.now()) {
+      return at - Date.now();
+    }
+  }
+  return DEFAULT_PAUSE_MS;
 }
 
 export async function chatApiFetch(input: string, init?: RequestInit): Promise<Response> {
@@ -35,29 +59,29 @@ export async function chatApiFetch(input: string, init?: RequestInit): Promise<R
   const res = await fetch(input, init);
 
   if (res.status === 429) {
-    const retryAfter = Number(res.headers.get("Retry-After"));
-    const pauseMs =
-      Number.isFinite(retryAfter) && retryAfter > 0
-        ? Math.min(retryAfter * 1000, MAX_PAUSE_MS)
-        : DEFAULT_PAUSE_MS;
-    pausedUntil = Date.now() + pauseMs;
+    const pauseMs = Math.min(parseRetryAfterMs(res.headers.get("Retry-After")), MAX_PAUSE_MS);
+    // Math.max: a concurrent in-flight 429 with a shorter window must not
+    // shorten an already-open pause.
+    pausedUntil = Math.max(pausedUntil, Date.now() + pauseMs);
   }
 
   return res;
 }
 
 export interface ChatPollQuery {
+  queryHash: string;
   state: {
     status: string;
     fetchFailureCount: number;
+    errorUpdateCount: number;
   };
 }
 
 /**
  * Failure-aware polling interval for React Query `refetchInterval` callbacks.
- * Healthy query -> `baseMs`. Erroring query -> `baseMs * 2^failures`, capped
- * at 10 minutes. While the guard pause is open, waits at least the remaining
- * pause so the next poll lands after the rate-limit window.
+ * Healthy query -> `baseMs`. Erroring query -> `baseMs * 2^consecutiveFailures`,
+ * capped at 10 minutes. While the guard pause is open, waits at least the
+ * remaining pause so the next poll lands after the rate-limit window.
  */
 export function chatPollInterval(baseMs: number, query: ChatPollQuery): number {
   const paused = chatApiPauseRemaining();
@@ -65,10 +89,20 @@ export function chatPollInterval(baseMs: number, query: ChatPollQuery): number {
     return Math.max(baseMs, paused);
   }
 
-  if (query.state.status !== "error") {
+  const { status, fetchFailureCount, errorUpdateCount } = query.state;
+
+  if (status !== "error") {
+    errorBaselines.set(query.queryHash, errorUpdateCount);
     return baseMs;
   }
 
-  const failures = Math.max(query.state.fetchFailureCount, 1);
+  let baseline = errorBaselines.get(query.queryHash);
+  if (baseline === undefined) {
+    // First sighting is already in error: count it as one failure.
+    baseline = errorUpdateCount - 1;
+    errorBaselines.set(query.queryHash, baseline);
+  }
+
+  const failures = Math.max(errorUpdateCount - baseline, fetchFailureCount, 1);
   return Math.min(baseMs * Math.pow(2, failures), MAX_POLL_MS);
 }

--- a/apps/web/src/features/chat/mattermost-api.ts
+++ b/apps/web/src/features/chat/mattermost-api.ts
@@ -5,6 +5,7 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { getAccessToken, getRefreshToken } from "@/utils";
 import { useGlobalStore } from "@/core/global-store";
 import { hsTokenRenew } from "@ecency/sdk";
+import { chatApiFetch, chatPollInterval, type ChatPollQuery } from "./chat-api-guard";
 
 /** Safely parse JSON from a fetch response, falling back to a readable error */
 async function safeJson<T>(res: Response): Promise<T> {
@@ -151,8 +152,11 @@ export function useMattermostChannels(enabled: boolean) {
     staleTime: 120 * 1000,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
+    // Invalidations re-run this; retrying more than once just piles requests
+    // onto an unhealthy backend.
+    retry: 1,
     queryFn: async () => {
-      const res = await fetch("/api/mattermost/channels");
+      const res = await chatApiFetch("/api/mattermost/channels");
       if (!res.ok) {
         const data = await safeJson<{ error?: string }>(res);
         throw new Error(data?.error || "Unable to load channels");
@@ -519,11 +523,15 @@ export function useMattermostUnread(enabled: boolean) {
   return useQuery({
     queryKey: ["mattermost-unread", username],
     enabled: enabled && Boolean(username),
-    refetchInterval: 60000,
+    // Mounted in the navbar on every page: back off while the endpoint is
+    // failing so open tabs don't keep a struggling backend under load.
+    refetchInterval: (query) => chatPollInterval(60000, query),
     refetchOnWindowFocus: false,
     staleTime: 60000,
+    // No retry: the next poll cycle is the retry.
+    retry: false,
     queryFn: async () => {
-      const res = await fetch("/api/mattermost/channels/unreads");
+      const res = await chatApiFetch("/api/mattermost/channels/unreads");
 
       if (res.status === 401) {
         return {
@@ -660,14 +668,18 @@ export function useMattermostPostsInfinite(
   return useInfiniteQuery({
     queryKey: ["mattermost-posts-infinite", channelId],
     enabled: Boolean(channelId),
-    refetchInterval: options?.refetchInterval ?? false,
+    // Polling fallback when the websocket is down: back off while failing.
+    refetchInterval: (query: ChatPollQuery) => {
+      const base = options?.refetchInterval;
+      return base ? chatPollInterval(base, query) : false;
+    },
     queryFn: async ({ pageParam }) => {
       const includeOnlineQuery = options?.includeOnline ? "include_online=1" : "";
       const url = pageParam
         ? `/api/mattermost/channels/${channelId}/posts?before=${pageParam}${includeOnlineQuery ? `&${includeOnlineQuery}` : ""}`
         : `/api/mattermost/channels/${channelId}/posts${includeOnlineQuery ? `?${includeOnlineQuery}` : ""}`;
 
-      const res = await fetch(url);
+      const res = await chatApiFetch(url);
       if (!res.ok) {
         const data = await safeJson<{ error?: string }>(res);
         throw new Error(data?.error || "Unable to load messages");

--- a/apps/web/src/specs/features/chat/chat-api-guard.spec.ts
+++ b/apps/web/src/specs/features/chat/chat-api-guard.spec.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  chatApiFetch,
+  chatApiPauseRemaining,
+  chatPollInterval,
+  resetChatApiGuard
+} from "@/features/chat/chat-api-guard";
+
+function mockResponse(status: number, headers: Record<string, string> = {}) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: new Headers(headers)
+  } as Response;
+}
+
+function pollQuery(status: string, fetchFailureCount = 0) {
+  return { state: { status, fetchFailureCount } };
+}
+
+describe("chatApiFetch", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    resetChatApiGuard();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("passes through normal responses without opening the pause", async () => {
+    fetchMock.mockResolvedValue(mockResponse(200));
+
+    const res = await chatApiFetch("/api/mattermost/channels");
+
+    expect(res.status).toBe(200);
+    expect(chatApiPauseRemaining()).toBe(0);
+  });
+
+  it("passes through server errors without opening the pause", async () => {
+    fetchMock.mockResolvedValue(mockResponse(500));
+
+    const res = await chatApiFetch("/api/mattermost/channels");
+
+    expect(res.status).toBe(500);
+    expect(chatApiPauseRemaining()).toBe(0);
+  });
+
+  it("opens a pause on 429 and short-circuits subsequent calls", async () => {
+    fetchMock.mockResolvedValue(mockResponse(429));
+
+    await chatApiFetch("/api/mattermost/channels/unreads");
+    expect(chatApiPauseRemaining()).toBeGreaterThan(0);
+
+    await expect(chatApiFetch("/api/mattermost/channels")).rejects.toThrow(/paused/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors Retry-After for the pause duration", async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue(mockResponse(429, { "Retry-After": "120" }));
+
+    await chatApiFetch("/api/mattermost/channels/unreads");
+
+    expect(chatApiPauseRemaining()).toBeLessThanOrEqual(120_000);
+    expect(chatApiPauseRemaining()).toBeGreaterThan(110_000);
+  });
+
+  it("caps an oversized Retry-After", async () => {
+    fetchMock.mockResolvedValue(mockResponse(429, { "Retry-After": "86400" }));
+
+    await chatApiFetch("/api/mattermost/channels/unreads");
+
+    expect(chatApiPauseRemaining()).toBeLessThanOrEqual(15 * 60_000);
+  });
+
+  it("resumes fetching after the pause expires", async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue(mockResponse(429, { "Retry-After": "60" }));
+
+    await chatApiFetch("/api/mattermost/channels/unreads");
+    await expect(chatApiFetch("/api/mattermost/channels")).rejects.toThrow(/paused/);
+
+    vi.advanceTimersByTime(61_000);
+    fetchMock.mockResolvedValue(mockResponse(200));
+
+    const res = await chatApiFetch("/api/mattermost/channels");
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("chatPollInterval", () => {
+  beforeEach(() => {
+    resetChatApiGuard();
+  });
+
+  it("returns the base interval for a healthy query", () => {
+    expect(chatPollInterval(60_000, pollQuery("success"))).toBe(60_000);
+    expect(chatPollInterval(60_000, pollQuery("pending"))).toBe(60_000);
+  });
+
+  it("backs off exponentially while the query errors", () => {
+    expect(chatPollInterval(60_000, pollQuery("error", 1))).toBe(120_000);
+    expect(chatPollInterval(60_000, pollQuery("error", 2))).toBe(240_000);
+    expect(chatPollInterval(60_000, pollQuery("error", 3))).toBe(480_000);
+  });
+
+  it("treats an errored query with zero failure count as one failure", () => {
+    expect(chatPollInterval(60_000, pollQuery("error", 0))).toBe(120_000);
+  });
+
+  it("caps the backoff at ten minutes", () => {
+    expect(chatPollInterval(60_000, pollQuery("error", 10))).toBe(600_000);
+  });
+
+  it("waits out an open pause even for a healthy query", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(429, { "Retry-After": "300" }));
+    vi.stubGlobal("fetch", fetchMock);
+    await chatApiFetch("/api/mattermost/channels/unreads");
+    vi.unstubAllGlobals();
+
+    const interval = chatPollInterval(60_000, pollQuery("success"));
+    expect(interval).toBeGreaterThan(290_000);
+    expect(interval).toBeLessThanOrEqual(300_000);
+  });
+});

--- a/apps/web/src/specs/features/chat/chat-api-guard.spec.ts
+++ b/apps/web/src/specs/features/chat/chat-api-guard.spec.ts
@@ -14,8 +14,13 @@ function mockResponse(status: number, headers: Record<string, string> = {}) {
   } as Response;
 }
 
-function pollQuery(status: string, fetchFailureCount = 0) {
-  return { state: { status, fetchFailureCount } };
+function pollQuery(
+  status: string,
+  fetchFailureCount = 0,
+  errorUpdateCount = fetchFailureCount,
+  queryHash = "test-query"
+) {
+  return { queryHash, state: { status, fetchFailureCount, errorUpdateCount } };
 }
 
 describe("chatApiFetch", () => {
@@ -58,6 +63,27 @@ describe("chatApiFetch", () => {
 
     await expect(chatApiFetch("/api/mattermost/channels")).rejects.toThrow(/paused/);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the longer pause when a concurrent 429 carries a shorter window", async () => {
+    resetChatApiGuard();
+    fetchMock.mockResolvedValueOnce(mockResponse(429, { "Retry-After": "600" }));
+    const first = chatApiFetch("/api/mattermost/channels/unreads");
+    fetchMock.mockResolvedValueOnce(mockResponse(429, { "Retry-After": "30" }));
+    const second = chatApiFetch("/api/mattermost/channels");
+    await Promise.all([first, second]);
+
+    expect(chatApiPauseRemaining()).toBeGreaterThan(500_000);
+  });
+
+  it("supports HTTP-date Retry-After", async () => {
+    const inTwoMinutes = new Date(Date.now() + 120_000).toUTCString();
+    fetchMock.mockResolvedValue(mockResponse(429, { "Retry-After": inTwoMinutes }));
+
+    await chatApiFetch("/api/mattermost/channels/unreads");
+
+    expect(chatApiPauseRemaining()).toBeGreaterThan(100_000);
+    expect(chatApiPauseRemaining()).toBeLessThanOrEqual(120_000);
   });
 
   it("honors Retry-After for the pause duration", async () => {
@@ -115,6 +141,27 @@ describe("chatPollInterval", () => {
 
   it("caps the backoff at ten minutes", () => {
     expect(chatPollInterval(60_000, pollQuery("error", 10))).toBe(600_000);
+  });
+
+  it("grows across poll cycles even though fetchFailureCount resets each fetch", () => {
+    // fetchFailureCount resets to 0 when a new fetch starts, so with
+    // retry: false it is always 1 after a failed cycle. Consecutive failures
+    // are derived from errorUpdateCount anchored at the last success.
+    expect(chatPollInterval(60_000, pollQuery("success", 0, 5))).toBe(60_000);
+    expect(chatPollInterval(60_000, pollQuery("error", 1, 6))).toBe(120_000);
+    expect(chatPollInterval(60_000, pollQuery("error", 1, 7))).toBe(240_000);
+    expect(chatPollInterval(60_000, pollQuery("error", 1, 8))).toBe(480_000);
+    expect(chatPollInterval(60_000, pollQuery("error", 1, 9))).toBe(600_000);
+    // Recovery resets the backoff
+    expect(chatPollInterval(60_000, pollQuery("success", 0, 9))).toBe(60_000);
+    expect(chatPollInterval(60_000, pollQuery("error", 1, 10))).toBe(120_000);
+  });
+
+  it("tracks failure streaks per query", () => {
+    expect(chatPollInterval(60_000, pollQuery("error", 1, 4, "unreads"))).toBe(120_000);
+    expect(chatPollInterval(60_000, pollQuery("error", 1, 5, "unreads"))).toBe(240_000);
+    // A different query starts its own streak
+    expect(chatPollInterval(60_000, pollQuery("error", 1, 9, "channels"))).toBe(120_000);
   });
 
   it("waits out an open pause even for a healthy query", async () => {


### PR DESCRIPTION
## What

Chat polling (unread badge in the navbar, channel list, posts fallback when the websocket is down) polled at full cadence even while the chat API was returning errors, and React Query's default retries added 3 extra requests per failed cycle. During a backend incident, every open tab kept amplifying load on the already-struggling `/api/mattermost/*` endpoints.

## Changes

- New `chat-api-guard` module shared by the chat pollers:
  - `chatApiFetch` — when the API answers **429**, opens a module-wide pause (honors `Retry-After`, default 10 min, capped at 15 min) so every chat poller stops calling the API for the rate-limit window instead of hammering into it.
  - `chatPollInterval` — failure-aware `refetchInterval`: normal cadence while healthy, exponential backoff up to 10 min while the endpoint errors.
- `useMattermostUnread` (mounted on every page via navbar): backoff interval + `retry: false` — the next poll cycle is the retry.
- `useMattermostChannels`: `retry: 1` — invalidations re-run it anyway.
- `useMattermostPostsInfinite`: the 60s polling fallback (websocket down) now backs off on failure too.

## Tests

11 new specs covering the 429 pause (open, short-circuit, Retry-After, cap, expiry) and the backoff interval math. Full web suite green, no new type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chat polling resilience when rate limits or request failures occur.
  * Chat requests now pause automatically after rate-limit responses and resume after the specified delay.
  * Polling intervals now adapt to failures with exponential backoff, capped at 10 minutes.

* **Bug Fixes**
  * Reduced repeated chat API requests during temporary rate limits and service errors.
  * Applied consistent protection across channel, unread-message, and message polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->