### PR TITLE
fix(hosting): atomic prorated custom-domain upgrade + re-confirm changed quote

### DIFF
--- a/apps/self-hosted/hosting/api/src/payment-listener-upgrade.test.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener-upgrade.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// processUpgrade must apply the standard->Pro flip and the payment record in ONE transaction, so a
+// transient failure or a duplicate block can never leave a Pro tenant with a failed/missing
+// payment. These tests drive the private method against a fake transaction client and assert the
+// exact SQL sequence: claim (dedup) -> eligibility under the row lock -> flip -> mark processed,
+// with any ineligible/duplicate/underpaid transfer taking a tenant-untouched path.
+
+vi.mock('@ecency/sdk/hive', () => ({
+  callRPC: vi.fn(),
+  config: { nodes: [] },
+  setNodes: vi.fn(),
+}));
+
+// A fake transaction client: each test programs a queue of results keyed by a substring of the SQL.
+type Row = Record<string, any>;
+let plan: Array<{ match: RegExp; rows: Row[] }>;
+const queries: string[] = [];
+
+function makeClient() {
+  return {
+    query: vi.fn(async (sql: string) => {
+      queries.push(sql);
+      const hit = plan.find((p) => p.match.test(sql));
+      return { rows: hit ? hit.rows : [], rowCount: hit ? hit.rows.length : 0 };
+    }),
+  };
+}
+
+const auditLog = vi.fn();
+vi.mock('./services/audit-service', () => ({ AuditService: { log: (...a: any[]) => auditLog(...a) } }));
+
+// A real-ish db.transaction that runs the callback against the fake client (BEGIN/COMMIT elided).
+const client = makeClient();
+vi.mock('./db/client', () => ({
+  db: {
+    query: vi.fn(),
+    queryOne: vi.fn(),
+    queryAll: vi.fn(),
+    transaction: vi.fn(async (fn: (c: any) => Promise<any>) => fn(client)),
+  },
+}));
+
+const { PaymentListener } = await import('./payment-listener');
+
+// One month from now keeps remainingMonths() >= 1 and the prorated amount modest.
+const IN_A_MONTH = new Date(Date.now() + 40 * 24 * 3600 * 1000).toISOString();
+const transfer = { trxId: 'tx1', blockNum: 1, from: 'alice', memo: 'upgrade:alice' };
+
+function run(amount: number) {
+  const listener: any = new PaymentListener();
+  return listener.processUpgrade(transfer, 'alice', amount);
+}
+
+function lastTenantUpdate() {
+  return queries.find((q) => /UPDATE tenants/.test(q) && /subscription_plan = 'pro'/.test(q));
+}
+function paymentStatuses() {
+  return queries
+    .filter((q) => /UPDATE payments SET status/.test(q))
+    .map((q) => (/'processed'/.test(q) ? 'processed' : /'failed'/.test(q) ? 'failed' : '?'));
+}
+
+describe('PaymentListener.processUpgrade (transactional)', () => {
+  beforeEach(() => {
+    queries.length = 0;
+    client.query.mockClear();
+    auditLog.mockClear();
+  });
+
+  it('claims, flips to Pro, and marks the payment processed for an eligible active standard tenant', async () => {
+    plan = [
+      { match: /SELECT \* FROM tenants/, rows: [{ id: 't1', subscription_status: 'active', subscription_plan: 'standard', subscription_expires_at: IN_A_MONTH }] },
+      { match: /INSERT INTO payments/, rows: [{ id: 'p1' }] },
+      { match: /UPDATE tenants/, rows: [{ id: 't1' }] },
+    ];
+    await run(10);
+    // Claimed as 'processing' with dedup, flipped to Pro, then payment set 'processed'.
+    expect(queries.some((q) => /INSERT INTO payments[\s\S]*ON CONFLICT \(trx_id\) DO NOTHING/.test(q))).toBe(true);
+    expect(lastTenantUpdate()).toBeTruthy();
+    expect(paymentStatuses()).toEqual(['processed']);
+    expect(auditLog).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing when the transfer is a duplicate (claim returns no row)', async () => {
+    plan = [
+      { match: /SELECT \* FROM tenants/, rows: [{ id: 't1', subscription_status: 'active', subscription_plan: 'standard', subscription_expires_at: IN_A_MONTH }] },
+      { match: /INSERT INTO payments/, rows: [] }, // ON CONFLICT DO NOTHING -> already processed
+    ];
+    await run(10);
+    expect(lastTenantUpdate()).toBeUndefined();
+    expect(paymentStatuses()).toEqual([]); // no processed/failed write
+    expect(auditLog).not.toHaveBeenCalled();
+  });
+
+  it('fails the payment without touching the tenant when already Pro', async () => {
+    plan = [
+      { match: /SELECT \* FROM tenants/, rows: [{ id: 't1', subscription_status: 'active', subscription_plan: 'pro', subscription_expires_at: IN_A_MONTH }] },
+      { match: /INSERT INTO payments/, rows: [{ id: 'p1' }] },
+    ];
+    await run(10);
+    expect(lastTenantUpdate()).toBeUndefined();
+    expect(paymentStatuses()).toEqual(['failed']);
+    expect(auditLog).not.toHaveBeenCalled();
+  });
+
+  it('fails the payment without touching the tenant when not active', async () => {
+    plan = [
+      { match: /SELECT \* FROM tenants/, rows: [{ id: 't1', subscription_status: 'expired', subscription_plan: 'standard', subscription_expires_at: IN_A_MONTH }] },
+      { match: /INSERT INTO payments/, rows: [{ id: 'p1' }] },
+    ];
+    await run(10);
+    expect(lastTenantUpdate()).toBeUndefined();
+    expect(paymentStatuses()).toEqual(['failed']);
+  });
+
+  it('fails an underpaid transfer without upgrading', async () => {
+    plan = [
+      { match: /SELECT \* FROM tenants/, rows: [{ id: 't1', subscription_status: 'active', subscription_plan: 'standard', subscription_expires_at: IN_A_MONTH }] },
+      { match: /INSERT INTO payments/, rows: [{ id: 'p1' }] },
+    ];
+    await run(0.001); // far below the prorated premium
+    expect(lastTenantUpdate()).toBeUndefined();
+    expect(paymentStatuses()).toEqual(['failed']);
+  });
+
+  it('flips only under the full eligibility predicate (standard + active + unexpired)', async () => {
+    plan = [
+      { match: /SELECT \* FROM tenants/, rows: [{ id: 't1', subscription_status: 'active', subscription_plan: 'standard', subscription_expires_at: IN_A_MONTH }] },
+      { match: /INSERT INTO payments/, rows: [{ id: 'p1' }] },
+      { match: /UPDATE tenants/, rows: [{ id: 't1' }] },
+    ];
+    await run(10);
+    const sql = lastTenantUpdate()!;
+    expect(sql).toMatch(/subscription_plan = 'standard'/);
+    expect(sql).toMatch(/subscription_status = 'active'/);
+    expect(sql).toMatch(/subscription_expires_at > NOW\(\)/);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -47,7 +47,7 @@ setNodes(CONFIG.HIVE_API_NODES);
 // stay false during a real backlog, loose enough to hold during normal one-block-behind tailing.
 const CAUGHT_UP_BLOCK_THRESHOLD = 3;
 
-class PaymentListener {
+export class PaymentListener {
   private lastProcessedBlock: number = 0;
   private isRunning: boolean = false;
   private expirationIntervalId: ReturnType<typeof setInterval> | null = null;
@@ -439,95 +439,127 @@ class PaymentListener {
   private async processUpgrade(transfer: any, username: string, amount: number) {
     console.log('[PaymentListener] Processing upgrade:', username);
 
+    // Result of the transaction, decided inside it and acted on after commit.
+    type UpgradeOutcome =
+      | { status: 'processed'; tenantId: string }
+      | { status: 'failed'; note: string }
+      | { status: 'duplicate' };
+    let outcome: UpgradeOutcome | null = null;
+
     try {
-      const tenant = await TenantService.getByUsername(username);
-      if (!tenant) {
-        console.log('[PaymentListener] Tenant not found for upgrade:', username);
-        await this.logPayment(transfer, amount, 'failed', 0, null, 'Tenant not found');
-        return;
-      }
+      // Everything that mutates state runs on the SAME transaction client so the payment dedup row
+      // and the standard->Pro flip commit or roll back together. Splitting them (flip via a
+      // separate autocommit, then a separate logPayment) let a single realistic path corrupt the
+      // record: if the flip commits and the payment write then fails transiently, the block retries,
+      // finds the tenant already Pro, and records the transfer 'failed' — leaving a Pro tenant with
+      // a failed payment. Two listeners on the same trx had the same split-brain. One transaction
+      // closes both. Mirrors processSubscription.
+      outcome = await db.transaction<UpgradeOutcome>(async (client) => {
+        // 1. Lock the tenant row FIRST — before any other await — so eligibility can't change under
+        // us. The expiry / abandon sweeps take the same row lock, so check-then-flip is atomic
+        // without relying on the UPDATE predicate alone.
+        const row = (
+          await client.query(`SELECT * FROM tenants WHERE username = $1 FOR UPDATE`, [username])
+        ).rows[0];
 
-      // A custom-domain (Pro) upgrade only applies to a currently-serviceable (active) blog — same
-      // rule the x402 /upgrade route enforces. Reject a reserved/inactive, reclaimed/abandoned, or
-      // expired tenant: upgrading one would take the payment for a blog that isn't running, and a
-      // plan bought while a name was abandoned must not carry over to a later fresh reservation.
-      if (tenant.subscriptionStatus !== 'active') {
-        console.log(
-          '[PaymentListener] Tenant not active for upgrade:',
-          username,
-          tenant.subscriptionStatus
+        // 2. Claim the transfer (dedup via unique trx_id). A replayed/duplicate block finds the row
+        // already present and bails, so the upgrade is applied at most once.
+        const claim = await client.query(
+          `INSERT INTO payments
+           (tenant_id, trx_id, block_num, from_account, amount, currency, memo, status, months_credited)
+           VALUES ($1, $2, $3, $4, $5, 'HBD', $6, 'processing', 0)
+           ON CONFLICT (trx_id) DO NOTHING
+           RETURNING id`,
+          [row?.id ?? null, transfer.trxId, transfer.blockNum, transfer.from, amount, transfer.memo]
         );
-        await this.logPayment(transfer, amount, 'failed', 0, null, 'Tenant not active for upgrade');
-        return;
-      }
+        if (claim.rows.length === 0) {
+          console.log('[PaymentListener] Duplicate upgrade transaction detected:', transfer.trxId);
+          return { status: 'duplicate' };
+        }
+        const paymentId = claim.rows[0].id;
 
-      // Already on the custom-domain (Pro) tier: a repeated or manually-sent upgrade memo would
-      // otherwise be recorded as processed for a no-op upgradeToPro, consuming the payment for no
-      // benefit (no term extension, already Pro). Reject it instead. The quote route likewise
-      // reports already-Pro tenants as ineligible, so the UI never offers this.
-      if (tenant.subscriptionPlan === 'pro') {
-        console.log('[PaymentListener] Tenant already on Pro plan, skipping upgrade:', username);
-        await this.logPayment(transfer, amount, 'failed', 0, null, 'Tenant already on Pro plan');
-        return;
-      }
+        // Mark an ineligible/underpaid transfer terminally 'failed' in the SAME transaction — it
+        // commits with the claim (so it isn't reprocessed) and no tenant change is made.
+        const fail = async (note: string): Promise<UpgradeOutcome> => {
+          await client.query(`UPDATE payments SET status = 'failed' WHERE id = $1`, [paymentId]);
+          console.log('[PaymentListener] Upgrade not applied for', username, '-', note);
+          return { status: 'failed', note };
+        };
 
-      // Prorated: the owner pays the +1/mo custom-domain premium for the months remaining on their
-      // current term (upgrade in place, no term extension). Integer-millis compare so an exact
-      // payment isn't rejected by float error. The quote and this validation use the same
-      // remainingMonths(); since time only moves forward, remaining only shrinks, so a payment made
-      // against the (equal-or-higher) quote is never rejected here.
-      const now = new Date();
-      const months = Pricing.remainingMonths(tenant.subscriptionExpiresAt, now);
-      if (months < 1) {
-        // Expiry has passed (active only because the hourly expire sweep hasn't run yet): there is
-        // no term to prorate, so don't take the payment for a term-less upgrade.
-        console.log('[PaymentListener] No remaining term to upgrade:', username);
-        await this.logPayment(transfer, amount, 'failed', 0, null, 'No remaining term to upgrade');
-        return;
-      }
-      const required = Pricing.customDomainUpgradeHbd(tenant.subscriptionExpiresAt, now);
-      if (Math.round(amount * 1000) < Math.round(required * 1000)) {
-        console.log('[PaymentListener] Insufficient for custom-domain upgrade:', amount, 'HBD <', required);
-        await this.logPayment(
-          transfer,
-          amount,
-          'failed',
-          0,
-          null,
-          `Insufficient for custom-domain upgrade (need ${Pricing.hbd(required)} HBD for ${months} month(s) remaining)`
+        // 3. Eligibility, evaluated against the locked row.
+        if (!row) return fail('Tenant not found');
+        // A custom-domain (Pro) upgrade only applies to a currently-serviceable (active) blog — same
+        // rule the x402 /upgrade route enforces. Reject a reserved/inactive, reclaimed/abandoned, or
+        // expired tenant: upgrading one would take the payment for a blog that isn't running, and a
+        // plan bought while a name was abandoned must not carry over to a later fresh reservation.
+        if (row.subscription_status !== 'active') return fail('Tenant not active for upgrade');
+        // Already Pro: a repeated or manual upgrade memo would otherwise be taken for a no-op.
+        if (row.subscription_plan === 'pro') return fail('Tenant already on Pro plan');
+
+        // Prorated: the owner pays the +1/mo custom-domain premium for the months remaining on their
+        // current term (upgrade in place, no term extension). Integer-millis compare so an exact
+        // payment isn't rejected by float error. The quote and this validation use the same
+        // remainingMonths(); since time only moves forward, remaining only shrinks, so a payment
+        // made against the (equal-or-higher) quote is never rejected here.
+        const now = new Date();
+        const expiresAt = row.subscription_expires_at
+          ? new Date(row.subscription_expires_at)
+          : null;
+        const months = Pricing.remainingMonths(expiresAt, now);
+        if (months < 1) {
+          // Expiry has passed (active only because the hourly expire sweep hasn't run yet): there is
+          // no term to prorate, so don't take the payment for a term-less upgrade.
+          return fail('No remaining term to upgrade');
+        }
+        const required = Pricing.customDomainUpgradeHbd(expiresAt, now);
+        if (Math.round(amount * 1000) < Math.round(required * 1000)) {
+          return fail(
+            `Insufficient for custom-domain upgrade (need ${Pricing.hbd(required)} HBD for ${months} month(s) remaining)`
+          );
+        }
+
+        // 4. Flip to Pro in place. The predicate re-asserts full eligibility (standard + active +
+        // unexpired) as a documented guard; it can't fail here since we hold the row lock and just
+        // validated the same conditions, but if it somehow matched nothing we record failed rather
+        // than mark a non-upgrade processed.
+        const upd = await client.query(
+          `UPDATE tenants
+              SET subscription_plan = 'pro', updated_at = NOW()
+            WHERE id = $1
+              AND subscription_plan = 'standard'
+              AND subscription_status = 'active'
+              AND subscription_expires_at > NOW()
+            RETURNING id`,
+          [row.id]
         );
-        return;
-      }
+        if (upd.rows.length === 0) return fail('Upgrade no longer eligible');
 
-      // Atomic standard->Pro transition. Returns null if a concurrent change between the checks
-      // above and here made the tenant ineligible — already Pro (a racing upgrade) or no longer
-      // active (the expiry sweep). Either way this transfer earned no usable upgrade, so record it
-      // as failed rather than a second/void 'processed' upgrade.
-      const upgraded = await TenantService.upgradeToPro(username);
-      if (!upgraded) {
-        console.log('[PaymentListener] Upgrade no longer eligible (raced), not crediting:', username);
-        await this.logPayment(transfer, amount, 'failed', 0, null, 'Upgrade no longer eligible (already Pro or not active)');
-        return;
-      }
-      await this.logPayment(transfer, amount, 'processed', 0, null, 'Upgraded to Pro (custom domain)');
+        // 5. Mark the payment processed in the SAME transaction.
+        await client.query(`UPDATE payments SET status = 'processed' WHERE id = $1`, [paymentId]);
 
-      void AuditService.log({
-        tenantId: tenant.id,
-        eventType: 'payment.upgrade',
-        eventData: { username, amount, trxId: transfer.trxId },
+        console.log('[PaymentListener] Upgraded', username, 'to Pro plan');
+        return { status: 'processed', tenantId: row.id };
       });
-
-      console.log('[PaymentListener] Upgraded', username, 'to Pro plan');
     } catch (error) {
-      // Same rule as processSubscription: a transient error (RPC/DB) must not record a
-      // 'failed' row, or the paid upgrade is stranded forever by the trx_id dedup. No
-      // 'processing' row is written here, so rethrowing simply lets the block retry.
+      // Transient error (RPC/DB): the whole transaction — claim included — rolled back, so no
+      // 'processing'/'failed' row persists and the block simply retries. Never record 'failed'
+      // here, or the trx_id dedup would strand a real paid upgrade forever.
       console.error(
         '[PaymentListener] Transient error, will retry upgrade for',
         username,
         (error as Error).message
       );
       throw error;
+    }
+
+    // Post-commit side effect (audit only). The upgrade + payment are ALREADY committed, so a
+    // failure here must not rethrow into the transient-retry path above.
+    if (outcome?.status === 'processed') {
+      void AuditService.log({
+        tenantId: outcome.tenantId,
+        eventType: 'payment.upgrade',
+        eventData: { username, amount, trxId: transfer.trxId },
+      });
     }
   }
 

--- a/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service-cleanup.test.ts
@@ -136,32 +136,6 @@ describe('TenantService.isListenerCaughtUp', () => {
   });
 });
 
-describe('TenantService.upgradeToPro (atomic standard->pro)', () => {
-  beforeEach(() => mocks.queryOne.mockReset());
-
-  it("guards the UPDATE on subscription_plan != 'pro' and returns the upgraded row", async () => {
-    mocks.queryOne.mockResolvedValueOnce({
-      id: "1",
-      username: "a",
-      owner: "a",
-      subscription_status: "active",
-      subscription_plan: "pro",
-      config: {}
-    });
-    const r = await TenantService.upgradeToPro("a");
-    expect(r).not.toBeNull();
-    const [sql] = mocks.queryOne.mock.calls[0];
-    // Both eligibility checks are in the single UPDATE (atomic against a concurrent flip).
-    expect(sql).toMatch(/subscription_plan != 'pro'/);
-    expect(sql).toMatch(/subscription_status = 'active'/);
-  });
-
-  it("returns null when no row is updated (already Pro / raced / gone)", async () => {
-    mocks.queryOne.mockResolvedValueOnce(null);
-    await expect(TenantService.upgradeToPro("a")).resolves.toBeNull();
-  });
-});
-
 describe('TenantService.getByOwner', () => {
   beforeEach(() => mocks.queryAll.mockReset());
 

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -180,30 +180,7 @@ export const TenantService = {
 
     return mapTenantFromDb(row!);
   },
-  
-  /**
-   * Upgrade an ACTIVE tenant to the Pro plan. Both eligibility checks are in the single UPDATE so
-   * the standard->Pro transition is atomic against a concurrent change between the caller's read and
-   * this write: `subscription_plan != 'pro'` (a racing upgrade already flipped it) and
-   * `subscription_status = 'active'` (the expiry sweep flipped it to 'expired' — upgrading then
-   * would sell Pro on a dead blog). When no row matches, no update happens and this returns null, so
-   * the caller records the racing payment as failed instead of a second/void "processed" upgrade.
-   */
-  async upgradeToPro(username: string): Promise<Tenant | null> {
-    const row = await db.queryOne<TenantRow>(
-      `UPDATE tenants
-       SET subscription_plan = 'pro',
-           updated_at = NOW()
-       WHERE username = $1
-         AND subscription_plan != 'pro'
-         AND subscription_status = 'active'
-       RETURNING *`,
-      [username.toLowerCase()]
-    );
 
-    return row ? mapTenantFromDb(row) : null;
-  },
-  
   /**
    * Update tenant config
    */

--- a/apps/web/src/features/hosting-signup/custom-domain-upgrade.tsx
+++ b/apps/web/src/features/hosting-signup/custom-domain-upgrade.tsx
@@ -84,6 +84,16 @@ export function CustomDomainUpgrade({
       setBusy(false);
       return;
     }
+    // The amount the user authorizes must match the amount on the button. A concurrent renewal can
+    // extend the term and raise the prorated price between the panel rendering and this click; if
+    // the fresh quote differs, update what's shown and require another click so the user confirms
+    // the NEW amount rather than us silently broadcasting a different one.
+    if (fresh.amount !== quote.amount) {
+      setQuote(fresh);
+      setError(i18next.t("hosting.upgrade-domain-amount-changed", { amount: fresh.amount }));
+      setBusy(false);
+      return;
+    }
     setPaying(true);
     try {
       await transfer.mutateAsync({ to: fresh.to, amount: fresh.amount, memo: fresh.memo });

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -41,6 +41,7 @@
     "upgrade-domain-pending": "Payment sent. If your custom domain isn't enabled shortly, use \"I've sent the payment\" below to re-check. Don't send again.",
     "upgrade-domain-loading": "Loading price…",
     "upgrade-domain-unavailable": "Custom domain upgrade isn't available for this blog right now.",
+    "upgrade-domain-amount-changed": "The price updated to {{amount}} (your remaining term changed). Review it and tap to pay again.",
     "success-title": "Your blog is live",
     "invalid-username": "Enter a valid Hive username.",
     "already-registered": "This blog is already registered.",

--- a/apps/web/src/specs/features/hosting-signup/custom-domain-upgrade.spec.tsx
+++ b/apps/web/src/specs/features/hosting-signup/custom-domain-upgrade.spec.tsx
@@ -85,6 +85,35 @@ describe("CustomDomainUpgrade", () => {
     expect(mutateAsync).not.toHaveBeenCalled();
   });
 
+  it("does not broadcast a changed amount; it re-displays and requires another click", async () => {
+    // The term (and thus the prorated price) changed between the panel rendering and the click —
+    // e.g. a concurrent renewal. The re-fetch returns a higher amount; we must NOT broadcast the
+    // amount the user didn't see. Instead update the shown price and wait for a fresh confirmation.
+    const onUpgraded = vi.fn();
+    hostingApi.upgradeQuote
+      .mockResolvedValueOnce(QUOTE)
+      .mockResolvedValueOnce({ ...QUOTE, amount: "6.000 HBD", remainingMonths: 6 });
+    render(<CustomDomainUpgrade tenant="alice" onUpgraded={onUpgraded} />);
+    const payBtn = await screen.findByRole("button", { name: "hosting.upgrade-domain-pay" });
+    fireEvent.click(payBtn);
+
+    // Notice shown, nothing broadcast on this click.
+    await screen.findByText("hosting.upgrade-domain-amount-changed");
+    expect(mutateAsync).not.toHaveBeenCalled();
+
+    // A second click now confirms the updated amount and broadcasts exactly that.
+    hostingApi.upgradeQuote.mockResolvedValue({ ...QUOTE, amount: "6.000 HBD", remainingMonths: 6 });
+    fireEvent.click(await screen.findByRole("button", { name: "hosting.upgrade-domain-pay" }));
+    await waitFor(() =>
+      expect(mutateAsync).toHaveBeenCalledWith({
+        to: "ecency.hosting",
+        amount: "6.000 HBD",
+        memo: "upgrade:alice"
+      })
+    );
+    await waitFor(() => expect(onUpgraded).toHaveBeenCalled());
+  });
+
   it("shows unavailable when the tenant isn't eligible (already Pro / not active)", async () => {
     hostingApi.upgradeQuote.mockResolvedValue({ eligible: false, reason: "already_pro" });
     render(<CustomDomainUpgrade tenant="alice" onUpgraded={vi.fn()} />);


### PR DESCRIPTION
Follow-up to #1169. CodeRabbit flagged three findings on the merged branch; this addresses all three.

### Listener — one transaction for the flip + payment (data integrity)
`processUpgrade` upgraded the tenant and recorded the payment as two separate autocommits (`upgradeToPro`, then `logPayment`). A single realistic path corrupted the record: if the flip commits and the payment write then fails transiently, the block retries, finds the tenant already Pro, and records the transfer **failed** — leaving a Pro tenant with a failed payment. Concurrent listeners on the same transfer had the same split-brain.

Now the flip and the payment run in **one transaction**, mirroring `processSubscription`:
1. Lock the tenant row `FOR UPDATE` (serializes against the expiry/abandon sweeps).
2. Claim the transfer (`INSERT … 'processing' ON CONFLICT (trx_id) DO NOTHING`) — dedup.
3. Check eligibility against the locked row.
4. Flip to Pro, its `UPDATE` predicate re-asserting full eligibility (`plan = 'standard' AND status = 'active' AND expires_at > NOW()`).
5. Mark the payment `processed`.

All of it commits or rolls back together, so a transient failure or a duplicate block can never leave a Pro tenant with a failed/missing payment. Ineligible/underpaid transfers are marked `failed` in the same transaction and never touch the tenant.

`upgradeToPro` is now dead code (the x402 `/upgrade` route and `internal/activate` already inline their own guarded UPDATE) and is removed.

### Web — don't broadcast a changed amount without re-confirmation
`payWithHive` re-fetches the quote right before broadcasting. If a concurrent renewal changed the remaining term (and thus the prorated price) since the button rendered, it now updates the displayed price and requires another click, instead of silently broadcasting an amount the user didn't confirm.

### Tests
- New transactional `processUpgrade` suite (happy path, duplicate, already-Pro, not-active, underpaid, full-predicate). API: 109 pass.
- New web test: changed amount re-displays and requires a second click before broadcasting the updated amount. Web spec: 5 pass.
- Removes the obsolete `upgradeToPro` unit test.