### PR TITLE
Hosting: verify login challenge against every posting key

### DIFF
--- a/apps/self-hosted/hosting/api/src/routes/auth.ts
+++ b/apps/self-hosted/hosting/api/src/routes/auth.ts
@@ -94,7 +94,9 @@ authRoutes.post(
 
     // Verify the signature against EVERY posting key on the account, not just the first:
     // accounts often carry several posting key_auths and the signer may hold any of them.
-    if (!verifyChallengeSignature(account.posting?.key_auths, challenge, signature)) {
+    // The full posting authority is passed so key weights are checked against the
+    // threshold (a partial-authority key on a multisig account must not log in).
+    if (!verifyChallengeSignature(account.posting, challenge, signature)) {
       return c.json({ error: 'Invalid signature' }, 401);
     }
 

--- a/apps/self-hosted/hosting/api/src/routes/auth.ts
+++ b/apps/self-hosted/hosting/api/src/routes/auth.ts
@@ -7,11 +7,15 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
-import { callRPC, Signature, PublicKey, config as hiveTxConfig } from '@ecency/sdk/hive';
-import { createHash } from 'crypto';
+import { callRPC, config as hiveTxConfig } from '@ecency/sdk/hive';
 import { TenantService } from '../services/tenant-service';
 import { nanoid } from 'nanoid';
-import { createToken, verifyToken, getTokenExpiry } from '../utils/auth';
+import {
+  createToken,
+  verifyChallengeSignature,
+  verifyToken,
+  getTokenExpiry,
+} from '../utils/auth';
 import { challengeStore } from '../utils/redis';
 import { AuditService, parseClientIp } from '../services/audit-service';
 
@@ -88,19 +92,10 @@ authRoutes.post(
 
     const account = accounts[0];
 
-    // Verify signature against posting key
-    try {
-      const publicKey = PublicKey.fromString(account.posting.key_auths[0][0]);
-      const sig = Signature.from(signature);
-      const messageHash = createHash('sha256').update(challenge).digest();
-
-      const verified = publicKey.verify(messageHash, sig);
-      if (!verified) {
-        return c.json({ error: 'Invalid signature' }, 401);
-      }
-    } catch (err) {
-      console.error('Signature verification error:', err);
-      return c.json({ error: 'Invalid signature format' }, 400);
+    // Verify the signature against EVERY posting key on the account, not just the first:
+    // accounts often carry several posting key_auths and the signer may hold any of them.
+    if (!verifyChallengeSignature(account.posting?.key_auths, challenge, signature)) {
+      return c.json({ error: 'Invalid signature' }, 401);
     }
 
     // Clean up challenge from Redis

--- a/apps/self-hosted/hosting/api/src/utils/auth.test.ts
+++ b/apps/self-hosted/hosting/api/src/utils/auth.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 process.env.JWT_SECRET = 'test-secret-string-of-32-characters!!';
 const { verifyChallengeSignature } = await import('./auth');
+type PostingAuthority = import('./auth').PostingAuthority;
 
 const CHALLENGE = 'ecency-hosting-login:tester:1234567890:abcdefghijklmnop';
 
@@ -13,42 +14,63 @@ const keyB = PrivateKey.fromSeed('hosting-test-key-b');
 const sign = (key: typeof keyA, message: string) =>
   key.sign(createHash('sha256').update(message).digest()).customToString();
 
+const authority = (
+  keyAuths: Array<[string, number]>,
+  weightThreshold = 1
+): PostingAuthority => ({ weight_threshold: weightThreshold, key_auths: keyAuths });
+
 describe('verifyChallengeSignature', () => {
   it('accepts a signature from a NON-first posting key', () => {
     // The regression: accounts with several posting key_auths (e.g. app keys) were
     // rejected because only key_auths[0][0] was checked.
-    const keyAuths: Array<[string, number]> = [
+    const posting = authority([
       [keyA.createPublic().toString(), 1],
       [keyB.createPublic().toString(), 1],
-    ];
-    expect(verifyChallengeSignature(keyAuths, CHALLENGE, sign(keyB, CHALLENGE))).toBe(true);
-    expect(verifyChallengeSignature(keyAuths, CHALLENGE, sign(keyA, CHALLENGE))).toBe(true);
+    ]);
+    expect(verifyChallengeSignature(posting, CHALLENGE, sign(keyB, CHALLENGE))).toBe(true);
+    expect(verifyChallengeSignature(posting, CHALLENGE, sign(keyA, CHALLENGE))).toBe(true);
   });
 
   it('rejects a signature from a key that is not on the account', () => {
-    const keyAuths: Array<[string, number]> = [[keyA.createPublic().toString(), 1]];
-    expect(verifyChallengeSignature(keyAuths, CHALLENGE, sign(keyB, CHALLENGE))).toBe(false);
+    const posting = authority([[keyA.createPublic().toString(), 1]]);
+    expect(verifyChallengeSignature(posting, CHALLENGE, sign(keyB, CHALLENGE))).toBe(false);
   });
 
   it('rejects a valid signature over a DIFFERENT challenge', () => {
-    const keyAuths: Array<[string, number]> = [[keyA.createPublic().toString(), 1]];
-    expect(verifyChallengeSignature(keyAuths, CHALLENGE, sign(keyA, 'other-message'))).toBe(
+    const posting = authority([[keyA.createPublic().toString(), 1]]);
+    expect(verifyChallengeSignature(posting, CHALLENGE, sign(keyA, 'other-message'))).toBe(
       false
     );
   });
 
-  it('skips malformed key entries and still verifies against a later valid key', () => {
-    const keyAuths: Array<[string, number]> = [
-      ['not-a-key', 1],
-      [keyA.createPublic().toString(), 1],
-    ];
-    expect(verifyChallengeSignature(keyAuths, CHALLENGE, sign(keyA, CHALLENGE))).toBe(true);
+  it('rejects a key whose weight cannot meet the posting threshold alone', () => {
+    // A single login signature proves one key; on a weighted/multisig authority a
+    // partial-authority key must not obtain a session.
+    const posting = authority(
+      [
+        [keyA.createPublic().toString(), 1],
+        [keyB.createPublic().toString(), 2],
+      ],
+      2
+    );
+    expect(verifyChallengeSignature(posting, CHALLENGE, sign(keyA, CHALLENGE))).toBe(false);
+    expect(verifyChallengeSignature(posting, CHALLENGE, sign(keyB, CHALLENGE))).toBe(true);
   });
 
-  it('fails closed on malformed signatures and missing key lists', () => {
-    const keyAuths: Array<[string, number]> = [[keyA.createPublic().toString(), 1]];
-    expect(verifyChallengeSignature(keyAuths, CHALLENGE, 'zz-not-a-signature')).toBe(false);
+  it('skips malformed key entries and still verifies against a later valid key', () => {
+    const posting = authority([
+      ['not-a-key', 1],
+      [keyA.createPublic().toString(), 1],
+    ]);
+    expect(verifyChallengeSignature(posting, CHALLENGE, sign(keyA, CHALLENGE))).toBe(true);
+  });
+
+  it('fails closed on malformed signatures and missing authorities', () => {
+    const posting = authority([[keyA.createPublic().toString(), 1]]);
+    expect(verifyChallengeSignature(posting, CHALLENGE, 'zz-not-a-signature')).toBe(false);
     expect(verifyChallengeSignature(undefined, CHALLENGE, sign(keyA, CHALLENGE))).toBe(false);
-    expect(verifyChallengeSignature([], CHALLENGE, sign(keyA, CHALLENGE))).toBe(false);
+    expect(verifyChallengeSignature(authority([]), CHALLENGE, sign(keyA, CHALLENGE))).toBe(
+      false
+    );
   });
 });

--- a/apps/self-hosted/hosting/api/src/utils/auth.test.ts
+++ b/apps/self-hosted/hosting/api/src/utils/auth.test.ts
@@ -1,0 +1,54 @@
+import { createHash } from 'crypto';
+import { PrivateKey } from '@ecency/sdk/hive';
+import { describe, expect, it } from 'vitest';
+
+process.env.JWT_SECRET = 'test-secret-string-of-32-characters!!';
+const { verifyChallengeSignature } = await import('./auth');
+
+const CHALLENGE = 'ecency-hosting-login:tester:1234567890:abcdefghijklmnop';
+
+const keyA = PrivateKey.fromSeed('hosting-test-key-a');
+const keyB = PrivateKey.fromSeed('hosting-test-key-b');
+
+const sign = (key: typeof keyA, message: string) =>
+  key.sign(createHash('sha256').update(message).digest()).customToString();
+
+describe('verifyChallengeSignature', () => {
+  it('accepts a signature from a NON-first posting key', () => {
+    // The regression: accounts with several posting key_auths (e.g. app keys) were
+    // rejected because only key_auths[0][0] was checked.
+    const keyAuths: Array<[string, number]> = [
+      [keyA.createPublic().toString(), 1],
+      [keyB.createPublic().toString(), 1],
+    ];
+    expect(verifyChallengeSignature(keyAuths, CHALLENGE, sign(keyB, CHALLENGE))).toBe(true);
+    expect(verifyChallengeSignature(keyAuths, CHALLENGE, sign(keyA, CHALLENGE))).toBe(true);
+  });
+
+  it('rejects a signature from a key that is not on the account', () => {
+    const keyAuths: Array<[string, number]> = [[keyA.createPublic().toString(), 1]];
+    expect(verifyChallengeSignature(keyAuths, CHALLENGE, sign(keyB, CHALLENGE))).toBe(false);
+  });
+
+  it('rejects a valid signature over a DIFFERENT challenge', () => {
+    const keyAuths: Array<[string, number]> = [[keyA.createPublic().toString(), 1]];
+    expect(verifyChallengeSignature(keyAuths, CHALLENGE, sign(keyA, 'other-message'))).toBe(
+      false
+    );
+  });
+
+  it('skips malformed key entries and still verifies against a later valid key', () => {
+    const keyAuths: Array<[string, number]> = [
+      ['not-a-key', 1],
+      [keyA.createPublic().toString(), 1],
+    ];
+    expect(verifyChallengeSignature(keyAuths, CHALLENGE, sign(keyA, CHALLENGE))).toBe(true);
+  });
+
+  it('fails closed on malformed signatures and missing key lists', () => {
+    const keyAuths: Array<[string, number]> = [[keyA.createPublic().toString(), 1]];
+    expect(verifyChallengeSignature(keyAuths, CHALLENGE, 'zz-not-a-signature')).toBe(false);
+    expect(verifyChallengeSignature(undefined, CHALLENGE, sign(keyA, CHALLENGE))).toBe(false);
+    expect(verifyChallengeSignature([], CHALLENGE, sign(keyA, CHALLENGE))).toBe(false);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/utils/auth.ts
+++ b/apps/self-hosted/hosting/api/src/utils/auth.ts
@@ -6,9 +6,40 @@
  */
 
 import jwt from 'jsonwebtoken';
+import { createHash } from 'crypto';
+import { PublicKey, Signature } from '@ecency/sdk/hive';
 
 export interface AuthUser {
   username: string;
+}
+
+/**
+ * True when `signature` over sha256(challenge) verifies against ANY of the account's
+ * posting keys. Accounts routinely carry several posting key_auths (app keys, rotated
+ * keys); checking only the first rejects valid logins from holders of the others.
+ * Malformed entries are skipped; a malformed signature or empty key list fails.
+ */
+export function verifyChallengeSignature(
+  keyAuths: Array<[string, number]> | undefined,
+  challenge: string,
+  signature: string
+): boolean {
+  let sig: Signature;
+  try {
+    sig = Signature.from(signature);
+  } catch {
+    return false;
+  }
+
+  const messageHash = createHash('sha256').update(challenge).digest();
+
+  return (keyAuths ?? []).some(([key]) => {
+    try {
+      return PublicKey.fromString(key).verify(messageHash, sig);
+    } catch {
+      return false;
+    }
+  });
 }
 
 interface TokenPayload {

--- a/apps/self-hosted/hosting/api/src/utils/auth.ts
+++ b/apps/self-hosted/hosting/api/src/utils/auth.ts
@@ -13,14 +13,22 @@ export interface AuthUser {
   username: string;
 }
 
+export interface PostingAuthority {
+  weight_threshold: number;
+  key_auths: Array<[string, number]>;
+}
+
 /**
- * True when `signature` over sha256(challenge) verifies against ANY of the account's
- * posting keys. Accounts routinely carry several posting key_auths (app keys, rotated
- * keys); checking only the first rejects valid logins from holders of the others.
+ * True when `signature` over sha256(challenge) verifies against one of the account's
+ * posting keys whose weight alone satisfies the posting threshold. Accounts routinely
+ * carry several posting key_auths (app keys, rotated keys); checking only the first
+ * rejects valid logins from holders of the others. A single login signature can only
+ * ever prove ONE key, so on weighted/multisig authorities the signing key's own weight
+ * must meet weight_threshold; a partial-authority key must not obtain a session.
  * Malformed entries are skipped; a malformed signature or empty key list fails.
  */
 export function verifyChallengeSignature(
-  keyAuths: Array<[string, number]> | undefined,
+  posting: PostingAuthority | undefined,
   challenge: string,
   signature: string
 ): boolean {
@@ -31,9 +39,11 @@ export function verifyChallengeSignature(
     return false;
   }
 
+  const threshold = posting?.weight_threshold ?? 1;
   const messageHash = createHash('sha256').update(challenge).digest();
 
-  return (keyAuths ?? []).some(([key]) => {
+  return (posting?.key_auths ?? []).some(([key, weight]) => {
+    if (typeof weight !== 'number' || weight < threshold) return false;
     try {
       return PublicKey.fromString(key).verify(messageHash, sig);
     } catch {


### PR DESCRIPTION
## What

Config saves from a tenant instance failed with 401 on `/v1/auth/verify` for accounts that carry more than one posting key: verification checked only `posting.key_auths[0][0]`, while the signer (e.g. Keychain) may hold any of the account's posting keys.

The check now verifies the signed challenge against every posting key on the account, skips malformed key entries, and fails closed on malformed signatures. Extracted as a pure helper with signing tests, including the regression case of a signature from a non-first key.

## Tests
- hosting-api: 54 tests pass (5 new, real key signing); tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication signature verification to support any valid posting key associated with a Hive account.
  * Invalid, malformed, missing, or unauthorized signatures are now consistently rejected.
  * Authentication challenges now fail safely when provided with invalid key data or signatures.

* **Tests**
  * Added coverage for multiple posting keys, malformed inputs, incorrect challenges, and unauthorized signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->