### PR TITLE
fix(chat): hide Mattermost default channels from channel search

### DIFF
--- a/apps/web/src/app/api/mattermost/channels/helpers.ts
+++ b/apps/web/src/app/api/mattermost/channels/helpers.ts
@@ -27,6 +27,23 @@ interface MattermostChannelMemberCounts {
   last_update_at?: number;
 }
 
+/**
+ * Mattermost auto-joins every user to these channels when they join a team.
+ * No Hive user intentionally joined them, so they are hidden from the channel
+ * list, excluded from the unread badge, and dropped from channel search. All
+ * three must agree: a default channel that is searchable but not listable puts
+ * the user in a channel that then vanishes from their sidebar.
+ *
+ * Matching is on the channel SLUG (`name`), never the display name — display
+ * names are editable and can collide with a real community channel.
+ */
+const MATTERMOST_DEFAULT_CHANNEL_NAMES = new Set(["town-square", "off-topic"]);
+
+/** Whether a channel is one of the Mattermost team defaults users never chose. */
+export function isMattermostDefaultChannel(channel: { name?: string | null }): boolean {
+  return MATTERMOST_DEFAULT_CHANNEL_NAMES.has(channel.name ?? "");
+}
+
 /** A channel is muted when the member opted out of unread marking (mobile parity). */
 export function isChannelMuted(member?: { notify_props?: { mark_unread?: string } }): boolean {
   return member?.notify_props?.mark_unread === "mention";

--- a/apps/web/src/app/api/mattermost/channels/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/route.ts
@@ -8,7 +8,8 @@ import {
 import {
   fetchAllChannelPages,
   fetchAllChannelMemberPages,
-  dmContributesToUnreadBadge
+  dmContributesToUnreadBadge,
+  isMattermostDefaultChannel
 } from "./helpers";
 
 interface MattermostChannel {
@@ -112,10 +113,6 @@ export async function GET() {
         .find((category) => category.type === "direct_messages")
         ?.channel_ids || []
     );
-    // Mattermost auto-joins users to these default channels when they join
-    // the team. Hide them since no Hive user intentionally joined these.
-    const MATTERMOST_DEFAULT_CHANNELS = new Set(["town-square", "off-topic"]);
-
     const channelMembersById = channelMembers.reduce<Record<string, MattermostChannelMemberCounts>>(
       (acc, member) => {
         acc[member.channel_id] = member;
@@ -135,7 +132,7 @@ export async function GET() {
     const hasCategories = (categoriesResponse.categories || []).length > 0;
     const filteredChannels = channels.filter((channel) => {
       // Filter out Mattermost team default channels
-      if (MATTERMOST_DEFAULT_CHANNELS.has(channel.name)) return false;
+      if (isMattermostDefaultChannel(channel)) return false;
 
       if (channel.type !== "D") return true;
 

--- a/apps/web/src/app/api/mattermost/channels/search/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/search/route.ts
@@ -61,8 +61,12 @@ export async function POST(req: Request) {
     // there, so surfacing them here would let a user open a channel that then
     // disappears from their sidebar. Their display names can also collide with
     // a real community channel, making the two results indistinguishable.
+    // A non-array body is an upstream anomaly, not an empty result set. Pass it
+    // through unchanged so callers can still tell the two apart.
     return NextResponse.json({
-      channels: (channels || []).filter((channel) => !isMattermostDefaultChannel(channel))
+      channels: Array.isArray(channels)
+        ? channels.filter((channel) => !isMattermostDefaultChannel(channel))
+        : channels
     });
   } catch (error) {
     if (isMattermostUnauthorizedError(error)) {

--- a/apps/web/src/app/api/mattermost/channels/search/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/search/route.ts
@@ -6,6 +6,7 @@ import {
   isMattermostUnauthorizedError,
   mmUserFetch
 } from "@/server/mattermost";
+import { isMattermostDefaultChannel } from "../helpers";
 
 interface MattermostChannelSummary {
   id: string;
@@ -56,7 +57,13 @@ export async function POST(req: Request) {
       }
     );
 
-    return NextResponse.json({ channels });
+    // Keep search in sync with the channel list: the team defaults are hidden
+    // there, so surfacing them here would let a user open a channel that then
+    // disappears from their sidebar. Their display names can also collide with
+    // a real community channel, making the two results indistinguishable.
+    return NextResponse.json({
+      channels: (channels || []).filter((channel) => !isMattermostDefaultChannel(channel))
+    });
   } catch (error) {
     if (isMattermostUnauthorizedError(error)) {
       return handleMattermostError(error);

--- a/apps/web/src/app/api/mattermost/channels/unreads/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/unreads/route.ts
@@ -11,7 +11,8 @@ import {
   fetchAllChannelMemberPages,
   isChannelMuted,
   isChannelNeverViewed,
-  channelUnreadMessageCount
+  channelUnreadMessageCount,
+  isMattermostDefaultChannel
 } from "../helpers";
 
 interface MattermostChannel {
@@ -161,13 +162,9 @@ export async function GET() {
       }
     });
 
-    // Mattermost auto-joins users to these default channels when they join
-    // a team. The UI hides them, so exclude their unreads from the badge.
-    const MATTERMOST_DEFAULT_CHANNELS = new Set(["town-square", "off-topic"]);
-
     // Filter out excluded DM channels and hidden default channels
     const filteredChannels = allChannels.filter(
-      (ch) => !excludedDmChannelIds.has(ch.id) && !MATTERMOST_DEFAULT_CHANNELS.has(ch.name ?? "")
+      (ch) => !excludedDmChannelIds.has(ch.id) && !isMattermostDefaultChannel(ch)
     );
 
     const memberByChannelId = members.reduce<Record<string, MattermostChannelMember>>((acc, member) => {

--- a/apps/web/src/specs/api/mattermost-default-channels-filter.spec.ts
+++ b/apps/web/src/specs/api/mattermost-default-channels-filter.spec.ts
@@ -1,18 +1,18 @@
 import { describe, it, expect } from "vitest";
+import { isMattermostDefaultChannel } from "@/app/api/mattermost/channels/helpers";
 
 /**
- * Regression test: MATTERMOST_DEFAULT_CHANNELS filtering.
+ * Regression test: Mattermost default-channel filtering.
  *
- * The channels route filters out Mattermost team defaults
- * ("town-square", "off-topic") that users are auto-joined to
- * when they join the team. This test verifies:
+ * Mattermost auto-joins users to "town-square" and "off-topic" when they join
+ * the team. Three routes must agree on hiding them — the channel list, the
+ * unread badge, and channel search — so this exercises the single shared
+ * predicate they all use. It verifies:
  * 1. Default channels are removed from the response
  * 2. Real community/DM channels survive the filter
  * 3. Channel selection logic picks the intended non-default channel
+ * 4. Search results hide the same channels the list hides
  */
-
-// Mirror the constant from the channels route
-const MATTERMOST_DEFAULT_CHANNELS = new Set(["town-square", "off-topic"]);
 
 interface TestChannel {
   id: string;
@@ -22,10 +22,10 @@ interface TestChannel {
 }
 
 function applyDefaultChannelFilter(channels: TestChannel[]): TestChannel[] {
-  return channels.filter((channel) => !MATTERMOST_DEFAULT_CHANNELS.has(channel.name));
+  return channels.filter((channel) => !isMattermostDefaultChannel(channel));
 }
 
-describe("MATTERMOST_DEFAULT_CHANNELS filtering", () => {
+describe("Mattermost default-channel filtering", () => {
   const payload: TestChannel[] = [
     { id: "ch-1", name: "town-square", display_name: "Town Square", type: "O" },
     { id: "ch-2", name: "off-topic", display_name: "Off-Topic", type: "O" },
@@ -95,5 +95,35 @@ describe("MATTERMOST_DEFAULT_CHANNELS filtering", () => {
     // not a Mattermost default
     const defaultChannelId = filtered[0]?.id;
     expect(defaultChannelId).toBe("ch-3"); // hive-123456, not town-square
+  });
+
+  it("keeps a community channel that shares a default channel's display name", () => {
+    // A community can be renamed to anything, including "Town Square". Only the
+    // slug decides, so the community channel stays and the default one goes.
+    const collision: TestChannel[] = [
+      { id: "ch-1", name: "town-square", display_name: "Town Square", type: "O" },
+      { id: "ch-2", name: "hive-125125", display_name: "Town Square", type: "O" }
+    ];
+    const filtered = applyDefaultChannelFilter(collision);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe("ch-2");
+  });
+
+  it("hides the same channels in search results as in the channel list", () => {
+    // Search used to return the raw Mattermost results, so a user could open a
+    // default channel that the list then hid — leaving no row to go back to.
+    const searchResults: TestChannel[] = [
+      { id: "ch-1", name: "town-square", display_name: "Town Square", type: "O" },
+      { id: "ch-2", name: "hive-125125", display_name: "Town Square", type: "O" }
+    ];
+    const searchable = applyDefaultChannelFilter(searchResults).map((ch) => ch.name);
+    const listed = applyDefaultChannelFilter(searchResults).map((ch) => ch.name);
+    expect(searchable).toEqual(listed);
+    expect(searchable).toEqual(["hive-125125"]);
+  });
+
+  it("treats a missing channel name as non-default", () => {
+    expect(isMattermostDefaultChannel({})).toBe(false);
+    expect(isMattermostDefaultChannel({ name: null })).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

`/api/mattermost/channels/search` returned Mattermost's raw search results, while `/api/mattermost/channels` and `/api/mattermost/channels/unreads` both filter out the team default channels (`town-square`, `off-topic`) that users are auto-joined to.

So a default channel could be found in search and opened, then vanish from the sidebar because the list endpoint hides it, leaving no row to return to. This got worse once a community channel ended up with a display name matching a default channel: search then returned two rows with identical labels and no way to tell them apart.

## Fix

- Move the default-channel check into `channels/helpers.ts` as `isMattermostDefaultChannel()` and use it in the list, unreads and search routes, so the three cannot drift apart again.
- The predicate matches on the channel slug (`name`) only. Display names are editable and can collide with a real community channel, so they must not decide.

Mobile needs no change: it reads channels and search through these same endpoints, so it picks the behaviour up automatically.

## Tests

`apps/web/src/specs/api/mattermost-default-channels-filter.spec.ts` now imports the shared predicate instead of mirroring a copy of the constant, plus new cases for the display-name collision, list/search parity, and a missing channel name. 11 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of Mattermost default channels across channel lists, search results, and unread indicators.
  * Default-channel matching now uses channel slugs rather than display names, preventing similarly named community channels from being hidden.
  * Improved handling of missing or unexpected channel data.

* **Tests**
  * Added regression coverage for channel filtering, search results, unread indicators, and invalid channel names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->