### PR TITLE
Rename AI Summarize label to Recap

### DIFF
--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -3980,7 +3980,7 @@
     "action-suggest_tags-desc": "Get relevant tags for your post",
     "action-generate_title": "Generate Title",
     "action-generate_title-desc": "Create compelling title options",
-    "action-summarize": "Summarize",
+    "action-summarize": "Recap",
     "action-summarize-desc": "Create a TL;DR summary",
     "action-check_grammar": "Check Grammar",
     "action-check_grammar-desc": "Fix grammar and spelling",


### PR DESCRIPTION
Renames the AI "Summarize" label to "Recap" so it fits its container on mobile and web content pages, where the longer word was overflowing.

Single string change in `en-US.json` (`ai-assist.action-summarize`). This key is shared, so the AI Assist editor action list also shows "Recap". Descriptions are unchanged; other locales regenerate via Crowdin.