### PR TITLE
Self-hosted: land on the first configured post filter

### DIFF
--- a/apps/self-hosted/src/features/blog/utils/post-filters.ts
+++ b/apps/self-hosted/src/features/blog/utils/post-filters.ts
@@ -9,7 +9,15 @@ export function getConfiguredPostsFilters(): string[] {
     ({ configuration }) =>
       configuration.instanceConfiguration.features.postsFilters,
   );
-  return filters && filters.length > 0 ? filters : ['posts'];
+  // Self-hosted config.json is hand-edited: a scalar like "trending" would
+  // otherwise pass a truthy length check and index to its first CHARACTER.
+  const validFilters = Array.isArray(filters)
+    ? filters.filter(
+        (filter): filter is string =>
+          typeof filter === 'string' && filter.length > 0,
+      )
+    : [];
+  return validFilters.length > 0 ? validFilters : ['posts'];
 }
 
 /**

--- a/apps/self-hosted/src/features/blog/utils/post-filters.ts
+++ b/apps/self-hosted/src/features/blog/utils/post-filters.ts
@@ -1,0 +1,26 @@
+import { InstanceConfigManager } from '@/core';
+
+/**
+ * The instance's configured post filters, e.g. ['trending', 'hot'] for a
+ * community or ['posts', 'blog'] for a personal blog.
+ */
+export function getConfiguredPostsFilters(): string[] {
+  const filters = InstanceConfigManager.getConfigValue(
+    ({ configuration }) =>
+      configuration.instanceConfiguration.features.postsFilters,
+  );
+  return filters && filters.length > 0 ? filters : ['posts'];
+}
+
+/**
+ * Clamp a requested filter to the configured list. Landing pages and stale
+ * bookmarks may carry a filter the owner removed (or the hardcoded historic
+ * default); those must resolve to the instance's FIRST configured filter, not
+ * to a feed the owner disabled.
+ */
+export function resolvePostsFilter(requested: unknown): string {
+  const configured = getConfiguredPostsFilters();
+  return typeof requested === 'string' && configured.includes(requested)
+    ? requested
+    : configured[0];
+}

--- a/apps/self-hosted/src/routes/blog/route.tsx
+++ b/apps/self-hosted/src/routes/blog/route.tsx
@@ -2,12 +2,15 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { useMemo } from 'react';
 import { BlogLayout } from '@/features/blog';
 import { BlogPostsList } from '@/features/blog/components/blog-posts-list';
+import { resolvePostsFilter } from '@/features/blog/utils/post-filters';
 
 export const Route = createFileRoute('/blog')({
   component: RouteComponent,
   validateSearch: (search: Record<string, unknown>) => {
+    // Clamp to the configured filters so a stale bookmark or the historic
+    // hardcoded default never selects a feed the owner disabled.
     return {
-      filter: (search.filter as string) || 'posts',
+      filter: resolvePostsFilter(search.filter),
     };
   },
 });
@@ -25,7 +28,8 @@ function HostingBanner() {
     <div className="bg-gradient-to-r from-blue-600 to-indigo-600 text-white">
       <div className="container mx-auto max-w-7xl px-4 py-3 flex items-center justify-between">
         <p className="text-sm font-medium">
-          Start your own Hive-powered blog - custom subdomain, instant setup, from 0.1 HBD/month
+          Start your own Hive-powered blog - custom subdomain, instant setup,
+          from $2/month
         </p>
         <Link
           to="/hosting"

--- a/apps/self-hosted/src/routes/index.tsx
+++ b/apps/self-hosted/src/routes/index.tsx
@@ -1,9 +1,18 @@
 import { createFileRoute, Navigate } from '@tanstack/react-router';
+import { resolvePostsFilter } from '@/features/blog/utils/post-filters';
 
 export const Route = createFileRoute('/')({
   component: Index,
 });
 
 function Index() {
-  return <Navigate to="/blog" search={{ filter: 'posts' }} replace />;
+  // Land on the instance's FIRST configured filter (e.g. trending for a
+  // community), not a hardcoded one the owner may have removed.
+  return (
+    <Navigate
+      to="/blog"
+      search={{ filter: resolvePostsFilter(undefined) }}
+      replace
+    />
+  );
 }


### PR DESCRIPTION
## What

Opening a tenant instance always redirected to `/blog?filter=posts`: the index route hardcoded the filter and the blog route defaulted to it, ignoring the instance's configured `postsFilters`. A community configured for trending/hot still landed on a feed missing from its own navigation.

- The blog route's `validateSearch` now clamps the requested filter to the configured list, falling back to the FIRST configured filter. This centrally covers the index redirect, stale bookmarks, and the hardcoded `filter: "posts"` navigations in publish/edit flows.
- The index redirect resolves the first configured filter explicitly.
- Also corrects the apex banner's stale 0.1 HBD price.

## Tests
- SPA: tests pass, tsc clean, production build clean.