### PR TITLE
Show Ecency Pro checkmark wherever a username renders; mute the source badge

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-team.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-team.tsx
@@ -6,6 +6,7 @@ import React, { useMemo } from "react";
 import { Community } from "@/entities";
 import { DialogInfo } from "../../_types";
 import { ProfileLink } from "@/features/shared";
+import { ProBadge } from "@/features/pro";
 
 interface Props {
   community: Community;
@@ -25,6 +26,7 @@ export function CommunityCardTeam({ community, toggleInfo }: Props) {
             <ProfileLink username={m[0]}>
               <span className="username">{`@${m[0]}`}</span>
             </ProfileLink>
+            <ProBadge username={m[0]} className="ml-1" />
             <span className="role">{m[1]}</span>
             {m[2] !== "" && <span className="extra">{m[2]}</span>}
           </div>

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-subscribers/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-subscribers/index.tsx
@@ -6,6 +6,7 @@ import { getCommunitySubscribersQueryOptions, getAccountsQueryOptions } from "@e
 import { useQuery } from "@tanstack/react-query";
 import { Community, roleMap, Subscription } from "@/entities";
 import { LinearProgress, ProfileLink, UserAvatar } from "@/features/shared";
+import { ProBadge } from "@/features/pro";
 import { accountReputation } from "@/utils";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { pencilOutlineSvg } from "@ui/svg";
@@ -76,6 +77,7 @@ export function CommunitySubscribers({ community }: Props) {
                             <ProfileLink username={username}>
                               <span className="item-name notranslate">{username}</span>
                             </ProfileLink>
+                            <ProBadge username={username} className="ml-1" />
                             {account?.reputation !== undefined && (
                                 <span className="item-reputation">
                           {accountReputation(account.reputation)}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-main-info.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-main-info.tsx
@@ -9,6 +9,7 @@ import {
   TimeLabel,
   UserAvatar
 } from "@/features/shared";
+import { ProBadge } from "@/features/pro";
 import { accountReputation } from "@/utils";
 import i18next from "i18next";
 import { EntryPageListen } from "./entry-page-listen";
@@ -41,6 +42,7 @@ export function EntryPageMainInfo({ entry }: Props) {
                 <span className="author-reputation" title={i18next.t("entry.author-reputation")}>
                   ({reputation})
                 </span>
+                <ProBadge username={entry.author} className="ml-1" />
               </div>
             </ProfileLink>
 

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/friend-list-item.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/friend-list-item.tsx
@@ -1,4 +1,5 @@
 import { ProfileLink, UserAvatar } from "@/features/shared";
+import { ProBadge } from "@/features/pro";
 import { accountReputation } from "@/utils";
 import i18next from "i18next";
 import { Friend } from "@/app/(dynamicPages)/profile/[username]/_components/friends/types";
@@ -18,6 +19,7 @@ export function FriendListItem({ item }: Props) {
           <ProfileLink username={item.name}>
             <span className="item-name notranslate">{item.name}</span>
           </ProfileLink>
+          <ProBadge username={item.name} className="ml-1" />
           {item?.reputation !== undefined && (
             <span className="item-reputation">{accountReputation(item.reputation)}</span>
           )}

--- a/apps/web/src/app/search/_components/search-people/index.tsx
+++ b/apps/web/src/app/search/_components/search-people/index.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { getSearchAccountQueryOptions } from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
 import { SearchQuery } from "@/utils/search-query";
+import { ProBadge } from "@/features/pro";
 import { truncate } from "@/utils";
 
 export function SearchPeople() {
@@ -53,6 +54,7 @@ export function SearchPeople() {
                           <span className="item-sub-title">
                             {"@"}
                             {username}
+                            <ProBadge username={username} className="ml-1" />
                           </span>
                         </div>
                       </div>

--- a/apps/web/src/app/waves/_components/waves-list-item-header.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-item-header.tsx
@@ -10,6 +10,7 @@ import { UilArrowRight, UilMultiply } from "@tooni/iconscout-unicons-react";
 import { TimeLabel } from "@/features/shared";
 import clsx from "clsx";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { ProBadge } from "@/features/pro";
 
 interface Props {
   entry: WaveEntry;
@@ -57,6 +58,7 @@ export function WavesListItemHeader({
             <Link className="font-semibold text-sm" href={`/@${entry.author}`}>
               {entry.author}
             </Link>
+            <ProBadge username={entry.author} />
             {activeUser?.username === entry.author && (
               <Badge className="!py-0 !text-[0.675rem]">{i18next.t("g.you")}</Badge>
             )}

--- a/apps/web/src/app/waves/_components/waves-reel-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-reel-item.tsx
@@ -111,7 +111,9 @@ export function WavesReelItem({ item, onReply }: Props) {
           <ProfileLink username={item.author}>
             <span className="font-semibold text-white">@{item.author}</span>
           </ProfileLink>
-          <ProBadge username={item.author} />
+          {/* Sits over arbitrary video frames; a drop shadow keeps the blue disc
+              legible on bright content, like the white author text beside it. */}
+          <ProBadge username={item.author} className="drop-shadow-[0_1px_2px_rgba(0,0,0,0.7)]" />
         </div>
         {caption && <div className="mt-2 line-clamp-2 text-sm text-white/90">{caption}</div>}
       </div>

--- a/apps/web/src/app/waves/_components/waves-reel-item.tsx
+++ b/apps/web/src/app/waves/_components/waves-reel-item.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import i18next from "i18next";
 import { ShortsFeedEntry } from "@ecency/sdk";
 import { EntryTipBtn, UserAvatar, ProfileLink } from "@/features/shared";
+import { ProBadge } from "@/features/pro";
 import { UilComment, UilPlay } from "@tooni/iconscout-unicons-react";
 import { ReelVideo } from "@/app/waves/_components/reel-video";
 import { ReelVoteButton } from "@/app/waves/_components/reel-vote-button";
@@ -110,6 +111,7 @@ export function WavesReelItem({ item, onReply }: Props) {
           <ProfileLink username={item.author}>
             <span className="font-semibold text-white">@{item.author}</span>
           </ProfileLink>
+          <ProBadge username={item.author} />
         </div>
         {caption && <div className="mt-2 line-clamp-2 text-sm text-white/90">{caption}</div>}
       </div>

--- a/apps/web/src/features/shared/ecency-source-badge/index.tsx
+++ b/apps/web/src/features/shared/ecency-source-badge/index.tsx
@@ -1,7 +1,6 @@
 import { appName } from "@/utils";
 import clsx from "clsx";
 import i18next from "i18next";
-import Image from "next/image";
 import React from "react";
 
 interface Props {
@@ -20,6 +19,13 @@ interface Props {
  * client ("ecency/x.y-vision" on web, "ecency-mobile" on mobile) so it's clear
  * at a glance which posts, comments and waves were published by/with Ecency.
  * Renders nothing for content from any other client.
+ *
+ * Deliberately low-emphasis: the bare "e" mark in muted gray, not the full blue
+ * gradient disc. The disc read as a status badge and sat right next to the blue
+ * Pro checkmark, so the two competed for the same attention — one means "this
+ * account pays for Pro", the other only "posted from Ecency", and they should
+ * not carry equal weight. Inlined rather than next/image so the glyph inherits
+ * currentColor and each surface can retone it via className.
  */
 export function EcencySourceBadge({ app, size = 14, className }: Props) {
   // Every Ecency client identifier starts with "ecency" (ecency/x.y-vision,
@@ -34,13 +40,19 @@ export function EcencySourceBadge({ app, size = 14, className }: Props) {
   const label = i18next.t("waves.source-ecency");
 
   return (
-    <Image
-      className={clsx("ecency-source-badge", className)}
-      src="/assets/logo-circle.svg"
-      alt={label}
-      title={label}
+    <svg
+      className={clsx("ecency-source-badge shrink-0 text-gray-300 dark:text-gray-700", className)}
+      // Tight square crop of the glyph, so the mark fills the requested box the
+      // way the circular asset did instead of floating in its own padding.
+      viewBox="40.6 28.7 80.4 80.4"
       width={size}
       height={size}
-    />
+      fill="currentColor"
+      role="img"
+      aria-label={label}
+    >
+      <title>{label}</title>
+      <path d="M88.27,105.71c-9,.08-30.35.27-35.13-.29-3.88-.46-11-3-11.11-12.81C42,87,41.66,64,42.46,59,44.13,48.4,47,41.77,59.05,36.33c10.26-4.44,32.17-.78,34.54,16.93.45,3.37,1.25,3.74,2.49,4,19.61,4.13,24,26.26,14.6,38.32C104.73,103.26,98.31,104.76,88.27,105.71ZM84.71,59.25c.68-11.52-11-19.82-22.82-13.66-8.42,4.39-9.15,10.76-9.68,18-.67,9.2-.25,15.91-.09,25.13.07,4.13,1.27,6.64,5.7,7,1.14.1,17,0,25.22.06,10.74.06,24.06-4.89,21.93-18a12.68,12.68,0,0,0-10.8-10.22,2.12,2.12,0,0,0-2.21,1C85,83,69.66,82.31,63.41,74.46c-5.61-7.06-2.7-18.73,4.68-21.2,2.78-.94,5.11-.11,6.25,1.86,1.84,3.18.11,6.06-2.49,7.65s-2.45,3.92-1.36,5.46c2.56,3.59,7.6,2.88,10.79-.28C83.87,65.4,84.52,62.47,84.71,59.25Z" />
+    </svg>
   );
 }

--- a/apps/web/src/features/shared/notifications/notification-list-item.tsx
+++ b/apps/web/src/features/shared/notifications/notification-list-item.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useEffect, useMemo, useRef, useState } from "react";
 import { ApiNotification } from "@/entities";
+import { ProBadge } from "@/features/pro";
 import { NotificationReferralType } from "@/features/shared/notifications/notification-types/notification-referral-type";
 import { NotificationInactiveType } from "@/features/shared/notifications/notification-types/notification-inactive-type";
 import { NotificationSpinType } from "@/features/shared/notifications/notification-types/notification-spin-type";
@@ -116,6 +117,7 @@ export const NotificationListItem = memo(function NotificationListItem({
       target={openLinksInNewTab ? "_blank" : undefined}
     >
       <span className="source-name">@{notification.source}</span>
+      <ProBadge username={notification.source} className="ml-1" />
     </ProfileLink>
   );
 

--- a/apps/web/src/features/shared/profile-popover/index.tsx
+++ b/apps/web/src/features/shared/profile-popover/index.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useState } from "react";
 import "./index.scss";
 import { Entry } from "@/entities";
 import ProfilePopoverCard from "@/features/shared/profile-popover/profile-popover-card";
-import { PROFILE_POPOVER_AUTHOR_CLASS } from "@/features/shared/profile-popover/consts";
+import { ProfilePopoverAuthor } from "@/features/shared/profile-popover/profile-popover-author";
 
 // The author label must stay in the server HTML (SEO + zero layout shift), but
 // the hover card around it (floating-ui, a resize listener, a click-away
@@ -28,7 +28,7 @@ export const ProfilePopover = ({ entry }: { entry: Entry }) => {
     // the popover.
     return (
       <div role="presentation" onMouseEnter={arm} onFocus={arm} onClick={arm}>
-        <div className={PROFILE_POPOVER_AUTHOR_CLASS}>{author}</div>
+        <ProfilePopoverAuthor author={author} />
       </div>
     );
   }

--- a/apps/web/src/features/shared/profile-popover/profile-popover-author.tsx
+++ b/apps/web/src/features/shared/profile-popover/profile-popover-author.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { ProBadge } from "@/features/pro";
+import { PROFILE_POPOVER_AUTHOR_CLASS } from "@/features/shared/profile-popover/consts";
+
+// The author label shared by the un-armed ProfilePopover and the mounted hover
+// card, so both render identically and arming on hover shifts nothing. Every
+// feed card, comment and discover row funnels through here, which makes it the
+// single place a Pro checkmark has to be added to cover all of them.
+//
+// ProBadge is inline-flex + align-middle and returns null for non-members, so
+// it flows after the handle without turning this into a flex row (the label is
+// also used as Popover `directContent`, where a block-level child would change
+// the trigger's box).
+export function ProfilePopoverAuthor({ author }: { author: string }) {
+  return (
+    <div className={PROFILE_POPOVER_AUTHOR_CLASS}>
+      {author}
+      <ProBadge username={author} className="ml-1" />
+    </div>
+  );
+}

--- a/apps/web/src/features/shared/profile-popover/profile-popover-card.tsx
+++ b/apps/web/src/features/shared/profile-popover/profile-popover-card.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { Popover } from "@ui/popover";
 import { ProfilePreview } from "@/features/shared/profile-popover/profile-preview";
-import { PROFILE_POPOVER_AUTHOR_CLASS } from "@/features/shared/profile-popover/consts";
+import { ProfilePopoverAuthor } from "@/features/shared/profile-popover/profile-popover-author";
 
 // The heavy half of ProfilePopover: floating-ui (useFloating), a window-resize
 // listener (useWindowSize), a click-away listener and two React portals, plus
@@ -22,7 +22,7 @@ export default function ProfilePopoverCard({ author }: { author: string }) {
       useMobileSheet={true}
       placement="bottom-start"
       defaultShow={true}
-      directContent={<div className={PROFILE_POPOVER_AUTHOR_CLASS}>{author}</div>}
+      directContent={<ProfilePopoverAuthor author={author} />}
       customClassName="rounded-2xl overflow-hidden bg-white dark:bg-gray-900 shadow-xl w-[320px]"
     >
       <ProfilePreview username={author} />

--- a/apps/web/src/features/shared/search-list-item/index.tsx
+++ b/apps/web/src/features/shared/search-list-item/index.tsx
@@ -11,6 +11,7 @@ import {
   UserAvatar
 } from "@/features/shared";
 import { TagLink } from "../tag";
+import { ProBadge } from "@/features/pro";
 import { commentSvg, peopleSvg } from "@ui/svg";
 import { accountReputation, dateToFormatted, dateToRelative, transformMarkedContent } from "@/utils";
 import Image from "next/image";
@@ -56,6 +57,7 @@ export function SearchListItem({ res }: Props) {
               <div className="author">
                 {res.author}
                 <span className="author-reputation">({reputation})</span>
+                <ProBadge username={res.author} className="ml-1" />
               </div>
             </ProfileLink>
           </div>

--- a/apps/web/src/specs/features/pro/profile-popover-author.spec.tsx
+++ b/apps/web/src/specs/features/pro/profile-popover-author.spec.tsx
@@ -1,0 +1,61 @@
+import { vi } from "vitest";
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// ProBadge reads the Pro roster through useQuery; stub it so the label can be
+// rendered against a known roster without a QueryClient or a network call.
+const useQueryMock = vi.fn();
+vi.mock("@tanstack/react-query", async () => ({
+  ...(await vi.importActual("@tanstack/react-query")),
+  useQuery: (...args: unknown[]) => useQueryMock(...args)
+}));
+
+import { ProfilePopoverAuthor } from "@/features/shared/profile-popover/profile-popover-author";
+
+// i18next is globally mocked to echo keys, so the badge's aria-label is the key.
+const BADGE = '[aria-label="pro.badge-title"]';
+
+// This label is what every feed card, comment and discover row renders for the
+// author, so a Pro member losing the checkmark here means losing it across the
+// whole site — which is exactly the regression this guards.
+describe("ProfilePopoverAuthor", () => {
+  beforeEach(() => {
+    useQueryMock.mockReset();
+  });
+
+  it("shows the Pro checkmark next to a member's handle", () => {
+    useQueryMock.mockReturnValue({ data: { members: ["seckorama"], count: 1 } });
+
+    const { container } = render(<ProfilePopoverAuthor author="seckorama" />);
+
+    expect(container.textContent).toContain("seckorama");
+    expect(container.querySelector(BADGE)).not.toBeNull();
+  });
+
+  it("matches the roster case-insensitively", () => {
+    useQueryMock.mockReturnValue({ data: { members: ["SeckoRama"], count: 1 } });
+
+    const { container } = render(<ProfilePopoverAuthor author="seckorama" />);
+
+    expect(container.querySelector(BADGE)).not.toBeNull();
+  });
+
+  it("renders no checkmark for a non-member", () => {
+    useQueryMock.mockReturnValue({ data: { members: ["seckorama"], count: 1 } });
+
+    const { container } = render(<ProfilePopoverAuthor author="good-karma" />);
+
+    expect(container.textContent).toContain("good-karma");
+    expect(container.querySelector(BADGE)).toBeNull();
+  });
+
+  it("renders the handle unchanged while the roster is still loading", () => {
+    useQueryMock.mockReturnValue({ data: undefined });
+
+    const { container } = render(<ProfilePopoverAuthor author="seckorama" />);
+
+    expect(container.textContent).toContain("seckorama");
+    expect(container.querySelector(BADGE)).toBeNull();
+  });
+});

--- a/apps/web/src/specs/features/pro/profile-popover-author.spec.tsx
+++ b/apps/web/src/specs/features/pro/profile-popover-author.spec.tsx
@@ -3,8 +3,12 @@ import React from "react";
 import { render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-// ProBadge reads the Pro roster through useQuery; stub it so the label can be
-// rendered against a known roster without a QueryClient or a network call.
+// setup-any-spec globally stubs ProBadge to a no-op so provider-free container
+// specs don't crash on its useQuery. This spec is specifically about the badge
+// wiring, so restore the real component here and instead stub useQuery, letting
+// us render it against a known roster without a QueryClient or a network call.
+vi.mock("@/features/pro/pro-badge", async (importOriginal) => await importOriginal());
+
 const useQueryMock = vi.fn();
 vi.mock("@tanstack/react-query", async () => ({
   ...(await vi.importActual("@tanstack/react-query")),

--- a/apps/web/src/specs/features/shared/ecency-source-badge.spec.tsx
+++ b/apps/web/src/specs/features/shared/ecency-source-badge.spec.tsx
@@ -13,8 +13,10 @@ vi.mock("@/utils", async () => ({
 
 import { EcencySourceBadge } from "@/features/shared/ecency-source-badge";
 
-// i18next is globally mocked to echo keys, so the badge alt is the raw key.
-const BADGE = 'img[alt="waves.source-ecency"]';
+// i18next is globally mocked to echo keys, so the badge label is the raw key.
+// The badge is an inline <svg role="img"> (not next/image) so the mark can
+// inherit currentColor and render in muted gray.
+const BADGE = '[role="img"][aria-label="waves.source-ecency"]';
 
 describe("EcencySourceBadge", () => {
   it("renders for the Ecency web client (ecency/x.y-vision)", () => {

--- a/apps/web/src/specs/features/waves/waves-list-item-header-badge.spec.tsx
+++ b/apps/web/src/specs/features/waves/waves-list-item-header-badge.spec.tsx
@@ -40,8 +40,9 @@ const baseProps = {
   interactable: true
 } as const;
 
-// i18next is globally mocked to echo keys, so the badge alt is the raw key.
-const BADGE = 'img[alt="waves.source-ecency"]';
+// i18next is globally mocked to echo keys, so the badge label is the raw key.
+// The source badge is now an inline <svg role="img"> rather than an <img>.
+const BADGE = '[role="img"][aria-label="waves.source-ecency"]';
 
 describe("WavesListItemHeader Ecency badge", () => {
   it("renders the Ecency badge for waves published from Ecency web", () => {

--- a/apps/web/src/specs/setup-any-spec.ts
+++ b/apps/web/src/specs/setup-any-spec.ts
@@ -170,6 +170,16 @@ vi.mock("@/features/post-renderer", () => ({
   setupPostEnhancements: vi.fn()
 }));
 
+// ProBadge fetches the Pro roster with useQuery. It's now embedded in shared
+// author labels (ProfilePopover, WavesListItemHeader, NotificationListItem, ...),
+// so every container spec that renders those with a plain render() — no
+// QueryClientProvider — would otherwise throw "No QueryClient set". Stub it to a
+// provider-free no-op here; the badge's real membership behavior is covered by
+// its own specs (pro-config + profile-popover-author), which override this mock.
+vi.mock("@/features/pro/pro-badge", () => ({
+  ProBadge: () => null
+}));
+
 vi.mock("@ecency/wallets", () => ({
   validateKey: vi.fn(),
   validateWif: vi.fn(),


### PR DESCRIPTION
## What

Two related changes to badges shown next to usernames.

### 1. Pro checkmark everywhere a username renders
The `ProBadge` existed but was wired into only the profile card and the profile popover preview, so it never showed on feeds, comments, waves, search, notifications or community pages.

- Extract the popover author label into `ProfilePopoverAuthor` and render the badge there. This single label backs feed cards, comments and the discover users table, so those are covered in one place.
- Add the badge to the surfaces that build their own author label: post page header, waves list + reels, followers/following, people search, search results, notifications, and community team + subscribers.

No extra requests: every badge shares the one cached `pro-members` roster query, and membership is an O(1) set lookup against it.

### 2. Mute the "published with Ecency" source badge
It was a filled blue gradient disc with a white glyph, nearly identical to the blue Pro checkmark beside it, so the two competed. Render just the bare "e" glyph in soft gray (`gray-300` / `gray-700`) instead. Inline the SVG (was `next/image`) so it inherits `currentColor` and each surface can retone it, and drop the disc so it no longer echoes the Pro badge shape. Now only paid membership carries a filled blue badge on a name.

## Tests
- Added `profile-popover-author.spec.tsx` covering member / non-member / case-insensitive / loading for the shared feed label.
- Updated `ecency-source-badge.spec.tsx` for the inline-SVG markup.
- `pnpm typecheck` clean; source-badge + pro specs pass.