### PR TITLE
UI: fix unreadable danger Alert (low-contrast red-on-red)

### DIFF
--- a/apps/web/src/features/ui/alert/styles.ts
+++ b/apps/web/src/features/ui/alert/styles.ts
@@ -9,6 +9,9 @@ export const ALERT_STYLES: Record<Appearance, string> = {
     "bg-green-040 border border-green-030 text-green dark:bg-opacity-[20%] dark:border-opacity-[20%]",
   warning:
     "bg-warning-040 border border-warning-030 text-orange dark:bg-opacity-[20%] dark:border-opacity-[20%] dark:text-warning-default",
+  // red-040 (#ec3323) is a vivid red used elsewhere as a solid badge with white text; pairing
+  // it as a background with the muted `text-red` gave low-contrast red-on-red (unreadable).
+  // Use a light red TINT background with dark-red text, matching the other alerts' pattern.
   danger:
-    "bg-red-040 border border-red-030 text-red dark:bg-opacity-[20%] dark:border-opacity-[20%]"
+    "bg-red-040/10 border border-red-030 text-red-030 dark:bg-red-040/20 dark:border-red-030 dark:text-red-light-020"
 };

--- a/apps/web/src/specs/features/ui/alert.spec.tsx
+++ b/apps/web/src/specs/features/ui/alert.spec.tsx
@@ -80,8 +80,10 @@ describe("Alert", () => {
     it("applies danger appearance", () => {
       const { container } = render(<Alert appearance="danger">Danger</Alert>);
       const alert = container.firstChild as HTMLElement;
-      expect(alert.className).toContain("bg-red-040");
-      expect(alert.className).toContain("text-red");
+      // Light red tint background with dark-red text for readable contrast (not vivid
+      // bg-red-040 with muted text-red, which was low-contrast red-on-red).
+      expect(alert.className).toContain("bg-red-040/10");
+      expect(alert.className).toContain("text-red-030");
       expect(alert.className).toContain("border-red-030");
     });
   });
@@ -146,11 +148,11 @@ describe("Alert", () => {
       expect(alert.className).toContain("dark:text-warning-default");
     });
 
-    it("applies dark mode opacity for danger appearance", () => {
+    it("applies dark mode tint and readable text for danger appearance", () => {
       const { container } = render(<Alert appearance="danger">Dark</Alert>);
       const alert = container.firstChild as HTMLElement;
-      expect(alert.className).toContain("dark:bg-opacity-[20%]");
-      expect(alert.className).toContain("dark:border-opacity-[20%]");
+      expect(alert.className).toContain("dark:bg-red-040/20");
+      expect(alert.className).toContain("dark:text-red-light-020");
     });
   });
 


### PR DESCRIPTION
Spotted while reviewing the /hosting "This blog is already registered." error — the text was barely readable.

The danger `Alert` used `bg-red-040` (#ec3323 — a **vivid, saturated** red, used elsewhere as a solid badge background with white text) paired with `text-red` (#e05e5e — a muted red). That's low-contrast **red text on a red background**. Every other alert appearance (primary/success/warning) uses a light `-040` tint background with darker colored text; red-040 breaks that pattern because it's a full-strength red, not a tint.

Fix (scoped to the danger alert style only — the vivid `red-040` stays as-is for the navbar badge etc.):
- **Light:** `bg-red-040/10` (light red tint) + `text-red-030` (#a43434, dark red) → strong contrast.
- **Dark:** `bg-red-040/20` + `text-red-light-020` (#ff6666) → readable on dark.

This is app-wide (every danger alert becomes readable), a genuine contrast/accessibility fix.

## Tests
Updated alert.spec danger assertions to the new classes; 38 alert tests pass.