### PR TITLE
fix(types): annotate implicit-any params in web (TS7006, chunk 1)

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/friends-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/friends-list.tsx
@@ -1,7 +1,11 @@
 import { useMemo, useState } from "react";
 import clsx from "clsx";
 import "./_index.scss";
-import { getFriendsInfiniteQueryOptions, getSearchFriendsQueryOptions } from "@ecency/sdk";
+import {
+  FriendsRow,
+  getFriendsInfiniteQueryOptions,
+  getSearchFriendsQueryOptions
+} from "@ecency/sdk";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Account } from "@/entities";
 import { Button } from "@ui/button";
@@ -61,7 +65,7 @@ export const FriendsList = ({ account, mode, variant = "modal" }: Props) => {
       ? searchData ?? []
       : data?.pages?.flat() ?? [];
 
-    const filtered = rawItems.filter((item) => {
+    const filtered = rawItems.filter((item: FriendsRow) => {
       if (!type) return true;
 
       const lastSeenTime = dayjs(item.active).toDate();
@@ -83,7 +87,7 @@ export const FriendsList = ({ account, mode, variant = "modal" }: Props) => {
       );
     });
 
-    return filtered.map((item) => ({
+    return filtered.map((item: FriendsRow) => ({
       name: item.name,
       reputation: item.reputation,
       lastSeen: dayjs(item.active).fromNow()

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-infinite-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-infinite-list.tsx
@@ -35,7 +35,7 @@ export function ProfileEntriesInfiniteList({
     const relevantPages = dropFirstPage ? pages.slice(1) : pages;
     return (
       relevantPages
-        ?.reduce<Entry[]>((acc, page) => [...acc, ...(page as Entry[])], [])
+        ?.reduce<Entry[]>((acc: Entry[], page: Entry[]) => [...acc, ...page], [])
         ?.filter((item: Entry) => item.permlink !== account.profile?.pinned) ?? []
     );
   }, [account.profile?.pinned, data?.pages, dropFirstPage]);

--- a/apps/web/src/app/chats/_components/chats-client.tsx
+++ b/apps/web/src/app/chats/_components/chats-client.tsx
@@ -25,7 +25,7 @@ import { FormControl } from "@ui/input";
 import { Button } from "@ui/button";
 import { Dropdown, DropdownItemWithIcon, DropdownMenu, DropdownToggle } from "@ui/dropdown";
 import { checkSvg, dotsHorizontal, settingsSvg, volumeOffSvg } from "@ui/svg";
-import { MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChangeEvent, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
 import { useChatAdminStore } from "@/features/chat/chat-admin-store";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
@@ -437,7 +437,7 @@ export function ChatsClient() {
             type="search"
             placeholder={i18next.t("chat.search-channels")}
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
             className="w-full"
           />
           {searchTerm && (

--- a/apps/web/src/app/decks/_components/columns/content-viewer/deck-topics-content-viewer.tsx
+++ b/apps/web/src/app/decks/_components/columns/content-viewer/deck-topics-content-viewer.tsx
@@ -6,6 +6,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { arrowLeftSvg } from "@ui/svg";
 import { useMounted } from "@/utils/use-mounted";
 import { makeEntryPath } from "@/utils";
+import { Entry } from "@/entities";
 
 interface Props {
   topic: string;
@@ -17,7 +18,7 @@ export const DeckTopicsContentViewer = ({ onClose, backTitle, topic }: Props) =>
   const { data } = useInfiniteQuery(getPostsRankedInfiniteQueryOptions("trending", "", 20, topic));
 
   const dataFlow = useMemo(
-    () => data?.pages?.reduce((acc, item) => [...acc, ...item], []) ?? [],
+    () => data?.pages?.reduce((acc: Entry[], item: Entry[]) => [...acc, ...item], []) ?? [],
     [data]
   );
   const isMounted = useMounted();
@@ -46,7 +47,7 @@ export const DeckTopicsContentViewer = ({ onClose, backTitle, topic }: Props) =>
         </div>
       </div>
       <div>
-        {dataFlow?.map((item: any, index) => (
+        {dataFlow?.map((item: any, index: number) => (
           <div className="virtual-list-item" key={item.post_id}>
             <SearchListItem
               index={index + 1}

--- a/apps/web/src/app/decks/_components/columns/deck-wallet-column.tsx
+++ b/apps/web/src/app/decks/_components/columns/deck-wallet-column.tsx
@@ -31,7 +31,7 @@ export const DeckWalletColumn = ({ id, settings, draggable }: Props) => {
   const [isFirstLoaded, setIsFirstLoaded] = useState(false);
 
   const dataFlow = useMemo(
-    () => data?.pages?.flatMap((page) => page.entries) ?? [],
+    () => data?.pages?.flatMap((page: { entries: Transaction[] }) => page.entries) ?? [],
     [data]
   ) as IdentifiableTransaction[];
 

--- a/apps/web/src/app/market/advanced/_advanced-mode/pairs/hive-hbd-observer.tsx
+++ b/apps/web/src/app/market/advanced/_advanced-mode/pairs/hive-hbd-observer.tsx
@@ -80,7 +80,9 @@ export const HiveHbdObserver = ({
 
   useEffect(() => {
     setAllOrders(
-      transactions?.pages?.[0]?.entries?.filter((item) => item.type === "limit_order_create") ?? []
+      transactions?.pages?.[0]?.entries?.filter(
+        (item: Transaction) => item.type === "limit_order_create"
+      ) ?? []
     );
   }, [setAllOrders, transactions]);
 

--- a/apps/web/src/app/proposals/_components/proposal-vote-btn/index.tsx
+++ b/apps/web/src/app/proposals/_components/proposal-vote-btn/index.tsx
@@ -3,7 +3,7 @@ import i18next from "i18next";
 import "./_index.scss";
 import { LoginRequired } from "@/features/shared";
 import { useProposalVoteMutation } from "@/api/sdk-mutations";
-import { getProposalVotesInfiniteQueryOptions } from "@ecency/sdk";
+import { getProposalVotesInfiniteQueryOptions, ProposalVoteRow } from "@ecency/sdk";
 import { UilArrowUp } from "@tooni/iconscout-unicons-react";
 import { Button } from "@ui/button";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
@@ -20,7 +20,11 @@ export function ProposalVoteBtn({ proposal }: Props) {
     getProposalVotesInfiniteQueryOptions(proposal, activeUser?.username ?? "", 1)
   );
   const votes = useMemo(
-    () => data?.pages?.reduce((acc, page) => [...acc, ...page], []),
+    () =>
+      data?.pages?.reduce(
+        (acc: ProposalVoteRow[], page: ProposalVoteRow[]) => [...acc, ...page],
+        []
+      ),
     [data?.pages]
   );
   const voted = useMemo(

--- a/apps/web/src/app/proposals/_components/proposal-votes/index.tsx
+++ b/apps/web/src/app/proposals/_components/proposal-votes/index.tsx
@@ -12,12 +12,24 @@ import { Entry, Proposal } from "@/entities";
 import { LinearProgress, ProfileLink, ProfilePopover, UserAvatar } from "@/features/shared";
 import { accountReputation, parseAsset } from "@/utils";
 import { DEFAULT_DYNAMIC_PROPS } from "@/consts/default-dynamic-props";
-import { getDynamicPropsQueryOptions, getProposalVotesInfiniteQueryOptions } from "@ecency/sdk";
+import {
+  getDynamicPropsQueryOptions,
+  getProposalVotesInfiniteQueryOptions,
+  ProposalVoteRow
+} from "@ecency/sdk";
 import { Spinner } from "@ui/spinner";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Pagination } from "@/features/ui";
 
 type SortOption = "reputation" | "hp";
+
+type VoterRow = {
+  name: string;
+  reputation: string | number;
+  hp: number;
+  proxyHp: number;
+  totalHp: number;
+};
 
 interface ProposalVotesProps {
   proposal: Proposal;
@@ -39,7 +51,11 @@ export function ProposalVotes({ proposal, onHide }: ProposalVotesProps) {
   } = useInfiniteQuery(getProposalVotesInfiniteQueryOptions(proposal.proposal_id, "", 1000));
 
   const votes = useMemo(
-    () => votesPages?.pages?.reduce((acc, page) => [...acc, ...page], []),
+    () =>
+      votesPages?.pages?.reduce(
+        (acc: ProposalVoteRow[], page: ProposalVoteRow[]) => [...acc, ...page],
+        []
+      ),
     [votesPages?.pages]
   );
 
@@ -67,9 +83,10 @@ export function ProposalVotes({ proposal, onHide }: ProposalVotesProps) {
           };
         })
         .filter(
-          (item) => !searchText || item.name.toLowerCase().includes(searchText.toLocaleLowerCase())
+          (item: VoterRow) =>
+            !searchText || item.name.toLowerCase().includes(searchText.toLocaleLowerCase())
         )
-        .sort((a, b) => {
+        .sort((a: VoterRow, b: VoterRow) => {
           if (sort === "reputation") {
             return b.reputation > a.reputation ? 1 : -1;
           }
@@ -138,7 +155,7 @@ export function ProposalVotes({ proposal, onHide }: ProposalVotesProps) {
         <div className="voters-list mb-4">
           <List grid={true} inline={true} defer={true}>
             {(voters?.length ?? 0) > 0 ? (
-              paginatedVoters?.map((x, index) => {
+              paginatedVoters?.map((x: VoterRow, index: number) => {
                 const strHp = numeral(x.hp).format("0.00,");
                 const strProxyHp = numeral(x.proxyHp).format("0.00,");
 

--- a/apps/web/src/app/publish/_editor-extensions/publish-editor-poll-editor.tsx
+++ b/apps/web/src/app/publish/_editor-extensions/publish-editor-poll-editor.tsx
@@ -120,7 +120,7 @@ export function PublishEditorPollEditor() {
           <div className="flex flex-col items-start gap-4 mt-4">
             <div>{i18next.t("polls.choices")}</div>
 
-            {poll.choices.map((choice, index) => (
+            {poll.choices.map((choice: string, index: number) => (
               <div key={index} className="animate-fade-in-up flex w-full items-center gap-2">
                 <FormControl
                   type="text"
@@ -143,7 +143,7 @@ export function PublishEditorPollEditor() {
                     onClick={() =>
                       setPoll({
                         ...poll,
-                        choices: poll.choices.filter((_, i) => i !== index)
+                        choices: poll.choices.filter((_: string, i: number) => i !== index)
                       })
                     }
                     aria-label={i18next.t("polls.remove-choice", { defaultValue: "Remove choice" })}

--- a/apps/web/src/app/search/_components/search-comment/index.tsx
+++ b/apps/web/src/app/search/_components/search-comment/index.tsx
@@ -125,7 +125,7 @@ export function SearchComment({ disableResults }: Props) {
           if (results.length > 0 && !disableResults) {
             return (
               <div className="search-list">
-                {results.map((res) => (
+                {results.map((res: SearchResult) => (
                   <Fragment key={`${res.author}-${res.permlink}`}>
                     <SearchListItem res={res} />
                   </Fragment>

--- a/apps/web/src/features/shared/navbar/matchMedia.tsx
+++ b/apps/web/src/features/shared/navbar/matchMedia.tsx
@@ -1,6 +1,6 @@
 Object.defineProperty(window, "matchMedia", {
   writable: true,
-  value: jest.fn().mockImplementation((query) => ({
+  value: jest.fn().mockImplementation((query: string) => ({
     matches: false,
     media: query,
     onchange: null,

--- a/apps/web/src/features/shared/transactions/index.tsx
+++ b/apps/web/src/features/shared/transactions/index.tsx
@@ -9,7 +9,7 @@ import i18next from "i18next";
 import { LinearProgress } from "@/features/shared";
 import { OperationGroup } from "@/consts";
 import { getTransactionsInfiniteQueryOptions } from "@ecency/sdk";
-import { Account } from "@/entities";
+import { Account, Transaction } from "@/entities";
 import useMount from "react-use/lib/useMount";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
@@ -30,11 +30,15 @@ export const TransactionsList = ({ account }: Props) => {
     refetch
   } = useInfiniteQuery(getTransactionsInfiniteQueryOptions(account.name, 20, group));
   const transactionsFlow = useMemo(
-    () => transactionsList?.pages?.flatMap((page) => page.entries) ?? [],
+    () =>
+      transactionsList?.pages?.flatMap((page: { entries: Transaction[] }) => page.entries) ?? [],
     [transactionsList?.pages]
   );
   const uniqueTransactionsList = useMemo(
-    () => Array.from(new Map(transactionsFlow.map((item) => [item["num"], item])).values()),
+    () =>
+      Array.from(
+        new Map(transactionsFlow.map((item: Transaction) => [item["num"], item])).values()
+      ),
     [transactionsFlow]
   );
 

--- a/apps/web/src/features/shared/transfer/transfer-step-1-to.tsx
+++ b/apps/web/src/features/shared/transfer/transfer-step-1-to.tsx
@@ -5,6 +5,7 @@ import { TransferFormText } from "@/features/shared/transfer/transfer-form-text"
 import React, { useContext, useMemo } from "react";
 import { TransferSharedStateContext } from "@/features/shared/transfer/transfer-shared-state";
 import { getTransactionsInfiniteQueryOptions } from "@ecency/sdk";
+import { Transaction } from "@/entities";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
@@ -20,7 +21,7 @@ export function TransferStep1To({ toWarning, toError }: Props) {
 
   const { data: transactions } = useInfiniteQuery(getTransactionsInfiniteQueryOptions(activeUser?.username));
   const transactionsFlow = useMemo(
-    () => transactions?.pages?.flatMap((page) => page.entries) ?? [],
+    () => transactions?.pages?.flatMap((page: { entries: Transaction[] }) => page.entries) ?? [],
     [transactions]
   );
 
@@ -30,14 +31,14 @@ export function TransferStep1To({ toWarning, toError }: Props) {
         new Set(
           transactionsFlow
             .filter(
-              (x) =>
+              (x: Transaction) =>
                 (x.type === "transfer" && x.from === activeUser?.username) ||
                 (x.type === "delegate_vesting_shares" && x.delegator === activeUser?.username)
             )
-            .map((x) =>
+            .map((x: Transaction) =>
               x.type === "transfer" ? x.to : x.type === "delegate_vesting_shares" ? x.delegatee : ""
             )
-            .filter((x) => {
+            .filter((x: string) => {
               if (to!.trim() === "") {
                 return true;
               }

--- a/apps/web/src/features/ui/input/key-input.tsx
+++ b/apps/web/src/features/ui/input/key-input.tsx
@@ -36,7 +36,7 @@ export interface KeyInputImperativeHandle {
   } | null>;
 }
 
-function capitalizeFirstLetter(str) {
+function capitalizeFirstLetter(str: string | undefined) {
     if (typeof str !== 'string' || str.length === 0) return '';
     return str[0].toUpperCase() + str.slice(1);
 }


### PR DESCRIPTION
First chunk of the web-app typecheck cleanup (the packages are already `tsc --noEmit` clean). Goal is to reach a `pnpm typecheck` gate; this PR clears one coherent error class so reviews stay small.

**TS7006 (implicit-any parameters): 32 -> 0. Web total 199 -> 167.**

All 32 are callback params (reduce / flatMap / map / filter / sort over infinite-query pages, plus a few event/util params) that were implicit-any. Each now gets its real type:

- Domain types imported where available: `Entry`, `Transaction`, `ProposalVoteRow`, `FriendsRow`, `SearchResult`, `ChangeEvent<HTMLInputElement>`.
- The three transaction `flatMap` sites use a minimal `{ entries: Transaction[] }` structural type because the SDK's page type is not exported.
- One local `VoterRow` type for the mapped voter shape in proposal-votes.
- Drops one now-redundant `page as Entry[]` cast.

**No `any` introduced; no runtime change** (annotations only). The one remaining `item: any` in deck-topics is pre-existing.

**Why the cluster exists:** `useInfiniteQuery(getX(...))` currently resolves `data` to the page type instead of `InfiniteData<page>`, so `data.pages` is `any`. That underlying react-query typing gap is a separate class (TS2339) and is handled in a later chunk.

Typecheck 167/0-TS7006 verified; `eslint` clean (0 errors); touched files are annotation-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety across profile, chat, proposal, search, publishing, transaction, transfer, and wallet components.
  * Added explicit typing for lists, filters, sorting, event handlers, and flattened data.
  * No visible changes to functionality or user interface behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->