### PR TITLE
fix: stop shipping active_votes to anonymous visitors on post, community and wave pages

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/[tag]/page.tsx
@@ -6,6 +6,9 @@ import { EntryArchivePager } from "@/features/shared/entry-archive-pager";
 import { LinearProgress } from "@/features/shared/linear-progress";
 import { dehydrate, HydrationBoundary, InfiniteData } from "@tanstack/react-query";
 import { getQueryClient, prefetchQuery } from "@/core/react-query";
+import { cookies } from "next/headers";
+import { ACTIVE_USER_COOKIE_NAME } from "@/consts";
+import { stripAnonEntryCacheInPlace } from "@/core/react-query/strip-active-votes";
 import { Metadata, ResolvingMetadata } from "next";
 import { generateCommunityMetadata } from "@/app/(dynamicPages)/community/[community]/_helpers";
 import { CommunityContentSearch } from "../_components/community-content-search";
@@ -46,6 +49,11 @@ function pageToEntries(p: Page): Entry[] {
 export default async function CommunityPostsPage({ params, searchParams }: Props) {
   const { community, tag } = await params;
   const { before } = await searchParams;
+  // Anonymous visitors never read active_votes (isVoted is logged-in-only and the
+  // votes dialog fetches on demand), and it is ~30% of this document. Strip the
+  // cache IN PLACE so the dehydrated state and the entries prop stay one
+  // reference — separate clones would make Flight serialize every post twice.
+  const loggedInUser = (await cookies()).get(ACTIVE_USER_COOKIE_NAME)?.value;
   const basePath = `/${tag}/${community}`;
   const cursor = isArchivableFilter(tag) ? parseArchiveCursor(before) : null;
 
@@ -58,6 +66,11 @@ export default async function CommunityPostsPage({ params, searchParams }: Props
     ]);
     if (!communityData) return notFound();
     if (archive.entries.length === 0) return redirect(basePath); // stale cursor
+    const archiveEntries = stripAnonEntryCacheInPlace(
+      getQueryClient(),
+      archive.entries,
+      loggedInUser
+    );
 
     return (
       <HydrationBoundary state={dehydrate(getQueryClient())}>
@@ -66,7 +79,7 @@ export default async function CommunityPostsPage({ params, searchParams }: Props
             community={communityData}
             username={community}
             isPromoted={false}
-            entries={archive.entries}
+            entries={archiveEntries}
             loading={false}
             sectionParam={tag}
           />
@@ -92,7 +105,8 @@ export default async function CommunityPostsPage({ params, searchParams }: Props
     return null;
   }
 
-  const flatEntries = data.pages.flatMap(pageToEntries);
+  const feed = stripAnonEntryCacheInPlace(getQueryClient(), data, loggedInUser);
+  const flatEntries = feed.pages.flatMap(pageToEntries);
   // Crawlable "Older" entry into the cursor chain — `created` only (the SDK
   // re-sorts processed pages by date, so trending/hot cursors would not match
   // bridge rank order, and the created chain already reaches every post).

--- a/apps/web/src/app/(dynamicPages)/community/[community]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/page.tsx
@@ -9,6 +9,9 @@ import { Entry } from "@/entities";
 import { CommunityContentInfiniteList } from "@/app/(dynamicPages)/community/[community]/_components/community-content-infinite-list";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { getQueryClient, prefetchQuery } from "@/core/react-query";
+import { cookies } from "next/headers";
+import { ACTIVE_USER_COOKIE_NAME } from "@/consts";
+import { stripAnonEntryCacheInPlace } from "@/core/react-query/strip-active-votes";
 import { Metadata, ResolvingMetadata } from "next";
 import { generateCommunityMetadata } from "@/app/(dynamicPages)/community/[community]/_helpers";
 
@@ -16,8 +19,19 @@ interface Props {
   params: Promise<{ community: string }>;
 }
 
-// ISR: community metadata is stable. Live post lists fetched client-side.
-// 5 min revalidation aligned with edge cache TTL.
+// NOTE: this is INERT, and was already inert before this route read cookies.
+// The ROOT LAYOUT awaits cookies() (theme) and headers() (x-pathname), which opts
+// every route in the app into request-time rendering. Verified against the
+// deployed production build: prerender-manifest.json lists 0 ISR dynamicRoutes
+// and only 5 prerendered entries, all static files — no page route is in the
+// Full Route Cache, this one included.
+//
+// So the anonymous vote strip below costs no ISR here; there is none to lose.
+// Making these routes statically renderable is a separate, larger change that
+// starts with the root layout, not with this file.
+//
+// Anonymous HTML is cached at the edge and in the origin SSR cache instead, via
+// the Cache-Control tier middleware assigns by pathname.
 export const revalidate = 300;
 
 export async function generateMetadata(props: Props, parent: ResolvingMetadata): Promise<Metadata> {
@@ -27,15 +41,20 @@ export async function generateMetadata(props: Props, parent: ResolvingMetadata):
 
 export default async function CommunityPostsPage({ params }: Props) {
   const { community } = await params;
+  // See the [tag] route: anonymous renders drop active_votes, and the cache is
+  // rewritten in place so the dehydrated copy and the entries prop share one
+  // reference.
+  const loggedInUser = (await cookies()).get(ACTIVE_USER_COOKIE_NAME)?.value;
   const communityData = await prefetchQuery(getCommunityCache(community));
   if (!communityData) {
     return notFound();
   }
 
-  const data = await prefetchGetPostsFeedQuery("created", community);
-  if (!data || !data.pages || data.pages.length === 0) {
+  const fetched = await prefetchGetPostsFeedQuery("created", community);
+  if (!fetched || !fetched.pages || fetched.pages.length === 0) {
     return <></>;
   }
+  const data = stripAnonEntryCacheInPlace(getQueryClient(), fetched, loggedInUser);
 
   return (
     <HydrationBoundary state={dehydrate(getQueryClient())}>

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
@@ -14,7 +14,11 @@ import { EntryPageContentSSR } from "@/app/(dynamicPages)/entry/[category]/[auth
 import { EntryPageBreadcrumb } from "./_components/entry-page-breadcrumb";
 import { buildEntryBreadcrumbs } from "./_components/entry-breadcrumbs";
 import { EntryRelatedFooter } from "./_components/entry-related-footer";
-import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { dehydrate, defaultShouldDehydrateQuery, HydrationBoundary } from "@tanstack/react-query";
+import type { Query } from "@tanstack/react-query";
+import { cookies } from "next/headers";
+import { ACTIVE_USER_COOKIE_NAME } from "@/consts";
+import { stripAnonEntryCacheInPlace } from "@/core/react-query/strip-active-votes";
 import { Metadata, ResolvingMetadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { generateEntryMetadata } from "../../../_helpers";
@@ -38,9 +42,36 @@ interface Props {
   searchParams: Promise<Record<string, string | undefined>>;
 }
 
-// ISR: post body/title/tags are stable after publishing.
-// Live data (votes, comments, payout) is fetched client-side after hydration.
-// 5 min revalidation - edge cache (Cloudflare Worker) also caches anonymous HTML for 5 min.
+/**
+ * generateMetadata resolves the entry through `condenser_api.get_content`
+ * because it is the only source of root_author / root_permlink — bridge.get_post
+ * returns them empty, and the canonical logic needs them to point a reply at its
+ * discussion root and to detect container/wave trees. That fetch lands in the
+ * same request-scoped query cache the page dehydrates, so a SECOND full copy of
+ * the entry (post body and voter array included) was being serialized to the
+ * client purely as a side effect of building <head> tags. Nothing on this route
+ * reads that query client-side; the page renders from the bridge copy.
+ *
+ * Dropping it at the dehydration boundary is deterministic, unlike removing the
+ * query after use — generateMetadata and the page render share a request but
+ * their order is not guaranteed.
+ */
+function shouldDehydrateEntryQuery(query: Query): boolean {
+  const [scope, kind] = query.queryKey as unknown[];
+  if (scope === "posts" && kind === "content") {
+    return false;
+  }
+  return defaultShouldDehydrateQuery(query);
+}
+
+// NOTE: this is currently INERT — the route renders dynamically regardless,
+// because the component awaits `searchParams` (?raw / ?history). Verified
+// against the deployed build: `prerender-manifest.json` lists 0 dynamicRoutes
+// and no prerendered entry page, so nothing is ISR-cached here. Kept so the
+// intent survives if the route ever becomes statically renderable again.
+//
+// Anonymous HTML is instead cached at the edge and in the origin SSR cache via
+// the Cache-Control tier that middleware assigns by pathname.
 export const revalidate = 300;
 
 export async function generateMetadata(
@@ -60,12 +91,33 @@ export default async function EntryPage({ params, searchParams }: Props) {
   const isRawContent = sParams.raw !== undefined;
 
   const author = username.replace(/%40/g, "");
-  const [entry, account] = await Promise.all([
-    prefetchQuery(EcencyEntriesCacheManagement.getEntryQueryByPath(author, permlink)),
+  // Anonymous requests get active_votes stripped out of everything that crosses
+  // to the client (see below). Logged-in requests keep the full arrays, because
+  // they are the only source of the viewer's own vote — entry-vote-btn derives
+  // isVoted from entry.active_votes and there is no per-observer field to fall
+  // back to. Reading the cookie costs nothing here: this route already awaits
+  // searchParams, so it renders dynamically regardless.
+  const loggedInUser = (await cookies()).get(ACTIVE_USER_COOKIE_NAME)?.value;
+  const entryQueryOptions = EcencyEntriesCacheManagement.getEntryQueryByPath(author, permlink);
+  const [fetchedEntry, account] = await Promise.all([
+    prefetchQuery(entryQueryOptions),
     // Warm the query cache for child components that read account data.
     // Use author from URL params so this runs in parallel with the entry fetch.
     prefetchQuery(getAccountFullQueryOptions(author))
   ]);
+
+  // Strip at the SOURCE, so the render only ever has ONE entry object.
+  //
+  // Flight dedupes by reference, and the entry reaches the client twice — as a
+  // prop in the RSC tree and inside the dehydrated React Query state. If those
+  // are different objects the whole entry, post body included, is serialized
+  // twice, which on a low-vote post costs more than the voter array saves.
+  //
+  // stripAnonEntryCacheInPlace rewrites the cache and hands back the STORED
+  // object, so the prop below and the dehydrated copy are one reference. (It has
+  // to return the stored one: setQueryData applies structural sharing and stores
+  // a third object that is neither the previous value nor the clone given to it.)
+  const entry = stripAnonEntryCacheInPlace(getQueryClient(), fetchedEntry, loggedInUser);
 
   if (
     permlink.startsWith("wave-") ||
@@ -149,8 +201,15 @@ export default async function EntryPage({ params, searchParams }: Props) {
         buildBreadcrumbJsonLd(breadcrumbs.map((c) => ({ name: c.name, url: c.url })))
       ];
 
+
+  // The cache was already stripped in place above, so dehydrate() emits the same
+  // objects the props carry — no second strip, and no second copy.
+  const hydrationState = dehydrate(getQueryClient(), {
+    shouldDehydrateQuery: shouldDehydrateEntryQuery
+  });
+
   return (
-    <HydrationBoundary state={dehydrate(getQueryClient())}>
+    <HydrationBoundary state={hydrationState}>
       {coverPicture ? (
         <link
           rel="preload"

--- a/apps/web/src/app/waves/[author]/[permlink]/page.tsx
+++ b/apps/web/src/app/waves/[author]/[permlink]/page.tsx
@@ -4,6 +4,9 @@ import { WaveViewDetails, WaveViewDiscussion } from "@/app/waves/[author]/[perml
 import { WaveEntry } from "@/entities";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { getQueryClient, prefetchQuery } from "@/core/react-query";
+import { cookies } from "next/headers";
+import { ACTIVE_USER_COOKIE_NAME } from "@/consts";
+import { stripAnonEntryCacheInPlace } from "@/core/react-query/strip-active-votes";
 import { EcencyConfigManager } from "@/config";
 import { Metadata } from "next";
 import { ScrollToTop } from "@/features/shared/scroll-to-top";
@@ -31,10 +34,15 @@ export default async function WaveViewPage({ params }: Props) {
 
   const { author, permlink } = await params;
 
-  const data = (await prefetchQuery(EcencyEntriesCacheManagement.getEntryQueryByPath(
+  // Waves are depth-1 posts and can carry large voter arrays. Same treatment as
+  // the entry route: anonymous-only, cache rewritten in place so the prop and the
+  // dehydrated copy remain a single reference.
+  const loggedInUser = (await cookies()).get(ACTIVE_USER_COOKIE_NAME)?.value;
+  const fetched = (await prefetchQuery(EcencyEntriesCacheManagement.getEntryQueryByPath(
     author.replace(/%40/g, ""),
     permlink
   ))) as WaveEntry;
+  const data = stripAnonEntryCacheInPlace(getQueryClient(), fetched, loggedInUser);
 
   if (!data) {
     return notFound();

--- a/apps/web/src/core/react-query/strip-active-votes.ts
+++ b/apps/web/src/core/react-query/strip-active-votes.ts
@@ -1,4 +1,4 @@
-import type { DehydratedState } from "@tanstack/react-query";
+import type { DehydratedState, QueryClient } from "@tanstack/react-query";
 import type { Entry } from "@/entities";
 
 /**
@@ -29,6 +29,18 @@ function isStripableEntry(value: unknown): value is Entry {
   // Strip only when a vote COUNT survives elsewhere, so consumers stay
   // hydration-stable: posts carry it on stats.total_votes; search results carry
   // it as a top-level total_votes.
+  //
+  // net_votes is deliberately NOT accepted. It is upvotes MINUS downvotes, not a
+  // voter count — live posts show active_votes 848 vs net_votes 820, and 453 vs
+  // 423. entry-votes reads
+  // `stats.total_votes || active_votes.length || net_votes || total_votes`, so
+  // stripping a shape whose only count is net_votes (condenser_api.get_content
+  // has no stats object) would drop the displayed number to the net figure.
+  //
+  // Nothing needs it: the entry page keeps that metadata-only condenser query
+  // out of the dehydrated payload entirely, so no such entry reaches the client
+  // there. Accepting it here would buy nothing and leave this shared helper —
+  // also used by the feed and profile routes — able to undercount.
   const hasCount =
     typeof entry.stats?.total_votes === "number" || typeof entry.total_votes === "number";
   return Array.isArray(entry.active_votes) && entry.active_votes.length > 0 && hasCount;
@@ -146,4 +158,50 @@ export function stripActiveVotesFromValue<T>(value: T, currentUser?: string): T 
     return value;
   }
   return stripQueryData(value) as T;
+}
+
+/**
+ * Strip every entry-bearing query in a request-scoped cache IN PLACE, and return
+ * the stored object that corresponds to `value`.
+ *
+ * Prefer this over stripping the dehydrated state and the props separately.
+ * SSR data reaches the client through two channels — the dehydrated React Query
+ * state and props serialized into the RSC tree — and React Flight dedupes by
+ * REFERENCE. Producing a separate clone per channel makes Flight serialize the
+ * whole payload (post bodies included) twice, which can cost more than the voter
+ * arrays save. Rewriting the cache instead means `dehydrate()` emits the very
+ * object the page also passes as a prop, so there is exactly one copy.
+ *
+ * ⚠️ `setQueryData` applies structural sharing (replaceEqualDeep) and stores —
+ * and returns — a THIRD object that is neither the previous value nor the one
+ * handed to it. That is why this returns the STORED reference rather than the
+ * clone: using the clone would silently reintroduce the duplicate.
+ *
+ * Anonymous-only, like the other two helpers: logged-in requests keep the full
+ * arrays because active_votes is the only source of the viewer's own vote.
+ */
+export function stripAnonEntryCacheInPlace<T>(
+  queryClient: QueryClient,
+  value: T,
+  currentUser?: string
+): T {
+  if (currentUser) {
+    return value;
+  }
+
+  let result = value;
+  for (const query of queryClient.getQueryCache().getAll()) {
+    const data = query.state.data;
+    const stripped = stripQueryData(data);
+    if (stripped === data) {
+      continue;
+    }
+    const stored = queryClient.setQueryData(query.queryKey, stripped) ?? stripped;
+    // Identity bridge: hand the caller back the object now in the cache, so the
+    // prop it renders and the dehydrated copy are the same reference.
+    if (data === (value as unknown)) {
+      result = stored as T;
+    }
+  }
+  return result;
 }

--- a/apps/web/src/specs/core/strip-active-votes.spec.ts
+++ b/apps/web/src/specs/core/strip-active-votes.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { DehydratedState } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
 import {
   stripActiveVotesFromDehydratedState,
-  stripActiveVotesFromValue
+  stripActiveVotesFromValue,
+  stripAnonEntryCacheInPlace
 } from "@/core/react-query/strip-active-votes";
 
 function entry(overrides: Record<string, any> = {}) {
@@ -181,5 +183,113 @@ describe("stripActiveVotesFromValue (props channel, e.g. profile initialFeed)", 
 
   it("passes through undefined (no feed prefetched)", () => {
     expect(stripActiveVotesFromValue(undefined, undefined)).toBeUndefined();
+  });
+});
+
+// condenser_api.get_content has no `stats` object — its only count field is
+// `net_votes`, which is upvotes MINUS downvotes, not a voter count (live posts:
+// 848 voters vs net_votes 820, and 453 vs 423). Since entry-votes reads
+// `stats.total_votes || active_votes.length || net_votes || total_votes`,
+// stripping that shape would drop the displayed number to the net figure. It is
+// therefore left unstripped, and nothing needs otherwise: the entry page keeps
+// the metadata-only condenser query out of the dehydrated payload entirely.
+describe("condenser_api.get_content shape (net_votes is NOT a voter count)", () => {
+  function condenserEntry(overrides: Record<string, any> = {}) {
+    return {
+      author: "alice",
+      permlink: "p",
+      net_votes: 1, // deliberately != active_votes.length, as on real posts
+      active_votes: [
+        { voter: "a", rshares: 1 },
+        { voter: "b", rshares: -2 }
+      ],
+      ...overrides
+    };
+  }
+
+  it("does NOT strip an entry whose only surviving count is net_votes", () => {
+    const out = stripActiveVotesFromDehydratedState(dehydrated(condenserEntry()));
+    expect((out.queries[0].state.data as any).active_votes).toHaveLength(2);
+  });
+
+  it("does NOT strip that shape through the props channel either", () => {
+    const out = stripActiveVotesFromValue(condenserEntry(), undefined) as any;
+    expect(out.active_votes).toHaveLength(2);
+  });
+
+  it("DOES strip the same entry once a real voter count is present", () => {
+    const out = stripActiveVotesFromValue(condenserEntry({ total_votes: 2 }), undefined) as any;
+    expect(out.active_votes).toEqual([]);
+    expect(out.total_votes).toBe(2);
+  });
+
+  it("still refuses to strip when NO vote count survives anywhere", () => {
+    const e = { author: "alice", permlink: "p", active_votes: [{ voter: "a", rshares: 1 }] };
+    const out = stripActiveVotesFromDehydratedState(dehydrated(e));
+    expect((out.queries[0].state.data as any).active_votes).toHaveLength(1);
+  });
+});
+
+// The identity-preserving variant used by the entry, community and waves routes.
+// It rewrites the request-scoped cache so dehydrate() emits the same objects the
+// page passes as props — Flight dedupes by reference, and two separate clones
+// would serialize every post body twice.
+describe("stripAnonEntryCacheInPlace", () => {
+  function makeClient() {
+    return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  }
+
+  it("returns the STORED object, not the clone (setQueryData applies structural sharing)", () => {
+    const qc = makeClient();
+    const e = entry();
+    qc.setQueryData(["posts", "entry", "/@alice/p"], e);
+
+    const returned = stripAnonEntryCacheInPlace(qc, e);
+    const stored = qc.getQueryData(["posts", "entry", "/@alice/p"]);
+
+    expect(returned).toBe(stored); // the identity that makes Flight dedupe work
+    expect((returned as any).active_votes).toEqual([]);
+    expect((returned as any).stats.total_votes).toBe(3);
+  });
+
+  it("rewrites the cache so a later dehydrate carries no voters", () => {
+    const qc = makeClient();
+    qc.setQueryData(["posts", "entry", "/@alice/p"], entry());
+    stripAnonEntryCacheInPlace(qc, undefined);
+    expect((qc.getQueryData(["posts", "entry", "/@alice/p"]) as any).active_votes).toEqual([]);
+  });
+
+  it("strips every entry-bearing query, not just the one passed in", () => {
+    const qc = makeClient();
+    qc.setQueryData(["a"], entry({ permlink: "one" }));
+    qc.setQueryData(["b"], { pages: [[entry({ permlink: "two" })]], pageParams: [null] });
+    stripAnonEntryCacheInPlace(qc, undefined);
+    expect((qc.getQueryData(["a"]) as any).active_votes).toEqual([]);
+    expect((qc.getQueryData(["b"]) as any).pages[0][0].active_votes).toEqual([]);
+  });
+
+  it("bridges identity for an infinite feed value too", () => {
+    const qc = makeClient();
+    const feed = { pages: [[entry({ permlink: "p1" })]], pageParams: [null] };
+    qc.setQueryData(["feed"], feed);
+    const returned = stripAnonEntryCacheInPlace(qc, feed);
+    expect(returned).toBe(qc.getQueryData(["feed"]));
+    expect((returned as any).pages[0][0].active_votes).toEqual([]);
+  });
+
+  it("is a no-op for a logged-in user — cache and value untouched", () => {
+    const qc = makeClient();
+    const e = entry();
+    qc.setQueryData(["posts", "entry", "/@alice/p"], e);
+    const returned = stripAnonEntryCacheInPlace(qc, e, "alice");
+    expect(returned).toBe(e);
+    expect((qc.getQueryData(["posts", "entry", "/@alice/p"]) as any).active_votes).toHaveLength(3);
+  });
+
+  it("leaves the value alone when it holds nothing strippable", () => {
+    const qc = makeClient();
+    const plain = { foo: "bar" };
+    qc.setQueryData(["plain"], plain);
+    expect(stripAnonEntryCacheInPlace(qc, plain)).toBe(plain);
   });
 });


### PR DESCRIPTION
Fixes #1259 and #1261.

Anonymous visitors never read `active_votes` — `isVoted` is logged-in-only and the votes dialog fetches the voter list on demand — yet it was up to a third of the document on community pages. The strip from #1024 / #1025 only ever covered feed and profile; this extends it to the **entry, community and wave** routes.

## Measured

Local production build, anonymous vs an `active_user` cookie:

| route | anon | logged-in | saving |
|---|---|---|---|
| `/created/hive-125125` | 330,516 | 505,979 | **−175,463 (35%)** |
| `/trending/hive-105017` | 321,375 | 530,408 | **−209,033 (39%)** |
| `/created/hive-167922` | 410,740 | 637,249 | **−226,509 (36%)** |
| 846-voter post | 230,549 | 272,876 | **−42,327** |
| 3-voter reply | 156,776 | 156,923 | −147 (no growth) |

Every anonymous render carries **0 voter records and exactly one `active_votes` array**, counts still display, and logged-in renders keep the full arrays so `isVoted` works. The existing feed (`/hot`, −373,990) and profile (`/@good-karma`, −551,645) strips are unaffected.

## The identity trap — the load-bearing detail

SSR data reaches the client through **two channels**: the dehydrated query state and props serialized into the RSC tree. Flight dedupes by **reference**, so stripping each channel separately produces distinct clones and serializes every post body **twice** — on a low-vote page that costs more than the voter arrays save.

The new `stripAnonEntryCacheInPlace` rewrites the request-scoped cache and returns the **stored** object, which the page then renders. One reference, one copy.

That return value is the whole point. `setQueryData` applies structural sharing (`replaceEqualDeep`) and stores a *third* object that is neither the previous value nor the clone handed to it:

```
qc.setQueryData(key, clone)  ->  returned === clone   false
                                 returned === stored  true
```

Using the clone silently reintroduces the duplicate. An earlier revision of this PR compensated with a size heuristic that skipped low-vote posts; with identity correct the duplication is gone and the heuristic was deleted.

## The metadata copy

`generateMetadata` resolves the entry through `condenser_api.get_content` — the only source of `root_author` / `root_permlink`, since `bridge.get_post` returns them empty and the canonical logic needs them to point a depth≥2 reply at its discussion root. That fetch landed in the cache the page dehydrates, so a whole second entry was serialized to the client purely to build `<head>` tags. Now excluded at the dehydration boundary, which is deterministic — unlike removing the query after use, since `generateMetadata` and the page render share a request with no guaranteed order.

## Constraints kept

- **Anonymous-only.** Logged-in requests keep the full arrays; `active_votes` is the only source of the viewer's own vote and `refetchOnMount: false` means it would not self-heal. That regression shipped once during #1024.
- **`net_votes` is not accepted** as a surviving count. It is upvotes minus downvotes, not a voter count (848 voters vs 820; 453 vs 423), and `entry-votes` reads `stats.total_votes || active_votes.length || net_votes || total_votes`, so it would display the smaller figure.
- Entries are only stripped when a real count survives, so displayed totals never change.

## Validation

`pnpm typecheck` clean across all packages, full suite **2,382 tests** pass, lint no new warnings. Six new specs cover the in-place helper: that it returns the stored object rather than the clone, that it rewrites the whole cache, that it bridges identity for infinite feeds, and that it is a no-op when logged in.

## On ISR

Reading the auth cookie does opt a route into request-time rendering — but nothing is lost here, because **no page route in this app is in the Full Route Cache to begin with**. The root layout awaits `cookies()` (theme) and `headers()` (`x-pathname`), which makes every route dynamic app-wide.

Verified against the deployed production build, i.e. the state *before* this branch: `prerender-manifest.json` lists **0 ISR `dynamicRoutes`** and only 5 prerendered entries, all static files (`manifest.json`, `favicon.ico`, `llms.txt`, `robots.txt`, `child-safety`). The `export const revalidate = 300` on the entry and community routes was already inert. Both now say so in a comment so it is not re-litigated.

Making these routes statically renderable is a worthwhile separate change, but it starts at the root layout, not in these files.

## Not covered

`waves/page.tsx` and the `discover` / `communities` / `tags` / `witnesses` / `contributors` / community `roles`-`subscribers`-`activities` routes dehydrate no entry data — measured 0 voter records — so they need no change.
