### PR TITLE
fix(types): remove unreachable operators and stale declarations

### DIFF
--- a/apps/web/src/app/decks/_components/deck-grid.tsx
+++ b/apps/web/src/app/decks/_components/deck-grid.tsx
@@ -47,7 +47,7 @@ export const DeckGrid = () => {
   useOldDeckMigration();
 
   const onDragEnd = (result: DropResult) => {
-    const originalIndex = +result.source?.index ?? -1;
+    const originalIndex = result.source?.index ?? -1;
     const newIndex = result.destination?.index ?? -1;
 
     if (newIndex > -1 && originalIndex > -1) {

--- a/apps/web/src/app/decks/_components/deck-settings/decks-settings.tsx
+++ b/apps/web/src/app/decks/_components/deck-settings/decks-settings.tsx
@@ -34,7 +34,7 @@ export const DecksSettings = ({ show, setShow, deck }: Props) => {
   useEffect(() => {
     setName(deck?.title ?? name);
     setIcon(deck?.icon ?? icon);
-    setIsLocalStorage(deck?.storageType === "local" ?? false);
+    setIsLocalStorage(deck?.storageType === "local");
   }, [deck, icon, name]);
 
   const submit = () => {

--- a/apps/web/src/app/market/advanced/_components/stake-widget.tsx
+++ b/apps/web/src/app/market/advanced/_components/stake-widget.tsx
@@ -49,7 +49,7 @@ export const StakeWidget = ({
   const [maxBuy, setMaxBuy] = useState(0);
   const [fraction, setFraction] = useState(storedFraction ?? 0.00001);
   const [viewType, setViewType] = useState(storedViewType ?? StakeWidgetViewType.All);
-  const [unlimited, setUnlimited] = useState(storedViewType !== StakeWidgetViewType.All ?? false);
+  const [unlimited, setUnlimited] = useState(storedViewType !== StakeWidgetViewType.All);
 
   const rowsCount = isMobile ? 5 : 20;
 

--- a/apps/web/src/features/chat/components/message-input.tsx
+++ b/apps/web/src/features/chat/components/message-input.tsx
@@ -539,7 +539,6 @@ export function MessageInput({
         </div>
       </form>
       {showEmojiPicker && (
-        // @ts-expect-error next/dynamic loses component type
         <EmojiPicker
           show={showEmojiPicker}
           changeState={(state) => setShowEmojiPicker(state)}

--- a/apps/web/src/features/shared/purchase-stripe/index.ts
+++ b/apps/web/src/features/shared/purchase-stripe/index.ts
@@ -1,4 +1,5 @@
 export * from "./stripe-config";
+export * from "./stripe-types";
 export * from "./stripe-points-dialog";
 export * from "./use-stripe-points-purchase";
 export * from "./stripe-account-checkout";

--- a/apps/web/src/features/shared/purchase-stripe/stripe-types.ts
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-types.ts
@@ -1,0 +1,9 @@
+// Shared between the points and account purchase hooks. Kept in its own
+// dependency-free module so both can use one declaration: duplicating them
+// made the feature barrel re-export the same names from two places.
+
+export interface CreateIntentResult {
+  client_secret: string;
+}
+
+export type StripeOrderStatusValue = "pending" | "processing" | "success" | "failed";

--- a/apps/web/src/features/shared/purchase-stripe/use-stripe-account-purchase.ts
+++ b/apps/web/src/features/shared/purchase-stripe/use-stripe-account-purchase.ts
@@ -1,6 +1,7 @@
 import { appAxios } from "@/api/axios";
 import { apiBase } from "@/api/helper";
 import { useMutation } from "@tanstack/react-query";
+import { CreateIntentResult, StripeOrderStatusValue } from "./stripe-types";
 
 // Premium Hive account, bought with a card. Mirrors ePoints STRIPE_PRODUCT_MAP
 // ('299accounts' => $2.99, no Points). The price/SKU are authoritative server-side; the
@@ -14,11 +15,6 @@ export interface AccountPurchaseMeta {
   referral?: string;
 }
 
-export interface CreateIntentResult {
-  client_secret: string;
-}
-
-export type StripeOrderStatusValue = "pending" | "processing" | "success" | "failed";
 
 export interface StripeAccountStatus {
   status: StripeOrderStatusValue | null;

--- a/apps/web/src/features/shared/purchase-stripe/use-stripe-points-purchase.ts
+++ b/apps/web/src/features/shared/purchase-stripe/use-stripe-points-purchase.ts
@@ -2,12 +2,7 @@ import { appAxios } from "@/api/axios";
 import { apiBase } from "@/api/helper";
 import { ensureValidToken } from "@/utils";
 import { useMutation } from "@tanstack/react-query";
-
-export interface CreateIntentResult {
-  client_secret: string;
-}
-
-export type StripeOrderStatusValue = "pending" | "processing" | "success" | "failed";
+import { CreateIntentResult, StripeOrderStatusValue } from "./stripe-types";
 
 export interface StripeOrderStatus {
   status: StripeOrderStatusValue | null;

--- a/apps/web/src/features/ui/accordion/accordion-toggle.tsx
+++ b/apps/web/src/features/ui/accordion/accordion-toggle.tsx
@@ -23,7 +23,7 @@ export function AccordionToggle(props: Props) {
       onClick: () =>
         setShow({
           ...show,
-          [props.eventKey]: !show[props.eventKey] ?? false
+          [props.eventKey]: !show[props.eventKey]
         })
     },
     props.children

--- a/apps/web/src/features/ui/button/index.tsx
+++ b/apps/web/src/features/ui/button/index.tsx
@@ -54,7 +54,7 @@ const ForwardedButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Button
       "flex-row-reverse": props.iconPlacement === "left",
 
       // Styles
-      [BUTTON_STYLES[props.appearance ?? "primary"]]: !props.outline ?? true,
+      [BUTTON_STYLES[props.appearance ?? "primary"]]: !props.outline,
       [BUTTON_OUTLINE_STYLES[props.appearance ?? "primary"]]: props.outline ?? false,
       [BUTTON_SIZES[props.size ?? "md"]]: true,
 

--- a/apps/web/src/features/ui/list/index.tsx
+++ b/apps/web/src/features/ui/list/index.tsx
@@ -14,7 +14,7 @@ export function List(props: HTMLProps<HTMLDivElement> & Props) {
     <div
       {...nativeProps}
       className={classNameObject({
-        "flex overflow-hidden": !props.grid ?? true,
+        "flex overflow-hidden": !props.grid,
         "grid grid-cols-2": props.grid ?? false,
         "gap-3": props.defer ?? false,
         "flex-row flex-wrap": props.inline ?? false,

--- a/apps/web/src/features/wallet/components/index.ts
+++ b/apps/web/src/features/wallet/components/index.ts
@@ -1,1 +1,0 @@
-// Seed-based wallet components removed — MetaMask handles external wallets

--- a/apps/web/src/features/wallet/index.ts
+++ b/apps/web/src/features/wallet/index.ts
@@ -1,5 +1,4 @@
 export * from "./wallet-operations-dialog";
 export * from "./consts";
 export * from "./hooks";
-export * from "./components";
 export * from "./external-transfer";


### PR DESCRIPTION
Web `tsc --noEmit`: **81 -> 71**, zero new errors. Mostly subtraction.

## Unreachable `??` operands (6)
Each left operand is always a boolean or a number, so the fallback could never run:

```ts
!props.outline ?? true              // ! always yields boolean
deck?.storageType === "local" ?? false   // === always yields boolean
storedViewType !== StakeWidgetViewType.All ?? false
!show[props.eventKey] ?? false
!props.grid ?? true
```

Dropping the dead operand is behaviour-identical. I checked each one individually rather than removing them in bulk -- a "never nullish" verdict is only as good as the type behind it, and one of the seven turned out **not** to be dead code at all (see below).

## `deck-grid` coerced on the wrong side
`+result.source?.index ?? -1` applies `+` **before** the fallback, so a missing `source` yields `NaN`, not `-1`. `DropResult.source` is required (`source: DraggableLocation`), so neither branch is reachable today and the guard `originalIndex > -1` rejects both values identically -- but the fallback now sits where it was intended instead of depending on that.

## Stale declarations
- Dropped a `@ts-expect-error` in `message-input` whose error no longer occurs (tsc flags it as unused).
- Removed `features/wallet/components/`, which held only a comment saying its contents were deleted, plus the `export * from "./components"` that made the barrel fail. Nothing imported it.
- Gave the stripe purchase hooks **one** declaration of `CreateIntentResult` and `StripeOrderStatusValue`. Both declared them byte-identically, so the feature barrel re-exported the same two names from two modules (`TS2308`). Nothing outside those two modules imported either name, and the barrel still exports both.

## Deliberately not included
`wave-link-render.tsx:65` is also a `TS2869`, but it is **not** dead code -- `!!description ?? !!image ?? !!title` was meant to be `||`, so a link preview with an image and title but no `og:description` is currently discarded. Fixing it changes what renders, so it belongs with the other behavioural fixes rather than in a subtraction-only PR.

Verified: full web suite **2238 tests / 229 files passing**, eslint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deck reordering behavior during drag-and-drop.
  - Corrected initialization of local-storage deck settings and staking options.
  - Improved accordion toggles and UI state handling for buttons and lists.
  - Removed an obsolete wallet component reference.
- **Improvements**
  - Consolidated payment status handling to support more consistent Stripe purchase flows.
  - Improved emoji picker integration and reduced unnecessary type-checking warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->