### PR TITLE
Self-hosted: fix search-crash, comment refetch, and publish redirect

### DIFF
--- a/apps/self-hosted/src/core/date-formatter.ts
+++ b/apps/self-hosted/src/core/date-formatter.ts
@@ -1,6 +1,5 @@
-import { format, formatDistanceToNow, formatRelative } from 'date-fns';
-import { toZonedTime } from 'date-fns-tz';
 import type { Locale } from 'date-fns';
+import { format, formatDistanceToNow, formatRelative } from 'date-fns';
 import {
   de,
   enUS,
@@ -18,6 +17,7 @@ import {
   vi,
   zhCN,
 } from 'date-fns/locale';
+import { toZonedTime } from 'date-fns-tz';
 import { InstanceConfigManager } from './configuration-loader';
 
 // Map language codes to date-fns locales
@@ -60,10 +60,24 @@ function parseHiveDate(date: Date | string | number): Date {
 
   // Hive dates don't have timezone indicator, treat as UTC
   const dateStr = String(date);
-  if (!dateStr.endsWith('Z') && !dateStr.includes('+') && !dateStr.includes('-', 10)) {
+  if (
+    !dateStr.endsWith('Z') &&
+    !dateStr.includes('+') &&
+    !dateStr.includes('-', 10)
+  ) {
     return new Date(dateStr + 'Z');
   }
   return new Date(dateStr);
+}
+
+/**
+ * True for an unparseable/invalid Date. date-fns v4's `format` THROWS a RangeError on an
+ * Invalid Date; since these formatters run during render and the only boundary is the
+ * app-wide ErrorBoundary, an unexpected date (e.g. an undefined field) would otherwise blank
+ * the entire page. The formatters below return "" for such input instead.
+ */
+function isValidDate(d: Date): boolean {
+  return !Number.isNaN(d.getTime());
 }
 
 function getLocale(): Locale {
@@ -105,6 +119,7 @@ function getDateTimeFormat(): string {
  */
 export function formatDate(date: Date | string | number): string {
   const utcDate = parseHiveDate(date);
+  if (!isValidDate(utcDate)) return '';
   const zonedDate = toZonedTime(utcDate, getTimezone());
   return format(zonedDate, getDateFormat(), { locale: getLocale() });
 }
@@ -114,6 +129,7 @@ export function formatDate(date: Date | string | number): string {
  */
 export function formatTime(date: Date | string | number): string {
   const utcDate = parseHiveDate(date);
+  if (!isValidDate(utcDate)) return '';
   const zonedDate = toZonedTime(utcDate, getTimezone());
   return format(zonedDate, getTimeFormat(), { locale: getLocale() });
 }
@@ -123,6 +139,7 @@ export function formatTime(date: Date | string | number): string {
  */
 export function formatDateTime(date: Date | string | number): string {
   const utcDate = parseHiveDate(date);
+  if (!isValidDate(utcDate)) return '';
   const zonedDate = toZonedTime(utcDate, getTimezone());
   return format(zonedDate, getDateTimeFormat(), { locale: getLocale() });
 }
@@ -133,6 +150,7 @@ export function formatDateTime(date: Date | string | number): string {
  */
 export function formatRelativeTime(date: Date | string | number): string {
   const utcDate = parseHiveDate(date);
+  if (!isValidDate(utcDate)) return '';
   // formatDistanceToNow compares UTC timestamps internally, so we just need
   // to ensure the input date is parsed as UTC (which parseHiveDate does)
   return formatDistanceToNow(utcDate, { addSuffix: true, locale: getLocale() });
@@ -143,6 +161,7 @@ export function formatRelativeTime(date: Date | string | number): string {
  */
 export function formatRelativeDate(date: Date | string | number): string {
   const utcDate = parseHiveDate(date);
+  if (!isValidDate(utcDate)) return '';
   const timezone = getTimezone();
   const zonedDate = toZonedTime(utcDate, timezone);
   const zonedNow = toZonedTime(new Date(), timezone);

--- a/apps/self-hosted/src/features/blog/components/blog-discussion-item.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-discussion-item.tsx
@@ -24,9 +24,12 @@ export function BlogDiscussionItem({
   const [showReplies, setShowReplies] = useState(false);
 
   const likesCount = useMemo(() => entry.active_votes?.length || 0, [entry]);
-  // Honor the likes flag; the reactive hook keeps it live if the owner toggles likes while
-  // previewing config, instead of showing a stale heart until an unrelated re-render.
-  const showLikes = InstanceConfigManager.useConfig(
+  // Honor the likes flag, read the same way every other config-flag consumer does
+  // (blog-post-item, blog-post-footer). A live owner-preview toggle is NOT reflected by any
+  // consumer because the preview flow applies edits via DOM attributes, not the config store;
+  // making it live is an app-wide preview change (store-based preview re-renders the whole
+  // tree per keystroke), out of scope here. For real visitors the config is static per load.
+  const showLikes = InstanceConfigManager.getConfigValue(
     ({ configuration }) =>
       configuration.instanceConfiguration.features.likes?.enabled ?? true,
   );

--- a/apps/self-hosted/src/features/blog/components/blog-discussion-item.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-discussion-item.tsx
@@ -4,7 +4,7 @@ import { renderPostBody } from '@ecency/render-helper';
 import type { Entry } from '@ecency/sdk';
 import { UilComment, UilHeart } from '@tooni/iconscout-unicons-react';
 import { useMemo, useState } from 'react';
-import { formatRelativeTime } from '@/core';
+import { formatRelativeTime, InstanceConfigManager } from '@/core';
 import { UserAvatar } from '@/features/shared/user-avatar';
 import { BlogDiscussionList } from './blog-discussion-list';
 
@@ -24,6 +24,12 @@ export function BlogDiscussionItem({
   const [showReplies, setShowReplies] = useState(false);
 
   const likesCount = useMemo(() => entry.active_votes?.length || 0, [entry]);
+  // Honor the same likes flag the post-level UI does, so a config with likes disabled
+  // doesn't still show a heart + count on every comment.
+  const showLikes = InstanceConfigManager.getConfigValue(
+    ({ configuration }) =>
+      configuration.instanceConfiguration.features.likes?.enabled ?? true,
+  );
 
   const repliesCount = useMemo(
     () =>
@@ -84,10 +90,12 @@ export function BlogDiscussionItem({
           </div>
 
           <div className="flex items-center gap-3 sm:gap-4 mt-2 sm:mt-3 text-xs text-theme-muted font-theme-ui">
-            <div className="flex items-center gap-1">
-              <UilHeart className="w-3 h-3" />
-              <span>{likesCount}</span>
-            </div>
+            {showLikes && (
+              <div className="flex items-center gap-1">
+                <UilHeart className="w-3 h-3" />
+                <span>{likesCount}</span>
+              </div>
+            )}
             {hasReplies && (
               <button
                 type="button"

--- a/apps/self-hosted/src/features/blog/components/blog-discussion-item.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-discussion-item.tsx
@@ -24,9 +24,9 @@ export function BlogDiscussionItem({
   const [showReplies, setShowReplies] = useState(false);
 
   const likesCount = useMemo(() => entry.active_votes?.length || 0, [entry]);
-  // Honor the same likes flag the post-level UI does, so a config with likes disabled
-  // doesn't still show a heart + count on every comment.
-  const showLikes = InstanceConfigManager.getConfigValue(
+  // Honor the likes flag; the reactive hook keeps it live if the owner toggles likes while
+  // previewing config, instead of showing a stale heart until an unrelated re-render.
+  const showLikes = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.features.likes?.enabled ?? true,
   );

--- a/apps/self-hosted/src/features/blog/components/blog-post-discussion.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-discussion.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { callRPC, type Entry } from '@ecency/sdk';
+import { callRPC, type Entry, QueryKeys } from '@ecency/sdk';
 import { useQuery } from '@tanstack/react-query';
 import { UilComment } from '@tooni/iconscout-unicons-react';
 import { useMemo, useState } from 'react';
-import { BlogDiscussionList } from './blog-discussion-list';
 import { CommentForm } from '@/features/auth';
+import { BlogDiscussionList } from './blog-discussion-list';
 
 interface Props {
   entry: Entry;
@@ -64,7 +64,16 @@ export function BlogPostDiscussion({ entry, isRawContent }: Props) {
   const entryData = entry.original_entry || entry;
 
   const { data: allComments = [], isLoading } = useQuery({
-    queryKey: ['discussions', entryData.author, entryData.permlink, order],
+    // Use the SDK's canonical discussions key so useComment's post-broadcast invalidation
+    // (which matches ["posts","discussions",author,permlink,...]) actually refetches this
+    // list; a bespoke ["discussions",...] key never matched, so new comments only appeared
+    // after a full reload.
+    queryKey: QueryKeys.posts.discussions(
+      entryData.author,
+      entryData.permlink,
+      order,
+      entryData.author,
+    ),
     queryFn: async () => {
       const response = await callRPC('bridge.get_discussion', {
         author: entryData.author,

--- a/apps/self-hosted/src/features/blog/components/search-results.tsx
+++ b/apps/self-hosted/src/features/blog/components/search-results.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { searchQueryOptions } from '@ecency/sdk';
+import { type Entry, type SearchResult, searchQueryOptions } from '@ecency/sdk';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { t } from '@/core';
@@ -9,6 +9,29 @@ import { BlogPostItem } from './blog-post-item';
 
 interface Props {
   query: string;
+}
+
+/**
+ * The search API returns a SearchResult (created_at, img_url, top-level tags), but BlogPostItem
+ * expects an Entry (created, json_metadata.image/tags, active_votes, ...). Passing the raw result
+ * left `created` undefined, and formatDate(undefined) threw during render, taking down the whole
+ * app via the root ErrorBoundary. Map into the shape BlogPostItem reads.
+ */
+function searchResultToEntry(result: SearchResult): Entry {
+  return {
+    author: result.author,
+    permlink: result.permlink,
+    title: result.title,
+    body: result.body,
+    category: result.category,
+    created: result.created_at,
+    children: result.children,
+    active_votes: [],
+    json_metadata: {
+      tags: result.tags,
+      image: result.img_url ? [result.img_url] : undefined,
+    },
+  } as unknown as Entry;
 }
 
 export function SearchResults({ query }: Props) {
@@ -42,17 +65,13 @@ export function SearchResults({ query }: Props) {
 
   if (isLoading) {
     return (
-      <div className="text-center py-12 text-theme-muted">
-        {t('searching')}
-      </div>
+      <div className="text-center py-12 text-theme-muted">{t('searching')}</div>
     );
   }
 
   if (error) {
     return (
-      <div className="text-center py-12 text-red-500">
-        {t('search_error')}
-      </div>
+      <div className="text-center py-12 text-red-500">{t('search_error')}</div>
     );
   }
 
@@ -75,7 +94,7 @@ export function SearchResults({ query }: Props) {
         {results.map((result, index) => (
           <BlogPostItem
             key={`${result.author}/${result.permlink}`}
-            entry={result as any}
+            entry={searchResultToEntry(result)}
             index={index}
           />
         ))}

--- a/apps/self-hosted/src/features/publish/hooks/use-publish-post.ts
+++ b/apps/self-hosted/src/features/publish/hooks/use-publish-post.ts
@@ -1,13 +1,17 @@
-import { useAuth } from "@/features/auth/hooks";
-import { useInstanceConfig } from "@/features/blog/hooks/use-instance-config";
-import { useNavigate } from "@tanstack/react-router";
-import { useComment } from "@ecency/sdk";
-import { useMutation } from "@tanstack/react-query";
-import { createPermlink } from "../utils/permlink";
-import { resolvePublishTarget } from "../utils/publish-target";
-import { createBroadcastAdapter } from "@/providers/sdk";
+import { useComment } from '@ecency/sdk';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { useAuth } from '@/features/auth/hooks';
+import { useInstanceConfig } from '@/features/blog/hooks/use-instance-config';
+import { createBroadcastAdapter } from '@/providers/sdk';
+import { createPermlink } from '../utils/permlink';
+import { resolvePublishTarget } from '../utils/publish-target';
 
-export function usePublishPost({ beforeNavigate }: { beforeNavigate?: () => void } = {}) {
+export function usePublishPost({
+  beforeNavigate,
+}: {
+  beforeNavigate?: () => void;
+} = {}) {
   const { user } = useAuth();
   const navigate = useNavigate();
   const { isCommunityMode, communityId } = useInstanceConfig();
@@ -16,7 +20,7 @@ export function usePublishPost({ beforeNavigate }: { beforeNavigate?: () => void
   const commentMutation = useComment(user?.username, { adapter });
 
   return useMutation({
-    mutationKey: ["publish-post"],
+    mutationKey: ['publish-post'],
     mutationFn: async ({
       title,
       body,
@@ -27,19 +31,19 @@ export function usePublishPost({ beforeNavigate }: { beforeNavigate?: () => void
       tags: string[];
     }) => {
       if (!user) {
-        throw new Error("Authentication required to publish post");
+        throw new Error('Authentication required to publish post');
       }
 
       if (!title.trim()) {
-        throw new Error("Title cannot be empty");
+        throw new Error('Title cannot be empty');
       }
 
       if (!body.trim()) {
-        throw new Error("Post content cannot be empty");
+        throw new Error('Post content cannot be empty');
       }
 
       if (!tags.length) {
-        throw new Error("At least one tag is required");
+        throw new Error('At least one tag is required');
       }
 
       const permlink = createPermlink(title, true);
@@ -53,25 +57,33 @@ export function usePublishPost({ beforeNavigate }: { beforeNavigate?: () => void
         communityId,
       });
 
-      const result = await commentMutation.mutateAsync({
+      await commentMutation.mutateAsync({
         author: user.username,
         permlink,
-        parentAuthor: "",
+        parentAuthor: '',
         parentPermlink,
         title: title.trim(),
         body: body.trim(),
         jsonMetadata: {
           tags: metadataTags,
-          app: "ecency-selfhost/1.0",
-          format: "markdown",
+          app: 'ecency-selfhost/1.0',
+          format: 'markdown',
         },
       });
 
-      return result;
+      // Return where the new post lives so onSuccess can land the author ON it.
+      return { author: user.username, permlink };
     },
-    onSuccess: () => {
+    onSuccess: ({ author, permlink }) => {
       beforeNavigate?.();
-      navigate({ to: "/blog", search: { filter: "posts" } });
+      // Redirect to the new post, not a hardcoded feed: a fresh post has no votes, so on a
+      // community (whose default filter is trending/hot) the author would land on a feed
+      // without their post and think publishing failed.
+      navigate({
+        to: '/$author/$permlink',
+        params: { author: `@${author}`, permlink },
+        search: { raw: undefined },
+      });
     },
   });
 }

--- a/apps/self-hosted/src/routes/search.tsx
+++ b/apps/self-hosted/src/routes/search.tsx
@@ -1,7 +1,7 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Navigate } from '@tanstack/react-router';
+import { InstanceConfigManager, t } from '@/core';
 import { BlogLayout } from '@/features/blog';
 import { SearchResults } from '@/features/blog/components/search-results';
-import { t } from '@/core';
 
 export const Route = createFileRoute('/search')({
   component: RouteComponent,
@@ -14,6 +14,17 @@ export const Route = createFileRoute('/search')({
 
 function RouteComponent() {
   const { q } = Route.useSearch();
+
+  // The search entry point is hidden when the owner disables search, but a direct or
+  // bookmarked /search?q= would still query Hive; send it home instead.
+  const searchEnabled = InstanceConfigManager.getConfigValue(
+    ({ configuration }) =>
+      configuration.instanceConfiguration.layout.search?.enabled ?? true,
+  );
+  if (!searchEnabled) {
+    // The /blog route's validateSearch clamps an empty filter to the first configured one.
+    return <Navigate to="/blog" search={{ filter: '' }} replace />;
+  }
 
   return (
     <BlogLayout>

--- a/apps/self-hosted/src/routes/search.tsx
+++ b/apps/self-hosted/src/routes/search.tsx
@@ -16,8 +16,9 @@ function RouteComponent() {
   const { q } = Route.useSearch();
 
   // The search entry point is hidden when the owner disables search, but a direct or
-  // bookmarked /search?q= would still query Hive; send it home instead.
-  const searchEnabled = InstanceConfigManager.getConfigValue(
+  // bookmarked /search?q= would still query Hive; send it home instead. Reactive read so the
+  // gate updates live if search is toggled while this route is mounted.
+  const searchEnabled = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.layout.search?.enabled ?? true,
   );

--- a/apps/self-hosted/src/routes/search.tsx
+++ b/apps/self-hosted/src/routes/search.tsx
@@ -16,9 +16,10 @@ function RouteComponent() {
   const { q } = Route.useSearch();
 
   // The search entry point is hidden when the owner disables search, but a direct or
-  // bookmarked /search?q= would still query Hive; send it home instead. Reactive read so the
-  // gate updates live if search is toggled while this route is mounted.
-  const searchEnabled = InstanceConfigManager.useConfig(
+  // bookmarked /search?q= would still query Hive; send it home instead. Snapshot read (as
+  // elsewhere in the app); a live owner-preview toggle isn't reflected because preview edits
+  // are applied via DOM attributes, not the config store. Config is static per real load.
+  const searchEnabled = InstanceConfigManager.getConfigValue(
     ({ configuration }) =>
       configuration.instanceConfiguration.layout.search?.enabled ?? true,
   );


### PR DESCRIPTION
Pre-announcement review of the self-hosted reader/writer flows (the area a prior review couldn't finish). All confirmed by tracing the query/bridge/mutation code end to end.

## HIGH — search crashed the whole app on any hit
`search-results.tsx` passed raw `SearchResult` objects into `BlogPostItem`, which reads `entryData.created`, `json_metadata.*`, etc. `created` was undefined, so `formatDate(undefined)` built `new Date("undefinedZ")` and date-fns v4 `format` threw a RangeError **during render**; the only boundary is the app-wide ErrorBoundary, so the entire page (nav, sidebar, content) was replaced by the fallback. Search is enabled by default, so any query returning results blanked the app until reload. Fixed by mapping `SearchResult`→ the `Entry` shape `BlogPostItem` expects, and hardening the date formatters to return "" on an invalid date so no unexpected field can take the page down again.

## HIGH — new comments/replies didn't appear until reload
The discussion list used a bespoke `['discussions', author, permlink, order]` query key. The SDK's `useComment` invalidates discussions with a predicate matching `['posts','discussions',author,permlink,...]`, which never matched, so a posted comment (textarea clears, looks successful) didn't show until a full reload. Now uses `QueryKeys.posts.discussions(...)`.

## MEDIUM — publishing in a community looked like it failed
`use-publish-post` redirected to a hardcoded `filter=posts`. The `/blog` route clamps that to a community's first configured filter (trending/hot), where a brand-new vote-less post isn't visible — so the author landed on a feed without their post. (The post publishes correctly into the community.) Now redirects to the new post's page.

## LOW
Per-comment like count now honors the same likes flag the post UI uses; `/search` redirects to the blog when the owner disabled search in config.

## Tests
tsc clean; production build clean.

## Confirmed correct (no change)
Community trending/hot/created → `bridge.get_ranked_posts` with the community tag; blog posts/blog/comments/replies → `get_account_posts`; publish-into-community targeting; edit loading; search scoping; permalink routing; config flag honoring; RSS URLs.