### PR TITLE
fix(self-hosted): render YouTube and 3Speak video embeds

### DIFF
--- a/apps/self-hosted/src/features/blog/components/blog-discussion-item.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-discussion-item.tsx
@@ -86,7 +86,16 @@ export function BlogDiscussionItem({
               <div
                 className="markdown-body text-sm! max-w-none entry-body"
                 dangerouslySetInnerHTML={{
-                  __html: renderPostBody(entry.body, false),
+                  // embedVideosDirectly: emit ready-to-play iframes for
+                  // YouTube/3Speak (no client-side enhancer runs here).
+                  __html: renderPostBody(
+                    entry.body,
+                    false,
+                    false,
+                    'ecency.com',
+                    undefined,
+                    { embedVideosDirectly: true },
+                  ),
                 }}
               />
             )}

--- a/apps/self-hosted/src/features/blog/components/blog-post-body.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-body.tsx
@@ -13,7 +13,13 @@ export function BlogPostBody({ entry, isRawContent }: Props) {
   const entryData = entry.original_entry || entry;
 
   const renderedBody = useMemo(
-    () => renderPostBody(entryData.body, false),
+    // embedVideosDirectly: emit ready-to-play iframes for YouTube/3Speak instead
+    // of click-to-play thumbnails. The self-hosted SPA does not run the web app's
+    // client-side video enhancers, so without this videos render as inert placeholders.
+    () =>
+      renderPostBody(entryData.body, false, false, 'ecency.com', undefined, {
+        embedVideosDirectly: true,
+      }),
     [entryData.body],
   );
 

--- a/apps/self-hosted/src/styles/blog-markdown.css
+++ b/apps/self-hosted/src/styles/blog-markdown.css
@@ -1405,3 +1405,73 @@
 .markdown-body .highlight pre:has(+ .zeroclipboard-container) {
   min-height: 52px;
 }
+
+/* ============================================
+   Video & iframe embeds
+   render-helper emits these as direct iframes (embedVideosDirectly).
+   YouTube/3Speak/Vimeo/Twitch/Loom/DTube etc. get a responsive 16:9
+   frame so the player fills the content column instead of the browser
+   default 300x150 box. Audio players keep their natural height.
+   ============================================ */
+.markdown-body .markdown-video-link-youtube,
+.markdown-body .markdown-video-link-speak,
+.markdown-body .markdown-video-link-vimeo,
+.markdown-body .markdown-video-link-twitch,
+.markdown-body .markdown-video-link-loom,
+.markdown-body .markdown-video-link-bitchute,
+.markdown-body .markdown-video-link-rumble,
+.markdown-body .markdown-video-link-brighteon,
+.markdown-body .markdown-video-link-dtube {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding-bottom: 56.25%; /* 16:9 aspect ratio */
+  height: 0;
+  overflow: hidden;
+  margin: 1rem auto 0.5rem;
+  background-color: #000;
+  line-height: 0;
+  font-size: 0;
+  vertical-align: top;
+}
+
+.markdown-body .markdown-video-link-youtube .er-youtube-frame,
+.markdown-body .markdown-video-link-speak .er-speak-frame,
+.markdown-body .markdown-video-link-youtube iframe,
+.markdown-body .markdown-video-link-speak iframe,
+.markdown-body .markdown-video-link-vimeo iframe,
+.markdown-body .markdown-video-link-twitch iframe,
+.markdown-body .markdown-video-link-loom iframe,
+.markdown-body .markdown-video-link-bitchute iframe,
+.markdown-body .markdown-video-link-rumble iframe,
+.markdown-body .markdown-video-link-brighteon iframe,
+.markdown-body .markdown-video-link-dtube iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: block;
+}
+
+/* Standalone iframe embeds (raw author <iframe>, spotify/loom via iframe, etc.)
+   stay responsive 16:9. The higher-specificity container rules above override
+   this for iframes inside a .markdown-video-link-* wrapper. */
+.markdown-body iframe:not(.markdown-audio-link *) {
+  max-width: 100%;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  border: none;
+  display: block;
+  margin: 1rem auto 0.5rem;
+}
+
+/* Audio players (3Speak audio, Spotify, Liketu) keep their natural height. */
+.markdown-body .markdown-audio-link iframe {
+  width: 100%;
+  border: none;
+}

--- a/apps/self-hosted/src/styles/blog-markdown.css
+++ b/apps/self-hosted/src/styles/blog-markdown.css
@@ -1408,20 +1408,20 @@
 
 /* ============================================
    Video & iframe embeds
-   render-helper emits these as direct iframes (embedVideosDirectly).
-   YouTube/3Speak/Vimeo/Twitch/Loom/DTube etc. get a responsive 16:9
-   frame so the player fills the content column instead of the browser
-   default 300x150 box. Audio players keep their natural height.
-   ============================================ */
+   render-helper emits real iframes for these providers: YouTube + 3Speak via
+   the embedVideosDirectly option, Vimeo/Twitch/Loom unconditionally. Each is
+   wrapped in a .markdown-video-link-<provider> anchor. Give that wrapper a
+   responsive 16:9 frame so the player fills the content column instead of the
+   browser default 300x150 box.
+   Note: bitchute/rumble/brighteon/dtube emit only the generic
+   .markdown-video-link class as click-to-play placeholders (no iframe, no
+   embedVideosDirectly branch), so they are not styled here and remain
+   non-playable on the self-hosted SPA. Audio embeds are handled separately below. */
 .markdown-body .markdown-video-link-youtube,
 .markdown-body .markdown-video-link-speak,
 .markdown-body .markdown-video-link-vimeo,
 .markdown-body .markdown-video-link-twitch,
-.markdown-body .markdown-video-link-loom,
-.markdown-body .markdown-video-link-bitchute,
-.markdown-body .markdown-video-link-rumble,
-.markdown-body .markdown-video-link-brighteon,
-.markdown-body .markdown-video-link-dtube {
+.markdown-body .markdown-video-link-loom {
   position: relative;
   display: block;
   width: 100%;
@@ -1441,11 +1441,7 @@
 .markdown-body .markdown-video-link-speak iframe,
 .markdown-body .markdown-video-link-vimeo iframe,
 .markdown-body .markdown-video-link-twitch iframe,
-.markdown-body .markdown-video-link-loom iframe,
-.markdown-body .markdown-video-link-bitchute iframe,
-.markdown-body .markdown-video-link-rumble iframe,
-.markdown-body .markdown-video-link-brighteon iframe,
-.markdown-body .markdown-video-link-dtube iframe {
+.markdown-body .markdown-video-link-loom iframe {
   position: absolute;
   top: 0;
   left: 0;
@@ -1457,10 +1453,20 @@
   display: block;
 }
 
-/* Standalone iframe embeds (raw author <iframe>, spotify/loom via iframe, etc.)
-   stay responsive 16:9. The higher-specificity container rules above override
-   this for iframes inside a .markdown-video-link-* wrapper. */
-.markdown-body iframe:not(.markdown-audio-link *) {
+/* Standalone iframe embeds (raw author-pasted <iframe> — the sanitizer strips
+   width/height, so without this they render at the 300x150 default). Kept
+   responsive 16:9. :where() holds this at zero added specificity so the
+   provider container rules above (and the audio overrides below) always win;
+   audio hosts are excluded so they are not stretched into video boxes. */
+.markdown-body
+  iframe:where(
+    :not(
+        .markdown-audio-link *,
+        .speak-audio-iframe,
+        [src*="open.spotify.com"],
+        [src*="soundcloud.com"]
+      )
+  ) {
   max-width: 100%;
   width: 100%;
   aspect-ratio: 16 / 9;
@@ -1470,8 +1476,14 @@
   margin: 1rem auto 0.5rem;
 }
 
-/* Audio players (3Speak audio, Spotify, Liketu) keep their natural height. */
-.markdown-body .markdown-audio-link iframe {
+/* Audio players (3Speak audio, Spotify, SoundCloud, Liketu): full width, natural
+   (short) height. width/height are stripped by the sanitizer, so the default
+   iframe height applies. */
+.markdown-body .markdown-audio-link iframe,
+.markdown-body iframe.speak-audio-iframe,
+.markdown-body iframe[src*="open.spotify.com"],
+.markdown-body iframe[src*="soundcloud.com"] {
   width: 100%;
+  max-width: 100%;
   border: none;
 }


### PR DESCRIPTION
## Problem

On self-hosted blogs, YouTube and 3Speak videos in post bodies do not render/play. The self-hosted SPA renders post bodies with `renderPostBody` but does not run the web app's client-side video enhancers, so:

- YouTube/3Speak links become inert click-to-play thumbnails (the renderer strips the `href` and expects an enhancer to swap in an iframe on click, which never runs here).
- There is no CSS for any embed markup, so even iframe-based embeds fall back to the browser default 300x150 box.

## Change

- Pass `embedVideosDirectly: true` to `renderPostBody` in the post body (`blog-post-body.tsx`) and comments (`blog-discussion-item.tsx`), so the renderer emits ready-to-play `<iframe>`s directly (same mechanism Waves already uses).
- Add responsive 16:9 styling for video embeds and a fallback for raw `<iframe>` embeds in `blog-markdown.css`; audio players keep their natural height.

Feed-card summaries are intentionally left unchanged — they are short text previews, not full bodies.

## Testing

- `pnpm --filter @ecency/self-hosted build` passes.
- `@ecency/render-helper` suite green (231/231), including the existing `embedVideosDirectly` cases that assert the YouTube/3Speak iframe output this styling targets.

## Note

`parentDomain` remains `ecency.com`, so Twitch embeds (which require `parent=<host>`) still will not load on custom domains. This is pre-existing and can be a follow-up.