### PR TITLE
fix(publish): use # glyph instead of £ icon in tag suggestions

### DIFF
--- a/apps/web/src/app/submit/_components/tag-selector/index.tsx
+++ b/apps/web/src/app/submit/_components/tag-selector/index.tsx
@@ -3,7 +3,7 @@ import { error, SuggestionList } from "@/features/shared";
 import { getTrendingTagsQueryOptions } from "@ecency/sdk";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { FormControl } from "@ui/input";
-import { closeSvg, poundSvg } from "@ui/svg";
+import { closeSvg } from "@ui/svg";
 import i18next from "i18next";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ItemInterface, ReactSortable } from "react-sortablejs";
@@ -225,7 +225,13 @@ export function TagSelector({ tags, onChange, onValid, maxItem }: Props) {
           renderer={(x: string) => {
             return (
               <>
-                {poundSvg} {x}
+                <span
+                  aria-hidden={true}
+                  className="inline-flex shrink-0 items-center justify-center size-4 leading-none"
+                >
+                  #
+                </span>
+                {x}
               </>
             );
           }}

--- a/apps/web/src/features/ui/svg.tsx
+++ b/apps/web/src/features/ui/svg.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { UilArrowLeft, UilArrowRight, UilBell, UilBrightness, UilCheck, UilComment, UilCreditCard, UilDesktop, UilEye, UilHeart, UilHistory, UilLink, UilMedal, UilPlus, UilPound, UilRefresh, UilRepeat, UilRocket, UilSync, UilTag, UilUpload } from "@tooni/iconscout-unicons-react";
+import { UilArrowLeft, UilArrowRight, UilBell, UilBrightness, UilCheck, UilComment, UilCreditCard, UilDesktop, UilEye, UilHeart, UilHistory, UilLink, UilMedal, UilPlus, UilRefresh, UilRepeat, UilRocket, UilSync, UilTag, UilUpload } from "@tooni/iconscout-unicons-react";
 
 export const appleSvg = (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 15 18">
@@ -276,8 +276,6 @@ export const pencilOutlineSvg = (
 );
 
 export const linkSvg = <UilLink className="size-6" />;
-
-export const poundSvg = <UilPound className="size-6" />;
 
 export const creditCardSvg = <UilCreditCard className="size-6" />;
 


### PR DESCRIPTION
The tag suggestion dropdown (publish preview → topics) rendered `poundSvg`, which is `UilPound` — the pound sterling currency symbol — so every suggestion row showed a £.

The unicons set we standardised on has no hashtag glyph (checked all 1206 exports), so the suggestion marker is now a literal `#` rendered in a `size-4` box, inheriting the row's text colour and hover states like the previous icon did.

Also removes the now-unused `poundSvg` export and its `UilPound` import from `features/ui/svg.tsx` — that was its only call site.

Note the box also drops 24px → 16px, matching the `size-4` default for list-row adornments in docs/icons.md; the old export was rendered bare at its native `size-6`.

Verified: `pnpm typecheck` clean, `icon-tsx-audit --fail` 0 findings, eslint clean on both files, full web suite 2277 tests passing.