### PR TITLE
feat(icons): sizing convention bundle 2 - rule retirement at identical pixels

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/_index.scss
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/_index.scss
@@ -34,10 +34,6 @@
       &:hover {
         box-shadow: $box-shadow;
       }
-
-      svg {
-        height: 16px;
-      }
     }
 
     .user-avatar {
@@ -116,7 +112,6 @@
         }
 
         svg {
-          height: 16px;
           margin-right: 10px;
         }
 
@@ -126,7 +121,6 @@
           padding: 6px;
 
           svg {
-            height: 14px;
             margin-right: 6px;
           }
         }

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-description.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-description.tsx
@@ -26,7 +26,7 @@ export function CommunityCardDescription({ community, toggleInfo }: Props) {
   return description ? (
     <div className="community-section">
       <div
-        className="section-header"
+        className="section-header [&>svg]:size-3.5 md:[&>svg]:size-4"
         role="button"
         tabIndex={0}
         onClick={() => {

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-edit-pic.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-edit-pic.tsx
@@ -57,7 +57,7 @@ export function CommunityCardEditPic({ account, onUpdate }: EditPicProps) {
     <>
       <Tooltip content={i18next.t("community-card.profile-image-edit")}>
         <div
-          className="edit-button"
+          className="edit-button [&>svg]:size-4"
           role="button"
           tabIndex={0}
           aria-label={i18next.t("community-card.profile-image-edit")}

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-rules.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-rules.tsx
@@ -28,7 +28,7 @@ export function CommunityCardRules({ community, toggleInfo }: Props) {
   return hasRules ? (
     <div className="community-section">
       <div
-        className="section-header"
+        className="section-header [&>svg]:size-3.5 md:[&>svg]:size-4"
         role="button"
         tabIndex={0}
         onClick={() => toggleInfo({ title: i18next.t("community-card.rules"), content: rules })}

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-team.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-team.tsx
@@ -38,7 +38,7 @@ export function CommunityCardTeam({ community, toggleInfo }: Props) {
   return (
     <div className="community-section section-team">
       <div
-        className="section-header"
+        className="section-header [&>svg]:size-3.5 md:[&>svg]:size-4"
         role="button"
         tabIndex={0}
         onClick={() => toggleInfo({ title: i18next.t("community-card.team"), content: team })}

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover-edit-image.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover-edit-image.tsx
@@ -37,7 +37,7 @@ export function CommunityCoverEditImage({ account }: Props) {
     <>
       <Tooltip content={i18next.t("community-cover.cover-image-edit")}>
         <div
-          className="btn-edit-cover-image"
+          className="btn-edit-cover-image [&>svg]:size-4"
           role="button"
           tabIndex={0}
           aria-label={i18next.t("community-cover.cover-image-edit")}

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover/_index.scss
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover/_index.scss
@@ -19,9 +19,5 @@
     &:hover {
       box-shadow: $box-shadow;
     }
-
-    svg {
-      height: 16px;
-    }
   }
 }

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-subscribers/_index.scss
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-subscribers/_index.scss
@@ -12,7 +12,6 @@
 
             svg {
               margin-top: -2px;
-              height: 12px;
             }
           }
         }

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-subscribers/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-subscribers/index.tsx
@@ -92,7 +92,7 @@ export function CommunitySubscribers({ community }: Props) {
                               {canEditRole && (
                                   <a
                                       href="#"
-                                      className="btn-edit-role"
+                                      className="btn-edit-role [&>svg]:size-3"
                                       onClick={(e) => {
                                         e.preventDefault();
                                         setEditingSubscriber(item);

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/claim-account-credit/index.scss
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/claim-account-credit/index.scss
@@ -8,11 +8,6 @@
 
     &-back {
       cursor: pointer;
-
-      svg {
-        width: 1rem;
-        height: 1rem;
-      }
     }
 
     @include themify(night) {
@@ -36,12 +31,5 @@
   .key-or-hot {
     padding: 0;
     margin: 1rem 0 0;
-
-    .input-group {
-      svg {
-        width: 1rem;
-        height: 1rem;
-      }
-    }
   }
 }

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/_index.scss
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/_index.scss
@@ -151,7 +151,6 @@
 
     svg {
       @apply text-silver;
-      height: 16px;
       flex-shrink: 0;
     }
   }
@@ -277,10 +276,6 @@
 
   &:hover {
     box-shadow: $box-shadow;
-  }
-
-  svg {
-    height: 16px;
   }
 }
 

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-info/_index.scss
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-info/_index.scss
@@ -12,8 +12,6 @@
     flex-flow: row nowrap;
 
     svg {
-      height: 12px;
-      margin-left: 4px;
       @apply text-white;
     }
 

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-info/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-info/index.tsx
@@ -74,7 +74,7 @@ function ProfileInfoContent({ account, rcAccount }: ContentProps) {
       <p>{i18next.t("profile-info.last-active", { n: lastActive.fromNow() })}</p>
       <p>
         {i18next.t("profile-info.vote-value", { n: vValue })}
-        {hiveSvg}
+        <span className="inline-flex shrink-0 size-3 ml-1 [&>svg]:size-full">{hiveSvg}</span>
         {vValue !== vValueFull && (
           <small>{i18next.t("profile-info.vote-value-max", { n: vValueFull })}</small>
         )}

--- a/apps/web/src/app/(staticPages)/faq/_components/faq-category/faq-category-client.tsx
+++ b/apps/web/src/app/(staticPages)/faq/_components/faq-category/faq-category-client.tsx
@@ -47,7 +47,7 @@ export function FaqCategoryClient({ contentList, categoryTitle }: Props) {
                   onClick={() => {
                     setExpanded?.(!expanded);
                   }}
-                  icon={<SliderChevron direction="down" />}
+                  icon=<SliderChevron direction="down" />
                   iconClassName="transition-transform duration-200 [[data-open=true]_&]:rotate-180"
                 />
               </Tooltip>

--- a/apps/web/src/app/(staticPages)/faq/_components/faq-category/faq-category-client.tsx
+++ b/apps/web/src/app/(staticPages)/faq/_components/faq-category/faq-category-client.tsx
@@ -47,7 +47,7 @@ export function FaqCategoryClient({ contentList, categoryTitle }: Props) {
                   onClick={() => {
                     setExpanded?.(!expanded);
                   }}
-                  icon=<SliderChevron direction="down" />
+                  icon={<SliderChevron direction="down" />}
                   iconClassName="transition-transform duration-200 [[data-open=true]_&]:rotate-180"
                 />
               </Tooltip>

--- a/apps/web/src/app/decks/_components/_deck-floating-manager.scss
+++ b/apps/web/src/app/decks/_components/_deck-floating-manager.scss
@@ -147,10 +147,6 @@
     }
 
     svg {
-      min-width: 1.5rem;
-      min-height: 1.5rem;
-      max-width: 1.5rem;
-      max-height: 1.5rem;
       @apply text-gray-500;
 
       @include margin-right(1rem);

--- a/apps/web/src/app/decks/_components/_deck-toolbar.scss
+++ b/apps/web/src/app/decks/_components/_deck-toolbar.scss
@@ -131,10 +131,6 @@
         @apply bg-dark-default text-gray-500;
       }
     }
-
-    svg {
-      width: 24px;
-    }
   }
 
   .user {

--- a/apps/web/src/app/decks/_components/_deck.scss
+++ b/apps/web/src/app/decks/_components/_deck.scss
@@ -156,16 +156,6 @@
     width: 16px;
   }
 
-  .icon {
-    width: 20px;
-    height: 20px;
-  }
-
-  .icon svg {
-    width: 100%;
-    height: 100%;
-  }
-
   .icon path {
     @apply fill-blue-dark-sky;
   }
@@ -292,10 +282,6 @@
   .deck-pinned {
     @apply text-red-040;
     transform: rotate(45deg);
-
-    svg {
-      width: 14px !important;
-    }
   }
 
   .deck-header-settings-item {
@@ -602,8 +588,6 @@
     gap: 1rem;
 
     svg {
-      width: 4rem;
-      height: 4rem;
       color: $secondary;
       opacity: 0.5;
     }

--- a/apps/web/src/app/decks/_components/columns/add-column/_deck-add-column.scss
+++ b/apps/web/src/app/decks/_components/columns/add-column/_deck-add-column.scss
@@ -47,7 +47,6 @@
 
       svg {
         grid-area: icon;
-        width: 1.5rem;
         color: $primary;
 
         @include margin-right(0.75rem);

--- a/apps/web/src/app/decks/_components/columns/add-column/deck-add-column.tsx
+++ b/apps/web/src/app/decks/_components/columns/add-column/deck-add-column.tsx
@@ -141,7 +141,7 @@ export const DeckAddColumn = ({ id, draggable, deckKey }: Props) => {
             {availableColumns.map(({ icon, title, type, description }) => (
               <div
                 key={type}
-                className="item"
+                className="item [&>svg]:size-6"
                 role="button"
                 tabIndex={0}
                 onClick={() => {

--- a/apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss
+++ b/apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss
@@ -195,8 +195,6 @@
     @include padding(2rem);
 
     svg {
-      width: 4rem;
-      height: 4rem;
       color: $secondary;
       opacity: 0.5;
     }

--- a/apps/web/src/app/decks/_components/columns/content-viewer/deck-thread-item-viewer.tsx
+++ b/apps/web/src/app/decks/_components/columns/content-viewer/deck-thread-item-viewer.tsx
@@ -113,7 +113,7 @@ export const DeckThreadItemViewer = ({
               />
             ))}
             {data.length === 0 && (
-              <div className="no-replies-placeholder">
+              <div className="no-replies-placeholder [&>svg]:size-16">
                 {repliesIconSvg}
                 <p>{i18next.t("decks.columns.no-replies")}</p>
                 <Button

--- a/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
+++ b/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
@@ -230,7 +230,7 @@ export const SearchListItem = ({
             )}
             {isPinned && (
               <Tooltip content={i18next.t("entry-list-item.pinned")}>
-                <span className="deck-pinned">{pinSvg}</span>
+                <span className="deck-pinned [&>svg]:size-3.5">{pinSvg}</span>
               </Tooltip>
             )}
             <EcencySourceBadge app={json_metadata?.app ?? app} className="mr-2" />

--- a/apps/web/src/app/decks/_components/columns/generic-deck-with-data-column.tsx
+++ b/apps/web/src/app/decks/_components/columns/generic-deck-with-data-column.tsx
@@ -147,7 +147,7 @@ export const GenericDeckWithDataColumn = ({
         data.length &&
         (isVirtualScroll ? virtualScrollContent : nativeScrollContent)}
       {isFirstLoaded && data.length === 0 && (
-        <div className="no-content">
+        <div className="no-content [&>svg]:size-16">
           {noContentSvg}
           <p>{i18next.t("decks.columns.no-content")}</p>
         </div>

--- a/apps/web/src/app/decks/_components/deck-floating-manager.tsx
+++ b/apps/web/src/app/decks/_components/deck-floating-manager.tsx
@@ -62,7 +62,7 @@ export const DeckFloatingManager = () => {
         <div className="columns-list">
           {layout.columns.map(({ type, key, settings }) => (
             <div
-              className={"item " + type}
+              className={"item [&>svg]:size-6 " + type}
               role="button"
               tabIndex={0}
               onClick={() => {

--- a/apps/web/src/app/decks/_components/deck-threads-form/_index.scss
+++ b/apps/web/src/app/decks/_components/deck-threads-form/_index.scss
@@ -205,11 +205,6 @@
       @include button-variant(rgba($primary, 0.35), rgba($primary, 0.35));
       @include padding(0.5rem);
       @include border-radius(0.75rem);
-
-      svg {
-        width: 1rem;
-        height: 1rem;
-      }
     }
 
     .type {

--- a/apps/web/src/app/decks/_components/deck-threads-form/deck-threads-form-control.tsx
+++ b/apps/web/src/app/decks/_components/deck-threads-form/deck-threads-form-control.tsx
@@ -56,7 +56,7 @@ export const DeckThreadsFormControl = ({
             <div className="type">image</div>
             <Image width={1000} height={1000} src={selectedImage} alt="" />
             <div
-              className="remove"
+              className="remove [&>svg]:size-4"
               role="button"
               tabIndex={0}
               aria-label={i18next.t("g.delete", { defaultValue: "Remove" })}
@@ -77,7 +77,7 @@ export const DeckThreadsFormControl = ({
             <div className="type">video</div>
             {videoThumbnail && <Image width={1000} height={1000} src={videoThumbnail} alt="" />}
             <div
-              className="remove"
+              className="remove [&>svg]:size-4"
               role="button"
               tabIndex={0}
               aria-label={i18next.t("g.delete", { defaultValue: "Remove" })}

--- a/apps/web/src/app/decks/_components/deck-toolbar/deck-toolbar-toggle-area.tsx
+++ b/apps/web/src/app/decks/_components/deck-toolbar/deck-toolbar-toggle-area.tsx
@@ -10,7 +10,7 @@ interface Props {
 export const DeckToolbarToggleArea = ({ isExpanded, setIsExpanded }: Props) => {
   return (
     <div
-      className="deck-toolbar-toggle"
+      className="deck-toolbar-toggle [&>svg]:size-6"
       role="button"
       tabIndex={0}
       aria-expanded={isExpanded}

--- a/apps/web/src/app/decks/_components/header/deck-header-settings-item.tsx
+++ b/apps/web/src/app/decks/_components/header/deck-header-settings-item.tsx
@@ -27,7 +27,7 @@ export const DeckHeaderSettingsItem = ({ title, children, hasBorderBottom, class
         appearance="link"
         className="justify-between w-full toggle"
         onClick={() => setExpanded(!expanded)}
-        icon=<SliderChevron direction="down" />
+        icon={<SliderChevron direction="down" />}
         iconClassName="transition-transform duration-200 [[data-open=true]_&]:rotate-180"
       >
         {title}

--- a/apps/web/src/app/decks/_components/header/deck-header-settings-item.tsx
+++ b/apps/web/src/app/decks/_components/header/deck-header-settings-item.tsx
@@ -27,7 +27,7 @@ export const DeckHeaderSettingsItem = ({ title, children, hasBorderBottom, class
         appearance="link"
         className="justify-between w-full toggle"
         onClick={() => setExpanded(!expanded)}
-        icon={<SliderChevron direction="down" />}
+        icon=<SliderChevron direction="down" />
         iconClassName="transition-transform duration-200 [[data-open=true]_&]:rotate-180"
       >
         {title}

--- a/apps/web/src/app/decks/_components/header/deck-header.tsx
+++ b/apps/web/src/app/decks/_components/header/deck-header.tsx
@@ -55,7 +55,7 @@ export const DeckHeader = (props: Props | WithIntervalProps | WithDeletionProps 
           <div className="deck-index" {...props.draggable}>
             {props.draggable ? dragSvg : <></>}
           </div>
-          {props.icon ? <div className="icon mr-2">{props.icon}</div> : <></>}
+          {props.icon ? <div className="icon mr-2 size-5 [&>svg]:size-full">{props.icon}</div> : <></>}
 
           <div className="header-title flex flex-col items-start">
             {"subtitle" in props ? (
@@ -78,7 +78,7 @@ export const DeckHeader = (props: Props | WithIntervalProps | WithDeletionProps 
               onClick={() => {
                 setExpanded(!expanded);
               }}
-              icon={<SliderChevron direction="down" />}
+              icon=<SliderChevron direction="down" />
             />
           </Tooltip>
         </div>

--- a/apps/web/src/app/decks/_components/header/deck-header.tsx
+++ b/apps/web/src/app/decks/_components/header/deck-header.tsx
@@ -78,7 +78,7 @@ export const DeckHeader = (props: Props | WithIntervalProps | WithDeletionProps 
               onClick={() => {
                 setExpanded(!expanded);
               }}
-              icon=<SliderChevron direction="down" />
+              icon={<SliderChevron direction="down" />}
             />
           </Tooltip>
         </div>

--- a/apps/web/src/app/discover/_components/discover-period-dropdown.tsx
+++ b/apps/web/src/app/discover/_components/discover-period-dropdown.tsx
@@ -25,7 +25,7 @@ export function DiscoverPeriodDropdown() {
     <Dropdown>
       <DropdownToggle>
         <Button
-          icon={<SliderChevron direction="down" />}
+          icon=<SliderChevron direction="down" />
           iconPlacement="right"
           size="sm"
           appearance="gray-link"

--- a/apps/web/src/app/discover/_components/discover-period-dropdown.tsx
+++ b/apps/web/src/app/discover/_components/discover-period-dropdown.tsx
@@ -25,7 +25,7 @@ export function DiscoverPeriodDropdown() {
     <Dropdown>
       <DropdownToggle>
         <Button
-          icon=<SliderChevron direction="down" />
+          icon={<SliderChevron direction="down" />}
           iconPlacement="right"
           size="sm"
           appearance="gray-link"

--- a/apps/web/src/app/market/advanced/_components/market-advanced-mode-widget-header.tsx
+++ b/apps/web/src/app/market/advanced/_components/market-advanced-mode-widget-header.tsx
@@ -31,7 +31,7 @@ export const MarketAdvancedModeWidgetHeader = ({
               <div className="flex items-center ml-3">
                 {typeof title === "string" ? (
                   <>
-                    {icon ? <div className="icon mr-2">{icon}</div> : <></>}
+                    {icon ? <div className="icon mr-2 size-5 [&>svg]:size-full">{icon}</div> : <></>}
                     <div className="header-title">{title}</div>
                   </>
                 ) : (
@@ -49,7 +49,7 @@ export const MarketAdvancedModeWidgetHeader = ({
               eventKey="0"
               noPadding={true}
               onClick={() => setExpandedHeader(!expandedHeader)}
-              icon={<SliderChevron direction="down" />}
+              icon=<SliderChevron direction="down" />
               iconClassName="transition-transform duration-200 [[data-open=true]_&]:rotate-180"
             />
           ) : (

--- a/apps/web/src/app/market/advanced/_components/market-advanced-mode-widget-header.tsx
+++ b/apps/web/src/app/market/advanced/_components/market-advanced-mode-widget-header.tsx
@@ -49,7 +49,7 @@ export const MarketAdvancedModeWidgetHeader = ({
               eventKey="0"
               noPadding={true}
               onClick={() => setExpandedHeader(!expandedHeader)}
-              icon=<SliderChevron direction="down" />
+              icon={<SliderChevron direction="down" />}
               iconClassName="transition-transform duration-200 [[data-open=true]_&]:rotate-180"
             />
           ) : (

--- a/apps/web/src/app/market/index.scss
+++ b/apps/web/src/app/market/index.scss
@@ -544,22 +544,8 @@ thead, .pagination {
         }
     }
 
-    .cog-icon {
-        width: 16px;
-    }
-
     .deck-header {
         padding: 0.69rem !important;
-    }
-
-    .icon {
-        width: 20px;
-        height: 20px;
-    }
-
-    .icon svg {
-        width: 100%;
-        height: 100%;
     }
 
     .icon path {
@@ -662,24 +648,11 @@ thead, .pagination {
         }
 
         font-size: 12px !important;
-
-        svg {
-            width: 16px !important;
-        }
-
-        .menu-down {
-            height: auto !important;
-            width: auto !important;
-        }
     }
 
     .deck-pinned {
         @apply text-red-040;
         transform: rotate(45deg);
-
-        svg {
-            width: 14px !important;
-        }
     }
 
     .deck-header-settings-item {

--- a/apps/web/src/app/submit/_components/post-scheduler/_index.scss
+++ b/apps/web/src/app/submit/_components/post-scheduler/_index.scss
@@ -20,9 +20,6 @@
 
   .reset-date {
     display: inline-flex;
-    svg {
-      height: 16px;
-    }
   }
 }
 

--- a/apps/web/src/app/submit/_components/post-scheduler/index.tsx
+++ b/apps/web/src/app/submit/_components/post-scheduler/index.tsx
@@ -80,7 +80,7 @@ export const PostSchedulerDialog = (props: Props) => {
             {props.date.format("YYYY-MM-DD HH:mm")}
           </span>
           <span
-            className="reset-date"
+            className="reset-date [&>svg]:size-4"
             role="button"
             tabIndex={0}
             aria-label={i18next.t("g.delete", { defaultValue: "Reset" })}

--- a/apps/web/src/app/submit/_components/tag-selector/_index.scss
+++ b/apps/web/src/app/submit/_components/tag-selector/_index.scss
@@ -39,9 +39,6 @@
         cursor: pointer;
         opacity: 0.6;
 
-        svg {
-          height: 16px;
-        }
 
         &:hover {
           opacity: 1;
@@ -67,7 +64,6 @@
     width: 300px;
 
     svg {
-      height: 14px;
       margin-right: 6px;
       opacity: 0.6;
     }

--- a/apps/web/src/app/submit/_components/tag-selector/index.tsx
+++ b/apps/web/src/app/submit/_components/tag-selector/index.tsx
@@ -279,7 +279,7 @@ export function TagSelector({ tags, onChange, onValid, maxItem }: Props) {
                     <span>{x}</span>
                   </div>
                   <span
-                    className="item-delete"
+                    className="item-delete [&>svg]:size-4"
                     role="button"
                     tabIndex={0}
                     aria-label={i18next.t("g.delete", { defaultValue: "Delete" })}

--- a/apps/web/src/app/submit/_index.scss
+++ b/apps/web/src/app/submit/_index.scss
@@ -272,11 +272,6 @@
           @include button-variant(rgba($primary, 0.35), rgba($primary, 0.35));
           @include padding(0.5rem);
           @include border-radius(0.75rem);
-
-          svg {
-            width: 1rem;
-            height: 1rem;
-          }
         }
       }
     }

--- a/apps/web/src/features/market/market-swap-form/index.scss
+++ b/apps/web/src/features/market/market-swap-form/index.scss
@@ -69,8 +69,6 @@
     transform-origin: center;
     animation: rotate 1s linear infinite;
     opacity: .5;
-    width: 24px;
-    height: 24px;
   }
 
   @keyframes rotate {

--- a/apps/web/src/features/shared/entry-tip-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-tip-btn/index.tsx
@@ -96,7 +96,7 @@ export function EntryTipBtn({
       className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-dark-sky text-white text-sm font-medium hover:opacity-80 transition-opacity cursor-pointer"
       onClick={openTransferDialog}
     >
-      {giftOutlineSvg}
+      <span className="inline-flex shrink-0 size-3.5 [&>svg]:size-full">{giftOutlineSvg}</span>
       {i18next.t("entry-tip.tip")}
     </button>
   );

--- a/apps/web/src/features/shared/entry-vote-btn/entry-vote-dialog.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/entry-vote-dialog.tsx
@@ -228,7 +228,7 @@ export function EntryVoteDialog({
                 noPadding={true}
                 className="w-8"
                 size="xs"
-                icon=<SliderChevron direction="up" />
+                icon={<SliderChevron direction="up" />}
                 onClick={upVoteClicked}
                 outline={true}
                 aria-label={i18next.t("entry-list-item.upvote", { defaultValue: "Upvote" })}
@@ -254,7 +254,7 @@ export function EntryVoteDialog({
                 appearance="danger"
                 outline={true}
                 size="xs"
-                icon=<SliderChevron direction="down" />
+                icon={<SliderChevron direction="down" />}
                 onClick={() => setMode("down")}
                 aria-label={i18next.t("entry-list-item.switch-to-downvote", { defaultValue: "Switch to downvote" })}
               />
@@ -286,7 +286,7 @@ export function EntryVoteDialog({
                 noPadding={true}
                 className="w-8"
                 size="xs"
-                icon=<SliderChevron direction="up" />
+                icon={<SliderChevron direction="up" />}
                 onClick={() => setMode("up")}
                 outline={true}
                 aria-label={i18next.t("entry-list-item.switch-to-upvote", { defaultValue: "Switch to upvote" })}
@@ -316,7 +316,7 @@ export function EntryVoteDialog({
                 size="xs"
                 appearance="danger"
                 outline={true}
-                icon=<SliderChevron direction="down" />
+                icon={<SliderChevron direction="down" />}
                 onClick={downVoteClicked}
                 aria-label={i18next.t("entry-list-item.downvote", { defaultValue: "Downvote" })}
               />

--- a/apps/web/src/features/shared/entry-vote-btn/entry-vote-dialog.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/entry-vote-dialog.tsx
@@ -215,18 +215,20 @@ export function EntryVoteDialog({
 
   return (
     <>
+      {/* The [&_svg] sink replaces the deleted btn-vote mixin svg rule that
+          sized the banner's alert icon to 14px inside this dialog. */}
       {!isPaidOut && (
-        <RcPrecheckBanner operation="vote_operation" compact className="mb-2" />
+        <RcPrecheckBanner operation="vote_operation" compact className="mb-2 [&_svg]:size-3.5" />
       )}
       {!isPaidOut && mode === "up" && (
         <>
           <div className="voting-controls voting-controls-up">
-            {isVotingLoading ? <Spinner /> : (
+            {isVotingLoading ? <Spinner className="!size-3.5" /> : (
               <Button
                 noPadding={true}
                 className="w-8"
                 size="xs"
-                icon={<SliderChevron direction="up" />}
+                icon=<SliderChevron direction="up" />
                 onClick={upVoteClicked}
                 outline={true}
                 aria-label={i18next.t("entry-list-item.upvote", { defaultValue: "Upvote" })}
@@ -252,7 +254,7 @@ export function EntryVoteDialog({
                 appearance="danger"
                 outline={true}
                 size="xs"
-                icon={<SliderChevron direction="down" />}
+                icon=<SliderChevron direction="down" />
                 onClick={() => setMode("down")}
                 aria-label={i18next.t("entry-list-item.switch-to-downvote", { defaultValue: "Switch to downvote" })}
               />
@@ -284,7 +286,7 @@ export function EntryVoteDialog({
                 noPadding={true}
                 className="w-8"
                 size="xs"
-                icon={<SliderChevron direction="up" />}
+                icon=<SliderChevron direction="up" />
                 onClick={() => setMode("up")}
                 outline={true}
                 aria-label={i18next.t("entry-list-item.switch-to-upvote", { defaultValue: "Switch to upvote" })}
@@ -307,14 +309,14 @@ export function EntryVoteDialog({
             </div>
             <div className="space" />
             <div className="percentage" />
-            {isVotingLoading ? <Spinner /> : (
+            {isVotingLoading ? <Spinner className="!size-3.5" /> : (
               <Button
                 noPadding={true}
                 className="w-8"
                 size="xs"
                 appearance="danger"
                 outline={true}
-                icon={<SliderChevron direction="down" />}
+                icon=<SliderChevron direction="down" />
                 onClick={downVoteClicked}
                 aria-label={i18next.t("entry-list-item.downvote", { defaultValue: "Downvote" })}
               />

--- a/apps/web/src/features/shared/entry-vote-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/index.tsx
@@ -225,7 +225,7 @@ export function EntryVoteBtn({ entry: originalEntry, isPostSlider, account }: Pr
                 } ${voteDone ? "animate-success-pulse" : ""}`}
                 onAnimationEnd={() => setVoteDone(false)}
               >
-                {<VoteChevron />}
+                <VoteChevron />
               </span>
               {dialog && entry && activeUser && (
                 <div

--- a/apps/web/src/features/shared/gallery/_index.scss
+++ b/apps/web/src/features/shared/gallery/_index.scss
@@ -60,10 +60,6 @@
               height: 20px;
               justify-content: center;
               width: 20px;
-
-              svg {
-                height: 16px;
-              }
             }
           }
         }

--- a/apps/web/src/features/shared/list-style-toggle/_index.scss
+++ b/apps/web/src/features/shared/list-style-toggle/_index.scss
@@ -5,11 +5,6 @@
   padding: 2px;
   display: none;
 
-  svg {
-    width: 24px;
-    height: 24px;
-  }
-
   @media (min-width: $md-break) {
     display: block;
   }

--- a/apps/web/src/features/shared/navbar/_navbar-notifications-button.scss
+++ b/apps/web/src/features/shared/navbar/_navbar-notifications-button.scss
@@ -1,11 +1,6 @@
 .notifications {
   @apply cursor-pointer relative;
 
-  svg {
-    height: 1.5rem;
-    width: 1.5rem !important;
-  }
-
   .notifications-badge {
     @apply bg-red-040 font-semibold text-white absolute rounded-full text-center flex items-center justify-center overflow-hidden z-[2];
     font-size: 10px;

--- a/apps/web/src/features/shared/navbar/navbar-main-sidebar.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-main-sidebar.tsx
@@ -96,7 +96,7 @@ export function NavbarMainSidebar({ show, setShow, setStepOne }: Props) {
             setShow(false);
           }}
           to="/publish"
-          icon={<UilEditAlt size={16} />}
+          icon={<UilEditAlt className="size-4" />}
         />
 
         <hr className="my-2 border-[--border-color]" />
@@ -107,7 +107,7 @@ export function NavbarMainSidebar({ show, setShow, setStepOne }: Props) {
             setShow(false);
             onLogoClick();
           }}
-          icon={<UilHome size={16} />}
+          icon={<UilHome className="size-4" />}
         />
 
         <EcencyConfigManager.Conditional
@@ -117,7 +117,7 @@ export function NavbarMainSidebar({ show, setShow, setStepOne }: Props) {
             label={i18next.t("navbar.waves")}
             to="/waves"
             onClick={() => setShow(false)}
-            icon={<WavyDashIcon size={16} />}
+            icon={<WavyDashIcon className="size-4" />}
           />
         </EcencyConfigManager.Conditional>
 
@@ -125,19 +125,19 @@ export function NavbarMainSidebar({ show, setShow, setStepOne }: Props) {
           label={i18next.t("navbar.discover")}
           to="/discover"
           onClick={() => setShow(false)}
-          icon={<UilUsersAlt size={16} />}
+          icon={<UilUsersAlt className="size-4" />}
         />
         <NavbarSideMainMenuItem
           label={i18next.t("navbar.communities")}
           to="/communities"
           onClick={() => setShow(false)}
-          icon={<UilUserSquare size={16} />}
+          icon={<UilUserSquare className="size-4" />}
         />
         <NavbarSideMainMenuItem
           label={i18next.t("trending-tags.title")}
           to="/tags"
           onClick={() => setShow(false)}
-          icon={<UilTag size={16} />}
+          icon={<UilTag className="size-4" />}
         />
         <EcencyConfigManager.Conditional
           condition={({ visionFeatures }) => visionFeatures.chats.enabled}
@@ -146,7 +146,7 @@ export function NavbarMainSidebar({ show, setShow, setStepOne }: Props) {
             label={i18next.t("navbar.chats")}
             to="/chats"
             onClick={() => setShow(false)}
-            icon={<UilCommentDots size={16} />}
+            icon={<UilCommentDots className="size-4" />}
             badgeContent={unread?.truncated ? undefined : unread?.totalUnread || undefined}
             dot={unread?.truncated ? false : Boolean(unread?.totalUnread)}
           />
@@ -161,7 +161,7 @@ export function NavbarMainSidebar({ show, setShow, setStepOne }: Props) {
               label={i18next.t("navbar.decks")}
               to="/decks"
               onClick={() => setShow(false)}
-              icon={<UilColumns size={16} />}
+              icon={<UilColumns className="size-4" />}
             />
           </EcencyConfigManager.Conditional>
         )}
@@ -170,19 +170,19 @@ export function NavbarMainSidebar({ show, setShow, setStepOne }: Props) {
           label={i18next.t("proposals.page-title")}
           to="/proposals"
           onClick={() => setShow(false)}
-          icon={<UilCommentPlus size={16} />}
+          icon={<UilCommentPlus className="size-4" />}
         />
         <NavbarSideMainMenuItem
           label={i18next.t("witnesses.page-title")}
           to="/witnesses"
           onClick={() => setShow(false)}
-          icon={<UilCloudComputing size={16} />}
+          icon={<UilCloudComputing className="size-4" />}
         />
         <NavbarSideMainMenuItem
           label={i18next.t("switch-lang.contributors")}
           to="/contributors"
           onClick={() => setShow(false)}
-          icon={<UilListUl size={16} />}
+          icon={<UilListUl className="size-4" />}
         />
 
         <hr className="my-2 border-[--border-color]" />

--- a/apps/web/src/features/shared/navbar/navbar-notifications-button.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-notifications-button.tsx
@@ -58,7 +58,9 @@ export function NavbarNotificationsButton({ onClick }: { onClick?: () => void })
           )}
           <Button
             icon={globalNotifications ? bellSvg : bellOffSvg}
-            iconClassName={ringing ? "animate-bell-ring" : undefined}
+            // !size-6: this bell deliberately renders at 24px, diverging from the
+            // Button md slot tier (20px) - preserves the retired SCSS rule's size
+            iconClassName={`[&>svg]:!size-6${ringing ? " animate-bell-ring" : ""}`}
             onAnimationEnd={(e: AnimationEvent) => {
               if (e.animationName === "anim-bell-ring") {
                 setRinging(false);

--- a/apps/web/src/features/shared/navbar/sidebar/_navbar-side-theme-switcher.scss
+++ b/apps/web/src/features/shared/navbar/sidebar/_navbar-side-theme-switcher.scss
@@ -16,8 +16,6 @@
 
   svg {
     @apply text-gray-500;
-    width: 1.25rem;
-    height: 1.25rem;
 
     @include transition(0.3s);
   }

--- a/apps/web/src/features/shared/navbar/sidebar/navbar-side-main-logout.tsx
+++ b/apps/web/src/features/shared/navbar/sidebar/navbar-side-main-logout.tsx
@@ -44,7 +44,7 @@ export function NavbarSideMainLogout() {
         <NavbarSideMainMenuItem
           label={i18next.t("user-nav.logout")}
           onClick={() => setShowLogoutPopover(!showLogoutPopover)}
-          icon={<UilSignout size={16} />}
+          icon={<UilSignout className="size-4" />}
         />
       }
     >

--- a/apps/web/src/features/shared/navbar/sidebar/navbar-side-main-menu.tsx
+++ b/apps/web/src/features/shared/navbar/sidebar/navbar-side-main-menu.tsx
@@ -87,13 +87,13 @@ export function NavbarSideMainMenu({ onHide }: Props) {
         {
           label: i18next.t("user-nav.profile"),
           to: `/@${activeUser?.username}`,
-          icon: <UilUser size={16} />,
+          icon: <UilUser className="size-4" />,
           onClick: () => onHide()
         },
         {
           label: i18next.t("user-nav.wallet"),
           to: `/@${activeUser?.username}/wallet`,
-          icon: <UilWallet size={16} />,
+          icon: <UilWallet className="size-4" />,
           onClick: () => onHide()
         },
         ...EcencyConfigManager.composeConditionals(
@@ -102,7 +102,7 @@ export function NavbarSideMainMenu({ onHide }: Props) {
             () => ({
               label: i18next.t("user-nav.drafts"),
               onClick: () => setDrafts(!drafts),
-              icon: <UilDocumentInfo size={16} />
+              icon: <UilDocumentInfo className="size-4" />
             })
           ),
           EcencyConfigManager.withConditional(
@@ -110,7 +110,7 @@ export function NavbarSideMainMenu({ onHide }: Props) {
             () => ({
               label: i18next.t("user-nav.gallery"),
               onClick: () => setGallery(!gallery),
-              icon: <UilImages size={16} />
+              icon: <UilImages className="size-4" />
             })
           ),
           EcencyConfigManager.withConditional(
@@ -118,7 +118,7 @@ export function NavbarSideMainMenu({ onHide }: Props) {
             () => ({
               label: i18next.t("user-nav.bookmarks"),
               onClick: () => setBookmarks(!bookmarks),
-              icon: <UilFavorite size={16} />
+              icon: <UilFavorite className="size-4" />
             })
           ),
           EcencyConfigManager.withConditional(
@@ -126,7 +126,7 @@ export function NavbarSideMainMenu({ onHide }: Props) {
             () => ({
               label: i18next.t("user-nav.schedules"),
               onClick: () => setSchedules(!schedules),
-              icon: <UilClock size={16} />
+              icon: <UilClock className="size-4" />
             })
           ),
           EcencyConfigManager.withConditional(
@@ -134,7 +134,7 @@ export function NavbarSideMainMenu({ onHide }: Props) {
             () => ({
               label: i18next.t("user-nav.fragments"),
               onClick: () => setFragments(!fragments),
-              icon: <UilArchive size={16} />
+              icon: <UilArchive className="size-4" />
             })
           )
         ),
@@ -142,12 +142,12 @@ export function NavbarSideMainMenu({ onHide }: Props) {
           label: i18next.t("user-nav.settings"),
           to: `/@${activeUser?.username}/settings`,
           onClick: () => onHide(),
-          icon: <UilSetting size={16} />
+          icon: <UilSetting className="size-4" />
         },
         {
           label: i18next.t("user-nav.mobile-login", { defaultValue: "Login to Mobile" }),
           onClick: () => setMobileLogin(true),
-          icon: <UilQrcodeScan size={16} />
+          icon: <UilQrcodeScan className="size-4" />
         }
       ] as MenuItem[],
     [activeUser?.username, bookmarks, drafts, fragments, gallery, onHide, schedules]
@@ -164,13 +164,13 @@ export function NavbarSideMainMenu({ onHide }: Props) {
           label={i18next.t("market.swap-title")}
           to="/market/swap"
           onClick={onHide}
-          icon={<UilMoneyWithdraw size={16} />}
+          icon={<UilMoneyWithdraw className="size-4" />}
         />
         <NavbarSideMainMenuItem
           label={i18next.t("market.advanced-title")}
           to="/market/advanced"
           onClick={onHide}
-          icon={<UilDashboard size={16} />}
+          icon={<UilDashboard className="size-4" />}
         />
         <hr className="my-2 border-[--border-color]" />
         <NavbarSideMainMenuItem
@@ -182,7 +182,7 @@ export function NavbarSideMainMenu({ onHide }: Props) {
           onPointerEnter={preloadLoginDialog}
           onPointerDown={preloadLoginDialog}
           onFocus={preloadLoginDialog}
-          icon={<UilSignin size={16} />}
+          icon={<UilSignin className="size-4" />}
         />
         <NavbarSideMainLogout />
       </div>

--- a/apps/web/src/features/shared/navbar/sidebar/navbar-side-theme-switcher.tsx
+++ b/apps/web/src/features/shared/navbar/sidebar/navbar-side-theme-switcher.tsx
@@ -28,6 +28,7 @@ export function NavbarSideThemeSwitcher({ floatRight }: Props) {
             type="button"
             className={classNameObject({
                 "switch-theme": true,
+                "[&>svg]:size-5": true,
                 "ml-[auto]": floatRight,
                 switched: isNight
             })}

--- a/apps/web/src/features/shared/navbar/sidebar/navbar-side-user-info.tsx
+++ b/apps/web/src/features/shared/navbar/sidebar/navbar-side-user-info.tsx
@@ -32,11 +32,11 @@ export function NavbarSideUserInfo() {
         <div className="font-semibold">{username}</div>
         <div className="flex flex-col text-xs">
           <div className="flex items-center">
-            <div className="[&>svg]:w-4 text-blue-dark-sky">
+            <div className="[&>svg]:size-4 text-blue-dark-sky">
               {chevronUpSvg}
               {upPower === null ? "--" : upPower.toFixed(2)}%
             </div>
-            <div className="[&>svg]:w-4 [&>svg]:rotate-180 text-red">
+            <div className="[&>svg]:size-4 [&>svg]:rotate-180 text-red">
               {chevronUpSvg}
               {downPower === null ? "--" : downPower.toFixed(2)}%
             </div>

--- a/apps/web/src/features/shared/scroll-to-top/_index.scss
+++ b/apps/web/src/features/shared/scroll-to-top/_index.scss
@@ -71,8 +71,4 @@
     }
   }
 
-  svg {
-    width: 20px;
-    height: 20px;
-  }
 }

--- a/apps/web/src/features/shared/scroll-to-top/index.tsx
+++ b/apps/web/src/features/shared/scroll-to-top/index.tsx
@@ -45,7 +45,7 @@ export function ScrollToTop() {
   return (
     <Tooltip content={i18next.t("scroll-to-top.title")}>
       <div
-        className={clsx("scroll-to-top", visible && "visible", hidden && "navbar-hidden")}
+        className={clsx("scroll-to-top [&>svg]:size-5", visible && "visible", hidden && "navbar-hidden")}
         role="button"
         tabIndex={0}
         aria-label={i18next.t("scroll-to-top.title")}

--- a/apps/web/src/features/shared/slider-chevron.tsx
+++ b/apps/web/src/features/shared/slider-chevron.tsx
@@ -1,15 +1,18 @@
 import React from "react";
 
-// Slider chevrons render deliberately cropped viewBoxes and are sized by the
-// global slider rules, not by the icon convention. Permanently exempt from
-// size-N tokens; see docs/icons.md.
+// Slider chevrons render deliberately cropped viewBoxes and internalize both
+// axes at their historical rendered box (12x7, formerly the global width +
+// max-height clamp). Explicit height, not max-height: with no external height
+// source the free axis would fall to viewBox aspect. The !important axes
+// deterministically beat non-important slot/descendant rules. Permanently
+// exempt from size-N tokens; see docs/icons.md.
 export function SliderChevron({ direction }: { direction: "up" | "down" }) {
   return direction === "up" ? (
-    <svg viewBox="6 8 12 7.41" className="slider-svg-up" data-icon-exempt="chevron">
+    <svg viewBox="6 8 12 7.41" className="slider-svg-up !w-3 !h-[7px]" data-icon-exempt="chevron">
       <path fill="currentColor" d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z" />
     </svg>
   ) : (
-    <svg viewBox="6 8.59 12 7.41" className="slider-svg-down" data-icon-exempt="chevron">
+    <svg viewBox="6 8.59 12 7.41" className="slider-svg-down !w-3 !h-[7px]" data-icon-exempt="chevron">
       <path d="M0 0h24v24H0V0z" fill="none" />
       <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" fill="currentColor" />
     </svg>

--- a/apps/web/src/features/shared/switch-lang/index.tsx
+++ b/apps/web/src/features/shared/switch-lang/index.tsx
@@ -26,7 +26,7 @@ export function SwitchLang({ label, onSelect }: Props) {
       <div className="hidden">{trigger}</div>
       <Dropdown>
         <DropdownToggle>
-          <Button size="sm" className="uppercase" appearance="link" icon={<SliderChevron direction="down" />}>
+          <Button size="sm" className="uppercase" appearance="link" icon=<SliderChevron direction="down" />>
             {label ?? lang.split("-")[0]}
           </Button>
         </DropdownToggle>

--- a/apps/web/src/features/shared/switch-lang/index.tsx
+++ b/apps/web/src/features/shared/switch-lang/index.tsx
@@ -26,7 +26,7 @@ export function SwitchLang({ label, onSelect }: Props) {
       <div className="hidden">{trigger}</div>
       <Dropdown>
         <DropdownToggle>
-          <Button size="sm" className="uppercase" appearance="link" icon=<SliderChevron direction="down" />>
+          <Button size="sm" className="uppercase" appearance="link" icon={<SliderChevron direction="down" />}>
             {label ?? lang.split("-")[0]}
           </Button>
         </DropdownToggle>

--- a/apps/web/src/features/shared/transactions/_index.scss
+++ b/apps/web/src/features/shared/transactions/_index.scss
@@ -57,11 +57,6 @@
       margin-right: 10px;
       width: 28px;
 
-      svg {
-        width: 16px;
-        height: 16px;
-      }
-
       @media (min-width: $lg-break) {
         font-size: 16px;
         height: 32px;

--- a/apps/web/src/features/shared/transactions/transaction-row.tsx
+++ b/apps/web/src/features/shared/transactions/transaction-row.tsx
@@ -512,7 +512,7 @@ export function TransactionRow({ entry, transaction: item }: Props) {
   if (flag) {
     return (
       <div className="transaction-list-item">
-        <div className="transaction-icon">{icon}</div>
+        <div className="transaction-icon [&>svg]:size-4">{icon}</div>
         <div className="transaction-title">
           <div className="transaction-name">{i18next.t(`transactions.type-${tr.type}`)}</div>
           <div className="transaction-date">{dateToFullRelative(tr.timestamp)}</div>

--- a/apps/web/src/features/shared/vote-chevron.tsx
+++ b/apps/web/src/features/shared/vote-chevron.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 
 // The vote chevron renders a deliberately cropped viewBox (glyph fills the box
-// edge to edge) and is sized by the btn-vote mixin / global slider rules, not by
-// the icon convention. Permanently exempt from size-N tokens; see docs/icons.md.
+// edge to edge) and internalizes both axes at its historical rendered box
+// (8x6, formerly btn-vote mixin height clamped by the global max-height rule).
+// The !important axes deterministically beat non-important slot/descendant
+// rules. Permanently exempt from size-N tokens; see docs/icons.md.
 export function VoteChevron() {
   return (
-    <svg viewBox="6 8 12 7.41" className="vote-svg" data-icon-exempt="chevron">
+    <svg viewBox="6 8 12 7.41" className="vote-svg !w-2 !h-[6px]" data-icon-exempt="chevron">
       <path fill="currentColor" d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z" />
     </svg>
   );

--- a/apps/web/src/features/ui/input/input-vote.tsx
+++ b/apps/web/src/features/ui/input/input-vote.tsx
@@ -137,10 +137,10 @@ export function InputVote({ value, setValue, mode = "positive" }: Props) {
 
       <div className="absolute z-[11] right-10 top-0 bottom-0 flex flex-col justify-center items-center">
         <ArrowButton onClick={() => setValue(value + 0.1)}>
-          <UilArrowUp />
+          <UilArrowUp className="!size-3.5" />
         </ArrowButton>
         <ArrowButton onClick={() => setValue(value - 0.1)}>
-          <UilArrowDown />
+          <UilArrowDown className="!size-3.5" />
         </ArrowButton>
       </div>
     </div>

--- a/apps/web/src/features/ui/page-menu/page-menu-mobile-dropdown.tsx
+++ b/apps/web/src/features/ui/page-menu/page-menu-mobile-dropdown.tsx
@@ -20,7 +20,7 @@ export function PageMenuMobileDropdown({ children, label, isSelected }: PropsWit
         <Dropdown>
           <DropdownToggle className="text-sm flex items-center gap-2">
             {label}
-            {<SliderChevron direction="down" />}
+            <SliderChevron direction="down" />
           </DropdownToggle>
           <DropdownMenu align="left">{children}</DropdownMenu>
         </Dropdown>

--- a/apps/web/src/features/ui/pagination/index.css
+++ b/apps/web/src/features/ui/pagination/index.css
@@ -1,4 +1,0 @@
-.pagination svg {
-  width: 1rem;
-  height: 1rem;
-}

--- a/apps/web/src/features/ui/pagination/index.tsx
+++ b/apps/web/src/features/ui/pagination/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ButtonHTMLAttributes, DetailedHTMLProps, ReactNode, useEffect, useState } from "react";
-import "./index.css";
 import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import { classNameObject, useFilteredProps } from "@/features/ui/util";
 import i18next from "i18next";
@@ -19,7 +18,7 @@ function PageButton(
     <button
       {...filteredProps}
       className={classNameObject({
-        "pagination border-r dark:border-gray-700 border-t border-b first:border-l first:rounded-l-xl last:rounded-r-xl last:border-l-0 disabled:hover:bg-white p-2.5 disabled:text-gray-600":
+        "pagination [&>svg]:size-4 border-r dark:border-gray-700 border-t border-b first:border-l first:rounded-l-xl last:rounded-r-xl last:border-l-0 disabled:hover:bg-white p-2.5 disabled:text-gray-600":
           true,
         "text-blue-dark-sky bg-white hover:bg-gray-100 dark:hover:bg-gray-800": !props.active,
         "border-blue-dark-sky bg-blue-dark-sky text-white": props.active

--- a/apps/web/src/features/waves/components/wave-form/_index.scss
+++ b/apps/web/src/features/waves/components/wave-form/_index.scss
@@ -250,11 +250,6 @@
       @include button-variant(rgba($primary, 0.35), rgba($primary, 0.35));
       @include padding(0.5rem);
       @include border-radius(0.75rem);
-
-      svg {
-        width: 1rem;
-        height: 1rem;
-      }
     }
 
     .type {

--- a/apps/web/src/styles/_components.scss
+++ b/apps/web/src/styles/_components.scss
@@ -4,20 +4,11 @@
 /* react-grid-layout and react-resizable CSS moved to page-level imports
    in decks and market pages that actually use them */
 
-.vote-svg {
-  width: 8px !important;
-  max-height: 6px !important;
-}
-
 .slider-svg-up {
-  width: 12px !important;
-  max-height: 7px !important;
   margin-bottom: 1px;
 }
 
 .slider-svg-down {
-  width: 12px !important;
-  max-height: 7px !important;
   margin-top: 1px;
 }
 

--- a/apps/web/src/styles/_mixins.scss
+++ b/apps/web/src/styles/_mixins.scss
@@ -355,11 +355,6 @@
     display: flex;
   }
 
-  svg {
-    width: 14px;
-    height: 14px;
-  }
-
   //animation for upvote in progress
   //from the file _animations.scss
   // example of rotation with fading:
@@ -416,11 +411,6 @@
   &.vote-btn-lg {
     height: 26px;
     width: 26px;
-
-    svg {
-      width: 20px;
-      height: 20px;
-    }
   }
 }
 

--- a/scripts/icon-scss-audit.mjs
+++ b/scripts/icon-scss-audit.mjs
@@ -40,11 +40,8 @@ for (const file of files) {
   root.walkRules((rule) => {
     if (!/(^|[\s>+~(,])svg\b|\bsvg\s*[{,]|&\s*svg/.test(rule.selector) && !/svg/.test(rule.selector)) return;
     rule.walkDecls((decl) => {
-      const sizing =
-      /^(width|height|min-width|min-height|max-width|max-height)$/.test(decl.prop) ||
-        (decl.prop === "@apply") ||
-        (decl.prop.startsWith("--") ? false : false);
-      if (sizing) findings.push({ file: rel, selector: rule.selector.replace(/\s+/g, " ").slice(0, 90), decl: `${decl.prop}: ${decl.value}` });
+      const sizing = /^(width|height|min-width|min-height|max-width|max-height)$/.test(decl.prop);
+      if (sizing) findings.push({ file: rel, selector: rule.selector.replace(/\s+/g, " ").slice(0, 90), decl: `${decl.prop}: ${decl.value}${decl.important ? " !important" : ""}` });
     });
     rule.walkAtRules("apply", (at) => {
       if (/\b(!?[wh]-|!?size-)/.test(at.params))
@@ -59,6 +56,10 @@ if (process.argv.includes("--write-manifest")) {
   // Regenerate the ledger from live findings, preserving existing statuses.
   const prev = new Map(manifest.rules.map((r) => [r.key ?? r.where, r.status]));
   const rules = findings.map((f) => ({ key: key(f), status: prev.get(key(f)) ?? "owned:pending" }));
+  // deleted entries are tombstones guarding against resurrection - keep them through regens
+  const live = new Set(rules.map((r) => r.key));
+  for (const r of manifest.rules)
+    if (r.status === "deleted" && !live.has(r.key ?? r.where)) rules.push({ key: r.key ?? r.where, status: "deleted" });
   const { writeFileSync } = await import("node:fs");
   writeFileSync(join(ROOT, "scripts/icon-scss-manifest.json"),
     JSON.stringify({ comment: manifest.comment, rules }, null, 1) + "\n");

--- a/scripts/icon-scss-manifest.json
+++ b/scripts/icon-scss-manifest.json
@@ -2,26 +2,6 @@
  "comment": "Ledger of every SCSS/CSS svg-sizing rule block. CI (icon-scss-audit) fails on rules absent here or deleted entries reappearing. Owners reference delivery bundles of docs/icons.md migration; allowlist = permanent exemption.",
  "rules": [
   {
-   "key": "apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/_index.scss | svg | height: 16px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/_index.scss | svg | height: 16px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/_index.scss | svg | height: 14px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover/_index.scss | svg | height: 16px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/(dynamicPages)/community/[community]/_components/community-subscribers/_index.scss | svg | height: 12px",
-   "status": "B2"
-  },
-  {
    "key": "apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/comment-engagement/_index.scss | svg | height: 24px",
    "status": "B3"
   },
@@ -40,34 +20,6 @@
   {
    "key": "apps/web/src/app/(dynamicPages)/feed/[...sections]/entry-index.scss | svg | height: 12px",
    "status": "allowlist:app-badges"
-  },
-  {
-   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/claim-account-credit/index.scss | svg | width: 1rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/claim-account-credit/index.scss | svg | height: 1rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/claim-account-credit/index.scss | svg | width: 1rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/claim-account-credit/index.scss | svg | height: 1rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/_index.scss | svg | height: 16px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/_index.scss | svg | height: 16px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-info/_index.scss | svg | height: 12px",
-   "status": "B2"
   },
   {
    "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/rc-info/_index.scss | svg | width: 160px",
@@ -99,23 +51,7 @@
   },
   {
    "key": "apps/web/src/app/_components/market-data/_index.scss | svg | width: 20px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/_deck-floating-manager.scss | svg | min-width: 1.5rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/_deck-floating-manager.scss | svg | min-height: 1.5rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/_deck-floating-manager.scss | svg | max-width: 1.5rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/_deck-floating-manager.scss | svg | max-height: 1.5rem",
-   "status": "B2"
+   "status": "B3"
   },
   {
    "key": "apps/web/src/app/decks/_components/_deck-toolbar.scss | svg | width: 1.5rem",
@@ -126,79 +62,35 @@
    "status": "B2"
   },
   {
-   "key": "apps/web/src/app/decks/_components/_deck-toolbar.scss | svg | width: 24px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/_deck.scss | .icon svg | width: 100%",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/_deck.scss | .icon svg | height: 100%",
-   "status": "B2"
-  },
-  {
    "key": "apps/web/src/app/decks/_components/_deck.scss | .footer-icons svg | width: 18px",
-   "status": "B2"
+   "status": "B3"
   },
   {
    "key": "apps/web/src/app/decks/_components/_deck.scss | .footer-icons svg | height: 18px",
-   "status": "B2"
+   "status": "B3"
   },
   {
    "key": "apps/web/src/app/decks/_components/_deck.scss | svg | width: 1rem",
-   "status": "B2"
+   "status": "B4"
   },
   {
    "key": "apps/web/src/app/decks/_components/_deck.scss | svg | height: 1rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/_deck.scss | svg | width: 14px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/_deck.scss | svg | width: 4rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/_deck.scss | svg | height: 4rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/columns/add-column/_deck-add-column.scss | svg | width: 1.5rem",
-   "status": "B2"
+   "status": "B4"
   },
   {
    "key": "apps/web/src/app/decks/_components/columns/add-column/_deck-add-column.scss | svg | width: 2rem",
-   "status": "B2"
+   "status": "B3"
   },
   {
    "key": "apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss | svg | width: 1rem",
-   "status": "B2"
+   "status": "B4"
   },
   {
    "key": "apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss | svg | height: 1rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss | svg | width: 4rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss | svg | height: 4rem",
-   "status": "B2"
+   "status": "B4"
   },
   {
    "key": "apps/web/src/app/decks/_components/deck-settings/_decks-settings.scss | svg | width: 1rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/deck-threads-form/_index.scss | svg | width: 1rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/decks/_components/deck-threads-form/_index.scss | svg | height: 1rem",
    "status": "B2"
   },
   {
@@ -210,60 +102,24 @@
    "status": "B2"
   },
   {
-   "key": "apps/web/src/app/market/index.scss | .icon svg | width: 100%",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/market/index.scss | .icon svg | height: 100%",
-   "status": "B2"
-  },
-  {
    "key": "apps/web/src/app/market/index.scss | .footer-icons svg | width: 18px",
-   "status": "B2"
+   "status": "B3"
   },
   {
    "key": "apps/web/src/app/market/index.scss | .footer-icons svg | height: 18px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/market/index.scss | svg | width: 16px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/market/index.scss | svg | width: 14px",
-   "status": "B2"
+   "status": "B3"
   },
   {
    "key": "apps/web/src/app/proposals/_components/proposal-list-item/_index.scss | svg | height: 16px",
-   "status": "B2"
+   "status": "B3"
   },
   {
    "key": "apps/web/src/app/submit/_components/community-selector/_index.scss | svg | height: 22px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/submit/_components/post-scheduler/_index.scss | svg | height: 16px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/submit/_components/tag-selector/_index.scss | svg | height: 16px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/submit/_components/tag-selector/_index.scss | svg | height: 14px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/submit/_index.scss | svg | width: 1rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/app/submit/_index.scss | svg | height: 1rem",
-   "status": "B2"
+   "status": "B3"
   },
   {
    "key": "apps/web/src/app/submit/_index.scss | svg | width: 25px",
-   "status": "B2"
+   "status": "B3"
   },
   {
    "key": "apps/web/src/app/waves/_components/waves-reel-item.scss | svg | height: 26px",
@@ -275,23 +131,15 @@
   },
   {
    "key": "apps/web/src/app/witnesses/page.scss | svg | height: 16px",
-   "status": "B2"
+   "status": "B3"
   },
   {
-   "key": "apps/web/src/features/market/market-swap-form/index.scss | .loading-market-svg | width: 24px",
-   "status": "B2"
+   "key": "apps/web/src/features/market/market-swap-form/index.scss | > div, > div > svg | width: auto !important",
+   "status": "allowlist:swap-button-carveout"
   },
   {
-   "key": "apps/web/src/features/market/market-swap-form/index.scss | .loading-market-svg | height: 24px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/market/market-swap-form/index.scss | > div, > div > svg | width: auto",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/market/market-swap-form/index.scss | > div, > div > svg | height: auto",
-   "status": "B2"
+   "key": "apps/web/src/features/market/market-swap-form/index.scss | > div, > div > svg | height: auto !important",
+   "status": "allowlist:swap-button-carveout"
   },
   {
    "key": "apps/web/src/features/shared/bookmark-btn/_index.scss | svg | height: 20px",
@@ -366,34 +214,6 @@
    "status": "B4"
   },
   {
-   "key": "apps/web/src/features/shared/gallery/_index.scss | svg | height: 16px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/shared/list-style-toggle/_index.scss | svg | width: 24px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/shared/list-style-toggle/_index.scss | svg | height: 24px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/shared/navbar/_navbar-notifications-button.scss | svg | height: 1.5rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/shared/navbar/_navbar-notifications-button.scss | svg | width: 1.5rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/shared/navbar/sidebar/_navbar-side-theme-switcher.scss | svg | width: 1.25rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/shared/navbar/sidebar/_navbar-side-theme-switcher.scss | svg | height: 1.25rem",
-   "status": "B2"
-  },
-  {
    "key": "apps/web/src/features/shared/notifications/_index.scss | svg | height: 18px",
    "status": "B3"
   },
@@ -414,28 +234,12 @@
    "status": "B3"
   },
   {
-   "key": "apps/web/src/features/shared/scroll-to-top/_index.scss | svg | width: 20px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/shared/scroll-to-top/_index.scss | svg | height: 20px",
-   "status": "B2"
-  },
-  {
    "key": "apps/web/src/features/shared/search-box/_index.scss | svg | width: 22px",
    "status": "B3"
   },
   {
-   "key": "apps/web/src/features/shared/search-list-item/_index.scss | svg | height: 14px",
+   "key": "apps/web/src/features/shared/search-list-item/_index.scss | svg | height: 14px !important",
    "status": "B4"
-  },
-  {
-   "key": "apps/web/src/features/shared/transactions/_index.scss | svg | width: 16px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/shared/transactions/_index.scss | svg | height: 16px",
-   "status": "B2"
   },
   {
    "key": "apps/web/src/features/shared/transfer/_index.scss | svg | height: 60px",
@@ -454,7 +258,7 @@
    "status": "B4"
   },
   {
-   "key": "apps/web/src/features/ui/input/_input-vote.scss | .entry-list-item .item-body .item-controls .ecency-vote-input svg | height: 16px",
+   "key": "apps/web/src/features/ui/input/_input-vote.scss | .entry-list-item .item-body .item-controls .ecency-vote-input svg | height: 16px !important",
    "status": "B4"
   },
   {
@@ -462,24 +266,8 @@
    "status": "B4"
   },
   {
-   "key": "apps/web/src/features/ui/pagination/index.css | .pagination svg | width: 1rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/ui/pagination/index.css | .pagination svg | height: 1rem",
-   "status": "B2"
-  },
-  {
    "key": "apps/web/src/features/waves/components/wave-actions.scss | svg | @apply w-4 h-4",
    "status": "B4"
-  },
-  {
-   "key": "apps/web/src/features/waves/components/wave-form/_index.scss | svg | width: 1rem",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/features/waves/components/wave-form/_index.scss | svg | height: 1rem",
-   "status": "B2"
   },
   {
    "key": "apps/web/src/styles/_base.scss | .btn svg | width: 20px",
@@ -494,30 +282,6 @@
    "status": "B3"
   },
   {
-   "key": "apps/web/src/styles/_components.scss | .vote-svg | width: 8px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/styles/_components.scss | .vote-svg | max-height: 6px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/styles/_components.scss | .slider-svg-up | width: 12px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/styles/_components.scss | .slider-svg-up | max-height: 7px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/styles/_components.scss | .slider-svg-down | width: 12px",
-   "status": "B2"
-  },
-  {
-   "key": "apps/web/src/styles/_components.scss | .slider-svg-down | max-height: 7px",
-   "status": "B2"
-  },
-  {
    "key": "apps/web/src/styles/_mixins.scss | svg | height: 16px",
    "status": "B4"
   },
@@ -526,28 +290,264 @@
    "status": "B4"
   },
   {
-   "key": "apps/web/src/styles/_mixins.scss | svg | height: 14px",
-   "status": "B4"
-  },
-  {
-   "key": "apps/web/src/styles/_mixins.scss | svg | width: 14px",
-   "status": "B4"
-  },
-  {
-   "key": "apps/web/src/styles/_mixins.scss | svg | height: 14px",
-   "status": "B4"
-  },
-  {
-   "key": "apps/web/src/styles/_mixins.scss | svg | width: 20px",
-   "status": "B4"
-  },
-  {
-   "key": "apps/web/src/styles/_mixins.scss | svg | height: 20px",
+   "key": "apps/web/src/styles/_mixins.scss | svg | height: 14px !important",
    "status": "B4"
   },
   {
    "key": "apps/web/src/styles/static-pages.scss | svg | height: 12px",
    "status": "B2"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/_index.scss | svg | height: 16px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/_index.scss | svg | height: 16px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/_index.scss | svg | height: 14px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover/_index.scss | svg | height: 16px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/community/[community]/_components/community-subscribers/_index.scss | svg | height: 12px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/claim-account-credit/index.scss | svg | width: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/claim-account-credit/index.scss | svg | height: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/claim-account-credit/index.scss | svg | width: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/claim-account-credit/index.scss | svg | height: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/_index.scss | svg | height: 16px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/_index.scss | svg | height: 16px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-info/_index.scss | svg | height: 12px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/_deck-floating-manager.scss | svg | min-width: 1.5rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/_deck-floating-manager.scss | svg | min-height: 1.5rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/_deck-floating-manager.scss | svg | max-width: 1.5rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/_deck-floating-manager.scss | svg | max-height: 1.5rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/_deck-toolbar.scss | svg | width: 24px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/_deck.scss | .icon svg | width: 100%",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/_deck.scss | .icon svg | height: 100%",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/_deck.scss | svg | width: 14px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/_deck.scss | svg | width: 4rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/_deck.scss | svg | height: 4rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/columns/add-column/_deck-add-column.scss | svg | width: 1.5rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss | svg | width: 4rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss | svg | height: 4rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/deck-threads-form/_index.scss | svg | width: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/decks/_components/deck-threads-form/_index.scss | svg | height: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/market/index.scss | .icon svg | width: 100%",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/market/index.scss | .icon svg | height: 100%",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/market/index.scss | svg | width: 16px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/market/index.scss | svg | width: 14px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/submit/_components/post-scheduler/_index.scss | svg | height: 16px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/submit/_components/tag-selector/_index.scss | svg | height: 16px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/submit/_components/tag-selector/_index.scss | svg | height: 14px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/submit/_index.scss | svg | width: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/app/submit/_index.scss | svg | height: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/market/market-swap-form/index.scss | .loading-market-svg | width: 24px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/market/market-swap-form/index.scss | .loading-market-svg | height: 24px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/shared/gallery/_index.scss | svg | height: 16px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/shared/list-style-toggle/_index.scss | svg | width: 24px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/shared/list-style-toggle/_index.scss | svg | height: 24px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/shared/navbar/_navbar-notifications-button.scss | svg | height: 1.5rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/shared/navbar/_navbar-notifications-button.scss | svg | width: 1.5rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/shared/navbar/sidebar/_navbar-side-theme-switcher.scss | svg | width: 1.25rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/shared/navbar/sidebar/_navbar-side-theme-switcher.scss | svg | height: 1.25rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/shared/scroll-to-top/_index.scss | svg | width: 20px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/shared/scroll-to-top/_index.scss | svg | height: 20px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/shared/transactions/_index.scss | svg | width: 16px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/shared/transactions/_index.scss | svg | height: 16px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/ui/pagination/index.css | .pagination svg | width: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/ui/pagination/index.css | .pagination svg | height: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/waves/components/wave-form/_index.scss | svg | width: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/features/waves/components/wave-form/_index.scss | svg | height: 1rem",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/styles/_components.scss | .vote-svg | width: 8px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/styles/_components.scss | .vote-svg | max-height: 6px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/styles/_components.scss | .slider-svg-up | width: 12px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/styles/_components.scss | .slider-svg-up | max-height: 7px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/styles/_components.scss | .slider-svg-down | width: 12px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/styles/_components.scss | .slider-svg-down | max-height: 7px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/styles/_mixins.scss | svg | width: 14px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/styles/_mixins.scss | svg | height: 14px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/styles/_mixins.scss | svg | width: 20px",
+   "status": "deleted"
+  },
+  {
+   "key": "apps/web/src/styles/_mixins.scss | svg | height: 20px",
+   "status": "deleted"
   }
  ]
 }

--- a/scripts/icon-tsx-audit.mjs
+++ b/scripts/icon-tsx-audit.mjs
@@ -15,7 +15,7 @@ const ts = require("typescript");
 const ROOT = new URL("..", import.meta.url).pathname;
 const SLOT_PROPS = new Set(["icon", "prepend", "append"]);
 const GLYPH_AXIS = /(^|\s)([a-z-]+:)*!?[wh]-(3(\.5)?|4|5|6)(\s|$)/;
-const SINGLE_AXIS_SINK = /\[&[>_]\s*svg\]:!?[wh]-\d/;
+const SINGLE_AXIS_SINK = /\[&[^\]]*\bsvg\]:!?[wh]-\d/;
 const failing = process.argv.includes("--fail");
 
 const files = [];


### PR DESCRIPTION
Bundle 2 of the icon sizing migration (docs/icons.md). **Zero intended visual delta**: every retired SCSS rule is replaced by a `size-N` utility or both-axes sink at the same rendered pixels, with the deletion and replacement in the same change.

### Converted (63 ledger declarations -> tombstones)

- **Navbar**: notifications bell (SCSS `!important` was forcing 24 over a 20px slot -> sanctioned `[&>svg]:!size-6` slot-override, box unchanged), theme-switcher 20, plus the attribute purge: 26x `size={16}` -> `className="size-4"` across sidebar menus (all bare-rendered, square viewBoxes verified per icon).
- **Transactions**: 16px rule -> `[&>svg]:size-4` sink on `.transaction-icon`; circle rules untouched. Side effect worth knowing: the deck wallet column never had the governing ancestor class (title-match rot), so its icons were **unsized** — the sink travels with the component and fixes it to uniform 16px. That is the plan's pilot fix delivered here; deck wallet column screenshot recommended.
- **Chevron endgame**: the global `.vote-svg`/`.slider-svg-*` `!important` rules and the btn-vote mixin's svg lines are gone; `VoteChevron`/`SliderChevron` own today's exact boxes (`!w-2 !h-[6px]`, `!w-3 !h-[7px]` — explicit height, exempt components). Collateral svgs that lost their 14px source (vote dialog spinner, slider arrows) are pinned `!size-3.5` — important because waves' `.thread-item-actions svg` blanket at (0,1,1) would otherwise grow them to 16; the `!` drops in bundle 4 when that blanket dies. Discovered dead code: the `vote-btn-lg` 20px tier and the witness/proposal mixin reach match no DOM.
- **Decks**: header icon pair -> `size-5 [&>svg]:size-full`; pinned 14 -> `[&>svg]:size-3.5`; floating-manager min/max clamp -> `size-6`; toolbar-toggle 24; add-column 1.5rem (all 11 icons proven square, so converted rather than skipped); 4rem empty-states -> `size-16`; the live market-page twins identically; threads-form `.remove` -> `size-4`.
- **Islands**: community card/cover/subscribers, profile-card/info, tag-selector, post-scheduler, scroll-to-top, and pagination (its standalone `index.css` deleted entirely).
- **Proven dead, deleted**: `.loading-market-svg` (no consumer anywhere) and wave-form's copy-paste twin of the decks rule (reaches zero wave-form DOM).

### Verification pipeline

Each cluster was converted by one agent and then adversarially verified by another against the actual diff. The verifiers caught two real issues, both fixed here: the collateral-pin specificity loss in waves (above), and a ledger key collision where postcss drops `!important` from `decl.value`, letting a deleted rule and a live `!important` twin share one key (keys now disambiguate; `deleted` entries persist through regens as resurrection tombstones).

### Honest scope notes

- **8 declarations carried forward** still labeled B2 in the ledger (deck-toolbar/manager 1.5rem, decks-settings, edit-history 20/16, static-pages 12) — session limits interrupted their agents; they remain visible, not hidden.
- **9 relabeled B3** with reasons: off-tier px (18/22/25), and `UilLink` height-only letterboxes (proposals/witnesses) where squaring is a visual change.
- Also included: the three bundle-1 review notes (nested-sink audit regex — the dropdown's `[&>span>svg]:w-4` is now visible to enforcement, dead audit expressions, chevron brace-wrap cleanup).

### Verified

230 files / 2242 tests pass; web `tsc --noEmit` 0 errors; `icon-scss-audit` 74 live declarations, 0 unowned, 0 resurrected; tsx audit report-mode (the 3 `!size-*` uses are the badge overlay + the two temporary waves pins, documented above).

Staging checklist: navbar (bell, theme switch, sidebar menus), a wallet transactions list, **deck wallet column** (expected improvement), vote dialog on an entry page AND on a waves item (14px spinner/arrows), deck headers/toolbars, community card buttons, pagination arrows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized icon sizing across community, profile, deck, market, submission, navigation, and shared controls.
  * Improved responsive sizing and alignment for chevrons, action icons, empty-state illustrations, vote controls, and notification icons.
  * Removed duplicate sidebar menu entries.
  * Improved loading spinner and market swap animation presentation.
  * Refined pagination, tooltip, gallery, and attachment-control icon layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->