### PR TITLE
fix(decks): stop rendering raw "Query: {{query}}" in search column labels

### DIFF
--- a/apps/web/src/app/decks/_components/columns/deck-search-column.tsx
+++ b/apps/web/src/app/decks/_components/columns/deck-search-column.tsx
@@ -126,7 +126,7 @@ export const DeckSearchColumn = ({ id, settings, draggable }: Props) => {
           <DeckPostViewer
             entry={currentViewingEntry}
             onClose={() => setCurrentViewingEntry(null)}
-            backTitle={i18next.t("decks.columns.search-query", { query: settings.query })}
+            backTitle={i18next.t("decks.columns.search-query-value", { query: settings.query })}
           />
         ) : (
           <></>

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -950,7 +950,7 @@
       "updated": "Edited {{n}} ago",
       "balance": "Balance",
       "custom": "Custom",
-      "search-query": "Query: {{query}}",
+      "search-query-value": "Query: {{query}}",
       "recent": "Recent",
       "balance-tab-ecency": "Ecency",
       "balance-tab-hive": "Hive",

--- a/apps/web/src/specs/features/i18n-locale-duplicate-keys.spec.ts
+++ b/apps/web/src/specs/features/i18n-locale-duplicate-keys.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+
+/**
+ * A duplicate key in a locale JSON is invisible: JSON.parse silently keeps the
+ * LAST value, so the earlier entry is dead and every call site resolves to the
+ * survivor. `decks.columns.search-query` was declared twice — once as the label
+ * "Search query", once as "Query: {{query}}" — so the two call sites that pass
+ * no interpolation rendered the raw "Query: {{query}}" in the UI.
+ *
+ * Nothing else catches this: it is valid JSON, prettier reformats it happily,
+ * and eslint never reads the file. JS has no `object_pairs_hook`, so the raw
+ * text is scanned for keys repeated within one object.
+ */
+const LOCALES_DIR = path.join(__dirname, "../../features/i18n/locales");
+
+/** Duplicate keys, as `parent.key` paths, in source order. */
+function findDuplicateKeys(raw: string): string[] {
+  const dups: string[] = [];
+  const scopes: { keys: Set<string>; name: string }[] = [];
+  let pendingKey: string | null = null;
+
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+
+    if (ch === '"') {
+      // Read the string literal, honouring backslash escapes.
+      let value = "";
+      i++;
+      while (i < raw.length && raw[i] !== '"') {
+        if (raw[i] === "\\") {
+          value += raw[i] + raw[i + 1];
+          i += 2;
+        } else {
+          value += raw[i];
+          i++;
+        }
+      }
+      pendingKey = value;
+    } else if (ch === ":" && pendingKey !== null) {
+      const scope = scopes[scopes.length - 1];
+      if (scope) {
+        if (scope.keys.has(pendingKey)) {
+          dups.push(scope.name ? `${scope.name}.${pendingKey}` : pendingKey);
+        }
+        scope.keys.add(pendingKey);
+      }
+      // Keep the key: if the value is an object, it names the new scope.
+    } else if (ch === "{") {
+      const parent = scopes[scopes.length - 1];
+      const name = [parent?.name, pendingKey].filter(Boolean).join(".");
+      scopes.push({ keys: new Set(), name });
+      pendingKey = null;
+    } else if (ch === "}") {
+      scopes.pop();
+      pendingKey = null;
+    } else if (ch === "," || ch === "[" || ch === "]") {
+      pendingKey = null;
+    }
+  }
+
+  return dups;
+}
+
+describe("i18n locale files", () => {
+  const files = fs.readdirSync(LOCALES_DIR).filter((f) => f.endsWith(".json"));
+
+  it("finds locale files to check", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)("%s declares no key twice in the same object", (file) => {
+    const raw = fs.readFileSync(path.join(LOCALES_DIR, file), "utf-8");
+    expect(findDuplicateKeys(raw)).toEqual([]);
+  });
+
+  it("detects a duplicate key that JSON.parse would hide", () => {
+    const sample = '{ "a": { "k": "first", "k": "second" }, "b": { "k": "ok" } }';
+    expect(JSON.parse(sample).a.k).toBe("second"); // silently survives
+    expect(findDuplicateKeys(sample)).toEqual(["a.k"]);
+  });
+
+  it("does not flag the same key used in sibling objects", () => {
+    expect(findDuplicateKeys('{ "a": { "k": 1 }, "b": { "k": 2 } }')).toEqual([]);
+  });
+});

--- a/apps/web/src/specs/features/i18n-locale-duplicate-keys.spec.ts
+++ b/apps/web/src/specs/features/i18n-locale-duplicate-keys.spec.ts
@@ -25,19 +25,25 @@ function findDuplicateKeys(raw: string): string[] {
     const ch = raw[i];
 
     if (ch === '"') {
-      // Read the string literal, honouring backslash escapes.
-      let value = "";
+      // Read the literal, keeping escapes intact so the whole token can be
+      // decoded: "k" and "k" are the same JSON key, so comparing raw
+      // spellings would miss that pair as a duplicate.
+      let literal = "";
       i++;
       while (i < raw.length && raw[i] !== '"') {
         if (raw[i] === "\\") {
-          value += raw[i] + raw[i + 1];
+          literal += raw[i] + raw[i + 1];
           i += 2;
         } else {
-          value += raw[i];
+          literal += raw[i];
           i++;
         }
       }
-      pendingKey = value;
+      try {
+        pendingKey = JSON.parse(`"${literal}"`);
+      } catch {
+        pendingKey = literal;
+      }
     } else if (ch === ":" && pendingKey !== null) {
       const scope = scopes[scopes.length - 1];
       if (scope) {
@@ -83,5 +89,12 @@ describe("i18n locale files", () => {
 
   it("does not flag the same key used in sibling objects", () => {
     expect(findDuplicateKeys('{ "a": { "k": 1 }, "b": { "k": 2 } }')).toEqual([]);
+  });
+
+  it("decodes escaped member names before comparing", () => {
+    // "k" and "k" are the same JSON key, so this collapses too.
+    const sample = String.raw`{ "a": { "k": 1, "k": 2 } }`;
+    expect(Object.keys(JSON.parse(sample).a)).toEqual(["k"]);
+    expect(findDuplicateKeys(sample)).toEqual(["a.k"]);
   });
 });


### PR DESCRIPTION
`decks.columns.search-query` was declared **twice** in `en-US.json`:

```json
"search-query": "Search query",      // line 904 - dead
...
"search-query": "Query: {{query}}",  // line 953 - wins
```

`JSON.parse` keeps the last value, so the first entry was dead and all three call sites resolved to the interpolated string. Two of them pass no variable:

| Call site | Passes `query`? | Rendered before |
|---|---|---|
| `deck-search-column-settings.tsx:49` (input placeholder) | no | `Query: {{query}}` |
| `deck-add-column-search-settings.tsx:36` (subtitle) | no | `Query: {{query}}` |
| `deck-search-column.tsx:129` (post-viewer back title) | yes | `Query: cats` — correct |

i18next leaves an unresolved placeholder in place rather than blanking it, confirmed against the app's own config (`escapeValue: false`, no `missingInterpolationHandler`):

```
with query   : "Query: cats"
without query: "Query: {{query}}"
```

So the decks search placeholder and subtitle have been showing literal template syntax. This started out looking cosmetic — a stray duplicate key — but the duplicate was masking a genuine collision between two different strings.

## Fix

- `decks.columns.search-query` → stays the plain label `"Search query"`
- new `decks.columns.search-query-value` → `"Query: {{query}}"`, used by the one call site that interpolates

`decks.search-query` (a different object, one level up) is untouched.

## Guard

Added a spec that scans every locale file for keys repeated within the same object. Nothing else catches this: the file is valid JSON, prettier reformats it happily, and eslint never reads it. JS has no `object_pairs_hook`, so it scans the raw text.

Verified by reintroducing the duplicate — the spec fails and names the offender by path:

```
AssertionError: expected [ 'decks.columns.search-query' ] to deeply equal []
```

It also asserts the detector does not flag the same key appearing in sibling objects.

## Verification

- All 19 locale files scanned — `en-US.json` was the only one affected
- `tsc --noEmit`: 0 errors
- Full web suite: 238 files / 2323 tests pass
- eslint clean on both changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the deck search query label so it displays the intended localized text consistently.

* **Documentation**
  * Updated English localization resources to use the corrected search query label.

* **Tests**
  * Added validation to detect duplicate keys in localization files, helping prevent translations from being silently overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->