### PR TITLE
Note that a private-api 401 is often not the user's token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,6 +403,20 @@ The `EcencyConfigManager` (`src/config/`) provides:
 - `hive.ts` - Hive blockchain API
 - `hive-engine.ts` - Hive Engine token API
 - `private-api.ts` - Ecency private API
+
+**Debugging a `/private-api/*` 401:** do not assume the user's token. Requests
+go through a proxy that validates the signed code and then pipes the upstream
+response through unchanged, so a 401 raised by a backend service is
+indistinguishable here from a rejected token. Before touching auth code, check
+whether other private-API calls succeed for the same session - if notifications
+work while one endpoint 401s, the code validated fine and the cause is
+server-side on that route. An endpoint failing for *every* user points at a
+backend gate rather than anything the client sends.
+
+Also note that not every query surfaces this: a queryFn that reads
+`response.json()` without checking `response.ok` swallows a 401 silently, while
+one that throws will retry and produce several console errors per page load. A
+noisy endpoint and a quiet one can be failing in exactly the same way.
 - `format-error.ts` - Error formatting for user-facing error messages
 
 **Mutation Architecture**:


### PR DESCRIPTION
Short addition to the API layer section of CLAUDE.md.

Private-API requests are proxied: the proxy validates the signed code and then pipes the upstream response through unchanged, so a 401 raised by a backend service is indistinguishable from a rejected token when viewed from the client. Debugging naturally starts at auth code, which is the wrong end.

Adds two checks that separate them - whether sibling private-API calls succeed for the same session, and whether the endpoint fails for every user or a subset - plus a note that a queryFn reading `response.json()` without checking `response.ok` swallows a 401 silently while one that throws retries and floods the console. The same underlying failure can therefore look loud on one endpoint and invisible on another.

No infrastructure specifics, per this repo being public. Documentation only, no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for 401 errors from private API requests.
  * Clarified how proxy validation and upstream responses affect error diagnosis.
  * Added recommendations for comparing endpoint behavior and checking response status before parsing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->