### PR TITLE
Use the shared 3Speak beneficiary constants at every call site

### DIFF
--- a/apps/web/src/api/threespeak-embed/beneficiary.ts
+++ b/apps/web/src/api/threespeak-embed/beneficiary.ts
@@ -1,7 +1,7 @@
 import { BeneficiaryRoute } from "@/entities";
 
-const THREESPEAK_ACCOUNT = "threespeakfund";
-const THREESPEAK_WEIGHT = 1100; // 11%
+export const THREESPEAK_ACCOUNT = "threespeakfund";
+export const THREESPEAK_WEIGHT = 1100; // 11%
 
 /**
  * Check if body content contains a 3Speak embed URL.

--- a/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
+++ b/apps/web/src/app/publish/_components/publish-editor-toolbar.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { isThreeSpeakBeneficiary } from "@/api/threespeak-embed";
+import {
+  isThreeSpeakBeneficiary,
+  THREESPEAK_ACCOUNT,
+  THREESPEAK_WEIGHT
+} from "@/api/threespeak-embed";
 import { EcencyConfigManager } from "@/config";
 import { error, LoginRequired } from "@/features/shared";
 import dynamic from "next/dynamic";
@@ -756,7 +760,7 @@ export function PublishEditorToolbar({ editor, allowToUploadVideo = true }: Prop
               if (prev.some((b) => isThreeSpeakBeneficiary(b.account))) {
                 return prev;
               }
-              return [...prev, { account: "threespeakfund", weight: 1100 }];
+              return [...prev, { account: THREESPEAK_ACCOUNT, weight: THREESPEAK_WEIGHT }];
             });
 
             setShowVideoUpload(false);

--- a/apps/web/src/app/submit/_page.tsx
+++ b/apps/web/src/app/submit/_page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { hasThreeSpeakEmbed } from "@/api/threespeak-embed";
+import { hasThreeSpeakEmbed, THREESPEAK_ACCOUNT } from "@/api/threespeak-embed";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
@@ -525,7 +525,7 @@ function Submit({ path, draftId, username, permlink, searchParams }: Props) {
                         <BeneficiaryEditorDialog
                           author={activeUser?.username}
                           list={beneficiaries}
-                          lockedAccounts={hasThreeSpeakEmbed(body) ? ["threespeakfund"] : []}
+                          lockedAccounts={hasThreeSpeakEmbed(body) ? [THREESPEAK_ACCOUNT] : []}
                           onAdd={(item) => {
                             const b = [...beneficiaries, item].sort((a, b) =>
                               a.account < b.account ? -1 : 1


### PR DESCRIPTION
Follow-up from #1249. This commit was pushed to that branch after it had already merged, so it never landed. Re-raised here against current develop, unchanged.

While comparing the 3Speak beneficiary logic against the mobile app I found the values are fully in sync (`threespeakfund`, weight `1100`, same `hasThreeSpeakEmbed` regex, same preserve / normalise / append enforcement). What was inconsistent is where web builds the route:

- `publish-editor-toolbar.tsx` built `{ account: "threespeakfund", weight: 1100 }` by hand for the optimistic beneficiary shown in the editor
- `submit/_page.tsx` locked the beneficiary row against a literal `"threespeakfund"`

Both sat next to the constants that already define them. The literal feeds the beneficiary the editor *displays*, while `enforceThreeSpeakBeneficiary` builds the one actually *broadcast*, so changing the weight in one place would leave the user seeing 11% while a different weight is enforced at publish.

`THREESPEAK_ACCOUNT` and `THREESPEAK_WEIGHT` are now exported and used at both sites.

The spec keeps its own literals deliberately: a test that imports the constant would still pass if the constant itself were changed by mistake, so the assertions stay independent of the value under test.

No behaviour change, the values are identical to before. No label needed, nothing under `packages/*/src` is touched.

### Verification

- `tsc --noEmit` 0 errors across `apps/web`
- eslint clean on the three changed files
- vitest: 245 files, 2366 tests passed