### PR TITLE
docs: document htmlLimitedBots dimension in the SSR cache key

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -162,6 +162,18 @@ const config = {
     // staging (alpha) vs production. Conditionally spread for the same reason.
     ...(process.env.SENTRY_ENVIRONMENT && { SENTRY_ENVIRONMENT: process.env.SENTRY_ENVIRONMENT })
   },
+  // UAs that get metadata rendered into <head> (blocking) instead of streamed
+  // into the body. Googlebot is intentionally absent — it executes JS, and
+  // blocking would cost it the streaming TTFB win for no benefit.
+  //
+  // ⚠️ This list is MIRRORED in the origin nginx SSR cache (`$html_limited_bot`
+  // in the `proxy_cache_key`). If the two drift, cached responses get served to
+  // the wrong UA class and this setting silently stops working — the failure is
+  // invisible in dev, where nothing is cached. See docs/cache/nginx.md and
+  // issue #1257 before editing.
+  //
+  // Note: Next.js applies this as `new RegExp(htmlLimitedBots, 'i')`, so
+  // matching is case-insensitive regardless of the flags written here.
   htmlLimitedBots:
     /Mediapartners-Google|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti/,
   sassOptions: {

--- a/docs/cache/cloudflare-worker.md
+++ b/docs/cache/cloudflare-worker.md
@@ -26,6 +26,23 @@ const cacheKeyUrl =
   `https://cache.internal/${authClass}${reqUrl.pathname}${reqUrl.search}`;
 ```
 
+### Known gap: no bot-class dimension
+
+The key does **not** encode the Next.js `htmlLimitedBots` UA class, which the
+origin SSR cache does (`$html_limited_bot`, see `nginx.md`). Those crawlers get
+metadata rendered into `<head>` while everyone else gets it streamed into the
+body, so the two are genuinely different responses for the same URL.
+
+This is currently **latent, not active**: post HTML is effectively pass-through
+at the edge — `x-edge-cache` is MISS even on repeat requests to clean, cacheable
+URLs, and the origin cache status advances on every request, which it could not
+do if the standard-cache subfetch were absorbing them. The origin key is the one
+that decides, and it does account for bot class.
+
+**If edge HTML caching is ever made to actually hit, this key must gain the same
+dimension first**, or browser-primed edge entries will be served to crawlers and
+the origin-side split becomes unreachable. See issue #1257.
+
 `active_user` cookie presence determines auth-class. Neither the cookie's
 value nor any other cookie is part of the key — empirical analysis confirmed
 that SSR is auth-class-equivalent (same for any logged-in user) on every

--- a/docs/cache/nginx.md
+++ b/docs/cache/nginx.md
@@ -26,13 +26,19 @@ proxy_cache_path /var/cache/nginx/ssr levels=1:2
 ## Per-host config
 
 ```nginx
+# See "Why the bot UA class is in the cache key" below.
+map $http_user_agent $html_limited_bot {
+  default "";
+  "~*(Mediapartners-Google|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti)" "|htmlbot";
+}
+
 server {
   listen 80;
-  server_name eu.ecency.com;  # or us / asia per host
+  server_name eu.ecency.com;  # or us per host
 
   location / {
     proxy_cache                  ssrcache;
-    proxy_cache_key              "$request_uri";
+    proxy_cache_key              "$request_uri$html_limited_bot";
     # Defer to origin Cache-Control. Fallback for responses without it.
     proxy_cache_valid            200 0;
     proxy_cache_valid            any 30s;
@@ -57,6 +63,41 @@ server {
   }
 }
 ```
+
+## Why the bot UA class is in the cache key
+
+`htmlLimitedBots` in `apps/web/next.config.js` makes Next.js render metadata
+(title, description, og:*, canonical) into `<head>` for crawlers that do not
+execute JavaScript. Every other client gets **streaming metadata**, where those
+tags are emitted far down the body instead. Googlebot is deliberately *not* on
+the list, because it renders JS.
+
+That means one URL has two legitimate response shapes. Keying the SSR cache on
+`$request_uri` alone let them share a single entry — and since real users vastly
+outnumber crawlers, the streamed variant is the one that got stored and then
+served to the very bots the setting exists for. `htmlLimitedBots` was effectively
+inert. It also failed the other way: a bot-primed entry served `<head>` metadata
+to browsers.
+
+`$html_limited_bot` splits them into two namespaces.
+
+Notes for anyone touching this:
+
+- **The default must stay empty.** Non-bot keys are then byte-identical to the
+  old key, so deploying the change does not invalidate the existing cache or
+  stampede the origin.
+- **The match must be case-insensitive** (`~*`). Next.js rebuilds the pattern as
+  `new RegExp(htmlLimitedBots, 'i')`, so it matches lowercase `bingbot` no matter
+  what flags the config regex carries. A case-sensitive match here would put
+  `bingbot` and `Bingbot` in one namespace while Next.js treated them as
+  different, reintroducing the bug for whichever spelling lost the race.
+- **The UA list is duplicated** between `next.config.js` and this nginx map. The
+  config is the source of truth; keep them in sync.
+- **Do not "simplify" this by making metadata blocking for everyone.** Blocking
+  delays the first byte until `generateMetadata` resolves. Measured on cold
+  renders that is hundreds of milliseconds to several seconds, versus tens of
+  milliseconds when streaming. TTFB is the dominant term in content-page LCP, so
+  the one-line version of this fix is a significant real-user regression.
 
 ## Why no cookie in cache key
 


### PR DESCRIPTION
Docs-only follow-up to #1257. No runtime behaviour changes.

The origin SSR cache keyed only on `$request_uri`, so the two legitimate response shapes for a URL — metadata in `<head>` for `htmlLimitedBots` UAs, streamed into the body for everyone else — shared one cache entry. Real traffic dominates, so the streamed variant is what got stored and then served to the crawlers the setting exists for, leaving `htmlLimitedBots` inert. It failed the other way too: a bot-primed entry served `<head>` metadata to browsers.

The origin config has been updated separately. This PR records the reasoning so it survives.

- `docs/cache/nginx.md` — show `$html_limited_bot` in the cache key and the map that produces it, plus the two constraints that make it correct: the default must stay empty (otherwise deploying it invalidates the whole HTML cache at once and stampedes the origin), and the match must be case-insensitive because Next.js recompiles the pattern as `new RegExp(htmlLimitedBots, 'i')` — real Bingbot sends lowercase `bingbot`.
- `apps/web/next.config.js` — comment marking the list as mirrored at the cache layer. Worth flagging loudly because the failure mode is invisible in dev, where nothing is cached.

Also documented as a non-fix: widening `htmlLimitedBots` to match every UA is a one-line correctness fix but makes metadata blocking for real users. Measured on cold renders, blocking TTFB is hundreds of milliseconds to several seconds versus tens of milliseconds streaming, and TTFB dominates content-page LCP.

Googlebot is unaffected throughout — it is deliberately excluded from the list because it renders JS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSR caching to distinguish responses for different bot user-agent categories.
  * Prevented cached content generated for one bot type from being incorrectly served to another request.

* **Documentation**
  * Added guidance on bot detection, cache-key behavior, case-insensitive matching, and keeping configuration synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->