### PR TITLE
Upload a single picked image right away, accept AVIF

### DIFF
--- a/apps/web/src/api/sdk-mutations/use-upload-image-mutation.ts
+++ b/apps/web/src/api/sdk-mutations/use-upload-image-mutation.ts
@@ -94,6 +94,12 @@ export function useUploadImageMutation() {
       success(i18next.t("ecency-images.success-upload"));
     },
     onError: (e: Error) => {
+      // The caller aborted (dialog closed, upload cancelled) - it is not a failure
+      // to report back, and the toast would contradict what the user just did
+      if (e.name === "AbortError") {
+        return;
+      }
+
       // Web-specific error handling for upload
       if ("status" in e) {
         const status = (e as { status?: number }).status;

--- a/apps/web/src/app/decks/_components/deck-threads-form/deck-threads-form-toolbar-image-picker.tsx
+++ b/apps/web/src/app/decks/_components/deck-threads-form/deck-threads-form-toolbar-image-picker.tsx
@@ -12,6 +12,8 @@ import { GalleryDialog } from "@/features/shared/gallery";
 import { EcencyConfigManager } from "@/config";
 import { Dropdown, DropdownItemWithIcon, DropdownMenu, DropdownToggle } from "@ui/dropdown";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { convertHeicToJpeg } from "@/utils/convert-heic";
+import { isAcceptedImageFilename } from "@/utils/image-upload-formats";
 
 interface Props {
   onAddImage: (link: string, name: string) => void;
@@ -29,10 +31,7 @@ export const DeckThreadsFormToolbarImagePicker = ({ onAddImage }: Props) => {
     onAddImage(url, text);
   };
 
-  const checkFile = (filename: string) => {
-    const filenameLow = filename.toLowerCase();
-    return ["jpg", "jpeg", "gif", "png", "webp"].some((el) => filenameLow.endsWith(el));
-  };
+  const checkFile = (filename: string) => isAcceptedImageFilename(filename);
 
   const fileInputChanged = (e: React.ChangeEvent<HTMLInputElement>): void => {
     let files = Array.from(e.target.files as FileList)
@@ -64,7 +63,7 @@ export const DeckThreadsFormToolbarImagePicker = ({ onAddImage }: Props) => {
     try {
       let token = await ensureValidToken(username);
       if (token) {
-        const resp = await uploadImage(file, token);
+        const resp = await uploadImage(await convertHeicToJpeg(file), token);
         imageUrl = resp.url;
         onAddImage(imageUrl, file.name);
       } else {

--- a/apps/web/src/app/publish/_components/publish-action-bar.tsx
+++ b/apps/web/src/app/publish/_components/publish-action-bar.tsx
@@ -118,7 +118,6 @@ export function PublishActionBar({
   useDefaultBeneficiary();
   useSupportEcencyBeneficiary();
 
-  const canContinue = !!title?.trim() && hasPublishContent(content);
   const hasEditorContent = !!title?.trim() || hasPublishContent(content);
 
   const { mutateAsync: saveToDraft, isPending: isDraftPending } = useSaveDraftApi(draftId);
@@ -126,6 +125,12 @@ export function PublishActionBar({
   const applyTemplate = useApplyTemplate(setEditorContent);
   const uploadTracker = useOptionalUploadTracker();
   const [_, setShowGuide] = useSynchronizedLocalStorage(PREFIX + "_pub_onboarding_passed", true);
+
+  // Images upload in the background (toolbar pick, drag and drop) and their
+  // markdown only lands in the body once the upload resolves - continuing
+  // before then would publish the post without them.
+  const canContinue =
+    !!title?.trim() && hasPublishContent(content) && !uploadTracker?.hasPendingUploads;
 
   return (
     <div className="container relative z-[11] justify-between gap-4 px-2 md:px-4 flex flex-col-reverse sm:flex-row sm:items-center max-w-[1024px] py-4 mx-auto publish-action-bar">

--- a/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
+++ b/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
@@ -71,7 +71,8 @@ import {
 import { DropdownContext } from "@ui/dropdown/dropdown-context";
 import i18next from "i18next";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
-import { usePublishState } from "../_hooks";
+import { usePublishState, useUploadAndInsertImages } from "../_hooks";
+import { IMAGE_UPLOAD_ACCEPT } from "@/utils/image-upload-formats";
 import { PublishEditorTableToolbar } from "./publish-editor-table-toolbar";
 
 import { PublishEditorToolbarFragments } from "./publish-editor-toolbar-fragments";
@@ -214,6 +215,7 @@ export function PublishEditorToolbar({ editor, allowToUploadVideo = true }: Prop
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [showImageByLink, setShowImageByLink] = useState(false);
   const [showImageUpload, setShowImageUpload] = useState(false);
+  const [pickedImages, setPickedImages] = useState<File[]>([]);
   const [showVideoUpload, setShowVideoUpload] = useState(false);
   const [showVideoLink, setShowVideoLink] = useState(false);
   const [showGeoTag, setShowGeoTag] = useState(false);
@@ -222,6 +224,31 @@ export function PublishEditorToolbar({ editor, allowToUploadVideo = true }: Prop
   const [showAiAssist, setShowAiAssist] = useState(false);
   const [showMemeMaker, setShowMemeMaker] = useState(false);
   const [isFocusingTable, setIsFocusingTable] = useState(false);
+
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const uploadAndInsertImages = useUploadAndInsertImages(editor);
+
+  const onImagesPicked = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files ?? []);
+      e.target.value = "";
+
+      if (files.length === 0) {
+        return;
+      }
+
+      // A single image has nothing to review - upload it straight away. Several
+      // images open the dialog so they can be previewed before uploading.
+      if (files.length === 1) {
+        uploadAndInsertImages(files, "toolbar");
+        return;
+      }
+
+      setPickedImages(files);
+      setShowImageUpload(true);
+    },
+    [uploadAndInsertImages]
+  );
 
   const activeTextColor = editor?.getAttributes("textStyle")?.color as string | undefined;
 
@@ -418,7 +445,7 @@ export function PublishEditorToolbar({ editor, allowToUploadVideo = true }: Prop
                   <DropdownItemWithIcon
                     icon={<UilUpload />}
                     label={i18next.t("publish.upload")}
-                    onClick={() => setShowImageUpload(true)}
+                    onClick={() => imageInputRef.current?.click()}
                   />
                   <DropdownItemWithIcon
                     icon={<UilImages />}
@@ -671,9 +698,23 @@ export function PublishEditorToolbar({ editor, allowToUploadVideo = true }: Prop
             setShowImageByLink(false);
           }}
         />
+        <input
+          ref={imageInputRef}
+          type="file"
+          multiple={true}
+          accept={IMAGE_UPLOAD_ACCEPT}
+          className="hidden"
+          onChange={onImagesPicked}
+        />
         <EcencyImagesUploadDialog
           show={showImageUpload}
-          setShow={setShowImageUpload}
+          setShow={(show) => {
+            setShowImageUpload(show);
+            if (!show) {
+              setPickedImages([]);
+            }
+          }}
+          initialFiles={pickedImages}
           onPick={(e) => {
             editor
               ?.chain()

--- a/apps/web/src/app/publish/_hooks/index.ts
+++ b/apps/web/src/app/publish/_hooks/index.ts
@@ -7,4 +7,5 @@ export * from "./use-default-beneficiary";
 export * from "./use-support-ecency-beneficiary";
 export * from "./use-publish-autosave";
 export * from "./use-upload-tracker";
+export * from "./use-upload-and-insert-images";
 export * from "./use-draft-tab-coordinator";

--- a/apps/web/src/app/publish/_hooks/use-editor-drag-drop.ts
+++ b/apps/web/src/app/publish/_hooks/use-editor-drag-drop.ts
@@ -1,56 +1,23 @@
-import { useUploadImageMutation } from "@/api/sdk-mutations";
-import { error, info } from "@/features/shared";
 import { Editor } from "@tiptap/core";
-import i18next from "i18next";
 import { useCallback, useEffect } from "react";
-import { useOptionalUploadTracker } from "./use-upload-tracker";
+import { useUploadAndInsertImages } from "./use-upload-and-insert-images";
 
 export function useEditorDragDrop(editor: Editor | null) {
-  const { mutateAsync: upload } = useUploadImageMutation();
-  const uploadTracker = useOptionalUploadTracker();
+  const uploadAndInsert = useUploadAndInsertImages(editor);
 
   const handleDrop = useCallback(
     async (event: DragEvent) => {
       event.stopPropagation();
       event.preventDefault();
 
-      const files = event.dataTransfer?.files;
-      if (files?.length === 0) {
+      const files = Array.from(event.dataTransfer?.files ?? []);
+      if (files.length === 0) {
         return;
       }
 
-      const file = files![0];
-      if (!file.type.startsWith("image/")) {
-        error(i18next.t("publish.no-image-found"));
-        return;
-      }
-
-      info(i18next.t("publish.upload-started"));
-
-      // Track upload if tracker is available
-      const uploadId = `drag-drop-${Date.now()}-${Math.random()}`;
-      const abortController = new AbortController();
-      uploadTracker?.registerUpload(uploadId, abortController);
-
-      try {
-        const { url } = await upload({ file, signal: abortController.signal });
-        uploadTracker?.markComplete(uploadId);
-
-        editor
-          ?.chain()
-          .focus()
-          .insertContent([
-            { type: "image", attrs: { src: url } },
-            { type: "paragraph" },
-            { type: "paragraph" }
-          ])
-          .run();
-      } catch (err) {
-        uploadTracker?.markFailed(uploadId);
-        throw err;
-      }
+      await uploadAndInsert(files, "drag-drop");
     },
-    [editor, upload, uploadTracker]
+    [uploadAndInsert]
   );
 
   const handleDragOver = useCallback((event: DragEvent) => {

--- a/apps/web/src/app/publish/_hooks/use-upload-and-insert-images.ts
+++ b/apps/web/src/app/publish/_hooks/use-upload-and-insert-images.ts
@@ -1,0 +1,59 @@
+import { useUploadImageMutation } from "@/api/sdk-mutations";
+import { error, info } from "@/features/shared";
+import { convertHeicToJpeg } from "@/utils/convert-heic";
+import { isAcceptedImageFile } from "@/utils/image-upload-formats";
+import { Editor } from "@tiptap/core";
+import i18next from "i18next";
+import { useCallback } from "react";
+import { useOptionalUploadTracker } from "./use-upload-tracker";
+
+/**
+ * Uploads images and inserts them into the editor as they land.
+ *
+ * Shared by every one-step upload entry point (toolbar single pick, drag and drop)
+ * so tracking, HEIC conversion and insertion behave identically. Uploads run one
+ * after another to keep insertion order stable and to avoid flooding the image
+ * server from a single drop.
+ */
+export function useUploadAndInsertImages(editor: Editor | null) {
+  const { mutateAsync: upload } = useUploadImageMutation();
+  const uploadTracker = useOptionalUploadTracker();
+
+  return useCallback(
+    async (files: File[], source: string) => {
+      const images = files.filter((file) => isAcceptedImageFile(file));
+      if (images.length === 0) {
+        error(i18next.t("publish.no-image-found"));
+        return;
+      }
+
+      info(i18next.t("publish.upload-started"));
+
+      for (let i = 0; i < images.length; i++) {
+        const uploadId = `${source}-${Date.now()}-${i}`;
+        const abortController = new AbortController();
+        uploadTracker?.registerUpload(uploadId, abortController);
+
+        try {
+          const file = await convertHeicToJpeg(images[i]);
+          const { url } = await upload({ file, signal: abortController.signal });
+          uploadTracker?.markComplete(uploadId);
+
+          editor
+            ?.chain()
+            .focus()
+            .insertContent([
+              { type: "image", attrs: { src: url } },
+              { type: "paragraph" },
+              { type: "paragraph" }
+            ])
+            .run();
+        } catch (e) {
+          // Failures are surfaced by the upload mutation itself
+          uploadTracker?.markFailed(uploadId);
+        }
+      }
+    },
+    [editor, upload, uploadTracker]
+  );
+}

--- a/apps/web/src/app/publish/_hooks/use-upload-and-insert-images.ts
+++ b/apps/web/src/app/publish/_hooks/use-upload-and-insert-images.ts
@@ -5,7 +5,7 @@ import { isAcceptedImageFile } from "@/utils/image-upload-formats";
 import { Editor } from "@tiptap/core";
 import i18next from "i18next";
 import { useCallback } from "react";
-import { useOptionalUploadTracker } from "./use-upload-tracker";
+import { nextUploadId, useOptionalUploadTracker } from "./use-upload-tracker";
 
 /**
  * Uploads images and inserts them into the editor as they land.
@@ -30,7 +30,7 @@ export function useUploadAndInsertImages(editor: Editor | null) {
       info(i18next.t("publish.upload-started"));
 
       for (let i = 0; i < images.length; i++) {
-        const uploadId = `${source}-${Date.now()}-${i}`;
+        const uploadId = nextUploadId(source);
         const abortController = new AbortController();
         uploadTracker?.registerUpload(uploadId, abortController);
 

--- a/apps/web/src/app/publish/_hooks/use-upload-tracker.tsx
+++ b/apps/web/src/app/publish/_hooks/use-upload-tracker.tsx
@@ -37,6 +37,18 @@ interface UploadTrackerContextValue {
 
 const UploadTrackerContext = createContext<UploadTrackerContextValue | undefined>(undefined);
 
+let uploadSequence = 0;
+
+/**
+ * Tracker id for one upload. Ids must be unique across batches - registering a
+ * reused id overwrites the earlier entry, dropping a still-running upload out
+ * of the pending set and releasing the publish gate too early.
+ */
+export function nextUploadId(source: string): string {
+  uploadSequence += 1;
+  return `${source}-${Date.now()}-${uploadSequence}`;
+}
+
 const UPLOAD_TIMEOUT_MS = 30000; // 30 seconds per upload
 const CHECK_INTERVAL_MS = 100; // Check every 100ms
 

--- a/apps/web/src/features/ecency-images/ecency-images-upload-dialog.tsx
+++ b/apps/web/src/features/ecency-images/ecency-images-upload-dialog.tsx
@@ -7,6 +7,8 @@ import { Spinner } from "@ui/spinner";
 import { useUploadImageMutation } from "@/api/sdk-mutations";
 import { useOptionalUploadTracker } from "@/app/publish/_hooks";
 import { convertHeicToJpeg } from "@/utils/convert-heic";
+import { isAcceptedImageFile } from "@/utils/image-upload-formats";
+import { error } from "@/features/shared";
 
 interface Props {
   show: boolean;
@@ -118,7 +120,15 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
 
   const onFilesPick = useCallback(
     async (files: File[]) => {
-      const converted = await Promise.all(files.map((f) => convertHeicToJpeg(f)));
+      // The input `accept` attribute is a hint only - files can still arrive
+      // through "All files" in the picker or through a drop
+      const accepted = files.filter((file) => isAcceptedImageFile(file));
+      if (accepted.length === 0) {
+        error(i18next.t("publish.no-image-found"));
+        return;
+      }
+
+      const converted = await Promise.all(accepted.map((f) => convertHeicToJpeg(f)));
       const picked = converted.map((file) => ({
         file,
         preview: URL.createObjectURL(file),
@@ -143,6 +153,9 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
   useEffect(() => {
     if (!show) {
       seededFilesRef.current = undefined;
+      // Closing the dialog stops the batch, so nothing gets inserted into the
+      // editor after the user dismissed it
+      cancelRef.current = true;
       if (itemsRef.current.length) {
         itemsRef.current.forEach((item) => URL.revokeObjectURL(item.preview));
         setItems([]);

--- a/apps/web/src/features/ecency-images/ecency-images-upload-dialog.tsx
+++ b/apps/web/src/features/ecency-images/ecency-images-upload-dialog.tsx
@@ -61,14 +61,15 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
     };
   }, []);
 
-  // Stop the request itself, not just the loop around it: a cancelled upload
-  // that keeps running holds the publish flow open until the network resolves
-  const abortInFlight = useCallback((list: UploadItem[]) => {
-    list.forEach((item) => {
-      if (item.status === "uploading") {
-        item.abortController?.abort();
-      }
-    });
+  // Controllers are tracked here rather than read back off `items`, which a
+  // cancel arriving in the same tick as the upload starting would still see
+  // without them. Stopping the request matters beyond the loop guard: an upload
+  // left running holds the publish flow open until the network resolves.
+  const activeControllersRef = useRef(new Set<AbortController>());
+
+  const abortInFlight = useCallback(() => {
+    activeControllersRef.current.forEach((controller) => controller.abort());
+    activeControllersRef.current.clear();
   }, []);
 
   // Closing has to cancel here, not in the effect that reacts to `show` turning
@@ -76,7 +77,7 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
   // would still insert its image into an editor the user had moved on from
   const cancelAndClose = useCallback(() => {
     cancelRef.current = true;
-    abortInFlight(itemsRef.current);
+    abortInFlight();
     setShow(false);
   }, [abortInFlight, setShow]);
 
@@ -91,6 +92,7 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
         // Register upload and create abort controller
         const uploadId = nextUploadId("dialog");
         const abortController = new AbortController();
+        activeControllersRef.current.add(abortController);
         uploadTracker?.registerUpload(uploadId, abortController);
 
         setItems((prev) => {
@@ -125,6 +127,8 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
         } catch {
           uploadTracker?.markFailed(uploadId);
           /* handled in mutation */
+        } finally {
+          activeControllersRef.current.delete(abortController);
         }
       }
 
@@ -181,7 +185,7 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
       // Closing the dialog stops the batch, so nothing gets inserted into the
       // editor after the user dismissed it
       cancelRef.current = true;
-      abortInFlight(itemsRef.current);
+      abortInFlight();
       if (itemsRef.current.length) {
         itemsRef.current.forEach((item) => URL.revokeObjectURL(item.preview));
         setItems([]);
@@ -233,7 +237,7 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
                   if (items.some((it) => it.status === "uploading")) {
                     cancelRef.current = true;
                     setIsCancelling(true);
-                    abortInFlight(items);
+                    abortInFlight();
                   }
                   // Clean up blob URLs before clearing items
                   items.forEach((item) => {

--- a/apps/web/src/features/ecency-images/ecency-images-upload-dialog.tsx
+++ b/apps/web/src/features/ecency-images/ecency-images-upload-dialog.tsx
@@ -5,7 +5,10 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { UilCheck } from "@tooni/iconscout-unicons-react";
 import { Spinner } from "@ui/spinner";
 import { useUploadImageMutation } from "@/api/sdk-mutations";
-import { useOptionalUploadTracker } from "@/app/publish/_hooks";
+// Import the tracker directly, not through the "@/app/publish/_hooks" barrel:
+// the barrel re-exports the whole TipTap editor graph, which this dialog does
+// not need
+import { nextUploadId, useOptionalUploadTracker } from "@/app/publish/_hooks/use-upload-tracker";
 import { convertHeicToJpeg } from "@/utils/convert-heic";
 import { isAcceptedImageFile } from "@/utils/image-upload-formats";
 import { error } from "@/features/shared";
@@ -55,6 +58,16 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
     };
   }, []);
 
+  // Stop the request itself, not just the loop around it: a cancelled upload
+  // that keeps running holds the publish flow open until the network resolves
+  const abortInFlight = useCallback((list: UploadItem[]) => {
+    list.forEach((item) => {
+      if (item.status === "uploading") {
+        item.abortController?.abort();
+      }
+    });
+  }, []);
+
   const startUpload = useCallback(
     async (list: UploadItem[]) => {
       cancelRef.current = false;
@@ -64,7 +77,7 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
         }
 
         // Register upload and create abort controller
-        const uploadId = `dialog-${Date.now()}-${i}`;
+        const uploadId = nextUploadId("dialog");
         const abortController = new AbortController();
         uploadTracker?.registerUpload(uploadId, abortController);
 
@@ -156,6 +169,7 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
       // Closing the dialog stops the batch, so nothing gets inserted into the
       // editor after the user dismissed it
       cancelRef.current = true;
+      abortInFlight(itemsRef.current);
       if (itemsRef.current.length) {
         itemsRef.current.forEach((item) => URL.revokeObjectURL(item.preview));
         setItems([]);
@@ -207,6 +221,7 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
                   if (items.some((it) => it.status === "uploading")) {
                     cancelRef.current = true;
                     setIsCancelling(true);
+                    abortInFlight(items);
                   }
                   // Clean up blob URLs before clearing items
                   items.forEach((item) => {

--- a/apps/web/src/features/ecency-images/ecency-images-upload-dialog.tsx
+++ b/apps/web/src/features/ecency-images/ecency-images-upload-dialog.tsx
@@ -1,7 +1,7 @@
 import i18next from "i18next";
 import { Modal, ModalBody, ModalHeader, Button } from "../ui";
 import { EcencyImagesUploadForm } from "./ecency-images-upload-form";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { UilCheck } from "@tooni/iconscout-unicons-react";
 import { Spinner } from "@ui/spinner";
 import { useUploadImageMutation } from "@/api/sdk-mutations";
@@ -12,6 +12,12 @@ interface Props {
   show: boolean;
   setShow: (show: boolean) => void;
   onPick: (link: string) => void;
+  /**
+   * Files already picked outside the dialog (e.g. by the toolbar file input).
+   * They are seeded as previews when the dialog opens, so the user does not
+   * have to pick them twice.
+   */
+  initialFiles?: File[];
 }
 
 interface UploadItem {
@@ -22,13 +28,16 @@ interface UploadItem {
   abortController?: AbortController;
 }
 
-export function EcencyImagesUploadDialog({ show, setShow, onPick }: Props) {
+export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }: Props) {
   const [items, setItems] = useState<UploadItem[]>([]);
   const { mutateAsync: upload } = useUploadImageMutation();
   const uploadTracker = useOptionalUploadTracker();
   const cancelRef = useRef(false);
   const [isCancelling, setIsCancelling] = useState(false);
+  // A single image skips the review step, so it has no Upload button to press
+  const [isAutoUploading, setIsAutoUploading] = useState(false);
   const itemsRef = useRef<UploadItem[]>([]);
+  const seededFilesRef = useRef<File[] | undefined>(undefined);
 
   // Keep track of current items for cleanup
   useEffect(() => {
@@ -44,65 +53,109 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick }: Props) {
     };
   }, []);
 
-  const startUpload = async () => {
-    cancelRef.current = false;
-    for (let i = 0; i < items.length; i++) {
-      if (cancelRef.current) {
-        break;
-      }
-
-      // Register upload and create abort controller
-      const uploadId = `dialog-${Date.now()}-${i}`;
-      const abortController = new AbortController();
-      uploadTracker?.registerUpload(uploadId, abortController);
-
-      setItems((prev) => {
-        if (cancelRef.current || !prev[i]) {
-          return prev;
-        }
-        const next = [...prev];
-        next[i].status = "uploading";
-        next[i].uploadId = uploadId;
-        next[i].abortController = abortController;
-        return next;
-      });
-
-      try {
-        const { url } = await upload({ file: items[i].file, signal: abortController.signal });
+  const startUpload = useCallback(
+    async (list: UploadItem[]) => {
+      cancelRef.current = false;
+      for (let i = 0; i < list.length; i++) {
         if (cancelRef.current) {
-          uploadTracker?.markFailed(uploadId);
           break;
         }
 
-        uploadTracker?.markComplete(uploadId);
-        onPick(url);
+        // Register upload and create abort controller
+        const uploadId = `dialog-${Date.now()}-${i}`;
+        const abortController = new AbortController();
+        uploadTracker?.registerUpload(uploadId, abortController);
 
         setItems((prev) => {
           if (cancelRef.current || !prev[i]) {
             return prev;
           }
           const next = [...prev];
-          next[i].status = "done";
+          next[i].status = "uploading";
+          next[i].uploadId = uploadId;
+          next[i].abortController = abortController;
           return next;
         });
-      } catch {
-        uploadTracker?.markFailed(uploadId);
-        /* handled in mutation */
+
+        try {
+          const { url } = await upload({ file: list[i].file, signal: abortController.signal });
+          if (cancelRef.current) {
+            uploadTracker?.markFailed(uploadId);
+            break;
+          }
+
+          uploadTracker?.markComplete(uploadId);
+          onPick(url);
+
+          setItems((prev) => {
+            if (cancelRef.current || !prev[i]) {
+              return prev;
+            }
+            const next = [...prev];
+            next[i].status = "done";
+            return next;
+          });
+        } catch {
+          uploadTracker?.markFailed(uploadId);
+          /* handled in mutation */
+        }
       }
+
+      if (!cancelRef.current) {
+        // Clean up blob URLs before clearing items
+        list.forEach((item) => {
+          URL.revokeObjectURL(item.preview);
+        });
+        setItems([]);
+        setShow(false);
+      }
+
+      setIsCancelling(false);
+      cancelRef.current = false;
+    },
+    [onPick, setShow, upload, uploadTracker]
+  );
+
+  const onFilesPick = useCallback(
+    async (files: File[]) => {
+      const converted = await Promise.all(files.map((f) => convertHeicToJpeg(f)));
+      const picked = converted.map((file) => ({
+        file,
+        preview: URL.createObjectURL(file),
+        status: "pending" as const
+      }));
+      setItems(picked);
+
+      // One image needs no review step - start uploading as soon as it is picked
+      if (picked.length === 1) {
+        setIsAutoUploading(true);
+        try {
+          await startUpload(picked);
+        } finally {
+          setIsAutoUploading(false);
+        }
+      }
+    },
+    [startUpload]
+  );
+
+  // Seed files picked outside of the dialog, and drop stale previews once closed
+  useEffect(() => {
+    if (!show) {
+      seededFilesRef.current = undefined;
+      if (itemsRef.current.length) {
+        itemsRef.current.forEach((item) => URL.revokeObjectURL(item.preview));
+        setItems([]);
+      }
+      return;
     }
 
-    if (!cancelRef.current) {
-      // Clean up blob URLs before clearing items
-      items.forEach((item) => {
-        URL.revokeObjectURL(item.preview);
-      });
-      setItems([]);
-      setShow(false);
+    if (!initialFiles?.length || seededFilesRef.current === initialFiles) {
+      return;
     }
-
-    setIsCancelling(false);
-    cancelRef.current = false;
-  };
+    seededFilesRef.current = initialFiles;
+    onFilesPick(initialFiles);
+  }, [show, initialFiles, onFilesPick]);
 
   return (
     <Modal
@@ -113,21 +166,7 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick }: Props) {
     >
       <ModalHeader closeButton={true}>{i18next.t("ecency-images.upload-image")}</ModalHeader>
       <ModalBody>
-        {!items.length && (
-          <EcencyImagesUploadForm
-            onFilesPick={async (files) => {
-              const converted = await Promise.all(files.map((f) => convertHeicToJpeg(f)));
-              setItems((prev) => [
-                ...prev,
-                ...converted.map((file) => ({
-                  file,
-                  preview: URL.createObjectURL(file),
-                  status: "pending" as const
-                }))
-              ]);
-            }}
-          />
-        )}
+        {!items.length && <EcencyImagesUploadForm onFilesPick={onFilesPick} />}
         {items.length > 0 && (
           <div>
             <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
@@ -165,14 +204,16 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick }: Props) {
               >
                 {i18next.t("g.cancel")}
               </Button>
-              <Button
-                size="sm"
-                isLoading={items.some((it) => it.status === "uploading")}
-                onClick={startUpload}
-                disabled={isCancelling}
-              >
-                {i18next.t("editor-toolbar.upload")}
-              </Button>
+              {!isAutoUploading && (
+                <Button
+                  size="sm"
+                  isLoading={items.some((it) => it.status === "uploading")}
+                  onClick={() => startUpload(items)}
+                  disabled={isCancelling}
+                >
+                  {i18next.t("editor-toolbar.upload")}
+                </Button>
+              )}
             </div>
           </div>
         )}

--- a/apps/web/src/features/ecency-images/ecency-images-upload-dialog.tsx
+++ b/apps/web/src/features/ecency-images/ecency-images-upload-dialog.tsx
@@ -42,6 +42,9 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
   // A single image skips the review step, so it has no Upload button to press
   const [isAutoUploading, setIsAutoUploading] = useState(false);
   const itemsRef = useRef<UploadItem[]>([]);
+  // Read at resolution time, so a result cannot outrun the close it raced
+  const showRef = useRef(show);
+  showRef.current = show;
   const seededFilesRef = useRef<File[] | undefined>(undefined);
 
   // Keep track of current items for cleanup
@@ -67,6 +70,15 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
       }
     });
   }, []);
+
+  // Closing has to cancel here, not in the effect that reacts to `show` turning
+  // false: that effect is a render behind, and an upload resolving in the gap
+  // would still insert its image into an editor the user had moved on from
+  const cancelAndClose = useCallback(() => {
+    cancelRef.current = true;
+    abortInFlight(itemsRef.current);
+    setShow(false);
+  }, [abortInFlight, setShow]);
 
   const startUpload = useCallback(
     async (list: UploadItem[]) => {
@@ -94,7 +106,7 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
 
         try {
           const { url } = await upload({ file: list[i].file, signal: abortController.signal });
-          if (cancelRef.current) {
+          if (cancelRef.current || !showRef.current) {
             uploadTracker?.markFailed(uploadId);
             break;
           }
@@ -187,7 +199,7 @@ export function EcencyImagesUploadDialog({ show, setShow, onPick, initialFiles }
   return (
     <Modal
       show={show}
-      onHide={() => setShow(false)}
+      onHide={cancelAndClose}
       centered={true}
       size={items.length ? "lg" : "md"}
     >

--- a/apps/web/src/features/ecency-images/ecency-images-upload-form.tsx
+++ b/apps/web/src/features/ecency-images/ecency-images-upload-form.tsx
@@ -2,6 +2,7 @@ import { UilFileDownload, UilFileUpload } from "@tooni/iconscout-unicons-react";
 import clsx from "clsx";
 import i18next from "i18next";
 import { useCallback, useRef, useState } from "react";
+import { IMAGE_UPLOAD_ACCEPT, isAcceptedImageFilename } from "@/utils/image-upload-formats";
 
 interface Props {
   onFilesPick: (files: File[]) => void;
@@ -19,8 +20,7 @@ export function EcencyImagesUploadForm({ onFilesPick }: Props) {
         Array.from(e.dataTransfer.items).forEach((item) => {
           if (item.kind === "file") {
             const file = item.getAsFile();
-            const fileExtension = file?.name.split(".").pop()?.toLowerCase();
-            if (file && fileExtension && ["png", "svg", "jpg", "jpeg", "webp", "gif", "heic", "heif"].includes(fileExtension)) {
+            if (file && isAcceptedImageFilename(file.name)) {
               files.push(file);
             }
           }
@@ -57,7 +57,7 @@ export function EcencyImagesUploadForm({ onFilesPick }: Props) {
   return (
     <div className="animate-fade-in-up">
       <input
-        accept="image/jpg, image/jpeg, image/webp, image/png, image/svg+xml, .svg, image/gif, image/heic, image/heif"
+        accept={IMAGE_UPLOAD_ACCEPT}
         type="file"
         multiple
         ref={fileInputRef}

--- a/apps/web/src/features/ecency-images/ecency-images-upload-form.tsx
+++ b/apps/web/src/features/ecency-images/ecency-images-upload-form.tsx
@@ -2,7 +2,7 @@ import { UilFileDownload, UilFileUpload } from "@tooni/iconscout-unicons-react";
 import clsx from "clsx";
 import i18next from "i18next";
 import { useCallback, useRef, useState } from "react";
-import { IMAGE_UPLOAD_ACCEPT, isAcceptedImageFilename } from "@/utils/image-upload-formats";
+import { IMAGE_UPLOAD_ACCEPT, isAcceptedImageFile } from "@/utils/image-upload-formats";
 
 interface Props {
   onFilesPick: (files: File[]) => void;
@@ -20,7 +20,7 @@ export function EcencyImagesUploadForm({ onFilesPick }: Props) {
         Array.from(e.dataTransfer.items).forEach((item) => {
           if (item.kind === "file") {
             const file = item.getAsFile();
-            if (file && isAcceptedImageFilename(file.name)) {
+            if (file && isAcceptedImageFile(file)) {
               files.push(file);
             }
           }

--- a/apps/web/src/features/shared/editor-toolbar/index.tsx
+++ b/apps/web/src/features/shared/editor-toolbar/index.tsx
@@ -12,6 +12,7 @@ import { useUploadImageMutation } from "@/api/sdk-mutations";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { insertOrReplace, replace } from "@/utils";
 import { convertHeicToJpeg } from "@/utils/convert-heic";
+import { isAcceptedImageFilename } from "@/utils/image-upload-formats";
 import { Tooltip } from "@ui/tooltip";
 import i18next from "i18next";
 import { EmojiPicker } from "@ui/emoji-picker/lazy-emoji-picker";
@@ -226,8 +227,7 @@ export function EditorToolbar({
       });
   };
 
-  const checkFile = (filename: string) =>
-    ["jpg", "jpeg", "gif", "png", "webp", "heic", "heif"].some((el) => filename.toLowerCase().endsWith(el));
+  const checkFile = (filename: string) => isAcceptedImageFilename(filename);
 
   const onDragOver = (e: DragEvent) => {
     e.preventDefault();

--- a/apps/web/src/features/tiptap-editor/plugins/clipboard/clipboard-plugin-image-strategy.ts
+++ b/apps/web/src/features/tiptap-editor/plugins/clipboard/clipboard-plugin-image-strategy.ts
@@ -12,7 +12,13 @@ export class ClipboardPluginImageStrategy implements ClipboardStrategy {
     const chain = this.editor?.chain();
 
     allFiles
-      .filter((file) => ["image/png", "image/jpeg", "image/jpg", "image/gif"].includes(file.type))
+      // Formats the browser can preview from a blob URL. HEIC is left out on
+      // purpose: it would show a broken preview until the upload TODO below lands.
+      .filter((file) =>
+        ["image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp", "image/avif"].includes(
+          file.type
+        )
+      )
       .forEach((file) => {
         // TODO: Ideally, pasted images should be uploaded to the server immediately
         // and the blob URL should be replaced with the server URL to avoid memory leaks

--- a/apps/web/src/features/waves/components/wave-form/wave-form-toolbar-image-picker.tsx
+++ b/apps/web/src/features/waves/components/wave-form/wave-form-toolbar-image-picker.tsx
@@ -12,6 +12,7 @@ import { EcencyConfigManager } from "@/config";
 import { Dropdown, DropdownItemWithIcon, DropdownMenu, DropdownToggle } from "@ui/dropdown";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { convertHeicToJpeg } from "@/utils/convert-heic";
+import { isAcceptedImageFilename } from "@/utils/image-upload-formats";
 
 interface Props {
   onAddImage: (link: string, name: string) => void;
@@ -33,10 +34,7 @@ export const WaveFormToolbarImagePicker = ({ onAddImage, disabled }: Props) => {
     [onAddImage]
   );
 
-  const checkFile = useCallback((filename: string) => {
-    const filenameLow = filename.toLowerCase();
-    return ["jpg", "jpeg", "gif", "png", "webp", "heic", "heif"].some((el) => filenameLow.endsWith(el));
-  }, []);
+  const checkFile = useCallback((filename: string) => isAcceptedImageFilename(filename), []);
 
   const upload = useCallback(
     async (file: File) => {

--- a/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
+++ b/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
@@ -8,8 +8,9 @@ vi.mock("@/api/sdk-mutations", () => ({
   useUploadImageMutation: () => ({ mutateAsync: uploadMock })
 }));
 
-vi.mock("@/app/publish/_hooks", () => ({
-  useOptionalUploadTracker: () => undefined
+vi.mock("@/app/publish/_hooks/use-upload-tracker", () => ({
+  useOptionalUploadTracker: () => undefined,
+  nextUploadId: (source: string) => `${source}-test`
 }));
 
 import { EcencyImagesUploadDialog } from "@/features/ecency-images";
@@ -68,10 +69,15 @@ describe("EcencyImagesUploadDialog", () => {
     expect(uploadMock).not.toHaveBeenCalled();
   });
 
-  it("does not insert an image when the dialog is closed mid-upload", async () => {
+  it("aborts and does not insert an image when the dialog is closed mid-upload", async () => {
     let resolveUpload: (value: { url: string }) => void = () => {};
+    let signal: AbortSignal | undefined;
     uploadMock.mockImplementationOnce(
-      () => new Promise<{ url: string }>((resolve) => (resolveUpload = resolve))
+      (args: { signal?: AbortSignal }) =>
+        new Promise<{ url: string }>((resolve) => {
+          signal = args.signal;
+          resolveUpload = resolve;
+        })
     );
 
     const onPick = vi.fn();
@@ -82,6 +88,8 @@ describe("EcencyImagesUploadDialog", () => {
     await waitFor(() => expect(uploadMock).toHaveBeenCalledTimes(1));
 
     rerender(<EcencyImagesUploadDialog show={false} {...props} />);
+    expect(signal?.aborted).toBe(true);
+
     resolveUpload({ url: "https://images.ecency.com/p/uploaded" });
     await new Promise((resolve) => setTimeout(resolve, 0));
 

--- a/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
+++ b/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
@@ -58,6 +58,28 @@ describe("EcencyImagesUploadDialog", () => {
     expect(screen.queryByText("editor-toolbar.upload")).toBeNull();
   });
 
+  it("cancels as soon as the modal close button is pressed, not a render later", async () => {
+    let resolveUpload: (value: { url: string }) => void = () => {};
+    uploadMock.mockImplementationOnce(
+      () => new Promise<{ url: string }>((resolve) => (resolveUpload = resolve))
+    );
+
+    const onPick = vi.fn();
+    // `show` stays true, as it does in the gap before the parent reacts to onHide
+    const { container } = render(
+      <EcencyImagesUploadDialog show={true} setShow={vi.fn()} onPick={onPick} />
+    );
+
+    pickFiles(container, [jpeg("one.jpg")]);
+    await waitFor(() => expect(uploadMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByLabelText("g.close"));
+    resolveUpload({ url: "https://images.ecency.com/p/uploaded" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onPick).not.toHaveBeenCalled();
+  });
+
   it("does not upload files that are not accepted images", async () => {
     const { container } = render(
       <EcencyImagesUploadDialog show={true} setShow={vi.fn()} onPick={vi.fn()} />

--- a/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
+++ b/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
@@ -24,6 +24,9 @@ function pickFiles(container: HTMLElement, files: File[]) {
 
 const jpeg = (name: string) => new File(["x"], name, { type: "image/jpeg" });
 
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
 describe("EcencyImagesUploadDialog", () => {
   beforeEach(() => {
     setupModalContainers();
@@ -34,6 +37,8 @@ describe("EcencyImagesUploadDialog", () => {
 
   afterEach(() => {
     cleanupModalContainers();
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
   });
 
   it("uploads a single picked image without a review step", async () => {
@@ -50,6 +55,17 @@ describe("EcencyImagesUploadDialog", () => {
     // The dialog closes itself once the only image is in
     await waitFor(() => expect(setShow).toHaveBeenCalledWith(false));
     expect(screen.queryByText("editor-toolbar.upload")).toBeNull();
+  });
+
+  it("does not upload files that are not accepted images", async () => {
+    const { container } = render(
+      <EcencyImagesUploadDialog show={true} setShow={vi.fn()} onPick={vi.fn()} />
+    );
+
+    pickFiles(container, [new File(["x"], "notes.txt", { type: "text/plain" })]);
+
+    await waitFor(() => expect(URL.createObjectURL).not.toHaveBeenCalled());
+    expect(uploadMock).not.toHaveBeenCalled();
   });
 
   it("shows the preview step for several images and waits for confirmation", async () => {

--- a/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
+++ b/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
@@ -68,6 +68,26 @@ describe("EcencyImagesUploadDialog", () => {
     expect(uploadMock).not.toHaveBeenCalled();
   });
 
+  it("does not insert an image when the dialog is closed mid-upload", async () => {
+    let resolveUpload: (value: { url: string }) => void = () => {};
+    uploadMock.mockImplementationOnce(
+      () => new Promise<{ url: string }>((resolve) => (resolveUpload = resolve))
+    );
+
+    const onPick = vi.fn();
+    const props = { setShow: vi.fn(), onPick };
+    const { container, rerender } = render(<EcencyImagesUploadDialog show={true} {...props} />);
+
+    pickFiles(container, [jpeg("one.jpg")]);
+    await waitFor(() => expect(uploadMock).toHaveBeenCalledTimes(1));
+
+    rerender(<EcencyImagesUploadDialog show={false} {...props} />);
+    resolveUpload({ url: "https://images.ecency.com/p/uploaded" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onPick).not.toHaveBeenCalled();
+  });
+
   it("shows the preview step for several images and waits for confirmation", async () => {
     const onPick = vi.fn();
     const { container } = render(

--- a/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
+++ b/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
@@ -1,0 +1,70 @@
+import { cleanupModalContainers, setupModalContainers } from "@/specs/test-utils";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const uploadMock = vi.fn(async () => ({ url: "https://images.ecency.com/p/uploaded" }));
+
+vi.mock("@/api/sdk-mutations", () => ({
+  useUploadImageMutation: () => ({ mutateAsync: uploadMock })
+}));
+
+vi.mock("@/app/publish/_hooks", () => ({
+  useOptionalUploadTracker: () => undefined
+}));
+
+import { EcencyImagesUploadDialog } from "@/features/ecency-images";
+
+function pickFiles(container: HTMLElement, files: File[]) {
+  const input = container.ownerDocument.querySelector(
+    "input[type=file]"
+  ) as HTMLInputElement | null;
+  expect(input).not.toBeNull();
+  fireEvent.change(input!, { target: { files } });
+}
+
+const jpeg = (name: string) => new File(["x"], name, { type: "image/jpeg" });
+
+describe("EcencyImagesUploadDialog", () => {
+  beforeEach(() => {
+    setupModalContainers();
+    uploadMock.mockClear();
+    URL.createObjectURL = vi.fn(() => "blob:preview");
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanupModalContainers();
+  });
+
+  it("uploads a single picked image without a review step", async () => {
+    const onPick = vi.fn();
+    const setShow = vi.fn();
+    const { container } = render(
+      <EcencyImagesUploadDialog show={true} setShow={setShow} onPick={onPick} />
+    );
+
+    pickFiles(container, [jpeg("one.jpg")]);
+
+    await waitFor(() => expect(uploadMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onPick).toHaveBeenCalledWith("https://images.ecency.com/p/uploaded"));
+    // The dialog closes itself once the only image is in
+    await waitFor(() => expect(setShow).toHaveBeenCalledWith(false));
+    expect(screen.queryByText("editor-toolbar.upload")).toBeNull();
+  });
+
+  it("shows the preview step for several images and waits for confirmation", async () => {
+    const onPick = vi.fn();
+    const { container } = render(
+      <EcencyImagesUploadDialog show={true} setShow={vi.fn()} onPick={onPick} />
+    );
+
+    pickFiles(container, [jpeg("one.jpg"), jpeg("two.jpg")]);
+
+    const uploadButton = await screen.findByText("editor-toolbar.upload");
+    expect(uploadMock).not.toHaveBeenCalled();
+
+    fireEvent.click(uploadButton);
+
+    await waitFor(() => expect(uploadMock).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
+++ b/apps/web/src/specs/features/ecency-images/upload-dialog.spec.tsx
@@ -80,6 +80,31 @@ describe("EcencyImagesUploadDialog", () => {
     expect(onPick).not.toHaveBeenCalled();
   });
 
+  it("aborts the in-flight request when the Cancel button is pressed", async () => {
+    const signals: AbortSignal[] = [];
+    uploadMock.mockImplementation(
+      (args: { signal?: AbortSignal }) =>
+        new Promise<{ url: string }>(() => {
+          if (args.signal) {
+            signals.push(args.signal);
+          }
+        })
+    );
+
+    const { container } = render(
+      <EcencyImagesUploadDialog show={true} setShow={vi.fn()} onPick={vi.fn()} />
+    );
+
+    pickFiles(container, [jpeg("one.jpg"), jpeg("two.jpg")]);
+    fireEvent.click(await screen.findByText("editor-toolbar.upload"));
+    await waitFor(() => expect(signals.length).toBe(1));
+
+    fireEvent.click(screen.getByText("g.cancel"));
+    expect(signals[0].aborted).toBe(true);
+
+    uploadMock.mockImplementation(async () => ({ url: "https://images.ecency.com/p/uploaded" }));
+  });
+
   it("does not upload files that are not accepted images", async () => {
     const { container } = render(
       <EcencyImagesUploadDialog show={true} setShow={vi.fn()} onPick={vi.fn()} />

--- a/apps/web/src/specs/utils/image-upload-formats.spec.ts
+++ b/apps/web/src/specs/utils/image-upload-formats.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  IMAGE_UPLOAD_ACCEPT,
+  isAcceptedImageFile,
+  isAcceptedImageFilename
+} from "@/utils/image-upload-formats";
+
+describe("image upload formats", () => {
+  it("accepts every format the image server stores", () => {
+    ["photo.jpg", "photo.jpeg", "photo.png", "photo.gif", "photo.webp", "photo.avif", "logo.svg", "photo.heic", "photo.heif"].forEach(
+      (name) => expect(isAcceptedImageFilename(name)).toBe(true)
+    );
+  });
+
+  it("is case-insensitive", () => {
+    expect(isAcceptedImageFilename("PHOTO.AVIF")).toBe(true);
+  });
+
+  it("rejects non-image files", () => {
+    expect(isAcceptedImageFilename("notes.txt")).toBe(false);
+    expect(isAcceptedImageFilename("clip.mp4")).toBe(false);
+    expect(isAcceptedImageFilename("archive.avif.zip")).toBe(false);
+  });
+
+  it("accepts a file by mime type when the name has no extension", () => {
+    expect(isAcceptedImageFile(new File([""], "pasted", { type: "image/avif" }))).toBe(true);
+    expect(isAcceptedImageFile(new File([""], "pasted", { type: "text/plain" }))).toBe(false);
+  });
+
+  it("offers avif in the file input accept attribute", () => {
+    expect(IMAGE_UPLOAD_ACCEPT).toContain("image/avif");
+    expect(IMAGE_UPLOAD_ACCEPT).toContain(".avif");
+  });
+});

--- a/apps/web/src/utils/image-upload-formats.ts
+++ b/apps/web/src/utils/image-upload-formats.ts
@@ -1,0 +1,51 @@
+/**
+ * Image formats accepted for upload.
+ *
+ * Kept in sync with the image server's accepted content types. Uploaded files are
+ * stored as-is; the image proxy negotiates the delivery format (AVIF/WebP/original)
+ * per request, so accepting a modern source format here costs nothing on delivery.
+ */
+export const ACCEPTED_IMAGE_EXTENSIONS = [
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "webp",
+  "avif",
+  "svg",
+  "heic",
+  "heif"
+] as const;
+
+export const ACCEPTED_IMAGE_MIME_TYPES = [
+  "image/jpg",
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+  "image/svg+xml",
+  "image/heic",
+  "image/heif"
+] as const;
+
+/**
+ * Value for a file input `accept` attribute. Extensions are listed alongside the
+ * MIME types because some browsers report an empty type for AVIF and HEIC files.
+ */
+export const IMAGE_UPLOAD_ACCEPT = [
+  ...ACCEPTED_IMAGE_MIME_TYPES,
+  ...ACCEPTED_IMAGE_EXTENSIONS.map((ext) => `.${ext}`)
+].join(", ");
+
+export function isAcceptedImageFilename(filename: string): boolean {
+  const ext = filename.toLowerCase().split(".").pop();
+  return !!ext && (ACCEPTED_IMAGE_EXTENSIONS as readonly string[]).includes(ext);
+}
+
+export function isAcceptedImageFile(file: File): boolean {
+  return (
+    (ACCEPTED_IMAGE_MIME_TYPES as readonly string[]).includes(file.type.toLowerCase()) ||
+    isAcceptedImageFilename(file.name)
+  );
+}


### PR DESCRIPTION
## What

Image upload from the publish editor was always two steps: pick files, then confirm in a dialog. For one image there is nothing to review, so that second step was pure friction.

- The toolbar **Upload** item now opens the file picker directly. One image uploads and is inserted immediately; two or more open the existing preview dialog, pre-seeded with the picked files.
- Dropping a single image on the dialog's dropzone also uploads right away instead of waiting for the Upload button.
- Drag and drop into the editor now uploads **all** dropped images (it previously took only the first) and converts HEIC like the other entry points, because it shares one `useUploadAndInsertImages` hook with the toolbar.

## AVIF

Accepted formats were duplicated across five pickers and none of them allowed AVIF, even though the image server has accepted `image/avif` for a while - picking an `.avif` file was silently ignored with no error. They now share `utils/image-upload-formats.ts`, which mirrors the server's accepted list (adds AVIF everywhere, plus HEIC/HEIF on the decks picker, which also gained the HEIC conversion the other pickers already had). Pasted AVIF/WebP images are no longer dropped either.

## Tests

New specs for the format helpers and for the dialog's single vs multiple behaviour. Full web suite, typecheck and lint pass.

## Verification

Needs a click-through on staging: single pick, multi pick, drag and drop of several files, and an `.avif` upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-image uploads in the publishing editor with previews and an upload review step.
  * Single-image selections now upload automatically, and drag-and-drop supports multiple images in order.
  * HEIC/HEIF images are converted to JPEG before uploading; added support for WebP and AVIF (plus existing formats).

* **Bug Fixes**
  * Standardized image validation across image pickers and upload flows.
  * Publish “Continue” now waits for background image uploads to finish.
  * Clipboard image paste now accepts the expanded formats set.

* **Tests**
  * Added coverage for accepted image formats and updated upload dialog behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->