### PR TITLE
test(sentry): guard hydration filters against quote/property over-match

### DIFF
--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -141,6 +141,17 @@ describe("beforeSend — $RS hydration-resume reclassification", () => {
     expect(out!.fingerprint).toEqual(["hydration-rs-autorecovered"]);
   });
 
+  it("reclassifies the Firefox parentNode phrasing inside $RS (ECENCY-NEXT-1C6V)", () => {
+    // The exact payload of ECENCY-NEXT-1C6V. SpiderMonkey quotes the property
+    // name with ASCII straight double-quotes, NOT typographic curly ones — this
+    // pins the `includes('"parentNode"')` branch against a refactor that assumes
+    // otherwise.
+    const out = beforeSend(makeEvent('can\'t access property "parentNode", b is null', [RS_FRAME]));
+    expect(out).not.toBeNull();
+    expect(out!.level).toBe("warning");
+    expect(out!.fingerprint).toEqual(["hydration-rs-autorecovered"]);
+  });
+
   it("does NOT over-match a multi-char null read even with a $RS frame", () => {
     // The narrowed single-char regex must leave a real "(reading 'document')"
     // bug as an error, even if a $RS frame happens to be on the stack.
@@ -490,6 +501,23 @@ describe("beforeSend — Firefox iframe contentWindow-null teardown is reclassif
       "https://ecency.com/hot/1am"
     );
     expect(beforeSend(ev)).toBe(ev);
+    expect(ev.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT match Firefox phrasing for a DIFFERENT property on a null contentWindow", () => {
+    // Twin of the Safari different-property guard below, for the SpiderMonkey
+    // grammar. The accessed property must be `document` itself — a null-access on
+    // a property whose name merely CONTAINS "document" (documentElement,
+    // ownerDocument) is a different bug and must stay a real error.
+    // Regression guard for a proposed relaxation to
+    //   includes("can't access property") && includes("document")
+    // which reclassified this case into the hydration bucket and hid it.
+    const ev = makeClientEvent(
+      'can\'t access property "documentElement", a.contentWindow is null',
+      "https://ecency.com/hot/1am"
+    );
+    expect(beforeSend(ev)).toBe(ev);
+    expect(ev.level).toBeUndefined();
     expect(ev.fingerprint).toBeUndefined();
   });
 


### PR DESCRIPTION
Test-only. No behaviour change to `sentry-before-send.ts`.

Two Seer PRs (#1221, #1222) proposed relaxing the hydration filters based on the assumption that Firefox quotes property names with single or typographic curly quotes. It does not — the live payloads for both target issues use ASCII straight double-quotes, so both filters already matched and both PRs were closed. #1221 would additionally have regressed the filter, and the existing 56-test suite went green on it.

This adds the two missing guards:

- **Iframe branch, different property.** The Safari branch already has a different-property guard; the Firefox branch did not. It only tested a message *missing* `contentWindow is null`, so a different property *with* it was uncovered. `can't access property "documentElement", a.contentWindow is null` must stay a reported error rather than land in the `hydration-iframe-autorecovered` bucket. Verified this test fails against #1221's source change and passes on develop.

- **$RS branch, real payload.** Pins the literal ECENCY-NEXT-1C6V value, `can't access property "parentNode", b is null`, so the `includes(%27"parentNode"%27)` branch is covered by the actual field string rather than only the Chrome grammar.

58 tests pass locally (`vitest run src/specs/utils/sentry-before-send.spec.ts`).

Worth noting these are the kind of regressions CI cannot catch on the branches that introduce them: build/test only run on `bugfix/*` and `feature/*`, so `seer/*` PRs show all-green without ever running the suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification for Firefox hydration recovery warnings.
  * Prevented unrelated Firefox iframe teardown errors from being incorrectly reclassified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->