### PR TITLE
fix(types): align react-query v5 helper signatures and call sites

### DIFF
--- a/apps/web/src/app/witnesses/_components/witnesses-list.tsx
+++ b/apps/web/src/app/witnesses/_components/witnesses-list.tsx
@@ -52,7 +52,7 @@ export function WitnessesList() {
   const { data: witnessesUserAccounts } = useQuery(getAccountsQueryOptions(witnessesUserNames));
 
   const originalWitnesses = useMemo(
-    () => makeUnique(convertToOriginalWitnesses(transformedWitnesses, witnessesUserAccounts)),
+    () => makeUnique(convertToOriginalWitnesses(transformedWitnesses, witnessesUserAccounts ?? [])),
     [transformedWitnesses, witnessesUserAccounts]
   );
   const witnesses = useMemo(

--- a/apps/web/src/config/index.tsx
+++ b/apps/web/src/config/index.tsx
@@ -60,9 +60,9 @@ export namespace EcencyConfigManager {
     useMutation(
       {
         ...options,
-        mutationFn: (args) => {
+        mutationFn: (args, context) => {
           if (condition(CONFIG) && options.mutationFn) {
-            return options.mutationFn(args);
+            return options.mutationFn(args, context);
           }
 
           if (!options.mutationFn) {

--- a/apps/web/src/core/react-query/query-helpers.ts
+++ b/apps/web/src/core/react-query/query-helpers.ts
@@ -82,9 +82,11 @@ export async function prefetchQuery<
  * // Server Component
  * const posts = await prefetchInfiniteQuery(getAccountPostsInfiniteQueryOptions(username));
  */
-export async function prefetchInfiniteQuery<TPage, TCursor>(
-  options: FetchInfiniteQueryOptions<TPage, Error, TPage, QueryKey, TCursor>
-) {
+export async function prefetchInfiniteQuery<
+  TPage,
+  TCursor,
+  TKey extends QueryKey = QueryKey
+>(options: FetchInfiniteQueryOptions<TPage, Error, TPage, TKey, TCursor>) {
   const qc = getQueryClient();
   await withSsrTimeout(qc.prefetchInfiniteQuery(options), options.queryKey);
   return qc.getQueryData<InfiniteData<TPage, TCursor>>(options.queryKey);

--- a/apps/web/src/features/shared/login/login-user-by-key.tsx
+++ b/apps/web/src/features/shared/login/login-user-by-key.tsx
@@ -37,7 +37,7 @@ export function LoginUserByKey({ username }: Props) {
   );
 
   const handleLogin = () => {
-    loginByKey().catch(() => {
+    loginByKey(undefined).catch(() => {
       /* Already handled in onError of the mutation */
     });
   };


### PR DESCRIPTION
Web `tsc --noEmit`: **90 -> 81**, zero new errors, 4 files.

## The main fix (one line, 6 errors)
`prefetchInfiniteQuery` pinned its options to the base `QueryKey`, while its sibling `prefetchQuery` already did the right thing:

```ts
// prefetchQuery  - generic in the key
export async function prefetchQuery<T, TKey extends QueryKey = QueryKey>(
  options: FetchQueryOptions<T, Error, T, TKey>
)

// prefetchInfiniteQuery - was pinned
options: FetchInfiniteQueryOptions<TPage, Error, TPage, QueryKey, TCursor>
```

Query keys are contravariant, so any caller whose options declare a narrower key type (the SDK factories use `(string | number)[]`) could not assign to `readonly unknown[]`. Making the helper generic in the key clears the whole family **with no call-site changes**.

## Three v5 API call sites
- **`config/index.tsx`** - the conditional-mutation wrapper forwarded only the first argument to the wrapped `mutationFn`, so it received an `undefined` context. Now forwards both.
- **`login-user-by-key.tsx`** - `useLoginByKey`'s variable is optional (`prefetchedAccount?`), but v5 still requires it to be passed explicitly. Calls with `undefined`; runtime identical.
- **`witnesses-list.tsx`** - `convertToOriginalWitnesses(data, accounts: FullAccount[])` calls `accounts.find(...)`, so passing the query's `undefined` **threw once per witness** on every render until accounts loaded. It was invisible because the per-item `try/catch` returns `i`, exactly what the no-account branch returns. `?? []` reaches that branch directly instead of via a thrown exception, so the result is unchanged and the throw/catch per row goes away.

Verified: web tsc 81 with an empty new-error-location diff, full web suite **2238 tests / 229 files passing**, eslint clean.
