### PR TITLE
Fix auto thumbnail seek position and submit editor passthrough

### DIFF
--- a/apps/web/src/app/submit/_page.tsx
+++ b/apps/web/src/app/submit/_page.tsx
@@ -78,6 +78,9 @@ function Submit({ path, draftId, username, permlink, searchParams }: Props) {
   const [tags, setTags] = useState<string[]>([]);
   const [thumbnails, setThumbnails] = useState<string[]>([]);
   const [selectedThumbnail, setSelectedThumbnail] = useState<string>();
+  // Thumbnails extracted from uploaded 3Speak videos. Held separately because they are not
+  // present in the body, so the body driven recompute below cannot rediscover them.
+  const [videoThumbnails, setVideoThumbnails] = useState<string[]>([]);
   const [preview, setPreview] = useState<PostBase>({
     title: "",
     tags: [],
@@ -266,16 +269,17 @@ function Submit({ path, draftId, username, permlink, searchParams }: Props) {
 
   useEffect(() => {
     // Whenever body changed then need to re-validate thumbnails
-    const { thumbnails: mergedThumbnails } = extractMetaData(body, editingEntry?.json_metadata ?? {});
-    setThumbnails(mergedThumbnails ?? []);
+    const { thumbnails: extracted } = extractMetaData(body, editingEntry?.json_metadata ?? {});
+    const mergedThumbnails = Array.from(new Set([...(extracted ?? []), ...videoThumbnails]));
+    setThumbnails(mergedThumbnails);
 
     // In case of thumbnail isn't part of the thumbnails then should be reset to first one
-    if (!selectedThumbnail || !mergedThumbnails?.includes(selectedThumbnail)) {
-      setSelectedThumbnail(mergedThumbnails?.[0]);
+    if (!selectedThumbnail || !mergedThumbnails.includes(selectedThumbnail)) {
+      setSelectedThumbnail(mergedThumbnails[0]);
     }
 
     setIsDraftEmpty(!Boolean(title?.length || tags?.length || body?.length));
-  }, [body, selectedThumbnail]);
+  }, [body, selectedThumbnail, videoThumbnails]);
 
   useEffect(() => {
     if (searchParams && typeof searchParams?.cat === "string" && searchParams.cat.length > 0) {
@@ -302,6 +306,7 @@ function Submit({ path, draftId, username, permlink, searchParams }: Props) {
     setSupportEcencySettled(false);
     setSelectedThumbnail(undefined);
     setThumbnails([]);
+    setVideoThumbnails([]);
     clearActivePoll();
   };
 
@@ -390,8 +395,13 @@ function Submit({ path, draftId, username, permlink, searchParams }: Props) {
             onVideoUploaded={
               editingEntry || hasThreeSpeakEmbed(body)
                 ? undefined
-                : (embedUrl) => {
+                : (embedUrl, thumbnailUrl) => {
                     setBody(`${body}\n${embedUrl}`);
+                    if (thumbnailUrl) {
+                      setVideoThumbnails((prev) =>
+                        prev.includes(thumbnailUrl) ? prev : [...prev, thumbnailUrl]
+                      );
+                    }
                   }
             }
             onAddPoll={(v) => setActivePoll(v)}

--- a/apps/web/src/app/submit/_page.tsx
+++ b/apps/web/src/app/submit/_page.tsx
@@ -79,8 +79,11 @@ function Submit({ path, draftId, username, permlink, searchParams }: Props) {
   const [thumbnails, setThumbnails] = useState<string[]>([]);
   const [selectedThumbnail, setSelectedThumbnail] = useState<string>();
   // Thumbnails extracted from uploaded 3Speak videos. Held separately because they are not
-  // present in the body, so the body driven recompute below cannot rediscover them.
-  const [videoThumbnails, setVideoThumbnails] = useState<string[]>([]);
+  // present in the body, so the body driven recompute below cannot rediscover them. Keyed by
+  // the embed they belong to, so removing the video also removes its thumbnail.
+  const [videoThumbnails, setVideoThumbnails] = useState<
+    { embedUrl: string; thumbUrl: string }[]
+  >([]);
   const [preview, setPreview] = useState<PostBase>({
     title: "",
     tags: [],
@@ -270,7 +273,20 @@ function Submit({ path, draftId, username, permlink, searchParams }: Props) {
   useEffect(() => {
     // Whenever body changed then need to re-validate thumbnails
     const { thumbnails: extracted } = extractMetaData(body, editingEntry?.json_metadata ?? {});
-    const mergedThumbnails = Array.from(new Set([...(extracted ?? []), ...videoThumbnails]));
+
+    // Drop the thumbnail of any video that is no longer embedded in the body
+    const activeVideoThumbnails = videoThumbnails
+      .filter(({ embedUrl }) => body.includes(embedUrl))
+      .map(({ thumbUrl }) => thumbUrl);
+
+    // A restored draft loses the in-memory list above, and its video thumbnail cannot be
+    // recovered by parsing the body, so bring it back from the saved metadata for as long
+    // as the video it belongs to is still embedded.
+    const restoredVideoThumbnails = hasThreeSpeakEmbed(body) ? (editingDraft?.meta?.image ?? []) : [];
+
+    const mergedThumbnails = Array.from(
+      new Set([...(extracted ?? []), ...activeVideoThumbnails, ...restoredVideoThumbnails])
+    );
     setThumbnails(mergedThumbnails);
 
     // In case of thumbnail isn't part of the thumbnails then should be reset to first one
@@ -279,7 +295,7 @@ function Submit({ path, draftId, username, permlink, searchParams }: Props) {
     }
 
     setIsDraftEmpty(!Boolean(title?.length || tags?.length || body?.length));
-  }, [body, selectedThumbnail, videoThumbnails]);
+  }, [body, selectedThumbnail, videoThumbnails, editingDraft]);
 
   useEffect(() => {
     if (searchParams && typeof searchParams?.cat === "string" && searchParams.cat.length > 0) {
@@ -399,7 +415,9 @@ function Submit({ path, draftId, username, permlink, searchParams }: Props) {
                     setBody(`${body}\n${embedUrl}`);
                     if (thumbnailUrl) {
                       setVideoThumbnails((prev) =>
-                        prev.includes(thumbnailUrl) ? prev : [...prev, thumbnailUrl]
+                        prev.some((v) => v.embedUrl === embedUrl)
+                          ? prev
+                          : [...prev, { embedUrl, thumbUrl: thumbnailUrl }]
                       );
                     }
                   }

--- a/apps/web/src/app/submit/_page.tsx
+++ b/apps/web/src/app/submit/_page.tsx
@@ -274,9 +274,12 @@ function Submit({ path, draftId, username, permlink, searchParams }: Props) {
     // Whenever body changed then need to re-validate thumbnails
     const { thumbnails: extracted } = extractMetaData(body, editingEntry?.json_metadata ?? {});
 
-    // Drop the thumbnail of any video that is no longer embedded in the body
+    // Drop the thumbnail of any video that is no longer embedded in the body. The embed is
+    // inserted on its own line, so match it as a whole token: a substring test would keep a
+    // removed video alive whenever its url is a prefix of the one that replaced it.
+    const bodyTokens = new Set(body.split(/\s+/));
     const activeVideoThumbnails = videoThumbnails
-      .filter(({ embedUrl }) => body.includes(embedUrl))
+      .filter(({ embedUrl }) => bodyTokens.has(embedUrl))
       .map(({ thumbUrl }) => thumbUrl);
 
     // A restored draft loses the in-memory list above, and its video thumbnail cannot be

--- a/apps/web/src/features/shared/editor-toolbar/index.tsx
+++ b/apps/web/src/features/shared/editor-toolbar/index.tsx
@@ -37,7 +37,7 @@ import { linkSvg } from "@ui/svg";
 interface Props {
   sm?: boolean;
   comment: boolean;
-  onVideoUploaded?: (embedUrl: string) => void;
+  onVideoUploaded?: (embedUrl: string, thumbnailUrl?: string) => void;
   onAddPoll?: (poll: PollSnapshot) => void;
   existingPoll?: PollSnapshot;
   onDeletePoll?: () => void;
@@ -624,7 +624,9 @@ export function EditorToolbar({
                 <VideoUpload
                   show={showVideoUpload}
                   setShow={(v) => setShowVideoUpload(v)}
-                  onVideoUploaded={(embedUrl) => onVideoUploaded(embedUrl)}
+                  onVideoUploaded={(embedUrl, thumbnailUrl) =>
+                    onVideoUploaded(embedUrl, thumbnailUrl)
+                  }
                 />
               </button>
             </Tooltip>

--- a/apps/web/src/features/shared/video-upload-threespeak/index.tsx
+++ b/apps/web/src/features/shared/video-upload-threespeak/index.tsx
@@ -200,7 +200,11 @@ export const VideoUpload = (props: Props & React.HTMLAttributes<HTMLDivElement>)
 
     const handleLoaded = () => {
       if (abortController.signal.aborted) return;
-      video.currentTime = Math.max(0.1, Math.min(1, video.duration * 0.25));
+      // Seek 25% in, past intros and black opening frames. The previous clamp capped this
+      // at 1s, so anything longer than 4s always grabbed a frame from the very start.
+      const { duration } = video;
+      video.currentTime =
+        Number.isFinite(duration) && duration > 0 ? Math.max(0.1, duration * 0.25) : 1;
     };
 
     video.addEventListener("seeked", handleSeeked, { once: true });


### PR DESCRIPTION
Two issues in the 3Speak auto thumbnail path, found while comparing against the mobile implementation.

### Seek position

`video.currentTime = Math.max(0.1, Math.min(1, video.duration * 0.25))` caps the seek at 1 second, so despite the 25% intent every video longer than 4 seconds grabbed a frame from the very start. Intros and black opening frames were a common result.

Now seeks to the intended 25%, falling back to 1s when duration is not finite.

### Submit editor passthrough

The legacy submit editor declared `onVideoUploaded?: (embedUrl: string) => void` and called it with the embed url only, discarding the second argument. The extracted thumbnail was still uploaded and set on 3Speak, but never landed in that post's metadata.

Widened the toolbar signature and added a `videoThumbnails` state in the submit page. It is held separately from `thumbnails` because video thumbnails are not present in the body, so the body driven recompute in the effect below cannot rediscover them, and merging into `thumbnails` directly would be overwritten on the next body change.

The publish editor already handled this correctly and is unchanged.

### Verification

- `npx tsc --noEmit` clean across apps/web, 0 errors
- `npx eslint` clean on changed files
- vitest: 244 files, 2357 tests passed