### PR TITLE
fix(cache): make the category->canonical post redirect edge-cacheable

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -507,20 +507,17 @@ const config = {
         destination: "/:author/wallet",
         permanent: false
       },
-      // SEO: consolidate post URLs onto bare /@author/permlink form.
-      // Matches /:category/@:author/:permlink (community-prefixed or any legacy
-      // category prefix). The (?!@) on :category prevents the wild edge case
-      // of /@x/@y/z matching. Edit URLs (/:cat/@a/p/edit) and sub-path URLs
-      // (/:cat/@a/p/:sub) are 4 segments and don't match this 3-segment rule —
-      // their existing rewrites in rewrites() handle them.
-      // 308 (permanent): consolidation verified — community-prefixed URLs
-      // converge onto the bare canonical with no traffic regression, so the
-      // redirect is now permanent for full SEO signal transfer.
-      {
-        source: "/:category((?!@)[^/]+)/:author(@[^/]+)/:permlink",
-        destination: "/:author/:permlink",
-        permanent: true
-      },
+      // NOTE: the /:category/@:author/:permlink -> /@author/permlink
+      // consolidation that used to live here now lives in middleware, as
+      // `handleCategoryEntryRedirect`. It had to move: Next drops the headers
+      // from headers() on responses produced by redirects() (the redirect
+      // branch in resolve-routes.js is the one return path that omits
+      // resHeaders), so a redirect declared here can never carry a
+      // Cache-Control. That left every legacy inbound link uncacheable at the
+      // edge, so each one cost an origin round trip. Middleware runs
+      // after this block and owns all other cache tiers, so it can emit the
+      // redirect and its Cache-Control together. Behaviour is otherwise
+      // identical: same 3-segment match, same 308, same query preservation.
       // SEO: a bare community URL (/hive-NNNNN) currently 404s — no route
       // matches a bare hive-id at the root. Canonicalize it onto the working
       // /created/:community form (mapped to the community feed by the rewrites

--- a/apps/web/src/features/next-middleware/handle-category-entry-redirect.ts
+++ b/apps/web/src/features/next-middleware/handle-category-entry-redirect.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Cache-Control for the category -> canonical entry redirect.
+ *
+ * The mapping is permanent and purely syntactic (drop the leading category
+ * segment), so it can never go stale the way rendered content can — a post
+ * being edited, muted or deleted does not change which URL is canonical. That
+ * makes a long edge TTL safe even though the entry page it points at is
+ * cached far more conservatively.
+ *
+ * s-maxage matches the `entry-ancient` tier (30d) so the redirect and the
+ * page it lands on age out on a comparable schedule. max-age is kept short
+ * (1h) because a browser-cached permanent redirect is effectively impossible
+ * to revoke, and we want an escape hatch if the canonical form ever changes.
+ */
+const REDIRECT_CACHE_CONTROL =
+  "public, max-age=3600, s-maxage=2592000, stale-while-revalidate=604800";
+
+/** Matches `/:category/@:author/:permlink` — exactly three segments. */
+const CATEGORY_ENTRY_PATH = /^\/([^/@][^/]*)\/(@[^/]+)\/([^/]+)$/;
+
+/**
+ * Consolidate category-prefixed post URLs onto the bare `/@author/permlink`
+ * canonical with a 308.
+ *
+ * This lived in `next.config.js` `redirects()` until it became clear that Next
+ * cannot attach a Cache-Control to it there: in
+ * `next/dist/server/lib/router-utils/resolve-routes.js` the redirect branch is
+ * the single return path that omits the accumulated `resHeaders`, so entries
+ * from `headers()` are silently dropped on redirect responses. The CF worker
+ * then fills in its `no-store` fallback for any HTML response that arrives
+ * without a Cache-Control, and additionally refuses to store anything that
+ * isn't a 200 — so every legacy inbound link cost a full origin round trip,
+ * a meaningful and entirely avoidable share of post traffic.
+ *
+ * Emitting the redirect from middleware instead lets the response carry its
+ * own cache policy, so the edge serves it and both URL forms converge on the
+ * one canonical `/@author/permlink` cache entry.
+ *
+ * Matching is deliberately identical to the old `redirects()` rule:
+ *   - exactly 3 segments, so edit URLs (`/:cat/@a/p/edit`) and other sub-paths
+ *     are 4 segments and fall through to the rewrites that handle them
+ *   - the category segment must not itself start with `@`, which rules out the
+ *     `/@x/@y/z` edge case
+ *   - the query string is preserved, as `redirects()` did
+ *
+ * Returns `null` when the path is not a category-prefixed entry URL.
+ */
+export function handleCategoryEntryRedirect(request: NextRequest): NextResponse | null {
+  const match = request.nextUrl.pathname.match(CATEGORY_ENTRY_PATH);
+  if (!match) return null;
+
+  const [, , author, permlink] = match;
+
+  const url = request.nextUrl.clone();
+  url.pathname = `/${author}/${permlink}`;
+
+  const response = NextResponse.redirect(url, 308);
+  response.headers.set("Cache-Control", REDIRECT_CACHE_CONTROL);
+  // Observability parity with the rest of the cache policy (see middleware.ts)
+  // so these show up as their own tier in origin logs rather than as untiered.
+  response.headers.set("x-cache-tier", "entry-redirect");
+  return response;
+}

--- a/apps/web/src/features/next-middleware/index.ts
+++ b/apps/web/src/features/next-middleware/index.ts
@@ -1,5 +1,6 @@
 export * from "./cache-policy";
 export * from "./handle-agent-readable-rewrite";
+export * from "./handle-category-entry-redirect";
 export * from "./handle-decoded-path-redirect";
 export * from "./handle-index-redirect";
 export * from "./handle-rss-xml-rewrite";

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -5,6 +5,7 @@ import {
   getCachePolicyForPath,
   getEntryTierForAge,
   handleAgentReadableRewrite,
+  handleCategoryEntryRedirect,
   handleDecodedPathRedirect,
   handleIndexRedirect,
   isIndexRedirect,
@@ -66,6 +67,14 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
   // open-redirect (CWE-601) and redirect-loop reasoning.
   const decodedRedirect = handleDecodedPathRedirect(request);
   if (decodedRedirect) return decodedRedirect;
+
+  // Category-prefixed post URLs -> bare /@author/permlink canonical. This used
+  // to be a next.config.js redirects() rule, which runs ahead of ALL of this
+  // middleware, so it must stay near the top to preserve that precedence over
+  // the file-extension 404 and social-bot rewrite below. It moved here so the
+  // 308 can carry a Cache-Control — see the helper for why redirects() cannot.
+  const categoryEntryRedirect = handleCategoryEntryRedirect(request);
+  if (categoryEntryRedirect) return categoryEntryRedirect;
 
   const path = request.nextUrl.pathname;
 

--- a/apps/web/src/specs/features/next-middleware/handle-category-entry-redirect.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/handle-category-entry-redirect.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import { handleCategoryEntryRedirect } from "@/features/next-middleware";
+
+function requestFor(rawPath: string) {
+  return new NextRequest(`https://ecency.com${rawPath}`);
+}
+
+function locationOf(res: NextResponse) {
+  return new URL(res.headers.get("location")!, "https://ecency.com");
+}
+
+describe("handleCategoryEntryRedirect", () => {
+  it("308s a community-prefixed post URL onto the bare canonical", () => {
+    const res = handleCategoryEntryRedirect(requestFor("/hive-125125/@good-karma/my-post"));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(308);
+    expect(locationOf(res!).pathname).toBe("/@good-karma/my-post");
+  });
+
+  it("308s any legacy category prefix, not just hive-NNNNN", () => {
+    const res = handleCategoryEntryRedirect(requestFor("/life/@alice/a-post"));
+    expect(res).not.toBeNull();
+    expect(locationOf(res!).pathname).toBe("/@alice/a-post");
+  });
+
+  // The whole point of the move: redirects() could not carry this header.
+  it("emits a cacheable Cache-Control so the edge can serve the redirect", () => {
+    const res = handleCategoryEntryRedirect(requestFor("/hive-125125/@good-karma/my-post"));
+    const cc = res!.headers.get("cache-control")!;
+    expect(cc).toContain("public");
+    expect(cc).toMatch(/s-maxage=\d+/);
+    expect(cc).not.toContain("no-store");
+    expect(cc).not.toContain("private");
+    // The CF worker only stores a response when s-maxage > 0.
+    const sMaxAge = Number(cc.match(/s-maxage=(\d+)/)![1]);
+    expect(sMaxAge).toBeGreaterThan(0);
+  });
+
+  it("labels the response with its own cache tier for origin-log observability", () => {
+    const res = handleCategoryEntryRedirect(requestFor("/hive-125125/@good-karma/my-post"));
+    expect(res!.headers.get("x-cache-tier")).toBe("entry-redirect");
+  });
+
+  it("preserves the query string, as the redirects() rule did", () => {
+    const res = handleCategoryEntryRedirect(
+      requestFor("/hive-125125/@good-karma/my-post?referral=bob")
+    );
+    const location = locationOf(res!);
+    expect(location.pathname).toBe("/@good-karma/my-post");
+    expect(location.searchParams.get("referral")).toBe("bob");
+  });
+
+  it("stays on-origin", () => {
+    const res = handleCategoryEntryRedirect(requestFor("/hive-125125/@good-karma/my-post"));
+    expect(locationOf(res!).host).toBe("ecency.com");
+  });
+
+  // 4-segment sub-paths kept their own rewrites and must not be swallowed here.
+  it("ignores edit URLs and other sub-paths (4 segments)", () => {
+    expect(handleCategoryEntryRedirect(requestFor("/hive-125125/@alice/a-post/edit"))).toBeNull();
+    expect(
+      handleCategoryEntryRedirect(requestFor("/hive-125125/@alice/a-post/comments"))
+    ).toBeNull();
+  });
+
+  // The (?!@) guard on the category segment in the original rule.
+  it("ignores paths whose first segment is itself an @author", () => {
+    expect(handleCategoryEntryRedirect(requestFor("/@alice/@bob/a-post"))).toBeNull();
+  });
+
+  it("ignores the canonical entry URL itself, so there is no redirect loop", () => {
+    expect(handleCategoryEntryRedirect(requestFor("/@alice/a-post"))).toBeNull();
+  });
+
+  it("ignores paths with no @author in the middle segment", () => {
+    expect(handleCategoryEntryRedirect(requestFor("/trending/photography/foo"))).toBeNull();
+    expect(handleCategoryEntryRedirect(requestFor("/hive-125125"))).toBeNull();
+    expect(handleCategoryEntryRedirect(requestFor("/@alice"))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Category-prefixed post URLs (`/:category/@author/:permlink`) 308 onto the bare `/@author/permlink` canonical. That redirect lived in `next.config.js` `redirects()`, where it can never carry a `Cache-Control`: in Next's `resolve-routes.js` the redirect branch is the **one return path that omits the accumulated `resHeaders`**, so entries from `headers()` are silently dropped on redirect responses.

With no `Cache-Control`, the edge applies a `no-store` fallback (and separately only stores 200s), so the redirect is uncacheable at every layer. Every inbound link using the legacy URL form therefore costs a full origin round trip plus a redirect hop, and these make up a meaningful share of post traffic.

## Fix

Move the rule into middleware, which runs after `redirects()` and already owns every other route's cache tier, so the 308 and its cache policy are emitted together. Verified against Next's shipped code that the middleware redirect path *does* propagate `resHeaders` (and that 308 is in `allowedStatusCodes`), so the header survives.

Both URL forms now converge on the single canonical `/@author/permlink` cache entry. The SEO consolidation is untouched — still a 308 to the same canonical.

TTL is a long `s-maxage` (matching the oldest entry tier) with a short `max-age`: the mapping is permanent and purely syntactic, so it cannot go stale the way rendered content can, but a browser-cached permanent redirect is hard to revoke.

## Behaviour parity

Matching is deliberately identical to the old rule:
- exactly 3 segments, so `/:cat/@a/p/edit` and other sub-paths still fall through to their rewrites
- category segment must not start with `@` (the old `(?!@)` guard)
- query string preserved
- same 308

Placed near the top of the middleware to keep its existing precedence over the file-extension 404 and the social-bot rewrite, both of which `redirects()` previously shadowed.

## Testing

10 new unit tests in `handle-category-entry-redirect.spec.ts` covering the redirect, the cacheable header, query preservation, on-origin target, and every non-match case. Full `next-middleware` suite: 160 passed. `tsc --noEmit` clean, ESLint clean.

## Note on the edge cache-admission rule

The companion edge-side change that allows a permanent redirect (not just a 200) to be stored has already been deployed, so this PR is the remaining half.