### PR TITLE
feat(icons): sizing convention bundle 3 - deliberate visual deltas

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/comment-engagement/_index.scss
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/comment-engagement/_index.scss
@@ -18,11 +18,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-
-    svg {
-      height: 24px;
-      margin-bottom: -2px;
-    }
   }
 
   .label {

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/comment-engagement/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/comment-engagement/index.tsx
@@ -13,7 +13,7 @@ export function CommentEngagement() {
   };
   return (
     <div className="comment-engagement">
-      <div className="icon">{commentSvg}</div>
+      <div className="icon [&>svg]:size-6 [&>svg]:-mb-0.5">{commentSvg}</div>
       <div className="label">{i18next.t("discussion.no-conversation")}</div>
       <Button id="scroll-to-input" onClick={scrollToCommentInput}>
         {i18next.t("discussion.start-conversation")}

--- a/apps/web/src/app/(staticPages)/about/page.tsx
+++ b/apps/web/src/app/(staticPages)/about/page.tsx
@@ -101,7 +101,7 @@ export default function About() {
           <h2 className="contacts-title">{i18next.t("static.about.contact-title")}</h2>
           <div className="contacts-links">
             <a
-              className="contacts-link"
+              className="contacts-link [&>svg]:size-3"
               target="_blank"
               href="https://ecency.com/@good-karma"
               rel="noopener noreferrer"
@@ -109,7 +109,7 @@ export default function About() {
               {blogSvg} {i18next.t("static.about.contact-blog")}
             </a>
             <a
-              className="contacts-link"
+              className="contacts-link [&>svg]:size-3"
               target="_blank"
               href="https://ecency.com/@ecency"
               rel="noopener noreferrer"
@@ -117,7 +117,7 @@ export default function About() {
               {newsSvg} {i18next.t("static.about.contact-news")}
             </a>
             <a
-              className="contacts-link"
+              className="contacts-link [&>svg]:size-3"
               target="_blank"
               href="mailto:hello@ecency.com?subject=Feedback"
               rel="noopener noreferrer"
@@ -125,7 +125,7 @@ export default function About() {
               {mailSvg} {i18next.t("static.about.contact-email")}
             </a>
             <a
-              className="contacts-link"
+              className="contacts-link [&>svg]:size-3"
               target="_blank"
               href="https://twitter.com/ecency_official"
               rel="noopener noreferrer"
@@ -133,7 +133,7 @@ export default function About() {
               {twitterSvg} Twitter
             </a>
             <a
-              className="contacts-link"
+              className="contacts-link [&>svg]:size-3"
               target="_blank"
               href="https://github.com/ecency"
               rel="noopener noreferrer"
@@ -141,7 +141,7 @@ export default function About() {
               {githubSvg} Github
             </a>
             <a
-              className="contacts-link"
+              className="contacts-link [&>svg]:size-3"
               target="_blank"
               href="https://t.me/ecency"
               rel="noopener noreferrer"
@@ -149,7 +149,7 @@ export default function About() {
               {telegramSvg} Telegram
             </a>
             <a
-              className="contacts-link"
+              className="contacts-link [&>svg]:size-3"
               target="_blank"
               href="https://discord.me/ecency"
               rel="noopener noreferrer"

--- a/apps/web/src/app/_components/market-data/_index.scss
+++ b/apps/web/src/app/_components/market-data/_index.scss
@@ -95,8 +95,3 @@
   }
 }
 
-.pointer {
-  svg {
-    width: 20px;
-  }
-}

--- a/apps/web/src/app/_components/market-data/index.tsx
+++ b/apps/web/src/app/_components/market-data/index.tsx
@@ -30,7 +30,7 @@ export function MarketData() {
         <span className="title flex items-center">
           {i18next.t("market-data.title")}
           <div
-            className="pointer ml-2"
+            className="pointer ml-2 [&>svg]:size-5"
             role="button"
             tabIndex={0}
             aria-label={i18next.t("g.toggle", { defaultValue: "Toggle" })}

--- a/apps/web/src/app/chats/_components/chats-client.tsx
+++ b/apps/web/src/app/chats/_components/chats-client.tsx
@@ -560,7 +560,7 @@ export function ChatsClient() {
                                   )}
                                   {isMuted && (
                                     <span
-                                      className="text-[--text-muted] flex-shrink-0"
+                                      className="text-[--text-muted] inline-flex shrink-0 size-4 [&>svg]:size-full"
                                       aria-label={i18next.t("chat.channel-muted")}
                                       title={i18next.t("chat.channel-muted")}
                                     >
@@ -811,7 +811,7 @@ export function ChatsClient() {
                                   <span className="truncate">{getChannelTitle(channel)}</span>
                                   {isMuted && (
                                     <span
-                                      className="text-[--text-muted] flex-shrink-0"
+                                      className="text-[--text-muted] inline-flex shrink-0 size-4 [&>svg]:size-full"
                                       aria-label={i18next.t("chat.channel-muted")}
                                       title={i18next.t("chat.channel-muted")}
                                     >
@@ -939,7 +939,7 @@ export function ChatsClient() {
                             )}
                             {isMuted && (
                               <span
-                                className="text-[--text-muted] flex-shrink-0"
+                                className="text-[--text-muted] inline-flex shrink-0 size-4 [&>svg]:size-full"
                                 aria-label={i18next.t("chat.channel-muted")}
                                 title={i18next.t("chat.channel-muted")}
                               >

--- a/apps/web/src/app/decks/_components/_deck-toolbar.scss
+++ b/apps/web/src/app/decks/_components/_deck-toolbar.scss
@@ -72,8 +72,6 @@
         }
 
         svg {
-          width: 1.5rem;
-          height: 1.5rem;
           @apply text-gray-500;
         }
       }

--- a/apps/web/src/app/decks/_components/_deck.scss
+++ b/apps/web/src/app/decks/_components/_deck.scss
@@ -203,11 +203,6 @@
     background-position-x: center;
   }
 
-  .footer-icons svg {
-    width: 18px;
-    height: 18px;
-  }
-
   .footer-icons {
     flex: 0.8;
   }

--- a/apps/web/src/app/decks/_components/columns/add-column/_deck-add-column.scss
+++ b/apps/web/src/app/decks/_components/columns/add-column/_deck-add-column.scss
@@ -119,7 +119,6 @@
         }
 
         svg {
-          width: 2rem;
           color: $primary;
         }
       }

--- a/apps/web/src/app/decks/_components/columns/add-column/deck-add-column-community-settings.tsx
+++ b/apps/web/src/app/decks/_components/columns/add-column/deck-add-column-community-settings.tsx
@@ -58,7 +58,7 @@ export const DeckAddColumnCommunitySettings = ({ deckKey }: SettingsProps) => {
           <div className="content-type-list">
             {COMMUNITY_CONTENT_TYPES.map(({ title, type }) => (
               <div
-                className={"content-type-item " + (contentType === type ? "selected" : "")}
+                className={"content-type-item [&>svg]:size-8 " + (contentType === type ? "selected" : "")}
                 key={title}
                 role="button"
                 tabIndex={0}

--- a/apps/web/src/app/decks/_components/columns/add-column/deck-add-column-notifications-settings.tsx
+++ b/apps/web/src/app/decks/_components/columns/add-column/deck-add-column-notifications-settings.tsx
@@ -53,7 +53,7 @@ export const DeckAddColumnNotificationsSettings = ({ deckKey }: SettingsProps) =
           <div className="content-type-list">
             {NOTIFICATION_CONTENT_TYPES.map(({ title, type }) => (
               <div
-                className={"content-type-item " + (contentType === type ? "selected" : "")}
+                className={"content-type-item [&>svg]:size-8 " + (contentType === type ? "selected" : "")}
                 key={title}
                 role="button"
                 tabIndex={0}

--- a/apps/web/src/app/decks/_components/columns/add-column/deck-add-column-user-settings.tsx
+++ b/apps/web/src/app/decks/_components/columns/add-column/deck-add-column-user-settings.tsx
@@ -51,7 +51,7 @@ export const DeckAddColumnUserSettings = ({ deckKey }: SettingsProps) => {
           <div className="content-type-list">
             {USER_CONTENT_TYPES.map(({ title, type }) => (
               <div
-                className={"content-type-item " + (contentType === type ? "selected" : "")}
+                className={"content-type-item [&>svg]:size-8 " + (contentType === type ? "selected" : "")}
                 key={title}
                 role="button"
                 tabIndex={0}

--- a/apps/web/src/app/decks/_components/columns/add-column/deck-add-column-wallet-settings.tsx
+++ b/apps/web/src/app/decks/_components/columns/add-column/deck-add-column-wallet-settings.tsx
@@ -51,7 +51,7 @@ export const DeckAddColumnWalletSettings = ({ deckKey }: SettingsProps) => {
           <div className="content-type-list">
             {WALLET_CONTENT_TYPES.map(({ title, type }) => (
               <div
-                className={"content-type-item " + (contentType === type ? "selected" : "")}
+                className={"content-type-item [&>svg]:size-8 " + (contentType === type ? "selected" : "")}
                 key={title}
                 role="button"
                 tabIndex={0}

--- a/apps/web/src/app/decks/_components/deck-settings/_decks-settings.scss
+++ b/apps/web/src/app/decks/_components/deck-settings/_decks-settings.scss
@@ -40,9 +40,5 @@
       top: calc(1.2em + 0.75rem);
       left: $input-padding-x;
     }
-
-    svg {
-      width: 1rem;
-    }
   }
 }

--- a/apps/web/src/app/decks/_components/deck-settings/decks-settings.tsx
+++ b/apps/web/src/app/decks/_components/deck-settings/decks-settings.tsx
@@ -120,6 +120,7 @@ export const DecksSettings = ({ show, setShow, deck }: Props) => {
                     <Button
                       ref={anchorRef}
                       appearance="link"
+                      className="[&_svg]:size-4"
                       onClick={() => {
                         setShowEmoji(!showEmoji);
                       }}

--- a/apps/web/src/app/decks/_components/deck-toolbar/_deck-toolbar-manager.scss
+++ b/apps/web/src/app/decks/_components/deck-toolbar/_deck-toolbar-manager.scss
@@ -154,11 +154,6 @@
 
     @include padding(0);
 
-    svg {
-      width: 1.5rem;
-      height: 1.5rem;
-    }
-
     &:hover {
       @apply text-blue-dark-sky;
     }

--- a/apps/web/src/app/decks/_components/deck-toolbar/deck-toolbar-base-actions.tsx
+++ b/apps/web/src/app/decks/_components/deck-toolbar/deck-toolbar-base-actions.tsx
@@ -31,7 +31,7 @@ export const DeckToolbarBaseActions = ({ setShowPurchaseDialog }: Props) => {
   const [showMainSide, setShowMainSide] = useState(false);
 
   return (
-    <div className="base-actions">
+    <div className="base-actions [&_svg]:size-6">
       {activeUser && (
         <>
           <EcencyConfigManager.Conditional

--- a/apps/web/src/app/decks/_components/deck-toolbar/deck-toolbar-manager.tsx
+++ b/apps/web/src/app/decks/_components/deck-toolbar/deck-toolbar-manager.tsx
@@ -25,7 +25,7 @@ export const DeckToolbarManager = ({ isExpanded }: Props) => {
           appearance="link"
           className="add-deck-btn"
           onClick={() => setShowDecksSettings(true)}
-          icon={addIconSvg}
+          icon={<span className="inline-flex !size-6 [&>svg]:size-full">{addIconSvg}</span>}
           aria-label={i18next.t("decks.add-deck", { defaultValue: "Add deck" })}
         />
       </div>

--- a/apps/web/src/app/market/index.scss
+++ b/apps/web/src/app/market/index.scss
@@ -608,11 +608,6 @@ thead, .pagination {
         background-position-x: center;
     }
 
-    .footer-icons svg {
-        width: 18px;
-        height: 18px;
-    }
-
     .footer-icons {
         flex: 0.8;
     }

--- a/apps/web/src/app/proposals/_components/proposal-list-item/_index.scss
+++ b/apps/web/src/app/proposals/_components/proposal-list-item/_index.scss
@@ -104,10 +104,6 @@
       .permlink {
         margin-bottom: 14px;
         font-size: 13px;
-
-        svg {
-          height: 16px;
-        }
       }
 
       .votes {

--- a/apps/web/src/app/proposals/_components/proposal-list-item/index.tsx
+++ b/apps/web/src/app/proposals/_components/proposal-list-item/index.tsx
@@ -94,7 +94,7 @@ export function ProposalListItem({
               </span>
             </div>
           </div>
-          <div className="permlink">
+          <div className="permlink [&_svg]:size-4">
             <EntryLink
               entry={{
                 category: "proposal",

--- a/apps/web/src/app/publish/_components/publish-success-state.tsx
+++ b/apps/web/src/app/publish/_components/publish-success-state.tsx
@@ -58,6 +58,7 @@ function ShareBar({ entryInfo }: { entryInfo: EntryInfo }) {
               target="_blank"
               rel="noopener noreferrer"
               title={label}
+              data-icon-exempt
               className="text-blue-dark-sky hover:opacity-70 transition-opacity [&_svg]:size-7"
             >
               {icon}

--- a/apps/web/src/app/submit/_components/community-selector/_index.scss
+++ b/apps/web/src/app/submit/_components/community-selector/_index.scss
@@ -14,7 +14,6 @@
   }
 
   svg {
-    height: 22px;
     @apply text-silver;
   }
 

--- a/apps/web/src/app/submit/_index.scss
+++ b/apps/web/src/app/submit/_index.scss
@@ -309,9 +309,5 @@
     font-size: 14px;
     top: 9px;
     right: 25px;
-
-    svg {
-      width: 25px;
-    }
   }
 }

--- a/apps/web/src/app/submit/_page.tsx
+++ b/apps/web/src/app/submit/_page.tsx
@@ -619,7 +619,7 @@ function Submit({ path, draftId, username, permlink, searchParams }: Props) {
                               key={item}
                             />
                             {selectedItem === item && (
-                              <div className="text-green check absolute bg-white rounded-full p-1 flex justify-center items-center">
+                              <div className="text-green check absolute bg-white rounded-full p-1 flex justify-center items-center [&>svg]:size-6">
                                 {checkSvg}
                               </div>
                             )}

--- a/apps/web/src/app/witnesses/_components/witness-card.tsx
+++ b/apps/web/src/app/witnesses/_components/witness-card.tsx
@@ -70,7 +70,7 @@ export const WitnessCard = ({ row, witness, onVotersClick }: Props) => {
         <b>{i18next.t("witnesses.list-miss")}: </b>
         <div className="ml-2">{row.miss}</div>{" "}
         <div>
-          <a target="_external" rel="nofollow ugc noopener" href={row.url} className="witness-link ml-3">
+          <a target="_external" rel="nofollow ugc noopener" href={row.url} className="witness-link ml-3 [&>svg]:size-4">
             {openInNewSvg}
           </a>
         </div>

--- a/apps/web/src/app/witnesses/_components/witnesses-list.tsx
+++ b/apps/web/src/app/witnesses/_components/witnesses-list.tsx
@@ -173,10 +173,10 @@ export function WitnessesList() {
                 <Td className="border p-2">
                   {row.parsedUrl ? (
                     <EntryLink entry={row.parsedUrl}>
-                      <span className="witness-link">{linkSvg}</span>
+                      <span className="witness-link [&>svg]:size-4">{linkSvg}</span>
                     </EntryLink>
                   ) : (
-                    <a target="_external" rel="nofollow ugc noopener" href={row.url} className="witness-link">
+                    <a target="_external" rel="nofollow ugc noopener" href={row.url} className="witness-link [&>svg]:size-4">
                       {openInNewSvg}
                     </a>
                   )}

--- a/apps/web/src/app/witnesses/page.scss
+++ b/apps/web/src/app/witnesses/page.scss
@@ -112,13 +112,7 @@
       align-items: flex-start;
     }
 
-    .witness-link {
-      svg {
-        height: 16px;
-      }
-    }
-
-    .witness-feed,
+.witness-feed,
     .witness-version {
       .inner {
         border-radius: 25px;

--- a/apps/web/src/app/witnesses/page.scss
+++ b/apps/web/src/app/witnesses/page.scss
@@ -112,7 +112,7 @@
       align-items: flex-start;
     }
 
-.witness-feed,
+    .witness-feed,
     .witness-version {
       .inner {
         border-radius: 25px;

--- a/apps/web/src/features/shared/boost/index.tsx
+++ b/apps/web/src/features/shared/boost/index.tsx
@@ -193,7 +193,7 @@ export function BoostDialog({ onHide }: Props) {
               {inProgress && <LinearProgress />}
               <div className="transaction-form-body">
                 <p className="flex justify-center align-content-center">
-                  <span className="svg-icon text-green">{checkAllSvg}</span>{" "}
+                  <span className="svg-icon text-green [&>svg]:size-4">{checkAllSvg}</span>{" "}
                   {i18next.t("redeem-common.success-message")}
                 </p>
                 <div className="flex justify-center">

--- a/apps/web/src/features/shared/discussion/_index.scss
+++ b/apps/web/src/features/shared/discussion/_index.scss
@@ -46,11 +46,6 @@
       @apply border-blue-dark-sky;
       width: 54px;
       height: 54px;
-
-      svg {
-        height: 24px;
-        margin-bottom: -2px;
-      }
     }
 
     .label {
@@ -77,7 +72,6 @@
       display: flex;
 
       svg {
-        height: 16px;
         margin-right: 6px;
         opacity: 0.5;
       }
@@ -250,10 +244,6 @@
 
               @media (min-width: $md-break) {
                 margin-left: 16px;
-              }
-
-              svg {
-                height: 14px;
               }
             }
 

--- a/apps/web/src/features/shared/discussion/index.tsx
+++ b/apps/web/src/features/shared/discussion/index.tsx
@@ -193,7 +193,7 @@ export function Discussion({ parent, community, isRawContent, hideControls, onTo
         {topLevelComments.length > 0 && (
             <div className="discussion" id="discussion">
               <div className="discussion-header">
-                <div className="count mr-4">
+                <div className="count mr-4 [&>svg]:size-4">
                   {commentSvg} {strCount}
                 </div>
                 <DiscussionBots entries={botsData} />

--- a/apps/web/src/features/shared/edit-history/index.scss
+++ b/apps/web/src/features/shared/edit-history/index.scss
@@ -116,10 +116,6 @@
             grid-row-end: 4;
             justify-content: center;
             @apply text-gray-steel-010;
-
-            svg {
-              height: 20px;
-            }
           }
 
           .item-title {
@@ -164,7 +160,6 @@
           align-items: center;
 
           svg {
-            height: 16px;
             margin-right: 6px;
           }
         }

--- a/apps/web/src/features/shared/edit-history/index.tsx
+++ b/apps/web/src/features/shared/edit-history/index.tsx
@@ -104,7 +104,7 @@ export function EditHistory({ onHide, entry }: Props) {
                       }
                     }}
                   >
-                    <div className="item-icon">{historySvg}</div>
+                    <div className="item-icon [&>svg]:size-5">{historySvg}</div>
                     <div className="item-title">
                       {i18next.t("edit-history.version", { n: i.v })}
                     </div>
@@ -120,7 +120,7 @@ export function EditHistory({ onHide, entry }: Props) {
                   __html: showDiff ? selectedItem.titleDiff! : selectedItem.title
                 }}
               />
-              <div className="entry-tags">
+              <div className="entry-tags [&>svg]:size-4">
                 {tagSvg}{" "}
                 <span
                   dangerouslySetInnerHTML={{

--- a/apps/web/src/features/shared/editor-toolbar/_index.scss
+++ b/apps/web/src/features/shared/editor-toolbar/_index.scss
@@ -47,10 +47,6 @@
       }
     }
 
-    svg {
-      height: 22px;
-    }
-
     .sub-tool-menu {
       border-bottom-left-radius: 10px;
       border-bottom-right-radius: 10px;
@@ -122,10 +118,6 @@
     .editor-tool {
       width: 29px;
       height: 30px;
-
-      svg {
-        height: 18px;
-      }
     }
 
     .emoji-picker {

--- a/apps/web/src/features/shared/editor-toolbar/index.tsx
+++ b/apps/web/src/features/shared/editor-toolbar/index.tsx
@@ -293,7 +293,13 @@ export function EditorToolbar({
 
   return (
     <>
-      <div id="editor-toolbar" className={`editor-toolbar ${sm ? "toolbar-sm" : ""}`} ref={rootRef}>
+      <div
+        id="editor-toolbar"
+        className={
+          sm ? "editor-toolbar toolbar-sm [&_svg]:size-4" : "editor-toolbar [&_svg]:size-5"
+        }
+        ref={rootRef}
+      >
         <Tooltip content={i18next.t("editor-toolbar.bold")}>
           <div
             className="editor-tool"

--- a/apps/web/src/features/shared/entry-menu/_index.scss
+++ b/apps/web/src/features/shared/entry-menu/_index.scss
@@ -14,41 +14,4 @@
     }
   }
 
-  .separated-share {
-    .share-button {
-      @apply text-gray-steel-light-005;
-      cursor: pointer;
-      margin-right: 14px;
-
-      &:hover {
-        @apply text-blue-dark-sky;
-      }
-
-      svg {
-        height: 18px;
-        width: 18px;
-      }
-
-      &.share-button-facebook, &.single-button {
-        svg {
-          margin-top: -1px;
-          height: 17px;
-          width: 17px;
-        }
-      }
-    }
-
-    .single-button {
-      @media (min-width: $sm-break) {
-        display: none;
-      }
-    }
-
-    .all-buttons {
-      display: none;
-      @media (min-width: $sm-break) {
-        display: flex;
-      }
-    }
-  }
 }

--- a/apps/web/src/features/shared/notifications/_index.scss
+++ b/apps/web/src/features/shared/notifications/_index.scss
@@ -47,7 +47,6 @@
       }
 
       svg {
-        height: 18px;
         color: $primary;
       }
 
@@ -107,37 +106,6 @@
       justify-content: space-between;
       align-items: center;
 
-      .select-svg {
-        cursor: pointer;
-        border: 1px solid;
-        @apply border-blue-dark-sky;
-        padding: 1px;
-
-        svg {
-          display: block;
-          height: 14px;
-          color: $primary;
-        }
-
-        &.active {
-          @apply bg-blue-dark-sky;
-
-          svg {
-            @apply text-white;
-          }
-        }
-      }
-
-      .mark-svg {
-        cursor: pointer;
-        margin-right: 10px;
-
-        svg {
-          display: block;
-          height: 22px;
-          color: $primary;
-        }
-      }
     }
   }
 

--- a/apps/web/src/features/shared/notifications/notifications-actions.tsx
+++ b/apps/web/src/features/shared/notifications/notifications-actions.tsx
@@ -130,7 +130,7 @@ export function NotificationsActions({ filter }: Props) {
   const refreshDisabled = isDataLoading || isUnreadLoading;
 
   return (
-    <div className="list-actions">
+    <div className="list-actions [&_svg]:size-5">
       <Tooltip content={i18next.t("notifications.mark-all-read")}>
         <span
           className={classNameObject({

--- a/apps/web/src/features/shared/notifications/notifications-content.tsx
+++ b/apps/web/src/features/shared/notifications/notifications-content.tsx
@@ -40,7 +40,7 @@ export function NotificationsContent({ openLinksInNewTab }: Props) {
   return (
     <div className="notification-list">
       <div className="list-header">
-        <div className="list-actions">
+        <div className="list-actions [&_svg]:size-5">
           <Dropdown>
             <DropdownToggle className="list-filter" withChevron={true}>
               {i18next.t(`notifications.type-${activeFilter ?? "all"}`)}

--- a/apps/web/src/features/shared/promote/index.tsx
+++ b/apps/web/src/features/shared/promote/index.tsx
@@ -246,7 +246,7 @@ export function Promote({ onHide, entry }: Props) {
               {inProgress && <LinearProgress />}
               <div className="transaction-form-body">
                 <p className="flex justify-center align-content-center">
-                  <span className="svg-icon text-green">{checkAllSvg}</span>{" "}
+                  <span className="svg-icon text-green [&>svg]:size-4">{checkAllSvg}</span>{" "}
                   {i18next.t("redeem-common.success-message")}
                 </p>
                 <div className="flex justify-center">

--- a/apps/web/src/features/shared/rc-topup/rc-topup-dialog.tsx
+++ b/apps/web/src/features/shared/rc-topup/rc-topup-dialog.tsx
@@ -213,7 +213,7 @@ export function RcTopupDialog({ onHide }: Props) {
               {inProgress && <LinearProgress />}
               <div className="transaction-form-body">
                 <p className="flex justify-center align-content-center">
-                  <span className="svg-icon text-green">{checkAllSvg}</span>{" "}
+                  <span className="svg-icon text-green [&>svg]:size-4">{checkAllSvg}</span>{" "}
                   {i18next.t("rc-topup.success-message")}
                 </p>
                 <div className="flex justify-center">

--- a/apps/web/src/features/shared/search-box/_index.scss
+++ b/apps/web/src/features/shared/search-box/_index.scss
@@ -41,10 +41,6 @@
     @include themify(night) {
       @apply text-dark-600;
     }
-
-    svg {
-      width: 22px;
-    }
   }
 
   .form-control {

--- a/apps/web/src/features/shared/search-box/index.tsx
+++ b/apps/web/src/features/shared/search-box/index.tsx
@@ -53,7 +53,11 @@ export function SearchBox({ showcopybutton, value, username, filter, ...other }:
           </InputGroup>
         </div>
       ) : (
-        <InputGroup prepend={searchIconSvg}>
+        <InputGroup
+          prepend={
+            <span className="inline-flex !size-5 [&>svg]:size-full">{searchIconSvg}</span>
+          }
+        >
           <FormControl type="text" {...{ ...other, value: searchValue, username, filter }} />
         </InputGroup>
       )}

--- a/apps/web/src/features/shared/wallet-badge.tsx
+++ b/apps/web/src/features/shared/wallet-badge.tsx
@@ -34,7 +34,7 @@ export const WalletBadge = ({ icon }: { icon: ReactNode }) => {
             : i18next.t("user-nav.wallet")
         }
       >
-        <Link href={`/@${username}/wallet`} className="user-wallet">
+        <Link href={`/@${username}/wallet`} className="user-wallet inline-flex [&_svg]:size-6">
           {hasUnclaimedRewards && <span className="reward-badge" />}
           {icon ?? creditCardSvg}
         </Link>

--- a/apps/web/src/features/ui/dropdown/dropdown-item.tsx
+++ b/apps/web/src/features/ui/dropdown/dropdown-item.tsx
@@ -119,7 +119,7 @@ export function DropdownItemWithIcon(
     <DropdownItem
       {...rest}
       className={clsx(
-        "flex items-center gap-3 text-gray-600 dark:text-gray-400 hover:text-blue-dark-sky [&>span>svg]:w-4",
+        "flex items-center gap-3 text-gray-600 dark:text-gray-400 hover:text-blue-dark-sky [&>span>svg]:size-4",
         className
       )}
     >

--- a/apps/web/src/styles/_base.scss
+++ b/apps/web/src/styles/_base.scss
@@ -23,10 +23,6 @@ body {
   }
 }
 
-.btn svg {
-  width: 20px;
-}
-
 /* custom select appearance */
 select {
   -moz-appearance: none;
@@ -59,10 +55,6 @@ select {
 
 .svg-icon {
   margin-right: 4px;
-
-  svg {
-    height: 16px;
-  }
 }
 
 

--- a/apps/web/src/styles/static-pages.scss
+++ b/apps/web/src/styles/static-pages.scss
@@ -291,7 +291,6 @@
           }
 
           svg {
-            height: 12px;
             margin-right: 4px;
             @apply text-gray-steel;
           }

--- a/scripts/icon-scss-manifest.json
+++ b/scripts/icon-scss-manifest.json
@@ -3,7 +3,7 @@
  "rules": [
   {
    "key": "apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/comment-engagement/_index.scss | svg | height: 24px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/entry.scss | svg | height: 17px",
@@ -51,23 +51,23 @@
   },
   {
    "key": "apps/web/src/app/_components/market-data/_index.scss | svg | width: 20px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/_deck-toolbar.scss | svg | width: 1.5rem",
-   "status": "B2"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/_deck-toolbar.scss | svg | height: 1.5rem",
-   "status": "B2"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/_deck.scss | .footer-icons svg | width: 18px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/_deck.scss | .footer-icons svg | height: 18px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/_deck.scss | svg | width: 1rem",
@@ -79,7 +79,7 @@
   },
   {
    "key": "apps/web/src/app/decks/_components/columns/add-column/_deck-add-column.scss | svg | width: 2rem",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss | svg | width: 1rem",
@@ -91,35 +91,35 @@
   },
   {
    "key": "apps/web/src/app/decks/_components/deck-settings/_decks-settings.scss | svg | width: 1rem",
-   "status": "B2"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/deck-toolbar/_deck-toolbar-manager.scss | svg | width: 1.5rem",
-   "status": "B2"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/deck-toolbar/_deck-toolbar-manager.scss | svg | height: 1.5rem",
-   "status": "B2"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/market/index.scss | .footer-icons svg | width: 18px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/market/index.scss | .footer-icons svg | height: 18px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/proposals/_components/proposal-list-item/_index.scss | svg | height: 16px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/submit/_components/community-selector/_index.scss | svg | height: 22px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/submit/_index.scss | svg | width: 25px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/waves/_components/waves-reel-item.scss | svg | height: 26px",
@@ -131,7 +131,7 @@
   },
   {
    "key": "apps/web/src/app/witnesses/page.scss | svg | height: 16px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/market/market-swap-form/index.scss | > div, > div > svg | width: auto !important",
@@ -147,47 +147,47 @@
   },
   {
    "key": "apps/web/src/features/shared/discussion/_index.scss | svg | height: 24px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/discussion/_index.scss | svg | height: 16px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/discussion/_index.scss | svg | height: 14px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/edit-history/index.scss | svg | height: 20px",
-   "status": "B2"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/edit-history/index.scss | svg | height: 16px",
-   "status": "B2"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/editor-toolbar/_index.scss | svg | height: 22px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/editor-toolbar/_index.scss | svg | height: 18px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/entry-menu/_index.scss | svg | height: 18px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/entry-menu/_index.scss | svg | width: 18px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/entry-menu/_index.scss | svg | height: 17px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/entry-menu/_index.scss | svg | width: 17px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/entry-reblog-btn/_index.scss | svg | height: 16px",
@@ -215,27 +215,27 @@
   },
   {
    "key": "apps/web/src/features/shared/notifications/_index.scss | svg | height: 18px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/notifications/_index.scss | .select-svg | height: 14px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/notifications/_index.scss | svg | height: 14px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/notifications/_index.scss | .mark-svg | height: 22px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/notifications/_index.scss | svg | height: 22px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/search-box/_index.scss | svg | width: 22px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/search-list-item/_index.scss | svg | height: 14px !important",
@@ -271,15 +271,15 @@
   },
   {
    "key": "apps/web/src/styles/_base.scss | .btn svg | width: 20px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/styles/_base.scss | .svg-icon | height: 16px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/styles/_base.scss | svg | height: 16px",
-   "status": "B3"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/styles/_mixins.scss | svg | height: 16px",
@@ -295,7 +295,7 @@
   },
   {
    "key": "apps/web/src/styles/static-pages.scss | svg | height: 12px",
-   "status": "B2"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/_index.scss | svg | height: 16px",


### PR DESCRIPTION
Bundle 3 of the icon sizing migration (docs/icons.md) — **the deliberate-visual-change bundle**. Unlike bundles 1–2, differences here are intended; this table is the review surface.

### Visible deltas

| surface | before → after | note |
|---|---|---|
| Dropdown menu icons, app-wide | 16×24 letterbox → **16×16** | `[&>span>svg]:size-4`; menu row rhythm tightens — entry/profile/deck menus, both themes |
| Editor toolbar (main / reply) | 22 → **20** / 18 → **16** | conditional root sink, letterboxes killed; dialogs/pickers untouched |
| Search magnifier (navbar + community) | 16 → **20** | `!size-5` sink span; the SCSS 22px rule matched nothing — real before was the slot's 16 |
| Market-data eye toggle (both states) | 20×24 / 20×13 → **20×20** | screenshot both ternary states; component currently unmounted anywhere, so latent |
| Proposals permlink link icon | 24×16 letterbox → **16×16** | `[&_svg]:size-4` (nested svg, child sink would miss) |
| Witnesses link/openInNew icons | 24×16 → **16×16** / 16 same | 3 sites |
| Submit thumbnail check | 25 → **24** | |
| Community selector | 22 → **16** | spec said size-5; call-site context is a 16 tier — stated deliberately |
| Deck add-column settings pickers ×4 | 32×24 letterbox → **32×32** | status tier `size-8` |
| Edit history | 24×20 → **20×20**, 24×16 → **16×16** | squared |
| Notifications drawer actions + filter chevron | 18 → **20** | second `.list-actions` container found and covered too |
| Discussion count icon | letterbox → **16×16** | |
| Static-pages contact marks | → **12×12** boxes | wide marks shrink ≤1.9px drawn width |
| Chats muted badges ×3 | container-accident → **16** | pinned per dense-row tier |

### Zero-delta and dead-rule cleanup riding along

Comment-engagement 24 (mechanism swap), deck-toolbar `.base-actions` 24, decks-settings 16, add-deck-btn 24 (`!size-6` — devtools should show it winning), `.svg-icon` green checks 16, plus the 8 bundle-2 stragglers. Dead rules deleted after grep-verification: `footer-icons` (deck + market twin), entry-menu `.separated-share` family, notifications `select-svg`/`mark-svg`, discussion `.icon` + edit/delete/mute, `.btn svg{width:20px}` (both `.btn` consumers are text-only).

### Adversarial verification results

A verifier agent re-traced every stated "before" against the real cascade and found 2 defects, both resolved:

1. **Token-history sink reverted.** The plan's premise ("exchange 16→24 matches siblings at 24") was false — engine-row siblings carry explicit `size-4`, and the box sink would have out-specified them, inflating every engine icon 16→24. Both files reverted; the surface stays as-is and moves to bundle 4 with a corrected premise.
2. **Search-box before-px corrected** in this description (16→20, not 22→20) — the 22px rule was dead; the slot governed at 16.

### Verified

Suite + tsc green; `icon-scss-audit`: 37 live declarations, 0 unowned, 0 resurrected (100 tombstones); tsx audit: no new findings (17 pre-existing, other bundles' surfaces). Ledger after this PR: **19 B4 + 18 allowlist remain** — bundle 4 is the last conversion bundle.

Staging checklist: every row of the delta table above, plus devtools who-wins on the search magnifier (`!size-5`) and add-deck button (`!size-6`).
