### PR TITLE
fix(keys): derive the posting key for posting-authority signing

### DIFF
--- a/apps/web/src/features/ui/input/key-input.tsx
+++ b/apps/web/src/features/ui/input/key-input.tsx
@@ -22,7 +22,7 @@ import clsx from "clsx";
 interface Props {
   isLoading?: boolean;
   onSign?: (key: PrivateKey) => void;
-  keyType?: "owner" | "active" | "memo";
+  keyType?: "owner" | "active" | "posting" | "memo";
 }
 
 export interface KeyInputImperativeHandle {
@@ -84,15 +84,21 @@ export const KeyInput = forwardRef<
             key,
             // detectHiveKeyDerivation only classifies the input format
             // (bip44 seed vs master password) against an owner/active
-            // authority. Memo keys are derived in the keyType === "memo"
-            // branches below, so classify against "active" here.
-            keyType === "memo" ? "active" : keyType
+            // authority. Posting and memo keys are derived from that same
+            // input in the branches below, so classify against "active" here.
+            keyType === "memo" || keyType === "posting" ? "active" : keyType
           );
 
           if (derivation === "bip44") {
             const keys = deriveHiveKeys(key);
+            // Every authority is mapped explicitly. "posting" used to fall
+            // through to keys.owner, so a posting-authority upgrade derived
+            // and signed with the owner key. The trailing keys.owner now
+            // covers only keyType "owner" and the callers that omit keyType
+            // and authenticate against the owner authority.
             const derivedKey =
               keyType === "active" ? keys.active :
+              keyType === "posting" ? keys.posting :
               keyType === "memo" ? keys.memo :
               keys.owner;
             privateKey = PrivateKey.fromString(derivedKey);

--- a/apps/web/src/specs/features/ui/key-input.spec.tsx
+++ b/apps/web/src/specs/features/ui/key-input.spec.tsx
@@ -6,7 +6,8 @@ import { createRef } from "react";
 const h = vi.hoisted(() => ({
   activeUser: { username: "testuser" } as { username: string } | null,
   errorSpy: vi.fn(),
-  setSigningKey: vi.fn()
+  setSigningKey: vi.fn(),
+  detectSpy: vi.fn(async () => "bip44")
 }));
 
 // KeyInput imports only `error` from the shared barrel; stub it to a spy so we
@@ -24,15 +25,34 @@ vi.mock("@/core/hooks/use-active-account", () => ({
   useActiveAccount: () => ({ activeUser: h.activeUser })
 }));
 
+// KeyInput lazy-imports these; distinct sentinel values per authority let the
+// derivation assertions below tell exactly which key was picked.
+const DERIVED = {
+  owner: "OWNER_WIF",
+  active: "ACTIVE_WIF",
+  posting: "POSTING_WIF",
+  memo: "MEMO_WIF"
+};
+
+vi.mock("@ecency/wallets", () => ({
+  deriveHiveKeys: () => DERIVED,
+  detectHiveKeyDerivation: (...args: unknown[]) => h.detectSpy(...args)
+}));
+
 import { KeyInput, KeyInputImperativeHandle } from "@ui/input";
 import { isWif, PrivateKey } from "@ecency/sdk";
 
 const mockIsWif = vi.mocked(isWif);
 const mockFromString = vi.mocked(PrivateKey.fromString);
 
-function setup(value?: string) {
+const SEED = "some twelve word mnemonic phrase used only for this test";
+
+function setup(
+  value?: string,
+  keyType: "owner" | "active" | "posting" | "memo" = "active"
+) {
   const ref = createRef<KeyInputImperativeHandle>();
-  const { container } = render(<KeyInput ref={ref} keyType="active" />);
+  const { container } = render(<KeyInput ref={ref} keyType={keyType} />);
   const input = container.querySelector('input[type="password"]') as HTMLInputElement;
   if (value !== undefined) {
     fireEvent.change(input, { target: { value } });
@@ -127,5 +147,59 @@ describe("KeyInput.handleSign contract", () => {
     });
 
     expect(h.errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("KeyInput bip44 derivation picks the requested authority", () => {
+  beforeEach(() => {
+    h.activeUser = { username: "testuser" };
+    h.errorSpy.mockClear();
+    h.setSigningKey.mockClear();
+    h.detectSpy.mockClear();
+    mockIsWif.mockReset().mockReturnValue(false);
+    mockFromString.mockReset().mockReturnValue({} as unknown as PrivateKey);
+  });
+
+  afterEach(cleanup);
+
+  it.each([
+    ["owner", DERIVED.owner],
+    ["active", DERIVED.active],
+    ["posting", DERIVED.posting],
+    ["memo", DERIVED.memo]
+  ] as const)("derives the %s key from a bip44 seed", async (keyType, expected) => {
+    const { ref } = setup(SEED, keyType);
+
+    await act(async () => {
+      await ref.current!.handleSign();
+    });
+
+    expect(mockFromString).toHaveBeenCalledWith(expected);
+  });
+
+  // Regression guard: "posting" was missing from the keyType union and fell
+  // through to keys.owner, so a posting-authority upgrade derived and signed
+  // with the account's owner key.
+  it("never derives the owner key for a posting-authority request", async () => {
+    const { ref } = setup(SEED, "posting");
+
+    await act(async () => {
+      await ref.current!.handleSign();
+    });
+
+    expect(mockFromString).toHaveBeenCalledWith(DERIVED.posting);
+    expect(mockFromString).not.toHaveBeenCalledWith(DERIVED.owner);
+  });
+
+  // detectHiveKeyDerivation only accepts owner/active, so posting (like memo)
+  // has to be classified against "active" rather than passed straight through.
+  it("classifies a posting request against the active authority", async () => {
+    const { ref } = setup(SEED, "posting");
+
+    await act(async () => {
+      await ref.current!.handleSign();
+    });
+
+    expect(h.detectSpy).toHaveBeenCalledWith("testuser", SEED, "active");
   });
 });


### PR DESCRIPTION
`KeyInput`'s `keyType` union was `"owner" | "active" | "memo"`, and the bip44 branch picked the key with a chain ending in a bare `keys.owner` fallback:

```ts
const derivedKey =
  keyType === "active" ? keys.active :
  keyType === "memo" ? keys.memo :
  keys.owner;
```

The auth-upgrade dialog computes `authority` as `"posting" | "active" | "owner"` and passes it as `keyType`, so a **posting**-authority request hit that fallback and derived, then signed with, the account's **owner** key. The master-password branch was already correct, since it forwards the authority to `PrivateKey.fromLogin`; only bip44 input was affected.

## Change
- `"posting"` added to the `keyType` union and mapped to `keys.posting` (`deriveHiveKeys` already derives it).
- Posting is classified against `"active"` when detecting the input format, exactly as memo already is, because `detectHiveKeyDerivation` only accepts `owner`/`active`.
- The trailing `keys.owner` now covers only `keyType === "owner"` and the callers that intentionally omit `keyType` to authenticate against the owner authority, so **no existing caller changes behaviour**. `key-or-hot` passes only `"owner" | "active"`, and `manage-key-password-dialog` consumes `raw` and does its own derivation.

## Tests
Adds a per-authority derivation suite (owner/active/posting/memo each resolve to their own key) plus two targeted guards: posting must never resolve to the owner key, and posting must be classified against `active`. **All three new assertions fail against the previous code and pass with this change** (verified by reverting the fix and re-running).

Web typecheck 127 -> 126 (this also clears the `auth-upgrade-dialog` assignability error), 20 related specs pass, eslint clean.
