### PR TITLE
Hosting web: restore login on /hosting, guard renewal, fix card-decline dead-end

### DIFF
--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -344,6 +344,7 @@ export async function POST(req: Request): Promise<Response> {
     "about",
     "faq",
     "perks",
+    "hosting",
     "mobile",
     "contributors",
     "creator-economy",

--- a/apps/web/src/app/hosting/layout.tsx
+++ b/apps/web/src/app/hosting/layout.tsx
@@ -1,0 +1,17 @@
+import { Feedback } from "@/features/shared/feedback";
+import { Navbar } from "@/features/shared/navbar";
+import { PropsWithChildren } from "react";
+
+// Without this layout the page rendered with no navbar, so a logged-out visitor from the
+// launch announcement had no way to log in — the LoginDialog is mounted inside Navbar, and
+// card checkout needs a logged-in user, so the community "Continue" button (which opens the
+// login dialog) did nothing at all. Mirrors gift/perks/signup layouts.
+export default function Layout({ children }: PropsWithChildren) {
+  return (
+    <div className="bg-blue-duck-egg dark:bg-transparent pt-[63px] md:pt-[69px] min-h-[100vh] pb-24 md:pb-16">
+      <Feedback />
+      <Navbar experimental={true} />
+      <div className="container mx-auto px-4">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/app/hosting/page.tsx
+++ b/apps/web/src/app/hosting/page.tsx
@@ -2,7 +2,8 @@ import { Metadata } from "next";
 import { HostingPage } from "./_page";
 
 export const metadata: Metadata = {
-  title: "Blog Hosting | Ecency",
+  // Root layout applies the "%s | Ecency" template; a bare title avoids "… | Ecency | Ecency".
+  title: "Blog Hosting",
   description: "Host your Hive blog on your own branded site at yourname.blogs.ecency.com."
 };
 

--- a/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
@@ -61,7 +61,13 @@ export function HostingCardCheckout({
   // PaymentIntent already created for the previous one. Fresh nonce per (sku, hostingTarget).
   const nonce = useMemo(genNonce, [sku, hostingTarget]);
   const [clientSecret, setClientSecret] = useState("");
+  // Terminal states that replace the whole checkout (mint failure, order failed, activation
+  // pending). A card decline is NOT terminal — it uses formError below so the user can retry.
   const [error, setError] = useState("");
+  const [errorAppearance, setErrorAppearance] = useState<"danger" | "primary">("danger");
+  // Decline / validation error shown ABOVE the still-mounted payment form so the buyer can
+  // fix the card and try again instead of dead-ending on a red alert.
+  const [formError, setFormError] = useState("");
   const [activating, setActivating] = useState(false);
   const pollingRef = useRef(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -79,8 +85,13 @@ export function HostingCardCheckout({
       try {
         const { client_secret } = await createIntent.mutateAsync({ sku, nonce, hosting_target: hostingTarget });
         if (alive) setClientSecret(client_secret);
-      } catch (e) {
-        if (alive) setError((e as Error).message || i18next.t("hosting.card-unavailable"));
+      } catch {
+        // Intent-mint failures throw raw messages / i18n keys (e.g. "stripe-points.not-
+        // authenticated") and axios status text; show a stable user-facing message instead.
+        if (alive) {
+          setErrorAppearance("danger");
+          setError(i18next.t("hosting.card-unavailable"));
+        }
       }
     })();
     return () => {
@@ -122,6 +133,7 @@ export function HostingCardCheckout({
         if (st.status === "failed") {
           pollingRef.current = false;
           setActivating(false);
+          setErrorAppearance("danger");
           setError(i18next.t("hosting.card-failed"));
           return;
         }
@@ -131,9 +143,10 @@ export function HostingCardCheckout({
       attempts += 1;
       if (attempts >= MAX_ATTEMPTS) {
         // Payment succeeded; ePoints keeps retrying activation with backoff, so this is not a
-        // hard failure -- stop the spinner and reassure rather than loop forever.
+        // hard failure -- stop the spinner and reassure (primary, not danger) rather than loop.
         pollingRef.current = false;
         setActivating(false);
+        setErrorAppearance("primary");
         setError(i18next.t("hosting.activation-pending"));
         return;
       }
@@ -145,8 +158,9 @@ export function HostingCardCheckout({
   if (!stripePromise) {
     return <Alert appearance="danger">{i18next.t("hosting.card-unavailable")}</Alert>;
   }
+  // Terminal states (mint failure, order failed, activation pending) replace the checkout.
   if (error) {
-    return <Alert appearance="danger">{error}</Alert>;
+    return <Alert appearance={errorAppearance}>{error}</Alert>;
   }
   if (activating) {
     return <div className="py-6 text-center text-sm opacity-75">{i18next.t("hosting.activating")}</div>;
@@ -158,16 +172,23 @@ export function HostingCardCheckout({
   }
 
   return (
-    <Elements
-      stripe={stripePromise}
-      options={{ clientSecret, appearance: { theme: isDarkMode() ? "night" : "stripe" } }}
-    >
-      <StripeCheckoutForm
-        returnUrl={returnUrl}
-        payLabel={payLabel}
-        onPaid={startPoll}
-        onError={setError}
-      />
-    </Elements>
+    <div className="flex flex-col gap-3">
+      {/* A card decline keeps the form mounted so the buyer can correct and retry. */}
+      {formError && <Alert appearance="danger">{formError}</Alert>}
+      <Elements
+        stripe={stripePromise}
+        options={{ clientSecret, appearance: { theme: isDarkMode() ? "night" : "stripe" } }}
+      >
+        <StripeCheckoutForm
+          returnUrl={returnUrl}
+          payLabel={payLabel}
+          onPaid={() => {
+            setFormError("");
+            startPoll();
+          }}
+          onError={setFormError}
+        />
+      </Elements>
+    </div>
   );
 }

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -73,6 +73,10 @@ export function HostingSignup() {
   // we must create the new one before payment (a stale guard would let them pay for a blog
   // that was never created and never activates).
   const createdForRef = useRef("");
+  // Expiry of an ALREADY-ACTIVE tenant captured when entering the payment step (renewal).
+  // "I've sent the payment" must then require the expiry to move FORWARD, otherwise a
+  // renewing owner sees "your blog is live" without any payment having landed.
+  const renewBaselineExpiryRef = useRef<string | null>(null);
 
   const baseDomain = "blogs.ecency.com";
   const isCommunity = instanceType === "community";
@@ -152,6 +156,7 @@ export function HostingSignup() {
         });
         createdForRef.current = uname;
         setBlogUrl(res.tenant.blogUrl);
+        renewBaselineExpiryRef.current = null; // freshly created, inactive
       }
       setStep("payment");
     } catch (e) {
@@ -162,17 +167,27 @@ export function HostingSignup() {
       // before letting them reach the payment/activation step.
       let canResume =
         msg === "Username already registered" && !isCommunity && activeUser?.username === uname;
-      if (msg === "Username already registered" && isCommunity && activeUser) {
+      let existing: Awaited<ReturnType<typeof hostingApi.tenant>> | null = null;
+      if (msg === "Username already registered" && activeUser) {
         try {
-          const existing = await hostingApi.tenant(uname);
-          canResume = existing.owner === activeUser.username;
+          existing = await hostingApi.tenant(uname);
+          if (isCommunity) {
+            canResume = existing.owner === activeUser.username;
+          }
         } catch {
-          canResume = false;
+          existing = null;
+          if (isCommunity) canResume = false;
         }
       }
       if (canResume) {
         createdForRef.current = uname;
         setBlogUrl(`https://${uname}.${baseDomain}`);
+        // Renewal of an already-active tenant: remember the current expiry so activation is
+        // only confirmed once it advances.
+        renewBaselineExpiryRef.current =
+          existing?.subscriptionStatus === "active"
+            ? (existing.subscriptionExpiresAt ?? null)
+            : null;
         setStep("payment");
       } else {
         setError(msg === "Username already registered" ? i18next.t("hosting.already-registered") : msg);
@@ -208,7 +223,15 @@ export function HostingSignup() {
     setBusy(true);
     try {
       const t = await hostingApi.tenant(tenantUsername);
-      if (t.subscriptionStatus === "active") {
+      // For a renewal (tenant was already active on entry) require the expiry to have moved
+      // forward — otherwise "active" is trivially true and would confirm success with no
+      // payment. For a first activation there is no baseline, so "active" is sufficient.
+      const baseline = renewBaselineExpiryRef.current;
+      const advanced =
+        !baseline ||
+        (!!t.subscriptionExpiresAt &&
+          new Date(t.subscriptionExpiresAt).getTime() > new Date(baseline).getTime());
+      if (t.subscriptionStatus === "active" && advanced) {
         setStep("success");
       } else {
         setError(i18next.t("hosting.not-yet-active"));
@@ -493,8 +516,10 @@ export function HostingSignup() {
           </div>
 
           {/* Custom domain plan -> let the owner attach and verify their domain now. For a
-              community the tenant is the community id while the logged-in owner authorizes. */}
-          {customDomain && activeUser && (isCommunity || username === activeUser.username) && (
+              community the tenant is the community id while the logged-in owner authorizes.
+              Compare the normalized tenantUsername (not the raw field) so "Alice"/"alice "
+              still shows the manager for tenant "alice". */}
+          {customDomain && activeUser && (isCommunity || tenantUsername === activeUser.username) && (
             <CustomDomainManager
               username={activeUser.username}
               tenant={isCommunity ? tenantUsername : undefined}

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -161,37 +161,42 @@ export function HostingSignup() {
       setStep("payment");
     } catch (e) {
       const msg = (e as Error).message;
-      // The tenant already existing is not an error: only its OWNER may resume to payment or renew.
-      // For a blog the owner is the account itself. For a community the owner is fixed at creation
-      // (and is not the community account), so confirm the logged-in user owns the existing tenant
-      // before letting them reach the payment/activation step.
-      let canResume =
-        msg === "Username already registered" && !isCommunity && activeUser?.username === uname;
-      let existing: Awaited<ReturnType<typeof hostingApi.tenant>> | null = null;
-      if (msg === "Username already registered" && activeUser) {
-        try {
-          existing = await hostingApi.tenant(uname);
-          if (isCommunity) {
-            canResume = existing.owner === activeUser.username;
-          }
-        } catch {
-          existing = null;
-          if (isCommunity) canResume = false;
-        }
+      if (msg !== "Username already registered") {
+        setError(msg);
+        return;
       }
-      if (canResume) {
-        createdForRef.current = uname;
-        setBlogUrl(`https://${uname}.${baseDomain}`);
-        // Renewal of an already-active tenant: remember the current expiry so activation is
-        // only confirmed once it advances.
-        renewBaselineExpiryRef.current =
-          existing?.subscriptionStatus === "active"
-            ? (existing.subscriptionExpiresAt ?? null)
-            : null;
-        setStep("payment");
-      } else {
-        setError(msg === "Username already registered" ? i18next.t("hosting.already-registered") : msg);
+      // The tenant already existing is not an error: only its OWNER may resume to payment or
+      // renew. Establishing the renewal baseline (the current expiry) requires reading the
+      // tenant, so if that read fails we must NOT proceed — otherwise checkActivation would
+      // treat this renewal as a first activation and could confirm success without the expiry
+      // moving. Surface a retry instead. (For a personal blog the owner is the account itself;
+      // for a community the owner is confirmed against the fetched record.)
+      if (!activeUser) {
+        setError(i18next.t("hosting.already-registered"));
+        return;
       }
+      let existing: Awaited<ReturnType<typeof hostingApi.tenant>>;
+      try {
+        existing = await hostingApi.tenant(uname);
+      } catch {
+        setError(i18next.t("hosting.status-check-failed"));
+        return;
+      }
+      const isOwner = isCommunity
+        ? existing.owner === activeUser.username
+        : activeUser.username === uname;
+      if (!isOwner) {
+        setError(i18next.t("hosting.already-registered"));
+        return;
+      }
+      createdForRef.current = uname;
+      setBlogUrl(`https://${uname}.${baseDomain}`);
+      // Renewal of an already-active tenant: remember the current expiry so activation is only
+      // confirmed once it advances. null (an inactive tenant resuming its first payment) means
+      // checkActivation confirms on active status alone.
+      renewBaselineExpiryRef.current =
+        existing.subscriptionStatus === "active" ? (existing.subscriptionExpiresAt ?? null) : null;
+      setStep("payment");
     } finally {
       setBusy(false);
     }

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -27,6 +27,7 @@
     "success-title": "Your blog is live",
     "invalid-username": "Enter a valid Hive username.",
     "already-registered": "This blog is already registered.",
+    "status-check-failed": "Could not load your blog status. Please try again in a moment.",
     "card-unavailable": "Card payment is unavailable right now.",
     "card-failed": "The payment could not be completed.",
     "activating": "Payment received. Activating your blog.",


### PR DESCRIPTION
Pre-announcement fixes for the ecency.com /hosting signup surfaces (companion to #1157 on the service side).

## Blocker — /hosting had no navbar, so logged-out visitors couldn't log in
`app/hosting/` shipped only `page.tsx`, no `layout.tsx`. Every other money page (gift, perks, signup) wraps itself in a layout that mounts `Navbar` — and the `LoginDialog` lives inside `Navbar`. So a visitor arriving from the launch announcement got a chrome-less form with no way to log in; card checkout (which needs a logged-in user) was unreachable, and the community "Continue" button — which calls `toggleUIProp("login")` — did nothing because the dialog isn't mounted on the page. Added `hosting/layout.tsx` mirroring `gift/layout.tsx`.

## High — renewal confirmed success with no payment
`checkActivation` only checked `subscriptionStatus === "active"`. On the renewal path (owner re-enters their name → resume) the tenant is already active, so "I've sent the payment" instantly showed "your blog is live" whether or not any HBD landed. Now captures the expiry when entering the payment step for an already-active tenant and requires it to advance; a first activation still passes on status alone.

## High — card decline dead-ended the checkout
A decline called `onError` → the parent replaced the whole `<Elements>` form with a red alert with no retry (only a full reload recovered, which resets the wizard). The form now stays mounted with the decline shown above it. Intent-mint failures show `hosting.card-unavailable` instead of a raw i18n key (`stripe-points.not-authenticated`), and the post-timeout activation-pending notice renders as reassurance rather than danger.

## Low
Success-screen custom-domain manager compares the normalized tenant name (was raw field), `/hosting` title no longer renders `… | Ecency | Ecency`, and `/hosting` is added to the sitemap.

## Tests
- hosting-signup specs pass; tsc clean on changed files.

## Not included (reported for decision)
Redirect-return payment handling, Pro-claim cached-roster 403, renew affordance in the manage panel, and the standard→pro upgrade path for claimed blogs.