### PR TITLE
refactor: derive the dehydration filter key from the SDK QueryKeys builder

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { prefetchQuery, getQueryClient } from "@/core/react-query";
-import { getAccountFullQueryOptions } from "@ecency/sdk";
+import { getAccountFullQueryOptions, QueryKeys } from "@ecency/sdk";
 import {
   buildPictureSources,
   buildSrcSet,
@@ -56,9 +56,33 @@ interface Props {
  * query after use — generateMetadata and the page render share a request but
  * their order is not guaranteed.
  */
+// The scope segments of a posts.content key, derived from the SDK builder itself
+// rather than assumed. Two keys are generated with different arguments and the
+// common leading segments are taken — those are exactly the parts that do NOT
+// depend on author/permlink. Nothing here hardcodes how many scope segments
+// there are or where they sit, so a reshaped key (say ["posts","v2","content",…])
+// still yields the right discriminator.
+//
+// Matching the family rather than one exact key is deliberate: generateMetadata
+// resolves the permlink with safeDecodeURIComponent().trim() while this page uses
+// the raw param, so an exact-key comparison would silently miss whenever those
+// differ and let the duplicate copy back in.
+const METADATA_CONTENT_KEY_PREFIX = (() => {
+  const a = QueryKeys.posts.content("\u0000a", "\u0000b");
+  const b = QueryKeys.posts.content("\u0000c", "\u0000d");
+  const shared: unknown[] = [];
+  for (let i = 0; i < a.length && a[i] === b[i]; i++) {
+    shared.push(a[i]);
+  }
+  return shared;
+})();
+
 function shouldDehydrateEntryQuery(query: Query): boolean {
-  const [scope, kind] = query.queryKey as unknown[];
-  if (scope === "posts" && kind === "content") {
+  const queryKey = query.queryKey as readonly unknown[];
+  const isMetadataContentQuery =
+    METADATA_CONTENT_KEY_PREFIX.length > 0 &&
+    METADATA_CONTENT_KEY_PREFIX.every((segment, index) => queryKey[index] === segment);
+  if (isMetadataContentQuery) {
     return false;
   }
   return defaultShouldDehydrateQuery(query);


### PR DESCRIPTION
Review follow-up to #1260. The fix was ready but missed that PR's merge by a few seconds, so it lands separately.

CodeRabbit flagged that `shouldDehydrateEntryQuery` matched raw `"posts"` / `"content"` literals, duplicating a key shape the SDK already owns and contradicting the guideline that `QueryKeys` from `@ecency/sdk` is the single source of truth. If the key shape ever changed, the filter would silently stop excluding the metadata-only query and the duplicate entry copy would quietly return to every anonymous post page.

Derives the scope prefix from the builder instead:

```ts
const METADATA_CONTENT_KEY_PREFIX = QueryKeys.posts.content("", "").slice(0, 2);
```

Only the first two segments are compared, since the author/permlink tail varies per request.

**Behaviourally identical** — verified against the real builder:

```
derived prefix: ["posts","content"]
real key      : ["posts","content","acidyo","wok-wok-wok-wok-wok"]  -> matches
entry key     : ["posts","entry","/@a/p"]                            -> does not match
```

`pnpm typecheck` clean across all packages, full suite 2,382 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved entry page data handling to prevent redundant metadata from being transferred during initial page loading.
  - Enhanced loading efficiency and consistency for entry content, especially when multiple related content queries are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->