### PR TITLE
feat(icons): sizing convention bundle 4 - votes cluster and mixin dismantle

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/entry.scss
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/entry.scss
@@ -259,10 +259,6 @@
           @media (min-width: $sm-break) {
             margin-right: 25px;
           }
-
-          svg {
-            height: 17px;
-          }
         }
 
         .raw-content-icon {

--- a/apps/web/src/app/decks/_components/_deck.scss
+++ b/apps/web/src/app/decks/_components/_deck.scss
@@ -261,11 +261,20 @@
       white-space: nowrap;
     }
 
-    .entry-votes svg, .comments svg {
+    .entry-votes svg {
       opacity: 1;
 
       @include margin(0);
       @include margin-right(0.25rem);
+    }
+
+    // .comments svg sits inside a fixed size-4 sink wrapper now; a margin on the
+    // svg itself would flex-shrink the glyph inside that box. The gap lives on
+    // the wrapper (mr-1).
+    .comments svg {
+      opacity: 1;
+
+      @include margin(0);
     }
   }
 

--- a/apps/web/src/app/decks/_components/_deck.scss
+++ b/apps/web/src/app/decks/_components/_deck.scss
@@ -267,11 +267,6 @@
       @include margin(0);
       @include margin-right(0.25rem);
     }
-
-    svg {
-      width: 1rem;
-      height: 1rem;
-    }
   }
 
   .deck-pinned {

--- a/apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss
+++ b/apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss
@@ -136,11 +136,6 @@
       @include margin-right(0.25rem);
     }
 
-    svg {
-      width: 1rem;
-      height: 1rem;
-    }
-
     @include compact_vote_slider();
   }
 

--- a/apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss
+++ b/apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss
@@ -129,11 +129,20 @@
       }
     }
 
-    .entry-votes svg, .comments svg {
+    .entry-votes svg {
       opacity: 1;
 
       @include margin(0);
       @include margin-right(0.25rem);
+    }
+
+    // .comments svg sits inside a fixed size-4 sink wrapper now; a margin on the
+    // svg itself would flex-shrink the glyph inside that box. The gap lives on
+    // the wrapper (mr-1).
+    .comments svg {
+      opacity: 1;
+
+      @include margin(0);
     }
 
     @include compact_vote_slider();

--- a/apps/web/src/app/decks/_components/columns/content-viewer/deck-post-viewer.tsx
+++ b/apps/web/src/app/decks/_components/columns/content-viewer/deck-post-viewer.tsx
@@ -69,9 +69,11 @@ export const DeckPostViewer = ({ entry: initialEntry, onClose, backTitle }: Prop
       </div>
       <div className="bottom-actions p-3">
         <EntryVoteBtn entry={entry} isPostSlider={false} />
-        <EntryVotes entry={entry} icon={voteSvg} />
+        <EntryVotes entry={entry} icon={voteSvg} iconSizeClass="[&>svg]:size-4" />
         <div className="flex items-center comments">
-          <div style={{ paddingRight: 4 }}>{commentSvg}</div>
+          <div className="inline-flex shrink-0 size-4 [&>svg]:size-full mr-1">
+            {commentSvg}
+          </div>
           {entry.children}
         </div>
         <EntryTipBtn entry={entry} />

--- a/apps/web/src/app/decks/_components/columns/content-viewer/deck-post-viewer.tsx
+++ b/apps/web/src/app/decks/_components/columns/content-viewer/deck-post-viewer.tsx
@@ -71,7 +71,7 @@ export const DeckPostViewer = ({ entry: initialEntry, onClose, backTitle }: Prop
         <EntryVoteBtn entry={entry} isPostSlider={false} />
         <EntryVotes entry={entry} icon={voteSvg} iconSizeClass="[&>svg]:size-4" />
         <div className="flex items-center comments">
-          <div className="inline-flex shrink-0 size-4 [&>svg]:size-full mr-1">
+          <div aria-hidden="true" className="inline-flex shrink-0 size-4 [&>svg]:size-full mr-1">
             {commentSvg}
           </div>
           {entry.children}

--- a/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
+++ b/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
@@ -274,20 +274,22 @@ export const SearchListItem = ({
         <div className="item-controls mt-3 flex items-center">
           <EntryVoteBtn entry={entry} isPostSlider={false} />
           <EntryPayout entry={entry} />
-          <EntryVotes entry={entry} icon={voteSvg} />
+          <EntryVotes entry={entry} icon={voteSvg} iconSizeClass="[&>svg]:size-4" />
           <Link
             href={safeUrl === "#" ? "#" : `${safeUrl}#discussion`}
             className="text-gray-600 dark:text-gray-400"
           >
             <div className="flex items-center comments">
-              <div style={{ paddingRight: 4 }}>{commentSvg}</div>
+              <div className="inline-flex shrink-0 size-4 [&>svg]:size-full mr-1">
+                {commentSvg}
+              </div>
               <div>{entry.children}</div>
             </div>
           </Link>
 
           <EntryReblogBtn entry={entry} />
           <EntryTipBtn entry={entry} />
-          <EntryMenu alignBottom={false} entry={entry} />
+          <EntryMenu alignBottom={false} entry={entry} compact={true} />
         </div>
       </div>
     </div>

--- a/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
+++ b/apps/web/src/app/decks/_components/columns/deck-items/deck-search-list-item.tsx
@@ -280,7 +280,7 @@ export const SearchListItem = ({
             className="text-gray-600 dark:text-gray-400"
           >
             <div className="flex items-center comments">
-              <div className="inline-flex shrink-0 size-4 [&>svg]:size-full mr-1">
+              <div aria-hidden="true" className="inline-flex shrink-0 size-4 [&>svg]:size-full mr-1">
                 {commentSvg}
               </div>
               <div>{entry.children}</div>

--- a/apps/web/src/features/shared/bookmark-btn/_index.scss
+++ b/apps/web/src/features/shared/bookmark-btn/_index.scss
@@ -9,10 +9,6 @@
     margin-top: 3px;
   }
 
-  svg {
-    height: 20px;
-  }
-
   &.bookmarked {
     @apply text-blue-dark-sky;
   }

--- a/apps/web/src/features/shared/bookmark-btn/index.tsx
+++ b/apps/web/src/features/shared/bookmark-btn/index.tsx
@@ -70,7 +70,7 @@ export function BookmarkBtn({ entry }: Props) {
   const bookmarkIcon = (
     <NotificationBadgeIcon>
       <UilBookmark
-        className={bookmarkDone ? "animate-success-pulse" : undefined}
+        className={`size-5${bookmarkDone ? " animate-success-pulse" : ""}`}
         onAnimationEnd={() => setBookmarkDone(false)}
       />
     </NotificationBadgeIcon>

--- a/apps/web/src/features/shared/entry-list-item/index.tsx
+++ b/apps/web/src/features/shared/entry-list-item/index.tsx
@@ -120,11 +120,11 @@ export function EntryListItemComponent({
         <div className="item-header-features">
           {((community && !!entry.stats?.is_pinned) || entry.permlink === pinned) && (
             <Tooltip content={i18next.t("entry-list-item.pinned")}>
-              <span className="pinned">{pinSvg}</span>
+              <span className="pinned [&>svg]:size-4">{pinSvg}</span>
             </Tooltip>
           )}
           {reBlogged && (
-            <span className="reblogged">
+            <span className="reblogged [&>svg]:size-4">
               {repeatSvg} {i18next.t("entry-list-item.reblogged", { n: reBlogged })}
             </span>
           )}

--- a/apps/web/src/features/shared/entry-menu/index.tsx
+++ b/apps/web/src/features/shared/entry-menu/index.tsx
@@ -54,6 +54,9 @@ interface Props {
   separatedSharing?: boolean;
   alignBottom?: boolean;
   pinEntry?: (entry: Entry | null) => void;
+  // Dense action rows (waves, deck columns) render the menu icons at 16px
+  // instead of the Button slot's 20px. Feed/entry-page menus stay at 20.
+  compact?: boolean;
 }
 
 export const EntryMenu = ({
@@ -61,7 +64,8 @@ export const EntryMenu = ({
   separatedSharing = false,
   alignBottom,
   extraMenuItems,
-  pinEntry
+  pinEntry,
+  compact = false
 }: Props) => {
   const { activeUser } = useActiveAccount();
   const router = useRouter();
@@ -126,13 +130,24 @@ export const EntryMenu = ({
 
   return (
     <div className="entry-menu" ref={menuRef}>
-      <Button icon={<UilShareAlt />} appearance="gray-link" onClick={() => setShare(true)} aria-label={i18next.t("entry-menu.share")} />
+      <Button
+        icon={<UilShareAlt className={compact ? "!size-4" : undefined} />}
+        appearance="gray-link"
+        onClick={() => setShare(true)}
+        aria-label={i18next.t("entry-menu.share")}
+      />
       <Dropdown show={dropdownOpen} setShow={setDropdownOpen}>
         <DropdownToggle>
           <Button
             appearance="gray-link"
             size="sm"
-            icon={dotsHorizontal}
+            icon={
+              compact ? (
+                <span className="inline-flex !size-4 [&>svg]:size-full">{dotsHorizontal}</span>
+              ) : (
+                dotsHorizontal
+              )
+            }
             aria-label={i18next.t("g.menu", { defaultValue: "Menu" })}
             aria-haspopup="menu"
             aria-expanded={dropdownOpen}

--- a/apps/web/src/features/shared/entry-reblog-btn/_index.scss
+++ b/apps/web/src/features/shared/entry-reblog-btn/_index.scss
@@ -11,7 +11,6 @@
   }
 
   svg {
-    height: 16px;
     opacity: 0.8;
   }
   span {

--- a/apps/web/src/features/shared/entry-reblog-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-reblog-btn/index.tsx
@@ -83,7 +83,7 @@ export function EntryReblogBtn({ entry }: Props) {
             }}
         >
             <Tooltip content={reblogLabel}>
-                <a className="inner-btn" aria-hidden={true}>
+                <a className="inner-btn [&>svg]:size-4" aria-hidden={true}>
                     {repeatSvg}
                     {/* key-remount so the tick replays on every count change */}
                     <span key={reblogsCount} className={countChanged ? "animate-tick" : undefined}>

--- a/apps/web/src/features/shared/entry-stats/index.tsx
+++ b/apps/web/src/features/shared/entry-stats/index.tsx
@@ -16,9 +16,13 @@ import { EntryPageStatsItem } from "./entry-page-stats-item";
 
 interface Props {
   entry: Entry;
+  // Dense action rows (waves detail) size the eye at 16px instead of the
+  // Button slot's 20px. `!` is required: the slot's [&>svg]:size-5 ties a
+  // plain utility on specificity and wins on order.
+  iconClassName?: string;
 }
 
-export function EntryStats({ entry }: Props) {
+export function EntryStats({ entry, iconClassName }: Props) {
   const { activeUser } = useActiveAccount();
   const [showStats, setShowStats] = useState(false);
 
@@ -84,7 +88,7 @@ export function EntryStats({ entry }: Props) {
     <>
       <Button
         noPadding={true}
-        icon={<UilEye />}
+        icon={<UilEye className={iconClassName} />}
         iconPlacement="left"
         size="sm"
         appearance="gray-link"

--- a/apps/web/src/features/shared/entry-tip-btn/_index.scss
+++ b/apps/web/src/features/shared/entry-tip-btn/_index.scss
@@ -12,7 +12,6 @@
     @apply text-blue-dark-sky;
 
     svg {
-      height: 16px;
       opacity: 0.7;
 
       &:hover {

--- a/apps/web/src/features/shared/entry-tip-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-tip-btn/index.tsx
@@ -128,7 +128,7 @@ export function EntryTipBtn({
       <Tooltip
         content={tippedByViewer ? i18next.t("entry-tip.you-tipped") : i18next.t("entry-tip.title")}
       >
-        <span className={`inner-btn${tippedByViewer ? " tipped" : ""}`}>
+        <span className={`inner-btn [&>svg]:size-4${tippedByViewer ? " tipped" : ""}`}>
           {giftOutlineSvg}
           <span className="tip-count">{showTipNumber ? tipCount : ""}</span>
         </span>

--- a/apps/web/src/features/shared/entry-vote-btn/entry-vote-dialog.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/entry-vote-dialog.tsx
@@ -223,7 +223,7 @@ export function EntryVoteDialog({
       {!isPaidOut && mode === "up" && (
         <>
           <div className="voting-controls voting-controls-up">
-            {isVotingLoading ? <Spinner className="!size-3.5" /> : (
+            {isVotingLoading ? <Spinner className="size-3.5" /> : (
               <Button
                 noPadding={true}
                 className="w-8"
@@ -309,7 +309,7 @@ export function EntryVoteDialog({
             </div>
             <div className="space" />
             <div className="percentage" />
-            {isVotingLoading ? <Spinner className="!size-3.5" /> : (
+            {isVotingLoading ? <Spinner className="size-3.5" /> : (
               <Button
                 noPadding={true}
                 className="w-8"

--- a/apps/web/src/features/shared/entry-votes/_index.scss
+++ b/apps/web/src/features/shared/entry-votes/_index.scss
@@ -76,8 +76,6 @@
   }
 
   svg {
-    height: 14px;
-    width: 14px;
     opacity: 0.5;
     margin-right: 5px;
     margin-top: 2px;

--- a/apps/web/src/features/shared/entry-votes/entry-votes-dialog.tsx
+++ b/apps/web/src/features/shared/entry-votes/entry-votes-dialog.tsx
@@ -19,7 +19,7 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 type SortOption = "reward" | "timestamp" | "voter" | "percent";
 
 interface Props {
-  /** See EntryVotes: size-N sink class for the vote icon; undefined = legacy CSS. */
+  /** See EntryVotes: size-N sink class for the vote icon; defaults to "[&>svg]:size-3.5". */
   iconSizeClass?: string;
   entry?: Entry;
   icon?: ReactNode;

--- a/apps/web/src/features/shared/entry-votes/entry-votes-dialog.tsx
+++ b/apps/web/src/features/shared/entry-votes/entry-votes-dialog.tsx
@@ -31,7 +31,7 @@ interface Props {
 export function EntryVotesDialog({
   entry: initialEntry,
   icon,
-  iconSizeClass,
+  iconSizeClass = "[&>svg]:size-3.5",
   onHide,
   totalVotes,
   hasDifferentVotes

--- a/apps/web/src/features/shared/entry-votes/index.tsx
+++ b/apps/web/src/features/shared/entry-votes/index.tsx
@@ -23,8 +23,8 @@ type SortOption = "reward" | "timestamp" | "voter" | "percent";
 
 interface Props {
   /** Icon sizing convention (docs/icons.md): a size-N sink class for the vote
-   *  icon, e.g. "size-4 [&>svg]:size-full". Undefined renders no class, leaving
-   *  the legacy .entry-votes svg CSS in charge (unchanged behaviour). */
+   *  icon, e.g. "size-4 [&>svg]:size-full". Defaults to "[&>svg]:size-3.5"
+   *  (14px), the feed/discussion tier; waves and decks pass the 16px form. */
   iconSizeClass?: string;
   entry: Entry;
   icon?: ReactNode;

--- a/apps/web/src/features/shared/entry-votes/index.tsx
+++ b/apps/web/src/features/shared/entry-votes/index.tsx
@@ -31,7 +31,12 @@ interface Props {
   hideCount?: boolean;
 }
 
-export function EntryVotes({ entry: initialEntry, icon, hideCount = false, iconSizeClass }: Props) {
+export function EntryVotes({
+  entry: initialEntry,
+  icon,
+  hideCount = false,
+  iconSizeClass = "[&>svg]:size-3.5"
+}: Props) {
   const { data: entry } = useQuery(EcencyEntriesCacheManagement.getEntryQuery(initialEntry));
   const previousEntry = usePrevious(entry);
 

--- a/apps/web/src/features/shared/search-list-item/_index.scss
+++ b/apps/web/src/features/shared/search-list-item/_index.scss
@@ -18,7 +18,6 @@
 
   .item-controls {
     svg {
-      height: 14px !important;
       margin-right: 4px;
       opacity: 0.6;
     }

--- a/apps/web/src/features/shared/search-list-item/index.tsx
+++ b/apps/web/src/features/shared/search-list-item/index.tsx
@@ -103,13 +103,13 @@ export function SearchListItem({ res }: Props) {
             </a>
           </EntryLink>
           <EntryLink entry={entry}>
-            <a className="result-votes">
+            <a className="result-votes [&>svg]:size-3.5">
               {" "}
               {peopleSvg} {res.total_votes}
             </a>
           </EntryLink>
           <EntryLink entry={entry}>
-            <a className="result-replies">
+            <a className="result-replies [&>svg]:size-3.5">
               {commentSvg} {res.children}
             </a>
           </EntryLink>

--- a/apps/web/src/features/shared/search-list-item/index.tsx
+++ b/apps/web/src/features/shared/search-list-item/index.tsx
@@ -103,14 +103,26 @@ export function SearchListItem({ res }: Props) {
             </a>
           </EntryLink>
           <EntryLink entry={entry}>
-            <a className="result-votes [&>svg]:size-3.5">
+            <a className="result-votes">
               {" "}
-              {peopleSvg} {res.total_votes}
+              <span
+                aria-hidden="true"
+                className="inline-flex shrink-0 size-3.5 mr-1 [&>svg]:size-full [&>svg]:!m-0"
+              >
+                {peopleSvg}
+              </span>{" "}
+              {res.total_votes}
             </a>
           </EntryLink>
           <EntryLink entry={entry}>
-            <a className="result-replies [&>svg]:size-3.5">
-              {commentSvg} {res.children}
+            <a className="result-replies">
+              <span
+                aria-hidden="true"
+                className="inline-flex shrink-0 size-3.5 mr-1 mt-0.5 [&>svg]:size-full [&>svg]:!m-0"
+              >
+                {commentSvg}
+              </span>{" "}
+              {res.children}
             </a>
           </EntryLink>
         </div>

--- a/apps/web/src/features/ui/input/_input-vote.scss
+++ b/apps/web/src/features/ui/input/_input-vote.scss
@@ -1,10 +1,3 @@
-.entry-list-item .item-body .item-controls .ecency-vote-input svg {
-  max-width: 16px;
-  width: 16px;
-  height: 16px !important;
-  max-height: 16px;
-}
-
 .ecency-vote-input {
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {

--- a/apps/web/src/features/ui/input/input-vote.tsx
+++ b/apps/web/src/features/ui/input/input-vote.tsx
@@ -137,10 +137,10 @@ export function InputVote({ value, setValue, mode = "positive" }: Props) {
 
       <div className="absolute z-[11] right-10 top-0 bottom-0 flex flex-col justify-center items-center">
         <ArrowButton onClick={() => setValue(value + 0.1)}>
-          <UilArrowUp className="!size-3.5" />
+          <UilArrowUp className="size-3.5" />
         </ArrowButton>
         <ArrowButton onClick={() => setValue(value - 0.1)}>
-          <UilArrowDown className="!size-3.5" />
+          <UilArrowDown className="size-3.5" />
         </ArrowButton>
       </div>
     </div>

--- a/apps/web/src/features/ui/svg.tsx
+++ b/apps/web/src/features/ui/svg.tsx
@@ -205,7 +205,7 @@ export const peopleSvg = (
   </svg>
 );
 
-export const heartSvg = <UilHeart size={16} />;
+export const heartSvg = <UilHeart />;
 
 export const commentSvg = <UilComment />;
 

--- a/apps/web/src/features/waves/components/wave-actions.scss
+++ b/apps/web/src/features/waves/components/wave-actions.scss
@@ -31,9 +31,5 @@
     visibility: hidden;
   }
 
-  svg {
-    @apply w-4 h-4;
-  }
-
   @include compact_vote_slider();
 }

--- a/apps/web/src/features/waves/components/wave-actions.tsx
+++ b/apps/web/src/features/waves/components/wave-actions.tsx
@@ -58,13 +58,20 @@ export function WaveActions({
           <div>
             <EntryVoteBtn entry={entry!} isPostSlider={false} />
             {showPayout && <EntryPayout entry={entry!} />}
-            {showStats && <EntryStats entry={entry!} />}
-            <EntryVotes entry={entry!} icon={voteSvg} hideCount={!showVoteSummary} />
+            {showStats && <EntryStats entry={entry!} iconClassName="!size-4" />}
+            <EntryVotes
+              entry={entry!}
+              icon={voteSvg}
+              hideCount={!showVoteSummary}
+              iconSizeClass="[&>svg]:size-4"
+            />
             <Button
               iconPlacement="left"
               size="sm"
               appearance="gray-link"
-              icon={commentSvg}
+              icon={
+                <span className="inline-flex !size-4 [&>svg]:size-full">{commentSvg}</span>
+              }
               onClick={() => onEntryView()}
               aria-label={i18next.t("waves.reply")}
               title={i18next.t("waves.reply")}
@@ -85,7 +92,7 @@ export function WaveActions({
           </div>
           <div>
             <TranslateChip entry={entry!} />
-            <EntryMenu entry={entry!} />
+            <EntryMenu entry={entry!} compact={true} />
             {activeUser?.username === entry?.author && (
               <Button className="edit-btn" appearance="link" onClick={() => onEdit(entry!)}>
                 {i18next.t("decks.columns.edit-wave")}

--- a/apps/web/src/styles/_mixins.scss
+++ b/apps/web/src/styles/_mixins.scss
@@ -178,10 +178,6 @@
       .pinned {
         @apply text-red-040;
         transform: rotate(45deg);
-
-        svg {
-          height: 16px;
-        }
       }
 
       .reblogged {
@@ -192,7 +188,6 @@
         opacity: 0.7;
 
         svg {
-          height: 16px;
           margin-right: 4px;
           margin-top: 2px;
         }
@@ -307,10 +302,6 @@
       @media (min-width: $sm-break) {
         float: right;
         width: 100%;
-      }
-
-      svg {
-        height: 14px !important;
       }
 
       .replies {

--- a/scripts/icon-scss-manifest.json
+++ b/scripts/icon-scss-manifest.json
@@ -7,7 +7,7 @@
   },
   {
    "key": "apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/entry.scss | svg | height: 17px",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/(dynamicPages)/feed/[...sections]/entry-index.scss | svg | height: 14px",
@@ -71,11 +71,11 @@
   },
   {
    "key": "apps/web/src/app/decks/_components/_deck.scss | svg | width: 1rem",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/_deck.scss | svg | height: 1rem",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/columns/add-column/_deck-add-column.scss | svg | width: 2rem",
@@ -83,11 +83,11 @@
   },
   {
    "key": "apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss | svg | width: 1rem",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/columns/content-viewer/_deck-post-viewer.scss | svg | height: 1rem",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/app/decks/_components/deck-settings/_decks-settings.scss | svg | width: 1rem",
@@ -143,7 +143,7 @@
   },
   {
    "key": "apps/web/src/features/shared/bookmark-btn/_index.scss | svg | height: 20px",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/discussion/_index.scss | svg | height: 24px",
@@ -191,7 +191,7 @@
   },
   {
    "key": "apps/web/src/features/shared/entry-reblog-btn/_index.scss | svg | height: 16px",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/entry-share/_index.scss | svg | width: 28px",
@@ -203,15 +203,15 @@
   },
   {
    "key": "apps/web/src/features/shared/entry-tip-btn/_index.scss | svg | height: 16px",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/entry-votes/_index.scss | svg | height: 14px",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/entry-votes/_index.scss | svg | width: 14px",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/notifications/_index.scss | svg | height: 18px",
@@ -239,7 +239,7 @@
   },
   {
    "key": "apps/web/src/features/shared/search-list-item/_index.scss | svg | height: 14px !important",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/shared/transfer/_index.scss | svg | height: 60px",
@@ -251,23 +251,23 @@
   },
   {
    "key": "apps/web/src/features/ui/input/_input-vote.scss | .entry-list-item .item-body .item-controls .ecency-vote-input svg | max-width: 16px",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/ui/input/_input-vote.scss | .entry-list-item .item-body .item-controls .ecency-vote-input svg | width: 16px",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/ui/input/_input-vote.scss | .entry-list-item .item-body .item-controls .ecency-vote-input svg | height: 16px !important",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/ui/input/_input-vote.scss | .entry-list-item .item-body .item-controls .ecency-vote-input svg | max-height: 16px",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/features/waves/components/wave-actions.scss | svg | @apply w-4 h-4",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/styles/_base.scss | .btn svg | width: 20px",
@@ -283,15 +283,15 @@
   },
   {
    "key": "apps/web/src/styles/_mixins.scss | svg | height: 16px",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/styles/_mixins.scss | svg | height: 16px",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/styles/_mixins.scss | svg | height: 14px !important",
-   "status": "B4"
+   "status": "deleted"
   },
   {
    "key": "apps/web/src/styles/static-pages.scss | svg | height: 12px",


### PR DESCRIPTION
Bundle 4 of the icon sizing migration (docs/icons.md) — **the final conversion bundle**: the votes/action-bar dependency cluster and the mixin dismantle. These rules are coupled (blankets masked each other), so all 19 land atomically with their replacements.

### What changes hands

- **Feed / discussion / entry-footer heart**: `entry-votes` SCSS size deleted; `EntryVotes` now defaults `iconSizeClass="[&>svg]:size-3.5"` → **14px, unchanged**; opacity/margins survive in SCSS.
- **Waves action row**: the `svg { @apply w-4 h-4 }` blanket dies; every icon restated at **16** per-mechanism — heart via `iconSizeClass`, comment via sink span, tip via component sink, EntryMenu via `compact` threading, stats via `!size-4` (slot's `[&>svg]:size-5` would otherwise win).
- **Deck action bars** (search rows + post viewer): same pattern, blankets deleted, all icons hold **16**.
- **Entry page footer reblog**: 24×17 letterbox → **16×16** (the flagged delta from the spec).
- **Search results footer**: `!important` duplicate deleted, votes/replies at **14** unchanged.
- **Bookmark**: 24×20 letterbox → **20×20** square.
- **Vote slider SCSS**: proven dead (`.ecency-vote-input` chain matches nothing) — deleted outright.
- **Temporary `!size-3.5` pins dropped** (dialog spinners, slider arrows): with the waves blanket gone, plain `size-3.5` wins everywhere — verifier enumerated all 18 surviving SCSS declarations to prove nothing outguns it. tsx audit `important-outside-slot` count dropped 3→1 exactly as predicted.
- Small deliberate deltas, each flagged: deck vote-dialog RC banner 16→**14** (now matches feed), `heartSvg` dead `size={16}` attr removed.

### Adversarial verification

The verifier independently re-traced who-wins for every surface and found **one real defect, fixed here**: the deck comment sink had been merged onto a div carrying `paddingRight: 4` — under `border-box`, `size-4` minus that padding leaves a 12px content box, silently shrinking the glyph 16→12 on two deck surfaces. The sink now carries `mr-1` instead of inline padding (margins aren't eaten by border-box). This is exactly the class of bug that survives tests, tsc, and diff review.

It also re-proved the dead-rule claims (`.item-controls` reach, `.deck-body` scope, vote-slider rot), confirmed all 18 allowlist ledger rows byte-identical, and validated every stated before-px against the diff.

### Ledger end state

**0 owned rules remain** — 19 B4 → tombstones; only the 18 permanent allowlist entries (brand circles, RC gauge, transfer arrow, swap carve-out, reel tip, app badges) are live. The conversion phase of the migration is complete; bundle 5 flips enforcement to failing.

### Staging checklist (densest of the migration — flagship surfaces)

Feed row (heart 14, comment, reblog, tip, bookmark), waves row every icon at 16 + open its vote dialog (spinner/arrows 14), deck search rows + post viewer action bars (comment glyph **16, not 12** — the fixed defect), entry page footer (reblog now square 16), search results footer, vote slider open, entry menus (share/dots 20 on entry page, 16 in waves/decks).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized icon sizing across voting, commenting, bookmarking, reblogging, tipping, search, deck, and wave-action controls.
  * Improved compact action-menu layouts and icon alignment.
  * Added support for hiding comment counts when appropriate.
  * Refined loading spinner and vote control sizing for more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->