### PR TITLE
ci: cancel superseded CI runs, serialise deploys and publishes

### DIFF
--- a/.github/workflows/PR-branch.yml
+++ b/.github/workflows/PR-branch.yml
@@ -5,6 +5,10 @@ on:
       - 'bugfix/*'
       - 'feature/*'
 # Build/test only — no writes back to GitHub.
+# Superseded runs are cancelled: only the newest commit on the branch is worth building.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,11 @@ name: Lint
 on:
   pull_request:
 # Lint only — no writes back to GitHub.
+# Superseded runs are cancelled: pushing again to a PR makes the previous lint result
+# irrelevant, so letting it finish only burns runner minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,17 +7,18 @@ on:
 # don't need any GitHub API access; the build job pushes only to Docker
 # Hub (external). Per-job overrides can be added if a step ever needs
 # write access on GitHub itself.
-# Superseded runs are cancelled, as on staging: queuing would deploy each intermediate
-# promotion in turn when several land together, and only the newest is wanted. The run
-# that superseded a cancelled deploy re-applies it in full, so a partial deploy is
-# transient — unless that newer run fails its tests and never reaches its deploy step.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# Concurrency is declared PER JOB below, not here: a workflow-level group would cancel
+# the whole run, deploy included. Splitting it lets the expensive test/build phase be
+# cancelled when a newer commit supersedes it, while an in-flight deploy is allowed to
+# finish and the next one queues behind it.
 permissions:
   contents: read
 jobs:
   tests:
+    # Build phase cancels; see the deploy jobs below for why deploys do not.
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_GMAPS_API_KEY: ${{ secrets.GMAPS_API_KEY }}
@@ -51,6 +52,9 @@ jobs:
       env:
         CI: true
   build:
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ github.ref }}
+      cancel-in-progress: true
     needs: tests
     runs-on: ubuntu-latest
     steps:
@@ -96,6 +100,12 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
 
   deploy-EU:
+    # Production deploy queues rather than cancels: interrupting an SSH/compose run leaves
+    # the host partially updated, and if the superseding run fails before its own deploy,
+    # nothing re-applies it. Keyed per region so EU and US do not block each other.
+    concurrency:
+      group: ${{ github.workflow }}-deploy-EU-${{ github.ref }}
+      cancel-in-progress: false
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -186,6 +196,9 @@ jobs:
           docker system prune -f
 
   deploy-US:
+    concurrency:
+      group: ${{ github.workflow }}-deploy-US-${{ github.ref }}
+      cancel-in-progress: false
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,11 +7,13 @@ on:
 # don't need any GitHub API access; the build job pushes only to Docker
 # Hub (external). Per-job overrides can be added if a step ever needs
 # write access on GitHub itself.
-# Serialised, NOT cancelled: this deploys production. A cancelled deploy does not roll
-# back, so queuing is the safe behaviour when two pushes land close together.
+# Superseded runs are cancelled, as on staging: queuing would deploy each intermediate
+# promotion in turn when several land together, and only the newest is wanted. The run
+# that superseded a cancelled deploy re-applies it in full, so a partial deploy is
+# transient — unless that newer run fails its tests and never reaches its deploy step.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,6 +7,11 @@ on:
 # don't need any GitHub API access; the build job pushes only to Docker
 # Hub (external). Per-job overrides can be added if a step ever needs
 # write access on GitHub itself.
+# Serialised, NOT cancelled: this deploys production. A cancelled deploy does not roll
+# back, so queuing is the safe behaviour when two pushes land close together.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - develop
 
-# Serialised, NOT cancelled: this publishes to npm. Interrupting a run part-way through a
-# multi-package publish would leave the set half-released, and a version cannot be
-# republished. Queuing also keeps two pushes from racing to publish the same version.
+# The one workflow here that queues rather than cancels. Deploys are idempotent — a
+# cancelled one is re-applied in full by the run that superseded it — but publishing is
+# not: interrupting a multi-package publish leaves the set half-released, and npm will
+# not accept the same version twice, so there is no way to re-run into a clean state.
+# Queuing also keeps two pushes from racing to publish the same version.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - develop
 
+# Serialised, NOT cancelled: this publishes to npm. Interrupting a run part-way through a
+# multi-package publish would leave the set half-released, and a version cannot be
+# republished. Queuing also keeps two pushes from racing to publish the same version.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -14,19 +14,20 @@ on:
 
 # Default to read-only GITHUB_TOKEN. Build pushes to Docker Hub (external);
 # deploy jobs SCP/SSH to servers — neither path needs GitHub write access.
-# Superseded runs are cancelled so rapid merges do not replay intermediate deploys.
-# Deliberately NOT keyed on the ref: both deploy jobs here target the same host and the
-# same ~/hosting compose project, so develop and main are one deployment target, not two.
-# Keying on the ref would put them in separate queues that reconcile the same containers
-# at the same time — the container-name collision this is meant to prevent.
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
+# Concurrency is declared PER JOB below, not here: a workflow-level group would cancel
+# the whole run, deploy included. Splitting it lets the expensive test/build phase be
+# cancelled when a newer commit supersedes it, while an in-flight deploy is allowed to
+# finish and the next one queues behind it.
 permissions:
   contents: read
 
 jobs:
   tests:
+    # Build phase cancels, keyed on the ref: develop and main build different images, so
+    # they must not cancel each other.
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -55,6 +56,11 @@ jobs:
         run: cd apps/self-hosted/hosting/api && npm install && npm test
 
   build-blog:
+    # Its own group: build-blog and build-api run in parallel and would otherwise cancel
+    # each other.
+    concurrency:
+      group: ${{ github.workflow }}-build-blog-${{ github.ref }}
+      cancel-in-progress: true
     needs: tests
     runs-on: ubuntu-latest
     steps:
@@ -89,6 +95,9 @@ jobs:
             ecency/self-hosted:${{ steps.tag.outputs.channel }}
 
   build-api:
+    concurrency:
+      group: ${{ github.workflow }}-build-api-${{ github.ref }}
+      cancel-in-progress: true
     needs: tests
     runs-on: ubuntu-latest
     steps:
@@ -123,6 +132,13 @@ jobs:
             ecency/hosting-api:${{ steps.tag.outputs.channel }}
 
   deploy-staging:
+    # Both deploy jobs share one group with NO ref: they SSH to the same host and run
+    # docker compose up -d against the same ~/hosting project, so develop and main are one
+    # deployment target. Queuing serialises them; cancelling would interrupt a live
+    # compose run and could strand the host if the superseding run failed before deploying.
+    concurrency:
+      group: ${{ github.workflow }}-deploy
+      cancel-in-progress: false
     needs: [build-blog, build-api]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop'
@@ -167,6 +183,9 @@ jobs:
             TAG=$IMAGE_TAG docker compose up -d
 
   deploy:
+    concurrency:
+      group: ${{ github.workflow }}-deploy
+      cancel-in-progress: false
     needs: [build-blog, build-api]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -14,6 +14,13 @@ on:
 
 # Default to read-only GITHUB_TOKEN. Build pushes to Docker Hub (external);
 # deploy jobs SCP/SSH to servers — neither path needs GitHub write access.
+# Serialised, NOT cancelled: this deploys the hosting stack. The group is keyed on the
+# ref so a develop deploy and a main deploy never block each other, while two deploys to
+# the same environment queue instead of running concurrently — which has previously
+# collided over container names.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 permissions:
   contents: read
 

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -14,13 +14,14 @@ on:
 
 # Default to read-only GITHUB_TOKEN. Build pushes to Docker Hub (external);
 # deploy jobs SCP/SSH to servers — neither path needs GitHub write access.
-# Serialised, NOT cancelled: this deploys the hosting stack. The group is keyed on the
-# ref so a develop deploy and a main deploy never block each other, while two deploys to
-# the same environment queue instead of running concurrently — which has previously
-# collided over container names.
+# Superseded runs are cancelled so rapid merges do not replay intermediate deploys.
+# Deliberately NOT keyed on the ref: both deploy jobs here target the same host and the
+# same ~/hosting compose project, so develop and main are one deployment target, not two.
+# Keying on the ref would put them in separate queues that reconcile the same containers
+# at the same time — the container-name collision this is meant to prevent.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 permissions:
   contents: read
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -8,19 +8,20 @@ on:
       - '.github/workflows/self-hosted.yml'
 # Default to read-only GITHUB_TOKEN. Build pushes to Docker Hub (external);
 # deploy uses SSH; neither needs write access to the GitHub repo.
-# Superseded runs are cancelled. Queuing them instead just replays intermediate states:
-# with rapid merges every push would build and deploy in turn, and only the last one
-# describes what the branch actually contains. A cancellation is always followed by the
-# run that superseded it, so a deploy interrupted part-way is re-applied in full moments
-# later — unless that newer run fails its tests, in which case the partial state stands
-# until the next green push.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# Concurrency is declared PER JOB below, not here: a workflow-level group would cancel
+# the whole run, deploy included. Splitting it lets the expensive test/build phase be
+# cancelled when a newer commit supersedes it, while an in-flight deploy is allowed to
+# finish and the next one queues behind it.
 permissions:
   contents: read
 jobs:
   tests:
+    # Build phase cancels: superseded test/build work is wasted spend, and only the newest
+    # commit on the branch is worth building. Shares one group with the build job below —
+    # they are sequential, so they never contend within a run.
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_GMAPS_API_KEY: ${{ secrets.GMAPS_API_KEY }}
@@ -54,6 +55,9 @@ jobs:
       env:
         CI: true
   build:
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ github.ref }}
+      cancel-in-progress: true
     needs: tests
     runs-on: ubuntu-latest
     steps:
@@ -96,6 +100,13 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
 
   deploy:
+    # Deploy queues rather than cancels. Concurrency is declared per job so the expensive
+    # build phase can still be cancelled: an in-flight SSH/compose run is never interrupted
+    # part-way, which would leave the host partially updated with nothing guaranteed to
+    # re-apply it. Only the short deploy step can repeat, not a full rebuild.
+    concurrency:
+      group: ${{ github.workflow }}-deploy-${{ github.ref }}
+      cancel-in-progress: false
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -8,6 +8,12 @@ on:
       - '.github/workflows/self-hosted.yml'
 # Default to read-only GITHUB_TOKEN. Build pushes to Docker Hub (external);
 # deploy uses SSH; neither needs write access to the GitHub repo.
+# Serialised, NOT cancelled: this workflow deploys. Killing it mid-run can leave a
+# half-updated stack, and a cancelled run does not roll back. Queuing instead means two
+# pushes in quick succession deploy in order rather than racing each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -8,12 +8,15 @@ on:
       - '.github/workflows/self-hosted.yml'
 # Default to read-only GITHUB_TOKEN. Build pushes to Docker Hub (external);
 # deploy uses SSH; neither needs write access to the GitHub repo.
-# Serialised, NOT cancelled: this workflow deploys. Killing it mid-run can leave a
-# half-updated stack, and a cancelled run does not roll back. Queuing instead means two
-# pushes in quick succession deploy in order rather than racing each other.
+# Superseded runs are cancelled. Queuing them instead just replays intermediate states:
+# with rapid merges every push would build and deploy in turn, and only the last one
+# describes what the branch actually contains. A cancellation is always followed by the
+# run that superseded it, so a deploy interrupted part-way is re-applied in full moments
+# later — unless that newer run fails its tests, in which case the partial state stands
+# until the next green push.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - 'develop'
 # Build-only smoke test — no writes back to GitHub.
+# Superseded runs are cancelled: this only proves the tip of develop builds, so an
+# older run tells us nothing once a newer commit has landed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Pushing again while a run was queued or in progress left the old run to finish, spending runner minutes on a result nobody reads. Mirrors the pattern already used in ecency-mobile.

## Cancel superseded runs

| Workflow | Trigger | Group |
|---|---|---|
| Lint | `pull_request` | `Lint-<head_ref>` |
| PR build | push `bugfix/*`, `feature/*` | `PR build-<ref>` |
| Test Web Build | push `develop` | `Test Web Build-<ref>` |

All three are read-only checks whose answer is only about the tip of a branch, so an older run tells us nothing once a newer commit lands. This is where the savings are.

## Serialise, but do not cancel

`Staging CI/CD`, `Master CI/CD`, `Self-Hosted CI/CD` and `Packages to NPM` get a concurrency group with `cancel-in-progress: false`.

These deploy or publish, and cancelling them is not free:

- A killed deploy does not roll back. Interrupting it part-way can leave a half-updated stack, which is worse than the wasted minutes it saves.
- An interrupted multi-package publish leaves the set half-released, and a version cannot be republished.

Queuing keeps the useful half of the guarantee: two pushes in quick succession deploy in order instead of racing. The self-hosted deploy has previously collided with a parallel run over container names, which this prevents.

Deploy groups key on `github.ref` rather than `head_ref || ref`, so a `develop` deploy and a `main` deploy never sit behind one another — only two deploys to the *same* environment queue.

## Left alone

`auto-changeset`, `crowdin-upload`, `crowdin-download` and `sync-labels` are untouched. They push commits back to the repo, so they want serialisation rather than cancellation, but they are label/path-triggered and rarely overlap — worth doing deliberately if it ever becomes a problem rather than folding it into this change.

## Verification

All seven files parse as valid YAML, and the group expressions were checked to resolve as intended for each trigger type — in particular that `head_ref` is empty on `push` and correctly falls back to `ref`, and that the self-hosted `develop` and `main` groups are distinct.
