### PR TITLE
Fix hosting payment races and activation retries

### DIFF
--- a/apps/self-hosted/hosting/api/src/middleware/payment-target-lock.test.ts
+++ b/apps/self-hosted/hosting/api/src/middleware/payment-target-lock.test.ts
@@ -23,17 +23,18 @@ describe('withPaymentTargetLock', () => {
       return 'OK';
     });
     redis.eval.mockReset().mockImplementation(
-      async (_script: string, options: { keys: string[]; arguments: string[] }) => {
+      async (script: string, options: { keys: string[]; arguments: string[] }) => {
         const [key] = options.keys;
         const [token] = options.arguments;
         if (locks.get(key) !== token) return 0;
+        if (script.includes('pexpire')) return 1;
         locks.delete(key);
         return 1;
       }
     );
   });
 
-  it('rejects a competing request before it reaches settlement', async () => {
+  it('serializes unpaid create and paid subscribe before settlement', async () => {
     const app = new Hono();
     let downstreamCalls = 0;
     let signalEntered!: () => void;
@@ -46,7 +47,7 @@ describe('withPaymentTargetLock', () => {
     });
 
     app.post(
-      '/subscribe',
+      '/create',
       (c, next) => withPaymentTargetLock(c, next, 'subscribe', 'alice'),
       async (c) => {
         downstreamCalls++;
@@ -55,8 +56,16 @@ describe('withPaymentTargetLock', () => {
         return c.json({ ok: true });
       }
     );
+    app.post(
+      '/subscribe',
+      (c, next) => withPaymentTargetLock(c, next, 'subscribe', 'alice'),
+      (c) => {
+        downstreamCalls++;
+        return c.json({ ok: true });
+      }
+    );
 
-    const first = app.request('/subscribe', { method: 'POST' });
+    const first = app.request('/create', { method: 'POST' });
     await entered;
 
     const competing = await app.request('/subscribe', { method: 'POST' });
@@ -70,6 +79,46 @@ describe('withPaymentTargetLock', () => {
     releaseFirst();
     expect((await first).status).toBe(200);
     expect(locks.size).toBe(0);
+  });
+
+  it('renews the lease while downstream work remains active', async () => {
+    vi.useFakeTimers();
+    const app = new Hono();
+    let signalEntered!: () => void;
+    let releaseRequest!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      signalEntered = resolve;
+    });
+    const holdRequest = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
+    });
+
+    app.post(
+      '/subscribe',
+      (c, next) => withPaymentTargetLock(c, next, 'subscribe', 'alice'),
+      async (c) => {
+        signalEntered();
+        await holdRequest;
+        return c.json({ ok: true });
+      }
+    );
+
+    try {
+      const request = app.request('/subscribe', { method: 'POST' });
+      await entered;
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(redis.eval).toHaveBeenCalledWith(
+        expect.stringContaining('pexpire'),
+        expect.objectContaining({ keys: ['lock:x402:subscribe:alice'] })
+      );
+
+      releaseRequest();
+      expect((await request).status).toBe(200);
+    } finally {
+      releaseRequest?.();
+      vi.useRealTimers();
+    }
   });
 
   it('fails closed when Redis cannot reserve the target', async () => {

--- a/apps/self-hosted/hosting/api/src/middleware/payment-target-lock.test.ts
+++ b/apps/self-hosted/hosting/api/src/middleware/payment-target-lock.test.ts
@@ -1,0 +1,93 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redis = vi.hoisted(() => ({
+  set: vi.fn(),
+  eval: vi.fn(),
+}));
+
+vi.mock('../utils/redis', () => ({
+  getRedisClient: vi.fn(async () => redis),
+}));
+
+const { withPaymentTargetLock } = await import('./payment-target-lock');
+
+describe('withPaymentTargetLock', () => {
+  const locks = new Map<string, string>();
+
+  beforeEach(() => {
+    locks.clear();
+    redis.set.mockReset().mockImplementation(async (key: string, token: string) => {
+      if (locks.has(key)) return null;
+      locks.set(key, token);
+      return 'OK';
+    });
+    redis.eval.mockReset().mockImplementation(
+      async (_script: string, options: { keys: string[]; arguments: string[] }) => {
+        const [key] = options.keys;
+        const [token] = options.arguments;
+        if (locks.get(key) !== token) return 0;
+        locks.delete(key);
+        return 1;
+      }
+    );
+  });
+
+  it('rejects a competing request before it reaches settlement', async () => {
+    const app = new Hono();
+    let downstreamCalls = 0;
+    let signalEntered!: () => void;
+    let releaseFirst!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      signalEntered = resolve;
+    });
+    const holdFirst = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    app.post(
+      '/subscribe',
+      (c, next) => withPaymentTargetLock(c, next, 'subscribe', 'alice'),
+      async (c) => {
+        downstreamCalls++;
+        signalEntered();
+        await holdFirst;
+        return c.json({ ok: true });
+      }
+    );
+
+    const first = app.request('/subscribe', { method: 'POST' });
+    await entered;
+
+    const competing = await app.request('/subscribe', { method: 'POST' });
+    expect(competing.status).toBe(409);
+    expect(await competing.json()).toEqual({
+      error: 'Payment operation already in progress',
+      retryable: true,
+    });
+    expect(downstreamCalls).toBe(1);
+
+    releaseFirst();
+    expect((await first).status).toBe(200);
+    expect(locks.size).toBe(0);
+  });
+
+  it('fails closed when Redis cannot reserve the target', async () => {
+    redis.set.mockRejectedValueOnce(new Error('redis unavailable'));
+    const app = new Hono();
+    let downstreamCalled = false;
+
+    app.post(
+      '/upgrade',
+      (c, next) => withPaymentTargetLock(c, next, 'upgrade', 'alice'),
+      (c) => {
+        downstreamCalled = true;
+        return c.json({ ok: true });
+      }
+    );
+
+    const response = await app.request('/upgrade', { method: 'POST' });
+    expect(response.status).toBe(503);
+    expect(downstreamCalled).toBe(false);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/middleware/payment-target-lock.ts
+++ b/apps/self-hosted/hosting/api/src/middleware/payment-target-lock.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from 'node:crypto';
+import type { Context, Next } from 'hono';
+import { getRedisClient } from '../utils/redis';
+
+// A paid x402 request can spend up to 30 seconds in facilitator verify + settle. Keep the
+// reservation beyond that window, but let Redis recover it automatically if this process dies.
+const PAYMENT_TARGET_LOCK_TTL_MS = 60_000;
+
+const RELEASE_LOCK_SCRIPT = `
+  if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+  end
+  return 0
+`;
+
+/**
+ * Serialize an x402 operation for one tenant across API replicas.
+ *
+ * The lock must wrap both the unpaid eligibility check and the paywall. A competing request is
+ * rejected before it reaches settlement, so it cannot pay and then lose a tenant/plan race in the
+ * post-settlement transaction. The random token makes release ownership-safe if a stale lock ever
+ * expires and another request acquires the same key.
+ */
+export async function withPaymentTargetLock(
+  c: Context,
+  next: Next,
+  operation: 'subscribe' | 'upgrade',
+  target: string
+): Promise<Response | void> {
+  const key = `lock:x402:${operation}:${target.trim().toLowerCase()}`;
+  const token = randomUUID();
+  let client: Awaited<ReturnType<typeof getRedisClient>>;
+
+  try {
+    client = await getRedisClient();
+    const acquired = await client.set(key, token, { NX: true, PX: PAYMENT_TARGET_LOCK_TTL_MS });
+    if (acquired !== 'OK') {
+      return c.json({ error: 'Payment operation already in progress', retryable: true }, 409);
+    }
+  } catch (error) {
+    // Fail closed before the paywall: proceeding without the reservation could settle a payment
+    // that the post-settlement tenant mutation then rejects.
+    console.error(
+      '[PaymentTargetLock] Failed to reserve payment target:',
+      (error as Error).message
+    );
+    return c.json({ error: 'Unable to reserve payment operation', retryable: true }, 503);
+  }
+
+  try {
+    await next();
+  } finally {
+    try {
+      await client.eval(RELEASE_LOCK_SCRIPT, { keys: [key], arguments: [token] });
+    } catch (error) {
+      // The TTL is the final recovery mechanism; never replace the real route response merely
+      // because eager cleanup failed.
+      console.error(
+        '[PaymentTargetLock] Failed to release payment target:',
+        (error as Error).message
+      );
+    }
+  }
+}

--- a/apps/self-hosted/hosting/api/src/middleware/payment-target-lock.ts
+++ b/apps/self-hosted/hosting/api/src/middleware/payment-target-lock.ts
@@ -2,9 +2,17 @@ import { randomUUID } from 'node:crypto';
 import type { Context, Next } from 'hono';
 import { getRedisClient } from '../utils/redis';
 
-// A paid x402 request can spend up to 30 seconds in facilitator verify + settle. Keep the
-// reservation beyond that window, but let Redis recover it automatically if this process dies.
-const PAYMENT_TARGET_LOCK_TTL_MS = 60_000;
+// A paid x402 request can spend up to 30 seconds in facilitator verify + settle. The lease is
+// renewed while the route remains active and still expires automatically if this process dies.
+const PAYMENT_TARGET_LOCK_TTL_MS = 120_000;
+const PAYMENT_TARGET_LOCK_REFRESH_MS = 15_000;
+
+const REFRESH_LOCK_SCRIPT = `
+  if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("pexpire", KEYS[1], ARGV[2])
+  end
+  return 0
+`;
 
 const RELEASE_LOCK_SCRIPT = `
   if redis.call("get", KEYS[1]) == ARGV[1] then
@@ -18,8 +26,9 @@ const RELEASE_LOCK_SCRIPT = `
  *
  * The lock must wrap both the unpaid eligibility check and the paywall. A competing request is
  * rejected before it reaches settlement, so it cannot pay and then lose a tenant/plan race in the
- * post-settlement transaction. The random token makes release ownership-safe if a stale lock ever
- * expires and another request acquires the same key.
+ * post-settlement transaction. A token-checked heartbeat keeps long-running requests covered; the
+ * random token also makes refresh and release ownership-safe if a stale lock ever expires and
+ * another request acquires the same key.
  */
 export async function withPaymentTargetLock(
   c: Context,
@@ -47,9 +56,38 @@ export async function withPaymentTargetLock(
     return c.json({ error: 'Unable to reserve payment operation', retryable: true }, 503);
   }
 
+  let refreshRunning = false;
+  const refreshTimer = setInterval(() => {
+    if (refreshRunning) return;
+    refreshRunning = true;
+    void client
+      .eval(REFRESH_LOCK_SCRIPT, {
+        keys: [key],
+        arguments: [token, String(PAYMENT_TARGET_LOCK_TTL_MS)],
+      })
+      .then((renewed) => {
+        if (renewed !== 1) {
+          console.error('[PaymentTargetLock] Lost payment target lease:', key);
+        }
+      })
+      .catch((error) => {
+        // The existing lease remains valid and the next heartbeat retries. The two-minute TTL
+        // leaves ample margin over the paywall's bounded 30-second facilitator window.
+        console.error(
+          '[PaymentTargetLock] Failed to refresh payment target:',
+          (error as Error).message
+        );
+      })
+      .finally(() => {
+        refreshRunning = false;
+      });
+  }, PAYMENT_TARGET_LOCK_REFRESH_MS);
+  refreshTimer.unref?.();
+
   try {
     await next();
   } finally {
+    clearInterval(refreshTimer);
     try {
       await client.eval(RELEASE_LOCK_SCRIPT, { keys: [key], arguments: [token] });
     } catch (error) {

--- a/apps/self-hosted/hosting/api/src/routes/internal.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  transaction: vi.fn(),
+  getByUsername: vi.fn(),
+  generateConfigFile: vi.fn(),
+}));
+
+vi.mock('../db/client', () => ({
+  db: { transaction: mocks.transaction },
+}));
+
+vi.mock('../services/tenant-service', () => ({
+  TenantService: {
+    getByUsername: mocks.getByUsername,
+  },
+}));
+
+vi.mock('../services/config-service', () => ({
+  ConfigService: {
+    generateConfigFile: mocks.generateConfigFile,
+  },
+}));
+
+const { internalRoutes } = await import('./internal');
+
+describe('POST /activate config publication', () => {
+  beforeEach(() => {
+    process.env.HOSTING_INTERNAL_SECRET = 'test-secret';
+    mocks.transaction.mockReset().mockResolvedValue({
+      status: 200,
+      expiresAt: new Date('2027-01-01T00:00:00.000Z'),
+      plan: 'standard',
+    });
+    mocks.getByUsername.mockReset().mockResolvedValue({
+      username: 'alice',
+      subscriptionStatus: 'active',
+    });
+    mocks.generateConfigFile.mockReset().mockResolvedValue('/configs/alice.json');
+  });
+
+  const activate = () =>
+    internalRoutes.request('/activate', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-internal-secret': 'test-secret',
+      },
+      body: JSON.stringify({
+        username: 'alice',
+        payer: 'alice',
+        months: 1,
+        order_id: 'order-1',
+        amount_usd: 2,
+      }),
+    });
+
+  it('returns a retryable server error when the served config cannot be published', async () => {
+    mocks.generateConfigFile.mockRejectedValueOnce(new Error('disk unavailable'));
+
+    const response = await activate();
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'activation_failed' });
+  });
+
+  it('acknowledges activation only after config publication succeeds', async () => {
+    const response = await activate();
+
+    expect(response.status).toBe(200);
+    expect(mocks.generateConfigFile).toHaveBeenCalledTimes(1);
+    expect(await response.json()).toMatchObject({ activated: true, plan: 'standard' });
+  });
+});

--- a/apps/self-hosted/hosting/api/src/routes/internal.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.test.ts
@@ -64,6 +64,56 @@ describe('POST /activate config publication', () => {
     expect(await response.json()).toEqual({ error: 'activation_failed' });
   });
 
+  it('returns a retryable server error when a new activation tenant is missing or inactive', async () => {
+    mocks.getByUsername.mockResolvedValueOnce(null);
+
+    const missingResponse = await activate();
+
+    expect(missingResponse.status).toBe(500);
+    expect(await missingResponse.json()).toEqual({ error: 'activation_failed' });
+
+    mocks.getByUsername.mockResolvedValueOnce({
+      username: 'alice',
+      subscriptionStatus: 'inactive',
+    });
+
+    const inactiveResponse = await activate();
+
+    expect(inactiveResponse.status).toBe(500);
+    expect(await inactiveResponse.json()).toEqual({ error: 'activation_failed' });
+  });
+
+  it('acknowledges an expired duplicate without extending or republishing it', async () => {
+    mocks.transaction.mockResolvedValueOnce({
+      status: 200,
+      duplicate: true,
+      plan: 'standard',
+    });
+    mocks.getByUsername.mockResolvedValueOnce({
+      username: 'alice',
+      subscriptionStatus: 'expired',
+    });
+
+    const response = await activate();
+
+    expect(response.status).toBe(200);
+    expect(mocks.generateConfigFile).not.toHaveBeenCalled();
+    expect(await response.json()).toMatchObject({ activated: true, duplicate: true });
+  });
+
+  it('retries config publication for an active duplicate', async () => {
+    mocks.transaction.mockResolvedValueOnce({
+      status: 200,
+      duplicate: true,
+      plan: 'standard',
+    });
+
+    const response = await activate();
+
+    expect(response.status).toBe(200);
+    expect(mocks.generateConfigFile).toHaveBeenCalledTimes(1);
+  });
+
   it('acknowledges activation only after config publication succeeds', async () => {
     const response = await activate();
 

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -173,14 +173,19 @@ internalRoutes.post('/activate', async (c) => {
       return c.json({ error: 'order_tenant_mismatch' }, 409);
     }
 
-    // Do not acknowledge fulfillment until the paid tenant is actually being served. A failure
-    // returns 500 so ePoints keeps the order VERIFIED and retries; replay is safe because the
-    // order claim above is idempotent and does not extend the subscription twice.
+    // Do not acknowledge a new fulfillment until the paid tenant is actually being served. An
+    // active duplicate also retries config publication (the first response may have failed here),
+    // while an expired/suspended duplicate is already-processed history and remains idempotently
+    // acknowledgeable without reactivating or extending it.
     const tenant = await TenantService.getByUsername(username);
-    if (!tenant || tenant.subscriptionStatus !== 'active') {
+    if (!tenant) {
       throw new Error(`Activated tenant ${username} is not available for config generation`);
     }
-    await ConfigService.generateConfigFile(tenant);
+    if (tenant.subscriptionStatus === 'active') {
+      await ConfigService.generateConfigFile(tenant);
+    } else if (!result.duplicate) {
+      throw new Error(`Activated tenant ${username} is not active for config generation`);
+    }
 
     // Echo the tenant's ACTUAL plan so the caller (ePoints) can confirm the Pro tier was honored.
     // Truthful on replays too (the upgrade is idempotent); an older service that ignores `plan`

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -173,18 +173,14 @@ internalRoutes.post('/activate', async (c) => {
       return c.json({ error: 'order_tenant_mismatch' }, 409);
     }
 
-    // Generate the served config file now that the tenant is active. Creation no longer
-    // writes it (so unpaid tenants can't serve), and the card/ePoints rail activates through
-    // this endpoint, so without this a paid tenant would serve the default blog until the
-    // periodic sync catches up. Non-fatal + idempotent (writes only on change).
-    try {
-      const tenant = await TenantService.getByUsername(username);
-      if (tenant && tenant.subscriptionStatus === 'active') {
-        await ConfigService.generateConfigFile(tenant);
-      }
-    } catch (err) {
-      console.error(`[internal/activate] config generation failed for ${username}:`, (err as Error).message);
+    // Do not acknowledge fulfillment until the paid tenant is actually being served. A failure
+    // returns 500 so ePoints keeps the order VERIFIED and retries; replay is safe because the
+    // order claim above is idempotent and does not extend the subscription twice.
+    const tenant = await TenantService.getByUsername(username);
+    if (!tenant || tenant.subscriptionStatus !== 'active') {
+      throw new Error(`Activated tenant ${username} is not available for config generation`);
     }
+    await ConfigService.generateConfigFile(tenant);
 
     // Echo the tenant's ACTUAL plan so the caller (ePoints) can confirm the Pro tier was honored.
     // Truthful on replays too (the upgrade is idempotent); an older service that ignores `plan`

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -164,54 +164,61 @@ async function resolveAndValidateTenant(
   return { ok: true, owner };
 }
 
-tenantRoutes.post('/', zValidator('json', createTenantSchema), async (c) => {
-  const body = c.req.valid('json');
+tenantRoutes.post(
+  '/',
+  zValidator('json', createTenantSchema),
+  // Use the same target reservation as paid /subscribe. Otherwise this unpaid create can insert
+  // after the paid request's availability check but before its post-settlement tenant insert.
+  (c, next) => withPaymentTargetLock(c, next, 'subscribe', c.req.valid('json').username),
+  async (c) => {
+    const body = c.req.valid('json');
 
-  // Check if username already exists
-  const existing = await TenantService.getByUsername(body.username);
-  if (existing) {
-    return c.json({ error: 'Username already registered' }, 409);
+    // Check if username already exists
+    const existing = await TenantService.getByUsername(body.username);
+    if (existing) {
+      return c.json({ error: 'Username already registered' }, 409);
+    }
+
+    // Validate accounts + community + ownership rules (shared with /subscribe).
+    const validation = await resolveAndValidateTenant(body);
+    if (!validation.ok) {
+      return c.json({ error: validation.error }, validation.status);
+    }
+    const { owner } = validation;
+
+    // Create tenant (inactive until payment). The served config file is NOT written here:
+    // nginx serves any file that exists with no subscription check, so writing it now would
+    // put an unpaid blog live forever. The file is generated only on activation (payment
+    // listener / internal activate / subscribe).
+    const tenant = await TenantService.create(body.username, owner, body.config);
+
+    const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
+    const paymentAccount = process.env.PAYMENT_ACCOUNT || 'ecency.hosting';
+    const monthlyPrice = process.env.MONTHLY_PRICE_HBD || '0.100';
+
+    void AuditService.log({
+      tenantId: tenant.id,
+      eventType: 'tenant.created',
+      eventData: { username: body.username, owner },
+      ipAddress: parseClientIp(c.req.header('x-forwarded-for')),
+      userAgent: c.req.header('user-agent'),
+    });
+
+    return c.json({
+      tenant: {
+        username: tenant.username,
+        subscriptionStatus: tenant.subscriptionStatus,
+        blogUrl: `https://${tenant.username}.${baseDomain}`,
+      },
+      paymentInstructions: {
+        to: paymentAccount,
+        amount: `${monthlyPrice} HBD`,
+        memo: `blog:${tenant.username}`,
+        note: 'Send this exact memo to activate your blog',
+      },
+    }, 201);
   }
-
-  // Validate accounts + community + ownership rules (shared with /subscribe).
-  const validation = await resolveAndValidateTenant(body);
-  if (!validation.ok) {
-    return c.json({ error: validation.error }, validation.status);
-  }
-  const { owner } = validation;
-
-  // Create tenant (inactive until payment). The served config file is NOT written here:
-  // nginx serves any file that exists with no subscription check, so writing it now would
-  // put an unpaid blog live forever. The file is generated only on activation (payment
-  // listener / internal activate / subscribe).
-  const tenant = await TenantService.create(body.username, owner, body.config);
-
-  const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
-  const paymentAccount = process.env.PAYMENT_ACCOUNT || 'ecency.hosting';
-  const monthlyPrice = process.env.MONTHLY_PRICE_HBD || '0.100';
-  
-  void AuditService.log({
-    tenantId: tenant.id,
-    eventType: 'tenant.created',
-    eventData: { username: body.username, owner },
-    ipAddress: parseClientIp(c.req.header('x-forwarded-for')),
-    userAgent: c.req.header('user-agent'),
-  });
-
-  return c.json({
-    tenant: {
-      username: tenant.username,
-      subscriptionStatus: tenant.subscriptionStatus,
-      blogUrl: `https://${tenant.username}.${baseDomain}`,
-    },
-    paymentInstructions: {
-      to: paymentAccount,
-      amount: `${monthlyPrice} HBD`,
-      memo: `blog:${tenant.username}`,
-      note: 'Send this exact memo to activate your blog',
-    },
-  }, 201);
-});
+);
 
 // POST /v1/tenants/subscribe - Create tenant via x402 payment
 // Validation runs before paywall so we don't settle payment for invalid requests

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -11,6 +11,7 @@ import { mapTenantFromDb } from '../types';
 import { ConfigService } from '../services/config-service';
 import { authMiddleware } from '../middleware/auth';
 import { subscriptionPaywall, proUpgradePaywall } from '../middleware/x402-paywall';
+import { withPaymentTargetLock } from '../middleware/payment-target-lock';
 import { AuditService, parseClientIp } from '../services/audit-service';
 
 export const tenantRoutes = new Hono();
@@ -216,6 +217,9 @@ tenantRoutes.post('/', zValidator('json', createTenantSchema), async (c) => {
 // Validation runs before paywall so we don't settle payment for invalid requests
 tenantRoutes.post('/subscribe',
   zValidator('json', createTenantSchema),
+  // Hold the target reservation across validation, facilitator settlement, and the DB mutation.
+  // A competing paid request is rejected here, before its signed transfer can be broadcast.
+  (c, next) => withPaymentTargetLock(c, next, 'subscribe', c.req.valid('json').username),
   async (c, next) => {
     const body = c.req.valid('json');
     const existing = await TenantService.getByUsername(body.username);
@@ -354,6 +358,9 @@ tenantRoutes.post('/subscribe',
 // Validation runs before paywall so we don't settle payment for invalid requests
 tenantRoutes.post('/:username/upgrade',
   authMiddleware,
+  // See /subscribe: serialize eligibility + settlement + mutation for this tenant so two
+  // concurrent upgrade requests cannot both pay before one observes the other's Pro update.
+  (c, next) => withPaymentTargetLock(c, next, 'upgrade', c.req.param('username')!),
   async (c, next) => {
     const username = c.req.param('username')!;
     const authUser = c.get('user');


### PR DESCRIPTION
## Summary

- serialize each tenant's x402 subscribe/upgrade flow with a Redis-backed reservation that spans eligibility checks, facilitator settlement, and the database mutation
- fail closed before settlement when the target is already being processed or Redis cannot reserve it
- return a retryable activation failure until the paid tenant config is actually published, relying on the existing idempotent order replay to avoid double extension
- add regression coverage for concurrent payment exclusion, Redis failure, and config-publication failure/success

## Root cause

x402 eligibility was checked before settlement but uniqueness and plan state were enforced afterward. Two concurrent requests could therefore both settle before one lost the tenant insert or Pro-plan race. Card activation also swallowed config-write errors and returned success, so fulfillment stopped retrying while the tenant could still serve the default blog until reconciliation.

## Impact

Competing x402 requests now receive a retryable conflict before their signed transfer reaches the paywall. A Redis outage returns a retryable 503 before settlement. Card fulfillment remains retryable until the activated tenant's served config exists; replay remains safe because the order claim is idempotent.

## Validation

- `pnpm test` in `apps/self-hosted/hosting/api`: 67 tests passed
- `pnpm build` in `apps/self-hosted/hosting/api`: TypeScript clean
- `git diff --check`: clean
- repository-wide `pnpm lint` is currently blocked by the existing `@ecency/ui` ESLint 9 setup (`eslint.config.*` is missing); this PR does not touch that package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protection against concurrent tenant subscription and upgrade requests.
  * Conflicting payment attempts now receive a retryable 409 response.
  * Temporary payment-processing failures return a retryable 503 response.

* **Bug Fixes**
  * Tenant activation now succeeds only after configuration generation completes successfully.
  * Activation failures are reported clearly instead of being acknowledged prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->