### PR TITLE
feat(hosting): claim landing for unclaimed *.blogs.ecency.com subdomains

### DIFF
--- a/apps/self-hosted/hosting/default-config.json
+++ b/apps/self-hosted/hosting/default-config.json
@@ -18,6 +18,7 @@
     },
     "instanceConfiguration": {
       "type": "blog",
+      "template": true,
       "username": "ecency",
       "communityId": "",
       "meta": {

--- a/apps/self-hosted/public/meta.html
+++ b/apps/self-hosted/public/meta.html
@@ -1,4 +1,3 @@
-<title>Claim this blog on Ecency</title>
-<meta name="description" content="This blog isn't set up yet. Claim it and launch your own on Ecency." />
-<meta name="robots" content="noindex, nofollow" />
+<title>Ecency blog</title>
+<meta name="description" content="A blog powered by Hive blockchain and Ecency." />
 <link rel="icon" href="/favicon.ico" />

--- a/apps/self-hosted/public/meta.html
+++ b/apps/self-hosted/public/meta.html
@@ -1,3 +1,4 @@
-<title>Ecency blog</title>
-<meta name="description" content="A blog powered by Hive blockchain and Ecency." />
+<title>Claim this blog on Ecency</title>
+<meta name="description" content="This blog isn't set up yet. Claim it and launch your own on Ecency." />
+<meta name="robots" content="noindex, nofollow" />
 <link rel="icon" href="/favicon.ico" />

--- a/apps/self-hosted/src/core/configuration-loader.ts
+++ b/apps/self-hosted/src/core/configuration-loader.ts
@@ -44,6 +44,12 @@ export interface InstanceConfig {
       owner?: string;
       /** Set by the managed-hosting API in served configs; absent on true self-hosting. */
       managed?: boolean;
+      /**
+       * Marks the shared default template served for an UNCLAIMED *.blogs.ecency.com subdomain
+       * (no tenant row yet). The app shows the claim landing instead of a blog. Only present on the
+       * managed default config, never on a real tenant or a true self-host.
+       */
+      template?: boolean;
       communityId: string;
       meta: {
         title: string;

--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -64,6 +64,10 @@ type TranslationKey =
   | 'page_not_found'
   | 'page_not_found_description'
   | 'back_to_blog'
+  | 'claim_title_blog'
+  | 'claim_title_community'
+  | 'claim_subtitle'
+  | 'claim_cta'
   | 'edit_post'
   | 'updating'
   | 'update'
@@ -151,6 +155,10 @@ const translations: Record<string, Translations> = {
     page_not_found: 'Page not found',
     page_not_found_description: 'The page you are looking for does not exist.',
     back_to_blog: 'Back to blog',
+    claim_title_blog: "This blog isn't set up yet",
+    claim_title_community: "This community isn't set up yet",
+    claim_subtitle: 'Is this yours? Claim it and launch on Ecency in minutes.',
+    claim_cta: 'Claim on Ecency',
     edit_post: 'Edit',
     updating: 'Updating...',
     update: 'Update',
@@ -234,6 +242,10 @@ const translations: Record<string, Translations> = {
     page_not_found: 'Página no encontrada',
     page_not_found_description: 'La página que buscas no existe.',
     back_to_blog: 'Volver al blog',
+    claim_title_blog: "This blog isn't set up yet",
+    claim_title_community: "This community isn't set up yet",
+    claim_subtitle: 'Is this yours? Claim it and launch on Ecency in minutes.',
+    claim_cta: 'Claim on Ecency',
     edit_post: 'Editar',
     updating: 'Actualizando...',
     update: 'Actualizar',
@@ -317,6 +329,10 @@ const translations: Record<string, Translations> = {
     page_not_found: 'Seite nicht gefunden',
     page_not_found_description: 'Die gesuchte Seite existiert nicht.',
     back_to_blog: 'Zurück zum Blog',
+    claim_title_blog: "This blog isn't set up yet",
+    claim_title_community: "This community isn't set up yet",
+    claim_subtitle: 'Is this yours? Claim it and launch on Ecency in minutes.',
+    claim_cta: 'Claim on Ecency',
     edit_post: 'Bearbeiten',
     updating: 'Aktualisierung...',
     update: 'Aktualisieren',
@@ -401,6 +417,10 @@ const translations: Record<string, Translations> = {
     page_not_found: 'Page non trouvée',
     page_not_found_description: "La page que vous recherchez n'existe pas.",
     back_to_blog: 'Retour au blog',
+    claim_title_blog: "This blog isn't set up yet",
+    claim_title_community: "This community isn't set up yet",
+    claim_subtitle: 'Is this yours? Claim it and launch on Ecency in minutes.',
+    claim_cta: 'Claim on Ecency',
     edit_post: 'Modifier',
     updating: 'Mise à jour...',
     update: 'Mettre à jour',
@@ -484,6 +504,10 @@ const translations: Record<string, Translations> = {
     page_not_found: '페이지를 찾을 수 없습니다',
     page_not_found_description: '찾으시는 페이지가 존재하지 않습니다.',
     back_to_blog: '블로그로 돌아가기',
+    claim_title_blog: "This blog isn't set up yet",
+    claim_title_community: "This community isn't set up yet",
+    claim_subtitle: 'Is this yours? Claim it and launch on Ecency in minutes.',
+    claim_cta: 'Claim on Ecency',
     edit_post: '편집',
     updating: '업데이트 중...',
     update: '업데이트',
@@ -567,6 +591,10 @@ const translations: Record<string, Translations> = {
     page_not_found: 'Страница не найдена',
     page_not_found_description: 'Запрашиваемая страница не существует.',
     back_to_blog: 'Вернуться в блог',
+    claim_title_blog: "This blog isn't set up yet",
+    claim_title_community: "This community isn't set up yet",
+    claim_subtitle: 'Is this yours? Claim it and launch on Ecency in minutes.',
+    claim_cta: 'Claim on Ecency',
     edit_post: 'Редактировать',
     updating: 'Обновление...',
     update: 'Обновить',

--- a/apps/self-hosted/src/features/claim/claim-landing.test.ts
+++ b/apps/self-hosted/src/features/claim/claim-landing.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseClaimTarget } from "./parse-claim-target";
+
+// The claim landing derives the target name and instance type from the hostname alone: a
+// hive-<digits> label is a community, anything else an author blog. Drives the title copy and the
+// ?claim= deep link to the hosting page.
+describe("parseClaimTarget", () => {
+  it("treats hive-<digits> subdomains as communities", () => {
+    expect(parseClaimTarget("hive-125126.blogs.ecency.com")).toEqual({
+      name: "hive-125126",
+      isCommunity: true,
+    });
+  });
+
+  it("treats a bare username subdomain as an author blog", () => {
+    expect(parseClaimTarget("alice.blogs.ecency.com")).toEqual({
+      name: "alice",
+      isCommunity: false,
+    });
+  });
+
+  it("does not mistake a hive-prefixed username for a community", () => {
+    // Only hive-<digits> is a community; a name like 'hive-fan' is an ordinary author.
+    expect(parseClaimTarget("hive-fan.blogs.ecency.com")).toEqual({
+      name: "hive-fan",
+      isCommunity: false,
+    });
+  });
+
+  it("falls back to the whole host when there is no subdomain", () => {
+    expect(parseClaimTarget("localhost")).toEqual({ name: "localhost", isCommunity: false });
+  });
+
+  it("handles an empty host without throwing", () => {
+    expect(parseClaimTarget("")).toEqual({ name: "", isCommunity: false });
+  });
+});

--- a/apps/self-hosted/src/features/claim/claim-landing.tsx
+++ b/apps/self-hosted/src/features/claim/claim-landing.tsx
@@ -8,9 +8,11 @@ import { parseClaimTarget } from "./parse-claim-target";
  * working blog full of someone else's content, it invites the visitor to claim the subdomain.
  *
  * The instance type is derived from the hostname client-side: a `hive-<digits>` label reads as a
- * community, anything else as an author blog. noindex is emitted server-side via public/meta.html
- * (the SSI fallback for unclaimed hosts); the runtime meta below is a belt-and-suspenders for
- * JS-capable crawlers.
+ * community, anything else as an author blog. The noindex meta is set here at runtime rather than
+ * in the shared static meta.html: that fallback is also served when a CLAIMED tenant's own meta is
+ * momentarily missing, so a static noindex there could deindex a live blog. Gating it on the same
+ * `template` flag that renders this page keeps it scoped to genuinely unclaimed hosts (Googlebot
+ * renders JS, and unclaimed subdomains carry no inbound links to index anyway).
  */
 const HOSTING_URL = "https://ecency.com/hosting";
 const BASE_DOMAIN = "blogs.ecency.com";
@@ -24,8 +26,7 @@ export function ClaimLanding() {
   useEffect(() => {
     const prevTitle = document.title;
     document.title = title;
-    // Keep unclaimed placeholders out of the index even for JS-running crawlers. The static
-    // fallback meta.html sets the same header for everyone else.
+    // Keep unclaimed placeholders out of the search index (only ever runs on a `template` host).
     const meta = document.createElement("meta");
     meta.name = "robots";
     meta.content = "noindex, nofollow";

--- a/apps/self-hosted/src/features/claim/claim-landing.tsx
+++ b/apps/self-hosted/src/features/claim/claim-landing.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+import { t } from "@/core";
+import { parseClaimTarget } from "./parse-claim-target";
+
+/**
+ * Shown on an UNCLAIMED *.blogs.ecency.com subdomain, which nginx serves the shared default
+ * template config (carrying `template: true`) because no tenant row exists yet. Instead of a
+ * working blog full of someone else's content, it invites the visitor to claim the subdomain.
+ *
+ * The instance type is derived from the hostname client-side: a `hive-<digits>` label reads as a
+ * community, anything else as an author blog. noindex is emitted server-side via public/meta.html
+ * (the SSI fallback for unclaimed hosts); the runtime meta below is a belt-and-suspenders for
+ * JS-capable crawlers.
+ */
+const HOSTING_URL = "https://ecency.com/hosting";
+const BASE_DOMAIN = "blogs.ecency.com";
+
+export function ClaimLanding() {
+  const host = typeof window !== "undefined" ? window.location.hostname : "";
+  const { name, isCommunity } = parseClaimTarget(host);
+  const title = isCommunity ? t("claim_title_community") : t("claim_title_blog");
+  const claimHref = `${HOSTING_URL}?claim=${encodeURIComponent(name)}`;
+
+  useEffect(() => {
+    const prevTitle = document.title;
+    document.title = title;
+    // Keep unclaimed placeholders out of the index even for JS-running crawlers. The static
+    // fallback meta.html sets the same header for everyone else.
+    const meta = document.createElement("meta");
+    meta.name = "robots";
+    meta.content = "noindex, nofollow";
+    document.head.appendChild(meta);
+    return () => {
+      document.title = prevTitle;
+      meta.remove();
+    };
+  }, [title]);
+
+  return (
+    <div className="min-h-screen bg-theme-primary flex items-center justify-center px-4">
+      <div className="text-center max-w-lg">
+        <div className="text-sm font-medium text-theme-muted mb-3">
+          {name}.{BASE_DOMAIN}
+        </div>
+        <h1 className="text-3xl sm:text-4xl font-bold mb-4 heading-theme">{title}</h1>
+        <p className="text-theme-muted mb-8">{t("claim_subtitle")}</p>
+        <a
+          href={claimHref}
+          className="inline-block px-6 py-3 rounded-lg bg-black text-white hover:bg-black/80 transition-colors font-medium"
+        >
+          {t("claim_cta")}
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default ClaimLanding;

--- a/apps/self-hosted/src/features/claim/index.ts
+++ b/apps/self-hosted/src/features/claim/index.ts
@@ -1,0 +1,2 @@
+export { ClaimLanding } from "./claim-landing";
+export { parseClaimTarget } from "./parse-claim-target";

--- a/apps/self-hosted/src/features/claim/parse-claim-target.ts
+++ b/apps/self-hosted/src/features/claim/parse-claim-target.ts
@@ -1,0 +1,9 @@
+/**
+ * Derive the claim target from a hostname. A `hive-<digits>` label reads as a community, anything
+ * else as an author blog. Pure and dependency-free so it can be unit-tested without pulling in the
+ * runtime config/i18n. "hive-125126.blogs.ecency.com" -> { name: "hive-125126", isCommunity: true }.
+ */
+export function parseClaimTarget(host: string): { name: string; isCommunity: boolean } {
+  const label = (host || "").split(".")[0] || host || "";
+  return { name: label, isCommunity: /^hive-\d+$/i.test(label) };
+}

--- a/apps/self-hosted/src/routes/__root.tsx
+++ b/apps/self-hosted/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import { ConfigManager } from "@ecency/sdk";
 import { queryClient } from "@/consts/react-query";
 import { FloatingMenu } from "@/features/floating-menu";
 import { AuthProvider, useIsBlogOwner } from "@/features/auth";
+import { ClaimLanding } from "@/features/claim";
 import { ErrorBoundary, SkipToContent } from "@/features/shared";
 import {
   clearHiveAuthSession,
@@ -13,7 +14,7 @@ import {
   getUser,
 } from "@/features/auth/storage";
 import { authenticationStore } from "@/store";
-import { t } from "@/core";
+import { t, InstanceConfigManager } from "@/core";
 
 // Check if we're in development mode
 const isDev = process.env.NODE_ENV === "development";
@@ -60,6 +61,13 @@ export const Route = createRootRoute({
 });
 
 function RootComponent() {
+  // Unclaimed *.blogs.ecency.com subdomains are served the shared default template config, which
+  // carries `template: true`. Short-circuit the whole app to the claim landing so no route renders
+  // someone else's content. Reactive so it flips once the runtime config replaces the build-time one.
+  const isTemplate = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.instanceConfiguration.template === true
+  );
+
   return (
     <QueryClientProvider client={queryClient}>
       {isDev && (
@@ -69,10 +77,14 @@ function RootComponent() {
       )}
       <SkipToContent />
       <ErrorBoundary>
-        <AuthProvider>
-          <Outlet />
-          <AuthorizedFloatingMenu />
-        </AuthProvider>
+        {isTemplate ? (
+          <ClaimLanding />
+        ) : (
+          <AuthProvider>
+            <Outlet />
+            <AuthorizedFloatingMenu />
+          </AuthProvider>
+        )}
       </ErrorBoundary>
     </QueryClientProvider>
   );

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -270,6 +270,25 @@ export function HostingSignup() {
     }
   }, [resumeName, step, tenantUsername, activeUser, goPayment]);
 
+  // Deep-link from an unclaimed *.blogs.ecency.com subdomain's claim landing: ?claim=<name>
+  // prefills the form so the visitor arrives ready to reserve that exact name. A hive-<digits>
+  // name preselects a community, anything else an author blog. Prefill only, no auto-advance: the
+  // visitor still reviews the plan and pays, and the usual validation applies. Runs once and
+  // consumes the param so a refresh doesn't re-apply it.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const claim = new URLSearchParams(window.location.search).get("claim")?.trim().toLowerCase();
+    if (!claim) return;
+    window.history.replaceState(null, "", window.location.pathname);
+    if (/^hive-\d+$/.test(claim)) {
+      setInstanceType("community");
+      setCommunityId(claim);
+    } else {
+      setInstanceType("blog");
+      setUsername(claim);
+    }
+  }, []);
+
   // HBD: refresh instructions for the selected term (and custom-domain add-on). Guard against a
   // slow earlier response (a different term/tier) landing after a newer one and showing a
   // mismatched amount/memo. With the add-on the endpoint returns the higher price and a ':domain'

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -277,9 +277,14 @@ export function HostingSignup() {
   // consumes the param so a refresh doesn't re-apply it.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const claim = new URLSearchParams(window.location.search).get("claim")?.trim().toLowerCase();
+    const params = new URLSearchParams(window.location.search);
+    const claim = params.get("claim")?.trim().toLowerCase();
     if (!claim) return;
-    window.history.replaceState(null, "", window.location.pathname);
+    // Consume ONLY the claim param, preserving any others (e.g. resume) so the resume effect,
+    // which reads window.location.search after auth state is available, still sees them.
+    params.delete("claim");
+    const qs = params.toString();
+    window.history.replaceState(null, "", window.location.pathname + (qs ? `?${qs}` : ""));
     if (/^hive-\d+$/.test(claim)) {
       setInstanceType("community");
       setCommunityId(claim);


### PR DESCRIPTION
Any unclaimed subdomain (no tenant row yet, e.g. hive-125126.blogs.ecency.com) was served the shared default template config, which showed @ecency's blog under a generic "My Hive Blog" title. That confuses visitors and creates thin/duplicate content across infinite hostnames.

### What changes
The managed default config now carries an explicit `template: true` flag (present only on the managed default, never on a real tenant or a genuine self-host). When the app sees it, the whole SPA short-circuits to a claim landing instead of rendering any blog content.

- **Type-aware, templated from the hostname:** a `hive-<digits>` label reads as a community, anything else as an author blog, so the title and copy fit the subdomain. No per-subdomain files and no on-chain lookups.
- **Claim CTA:** links to `ecency.com/hosting?claim=<name>`. The hosting form now reads `?claim=` to prefill the name and instance type. Prefill only, no auto-advance: the visitor still reviews the plan and pays, and the usual validation applies.
- **noindex:** the static `meta.html` (the SSI fallback served only for unclaimed hosts on the managed nginx, and inert for self-hosters who run without SSI) now emits `robots: noindex, nofollow`; the landing sets the same at runtime for JS crawlers. Claimed tenants keep their own indexable meta.

### Safety
- `template: true` is injected only into the managed default config, so a real tenant or a true self-host never shows the claim landing.
- The self-host Docker image uses the simpler nginx that does not SSI-include `meta.html`, so the noindex only affects managed unclaimed subdomains.

### Tests
- New unit test for the hostname-to-target parser (community vs author, hive-prefixed username, empty host). Self-hosted suite: 36 pass. tsc clean on changed files; web hosting-signup tsc clean.

Follows the earlier decision to keep custom domains on CNAME + DNS-only and to split defaults by community vs author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a claim landing page for unclaimed blog and community subdomains.
  * Added localized claim messaging and a call-to-action linking to hosted signup.
  * Signup links can now prefill blog or community details from claim links.
  * Added support for identifying community claim targets from their subdomain.
* **Bug Fixes**
  * Prevented unclaimed placeholder pages from appearing in search engine results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->