### PR TITLE
test(bridge-requests): cover non-array API response handling

### DIFF
--- a/packages/sdk/src/modules/bridge/requests.spec.ts
+++ b/packages/sdk/src/modules/bridge/requests.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockCallRPC = vi.hoisted(() => vi.fn());
+
+vi.mock("@/modules/core/hive-tx", () => ({
+  callRPC: mockCallRPC,
+}));
+
+// Keep the DMCA filter as a pass-through so these tests stay focused on the
+// array-guard logic rather than DMCA censoring.
+vi.mock("@/modules/posts/utils/filter-dmca-entries", () => ({
+  filterDmcaEntry: vi.fn((entries: unknown) => entries),
+}));
+
+import { getAccountPosts, getPostsRanked } from "./requests";
+
+describe("bridge requests — non-array API responses", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe("getPostsRanked", () => {
+    it("returns null and warns when the response is a truthy non-array", async () => {
+      mockCallRPC.mockResolvedValue({ error: "unexpected shape" });
+
+      const result = await getPostsRanked("trending");
+
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain(
+        "get_ranked_posts returned object"
+      );
+    });
+
+    it("returns null without warning when the response is null", async () => {
+      mockCallRPC.mockResolvedValue(null);
+
+      const result = await getPostsRanked("trending");
+
+      expect(result).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty array (not null) for an empty array response", async () => {
+      mockCallRPC.mockResolvedValue([]);
+
+      const result = await getPostsRanked("trending");
+
+      expect(result).toEqual([]);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("resolves posts when the response is a non-empty array", async () => {
+      mockCallRPC.mockResolvedValue([
+        { author: "alice", permlink: "p1", json_metadata: {} },
+      ]);
+
+      const result = await getPostsRanked("trending");
+
+      expect(result).toHaveLength(1);
+      expect(result?.[0]?.author).toBe("alice");
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getAccountPosts", () => {
+    it("returns null and warns when the response is a truthy non-array", async () => {
+      mockCallRPC.mockResolvedValue({ error: "unexpected shape" });
+
+      const result = await getAccountPosts("posts", "alice");
+
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain(
+        "get_account_posts returned object"
+      );
+    });
+
+    it("returns null without warning when the response is null", async () => {
+      mockCallRPC.mockResolvedValue(null);
+
+      const result = await getAccountPosts("posts", "alice");
+
+      expect(result).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty array (not null) for an empty array response", async () => {
+      mockCallRPC.mockResolvedValue([]);
+
+      const result = await getAccountPosts("posts", "alice");
+
+      expect(result).toEqual([]);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("resolves posts when the response is a non-empty array", async () => {
+      mockCallRPC.mockResolvedValue([
+        { author: "bob", permlink: "p1", json_metadata: {} },
+      ]);
+
+      const result = await getAccountPosts("posts", "bob");
+
+      expect(result).toHaveLength(1);
+      expect(result?.[0]?.author).toBe("bob");
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/sdk/src/modules/bridge/requests.spec.ts
+++ b/packages/sdk/src/modules/bridge/requests.spec.ts
@@ -34,8 +34,8 @@ describe("bridge requests — non-array API responses", () => {
 
       expect(result).toBeNull();
       expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(String(warnSpy.mock.calls[0][0])).toContain(
-        "get_ranked_posts returned object"
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("get_ranked_posts returned object")
       );
     });
 
@@ -78,8 +78,8 @@ describe("bridge requests — non-array API responses", () => {
 
       expect(result).toBeNull();
       expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(String(warnSpy.mock.calls[0][0])).toContain(
-        "get_account_posts returned object"
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("get_account_posts returned object")
       );
     });
 


### PR DESCRIPTION
Follow-up to #1233, which added array validation (and a warn) to `getPostsRanked` / `getAccountPosts` in `@ecency/sdk` bridge requests. That fix merged without a regression test; this adds one.

Covers, for both functions:
- truthy non-array response → returns `null` and logs a single `console.warn` (the Sentry breadcrumb)
- `null` response → returns `null`, no warn
- empty array → returns `[]` (not `null`)
- non-empty array → resolves normally

Test-only; no runtime changes. `vitest run` (8 passing) and `tsc --noEmit` both green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for handling unexpected bridge request responses.
  * Verified that invalid response objects return `null` with a warning.
  * Confirmed that `null`, empty arrays, and populated arrays are handled correctly without unnecessary warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->