### PR TITLE
Hosting: auto-delete abandoned unpaid tenants after a grace window

### DIFF
--- a/apps/self-hosted/hosting/api/src/payment-listener-grace.test.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener-grace.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// parseAbandonedGraceDays must fail safe: any value that is not a positive integer falls back to
+// 7. A zero/negative/NaN grace would make the reclaim cutoff `NOW() - (n * INTERVAL '1 day')`
+// land at or after now and sweep EVERY inactive tenant, so the guard prevents mass reclamation
+// from a misconfigured ABANDONED_TENANT_GRACE_DAYS. The module auto-start is skipped under Vitest.
+vi.mock('@ecency/sdk/hive', () => ({
+  callRPC: vi.fn(),
+  config: { nodes: [] },
+  setNodes: vi.fn(),
+}));
+vi.mock('./db/client', () => ({ db: { query: vi.fn(), queryOne: vi.fn(), queryAll: vi.fn() } }));
+
+const { parseAbandonedGraceDays } = await import('./payment-listener');
+
+describe('parseAbandonedGraceDays', () => {
+  it('accepts a valid positive integer', () => {
+    expect(parseAbandonedGraceDays('7')).toBe(7);
+    expect(parseAbandonedGraceDays('30')).toBe(30);
+    expect(parseAbandonedGraceDays('1')).toBe(1);
+  });
+
+  it('falls back to 7 for zero, negative, NaN, empty, or undefined', () => {
+    expect(parseAbandonedGraceDays('0')).toBe(7);
+    expect(parseAbandonedGraceDays('-1')).toBe(7);
+    expect(parseAbandonedGraceDays('-30')).toBe(7);
+    expect(parseAbandonedGraceDays('abc')).toBe(7);
+    expect(parseAbandonedGraceDays('')).toBe(7);
+    expect(parseAbandonedGraceDays(undefined)).toBe(7);
+  });
+
+  it('truncates a decimal via parseInt (13.9 -> 13, still positive)', () => {
+    expect(parseAbandonedGraceDays('13.9')).toBe(13);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/payment-listener-grace.test.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener-grace.test.ts
@@ -29,7 +29,15 @@ describe('parseAbandonedGraceDays', () => {
     expect(parseAbandonedGraceDays(undefined)).toBe(7);
   });
 
-  it('truncates a decimal via parseInt (13.9 -> 13, still positive)', () => {
-    expect(parseAbandonedGraceDays('13.9')).toBe(13);
+  it('rejects partial-numeric strings that parseInt would otherwise truncate', () => {
+    // parseInt('13.9') === 13 and parseInt('7foo') === 7; both must fall back, not slip through.
+    expect(parseAbandonedGraceDays('13.9')).toBe(7);
+    expect(parseAbandonedGraceDays('7foo')).toBe(7);
+    expect(parseAbandonedGraceDays('7.0')).toBe(7); // rejected as non-integer, coincidentally 7
+    expect(parseAbandonedGraceDays('1e3')).toBe(7);
+  });
+
+  it('trims surrounding whitespace on an otherwise-valid integer', () => {
+    expect(parseAbandonedGraceDays('  14  ')).toBe(14);
   });
 });

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -118,6 +118,29 @@ class PaymentListener {
         break; // Stop and retry this block next iteration
       }
     }
+
+    // Publish a caught-up watermark for the hosting-api. Re-registration of a reclaimed username
+    // is gated on this being fresh (see TenantService.create), so that even after the time-based
+    // quarantine expires, a listener that is stalled or replaying a backlog — and therefore may not
+    // have processed a pending on-chain payment yet — blocks the name from being overwritten. It is
+    // written only while genuinely near head; a backlog or a stall leaves it stale.
+    if (headBlock - this.lastProcessedBlock <= CAUGHT_UP_BLOCK_THRESHOLD) {
+      await this.markCaughtUp();
+    }
+  }
+
+  private async markCaughtUp(): Promise<void> {
+    try {
+      await db.query(
+        `INSERT INTO system_config (key, value, updated_at)
+         VALUES ('payment_listener.caught_up', '1', NOW())
+         ON CONFLICT (key) DO UPDATE SET value = '1', updated_at = NOW()`
+      );
+    } catch (error) {
+      // Best-effort heartbeat: a write failure must not break block processing. A stale watermark
+      // fails safe (re-registration is blocked), so skipping one write is harmless.
+      console.error('[PaymentListener] Error writing caught-up watermark:', (error as Error).message);
+    }
   }
 
   private async processBlock(blockNum: number) {

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -13,9 +13,12 @@ import { parseMemo, mapTenantFromDb, type ParsedMemo } from './types';
 import { AuditService } from './services/audit-service';
 
 // Parse the abandoned-tenant grace window from env, failing safe to 7 for any value that is not a
-// positive integer (empty, non-numeric, zero, or negative). Exported for unit testing.
+// positive integer. The whole (trimmed) string must be digits — parseInt alone would accept
+// partial matches like '13.9' or '7foo', silently bypassing the safe fallback with a truncated
+// value. Empty, non-numeric, zero, and negative all fall back to 7. Exported for unit testing.
 export function parseAbandonedGraceDays(raw: string | undefined): number {
-  const n = parseInt(raw ?? '', 10);
+  const trimmed = (raw ?? '').trim();
+  const n = /^\d+$/.test(trimmed) ? parseInt(trimmed, 10) : NaN;
   return Number.isInteger(n) && n > 0 ? n : 7;
 }
 
@@ -415,6 +418,20 @@ class PaymentListener {
       if (!tenant) {
         console.log('[PaymentListener] Tenant not found for upgrade:', username);
         await this.logPayment(transfer, amount, 'failed', 0, null, 'Tenant not found');
+        return;
+      }
+
+      // A Pro upgrade only applies to a currently-serviceable (active) blog — same rule the x402
+      // /upgrade route enforces. Reject a reserved/inactive, reclaimed/abandoned, or expired
+      // tenant: upgrading one would take the payment for a blog that isn't running, and a plan
+      // bought while a name was abandoned must not carry over to a later fresh reservation.
+      if (tenant.subscriptionStatus !== 'active') {
+        console.log(
+          '[PaymentListener] Tenant not active for upgrade:',
+          username,
+          tenant.subscriptionStatus
+        );
+        await this.logPayment(transfer, amount, 'failed', 0, null, 'Tenant not active for upgrade');
         return;
       }
 

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -28,14 +28,14 @@ const CONFIG = {
 // empty list, so a misconfigured HIVE_API_URL can't wipe the built-in fallbacks.
 setNodes(CONFIG.HIVE_API_NODES);
 
+// How close to head the listener must be for the abandoned-tenant sweep to run. A payment in
+// an unreplayed block has no `payments` row yet, so sweeping while behind could delete a tenant
+// whose payment is about to activate it; requiring near-head replay avoids that.
+const CAUGHT_UP_BLOCK_THRESHOLD = 3;
+
 class PaymentListener {
   private lastProcessedBlock: number = 0;
   private isRunning: boolean = false;
-  // True once block processing has reached the chain head. The abandoned-tenant sweep is
-  // gated on this so it can't delete an abandoned tenant whose late payment is still sitting
-  // in an unreplayed block during a post-downtime catch-up (which would briefly free the name
-  // before the replayed payment re-creates it).
-  private caughtUp: boolean = false;
   private expirationIntervalId: ReturnType<typeof setInterval> | null = null;
 
   async start() {
@@ -107,13 +107,19 @@ class PaymentListener {
         break; // Stop and retry this block next iteration
       }
     }
+  }
 
-    // Caught up only once this pass has actually drained the backlog up to the head it saw
-    // (i.e. no block errored out and broke the loop early). Set AFTER the loop so the sweep,
-    // which is gated on this flag, can never run while a payment in one of the just-processed
-    // blocks is still pending. Never un-set: a normal 1-block steady-state lag isn't a backlog.
-    if (this.lastProcessedBlock >= headBlock) {
-      this.caughtUp = true;
+  /**
+   * Whether block replay is currently near head. Checked at sweep time (not a sticky flag) so
+   * it reflects the LIVE state: a later RPC/DB outage that leaves the listener lagging again
+   * correctly blocks the sweep. Fails safe (returns false) if head can't be read.
+   */
+  private async isCaughtUp(): Promise<boolean> {
+    try {
+      const headBlock = await this.getHeadBlockNumber();
+      return headBlock - this.lastProcessedBlock <= CAUGHT_UP_BLOCK_THRESHOLD;
+    } catch {
+      return false;
     }
   }
 
@@ -479,11 +485,12 @@ class PaymentListener {
         console.log('[PaymentListener] Expired', expired, 'subscriptions');
       }
 
-      // Sweep abandoned signups (created, never paid, past the grace window), but ONLY once
-      // caught up to head — otherwise a late payment still in an unreplayed block could see
-      // its 7-day-old inactive tenant deleted first (it would be re-created on replay, but the
-      // name would be briefly free). This frees usernames an inactive record would else hold.
-      if (this.caughtUp) {
+      // Sweep abandoned signups (created, never paid, past the grace window), but ONLY when
+      // replay is currently near head — otherwise a payment still in an unreplayed block could
+      // see its 7-day-old inactive tenant deleted first (it would be re-created on replay, but
+      // the name would be briefly free). Checked live so a mid-run outage that leaves the
+      // listener lagging again also blocks the sweep. Frees names an inactive record would hold.
+      if (await this.isCaughtUp()) {
         const deleted = await TenantService.deleteAbandonedTenants(CONFIG.ABANDONED_GRACE_DAYS);
         if (deleted.length > 0) {
           console.log('[PaymentListener] Deleted', deleted.length, 'abandoned inactive tenants');

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -31,6 +31,16 @@ setNodes(CONFIG.HIVE_API_NODES);
 // How close to head the listener must be for the abandoned-tenant sweep to run. A payment in
 // an unreplayed block has no `payments` row yet, so sweeping while behind could delete a tenant
 // whose payment is about to activate it; requiring near-head replay avoids that.
+//
+// A small tolerance (not exact head) is deliberate: checkExpirations samples head on its own
+// hourly timer, and by the time it reads head the live-tailing loop has almost always fallen one
+// block behind (a block is produced during each POLL_INTERVAL_MS sleep), so an exact `>= head`
+// gate would seldom be satisfied and the sweep would rarely run. The residual 1-3 block window is
+// harmless: an abandoned tenant is 'inactive', so its config can never have been edited (both the
+// config read and update routes reject inactive tenants) and no served file exists; if a valid
+// payment does land in that window, replay recreates the tenant from the same default config and
+// activates it. The sweep is therefore self-healing, never lossy — it only reclaims the username
+// slightly early.
 const CAUGHT_UP_BLOCK_THRESHOLD = 3;
 
 class PaymentListener {

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -281,7 +281,16 @@ class PaymentListener {
       // makes a retry safe: a transient failure after activation rolls the extension back
       // WITH the dedup row, so reprocessing extends exactly once (no double-credit).
       updatedTenant = await db.transaction(async (client) => {
-        // 1. Claim the transfer (dedup via unique trx_id).
+        // 1. Lock the target tenant row FIRST (before claiming the payment). The abandoned
+        // sweep's DELETE must lock the same row, so it blocks here and then re-evaluates its
+        // 'inactive' predicate against the now-active row -> it skips the tenant instead of
+        // deleting one whose payment we're mid-recording. (The payment row is inserted with
+        // tenant_id NULL, so a guard keyed on tenant_id alone can't protect this window.)
+        let row = (
+          await client.query(`SELECT * FROM tenants WHERE username = $1 FOR UPDATE`, [username])
+        ).rows[0];
+
+        // 2. Claim the transfer (dedup via unique trx_id).
         const insertResult = await client.query(
           `INSERT INTO payments
            (tenant_id, trx_id, block_num, from_account, amount, currency, memo, status, months_credited)
@@ -296,11 +305,8 @@ class PaymentListener {
         }
         const paymentId = insertResult.rows[0].id;
 
-        // 2. Ensure the tenant exists, locked for update. ON CONFLICT + re-select handles a
-        // concurrent create (e.g. the web signup racing us) without failing.
-        let row = (
-          await client.query(`SELECT * FROM tenants WHERE username = $1 FOR UPDATE`, [username])
-        ).rows[0];
+        // 3. Create the tenant if it didn't exist. ON CONFLICT + re-select handles a concurrent
+        // create (e.g. the web signup racing us) without failing.
         if (!row) {
           const inserted = await client.query(
             `INSERT INTO tenants (username, owner, config, subscription_status, subscription_plan)
@@ -316,7 +322,7 @@ class PaymentListener {
           console.log('[PaymentListener] Created new tenant:', username);
         }
 
-        // 3. Extend from the later of now / current expiry (same rule as activateSubscription).
+        // 4. Extend from the later of now / current expiry (same rule as activateSubscription).
         const now = new Date();
         const currentExpiry = row.subscription_expires_at
           ? new Date(row.subscription_expires_at)
@@ -337,7 +343,7 @@ class PaymentListener {
           [row.id, startedAt, newExpiry]
         );
 
-        // 4. Mark the payment processed in the SAME transaction.
+        // 5. Mark the payment processed in the SAME transaction.
         await client.query(
           `UPDATE payments
            SET tenant_id = $2, status = 'processed', subscription_extended_to = $3

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -268,12 +268,18 @@ class PaymentListener {
       // makes a retry safe: a transient failure after activation rolls the extension back
       // WITH the dedup row, so reprocessing extends exactly once (no double-credit).
       updatedTenant = await db.transaction(async (client) => {
-        // 1. Lock the target tenant row FIRST — before any other await — so the lock covers
-        // the WHOLE processing window that can overlap the abandoned sweep. The sweep's DELETE
-        // must lock the same row, so it blocks here and then re-evaluates its 'inactive'
-        // predicate against the now-active row -> it skips the tenant instead of deleting one
-        // whose payment we're mid-recording. (An existing tenant is the only sweep target; a
-        // payment row keyed on tenant_id NULL can't protect this window on its own.)
+        // 1. Lock the target tenant row FIRST — before any other await. The abandoned sweep
+        // takes the same row lock to flip status to 'abandoned', so the two serialize: if we
+        // win, the sweep re-evaluates its 'inactive' predicate against the now-active row and
+        // skips it; if the sweep won, we find the surviving 'abandoned' row here and revive it.
+        // Either way the payment lands on the ORIGINAL row, keeping its owner + config intact.
+        //
+        // Note this path never assigns ownership to the payer: an existing row (inactive or
+        // abandoned) is activated under its stored owner, and a brand-new row (step 3) is created
+        // with owner = username. An HBD transfer is thus gift-style — it activates the named blog
+        // under its existing owner — while an actual ownership change goes through create/subscribe
+        // (which runs ownership validation). This is exactly why reviving beats recreating: a
+        // recreate would reset a community's owner to the community account and orphan it.
         let row = (
           await client.query(`SELECT * FROM tenants WHERE username = $1 FOR UPDATE`, [username])
         ).rows[0];
@@ -293,13 +299,13 @@ class PaymentListener {
         }
         const paymentId = insertResult.rows[0].id;
 
-        // 3. Create the tenant if it didn't exist. The account check + config build happen
-        // HERE, inside the transaction, but only for a brand-new tenant — which is never a
-        // sweep target (the sweep only deletes existing 'inactive' rows), so no lock is held
-        // across the RPC for a tenant that could be swept. accountExistsStrict THROWS on an
-        // RPC outage (transient -> retry) rather than reporting the account absent, so a real
-        // payment isn't stranded when a node is down. ON CONFLICT + re-select handles a
-        // concurrent create (e.g. the web signup racing us) without failing.
+        // 3. Create the tenant if no row exists at all. The account check + config build happen
+        // HERE, inside the transaction, but only for a brand-new tenant. accountExistsStrict
+        // THROWS on an RPC outage (transient -> retry) rather than reporting the account absent,
+        // so a real payment isn't stranded when a node is down. ON CONFLICT + re-select handles a
+        // concurrent create (e.g. the web signup racing us) without failing. An already-existing
+        // row — including one the sweep marked 'abandoned' — skips this block and is revived in
+        // place by the activation in step 4, preserving its stored owner + config.
         if (!row) {
           if (!(await TenantService.accountExistsStrict(username))) {
             throw Object.assign(new Error('Hive account not found'), { permanent: true });

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -273,27 +273,17 @@ class PaymentListener {
     let updatedTenant: any = null;
 
     try {
-      // Pre-transaction (no DB mutation): if the tenant doesn't exist yet, confirm the Hive
-      // account is real. accountExistsStrict THROWS on an RPC outage (transient -> retry the
-      // block) rather than reporting the account absent, so a real payment isn't stranded when
-      // a node is down. Kept out of the transaction so no RPC holds a DB tx open.
-      const preexisting = await TenantService.getByUsername(username);
-      if (!preexisting && !(await TenantService.accountExistsStrict(username))) {
-        throw Object.assign(new Error('Hive account not found'), { permanent: true });
-      }
-      // Default config for a possible create (pure for a blog tenant, no RPC).
-      const defaultConfig = await TenantService.buildConfig(username);
-
       // Everything that mutates state runs on the SAME transaction client so the payment
       // dedup row and the subscription extension commit or roll back together. This is what
       // makes a retry safe: a transient failure after activation rolls the extension back
       // WITH the dedup row, so reprocessing extends exactly once (no double-credit).
       updatedTenant = await db.transaction(async (client) => {
-        // 1. Lock the target tenant row FIRST (before claiming the payment). The abandoned
-        // sweep's DELETE must lock the same row, so it blocks here and then re-evaluates its
-        // 'inactive' predicate against the now-active row -> it skips the tenant instead of
-        // deleting one whose payment we're mid-recording. (The payment row is inserted with
-        // tenant_id NULL, so a guard keyed on tenant_id alone can't protect this window.)
+        // 1. Lock the target tenant row FIRST — before any other await — so the lock covers
+        // the WHOLE processing window that can overlap the abandoned sweep. The sweep's DELETE
+        // must lock the same row, so it blocks here and then re-evaluates its 'inactive'
+        // predicate against the now-active row -> it skips the tenant instead of deleting one
+        // whose payment we're mid-recording. (An existing tenant is the only sweep target; a
+        // payment row keyed on tenant_id NULL can't protect this window on its own.)
         let row = (
           await client.query(`SELECT * FROM tenants WHERE username = $1 FOR UPDATE`, [username])
         ).rows[0];
@@ -313,9 +303,18 @@ class PaymentListener {
         }
         const paymentId = insertResult.rows[0].id;
 
-        // 3. Create the tenant if it didn't exist. ON CONFLICT + re-select handles a concurrent
-        // create (e.g. the web signup racing us) without failing.
+        // 3. Create the tenant if it didn't exist. The account check + config build happen
+        // HERE, inside the transaction, but only for a brand-new tenant — which is never a
+        // sweep target (the sweep only deletes existing 'inactive' rows), so no lock is held
+        // across the RPC for a tenant that could be swept. accountExistsStrict THROWS on an
+        // RPC outage (transient -> retry) rather than reporting the account absent, so a real
+        // payment isn't stranded when a node is down. ON CONFLICT + re-select handles a
+        // concurrent create (e.g. the web signup racing us) without failing.
         if (!row) {
+          if (!(await TenantService.accountExistsStrict(username))) {
+            throw Object.assign(new Error('Hive account not found'), { permanent: true });
+          }
+          const defaultConfig = await TenantService.buildConfig(username);
           const inserted = await client.query(
             `INSERT INTO tenants (username, owner, config, subscription_status, subscription_plan)
              VALUES ($1, $1, $2, 'inactive', 'standard')
@@ -493,22 +492,11 @@ class PaymentListener {
       if (await this.isCaughtUp()) {
         const deleted = await TenantService.deleteAbandonedTenants(CONFIG.ABANDONED_GRACE_DAYS);
         if (deleted.length > 0) {
+          // No served-file cleanup here: an abandoned tenant is 'inactive' with no payments,
+          // i.e. NEVER activated, and config files are only written on activation — so it has
+          // none. Deleting files by the (now reusable) username would only risk removing a
+          // freshly-recreated tenant's config.
           console.log('[PaymentListener] Deleted', deleted.length, 'abandoned inactive tenants');
-          for (const username of deleted) {
-            try {
-              // Re-check: if the name was claimed again between the DELETE and now (a paid
-              // /subscribe or HBD activation racing this sweep), leave the new tenant's freshly
-              // generated files alone. A never-activated tenant has no files anyway.
-              const current = await TenantService.getByUsername(username);
-              if (current) continue;
-              await ConfigService.deleteConfigFile(username);
-            } catch (err) {
-              console.error(
-                `[PaymentListener] Failed to remove files for abandoned tenant ${username}:`,
-                (err as Error).message
-              );
-            }
-          }
         }
       }
     } catch (error) {

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -31,6 +31,11 @@ setNodes(CONFIG.HIVE_API_NODES);
 class PaymentListener {
   private lastProcessedBlock: number = 0;
   private isRunning: boolean = false;
+  // True once block processing has reached the chain head. The abandoned-tenant sweep is
+  // gated on this so it can't delete an abandoned tenant whose late payment is still sitting
+  // in an unreplayed block during a post-downtime catch-up (which would briefly free the name
+  // before the replayed payment re-creates it).
+  private caughtUp: boolean = false;
   private expirationIntervalId: ReturnType<typeof setInterval> | null = null;
 
   async start() {
@@ -89,6 +94,12 @@ class PaymentListener {
 
     // Process up to 100 blocks at a time to catch up
     const maxBlocks = Math.min(headBlock - this.lastProcessedBlock, 100);
+
+    // Caught up once we're within a block or two of head (no meaningful replay backlog left).
+    // Gates the abandoned-tenant sweep; never un-set, since a normal small lag isn't a backlog.
+    if (headBlock - this.lastProcessedBlock <= 2) {
+      this.caughtUp = true;
+    }
 
     for (let i = 0; i < maxBlocks; i++) {
       const blockNum = this.lastProcessedBlock + 1;
@@ -460,20 +471,28 @@ class PaymentListener {
         console.log('[PaymentListener] Expired', expired, 'subscriptions');
       }
 
-      // Sweep abandoned signups (created, never paid, past the grace window). This frees
-      // usernames an inactive record would otherwise hold forever. Remove any leftover served
-      // files too, though a never-activated tenant should have none.
-      const deleted = await TenantService.deleteAbandonedTenants(CONFIG.ABANDONED_GRACE_DAYS);
-      if (deleted.length > 0) {
-        console.log('[PaymentListener] Deleted', deleted.length, 'abandoned inactive tenants');
-        for (const username of deleted) {
-          try {
-            await ConfigService.deleteConfigFile(username);
-          } catch (err) {
-            console.error(
-              `[PaymentListener] Failed to remove files for abandoned tenant ${username}:`,
-              (err as Error).message
-            );
+      // Sweep abandoned signups (created, never paid, past the grace window), but ONLY once
+      // caught up to head — otherwise a late payment still in an unreplayed block could see
+      // its 7-day-old inactive tenant deleted first (it would be re-created on replay, but the
+      // name would be briefly free). This frees usernames an inactive record would else hold.
+      if (this.caughtUp) {
+        const deleted = await TenantService.deleteAbandonedTenants(CONFIG.ABANDONED_GRACE_DAYS);
+        if (deleted.length > 0) {
+          console.log('[PaymentListener] Deleted', deleted.length, 'abandoned inactive tenants');
+          for (const username of deleted) {
+            try {
+              // Re-check: if the name was claimed again between the DELETE and now (a paid
+              // /subscribe or HBD activation racing this sweep), leave the new tenant's freshly
+              // generated files alone. A never-activated tenant has no files anyway.
+              const current = await TenantService.getByUsername(username);
+              if (current) continue;
+              await ConfigService.deleteConfigFile(username);
+            } catch (err) {
+              console.error(
+                `[PaymentListener] Failed to remove files for abandoned tenant ${username}:`,
+                (err as Error).message
+              );
+            }
           }
         }
       }

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -95,12 +95,6 @@ class PaymentListener {
     // Process up to 100 blocks at a time to catch up
     const maxBlocks = Math.min(headBlock - this.lastProcessedBlock, 100);
 
-    // Caught up once we're within a block or two of head (no meaningful replay backlog left).
-    // Gates the abandoned-tenant sweep; never un-set, since a normal small lag isn't a backlog.
-    if (headBlock - this.lastProcessedBlock <= 2) {
-      this.caughtUp = true;
-    }
-
     for (let i = 0; i < maxBlocks; i++) {
       const blockNum = this.lastProcessedBlock + 1;
 
@@ -112,6 +106,14 @@ class PaymentListener {
         console.error('[PaymentListener] Error processing block', blockNum, error);
         break; // Stop and retry this block next iteration
       }
+    }
+
+    // Caught up only once this pass has actually drained the backlog up to the head it saw
+    // (i.e. no block errored out and broke the loop early). Set AFTER the loop so the sweep,
+    // which is gated on this flag, can never run while a payment in one of the just-processed
+    // blocks is still pending. Never un-set: a normal 1-block steady-state lag isn't a backlog.
+    if (this.lastProcessedBlock >= headBlock) {
+      this.caughtUp = true;
     }
   }
 

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -12,6 +12,13 @@ import { ConfigService } from './services/config-service';
 import { parseMemo, mapTenantFromDb, type ParsedMemo } from './types';
 import { AuditService } from './services/audit-service';
 
+// Parse the abandoned-tenant grace window from env, failing safe to 7 for any value that is not a
+// positive integer (empty, non-numeric, zero, or negative). Exported for unit testing.
+export function parseAbandonedGraceDays(raw: string | undefined): number {
+  const n = parseInt(raw ?? '', 10);
+  return Number.isInteger(n) && n > 0 ? n : 7;
+}
+
 // Configuration
 const CONFIG = {
   PAYMENT_ACCOUNT: process.env.PAYMENT_ACCOUNT || 'ecency.hosting',
@@ -19,29 +26,16 @@ const CONFIG = {
   PRO_UPGRADE_PRICE_HBD: parseFloat(process.env.PRO_UPGRADE_PRICE_HBD || '0.500'),
   HIVE_API_NODES: (process.env.HIVE_API_URL || 'https://api.hive.blog').split(','),
   POLL_INTERVAL_MS: 3000, // 3 seconds (1 block)
-  // Days an unpaid (inactive) tenant reserves its username before the sweep deletes it. Long
-  // enough to comfortably cover an in-flight HBD payment; a late payment re-creates the tenant.
-  ABANDONED_GRACE_DAYS: parseInt(process.env.ABANDONED_TENANT_GRACE_DAYS || '7', 10) || 7,
+  // Days an unpaid (inactive) tenant reserves its username before the sweep reclaims it (marks
+  // it 'abandoned'). Must be a positive integer: a zero/negative/NaN value would make the SQL
+  // cutoff `NOW() - (n * INTERVAL '1 day')` land at or after now and sweep EVERY inactive tenant,
+  // so a misconfigured env falls back to 7 rather than mass-reclaiming.
+  ABANDONED_GRACE_DAYS: parseAbandonedGraceDays(process.env.ABANDONED_TENANT_GRACE_DAYS),
 };
 
 // Configure hive-tx nodes. setNodes() trims/validates entries and no-ops on an
 // empty list, so a misconfigured HIVE_API_URL can't wipe the built-in fallbacks.
 setNodes(CONFIG.HIVE_API_NODES);
-
-// How close to head the listener must be for the abandoned-tenant sweep to run. A payment in
-// an unreplayed block has no `payments` row yet, so sweeping while behind could delete a tenant
-// whose payment is about to activate it; requiring near-head replay avoids that.
-//
-// A small tolerance (not exact head) is deliberate: checkExpirations samples head on its own
-// hourly timer, and by the time it reads head the live-tailing loop has almost always fallen one
-// block behind (a block is produced during each POLL_INTERVAL_MS sleep), so an exact `>= head`
-// gate would seldom be satisfied and the sweep would rarely run. The residual 1-3 block window is
-// harmless: an abandoned tenant is 'inactive', so its config can never have been edited (both the
-// config read and update routes reject inactive tenants) and no served file exists; if a valid
-// payment does land in that window, replay recreates the tenant from the same default config and
-// activates it. The sweep is therefore self-healing, never lossy — it only reclaims the username
-// slightly early.
-const CAUGHT_UP_BLOCK_THRESHOLD = 3;
 
 class PaymentListener {
   private lastProcessedBlock: number = 0;
@@ -116,20 +110,6 @@ class PaymentListener {
         console.error('[PaymentListener] Error processing block', blockNum, error);
         break; // Stop and retry this block next iteration
       }
-    }
-  }
-
-  /**
-   * Whether block replay is currently near head. Checked at sweep time (not a sticky flag) so
-   * it reflects the LIVE state: a later RPC/DB outage that leaves the listener lagging again
-   * correctly blocks the sweep. Fails safe (returns false) if head can't be read.
-   */
-  private async isCaughtUp(): Promise<boolean> {
-    try {
-      const headBlock = await this.getHeadBlockNumber();
-      return headBlock - this.lastProcessedBlock <= CAUGHT_UP_BLOCK_THRESHOLD;
-    } catch {
-      return false;
     }
   }
 
@@ -494,20 +474,15 @@ class PaymentListener {
         console.log('[PaymentListener] Expired', expired, 'subscriptions');
       }
 
-      // Sweep abandoned signups (created, never paid, past the grace window), but ONLY when
-      // replay is currently near head — otherwise a payment still in an unreplayed block could
-      // see its 7-day-old inactive tenant deleted first (it would be re-created on replay, but
-      // the name would be briefly free). Checked live so a mid-run outage that leaves the
-      // listener lagging again also blocks the sweep. Frees names an inactive record would hold.
-      if (await this.isCaughtUp()) {
-        const deleted = await TenantService.deleteAbandonedTenants(CONFIG.ABANDONED_GRACE_DAYS);
-        if (deleted.length > 0) {
-          // No served-file cleanup here: an abandoned tenant is 'inactive' with no payments,
-          // i.e. NEVER activated, and config files are only written on activation — so it has
-          // none. Deleting files by the (now reusable) username would only risk removing a
-          // freshly-recreated tenant's config.
-          console.log('[PaymentListener] Deleted', deleted.length, 'abandoned inactive tenants');
-        }
+      // Reclaim abandoned signups (created, never paid, past the grace window). This is a SOFT
+      // delete — it flips status to 'abandoned' and keeps the row — so it needs no "listener
+      // caught up to head" gate: a payment still sitting in an unreplayed block (or a card order
+      // mid-settlement) simply revives the surviving row in place on replay/activation, with its
+      // original owner + config intact. No served-file cleanup: an abandoned tenant was never
+      // activated, and files are only written on activation, so it has none.
+      const reclaimed = await TenantService.reclaimAbandonedTenants(CONFIG.ABANDONED_GRACE_DAYS);
+      if (reclaimed.length > 0) {
+        console.log('[PaymentListener] Reclaimed', reclaimed.length, 'abandoned inactive tenants');
       }
     } catch (error) {
       // Never let a transient DB error escape an interval/void call as an unhandled rejection.
@@ -570,12 +545,18 @@ class PaymentListener {
 // Start the listener. A boot-time failure (e.g. RPC down while fetching the head block) must
 // not crash-loop through the fragile startup path with an unhandled rejection: log and let
 // the container's restart policy retry with backoff.
-const listener = new PaymentListener();
-listener.start().catch((error) => {
-  console.error('[PaymentListener] Fatal startup error:', (error as Error).message);
-  process.exit(1);
-});
+//
+// Skipped under Vitest (which sets process.env.VITEST) so a unit test can import this module for
+// its pure helpers without opening a block-poll loop or DB/RPC connections. Production is
+// unaffected — VITEST is never set there.
+if (!process.env.VITEST) {
+  const listener = new PaymentListener();
+  listener.start().catch((error) => {
+    console.error('[PaymentListener] Fatal startup error:', (error as Error).message);
+    process.exit(1);
+  });
 
-// Handle graceful shutdown
-process.on('SIGTERM', () => listener.stop());
-process.on('SIGINT', () => listener.stop());
+  // Handle graceful shutdown
+  process.on('SIGTERM', () => listener.stop());
+  process.on('SIGINT', () => listener.stop());
+}

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -19,6 +19,9 @@ const CONFIG = {
   PRO_UPGRADE_PRICE_HBD: parseFloat(process.env.PRO_UPGRADE_PRICE_HBD || '0.500'),
   HIVE_API_NODES: (process.env.HIVE_API_URL || 'https://api.hive.blog').split(','),
   POLL_INTERVAL_MS: 3000, // 3 seconds (1 block)
+  // Days an unpaid (inactive) tenant reserves its username before the sweep deletes it. Long
+  // enough to comfortably cover an in-flight HBD payment; a late payment re-creates the tenant.
+  ABANDONED_GRACE_DAYS: parseInt(process.env.ABANDONED_TENANT_GRACE_DAYS || '7', 10) || 7,
 };
 
 // Configure hive-tx nodes. setNodes() trims/validates entries and no-ops on an
@@ -455,6 +458,24 @@ class PaymentListener {
       const expired = await TenantService.expireSubscriptions();
       if (expired > 0) {
         console.log('[PaymentListener] Expired', expired, 'subscriptions');
+      }
+
+      // Sweep abandoned signups (created, never paid, past the grace window). This frees
+      // usernames an inactive record would otherwise hold forever. Remove any leftover served
+      // files too, though a never-activated tenant should have none.
+      const deleted = await TenantService.deleteAbandonedTenants(CONFIG.ABANDONED_GRACE_DAYS);
+      if (deleted.length > 0) {
+        console.log('[PaymentListener] Deleted', deleted.length, 'abandoned inactive tenants');
+        for (const username of deleted) {
+          try {
+            await ConfigService.deleteConfigFile(username);
+          } catch (err) {
+            console.error(
+              `[PaymentListener] Failed to remove files for abandoned tenant ${username}:`,
+              (err as Error).message
+            );
+          }
+        }
       }
     } catch (error) {
       // Never let a transient DB error escape an interval/void call as an unhandled rejection.

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -40,6 +40,10 @@ const CONFIG = {
 // empty list, so a misconfigured HIVE_API_URL can't wipe the built-in fallbacks.
 setNodes(CONFIG.HIVE_API_NODES);
 
+// How near head replay must be for the abandoned sweep to run (see isCaughtUp). Small enough to
+// stay false during a real backlog, loose enough to hold during normal one-block-behind tailing.
+const CAUGHT_UP_BLOCK_THRESHOLD = 3;
+
 class PaymentListener {
   private lastProcessedBlock: number = 0;
   private isRunning: boolean = false;
@@ -498,14 +502,24 @@ class PaymentListener {
       }
 
       // Reclaim abandoned signups (created, never paid, past the grace window). This is a SOFT
-      // delete — it flips status to 'abandoned' and keeps the row — so it needs no "listener
-      // caught up to head" gate: a payment still sitting in an unreplayed block (or a card order
-      // mid-settlement) simply revives the surviving row in place on replay/activation, with its
-      // original owner + config intact. No served-file cleanup: an abandoned tenant was never
-      // activated, and files are only written on activation, so it has none.
-      const reclaimed = await TenantService.reclaimAbandonedTenants(CONFIG.ABANDONED_GRACE_DAYS);
-      if (reclaimed.length > 0) {
-        console.log('[PaymentListener] Reclaimed', reclaimed.length, 'abandoned inactive tenants');
+      // delete — it flips status to 'abandoned' and keeps the row — so a payment still in flight
+      // simply revives the surviving row in place on replay/activation, with its original owner +
+      // config intact. No served-file cleanup: an abandoned tenant was never activated, and files
+      // are only written on activation, so it has none.
+      //
+      // Gated on the listener being caught up to head, so the reclaim never runs concurrently with
+      // a replay backlog (e.g. at startup after downtime). While behind, an on-chain HBD payment
+      // for a reservation may sit in a not-yet-replayed block; reclaiming then, with catch-up
+      // taking longer than the re-registration quarantine, could free the name before the payment
+      // is processed. Waiting until caught up guarantees any such payment has already activated its
+      // reservation (so it is not a reclaim target), and the quarantine only ever has to cover the
+      // seconds of live tailing, not an unbounded backlog. (Card orders, which have no on-chain
+      // signal, are instead protected by the checkout grace-clock refresh in TenantService.create.)
+      if (await this.isCaughtUp()) {
+        const reclaimed = await TenantService.reclaimAbandonedTenants(CONFIG.ABANDONED_GRACE_DAYS);
+        if (reclaimed.length > 0) {
+          console.log('[PaymentListener] Reclaimed', reclaimed.length, 'abandoned inactive tenants');
+        }
       }
     } catch (error) {
       // Never let a transient DB error escape an interval/void call as an unhandled rejection.
@@ -516,6 +530,20 @@ class PaymentListener {
   private async getHeadBlockNumber(): Promise<number> {
     const props = await callRPC('condenser_api.get_dynamic_global_properties', []) as any;
     return props.head_block_number;
+  }
+
+  // Whether block replay has essentially caught up to head. A small tolerance (not exact head) is
+  // deliberate: during healthy live tailing the loop trails head by the one block produced each
+  // poll interval, so requiring exact equality would seldom hold. When genuinely behind (a startup
+  // backlog of thousands of blocks), this is false and the abandoned sweep is deferred. Fails safe
+  // to false if head can't be read.
+  private async isCaughtUp(): Promise<boolean> {
+    try {
+      const headBlock = await this.getHeadBlockNumber();
+      return headBlock - this.lastProcessedBlock <= CAUGHT_UP_BLOCK_THRESHOLD;
+    } catch {
+      return false;
+    }
   }
 
   private async getLastProcessedBlock(): Promise<number | null> {

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -325,12 +325,18 @@ internalRoutes.post('/claim-blog', async (c) => {
     const config = await TenantService.buildConfig(username, { title, description });
 
     const result = await db.transaction<{ created: boolean; row: any }>(async (client) => {
-      // Try to create; ON CONFLICT means the tenant already exists (blocks on a concurrent claim
-      // until it commits, then returns 0 rows) -> we return the existing row unchanged.
+      // Try to create; ON CONFLICT means the tenant already exists. DO UPDATE revives a row the
+      // sweep marked 'abandoned' (an unpaid reservation) so a returning Pro member still gets their
+      // free blog activated below; a LIVE tenant (WHERE unsatisfied) returns 0 rows and is handed
+      // back unchanged (no re-activation, no extension).
       const inserted = await client.query(
         `INSERT INTO tenants (username, config, subscription_status, subscription_plan)
          VALUES ($1, $2, 'inactive', 'standard')
-         ON CONFLICT (username) DO NOTHING
+         ON CONFLICT (username) DO UPDATE
+           SET config = EXCLUDED.config,
+               subscription_status = 'inactive',
+               updated_at = NOW()
+           WHERE tenants.subscription_status = 'abandoned'
          RETURNING *`,
         [username, JSON.stringify(config)]
       );

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -7,7 +7,7 @@
 
 import { Hono } from 'hono';
 import { db } from '../db/client';
-import { TenantService } from '../services/tenant-service';
+import { TenantService, ABANDONED_REREGISTER_QUARANTINE_HOURS } from '../services/tenant-service';
 import { DomainService } from '../services/domain-service';
 import { ConfigService } from '../services/config-service';
 import { mapTenantFromDb } from '../types';
@@ -328,7 +328,9 @@ internalRoutes.post('/claim-blog', async (c) => {
       // Try to create; ON CONFLICT means the tenant already exists. DO UPDATE revives a row the
       // sweep marked 'abandoned' (an unpaid reservation) so a returning Pro member still gets their
       // free blog activated below; a LIVE tenant (WHERE unsatisfied) returns 0 rows and is handed
-      // back unchanged (no re-activation, no extension).
+      // back unchanged (no re-activation, no extension). The revive is gated on the same
+      // re-registration quarantine as the public create/subscribe paths, so a claim can't overwrite
+      // a just-reclaimed row whose in-flight payment hasn't settled yet.
       const inserted = await client.query(
         `INSERT INTO tenants (username, config, subscription_status, subscription_plan)
          VALUES ($1, $2, 'inactive', 'standard')
@@ -337,8 +339,9 @@ internalRoutes.post('/claim-blog', async (c) => {
                subscription_status = 'inactive',
                updated_at = NOW()
            WHERE tenants.subscription_status = 'abandoned'
+             AND tenants.updated_at < NOW() - ($3 * INTERVAL '1 hour')
          RETURNING *`,
-        [username, JSON.stringify(config)]
+        [username, JSON.stringify(config), ABANDONED_REREGISTER_QUARANTINE_HOURS]
       );
 
       if (inserted.rowCount === 0) {

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -351,8 +351,20 @@ internalRoutes.post('/claim-blog', async (c) => {
       );
 
       if (inserted.rowCount === 0) {
-        const existing = await client.query(`SELECT * FROM tenants WHERE username = $1`, [username]);
-        return { created: false, row: existing.rows[0] };
+        const existing = await client.query(
+          `SELECT * FROM tenants WHERE username = $1 FOR UPDATE`,
+          [username]
+        );
+        const row = existing.rows[0];
+        // A row that is still 'abandoned' means the DO UPDATE was blocked by the re-registration
+        // quarantine, not by a live tenant. Returning it here would report success while skipping
+        // activation, leaving the claimant a non-active blog. Reject as retryable so the claim is
+        // retried after the quiet period instead. A live tenant (any other status) is a genuine
+        // "already exists" and is returned unchanged.
+        if (row?.subscription_status === 'abandoned') {
+          throw Object.assign(new Error('reclaimed_recently'), { retryable: true });
+        }
+        return { created: false, row };
       }
 
       const tenantId = inserted.rows[0].id;
@@ -398,7 +410,11 @@ internalRoutes.post('/claim-blog', async (c) => {
       },
     });
   } catch (e) {
-    console.error('[internal/claim-blog] error:', (e as Error).message);
+    const err = e as Error & { retryable?: boolean };
+    console.error('[internal/claim-blog] error:', err.message);
+    // 503 (transient) so the caller retries the claim after the re-registration quiet period,
+    // rather than a permanent failure or a false success.
+    if (err.retryable) return c.json({ error: 'reclaimed_recently' }, 503);
     return c.json({ error: 'claim_failed' }, 500);
   }
 });

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -7,7 +7,11 @@
 
 import { Hono } from 'hono';
 import { db } from '../db/client';
-import { TenantService, ABANDONED_REREGISTER_QUARANTINE_HOURS } from '../services/tenant-service';
+import {
+  TenantService,
+  ABANDONED_REREGISTER_QUARANTINE_HOURS,
+  CAUGHT_UP_SQL,
+} from '../services/tenant-service';
 import { DomainService } from '../services/domain-service';
 import { ConfigService } from '../services/config-service';
 import { mapTenantFromDb } from '../types';
@@ -346,6 +350,7 @@ internalRoutes.post('/claim-blog', async (c) => {
                updated_at = NOW()
            WHERE tenants.subscription_status = 'abandoned'
              AND tenants.updated_at < NOW() - ($3 * INTERVAL '1 hour')
+             AND ${CAUGHT_UP_SQL}
          RETURNING *`,
         [username, JSON.stringify(config), ABANDONED_REREGISTER_QUARANTINE_HOURS]
       );

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -331,11 +331,17 @@ internalRoutes.post('/claim-blog', async (c) => {
       // back unchanged (no re-activation, no extension). The revive is gated on the same
       // re-registration quarantine as the public create/subscribe paths, so a claim can't overwrite
       // a just-reclaimed row whose in-flight payment hasn't settled yet.
+      //
+      // owner is set to the claimant (= username; claim-blog is a personal Pro blog, owned by its
+      // own account) on BOTH insert and revive. Setting it on revive avoids leaving a reclaimed
+      // row's stale previous owner in place, and setting it on insert fixes the owner NOT NULL
+      // column, which this INSERT previously omitted.
       const inserted = await client.query(
-        `INSERT INTO tenants (username, config, subscription_status, subscription_plan)
-         VALUES ($1, $2, 'inactive', 'standard')
+        `INSERT INTO tenants (username, owner, config, subscription_status, subscription_plan)
+         VALUES ($1, $1, $2, 'inactive', 'standard')
          ON CONFLICT (username) DO UPDATE
-           SET config = EXCLUDED.config,
+           SET owner = EXCLUDED.owner,
+               config = EXCLUDED.config,
                subscription_status = 'inactive',
                updated_at = NOW()
            WHERE tenants.subscription_status = 'abandoned'

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -10,7 +10,6 @@ import {
   TenantService,
   isReregisterableAbandoned,
   ABANDONED_REREGISTER_QUARANTINE_HOURS,
-  CAUGHT_UP_SQL,
 } from '../services/tenant-service';
 import { mapTenantFromDb } from '../types';
 import { ConfigService } from '../services/config-service';
@@ -297,11 +296,14 @@ tenantRoutes.post('/subscribe',
 
     // All mutations inside a DB transaction to prevent orphan tenants
     const result = await db.transaction(async (client) => {
-      // Create tenant — the upsert both handles a concurrent-create race and revives a row the
-      // sweep marked 'abandoned' AND past the re-registration quarantine. A live tenant, or one
-      // reclaimed too recently (a payment could still be in flight for it), leaves the WHERE
-      // unsatisfied, returns no row, and is reported as a conflict rather than silently
-      // overwritten. This matches the pre-paywall availability check above.
+      // Create tenant — the upsert handles a concurrent-create race and revives a row the sweep
+      // marked 'abandoned' AND past the re-registration quarantine. Unlike the create/claim-blog
+      // upserts, this one deliberately does NOT re-check the listener caught-up watermark: this
+      // runs AFTER the paywall has settled the payment, and the pre-paywall availability check
+      // already verified the watermark (a fresh watermark there means the name had no pending
+      // on-chain payment at settle time). Re-checking a watermark that can flip stale during
+      // settlement would turn a listener blip into a paid-but-unrecorded order. The quarantine
+      // guard, which only moves forward, is stable across the settlement and is kept.
       const tenantRow = await client.query(
         `INSERT INTO tenants (username, owner, config, subscription_status, subscription_plan)
          VALUES ($1, $2, $3, 'inactive', 'standard')
@@ -314,7 +316,6 @@ tenantRoutes.post('/subscribe',
                updated_at = NOW()
            WHERE tenants.subscription_status = 'abandoned'
              AND tenants.updated_at < NOW() - ($4 * INTERVAL '1 hour')
-             AND ${CAUGHT_UP_SQL}
          RETURNING *`,
         [body.username.toLowerCase(), owner, JSON.stringify(tenantConfig), ABANDONED_REREGISTER_QUARANTINE_HOURS]
       );

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -6,7 +6,11 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 import { db } from '../db/client';
-import { TenantService } from '../services/tenant-service';
+import {
+  TenantService,
+  isReregisterableAbandoned,
+  ABANDONED_REREGISTER_QUARANTINE_HOURS,
+} from '../services/tenant-service';
 import { mapTenantFromDb } from '../types';
 import { ConfigService } from '../services/config-service';
 import { authMiddleware } from '../middleware/auth';
@@ -174,9 +178,11 @@ tenantRoutes.post(
     const body = c.req.valid('json');
 
     // Check if username already exists. An 'abandoned' row (an unpaid reservation the sweep
-    // reclaimed) reads as available — create() revives it below.
+    // reclaimed) reads as available once it has cleared the re-registration quarantine — create()
+    // revives it below. Within the quarantine it is still treated as taken so an in-flight
+    // payment for it isn't overwritten.
     const existing = await TenantService.getByUsername(body.username);
-    if (existing && existing.subscriptionStatus !== 'abandoned') {
+    if (existing && !isReregisterableAbandoned(existing)) {
       return c.json({ error: 'Username already registered' }, 409);
     }
 
@@ -240,9 +246,11 @@ tenantRoutes.post('/subscribe',
   (c, next) => withPaymentTargetLock(c, next, 'subscribe', c.req.valid('json').username),
   async (c, next) => {
     const body = c.req.valid('json');
-    // An 'abandoned' row reads as available; the DB transaction below revives it on settlement.
+    // An 'abandoned' row past the re-registration quarantine reads as available; the DB
+    // transaction below revives it on settlement. Checked BEFORE the paywall so a payment is
+    // never settled for a name that is still quarantined (and would fail the upsert's guard).
     const existing = await TenantService.getByUsername(body.username);
-    if (existing && existing.subscriptionStatus !== 'abandoned') {
+    if (existing && !isReregisterableAbandoned(existing)) {
       return c.json({ error: 'Username already registered' }, 409);
     }
     // Same account + community + ownership validation as POST /, BEFORE the paywall so a payment is
@@ -287,9 +295,10 @@ tenantRoutes.post('/subscribe',
     // All mutations inside a DB transaction to prevent orphan tenants
     const result = await db.transaction(async (client) => {
       // Create tenant — the upsert both handles a concurrent-create race and revives a row the
-      // sweep marked 'abandoned'. DO UPDATE is gated on `status = 'abandoned'`, so a live tenant
-      // (inactive/active/expired/suspended) leaves the WHERE unsatisfied, returns no row, and is
-      // reported as a conflict rather than silently overwritten.
+      // sweep marked 'abandoned' AND past the re-registration quarantine. A live tenant, or one
+      // reclaimed too recently (a payment could still be in flight for it), leaves the WHERE
+      // unsatisfied, returns no row, and is reported as a conflict rather than silently
+      // overwritten. This matches the pre-paywall availability check above.
       const tenantRow = await client.query(
         `INSERT INTO tenants (username, owner, config, subscription_status, subscription_plan)
          VALUES ($1, $2, $3, 'inactive', 'standard')
@@ -301,8 +310,9 @@ tenantRoutes.post('/subscribe',
                created_at = NOW(),
                updated_at = NOW()
            WHERE tenants.subscription_status = 'abandoned'
+             AND tenants.updated_at < NOW() - ($4 * INTERVAL '1 hour')
          RETURNING *`,
-        [body.username.toLowerCase(), owner, JSON.stringify(tenantConfig)]
+        [body.username.toLowerCase(), owner, JSON.stringify(tenantConfig), ABANDONED_REREGISTER_QUARANTINE_HOURS]
       );
       if (tenantRow.rowCount === 0) {
         throw Object.assign(new Error('Username already registered'), { isConflict: true });

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -10,6 +10,7 @@ import {
   TenantService,
   isReregisterableAbandoned,
   ABANDONED_REREGISTER_QUARANTINE_HOURS,
+  CAUGHT_UP_SQL,
 } from '../services/tenant-service';
 import { mapTenantFromDb } from '../types';
 import { ConfigService } from '../services/config-service';
@@ -179,10 +180,11 @@ tenantRoutes.post(
 
     // Check if username already exists. An 'abandoned' row (an unpaid reservation the sweep
     // reclaimed) reads as available once it has cleared the re-registration quarantine — create()
-    // revives it below. Within the quarantine it is still treated as taken so an in-flight
-    // payment for it isn't overwritten.
+    // revives it below. Within the quarantine — or while the payment listener isn't confirmed
+    // caught up to head (so a pending on-chain payment for it may be unprocessed) — it is still
+    // treated as taken so an in-flight payment for it isn't overwritten.
     const existing = await TenantService.getByUsername(body.username);
-    if (existing && !isReregisterableAbandoned(existing)) {
+    if (existing && !(isReregisterableAbandoned(existing) && (await TenantService.isListenerCaughtUp()))) {
       return c.json({ error: 'Username already registered' }, 409);
     }
 
@@ -247,10 +249,11 @@ tenantRoutes.post('/subscribe',
   async (c, next) => {
     const body = c.req.valid('json');
     // An 'abandoned' row past the re-registration quarantine reads as available; the DB
-    // transaction below revives it on settlement. Checked BEFORE the paywall so a payment is
-    // never settled for a name that is still quarantined (and would fail the upsert's guard).
+    // transaction below revives it on settlement. Checked BEFORE the paywall so a payment is never
+    // settled for a name that is still quarantined, or whose listener isn't confirmed caught up
+    // (either of which would fail the upsert's guard and strand the settlement).
     const existing = await TenantService.getByUsername(body.username);
-    if (existing && !isReregisterableAbandoned(existing)) {
+    if (existing && !(isReregisterableAbandoned(existing) && (await TenantService.isListenerCaughtUp()))) {
       return c.json({ error: 'Username already registered' }, 409);
     }
     // Same account + community + ownership validation as POST /, BEFORE the paywall so a payment is
@@ -311,6 +314,7 @@ tenantRoutes.post('/subscribe',
                updated_at = NOW()
            WHERE tenants.subscription_status = 'abandoned'
              AND tenants.updated_at < NOW() - ($4 * INTERVAL '1 hour')
+             AND ${CAUGHT_UP_SQL}
          RETURNING *`,
         [body.username.toLowerCase(), owner, JSON.stringify(tenantConfig), ABANDONED_REREGISTER_QUARANTINE_HOURS]
       );

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -173,9 +173,10 @@ tenantRoutes.post(
   async (c) => {
     const body = c.req.valid('json');
 
-    // Check if username already exists
+    // Check if username already exists. An 'abandoned' row (an unpaid reservation the sweep
+    // reclaimed) reads as available — create() revives it below.
     const existing = await TenantService.getByUsername(body.username);
-    if (existing) {
+    if (existing && existing.subscriptionStatus !== 'abandoned') {
       return c.json({ error: 'Username already registered' }, 409);
     }
 
@@ -189,8 +190,18 @@ tenantRoutes.post(
     // Create tenant (inactive until payment). The served config file is NOT written here:
     // nginx serves any file that exists with no subscription check, so writing it now would
     // put an unpaid blog live forever. The file is generated only on activation (payment
-    // listener / internal activate / subscribe).
-    const tenant = await TenantService.create(body.username, owner, body.config);
+    // listener / internal activate / subscribe). create() upserts, so it also revives an
+    // 'abandoned' row and throws isConflict only if a LIVE tenant now holds the name (a race
+    // the target lock makes near-impossible, but handled for safety).
+    let tenant;
+    try {
+      tenant = await TenantService.create(body.username, owner, body.config);
+    } catch (err: any) {
+      if (err?.isConflict) {
+        return c.json({ error: 'Username already registered' }, 409);
+      }
+      throw err;
+    }
 
     const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
     const paymentAccount = process.env.PAYMENT_ACCOUNT || 'ecency.hosting';
@@ -229,8 +240,9 @@ tenantRoutes.post('/subscribe',
   (c, next) => withPaymentTargetLock(c, next, 'subscribe', c.req.valid('json').username),
   async (c, next) => {
     const body = c.req.valid('json');
+    // An 'abandoned' row reads as available; the DB transaction below revives it on settlement.
     const existing = await TenantService.getByUsername(body.username);
-    if (existing) {
+    if (existing && existing.subscriptionStatus !== 'abandoned') {
       return c.json({ error: 'Username already registered' }, 409);
     }
     // Same account + community + ownership validation as POST /, BEFORE the paywall so a payment is
@@ -274,11 +286,21 @@ tenantRoutes.post('/subscribe',
 
     // All mutations inside a DB transaction to prevent orphan tenants
     const result = await db.transaction(async (client) => {
-      // Create tenant — ON CONFLICT handles race with concurrent requests
+      // Create tenant — the upsert both handles a concurrent-create race and revives a row the
+      // sweep marked 'abandoned'. DO UPDATE is gated on `status = 'abandoned'`, so a live tenant
+      // (inactive/active/expired/suspended) leaves the WHERE unsatisfied, returns no row, and is
+      // reported as a conflict rather than silently overwritten.
       const tenantRow = await client.query(
         `INSERT INTO tenants (username, owner, config, subscription_status, subscription_plan)
          VALUES ($1, $2, $3, 'inactive', 'standard')
-         ON CONFLICT (username) DO NOTHING
+         ON CONFLICT (username) DO UPDATE
+           SET owner = EXCLUDED.owner,
+               config = EXCLUDED.config,
+               subscription_plan = 'standard',
+               subscription_status = 'inactive',
+               created_at = NOW(),
+               updated_at = NOW()
+           WHERE tenants.subscription_status = 'abandoned'
          RETURNING *`,
         [body.username.toLowerCase(), owner, JSON.stringify(tenantConfig)]
       );

--- a/apps/self-hosted/hosting/api/src/services/config-service.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-service.test.ts
@@ -141,6 +141,26 @@ describe('ConfigService.syncAllConfigs ordering', () => {
       spy.mockRestore();
     }
   });
+
+  it('sync removes the served file of a reclaimed (abandoned) tenant', async () => {
+    // Once the sweep marks a stale row 'abandoned' it must not keep serving; sync treats
+    // abandoned like inactive and removes any leftover file (a status-skip would strand it).
+    await ConfigService.generateConfigFile(tenant('gone', 'Gone'));
+    await expect(fs.access(ConfigService.getConfigPath('gone'))).resolves.toBeUndefined();
+
+    const spy = vi
+      .spyOn(TenantService, 'getByUsername')
+      .mockImplementation(async (u: string) =>
+        u === 'gone' ? { ...tenant('gone', 'Gone'), subscriptionStatus: 'abandoned' } : null
+      );
+    try {
+      await ConfigService.syncAllConfigs([]);
+      await expect(fs.access(ConfigService.getConfigPath('gone'))).rejects.toThrow();
+      await expect(fs.access(ConfigService.getMetaPath('gone'))).rejects.toThrow();
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });
 
 describe('ConfigService.buildMetaHtml', () => {

--- a/apps/self-hosted/hosting/api/src/services/config-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-service.ts
@@ -246,16 +246,18 @@ export const ConfigService = {
       }
     }
 
-    // Remove files for tenants that were NEVER activated (status 'inactive') or whose row
-    // is gone. nginx serves any file that exists with no subscription check, so a file
-    // written for an unpaid tenant keeps a free blog live forever. Expired/suspended tenants
-    // are intentionally left serving (accepted grace-period behavior) and handled elsewhere.
+    // Remove files for tenants that were NEVER activated (status 'inactive'), that the sweep
+    // reclaimed ('abandoned'), or whose row is gone. nginx serves any file that exists with no
+    // subscription check, so a file left behind for a non-serving tenant keeps a free blog live
+    // forever. Expired/suspended tenants are intentionally left serving (accepted grace-period
+    // behavior) and handled elsewhere.
+    const removableStatuses = new Set(['inactive', 'abandoned']);
     let removed = 0;
     for (const username of await this.listConfigFiles()) {
       if (activeNames.has(username.toLowerCase())) continue;
       try {
         const tenant = await TenantService.getByUsername(username);
-        if (tenant && tenant.subscriptionStatus !== 'inactive') continue;
+        if (tenant && !removableStatuses.has(tenant.subscriptionStatus)) continue;
         await this.deleteConfigFile(username);
         removed++;
       } catch (err) {

--- a/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// deleteAbandonedTenants issues one parameterized DELETE ... RETURNING; assert the query shape
-// (status + grace-window + no-payments guards) and that it returns the freed usernames.
-const mocks = vi.hoisted(() => ({ queryAll: vi.fn() }));
+// reclaimAbandonedTenants SOFT-deletes: one parameterized UPDATE ... SET status='abandoned'
+// ... RETURNING. Assert the query shape (it marks, never DELETEs; keeps the status + grace-window
+// + no-payments guards) and that it returns the reclaimed usernames. create() upserts so a
+// reclaimed username can be reserved again — assert it revives an 'abandoned' row and reports a
+// conflict when a live tenant holds the name.
+const mocks = vi.hoisted(() => ({ queryAll: vi.fn(), queryOne: vi.fn() }));
 
 vi.mock('../db/client', () => ({
-  db: { queryAll: mocks.queryAll },
+  db: { queryAll: mocks.queryAll, queryOne: mocks.queryOne },
 }));
 vi.mock('@ecency/sdk/hive', () => ({
   callRPC: vi.fn(),
@@ -15,18 +18,22 @@ vi.mock('@ecency/sdk/hive', () => ({
 
 const { TenantService } = await import('./tenant-service');
 
-describe('TenantService.deleteAbandonedTenants', () => {
+describe('TenantService.reclaimAbandonedTenants', () => {
   beforeEach(() => mocks.queryAll.mockReset());
 
-  it('deletes only inactive, unpaid, past-grace tenants and returns the freed usernames', async () => {
+  it('marks (not deletes) only inactive, unpaid, past-grace tenants and returns the freed usernames', async () => {
     mocks.queryAll.mockResolvedValueOnce([{ username: 'demo' }, { username: 'test' }]);
 
-    const deleted = await TenantService.deleteAbandonedTenants(7);
+    const reclaimed = await TenantService.reclaimAbandonedTenants(7);
 
-    expect(deleted).toEqual(['demo', 'test']);
+    expect(reclaimed).toEqual(['demo', 'test']);
     const [sql, params] = mocks.queryAll.mock.calls[0];
-    expect(sql).toMatch(/DELETE FROM tenants/i);
-    expect(sql).toMatch(/subscription_status = 'inactive'/);
+    // Soft delete: it must UPDATE to 'abandoned', never DELETE the row (a deleted row can't be
+    // revived by an in-flight payment).
+    expect(sql).toMatch(/UPDATE tenants/i);
+    expect(sql).not.toMatch(/DELETE/i);
+    expect(sql).toMatch(/SET subscription_status = 'abandoned'/);
+    expect(sql).toMatch(/subscription_status = 'inactive'/); // still only targets inactive rows
     expect(sql).toMatch(/created_at < NOW\(\) - \(\$1 \* INTERVAL '1 day'\)/);
     expect(sql).toMatch(/NOT IN \(SELECT tenant_id FROM payments/i);
     expect(params).toEqual([7]);
@@ -34,6 +41,40 @@ describe('TenantService.deleteAbandonedTenants', () => {
 
   it('returns an empty array when nothing is abandoned', async () => {
     mocks.queryAll.mockResolvedValueOnce([]);
-    await expect(TenantService.deleteAbandonedTenants(7)).resolves.toEqual([]);
+    await expect(TenantService.reclaimAbandonedTenants(7)).resolves.toEqual([]);
+  });
+});
+
+describe('TenantService.create (revives abandoned reservations)', () => {
+  beforeEach(() => {
+    mocks.queryOne.mockReset();
+    mocks.queryAll.mockReset();
+  });
+
+  it('upserts with a DO UPDATE gated on the abandoned status (so a live row is never overwritten)', async () => {
+    mocks.queryOne.mockResolvedValueOnce({
+      id: '1',
+      username: 'demo',
+      owner: 'demo',
+      subscription_status: 'inactive',
+      subscription_plan: 'standard',
+      config: {},
+    });
+
+    await TenantService.create('demo', 'demo', undefined);
+
+    // A personal blog with no overrides makes no other queryOne calls, so the upsert is call 0.
+    const [sql] = mocks.queryOne.mock.calls[mocks.queryOne.mock.calls.length - 1];
+    expect(sql).toMatch(/INSERT INTO tenants/i);
+    expect(sql).toMatch(/ON CONFLICT \(username\) DO UPDATE/i);
+    expect(sql).toMatch(/WHERE tenants\.subscription_status = 'abandoned'/);
+  });
+
+  it('throws a conflict when the upsert returns no row (a live tenant holds the name)', async () => {
+    mocks.queryOne.mockResolvedValueOnce(null); // DO UPDATE WHERE abandoned matched nothing
+
+    await expect(TenantService.create('demo', 'demo', undefined)).rejects.toMatchObject({
+      isConflict: true,
+    });
   });
 });

--- a/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// deleteAbandonedTenants issues one parameterized DELETE ... RETURNING; assert the query shape
+// (status + grace-window + no-payments guards) and that it returns the freed usernames.
+const mocks = vi.hoisted(() => ({ queryAll: vi.fn() }));
+
+vi.mock('../db/client', () => ({
+  db: { queryAll: mocks.queryAll },
+}));
+vi.mock('@ecency/sdk/hive', () => ({
+  callRPC: vi.fn(),
+  config: { nodes: [] },
+  setNodes: vi.fn(),
+}));
+
+const { TenantService } = await import('./tenant-service');
+
+describe('TenantService.deleteAbandonedTenants', () => {
+  beforeEach(() => mocks.queryAll.mockReset());
+
+  it('deletes only inactive, unpaid, past-grace tenants and returns the freed usernames', async () => {
+    mocks.queryAll.mockResolvedValueOnce([{ username: 'demo' }, { username: 'test' }]);
+
+    const deleted = await TenantService.deleteAbandonedTenants(7);
+
+    expect(deleted).toEqual(['demo', 'test']);
+    const [sql, params] = mocks.queryAll.mock.calls[0];
+    expect(sql).toMatch(/DELETE FROM tenants/i);
+    expect(sql).toMatch(/subscription_status = 'inactive'/);
+    expect(sql).toMatch(/created_at < NOW\(\) - \(\$1 \* INTERVAL '1 day'\)/);
+    expect(sql).toMatch(/NOT IN \(SELECT tenant_id FROM payments/i);
+    expect(params).toEqual([7]);
+  });
+
+  it('returns an empty array when nothing is abandoned', async () => {
+    mocks.queryAll.mockResolvedValueOnce([]);
+    await expect(TenantService.deleteAbandonedTenants(7)).resolves.toEqual([]);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
@@ -75,6 +75,9 @@ describe('TenantService.create (revives abandoned reservations)', () => {
     // Abandoned branch: reclaimable only past the re-registration quarantine.
     expect(sql).toMatch(/subscription_status = 'abandoned'/);
     expect(sql).toMatch(/tenants\.updated_at < NOW\(\) - \(\$4 \* INTERVAL '1 hour'\)/);
+    // Reclaim is additionally gated on a fresh payment-listener caught-up watermark, so a stalled
+    // or backlogged listener (whose pending payments may be unprocessed) can't have its name reused.
+    expect(sql).toMatch(/payment_listener\.caught_up/);
     // Resume branch: an existing same-owner inactive reservation refreshes its grace clock so an
     // active checkout is not swept mid-payment.
     expect(sql).toMatch(/tenants\.subscription_status = 'inactive' AND tenants\.owner = EXCLUDED\.owner/);
@@ -111,6 +114,25 @@ describe('isReregisterableAbandoned (re-registration quarantine)', () => {
   it('is true once an abandoned row has cleared the quarantine window', () => {
     const past = new Date(Date.now() - (ABANDONED_REREGISTER_QUARANTINE_HOURS + 1) * HOUR_MS);
     expect(isReregisterableAbandoned(mk('abandoned', past))).toBe(true);
+  });
+});
+
+describe('TenantService.isListenerCaughtUp', () => {
+  beforeEach(() => mocks.queryOne.mockReset());
+
+  it('reads the caught_up watermark freshness and returns true only when fresh', async () => {
+    mocks.queryOne.mockResolvedValueOnce({ fresh: true });
+    await expect(TenantService.isListenerCaughtUp()).resolves.toBe(true);
+    const [sql] = mocks.queryOne.mock.calls[0];
+    expect(sql).toMatch(/system_config WHERE key = 'payment_listener\.caught_up'/);
+    expect(sql).toMatch(/updated_at > NOW\(\) - INTERVAL/);
+  });
+
+  it('fails safe to false when the watermark is missing or stale', async () => {
+    mocks.queryOne.mockResolvedValueOnce(null);
+    await expect(TenantService.isListenerCaughtUp()).resolves.toBe(false);
+    mocks.queryOne.mockResolvedValueOnce({ fresh: false });
+    await expect(TenantService.isListenerCaughtUp()).resolves.toBe(false);
   });
 });
 

--- a/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
@@ -56,7 +56,7 @@ describe('TenantService.create (revives abandoned reservations)', () => {
     mocks.queryAll.mockReset();
   });
 
-  it('upserts with a DO UPDATE gated on the abandoned status (so a live row is never overwritten)', async () => {
+  it('upserts with a DO UPDATE that reclaims abandoned (quarantined) OR refreshes same-owner inactive', async () => {
     mocks.queryOne.mockResolvedValueOnce({
       id: '1',
       username: 'demo',
@@ -72,15 +72,20 @@ describe('TenantService.create (revives abandoned reservations)', () => {
     const [sql, params] = mocks.queryOne.mock.calls[mocks.queryOne.mock.calls.length - 1];
     expect(sql).toMatch(/INSERT INTO tenants/i);
     expect(sql).toMatch(/ON CONFLICT \(username\) DO UPDATE/i);
-    expect(sql).toMatch(/WHERE tenants\.subscription_status = 'abandoned'/);
-    // The overwrite is also gated on the re-registration quarantine so an in-flight payment's
-    // reservation can't be replaced before it settles.
+    // Abandoned branch: reclaimable only past the re-registration quarantine.
+    expect(sql).toMatch(/subscription_status = 'abandoned'/);
     expect(sql).toMatch(/tenants\.updated_at < NOW\(\) - \(\$4 \* INTERVAL '1 hour'\)/);
+    // Resume branch: an existing same-owner inactive reservation refreshes its grace clock so an
+    // active checkout is not swept mid-payment.
+    expect(sql).toMatch(/tenants\.subscription_status = 'inactive' AND tenants\.owner = EXCLUDED\.owner/);
+    expect(sql).toMatch(/created_at = NOW\(\)/);
+    // Config/owner are only overwritten for the abandoned (reclaim) branch, never on a resume.
+    expect(sql).toMatch(/config = CASE WHEN tenants\.subscription_status = 'abandoned'/);
     expect(params[3]).toBe(ABANDONED_REREGISTER_QUARANTINE_HOURS);
   });
 
-  it('throws a conflict when the upsert returns no row (a live tenant holds the name)', async () => {
-    mocks.queryOne.mockResolvedValueOnce(null); // DO UPDATE WHERE abandoned matched nothing
+  it('throws a conflict when the upsert returns no row (a live or other-owner tenant holds the name)', async () => {
+    mocks.queryOne.mockResolvedValueOnce(null); // DO UPDATE WHERE matched nothing
 
     await expect(TenantService.create('demo', 'demo', undefined)).rejects.toMatchObject({
       isConflict: true,

--- a/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
@@ -16,7 +16,10 @@ vi.mock('@ecency/sdk/hive', () => ({
   setNodes: vi.fn(),
 }));
 
-const { TenantService } = await import('./tenant-service');
+const { TenantService, isReregisterableAbandoned, ABANDONED_REREGISTER_QUARANTINE_HOURS } =
+  await import('./tenant-service');
+
+const HOUR_MS = 60 * 60 * 1000;
 
 describe('TenantService.reclaimAbandonedTenants', () => {
   beforeEach(() => mocks.queryAll.mockReset());
@@ -64,10 +67,14 @@ describe('TenantService.create (revives abandoned reservations)', () => {
     await TenantService.create('demo', 'demo', undefined);
 
     // A personal blog with no overrides makes no other queryOne calls, so the upsert is call 0.
-    const [sql] = mocks.queryOne.mock.calls[mocks.queryOne.mock.calls.length - 1];
+    const [sql, params] = mocks.queryOne.mock.calls[mocks.queryOne.mock.calls.length - 1];
     expect(sql).toMatch(/INSERT INTO tenants/i);
     expect(sql).toMatch(/ON CONFLICT \(username\) DO UPDATE/i);
     expect(sql).toMatch(/WHERE tenants\.subscription_status = 'abandoned'/);
+    // The overwrite is also gated on the re-registration quarantine so an in-flight payment's
+    // reservation can't be replaced before it settles.
+    expect(sql).toMatch(/tenants\.updated_at < NOW\(\) - \(\$4 \* INTERVAL '1 hour'\)/);
+    expect(params[3]).toBe(ABANDONED_REREGISTER_QUARANTINE_HOURS);
   });
 
   it('throws a conflict when the upsert returns no row (a live tenant holds the name)', async () => {
@@ -76,5 +83,37 @@ describe('TenantService.create (revives abandoned reservations)', () => {
     await expect(TenantService.create('demo', 'demo', undefined)).rejects.toMatchObject({
       isConflict: true,
     });
+  });
+});
+
+describe('isReregisterableAbandoned (re-registration quarantine)', () => {
+  const mk = (status: string, updatedAt: Date) => ({ subscriptionStatus: status, updatedAt } as any);
+
+  it('is false for any non-abandoned status', () => {
+    const old = new Date(Date.now() - 100 * HOUR_MS);
+    for (const s of ['inactive', 'active', 'expired', 'suspended']) {
+      expect(isReregisterableAbandoned(mk(s, old))).toBe(false);
+    }
+  });
+
+  it('is false for a freshly-reclaimed row still inside the quarantine window', () => {
+    const justNow = new Date(Date.now() - (ABANDONED_REREGISTER_QUARANTINE_HOURS / 2) * HOUR_MS);
+    expect(isReregisterableAbandoned(mk('abandoned', justNow))).toBe(false);
+  });
+
+  it('is true once an abandoned row has cleared the quarantine window', () => {
+    const past = new Date(Date.now() - (ABANDONED_REREGISTER_QUARANTINE_HOURS + 1) * HOUR_MS);
+    expect(isReregisterableAbandoned(mk('abandoned', past))).toBe(true);
+  });
+});
+
+describe('TenantService.getByOwner', () => {
+  beforeEach(() => mocks.queryAll.mockReset());
+
+  it('excludes abandoned rows so reclaimed reservations do not show in the owner listing', async () => {
+    mocks.queryAll.mockResolvedValueOnce([]);
+    await TenantService.getByOwner('alice');
+    const [sql] = mocks.queryAll.mock.calls[0];
+    expect(sql).toMatch(/subscription_status != 'abandoned'/);
   });
 });

--- a/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
@@ -38,7 +38,9 @@ describe('TenantService.reclaimAbandonedTenants', () => {
     expect(sql).toMatch(/SET subscription_status = 'abandoned'/);
     expect(sql).toMatch(/subscription_status = 'inactive'/); // still only targets inactive rows
     expect(sql).toMatch(/created_at < NOW\(\) - \(\$1 \* INTERVAL '1 day'\)/);
-    expect(sql).toMatch(/NOT IN \(SELECT tenant_id FROM payments/i);
+    expect(sql).toMatch(/NOT IN \(\s*SELECT tenant_id FROM payments/i);
+    // Only real/in-flight payments pin a name; a 'failed'/'refunded' row must not protect it.
+    expect(sql).toMatch(/status NOT IN \('failed', 'refunded'\)/);
     expect(params).toEqual([7]);
   });
 

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -400,12 +400,32 @@ export const TenantService = {
    */
   async expireSubscriptions(): Promise<number> {
     const result = await db.query(
-      `UPDATE tenants 
+      `UPDATE tenants
        SET subscription_status = 'expired'
-       WHERE subscription_status = 'active' 
+       WHERE subscription_status = 'active'
          AND subscription_expires_at < NOW()`
     );
     return result.rowCount || 0;
+  },
+
+  /**
+   * Delete abandoned signups: tenants that were created but NEVER paid (status 'inactive',
+   * no payment rows) and have sat past the grace window. This frees their username, which an
+   * inactive record would otherwise reserve forever. Safe to run repeatedly — a tenant with
+   * any payment history (which would have activated it) is excluded, and a late HBD payment
+   * simply re-creates + activates the tenant. Returns the deleted usernames so the caller can
+   * remove any leftover served files.
+   */
+  async deleteAbandonedTenants(graceDays: number): Promise<string[]> {
+    const rows = await db.queryAll<{ username: string }>(
+      `DELETE FROM tenants
+         WHERE subscription_status = 'inactive'
+           AND created_at < NOW() - ($1 * INTERVAL '1 day')
+           AND id NOT IN (SELECT tenant_id FROM payments WHERE tenant_id IS NOT NULL)
+       RETURNING username`,
+      [graceDays]
+    );
+    return rows.map((r) => r.username);
   },
   
   /**

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -13,6 +13,27 @@ export type { Tenant } from '../types';
 hiveTxConfig.nodes = process.env.HIVE_API_URL?.split(',') || ['https://api.hive.blog'];
 const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
 
+// Quiet period after the sweep marks a username 'abandoned' before it can be reserved again.
+// A payment that was already in flight when the sweep ran (an on-chain HBD transfer awaiting
+// block replay, or a card order awaiting settlement) has no payments row yet, so nothing else
+// pins the row; this window lets that payment settle and activate the ORIGINAL reservation
+// (owner + config intact) before a different owner could overwrite it via re-registration.
+// One hour comfortably covers HBD replay — including catch-up after a listener restart — and
+// settlement latency; the web also creates/refreshes the reservation immediately before card or
+// HBD checkout, so a row is not sweepable mid-flow and this mainly defends a direct on-chain
+// transfer against an old reservation.
+export const ABANDONED_REREGISTER_QUARANTINE_HOURS = 1;
+
+// Whether an existing row is an abandoned reservation that has cleared the re-registration
+// quarantine (so a fresh signup may reclaim its username). A live row, or one reclaimed within
+// the quarantine, is NOT reusable. The SQL upsert applies the same guard atomically; this is the
+// pre-check that also lets /subscribe reject before settling a payment.
+export function isReregisterableAbandoned(t: Pick<Tenant, 'subscriptionStatus' | 'updatedAt'>): boolean {
+  if (t.subscriptionStatus !== 'abandoned') return false;
+  const cutoff = Date.now() - ABANDONED_REREGISTER_QUARANTINE_HOURS * 60 * 60 * 1000;
+  return t.updatedAt.getTime() < cutoff;
+}
+
 export const TenantService = {
   /**
    * Get tenant by username
@@ -40,8 +61,11 @@ export const TenantService = {
    * All tenants controlled by an owner account (their personal blog and any communities).
    */
   async getByOwner(owner: string): Promise<Tenant[]> {
+    // Exclude 'abandoned' rows: a reclaimed, re-registerable reservation is effectively gone, so
+    // it must not surface in the owner's manage listing (where an unmodeled status would render
+    // as a misleading "expired" label).
     const rows = await db.queryAll<TenantRow>(
-      'SELECT * FROM tenants WHERE owner = $1 ORDER BY created_at',
+      `SELECT * FROM tenants WHERE owner = $1 AND subscription_status != 'abandoned' ORDER BY created_at`,
       [owner.toLowerCase()]
     );
     return rows.map(mapTenantFromDb);
@@ -66,9 +90,11 @@ export const TenantService = {
 
     // Upsert so a username the sweep marked 'abandoned' can be reserved again: the row still
     // exists (we soft-delete, never hard-delete, so an in-flight payment can revive it), and a
-    // fresh reservation reclaims it. DO UPDATE is gated on `status = 'abandoned'` — a live row
-    // (inactive/active/expired/suspended) makes the WHERE fail so nothing is updated and no row
-    // is returned, which we surface as a conflict. A brand-new username inserts normally.
+    // fresh reservation reclaims it. DO UPDATE is gated on `status = 'abandoned'` AND the
+    // re-registration quarantine (updated_at older than the window) — a live row, or one
+    // reclaimed too recently to be sure no payment is still in flight for it, makes the WHERE
+    // fail so nothing is updated and no row is returned, which we surface as a conflict. A
+    // brand-new username inserts normally.
     const row = await db.queryOne<TenantRow>(
       `INSERT INTO tenants (username, owner, config, subscription_status, subscription_plan)
        VALUES ($1, $2, $3, 'inactive', 'standard')
@@ -80,8 +106,9 @@ export const TenantService = {
              created_at = NOW(),
              updated_at = NOW()
          WHERE tenants.subscription_status = 'abandoned'
+           AND tenants.updated_at < NOW() - ($4 * INTERVAL '1 hour')
        RETURNING *`,
-      [username.toLowerCase(), ownerName, JSON.stringify(config)]
+      [username.toLowerCase(), ownerName, JSON.stringify(config), ABANDONED_REREGISTER_QUARANTINE_HOURS]
     );
 
     if (!row) {

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -64,14 +64,32 @@ export const TenantService = {
     // were silently dropped (and any community override too). Route both paths through buildConfig.
     const config = await this.buildConfig(username, configOverrides, ownerName);
 
+    // Upsert so a username the sweep marked 'abandoned' can be reserved again: the row still
+    // exists (we soft-delete, never hard-delete, so an in-flight payment can revive it), and a
+    // fresh reservation reclaims it. DO UPDATE is gated on `status = 'abandoned'` — a live row
+    // (inactive/active/expired/suspended) makes the WHERE fail so nothing is updated and no row
+    // is returned, which we surface as a conflict. A brand-new username inserts normally.
     const row = await db.queryOne<TenantRow>(
       `INSERT INTO tenants (username, owner, config, subscription_status, subscription_plan)
        VALUES ($1, $2, $3, 'inactive', 'standard')
+       ON CONFLICT (username) DO UPDATE
+         SET owner = EXCLUDED.owner,
+             config = EXCLUDED.config,
+             subscription_plan = 'standard',
+             subscription_status = 'inactive',
+             created_at = NOW(),
+             updated_at = NOW()
+         WHERE tenants.subscription_status = 'abandoned'
        RETURNING *`,
       [username.toLowerCase(), ownerName, JSON.stringify(config)]
     );
 
-    return mapTenantFromDb(row!);
+    if (!row) {
+      // Conflict with a live (non-abandoned) tenant — the username is genuinely taken.
+      throw Object.assign(new Error('Username already registered'), { isConflict: true });
+    }
+
+    return mapTenantFromDb(row);
   },
   
   /**
@@ -409,16 +427,28 @@ export const TenantService = {
   },
 
   /**
-   * Delete abandoned signups: tenants that were created but NEVER paid (status 'inactive',
+   * Reclaim abandoned signups: tenants that were created but NEVER paid (status 'inactive',
    * no payment rows) and have sat past the grace window. This frees their username, which an
-   * inactive record would otherwise reserve forever. Safe to run repeatedly — a tenant with
-   * any payment history (which would have activated it) is excluded, and a late HBD payment
-   * simply re-creates + activates the tenant. Returns the deleted usernames so the caller can
-   * remove any leftover served files.
+   * inactive record would otherwise reserve forever.
+   *
+   * It SOFT-deletes — flips status to 'abandoned' rather than removing the row — precisely so a
+   * payment that is still in flight when the sweep runs stays safe:
+   *   - An HBD transfer sitting in a not-yet-replayed block has no payment row yet, so the
+   *     `id NOT IN payments` guard cannot protect it; but because the row survives, replay's
+   *     processSubscription finds it and activates it IN PLACE, keeping the original owner and
+   *     config (a hard delete would recreate it with default config + owner = username, losing a
+   *     personal blog's setup and making a community unmanageable).
+   *   - A card order mid-settlement has no payment row either; the row surviving means
+   *     /internal/activate still finds it and does not 404 the paid order.
+   * A fresh reservation revives an 'abandoned' row (see create()), and every serve/list path
+   * already keys on 'active', so an abandoned row neither serves nor blocks re-registration.
+   * Because the operation is reversible, it needs no "listener caught up to head" gate — a
+   * premature mark is harmless. Returns the reclaimed usernames for logging.
    */
-  async deleteAbandonedTenants(graceDays: number): Promise<string[]> {
+  async reclaimAbandonedTenants(graceDays: number): Promise<string[]> {
     const rows = await db.queryAll<{ username: string }>(
-      `DELETE FROM tenants
+      `UPDATE tenants
+         SET subscription_status = 'abandoned', updated_at = NOW()
          WHERE subscription_status = 'inactive'
            AND created_at < NOW() - ($1 * INTERVAL '1 day')
            AND id NOT IN (SELECT tenant_id FROM payments WHERE tenant_id IS NOT NULL)

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -471,6 +471,11 @@ export const TenantService = {
    * already keys on 'active', so an abandoned row neither serves nor blocks re-registration.
    * Because the operation is reversible, it needs no "listener caught up to head" gate — a
    * premature mark is harmless. Returns the reclaimed usernames for logging.
+   *
+   * The "has a payment" guard counts only real/in-flight payments (status not 'failed' or
+   * 'refunded'): a rejected payment — e.g. an upgrade transfer refused because the tenant was
+   * not active — logs a 'failed' row linked to the tenant, and if that counted here it would
+   * permanently pin the (reusable) username against every future reclaim.
    */
   async reclaimAbandonedTenants(graceDays: number): Promise<string[]> {
     const rows = await db.queryAll<{ username: string }>(
@@ -478,7 +483,10 @@ export const TenantService = {
          SET subscription_status = 'abandoned', updated_at = NOW()
          WHERE subscription_status = 'inactive'
            AND created_at < NOW() - ($1 * INTERVAL '1 day')
-           AND id NOT IN (SELECT tenant_id FROM payments WHERE tenant_id IS NOT NULL)
+           AND id NOT IN (
+             SELECT tenant_id FROM payments
+             WHERE tenant_id IS NOT NULL AND status NOT IN ('failed', 'refunded')
+           )
        RETURNING username`,
       [graceDays]
     );

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -13,15 +13,14 @@ export type { Tenant } from '../types';
 hiveTxConfig.nodes = process.env.HIVE_API_URL?.split(',') || ['https://api.hive.blog'];
 const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
 
-// Quiet period after the sweep marks a username 'abandoned' before it can be reserved again.
-// A payment that was already in flight when the sweep ran (an on-chain HBD transfer awaiting
-// block replay, or a card order awaiting settlement) has no payments row yet, so nothing else
-// pins the row; this window lets that payment settle and activate the ORIGINAL reservation
-// (owner + config intact) before a different owner could overwrite it via re-registration.
-// One hour comfortably covers HBD replay — including catch-up after a listener restart — and
-// settlement latency; the web also creates/refreshes the reservation immediately before card or
-// HBD checkout, so a row is not sweepable mid-flow and this mainly defends a direct on-chain
-// transfer against an old reservation.
+// Quiet period after the sweep marks a username 'abandoned' before it can be reserved again. It is
+// a backstop, not the primary defence: a reservation that is actively being paid for is kept out
+// of the sweep entirely — create() refreshes its grace clock on every checkout re-entry, and the
+// sweep waits for block replay to catch up (payment-listener isCaughtUp) so a pending on-chain
+// payment has already activated its reservation before any reclaim. The quarantine only has to
+// cover the residual: a reservation reclaimed at the very moment its payment lands. One hour
+// dwarfs live HBD replay (seconds) and normal card settlement, so a payment in flight when the
+// sweep ran settles onto the ORIGINAL reservation before a different owner could re-register it.
 export const ABANDONED_REREGISTER_QUARANTINE_HOURS = 1;
 
 // Whether an existing row is an abandoned reservation that has cleared the re-registration
@@ -88,25 +87,35 @@ export const TenantService = {
     // were silently dropped (and any community override too). Route both paths through buildConfig.
     const config = await this.buildConfig(username, configOverrides, ownerName);
 
-    // Upsert so a username the sweep marked 'abandoned' can be reserved again: the row still
-    // exists (we soft-delete, never hard-delete, so an in-flight payment can revive it), and a
-    // fresh reservation reclaims it. DO UPDATE is gated on `status = 'abandoned'` AND the
-    // re-registration quarantine (updated_at older than the window) — a live row, or one
-    // reclaimed too recently to be sure no payment is still in flight for it, makes the WHERE
-    // fail so nothing is updated and no row is returned, which we surface as a conflict. A
-    // brand-new username inserts normally.
+    // Upsert with two conflict outcomes, distinguished by the existing row's status:
+    //
+    //  - 'abandoned' (past the re-registration quarantine): a fresh reservation RECLAIMS the name —
+    //    overwrite owner + config. The quarantine (updated_at older than the window) protects a row
+    //    whose earlier payment may still be in flight.
+    //  - 'inactive' owned by the SAME owner: this is a re-entry into checkout for an existing
+    //    reservation. REFRESH its grace clock (created_at = NOW) so the abandoned sweep can't
+    //    reclaim it while it is actively being paid for — closing the window where an old reservation
+    //    is swept mid-checkout and then overwritten before a slow payment (e.g. a card order ePoints
+    //    retries with backoff for far longer than the quarantine) is finally recorded. Keep owner +
+    //    config unchanged here (via CASE) so re-entry never overwrites an unpaid reservation's config.
+    //
+    // Any other row (live tenant, or a different owner's inactive reservation) leaves the WHERE
+    // unsatisfied, returns no row, and is surfaced as a conflict. A brand-new username inserts.
     const row = await db.queryOne<TenantRow>(
       `INSERT INTO tenants (username, owner, config, subscription_status, subscription_plan)
        VALUES ($1, $2, $3, 'inactive', 'standard')
        ON CONFLICT (username) DO UPDATE
-         SET owner = EXCLUDED.owner,
-             config = EXCLUDED.config,
+         SET owner = CASE WHEN tenants.subscription_status = 'abandoned'
+                          THEN EXCLUDED.owner ELSE tenants.owner END,
+             config = CASE WHEN tenants.subscription_status = 'abandoned'
+                           THEN EXCLUDED.config ELSE tenants.config END,
              subscription_plan = 'standard',
              subscription_status = 'inactive',
              created_at = NOW(),
              updated_at = NOW()
-         WHERE tenants.subscription_status = 'abandoned'
-           AND tenants.updated_at < NOW() - ($4 * INTERVAL '1 hour')
+         WHERE (tenants.subscription_status = 'abandoned'
+                  AND tenants.updated_at < NOW() - ($4 * INTERVAL '1 hour'))
+            OR (tenants.subscription_status = 'inactive' AND tenants.owner = EXCLUDED.owner)
        RETURNING *`,
       [username.toLowerCase(), ownerName, JSON.stringify(config), ABANDONED_REREGISTER_QUARANTINE_HOURS]
     );

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -14,13 +14,16 @@ hiveTxConfig.nodes = process.env.HIVE_API_URL?.split(',') || ['https://api.hive.
 const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
 
 // Quiet period after the sweep marks a username 'abandoned' before it can be reserved again. It is
-// a backstop, not the primary defence: a reservation that is actively being paid for is kept out
-// of the sweep entirely — create() refreshes its grace clock on every checkout re-entry, and the
-// sweep waits for block replay to catch up (payment-listener isCaughtUp) so a pending on-chain
-// payment has already activated its reservation before any reclaim. The quarantine only has to
-// cover the residual: a reservation reclaimed at the very moment its payment lands. One hour
-// dwarfs live HBD replay (seconds) and normal card settlement, so a payment in flight when the
-// sweep ran settles onto the ORIGINAL reservation before a different owner could re-register it.
+// a backstop; three enforced guarantees keep a paid-for reservation out of a re-registration:
+//   1. create() refreshes the grace clock on every checkout re-entry, so an actively-paid
+//      reservation is never a sweep target (covers card, whose ePoints activation may retry with
+//      backoff far longer than an hour, and any web re-entry).
+//   2. The sweep only reclaims while the listener is caught up (payment-listener isCaughtUp), so it
+//      never marks a row abandoned during a replay backlog with unprocessed on-chain payments.
+//   3. Re-registration itself is gated on a FRESH listener caught-up watermark (CAUGHT_UP_SQL), so
+//      a listener that stalls AFTER a reclaim — leaving a just-arrived on-chain payment unprocessed
+//      — blocks the name from being overwritten no matter how long the stall lasts.
+// The time-based quarantine then only has to cover the residual seconds of healthy live tailing.
 export const ABANDONED_REREGISTER_QUARANTINE_HOURS = 1;
 
 // Whether an existing row is an abandoned reservation that has cleared the re-registration
@@ -32,6 +35,22 @@ export function isReregisterableAbandoned(t: Pick<Tenant, 'subscriptionStatus' |
   const cutoff = Date.now() - ABANDONED_REREGISTER_QUARANTINE_HOURS * 60 * 60 * 1000;
   return t.updatedAt.getTime() < cutoff;
 }
+
+// How fresh the payment-listener's caught-up watermark must be for re-registration of a reclaimed
+// name to be allowed. The listener refreshes it every poll (~3s) while near head, so a value older
+// than this means it is stalled or replaying a backlog and may not have processed a pending payment
+// yet — in which case re-registration must be blocked regardless of the time-based quarantine. Used
+// both as the SQL guard on the reclaim branch and by isListenerCaughtUp for the pre-paywall check.
+export const LISTENER_CAUGHT_UP_MAX_AGE = "2 minutes";
+
+// Reclaim-branch guard: true only if the payment listener has reported itself caught up to head
+// recently. Fails safe to false (blocks re-registration) if the watermark is missing or stale.
+// Exported so the /subscribe and claim-blog upserts apply the identical guard.
+export const CAUGHT_UP_SQL = `EXISTS (
+  SELECT 1 FROM system_config
+  WHERE key = 'payment_listener.caught_up'
+    AND updated_at > NOW() - INTERVAL '${LISTENER_CAUGHT_UP_MAX_AGE}'
+)`;
 
 export const TenantService = {
   /**
@@ -114,7 +133,8 @@ export const TenantService = {
              created_at = NOW(),
              updated_at = NOW()
          WHERE (tenants.subscription_status = 'abandoned'
-                  AND tenants.updated_at < NOW() - ($4 * INTERVAL '1 hour'))
+                  AND tenants.updated_at < NOW() - ($4 * INTERVAL '1 hour')
+                  AND ${CAUGHT_UP_SQL})
             OR (tenants.subscription_status = 'inactive' AND tenants.owner = EXCLUDED.owner)
        RETURNING *`,
       [username.toLowerCase(), ownerName, JSON.stringify(config), ABANDONED_REREGISTER_QUARANTINE_HOURS]
@@ -486,6 +506,20 @@ export const TenantService = {
    * not active — logs a 'failed' row linked to the tenant, and if that counted here it would
    * permanently pin the (reusable) username against every future reclaim.
    */
+  /**
+   * Whether the payment listener has reported itself caught up to head recently. Mirrors the
+   * CAUGHT_UP_SQL guard for use as a pre-check on paths that must decide BEFORE a payment settles
+   * (e.g. /subscribe's pre-paywall availability check) whether a reclaimed name may be reused.
+   * Fails safe to false if the watermark is missing or stale.
+   */
+  async isListenerCaughtUp(): Promise<boolean> {
+    const row = await db.queryOne<{ fresh: boolean }>(
+      `SELECT (updated_at > NOW() - INTERVAL '${LISTENER_CAUGHT_UP_MAX_AGE}') AS fresh
+         FROM system_config WHERE key = 'payment_listener.caught_up'`
+    );
+    return row?.fresh === true;
+  },
+
   async reclaimAbandonedTenants(graceDays: number): Promise<string[]> {
     const rows = await db.queryAll<{ username: string }>(
       `UPDATE tenants

--- a/apps/self-hosted/hosting/api/src/types.ts
+++ b/apps/self-hosted/hosting/api/src/types.ts
@@ -11,8 +11,10 @@ export interface Tenant {
   username: string; // Showcased Hive account, also used as subdomain (hive-NNNNN for a community)
   owner: string; // Hive account that created and controls this instance (equals username for a personal blog)
 
-  // Subscription
-  subscriptionStatus: 'inactive' | 'active' | 'expired' | 'suspended';
+  // Subscription. 'abandoned' = an unpaid reservation the sweep reclaimed after the grace
+  // window; the row is kept (not deleted) so an in-flight payment can still revive it in place,
+  // and the username reads as available again for a fresh reservation.
+  subscriptionStatus: 'inactive' | 'active' | 'expired' | 'suspended' | 'abandoned';
   subscriptionPlan: 'standard' | 'pro';
   subscriptionStartedAt: Date | null;
   subscriptionExpiresAt: Date | null;
@@ -86,7 +88,7 @@ export interface TenantRow {
   id: string;
   username: string;
   owner: string;
-  subscription_status: 'inactive' | 'active' | 'expired' | 'suspended';
+  subscription_status: 'inactive' | 'active' | 'expired' | 'suspended' | 'abandoned';
   subscription_plan: 'standard' | 'pro';
   subscription_started_at: string | null;
   subscription_expires_at: string | null;


### PR DESCRIPTION
Follow-up from cleaning 7 stale test tenants that were squatting usernames (demo, test, good-karma, softdev, ...). An `inactive` tenant — signup started but never paid — reserved its username forever, so abandoned signups and test records permanently blocked those names (a user typing that name gets "already registered").

The hourly expiry sweep (which already flips lapsed active subscriptions to `expired`) now also deletes tenants that are:
- `subscription_status = 'inactive'` (never activated), AND
- have **no payment rows** (any payment would have activated them), AND
- are older than a grace window (`ABANDONED_TENANT_GRACE_DAYS`, default 7 days — comfortably longer than an in-flight HBD payment).

Safe to run repeatedly: a tenant with any payment history is excluded, and a late HBD payment re-creates + activates the tenant (the listener creates on payment if absent). Leftover served files are removed for deleted usernames, though a never-activated tenant should have none post the earlier free-blog fix.

## Tests
- hosting-api: 80 pass (2 new: query-shape guards + freed-usernames return, empty case); tsc clean.

## Note
The 7 existing stale tenants were already removed manually; this prevents recurrence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic reclaim of abandoned, unpaid tenants after a configurable grace period (with a safe default).
  * Re-submitting/claiming now revives previously abandoned tenants, restoring their setup and reactivating the subscription.
* **Bug Fixes**
  * Improved subscription activation reliability by ensuring updates are safely coordinated during the transaction.
* **Tests**
  * Expanded Vitest coverage for grace-period parsing and abandoned tenant reclaim/revival behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->