### PR TITLE
fix(icons): unpin heart and exchange sizes so rows render evenly

### DIFF
--- a/apps/web/src/assets/img/svg.tsx
+++ b/apps/web/src/assets/img/svg.tsx
@@ -171,7 +171,7 @@ export const cashMultiple = (
   </svg>
 );
 
-export const exchangeSvg = <UilExchange size={16} />;
+export const exchangeSvg = <UilExchange />;
 
 export const cashCoinSvg = (
   <svg

--- a/apps/web/src/features/ui/svg.tsx
+++ b/apps/web/src/features/ui/svg.tsx
@@ -218,7 +218,7 @@ export const peopleSvg = (
   </svg>
 );
 
-export const heartSvg = <UilHeart size={16} />;
+export const heartSvg = <UilHeart />;
 
 export const commentSvg = <UilComment />;
 


### PR DESCRIPTION
Visual regression from #1197, spotted on staging: the vote heart renders smaller than the icons beside it.

### Cause

Most hand-rolled glyphs carried no intrinsic `width`/`height` and took their size from CSS. Rendering them from the package gave them `width/height=24`. The few that declared an explicit width kept it, so those now sit smaller than everything around them.

`heartSvg` declared `width="16"` with a `0 0 16 16` viewBox and is rendered by `EntryVotes` next to `commentSvg` and `repeatSvg`, both of which were unsized and are now 24. The heart did not shrink — its neighbours grew.

Preserving each icon's declared size was right in isolation and wrong in context: sizes were checked against each icon's own original, never against the icons it renders beside.

### Also fixed

`exchangeSvg` has the same problem and is worse placed. `hive-transaction-row.tsx` assigns both it and `ticketSvg` to the same `icon` variable, so a single transaction list was drawing icons at two different sizes depending on transaction type.

### Left alone

`medalSvg` (32, discover leaderboard) and `chatSvg` (21, entry-share) keep their sizes. Both are standalone with no neighbouring icon to match, and both are faithful to their originals.

### Verification

`vitest run` in `apps/web`: 229 files / 2238 tests pass.

Nothing automated catches this class of bug — tests, typecheck and the production build were all green on #1197. It needed eyes on staging.
