### PR TITLE
Validate the chat channel id instead of asserting it

### DIFF
--- a/apps/web/src/features/chat/mattermost-api.ts
+++ b/apps/web/src/features/chat/mattermost-api.ts
@@ -30,7 +30,13 @@ async function safeJson<T>(res: Response): Promise<T> {
  * bad payload is caught at the boundary instead of becoming a broken URL.
  */
 function asChannelId(value: unknown): string | null {
-  return typeof value === "string" && value.length > 0 ? value : null;
+  if (typeof value !== "string") {
+    return null;
+  }
+  // Trim before the emptiness test: a whitespace-only id is still truthy and
+  // would interpolate into a URL just as badly as a non-string one.
+  const channelId = value.trim();
+  return channelId.length > 0 ? channelId : null;
 }
 
 interface MattermostChannel {

--- a/apps/web/src/features/chat/mattermost-api.ts
+++ b/apps/web/src/features/chat/mattermost-api.ts
@@ -22,6 +22,17 @@ async function safeJson<T>(res: Response): Promise<T> {
   }
 }
 
+/**
+ * Chat API responses are cast rather than parsed, so a shape change upstream
+ * reaches the UI unchecked. A channel id that arrives as anything but a string
+ * still satisfies a truthiness check and then interpolates into a template
+ * literal, producing a request to `/chats/[object Object]`. Narrow it here so a
+ * bad payload is caught at the boundary instead of becoming a broken URL.
+ */
+function asChannelId(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 interface MattermostChannel {
   id: string;
   name: string;
@@ -137,7 +148,18 @@ export function useMattermostBootstrap(community?: string) {
         throw new Error(data?.error || "Unable to initialize chat");
       }
 
-      return (await safeJson(res)) as { ok: boolean; userId: string; channelId?: string | null };
+      const bootstrap = (await safeJson(res)) as {
+        ok: boolean;
+        userId: string;
+        channelId?: unknown;
+      };
+      // A non-string channel id is treated as absent: the caller already has a
+      // branch that reports the channel could not be prepared, which is a far
+      // better outcome than navigating somewhere that cannot exist.
+      return {
+        ...bootstrap,
+        channelId: asChannelId(bootstrap.channelId)
+      } as { ok: boolean; userId: string; channelId: string | null };
     }
   });
 }
@@ -831,7 +853,12 @@ export function useMattermostDirectChannel() {
         throw new Error(data?.error || "Unable to start direct message");
       }
 
-      return (await safeJson(res)) as { channelId: string };
+      const direct = (await safeJson(res)) as { channelId?: unknown };
+      const channelId = asChannelId(direct.channelId);
+      if (!channelId) {
+        throw new Error("Unable to start direct message");
+      }
+      return { channelId };
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["mattermost-channels"], exact: false });


### PR DESCRIPTION
Both chat endpoints **cast** their response rather than parsing it:

```ts
return (await safeJson(res)) as { ok: boolean; userId: string; channelId?: string | null };
return (await safeJson(res)) as { channelId: string };
```

TypeScript is satisfied at compile time, but nothing checks at runtime. A `channelId` arriving as anything other than a string still passes the consumer's truthiness test:

```ts
if (data?.channelId) router.replace(`/chats/${data.channelId}`);
```

and interpolates into the URL, turning a navigation into a request for a path that cannot exist. The declared types claim a guarantee the code does not provide.

**What changes**

- `asChannelId()` narrows at the boundary, so the types now describe what is actually guaranteed.
- **Bootstrap** treats a non-string id as absent. That routes into the branch this component already has for "channel could not be prepared", which is a much better outcome than navigating somewhere broken.
- **Direct message** fails with its existing error, since without an id there is nowhere to navigate.

**Context.** This came out of chasing a recurring `GET /[object%20Object] 404` in production. That specific request has *not* been traced to this code — it is issued with no JS initiator and no matching DOM element, so it may well be external. These two casts are a latent instance of the same failure mode regardless, and are worth closing on their own merits: today a bad payload here produces a silent broken navigation rather than a visible error.

No behaviour change on the happy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Mattermost channel IDs returned by the API.
  * Prevented invalid or empty channel IDs from being used during chat setup.
  * Direct-message creation now reports an error when a valid channel ID is not returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->