### PR TITLE
fix(mutes): page the full mute list instead of taking the first 100

### DIFF
--- a/apps/web/src/app/waves/_hooks/use-muted-users.ts
+++ b/apps/web/src/app/waves/_hooks/use-muted-users.ts
@@ -4,8 +4,12 @@ import { getMutedUsersQueryOptions } from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 
-export function useMutedUsers(limit = 1000) {
+// No limit argument: the query pages the whole mute list. It used to take one,
+// but the cache key is the username alone, so this hook's limit of 1000 and the
+// entry-list/discussion components' default of 100 wrote over each other in a
+// single cache entry and mount order decided which list won.
+export function useMutedUsers() {
   const { activeUser } = useActiveAccount();
 
-  return useQuery(getMutedUsersQueryOptions(activeUser?.username, limit));
+  return useQuery(getMutedUsersQueryOptions(activeUser?.username));
 }

--- a/packages/sdk/src/modules/accounts/queries/get-muted-users-query-options.spec.ts
+++ b/packages/sdk/src/modules/accounts/queries/get-muted-users-query-options.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getMutedUsersQueryOptions } from './get-muted-users-query-options'
+
+const mockCallRPC = vi.hoisted(() => vi.fn())
+
+vi.mock('@/modules/core/hive-tx', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/modules/core/hive-tx')>()
+  return {
+    ...actual,
+    callRPC: mockCallRPC,
+  }
+})
+
+const PAGE_SIZE = 1000
+
+const rows = (names: string[]) => names.map((following) => ({ following }))
+const names = (count: number, prefix: string) =>
+  Array.from({ length: count }, (_, i) => `${prefix}${i}`)
+
+function runQueryFn<T extends { queryFn?: unknown }>(options: T) {
+  const queryFn = options.queryFn as (context: Record<string, never>) => Promise<string[]>
+  return queryFn({})
+}
+
+describe('getMutedUsersQueryOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns a short list in a single request', async () => {
+    mockCallRPC.mockResolvedValueOnce(rows(['spammer', 'bot']))
+
+    await expect(runQueryFn(getMutedUsersQueryOptions('alice'))).resolves.toEqual([
+      'spammer',
+      'bot',
+    ])
+    expect(mockCallRPC).toHaveBeenCalledTimes(1)
+    expect(mockCallRPC).toHaveBeenCalledWith('condenser_api.get_following', [
+      'alice',
+      '',
+      'ignore',
+      PAGE_SIZE,
+    ])
+  })
+
+  // The bug this guards: the query used to take the first 100 only, so a user
+  // with a longer mute list saw muted authors rendered as if never muted.
+  it('pages past the first response until the list is exhausted', async () => {
+    const first = names(PAGE_SIZE, 'a')
+    const second = names(PAGE_SIZE, 'b')
+    const third = names(12, 'c')
+
+    mockCallRPC
+      .mockResolvedValueOnce(rows(first))
+      .mockResolvedValueOnce(rows(second))
+      .mockResolvedValueOnce(rows(third))
+
+    const result = await runQueryFn(getMutedUsersQueryOptions('alice'))
+
+    expect(result).toHaveLength(PAGE_SIZE * 2 + 12)
+    expect(result).toEqual([...first, ...second, ...third])
+    expect(mockCallRPC).toHaveBeenCalledTimes(3)
+  })
+
+  it('advances the cursor to the last account of the previous page', async () => {
+    mockCallRPC
+      .mockResolvedValueOnce(rows(names(PAGE_SIZE, 'a')))
+      .mockResolvedValueOnce(rows(['zed']))
+
+    await runQueryFn(getMutedUsersQueryOptions('alice'))
+
+    expect(mockCallRPC).toHaveBeenNthCalledWith(2, 'condenser_api.get_following', [
+      'alice',
+      `a${PAGE_SIZE - 1}`,
+      'ignore',
+      PAGE_SIZE,
+    ])
+  })
+
+  // Hive treats `start` as exclusive, so this should not happen. If a node ever
+  // returned it inclusively the loop must still terminate rather than re-append
+  // the cursor account until it hits the page cap.
+  it('does not duplicate or loop when a node echoes the cursor row', async () => {
+    const first = names(PAGE_SIZE, 'a')
+    const cursor = first[first.length - 1]
+
+    mockCallRPC
+      .mockResolvedValueOnce(rows(first))
+      .mockResolvedValueOnce(rows([cursor, 'newone']))
+
+    const result = await runQueryFn(getMutedUsersQueryOptions('alice'))
+
+    expect(result).toEqual([...first, 'newone'])
+    expect(result.filter((name) => name === cursor)).toHaveLength(1)
+    expect(mockCallRPC).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops at the page cap when a node never advances the cursor', async () => {
+    mockCallRPC.mockResolvedValue(rows(names(PAGE_SIZE, 'a')))
+
+    const result = await runQueryFn(getMutedUsersQueryOptions('alice'))
+
+    // 20 pages, not an endless loop.
+    expect(mockCallRPC).toHaveBeenCalledTimes(20)
+    expect(result.length).toBeLessThanOrEqual(PAGE_SIZE * 20)
+  })
+
+  it('handles an empty mute list', async () => {
+    mockCallRPC.mockResolvedValueOnce([])
+
+    await expect(runQueryFn(getMutedUsersQueryOptions('alice'))).resolves.toEqual([])
+    expect(mockCallRPC).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays disabled without a username', () => {
+    expect(getMutedUsersQueryOptions(undefined).enabled).toBe(false)
+    expect(getMutedUsersQueryOptions('alice').enabled).toBe(true)
+  })
+})

--- a/packages/sdk/src/modules/accounts/queries/get-muted-users-query-options.ts
+++ b/packages/sdk/src/modules/accounts/queries/get-muted-users-query-options.ts
@@ -3,24 +3,75 @@ import { QueryKeys } from "@/modules/core";
 import { Follow } from "../types";
 import { callRPC } from "@/modules/core/hive-tx";
 
+/** `condenser_api.get_following` caps a single response at 1000 rows. */
+const MUTED_USERS_PAGE_SIZE = 1000;
+
 /**
- * Get list of users that an account has muted
- *
- * @param username - The account username
- * @param limit - Maximum number of results (default: 100)
+ * Safety valve for the paging loop: 20 pages is 20k muted accounts, far past
+ * any real mute list. Bounds the work if a node ever stops advancing the
+ * cursor, so a malformed response degrades to a truncated list rather than an
+ * endless request loop.
  */
-export function getMutedUsersQueryOptions(username: string | undefined, limit = 100) {
+const MUTED_USERS_MAX_PAGES = 20;
+
+/**
+ * Get the full list of accounts a user has muted.
+ *
+ * Pages until the list is exhausted instead of taking the first N. That is
+ * load-bearing: this result dims muted authors in feeds and collapses their
+ * comments (`entry-list-item-muted-content`, `discussion-list`), so a truncated
+ * list silently renders muted accounts as though they were never muted.
+ *
+ * Takes no limit, on purpose. `QueryKeys.accounts.mutedUsers` keys on the
+ * username alone, so a limit parameter meant callers requesting different
+ * amounts shared one cache entry and whichever mounted first decided how much
+ * of the list every other caller saw.
+ *
+ * @param username - The account whose mute list to fetch
+ */
+export function getMutedUsersQueryOptions(username: string | undefined) {
   return queryOptions({
     queryKey: QueryKeys.accounts.mutedUsers(username!),
     queryFn: async () => {
-      const response = (await callRPC("condenser_api.get_following", [
-        username,
-        "",
-        "ignore",
-        limit,
-      ])) as Follow[];
+      const muted: string[] = [];
+      let start = "";
 
-      return response.map((user) => user.following);
+      for (let page = 0; page < MUTED_USERS_MAX_PAGES; page++) {
+        const response = (await callRPC("condenser_api.get_following", [
+          username,
+          start,
+          "ignore",
+          MUTED_USERS_PAGE_SIZE,
+        ])) as Follow[];
+
+        if (!response?.length) {
+          break;
+        }
+
+        let names = response.map((user) => user.following);
+
+        // `start` is exclusive on Hive, so a page should not repeat the cursor.
+        // Drop it defensively anyway: against a node treating `start` as
+        // inclusive, this loop would otherwise re-append the same account until
+        // it hit the page cap.
+        if (names[0] === start) {
+          names = names.slice(1);
+        }
+
+        if (!names.length) {
+          break;
+        }
+
+        muted.push(...names);
+
+        if (response.length < MUTED_USERS_PAGE_SIZE) {
+          break;
+        }
+
+        start = names[names.length - 1];
+      }
+
+      return muted;
     },
     enabled: !!username,
   });


### PR DESCRIPTION
## Problem

`getMutedUsersQueryOptions` made a single `condenser_api.get_following` request with a default limit of 100:

```ts
export function getMutedUsersQueryOptions(username: string | undefined, limit = 100) {
  const response = await callRPC("condenser_api.get_following", [username, "", "ignore", limit]);
  return response.map((user) => user.following);
}
```

Two defects fell out of that.

**1. Mute lists over 100 were silently truncated.** This result is what dims muted authors in feeds (`entry-list-item-muted-content.tsx:31`) and collapses their comments (`discussion-list.tsx:35`). Accounts past the cut rendered as though they had never been muted, with no error and nothing to indicate the list was incomplete. This is not hypothetical: `acidyo` has 208 muted accounts and `azircon` has 116.

**2. The `limit` parameter collided in the cache.** `QueryKeys.accounts.mutedUsers` keys on the username alone, so the limit never reached the key:

| Caller | limit requested |
|---|---|
| `use-muted-users.ts` (waves) | 1000 |
| `entry-list-item-muted-content.tsx` | 100 (default) |
| `discussion-list.tsx` | 100 (default) |

All three shared one cache entry, so whichever query mounted first decided how much of the mute list every other consumer saw. On a page rendering both waves items and entry items, the result depended on mount order.

## Fix

Page until the list is exhausted, and drop the `limit` parameter so the username-keyed cache entry has exactly one meaning.

Pagination behaviour was verified against the live API rather than assumed. `condenser_api.get_following` treats `start` as **exclusive**: paging `acidyo` at 100 per page gives `juanmolina` as the last row of page 1 and `jza` as the first of page 2, no repeat, and the reconstructed list matches a single 1000-row fetch exactly (208 entries, identical order). The query pages at 1000, the API's own cap.

Two guards, since this loop talks to third-party nodes:

- An echoed cursor row is dropped. Against a node that treated `start` as inclusive the loop would otherwise re-append the same account until it hit the page cap.
- A hard stop at 20 pages (20k accounts, far past any real mute list) bounds the work if a node ever stops advancing the cursor, degrading to a truncated list rather than an endless request loop.

## Consumers

`useMutedUsers()` loses its unused `limit` argument; its only caller (`waves-list-item.tsx:89`) already called it with none.

Mobile calls `getMutedUsersQueryOptions(username)` with a single argument at all three of its call sites (`applicationContainer.tsx:672,1244`, `auth.ts:148`), so removing the parameter does not break it. It also picks up the same fix, since `auth.ts:148` stores the result as `account.mutes` and was capped at 100 too.

## Context

Follow-up to #1244. Narrowing the observer on profile and community routes leaned on this client-side layer to carry a logged-in user's own mutes, which made the 100 cap load-bearing in a way it had not been before.

## Testing

- `pnpm --filter @ecency/sdk test`: 41 files, 559 tests. New spec covers the single-page case, paging past the first response until exhausted, cursor advancement, the echoed-cursor guard, the page cap, an empty list, and the disabled-without-username case.
- `pnpm --filter @ecency/web test`: 244 files, 2356 tests.
- `pnpm --filter @ecency/web typecheck` and `pnpm lint` clean.
- `apps/self-hosted` builds, since this touches the SDK.
