### PR TITLE
fix(seo): prune posts-1.xml from retired sitemap shards

### DIFF
--- a/apps/web/src/features/seo/sitemap-shards.ts
+++ b/apps/web/src/features/seo/sitemap-shards.ts
@@ -32,8 +32,13 @@ export function isKnownShard(name: string): name is SitemapShard {
  * was permanently removed; the route returns 503 (transient) for these instead
  * so it's retried, then disappears from the index on the next cron run. Prune
  * an entry once every environment has regenerated past the rename.
+ *
+ * Currently empty, and it should stay that way outside a rename window: an
+ * entry left here past its cron cycle serves a permanent 503 + Retry-After to
+ * crawlers, which they retry indefinitely instead of dropping. "posts-1.xml"
+ * was pruned 2026-07-22 after ~3 weeks in that state.
  */
-const RETIRED_SHARDS: ReadonlySet<string> = new Set<string>(["posts-1.xml"]);
+const RETIRED_SHARDS: ReadonlySet<string> = new Set<string>();
 
 export function isRetiredShard(name: string): boolean {
   return RETIRED_SHARDS.has(name);

--- a/apps/web/src/specs/features/seo/sitemap-shards.spec.ts
+++ b/apps/web/src/specs/features/seo/sitemap-shards.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import {
+  SITEMAP_SHARDS,
+  isKnownShard,
+  isRetiredShard
+} from "@/features/seo/sitemap-shards";
+
+describe("sitemap-shards", () => {
+  describe("isKnownShard", () => {
+    it("accepts every shard the generator emits", () => {
+      for (const shard of SITEMAP_SHARDS) {
+        expect(isKnownShard(shard)).toBe(true);
+      }
+    });
+
+    it("rejects unknown names (route serves these as 404)", () => {
+      expect(isKnownShard("posts-0.xml")).toBe(false);
+      expect(isKnownShard("posts-2.xml")).toBe(false);
+      expect(isKnownShard("nope.xml")).toBe(false);
+      expect(isKnownShard("")).toBe(false);
+    });
+
+    it("is exact-match, not prefix or case insensitive", () => {
+      expect(isKnownShard("Posts.xml")).toBe(false);
+      expect(isKnownShard("posts")).toBe(false);
+      expect(isKnownShard("posts.xml.bak")).toBe(false);
+    });
+  });
+
+  describe("isRetiredShard", () => {
+    // Regression: "posts-1.xml" sat in RETIRED_SHARDS long after every
+    // environment had regenerated past the rename, so /sitemap/posts-1.xml
+    // served a permanent 503 + Retry-After for ~3 weeks. Crawlers retry that
+    // forever rather than dropping the URL. Outside an active rename window
+    // the retired set belongs empty, and a retired name must never also be a
+    // known shard (the route checks retired first, which would mask a live one).
+    it("is empty outside a rename window", () => {
+      expect(isRetiredShard("posts-1.xml")).toBe(false);
+      expect(isRetiredShard("posts-0.xml")).toBe(false);
+      expect(isRetiredShard("nope.xml")).toBe(false);
+    });
+
+    it("never overlaps the live shard allowlist", () => {
+      for (const shard of SITEMAP_SHARDS) {
+        expect(isRetiredShard(shard)).toBe(false);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`/sitemap/posts-1.xml` has been returning `503 Service Unavailable` on every origin, every hour, for at least three weeks (confirmed back to 2026-07-01 in the hourly sitemap probe log; live check today returns 503 at the EU origin and 502 through CF).

The cause is the `RETIRED_SHARDS` entry in `sitemap-shards.ts`. That set exists as a one-cron-cycle grace window: after a shard rename, a Redis-cached index written by the previous deploy can still advertise the old name, so `/sitemap/[shard]` deliberately serves `503 + Retry-After: 600` instead of 404 so crawlers retry rather than treat the URL as permanently gone. The module comment says to prune an entry once every environment has regenerated past the rename.

That never happened for `posts-1.xml`. The index regenerated long ago and now lists only `posts.xml`, `authors.xml`, `communities.xml`, `tags.xml`, `static.xml`, with no reference to `posts-1.xml`, so the grace window has been closed for weeks while the 503 kept being served.

Two things confirm this is the allowlist rather than a generation failure:

- `posts-0.xml` and `posts-2.xml` both 404 correctly; only `posts-1.xml` 503s.
- The route checks `isRetiredShard` before `isKnownShard`, so the entry short-circuits ahead of any Redis lookup.

Crawlers honour `Retry-After` and keep re-requesting. This lines up with the currently-open Bing CrawlErrors alert (3d avg up 72%, ~2,397 to ~4,127/day).

## Change

Empty `RETIRED_SHARDS`. `posts-1.xml` then falls through to the `isKnownShard` check and 404s, matching its neighbours.

The mechanism itself is kept, since it is still the right behaviour during a real rename. The comment now records why an entry must not outlive its cron cycle.

## Tests

Adds `sitemap-shards.spec.ts`: covers the `isKnownShard` allowlist (exact match, not prefix or case insensitive) and asserts the retired set is empty and never overlaps the live shards.

Verified the regression test guards the fix by temporarily reintroducing the entry, which fails `is empty outside a rename window`, then restoring it.

- `pnpm typecheck` clean across the workspace
- Full web suite green: 236 files, 2277 tests
- `pnpm --filter @ecency/web lint` reports no findings on the changed files

## Verifying after deploy

`curl -so /dev/null -w '%{http_code}' https://ecency.com/sitemap/posts-1.xml` should return 404.