### PR TITLE
fix(publish): commit the clicked tag suggestion, not the typed prefix

### DIFF
--- a/apps/web/src/app/submit/_components/tag-selector/index.tsx
+++ b/apps/web/src/app/submit/_components/tag-selector/index.tsx
@@ -242,10 +242,7 @@ export function TagSelector({ tags, onChange, onValid, maxItem }: Props) {
           header={i18next.t("tag-selector.suggestion-header")}
           onSelect={(value: string) => {
             if (add(value)) {
-              setTimeout(() => {
-                // delay focus due to click out issue on suggestion list
-                focusInput();
-              }, 200);
+              focusInput();
             }
           }}
         >

--- a/apps/web/src/features/shared/suggestion-list/index.tsx
+++ b/apps/web/src/features/shared/suggestion-list/index.tsx
@@ -60,6 +60,9 @@ export function SuggestionList({
       }
 
       input.addEventListener("focus", watchInputFocus);
+      // Selecting an item closes the list without moving focus, so a focus event
+      // alone never comes back — reopen on typing too.
+      input.addEventListener("input", watchInputFocus);
     }
   });
 
@@ -70,6 +73,7 @@ export function SuggestionList({
     const input = getPossibleInput();
     if (input) {
       input.removeEventListener("focus", watchInputFocus);
+      input.removeEventListener("input", watchInputFocus);
     }
   });
 
@@ -187,6 +191,10 @@ export function SuggestionList({
                             href="#"
                             key={i}
                             className="flex pointer items-center px-4 py-3 text-gray-warm hover:bg-blue-dark-sky-040 dark:text-silver dark:hover:text-white dark:bg-dark-200 dark:hover:bg-dark-default duration-300 border-b border-[--border-color] last:border-0"
+                            // Keep focus on the input: a blur here can commit the
+                            // half-typed value and re-render this item away before
+                            // the click lands.
+                            onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
                             onClick={(e: React.MouseEvent) => {
                               e.preventDefault();
                               modeItem.onSelect?.(x);
@@ -230,6 +238,10 @@ export function SuggestionList({
                     href="#"
                     key={i}
                     className="flex gap-2 pointer items-center px-4 py-3 text-gray-warm hover:bg-blue-dark-sky-040 dark:text-silver dark:hover:text-white dark:bg-dark-200 dark:hover:bg-dark-default duration-300 border-b border-[--border-color] last:border-0"
+                    // Keep focus on the input: a blur here can commit the
+                    // half-typed value and re-render this item away before the
+                    // click lands.
+                    onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
                     onClick={(e: React.MouseEvent) => {
                       e.preventDefault();
                       onSelect?.(x);

--- a/apps/web/src/specs/app/submit/tag-selector-suggestion-click.spec.tsx
+++ b/apps/web/src/specs/app/submit/tag-selector-suggestion-click.spec.tsx
@@ -9,6 +9,7 @@ vi.mock("next/navigation", () => ({
   useParams: () => ({})
 }));
 
+import { getTrendingTagsQueryOptions } from "@ecency/sdk";
 import { TagSelector } from "@/app/submit/_components/tag-selector";
 import { createTestQueryClient, renderWithQueryClient } from "@/specs/test-utils";
 
@@ -34,8 +35,10 @@ function renderSelector() {
     );
   }
 
+  // Seed through the same factory the component calls, so the key can never drift
+  // apart from the mock's.
   const queryClient = createTestQueryClient();
-  queryClient.setQueryData(["tags", "trending", 250], {
+  queryClient.setQueryData(getTrendingTagsQueryOptions(250).queryKey, {
     pages: [TRENDING],
     pageParams: [""]
   });

--- a/apps/web/src/specs/app/submit/tag-selector-suggestion-click.spec.tsx
+++ b/apps/web/src/specs/app/submit/tag-selector-suggestion-click.spec.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from "react";
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/publish",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({})
+}));
+
+import { TagSelector } from "@/app/submit/_components/tag-selector";
+import { createTestQueryClient, renderWithQueryClient } from "@/specs/test-utils";
+
+const TRENDING = ["deutsch", "dibujodigital", "defence", "discord"];
+
+function renderSelector() {
+  const onChange = vi.fn();
+
+  // The selector is controlled, so keep the committed tags in state — otherwise a
+  // stale `tags` prop hides whether the second commit saw the first one.
+  function Harness() {
+    const [tags, setTags] = useState<string[]>([]);
+    return (
+      <TagSelector
+        tags={tags}
+        maxItem={10}
+        onValid={() => {}}
+        onChange={(next) => {
+          onChange(next);
+          setTags(next);
+        }}
+      />
+    );
+  }
+
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(["tags", "trending", 250], {
+    pages: [TRENDING],
+    pageParams: [""]
+  });
+
+  renderWithQueryClient(<Harness />, { queryClient });
+
+  const input = screen.getByRole("textbox") as HTMLInputElement;
+  fireEvent.focus(input);
+
+  return { input, onChange };
+}
+
+/**
+ * jsdom does not implement the browser's focus-on-mousedown behaviour, and the app
+ * has no user-event dependency, so spell the real sequence out: a browser moves
+ * focus off the input on mousedown *unless* the handler calls preventDefault, and
+ * only then delivers the click. `fireEvent` returns false when the event was
+ * cancelled, which is exactly that condition.
+ */
+function clickSuggestion(input: HTMLInputElement, label: string) {
+  const item = screen.getByText(label).closest("a")!;
+  const focusMoves = fireEvent.mouseDown(item);
+  if (focusMoves) {
+    fireEvent.blur(input);
+  }
+  fireEvent.click(item);
+}
+
+describe("TagSelector suggestion click", () => {
+  it("commits the clicked suggestion, not the partially typed value", () => {
+    const { input, onChange } = renderSelector();
+
+    fireEvent.input(input, { target: { value: "de" } });
+    expect(screen.getByText("deutsch")).toBeTruthy();
+
+    clickSuggestion(input, "deutsch");
+
+    // Regression: the input's blur handler used to commit "de" first, which emptied
+    // the suggestion list and unmounted the row before its click could land.
+    expect(onChange).toHaveBeenCalledWith(["deutsch"]);
+    expect(onChange).not.toHaveBeenCalledWith(["de"]);
+    expect(input.value).toBe("");
+  });
+
+  it("keeps the input focused so a second suggestion can be picked", () => {
+    const { input, onChange } = renderSelector();
+
+    fireEvent.input(input, { target: { value: "de" } });
+    clickSuggestion(input, "deutsch");
+
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.input(input, { target: { value: "di" } });
+    clickSuggestion(input, "discord");
+
+    expect(onChange).toHaveBeenLastCalledWith(["deutsch", "discord"]);
+  });
+});

--- a/apps/web/src/specs/setup-any-spec.ts
+++ b/apps/web/src/specs/setup-any-spec.ts
@@ -82,6 +82,12 @@ vi.mock("@ecency/sdk", () => ({
   getBoostPlusPricesQueryOptions: vi.fn(() => ({ queryKey: ["boost-prices"], queryFn: vi.fn() })),
   getPointsQueryOptions: vi.fn(() => ({ queryKey: ["points"], queryFn: vi.fn() })),
   getProMembersQueryOptions: vi.fn(() => ({ queryKey: ["accounts", "pro-members"], queryFn: vi.fn() })),
+  getTrendingTagsQueryOptions: vi.fn((limit?: number) => ({
+    queryKey: ["tags", "trending", limit],
+    queryFn: vi.fn(() => []),
+    initialPageParam: "",
+    getNextPageParam: () => undefined
+  })),
   // Real pure impl (no deps) so pro-config's isProMember + its spec behave like production.
   proMembersSet: (members?: string[]) =>
     new Set((members ?? []).map((m: string) => m.toLowerCase())),


### PR DESCRIPTION
Clicking a tag in the publish topic suggestions added the half-typed text instead of the tag that was clicked.

### Cause

1. Mousedown on a suggestion row blurs the input
2. The input's `onBlur` calls `add(value)` — committing the **partial** text — and `setValue("")`
3. `suggestions` recomputes off the now-empty value and becomes `[]`
4. `SuggestionList` only renders rows when `items?.length > 0`, so the row unmounts between mousedown and mouseup
5. The `onClick` that would have added the real tag never fires

### Fix

Suggestion rows `preventDefault` on mousedown, so the input never loses focus and the click lands normally. This is scoped to `SuggestionList`, which no other consumer pairs with a commit-on-blur input.

Because selecting now closes the list without focus ever leaving the input, a focus event never comes back to reopen it — so the list also reopens on `input` events, otherwise typing the next tag showed no suggestions. The `setTimeout(focusInput, 200)` workaround in the tag selector (commented "delay focus due to click out issue") is no longer needed and becomes a direct call.

### Tests

`tag-selector-suggestion-click.spec.tsx` covers both the commit and the pick-a-second-tag path. jsdom does not implement focus-on-mousedown and the app has no user-event dependency, so the spec spells out the browser rule: focus moves on mousedown unless the handler cancels it. Verified the spec fails on develop (`expected "vi.fn()" to be called with arguments: [ [ 'deutsch' ] ]`) and passes with the fix.

Also adds `getTrendingTagsQueryOptions` to the shared `@ecency/sdk` spec mock.

Verified: `pnpm typecheck` clean, eslint clean, 2303 tests passing.

### Noted, not fixed here

`SuggestionList`'s arrow-key navigation is dead code — `focusItem`/`getFocusedIndex` query `.list-item`, but the rows carry no such class, so up/down match nothing. Fixing it means moving focus onto a row, which re-opens the same commit-on-blur hazard, so it wants its own change.