### PR TITLE
Fall back to body summary for title-less post titles

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-breadcrumbs.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-breadcrumbs.ts
@@ -1,4 +1,5 @@
 import { Entry } from "@/entities";
+import { entryDisplayTitle } from "@/utils/entry-display-title";
 
 export interface BreadcrumbCrumb {
   name: string;
@@ -14,11 +15,14 @@ export interface BreadcrumbCrumb {
  * return []). The section crumb is omitted when the category is a raw
  * "hive-12345" id and there is no community title, so the trail never surfaces a
  * machine id (mirrors buildArticleJsonLd's articleSection + resolveRelatedSource).
+ * The last crumb uses entryDisplayTitle, so a title-less post (e.g. a D.Buzz
+ * microblog) never emits an empty BreadcrumbList item name — Google flags
+ * those as invalid structured data.
  */
 export function buildEntryBreadcrumbs(
   entry: Pick<
     Entry,
-    "parent_author" | "category" | "community_title" | "title" | "author" | "permlink"
+    "parent_author" | "category" | "community_title" | "title" | "body" | "author" | "permlink"
   >,
   opts: { siteName: string; base: string; entryUrl: string }
 ): BreadcrumbCrumb[] {
@@ -41,6 +45,6 @@ export function buildEntryBreadcrumbs(
           }
         ]
       : []),
-    { name: entry.title, path: `/@${entry.author}/${entry.permlink}`, url: entryUrl }
+    { name: entryDisplayTitle(entry), path: `/@${entry.author}/${entry.permlink}`, url: entryUrl }
   ];
 }

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-card-fields.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-card-fields.ts
@@ -1,4 +1,5 @@
 import { truncate } from "@/utils";
+import { entryDisplayTitle } from "@/utils/entry-display-title";
 import { catchPostImage, postBodySummary } from "@ecency/render-helper";
 import type { Entry } from "@/entities";
 
@@ -33,7 +34,10 @@ export interface EntryCardFields {
 export function buildEntryCardFields(entry: Entry): EntryCardFields {
   const isComment = !!entry.parent_author;
 
-  let title = truncate(entry.title, 67);
+  // entryDisplayTitle never returns "" (title-less microblog posts fall back
+  // to a body summary, then a byline), so the page <title>, og/twitter cards
+  // and oEmbed can't render an empty title.
+  let title = truncate(entryDisplayTitle(entry), 67);
   if (isComment) {
     const rawCommentTitle = truncate(postBodySummary(entry.body, 12), 67);
     title = `@${entry.author}: ${rawCommentTitle}`;

--- a/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-card-fields.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/_helpers/entry-card-fields.ts
@@ -34,13 +34,16 @@ export interface EntryCardFields {
 export function buildEntryCardFields(entry: Entry): EntryCardFields {
   const isComment = !!entry.parent_author;
 
-  // entryDisplayTitle never returns "" (title-less microblog posts fall back
-  // to a body summary, then a byline), so the page <title>, og/twitter cards
-  // and oEmbed can't render an empty title.
-  let title = truncate(entryDisplayTitle(entry), 67);
+  let title: string;
   if (isComment) {
     const rawCommentTitle = truncate(postBodySummary(entry.body, 12), 67);
     title = `@${entry.author}: ${rawCommentTitle}`;
+  } else {
+    // entryDisplayTitle never returns "" (title-less microblog posts fall back
+    // to a body summary, then a byline), so the page <title>, og/twitter cards
+    // and oEmbed can't render an empty title. Root posts only: comments build
+    // their own summary above (entryDisplayTitle would render the body twice).
+    title = truncate(entryDisplayTitle(entry), 67);
   }
 
   // Cap at 160 chars to match Google's desktop snippet width; consumers may

--- a/apps/web/src/features/structured-data/index.tsx
+++ b/apps/web/src/features/structured-data/index.tsx
@@ -1,5 +1,6 @@
 import { catchPostImage, postBodySummary } from "@ecency/render-helper";
 import defaults from "@/defaults.json";
+import { entryDisplayTitle } from "@/utils/entry-display-title";
 import { Entry, FullAccount, Community } from "@/entities";
 
 /**
@@ -133,7 +134,8 @@ export function buildArticleJsonLd({
   base?: string;
 }): JsonLdData {
   const authorName = account?.profile?.name?.trim() || entry.author;
-  const headline = (entry.title ?? "").slice(0, HEADLINE_MAX);
+  // entryDisplayTitle: title-less posts get a body-summary headline instead of "".
+  const headline = entryDisplayTitle(entry).slice(0, HEADLINE_MAX);
   const image = catchPostImage(entry, 1200, 630, "match") || undefined;
   // json_metadata is untrusted on-chain data: guard that `tags` is actually an
   // array before filtering to non-empty strings — a truthy non-array value

--- a/apps/web/src/specs/app/entry-card-fields.spec.ts
+++ b/apps/web/src/specs/app/entry-card-fields.spec.ts
@@ -46,6 +46,18 @@ describe("buildEntryCardFields", () => {
     expect(fields.title).toBe(`@${e.author}: ${truncate(postBodySummary(e.body, 12), 67)}`);
   });
 
+  it("falls back to a body-summary title for a title-less root post (e.g. D.Buzz)", () => {
+    const e = entry({ title: "" });
+    const fields = buildEntryCardFields(e as any);
+    expect(fields.title).toBe(truncate(postBodySummary(e.body, 67), 67));
+    expect(fields.title.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to a byline title when a title-less post has no summarizable body", () => {
+    const e = entry({ title: "", body: "![img](https://example.com/a.png)" });
+    expect(buildEntryCardFields(e as any).title).toBe("Post by @alice");
+  });
+
   it("prefers an author-set json_metadata.description for the summary", () => {
     const e = entry({ json_metadata: { description: "Author provided summary" } });
     expect(buildEntryCardFields(e as any).summary).toBe("Author provided summary");

--- a/apps/web/src/specs/features/entry/entry-related.spec.tsx
+++ b/apps/web/src/specs/features/entry/entry-related.spec.tsx
@@ -117,7 +117,7 @@ describe("buildEntryBreadcrumbs", () => {
 
   it("builds Home > #tag > title for a normal tag post", () => {
     const crumbs = buildEntryBreadcrumbs(
-      { parent_author: undefined, category: "photography", community_title: undefined, title: "Pic", author: "alice", permlink: "p" },
+      { parent_author: undefined, category: "photography", community_title: undefined, title: "Pic", body: "body", author: "alice", permlink: "p" },
       opts
     );
     expect(crumbs.map((c) => c.name)).toEqual(["Ecency", "#photography", "Pic"]);
@@ -126,7 +126,7 @@ describe("buildEntryBreadcrumbs", () => {
 
   it("uses the community title as the section for a community post", () => {
     const crumbs = buildEntryBreadcrumbs(
-      { parent_author: undefined, category: "hive-125125", community_title: "Ecency", title: "Pic", author: "alice", permlink: "p" },
+      { parent_author: undefined, category: "hive-125125", community_title: "Ecency", title: "Pic", body: "body", author: "alice", permlink: "p" },
       opts
     );
     expect(crumbs.map((c) => c.name)).toEqual(["Ecency", "Ecency", "Pic"]);
@@ -134,16 +134,24 @@ describe("buildEntryBreadcrumbs", () => {
 
   it("omits the section crumb (no raw hive id) when a community post has no title", () => {
     const crumbs = buildEntryBreadcrumbs(
-      { parent_author: undefined, category: "hive-125125", community_title: undefined, title: "Pic", author: "alice", permlink: "p" },
+      { parent_author: undefined, category: "hive-125125", community_title: undefined, title: "Pic", body: "body", author: "alice", permlink: "p" },
       opts
     );
     expect(crumbs.map((c) => c.name)).toEqual(["Ecency", "Pic"]);
     expect(crumbs.some((c) => c.name.includes("hive-"))).toBe(false);
   });
 
+  it("never emits an empty last-crumb name: a title-less post falls back to its body summary", () => {
+    const crumbs = buildEntryBreadcrumbs(
+      { parent_author: undefined, category: "hive-193084", community_title: "DBuzz", title: "", body: "Short buzz message here", author: "alice", permlink: "p" },
+      opts
+    );
+    expect(crumbs.map((c) => c.name)).toEqual(["Ecency", "DBuzz", "Short buzz message here"]);
+  });
+
   it("returns no trail for a comment", () => {
     const crumbs = buildEntryBreadcrumbs(
-      { parent_author: "bob", category: "photography", community_title: undefined, title: "re", author: "alice", permlink: "p" },
+      { parent_author: "bob", category: "photography", community_title: undefined, title: "re", body: "body", author: "alice", permlink: "p" },
       opts
     );
     expect(crumbs).toEqual([]);

--- a/apps/web/src/specs/utils/truncate.spec.ts
+++ b/apps/web/src/specs/utils/truncate.spec.ts
@@ -8,4 +8,11 @@ describe("Truncate", () => {
   it("(2) truncate", () => {
     expect(truncate("lore", 5)).toBe("lore");
   });
+
+  it("never cuts through a surrogate pair (emoji at the boundary)", () => {
+    // "ab" + 😀 (2 UTF-16 units) — a cut at 3 would leave a dangling high surrogate
+    expect(truncate("ab\u{1F600}xyz", 3)).toBe("ab...");
+    // cut cleanly after the pair keeps the emoji intact
+    expect(truncate("ab\u{1F600}xyz", 4)).toBe("ab\u{1F600}...");
+  });
 });

--- a/apps/web/src/utils/entry-display-title.ts
+++ b/apps/web/src/utils/entry-display-title.ts
@@ -1,0 +1,18 @@
+import { postBodySummary } from "@ecency/render-helper";
+import type { Entry } from "@/entities";
+import { truncate } from "./truncate";
+
+/**
+ * Non-empty display title for an entry. Microblog-style root posts (e.g.
+ * D.Buzz) legitimately carry an empty on-chain title; every title surface
+ * (page <title>, og/twitter cards, BlogPosting headline, BreadcrumbList item
+ * names) falls back to a short body summary, then to a generic byline —
+ * Google rejects structured data whose breadcrumb name is empty.
+ */
+export function entryDisplayTitle(entry: Pick<Entry, "title" | "body" | "author">): string {
+  return (
+    (entry.title ?? "").trim() ||
+    truncate(postBodySummary(entry.body, 67), 67) ||
+    `Post by @${entry.author}`
+  );
+}

--- a/apps/web/src/utils/truncate.ts
+++ b/apps/web/src/utils/truncate.ts
@@ -2,5 +2,7 @@ export function truncate(str: string, num: number): string {
   if (str.length <= num) {
     return str;
   }
-  return str.slice(0, num) + "...";
+  // Never cut through a surrogate pair (emoji etc.): a dangling high
+  // surrogate renders as a replacement character.
+  return str.slice(0, num).replace(/[\uD800-\uDBFF]$/, "") + "...";
 }


### PR DESCRIPTION
## What

Root posts with an empty on-chain title (e.g. D.Buzz microblogs) rendered with:

- BreadcrumbList JSON-LD whose last crumb has `"name": ""` - Search Console flags these pages as invalid breadcrumb structured data ("Either 'name' or 'item.name' should be specified")
- an empty page `<title>` (" | Ecency") and empty og/twitter/oEmbed titles
- an empty BlogPosting `headline`

## How

New `entryDisplayTitle(entry)` helper: trimmed `entry.title`, falling back to a short body summary (67 chars), then to a "Post by @author" byline, so it never returns an empty string. Wired into:

- `buildEntryCardFields` (page title, og/twitter cards, oEmbed)
- `buildEntryBreadcrumbs` last crumb name (visible trail + JSON-LD, shared source)
- `buildArticleJsonLd` headline

## Tests

- breadcrumb: title-less post falls back to body summary (never an empty name)
- card fields: body-summary fallback + byline fallback when the body has no summarizable text


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Posts without titles now receive meaningful display titles based on their content or author.
  * Breadcrumbs, entry cards, and structured metadata consistently use these fallback titles.
  * Improved text truncation prevents emoji and other special characters from being cut incorrectly.

* **Bug Fixes**
  * Empty titles no longer appear in entry cards, breadcrumbs, or search-engine metadata.
  * Added fallback handling for posts with non-summarizable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->