### PR TITLE
fix(docker): copy patches before pnpm install

### DIFF
--- a/apps/self-hosted/Dockerfile
+++ b/apps/self-hosted/Dockerfile
@@ -38,6 +38,8 @@ COPY packages/sdk/package.json ./packages/sdk/
 COPY packages/render-helper/package.json ./packages/render-helper/
 COPY packages/ui/package.json ./packages/ui/
 COPY packages/wallets/package.json ./packages/wallets/
+# patchedDependencies resolves these at install time, before the source COPY below
+COPY patches ./patches
 
 # Install dependencies
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -14,6 +14,8 @@ COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/wallets/package.json packages/wallets/package.json
 COPY packages/render-helper/package.json packages/render-helper/package.json
 COPY packages/ui/package.json packages/ui/package.json
+# patchedDependencies resolves these at install time, before the source COPY below
+COPY patches patches
 
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Fixes the staging image build broken by #1188.

### What broke

Both workspace images copy manifests, run `pnpm install --frozen-lockfile`, and only copy the source tree afterwards. pnpm resolves `patchedDependencies` during install, so once #1188 added a patch the image build failed before the source COPY:

```
[ENOENT] no such file or directory, open '/var/app/patches/@tooni__iconscout-unicons-react@1.0.1.patch'
pnpm install --frozen-lockfile -> exit code 254
```

CI did not catch this pre-merge because the test and build jobs run against a full checkout, where the file is already there. Only the Docker path installs from a partial context.

`deploy` was skipped after the failed `build`, so no broken image was pushed and staging kept serving its previous image. `main` has no `patches/` directory, so production was unaffected.

### Fix

`COPY patches` before the install step in both workspace Dockerfiles.

`apps/self-hosted/Dockerfile` has the identical manifests-then-install layout and would have failed on its next build, so it gets the same line. The two `hosting/api` images build from their own context and do not use workspace patches, so they are untouched.

### Verification

Reproduced the failing install step in a local Docker build, which now completes and confirms the patch is applied inside the image:

```
Step 15/15 : RUN grep -c '@__PURE__ */ h(' .../dist/line.js
1206
Successfully built
```

So this restores the deploy and confirms the tree-shaking fix survives into the shipped image.

Note `master.yml` uses the same `apps/web/Dockerfile`, so this is also a prerequisite for the next production release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container build setup to ensure patched dependencies are available during installation.
  * Applied the update consistently across self-hosted and web application images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->