### PR TITLE
fix: audit-log the internal hosting endpoints, space the Pro badge from following text

### DIFF
--- a/apps/self-hosted/hosting/api/src/routes/internal.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.test.ts
@@ -4,6 +4,9 @@ const mocks = vi.hoisted(() => ({
   transaction: vi.fn(),
   getByUsername: vi.fn(),
   generateConfigFile: vi.fn(),
+  auditLog: vi.fn(),
+  buildConfig: vi.fn(),
+  getBlogUrl: vi.fn(),
 }));
 
 vi.mock('../db/client', () => ({
@@ -13,13 +16,22 @@ vi.mock('../db/client', () => ({
 vi.mock('../services/tenant-service', () => ({
   TenantService: {
     getByUsername: mocks.getByUsername,
+    buildConfig: mocks.buildConfig,
+    getBlogUrl: mocks.getBlogUrl,
   },
+  ABANDONED_REREGISTER_QUARANTINE_HOURS: 24,
+  CAUGHT_UP_SQL: 'TRUE',
 }));
 
 vi.mock('../services/config-service', () => ({
   ConfigService: {
     generateConfigFile: mocks.generateConfigFile,
   },
+}));
+
+vi.mock('../services/audit-service', () => ({
+  AuditService: { log: (...args: any[]) => mocks.auditLog(...args) },
+  parseClientIp: (xff: string | undefined) => xff?.split(',').pop()?.trim() ?? null,
 }));
 
 const { internalRoutes } = await import('./internal');
@@ -29,6 +41,7 @@ describe('POST /activate config publication', () => {
     process.env.HOSTING_INTERNAL_SECRET = 'test-secret';
     mocks.transaction.mockReset().mockResolvedValue({
       status: 200,
+      tenantId: 'tenant-1',
       expiresAt: new Date('2027-01-01T00:00:00.000Z'),
       plan: 'standard',
     });
@@ -37,6 +50,7 @@ describe('POST /activate config publication', () => {
       subscriptionStatus: 'active',
     });
     mocks.generateConfigFile.mockReset().mockResolvedValue('/configs/alice.json');
+    mocks.auditLog.mockReset();
   });
 
   const activate = () =>
@@ -120,5 +134,147 @@ describe('POST /activate config publication', () => {
     expect(response.status).toBe(200);
     expect(mocks.generateConfigFile).toHaveBeenCalledTimes(1);
     expect(await response.json()).toMatchObject({ activated: true, plan: 'standard' });
+  });
+});
+
+describe('internal endpoint audit trail', () => {
+  beforeEach(() => {
+    process.env.HOSTING_INTERNAL_SECRET = 'test-secret';
+    mocks.transaction.mockReset().mockResolvedValue({
+      status: 200,
+      tenantId: 'tenant-1',
+      expiresAt: new Date('2027-01-01T00:00:00.000Z'),
+      plan: 'standard',
+    });
+    mocks.getByUsername.mockReset().mockResolvedValue({
+      id: 'tenant-1',
+      username: 'alice',
+      subscriptionStatus: 'active',
+    });
+    mocks.generateConfigFile.mockReset().mockResolvedValue('/configs/alice.json');
+    mocks.buildConfig.mockReset().mockResolvedValue({ version: 1 });
+    mocks.getBlogUrl.mockReset().mockReturnValue('https://alice.blogs.ecency.com');
+    mocks.auditLog.mockReset();
+  });
+
+  const post = (path: string, body: Record<string, unknown>) =>
+    internalRoutes.request(path, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-internal-secret': 'test-secret',
+        'x-forwarded-for': '203.0.113.9, 10.0.0.2',
+        'user-agent': 'epoints-fulfillment/1.0',
+      },
+      body: JSON.stringify(body),
+    });
+
+  const activateBody = {
+    username: 'alice',
+    payer: 'alice',
+    months: 12,
+    order_id: 'order-1',
+    amount_usd: 24,
+  };
+
+  it('records a card activation with its order, term and rail', async () => {
+    const response = await post('/activate', activateBody);
+
+    expect(response.status).toBe(200);
+    expect(mocks.auditLog).toHaveBeenCalledTimes(1);
+    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({
+      tenantId: 'tenant-1',
+      eventType: 'tenant.activated',
+      eventData: {
+        username: 'alice',
+        payer: 'alice',
+        orderId: 'order-1',
+        months: 12,
+        amountUsd: 24,
+        plan: 'standard',
+        duplicate: false,
+        rail: 'card',
+      },
+      ipAddress: '10.0.0.2',
+      userAgent: 'epoints-fulfillment/1.0',
+    });
+  });
+
+  it('does not record an activation that failed to publish', async () => {
+    mocks.generateConfigFile.mockRejectedValueOnce(new Error('disk unavailable'));
+
+    const response = await post('/activate', activateBody);
+
+    expect(response.status).toBe(500);
+    expect(mocks.auditLog).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [403, 'payer_not_owner'],
+    [409, 'order_tenant_mismatch'],
+  ])('records a %i activation denial with its reason', async (status, reason) => {
+    mocks.transaction.mockResolvedValueOnce({ status, tenantId: 'tenant-1' });
+
+    const response = await post('/activate', activateBody);
+
+    expect(response.status).toBe(status);
+    expect(mocks.auditLog).toHaveBeenCalledTimes(1);
+    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({
+      tenantId: 'tenant-1',
+      eventType: 'tenant.activation_denied',
+      eventData: { username: 'alice', orderId: 'order-1', reason },
+    });
+  });
+
+  it('records a denial for an activation against a tenant that no longer exists', async () => {
+    mocks.transaction.mockResolvedValueOnce({ status: 404 });
+
+    const response = await post('/activate', activateBody);
+
+    expect(response.status).toBe(404);
+    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({
+      tenantId: null,
+      eventType: 'tenant.activation_denied',
+      eventData: { reason: 'tenant_not_found' },
+    });
+  });
+
+  it('records a Pro free-blog claim, flagging whether it provisioned the blog', async () => {
+    const row = {
+      id: 'tenant-9',
+      username: 'alice',
+      owner: 'alice',
+      subscription_status: 'active',
+      subscription_plan: 'standard',
+      subscription_started_at: null,
+      subscription_expires_at: null,
+      custom_domain: null,
+      custom_domain_verified: false,
+      custom_domain_verified_at: null,
+      config: {},
+      created_at: '2026-07-27T10:25:13.000Z',
+      updated_at: '2026-07-27T10:25:13.000Z',
+    };
+    mocks.transaction.mockResolvedValueOnce({ created: true, row });
+
+    const created = await post('/claim-blog', { username: 'alice' });
+
+    expect(created.status).toBe(200);
+    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({
+      tenantId: 'tenant-9',
+      eventType: 'tenant.pro_blog_claimed',
+      eventData: { username: 'alice', created: true, subscriptionStatus: 'active' },
+    });
+
+    mocks.auditLog.mockReset();
+    mocks.transaction.mockResolvedValueOnce({ created: false, row });
+
+    const existing = await post('/claim-blog', { username: 'alice' });
+
+    expect(existing.status).toBe(200);
+    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({
+      eventType: 'tenant.pro_blog_claimed',
+      eventData: { created: false },
+    });
   });
 });

--- a/apps/self-hosted/hosting/api/src/routes/internal.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.test.ts
@@ -224,6 +224,7 @@ describe('internal endpoint audit trail', () => {
         amountUsd: 24,
         plan: 'standard',
         duplicate: false,
+        published: true,
         rail: 'card',
       },
       ipAddress: '10.0.0.2',
@@ -231,13 +232,33 @@ describe('internal endpoint audit trail', () => {
     });
   });
 
-  it('does not record an activation that failed to publish', async () => {
+  it('records a committed activation whose config failed to publish', async () => {
     mocks.generateConfigFile.mockRejectedValueOnce(new Error('disk unavailable'));
 
     const response = await post('/activate', activateBody);
 
+    // The transaction has committed - the tenant is active and the order is recorded - so the
+    // event must exist even though the caller gets a retryable 500 and may never come back.
     expect(response.status).toBe(500);
-    expect(mocks.auditLog).not.toHaveBeenCalled();
+    expect(mocks.auditLog).toHaveBeenCalledTimes(1);
+    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({
+      tenantId: 'tenant-1',
+      eventType: 'tenant.activated',
+      eventData: { orderId: 'order-1', published: false, publishError: 'disk unavailable' },
+    });
+  });
+
+  it('records a committed activation whose tenant could not be reloaded', async () => {
+    mocks.getByUsername.mockResolvedValueOnce(null);
+
+    const response = await post('/activate', activateBody);
+
+    expect(response.status).toBe(500);
+    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({
+      tenantId: 'tenant-1',
+      eventType: 'tenant.activated',
+      eventData: { published: false, tenantStatus: null },
+    });
   });
 
   it.each([
@@ -308,6 +329,23 @@ describe('internal endpoint audit trail', () => {
       eventType: 'domain.added',
       eventData: { domain: 'blog.example.com', username: 'alice', via: 'internal' },
     });
+
+    // setCustomDomain has committed (and cleared the verified flag) before the verification record
+    // is created, so a failure there must not cost the event describing that change.
+    mocks.auditLog.mockReset();
+    mocks.getByUsername.mockResolvedValueOnce({
+      id: 'tenant-1',
+      username: 'alice',
+      subscriptionPlan: 'pro',
+    });
+    mocks.createVerification.mockRejectedValueOnce(new Error('verification insert failed'));
+
+    await Promise.resolve(
+      post('/domain', { username: 'alice', domain: 'blog.example.com' })
+    ).catch(() => undefined);
+
+    expect(mocks.auditLog).toHaveBeenCalledTimes(1);
+    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({ eventType: 'domain.added' });
   });
 
   it('records a domain verification before the bookkeeping that could strand it', async () => {

--- a/apps/self-hosted/hosting/api/src/routes/internal.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.test.ts
@@ -7,6 +7,13 @@ const mocks = vi.hoisted(() => ({
   auditLog: vi.fn(),
   buildConfig: vi.fn(),
   getBlogUrl: vi.fn(),
+  getByDomain: vi.fn(),
+  setCustomDomain: vi.fn(),
+  verifyCustomDomain: vi.fn(),
+  createVerification: vi.fn(),
+  verifyDomain: vi.fn(),
+  markVerified: vi.fn(),
+  addVerifiedDomainOrigin: vi.fn(),
 }));
 
 vi.mock('../db/client', () => ({
@@ -18,6 +25,9 @@ vi.mock('../services/tenant-service', () => ({
     getByUsername: mocks.getByUsername,
     buildConfig: mocks.buildConfig,
     getBlogUrl: mocks.getBlogUrl,
+    getByDomain: mocks.getByDomain,
+    setCustomDomain: mocks.setCustomDomain,
+    verifyCustomDomain: mocks.verifyCustomDomain,
   },
   ABANDONED_REREGISTER_QUARANTINE_HOURS: 24,
   CAUGHT_UP_SQL: 'TRUE',
@@ -29,9 +39,23 @@ vi.mock('../services/config-service', () => ({
   },
 }));
 
-vi.mock('../services/audit-service', () => ({
+vi.mock('../services/domain-service', () => ({
+  DomainService: {
+    createVerification: mocks.createVerification,
+    verifyDomain: mocks.verifyDomain,
+    markVerified: mocks.markVerified,
+  },
+}));
+
+vi.mock('../utils/cors-domains', () => ({
+  addVerifiedDomainOrigin: mocks.addVerifiedDomainOrigin,
+}));
+
+// Only the write path is mocked: parseClientIp stays real so the tests keep asserting the
+// production forwarded-for rule rather than a copy of it that can silently drift.
+vi.mock('../services/audit-service', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/audit-service')>()),
   AuditService: { log: (...args: any[]) => mocks.auditLog(...args) },
-  parseClientIp: (xff: string | undefined) => xff?.split(',').pop()?.trim() ?? null,
 }));
 
 const { internalRoutes } = await import('./internal');
@@ -154,6 +178,13 @@ describe('internal endpoint audit trail', () => {
     mocks.generateConfigFile.mockReset().mockResolvedValue('/configs/alice.json');
     mocks.buildConfig.mockReset().mockResolvedValue({ version: 1 });
     mocks.getBlogUrl.mockReset().mockReturnValue('https://alice.blogs.ecency.com');
+    mocks.getByDomain.mockReset().mockResolvedValue(null);
+    mocks.setCustomDomain.mockReset().mockResolvedValue(undefined);
+    mocks.verifyCustomDomain.mockReset().mockResolvedValue(undefined);
+    mocks.createVerification.mockReset().mockResolvedValue({ verificationMethod: 'cname' });
+    mocks.verifyDomain.mockReset().mockResolvedValue(true);
+    mocks.markVerified.mockReset().mockResolvedValue(undefined);
+    mocks.addVerifiedDomainOrigin.mockReset();
     mocks.auditLog.mockReset();
   });
 
@@ -237,6 +268,91 @@ describe('internal endpoint audit trail', () => {
       eventType: 'tenant.activation_denied',
       eventData: { reason: 'tenant_not_found' },
     });
+  });
+
+  it('carries the tenant status so a replay that reactivated nothing is not read as an activation', async () => {
+    mocks.transaction.mockResolvedValueOnce({
+      status: 200,
+      tenantId: 'tenant-1',
+      duplicate: true,
+      plan: 'standard',
+    });
+    mocks.getByUsername.mockResolvedValueOnce({
+      id: 'tenant-1',
+      username: 'alice',
+      subscriptionStatus: 'expired',
+    });
+
+    const response = await post('/activate', activateBody);
+
+    expect(response.status).toBe(200);
+    expect(mocks.generateConfigFile).not.toHaveBeenCalled();
+    expect(mocks.auditLog.mock.calls[0][0].eventData).toMatchObject({
+      duplicate: true,
+      tenantStatus: 'expired',
+    });
+  });
+
+  it('records an internally attached custom domain', async () => {
+    mocks.getByUsername.mockResolvedValueOnce({
+      id: 'tenant-1',
+      username: 'alice',
+      subscriptionPlan: 'pro',
+    });
+
+    const response = await post('/domain', { username: 'alice', domain: 'blog.example.com' });
+
+    expect(response.status).toBe(200);
+    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({
+      tenantId: 'tenant-1',
+      eventType: 'domain.added',
+      eventData: { domain: 'blog.example.com', username: 'alice', via: 'internal' },
+    });
+  });
+
+  it('records a domain verification before the bookkeeping that could strand it', async () => {
+    mocks.getByUsername.mockResolvedValue({
+      id: 'tenant-1',
+      username: 'alice',
+      customDomain: 'blog.example.com',
+      customDomainVerified: false,
+    });
+
+    const response = await post('/domain/verify', { username: 'alice' });
+
+    expect(response.status).toBe(200);
+    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({
+      tenantId: 'tenant-1',
+      eventType: 'domain.verified',
+      eventData: { domain: 'blog.example.com', username: 'alice', via: 'internal' },
+    });
+
+    // The tenant is verified the moment verifyCustomDomain commits, and the already-verified early
+    // return means a retry never reaches an audit call placed later. So a failure in the trailing
+    // bookkeeping must not cost the event.
+    mocks.auditLog.mockReset();
+    mocks.markVerified.mockRejectedValueOnce(new Error('bookkeeping write failed'));
+
+    await Promise.resolve(post('/domain/verify', { username: 'alice' })).catch(() => undefined);
+
+    expect(mocks.auditLog).toHaveBeenCalledTimes(1);
+    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({ eventType: 'domain.verified' });
+  });
+
+  it('does not record a domain verification that DNS rejected', async () => {
+    mocks.getByUsername.mockResolvedValueOnce({
+      id: 'tenant-1',
+      username: 'alice',
+      customDomain: 'blog.example.com',
+      customDomainVerified: false,
+    });
+    mocks.verifyDomain.mockResolvedValueOnce(false);
+
+    const response = await post('/domain/verify', { username: 'alice' });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ verified: false });
+    expect(mocks.auditLog).not.toHaveBeenCalled();
   });
 
   it('records a Pro free-blog claim, flagging whether it provisioned the blog', async () => {

--- a/apps/self-hosted/hosting/api/src/routes/internal.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.test.ts
@@ -224,7 +224,7 @@ describe('internal endpoint audit trail', () => {
         amountUsd: 24,
         plan: 'standard',
         duplicate: false,
-        published: true,
+        publication: 'published',
         rail: 'card',
       },
       ipAddress: '10.0.0.2',
@@ -244,7 +244,7 @@ describe('internal endpoint audit trail', () => {
     expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({
       tenantId: 'tenant-1',
       eventType: 'tenant.activated',
-      eventData: { orderId: 'order-1', published: false, publishError: 'disk unavailable' },
+      eventData: { orderId: 'order-1', publication: 'failed', publishError: 'disk unavailable' },
     });
   });
 
@@ -257,7 +257,7 @@ describe('internal endpoint audit trail', () => {
     expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({
       tenantId: 'tenant-1',
       eventType: 'tenant.activated',
-      eventData: { published: false, tenantStatus: null },
+      eventData: { publication: 'failed', tenantStatus: null },
     });
   });
 
@@ -308,8 +308,11 @@ describe('internal endpoint audit trail', () => {
 
     expect(response.status).toBe(200);
     expect(mocks.generateConfigFile).not.toHaveBeenCalled();
+    // Publication was deliberately not attempted, which is a third outcome: recording it as
+    // published would claim a blog is being served when nothing was written.
     expect(mocks.auditLog.mock.calls[0][0].eventData).toMatchObject({
       duplicate: true,
+      publication: 'skipped',
       tenantStatus: 'expired',
     });
   });

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -15,7 +15,7 @@ import {
 import { DomainService } from '../services/domain-service';
 import { ConfigService } from '../services/config-service';
 import { AuditService, parseClientIp } from '../services/audit-service';
-import { mapTenantFromDb } from '../types';
+import { mapTenantFromDb, type Tenant } from '../types';
 import { addVerifiedDomainOrigin } from '../utils/cors-domains';
 
 export const internalRoutes = new Hono();
@@ -220,19 +220,28 @@ internalRoutes.post('/activate', async (c) => {
     // active duplicate also retries config publication (the first response may have failed here),
     // while an expired/suspended duplicate is already-processed history and remains idempotently
     // acknowledgeable without reactivating or extending it.
-    const tenant = await TenantService.getByUsername(username);
-    if (!tenant) {
-      throw new Error(`Activated tenant ${username} is not available for config generation`);
-    }
-    if (tenant.subscriptionStatus === 'active') {
-      await ConfigService.generateConfigFile(tenant);
-    } else if (!result.duplicate) {
-      throw new Error(`Activated tenant ${username} is not active for config generation`);
+    let tenant: Tenant | null = null;
+    let publishError: Error | null = null;
+    try {
+      tenant = await TenantService.getByUsername(username);
+      if (!tenant) {
+        throw new Error(`Activated tenant ${username} is not available for config generation`);
+      }
+      if (tenant.subscriptionStatus === 'active') {
+        await ConfigService.generateConfigFile(tenant);
+      } else if (!result.duplicate) {
+        throw new Error(`Activated tenant ${username} is not active for config generation`);
+      }
+    } catch (e) {
+      publishError = e as Error;
     }
 
-    // Logged only once the activation is fully delivered (config published), so the trail cannot
-    // claim an activation that the retryable throws above turned into a 500.
-    auditInternal(c, result.tenantId ?? tenant.id, 'tenant.activated', {
+    // The activation transaction is COMMITTED by this point -- the tenant is active and the order
+    // is recorded -- so the event is written whatever publication did, carrying the outcome rather
+    // than being skipped. Skipping it would leave an active, paid tenant with no event at all once
+    // the caller stops retrying, and a later successful retry would log `duplicate: true` at the
+    // retry's timestamp, describing the retry instead of the mutation that actually happened.
+    auditInternal(c, result.tenantId ?? tenant?.id, 'tenant.activated', {
       username,
       payer,
       orderId,
@@ -243,10 +252,18 @@ internalRoutes.post('/activate', async (c) => {
       duplicate: !!result.duplicate,
       // An expired/suspended duplicate is acknowledged without being reactivated, so the event
       // carries the tenant's real status: 'active' means a blog is being served, anything else
-      // means this was a replay acknowledgment that changed nothing.
-      tenantStatus: tenant.subscriptionStatus,
+      // means this was a replay acknowledgment that changed nothing. Null when the reload itself
+      // failed, which is what `published: false` then explains.
+      tenantStatus: tenant?.subscriptionStatus ?? null,
+      published: !publishError,
+      ...(publishError ? { publishError: publishError.message } : {}),
       rail: 'card',
     });
+
+    // Unchanged behaviour: publication failure is still a retryable 500 for the caller.
+    if (publishError) {
+      throw publishError;
+    }
 
     // Echo the tenant's ACTUAL plan so the caller (ePoints) can confirm the Pro tier was honored.
     // Truthful on replays too (the upgrade is idempotent); an older service that ignores `plan`
@@ -300,10 +317,13 @@ internalRoutes.post('/domain', async (c) => {
   }
 
   await TenantService.setCustomDomain(username, domain);
+  // Recorded as soon as the tenant row changes, before the verification record it does not depend
+  // on: setCustomDomain also clears custom_domain_verified, so if createVerification then threw,
+  // the tenant's domain state would have changed with nothing in the trail to say what changed it.
+  auditInternal(c, tenant.id, 'domain.added', { domain, username, via: 'internal' });
+
   await DomainService.createVerification(username, domain);
   const value = `${username}.${baseDomain}`;
-
-  auditInternal(c, tenant.id, 'domain.added', { domain, username, via: 'internal' });
 
   // The record NAME must be the domain itself: verification resolves the domain's CNAME
   // (and serving requires it too). The internal verification token is bookkeeping only;

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -222,6 +222,9 @@ internalRoutes.post('/activate', async (c) => {
     // acknowledgeable without reactivating or extending it.
     let tenant: Tenant | null = null;
     let publishError: Error | null = null;
+    // Tri-state, not a boolean: an expired/suspended replay deliberately does not attempt
+    // publication, and "not attempted" must not be recorded as "published".
+    let publication: 'published' | 'skipped' | 'failed' = 'failed';
     try {
       tenant = await TenantService.getByUsername(username);
       if (!tenant) {
@@ -229,11 +232,15 @@ internalRoutes.post('/activate', async (c) => {
       }
       if (tenant.subscriptionStatus === 'active') {
         await ConfigService.generateConfigFile(tenant);
+        publication = 'published';
       } else if (!result.duplicate) {
         throw new Error(`Activated tenant ${username} is not active for config generation`);
+      } else {
+        publication = 'skipped';
       }
     } catch (e) {
       publishError = e as Error;
+      publication = 'failed';
     }
 
     // The activation transaction is COMMITTED by this point -- the tenant is active and the order
@@ -253,9 +260,9 @@ internalRoutes.post('/activate', async (c) => {
       // An expired/suspended duplicate is acknowledged without being reactivated, so the event
       // carries the tenant's real status: 'active' means a blog is being served, anything else
       // means this was a replay acknowledgment that changed nothing. Null when the reload itself
-      // failed, which is what `published: false` then explains.
+      // failed, which is what `publication: 'failed'` then explains.
       tenantStatus: tenant?.subscriptionStatus ?? null,
-      published: !publishError,
+      publication,
       ...(publishError ? { publishError: publishError.message } : {}),
       rail: 'card',
     });

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -5,7 +5,7 @@
  * confused with a customer-facing path.
  */
 
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { db } from '../db/client';
 import {
   TenantService,
@@ -14,6 +14,7 @@ import {
 } from '../services/tenant-service';
 import { DomainService } from '../services/domain-service';
 import { ConfigService } from '../services/config-service';
+import { AuditService, parseClientIp } from '../services/audit-service';
 import { mapTenantFromDb } from '../types';
 import { addVerifiedDomainOrigin } from '../utils/cors-domains';
 
@@ -25,6 +26,26 @@ const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
 const USERNAME_RE = /^[a-z][a-z0-9.-]{2,15}$/;
 // Same domain shape the public /v1/domains route enforces (zod regex, case-insensitive).
 const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+
+// Every internal endpoint records its outcome here. These are service-to-service calls with no
+// user session, so without a trail the tenants row is the only trace and it cannot say what asked
+// for the change: a card-paid activation and a free Pro claim leave an identical `active` row, and
+// a denied one leaves nothing at all. Fire-and-forget, exactly like the public routes -- a failed
+// audit insert is logged by AuditService and never fails the operation it describes.
+function auditInternal(
+  c: Context,
+  tenantId: string | null | undefined,
+  eventType: string,
+  eventData: Record<string, unknown>
+): void {
+  void AuditService.log({
+    tenantId: tenantId ?? null,
+    eventType,
+    eventData,
+    ipAddress: parseClientIp(c.req.header('x-forwarded-for')),
+    userAgent: c.req.header('user-agent'),
+  });
+}
 
 // Constant-time check of the shared service-to-service secret (ePoints -> hosting).
 // Fails CLOSED when the secret is unset, so a misconfigured deploy cannot activate blogs.
@@ -75,7 +96,7 @@ internalRoutes.post('/activate', async (c) => {
   }
 
   try {
-    const result = await db.transaction<{ status: 200 | 403 | 404 | 409; duplicate?: boolean; expiresAt?: Date; plan?: string }>(
+    const result = await db.transaction<{ status: 200 | 403 | 404 | 409; tenantId?: string; duplicate?: boolean; expiresAt?: Date; plan?: string }>(
       async (client) => {
         // Lock the tenant row (serializes retries) and confirm it still exists.
         const t = await client.query(
@@ -92,7 +113,7 @@ internalRoutes.post('/activate', async (c) => {
         // activates a tenant different from the payer only for a community the payer owns; anything
         // else (including an empty payer) is refused. Omitted payer (null) means no check.
         if (payer !== null && payer !== tenant.owner) {
-          return { status: 403 };
+          return { status: 403, tenantId: tenant.id };
         }
 
         // Idempotent Pro upgrade for THIS tenant (a standard activation never touches the plan, so
@@ -126,11 +147,11 @@ internalRoutes.post('/activate', async (c) => {
             [orderId]
           );
           if (owner.rows[0]?.tenant_id !== tenant.id) {
-            return { status: 409 };
+            return { status: 409, tenantId: tenant.id };
           }
           // Genuine replay of this tenant's order: re-apply the upgrade idempotently (self-heal
           // after a staggered deploy) without re-extending the term.
-          return { status: 200, duplicate: true, plan: await applyPlan() };
+          return { status: 200, tenantId: tenant.id, duplicate: true, plan: await applyPlan() };
         }
 
         const effectivePlan = await applyPlan();
@@ -158,7 +179,7 @@ internalRoutes.post('/activate', async (c) => {
           `UPDATE payments SET processed_at = NOW(), subscription_extended_to = $2 WHERE trx_id = $1`,
           [orderId, newExpiry]
         );
-        return { status: 200, expiresAt: newExpiry, plan: effectivePlan };
+        return { status: 200, tenantId: tenant.id, expiresAt: newExpiry, plan: effectivePlan };
       }
     );
 
@@ -166,14 +187,32 @@ internalRoutes.post('/activate', async (c) => {
       // The paying account does not own this tenant: terminal for the caller. Distinguished from the
       // secret-misconfig 403 (returned at the top, before any processing) by this error body, which
       // the caller matches to treat ownership denial as terminal.
+      auditInternal(c, result.tenantId, 'tenant.activation_denied', {
+        username,
+        payer,
+        orderId,
+        reason: 'payer_not_owner',
+      });
       return c.json({ error: 'payer_not_owner' }, 403);
     }
     if (result.status === 404) {
+      auditInternal(c, null, 'tenant.activation_denied', {
+        username,
+        payer,
+        orderId,
+        reason: 'tenant_not_found',
+      });
       return c.json({ error: 'tenant_not_found' }, 404);
     }
     if (result.status === 409) {
       // The order id is already recorded against a DIFFERENT tenant -- a collision/misroute.
       // Surface it (the caller treats non-200/404 as retryable + alerts) rather than mutate.
+      auditInternal(c, result.tenantId, 'tenant.activation_denied', {
+        username,
+        payer,
+        orderId,
+        reason: 'order_tenant_mismatch',
+      });
       return c.json({ error: 'order_tenant_mismatch' }, 409);
     }
 
@@ -190,6 +229,20 @@ internalRoutes.post('/activate', async (c) => {
     } else if (!result.duplicate) {
       throw new Error(`Activated tenant ${username} is not active for config generation`);
     }
+
+    // Logged only once the activation is fully delivered (config published), so the trail cannot
+    // claim an activation that the retryable throws above turned into a 500.
+    auditInternal(c, result.tenantId ?? tenant.id, 'tenant.activated', {
+      username,
+      payer,
+      orderId,
+      months,
+      amountUsd,
+      plan: result.plan,
+      requestedPlan: plan,
+      duplicate: !!result.duplicate,
+      rail: 'card',
+    });
 
     // Echo the tenant's ACTUAL plan so the caller (ePoints) can confirm the Pro tier was honored.
     // Truthful on replays too (the upgrade is idempotent); an older service that ignores `plan`
@@ -246,6 +299,8 @@ internalRoutes.post('/domain', async (c) => {
   await DomainService.createVerification(username, domain);
   const value = `${username}.${baseDomain}`;
 
+  auditInternal(c, tenant.id, 'domain.added', { domain, username, via: 'internal' });
+
   // The record NAME must be the domain itself: verification resolves the domain's CNAME
   // (and serving requires it too). The internal verification token is bookkeeping only;
   // surfacing it as the record name produced instructions that could never verify.
@@ -298,6 +353,13 @@ internalRoutes.post('/domain/verify', async (c) => {
   await TenantService.verifyCustomDomain(username);
   await DomainService.markVerified(username, tenant.customDomain);
   addVerifiedDomainOrigin(tenant.customDomain);
+
+  auditInternal(c, tenant.id, 'domain.verified', {
+    domain: tenant.customDomain,
+    username,
+    via: 'internal',
+  });
+
   return c.json({ verified: true }, 200);
 });
 
@@ -405,6 +467,15 @@ internalRoutes.post('/claim-blog', async (c) => {
         console.error(`[internal/claim-blog] config generation failed for ${username}:`, err);
       }
     }
+
+    // A claim that found a live tenant is logged too: it is still a Pro member exercising the perk,
+    // and `created: false` is what distinguishes it from the grant that actually provisioned a blog.
+    auditInternal(c, tenant.id, 'tenant.pro_blog_claimed', {
+      username,
+      created: result.created,
+      plan: tenant.subscriptionPlan,
+      subscriptionStatus: tenant.subscriptionStatus,
+    });
 
     return c.json({
       tenant: {

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -241,6 +241,10 @@ internalRoutes.post('/activate', async (c) => {
       plan: result.plan,
       requestedPlan: plan,
       duplicate: !!result.duplicate,
+      // An expired/suspended duplicate is acknowledged without being reactivated, so the event
+      // carries the tenant's real status: 'active' means a blog is being served, anything else
+      // means this was a replay acknowledgment that changed nothing.
+      tenantStatus: tenant.subscriptionStatus,
       rail: 'card',
     });
 
@@ -351,14 +355,17 @@ internalRoutes.post('/domain/verify', async (c) => {
   }
 
   await TenantService.verifyCustomDomain(username);
-  await DomainService.markVerified(username, tenant.customDomain);
-  addVerifiedDomainOrigin(tenant.customDomain);
-
+  // Recorded here, not after the bookkeeping below: the tenant is already verified at this point,
+  // and the idempotent early return above means a retry would never reach a later audit call. If
+  // markVerified threw, the event would be lost permanently for a domain that IS verified.
   auditInternal(c, tenant.id, 'domain.verified', {
     domain: tenant.customDomain,
     username,
     via: 'internal',
   });
+
+  await DomainService.markVerified(username, tenant.customDomain);
+  addVerifiedDomainOrigin(tenant.customDomain);
 
   return c.json({ verified: true }, 200);
 });

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-team.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/community-card-team.tsx
@@ -26,7 +26,8 @@ export function CommunityCardTeam({ community, toggleInfo }: Props) {
             <ProfileLink username={m[0]}>
               <span className="username">{`@${m[0]}`}</span>
             </ProfileLink>
-            <ProBadge username={m[0]} className="ml-1" />
+            {/* .username carries the leading gap; the role label that follows has none. */}
+            <ProBadge username={m[0]} className="mr-1" />
             <span className="role">{m[1]}</span>
             {m[2] !== "" && <span className="extra">{m[2]}</span>}
           </div>

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-subscribers/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-subscribers/index.tsx
@@ -77,7 +77,8 @@ export function CommunitySubscribers({ community }: Props) {
                             <ProfileLink username={username}>
                               <span className="item-name notranslate">{username}</span>
                             </ProfileLink>
-                            <ProBadge username={username} className="ml-1" />
+                            {/* .item-name carries the leading gap; the reputation pill that follows has none. */}
+                            <ProBadge username={username} className="mr-1" />
                             {account?.reputation !== undefined && (
                                 <span className="item-reputation">
                           {accountReputation(account.reputation)}

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/friend-list-item.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/friends/friend-list-item.tsx
@@ -19,7 +19,8 @@ export function FriendListItem({ item }: Props) {
           <ProfileLink username={item.name}>
             <span className="item-name notranslate">{item.name}</span>
           </ProfileLink>
-          <ProBadge username={item.name} className="ml-1" />
+          {/* .item-name carries the leading gap; the reputation pill that follows has none. */}
+          <ProBadge username={item.name} className="mr-1" />
           {item?.reputation !== undefined && (
             <span className="item-reputation">{accountReputation(item.reputation)}</span>
           )}

--- a/apps/web/src/features/shared/notifications/notification-list-item.tsx
+++ b/apps/web/src/features/shared/notifications/notification-list-item.tsx
@@ -117,7 +117,9 @@ export const NotificationListItem = memo(function NotificationListItem({
       target={openLinksInNewTab ? "_blank" : undefined}
     >
       <span className="source-name">@{notification.source}</span>
-      <ProBadge username={notification.source} className="ml-1" />
+      {/* mr, not ml: .source-name already carries the leading gap, and the action text
+          ("reblogged", "replied", ...) follows immediately with no margin of its own. */}
+      <ProBadge username={notification.source} className="mr-1" />
     </ProfileLink>
   );
 


### PR DESCRIPTION
Two unrelated small fixes found while verifying a live Ecency Pro purchase.

## 1. Internal hosting endpoints wrote no audit trail

Everything under `/v1/internal` mutated tenants without an `audit_log` row. Only the user-facing signup path emitted `tenant.created`, so:

- a card-paid activation and a free Pro blog claim both left an indistinguishable `active` tenant with no record of what asked for it
- a denied activation (wrong payer, order id already recorded against another tenant, tenant gone) left nothing at all
- a real Pro claim today appeared in `tenants` with no matching audit event, reconstructable only from container logs

New events, all through the existing fire-and-forget `AuditService`:

| endpoint | event | data |
|---|---|---|
| `/activate` | `tenant.activated` | username, payer, orderId, months, amountUsd, requested vs applied plan, duplicate, `rail: card` |
| `/activate` | `tenant.activation_denied` | reason: `payer_not_owner` / `order_tenant_mismatch` / `tenant_not_found` |
| `/claim-blog` | `tenant.pro_blog_claimed` | username, `created` (distinguishes the grant that provisioned a blog from a no-op claim), plan, status |
| `/domain` | `domain.added` | domain, username, `via: internal` |
| `/domain/verify` | `domain.verified` | domain, username, `via: internal` |

The activation event is written only after the served config is published, so the trail cannot claim an activation that ended in a retryable 500. A failed audit insert still never fails the operation it describes. No schema change: `event_type` is a free-form varchar.

## 2. Pro badge sat flush against the text after it

In the notifications list the checkmark touched the action text (`@user`[badge]`reblogged post`). `.source-name` supplies the leading gap and the badge only carried `ml-1`, so nothing separated it from `.item-action`, which has no left margin. Same pattern in the community team list, community subscribers and the friends list, where a role label or reputation pill follows the badge. Swapped `ml-1` for `mr-1` at those four call sites, which leaves the badge with the same 4-6px on both sides. Call sites where the badge is last in its container, or inside a `gap-*` flex row, are untouched.

## Test plan

- `apps/self-hosted/hosting/api`: `vitest run` 115/115 pass, including 6 new cases covering the activated event's payload, both denial reasons, the missing-tenant denial, `created: true` vs `created: false` on a claim, and no audit row when publication fails. `tsc --noEmit` clean.
- `apps/web`: eslint clean on the four changed files, `vitest run src/specs/features/pro` 22/22, both icon audits pass (`icon-tsx-audit --fail`, `icon-scss-audit`).
- The badge change is CSS-only and unverifiable by tests: it needs a visual confirm on staging notifications for a Pro member.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit trail events for tenant activation, activation denials, domain changes, and blog claims.
  * Audit records now include relevant outcomes, client IP addresses, and user-agent details.

* **Bug Fixes**
  * Corrected Pro badge spacing across community, profile, and notification views for improved alignment.

* **Tests**
  * Added coverage for successful and failed activation flows, denial reasons, and blog claim outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->