### PR TITLE
fix(icons): size the entry-votes icon for the package glyph

### DIFF
--- a/apps/web/src/features/shared/entry-votes/_index.scss
+++ b/apps/web/src/features/shared/entry-votes/_index.scss
@@ -76,8 +76,8 @@
   }
 
   svg {
-    height: 12px;
-    width: 12px;
+    height: 14px;
+    width: 14px;
     opacity: 0.5;
     margin-right: 5px;
     margin-top: 2px;


### PR DESCRIPTION
Fixes the vote heart rendering smaller than the icons beside it in the feed action row, reported from staging after #1197.

### Cause

The `12px` in `.entry-votes svg` was tuned for the old hand-drawn heart, which filled its `0 0 16 16` viewBox edge to edge. The package heart sits inside a `0 0 24 24` viewBox with padding, so the same 12px box renders a visibly smaller glyph — next to a comment icon that is `w-3.5` (14px).

The size is set by CSS, not by the component, so the attribute on the icon export is irrelevant here: `.entry-votes svg` wins over any `width`/`height` the component emits.

### Scope

- **Feed** — the mismatch. Heart goes 12px to 14px, matching the `w-3.5` comment icon beside it.
- **Waves** — unaffected. `wave-actions.scss` sets `svg { @apply w-4 h-4 }` across the whole row, so heart and neighbours already move together at 16px, and that rule still wins.
- **Decks** — picks up the same correction. Its `.entry-votes svg` override only sets opacity and margin.

### Verification

`vitest run` in `apps/web`: 229 files / 2238 tests pass.

### Note

This is a targeted fix, not the general one. Icon sizing across the app is set per surface — 32 SCSS rules size an `svg`, and package icons carry inline Tailwind sizes in ~180 places (`w-4 h-4` alone appears 77 times). Any icon whose CSS box was tuned for a hand-drawn glyph can show the same mismatch now that the glyph comes from the package. Worth a follow-up that gives icons a single sizing convention rather than a value per call site.
