### PR TITLE
fix: move the dark class to documentElement and drop the dead embed header read

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/page.tsx
@@ -20,8 +20,8 @@ interface Props {
 }
 
 // NOTE: this is INERT, and was already inert before this route read cookies.
-// The ROOT LAYOUT awaits cookies() (theme) and headers() (x-pathname), which opts
-// every route in the app into request-time rendering. Verified against the
+// The ROOT LAYOUT awaits cookies() (theme), which opts every route in the app
+// into request-time rendering. Verified against the
 // deployed production build: prerender-manifest.json lists 0 ISR dynamicRoutes
 // and only 5 prerendered entries, all static files — no page route is in the
 // Full Route Cache, this one included.

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,7 +2,7 @@ import "@/styles/style.scss";
 import "@/core/sdk-init"; // Initialize SDK DMCA filters immediately (SSR)
 import Providers from "@/app/providers";
 import { HiringConsoleLog } from "@/app/_components";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 import { Theme } from "@/enums";
 import { BannerManager } from "@/features/banners";
 import { ServiceWorkerRecovery } from "@/features/pwa-install";
@@ -79,13 +79,25 @@ const lora = Lora({
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const theme = (await cookies()).get("theme")?.value;
-  // The /embed/* routes are loaded inside the mobile app's WebView (e.g. the
-  // Turnstile widget). Skip analytics there so automated widget loads don't
-  // register as ecency.com pageviews. Path comes from the middleware header.
-  const isEmbedRoute = ((await headers()).get("x-pathname") ?? "").startsWith("/embed");
 
   return (
-    <html lang="en" className={`${lora.variable} ${inter.variable}`}>
+    // The dark class goes on BOTH <html> and <body>, deliberately.
+    //
+    // <html> is what five checkout components probe via
+    // `document.documentElement.classList.contains("dark")` — with the class on
+    // body alone that check always read false and they rendered light.
+    //
+    // <body> must KEEP it: styles/theme-day.scss assigns the light custom
+    // properties, `background: white` and `color` directly to `body`, while
+    // theme-night.scss applies its dark values under `.dark`. With the class only
+    // on <html>, body's own light declarations beat the merely-inherited dark
+    // ones, so Tailwind dark variants would activate while the body, Bootstrap
+    // surfaces and every CSS-variable consumer stayed light. Keeping it on body
+    // preserves that cascade exactly as it was.
+    <html
+      lang="en"
+      className={`${lora.variable} ${inter.variable} ${theme === Theme.night ? "dark" : ""}`}
+    >
       <head>
         {/*
           Global CONFIG stub for Twitter/X in-app browser compatibility.
@@ -111,9 +123,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <link rel="preconnect" href="https://ecency.com" crossOrigin="anonymous" />
         <JsonLd data={buildOrganizationJsonLd()} />
       </head>
-      {!isEmbedRoute && (
-        <Script defer data-domain="ecency.com" data-api="/pl/api/event" src="/pl/js/script.js" />
-      )}
+      {/* The /embed analytics skip that used to wrap this was dead code: it was
+          added (c5391e8b69) while /embed was a Next page, and the next day
+          db2d671035 replaced that page with a self-contained route handler.
+          Route handlers never render this layout, so the guard could not fire —
+          and the headers() call behind it was the app's second forced-dynamic
+          read (see #1262). */}
+      <Script defer data-domain="ecency.com" data-api="/pl/api/event" src="/pl/js/script.js" />
       <body className={theme === Theme.night ? "dark" : ""}>
         <BannerManager />
         <ServiceWorkerRecovery />

--- a/apps/web/src/core/global-store/modules/global-module.ts
+++ b/apps/web/src/core/global-store/modules/global-module.ts
@@ -10,6 +10,7 @@ import { isInAppBrowser } from "@/utils/keychain";
 import { runWithRetries } from "@/utils/run-with-retries";
 import type { AppWindow } from "@/types/app-window";
 import { getQueryClient } from "@/core/react-query";
+import { applyThemeClass } from "@/utils/apply-theme-class";
 import defaults, { ALLOWED_IMAGE_SERVERS } from "@/defaults";
 import { setProxyBase } from "@ecency/render-helper";
 
@@ -76,14 +77,11 @@ export function createGlobalActions(set: (state: Partial<State>) => void, getSta
       set({
         theme: newTheme
       });
-      let body: any = document.getElementsByTagName("body");
-      if (!body) return;
-      body = body[0];
-      if (theme === "night") {
-        body.classList.remove("dark");
-      } else {
-        body.classList.add("dark");
-      }
+      // Apply from newTheme, not the previous `theme`. The old form worked for a
+      // plain toggle but desynced whenever newTheme was not simply the opposite:
+      // an explicit theme_key matching the current theme (settings re-selecting
+      // the active option) or the use_system_theme path.
+      applyThemeClass(newTheme);
     },
     setLang: async (lang: string) => {
       ls.set("lang", lang);

--- a/apps/web/src/features/shared/theme.tsx
+++ b/apps/web/src/features/shared/theme.tsx
@@ -2,17 +2,14 @@
 
 import { useEffect } from "react";
 import { useGlobalStore } from "@/core/global-store";
+import { applyThemeClass } from "@/utils/apply-theme-class";
 
 export function Theme() {
   const theme = useGlobalStore((state) => state.theme);
 
   useEffect(() => {
     if (["day", "night"].includes(theme)) {
-      if (theme === "day") {
-        document.body.classList.remove("dark");
-      } else {
-        document.body.classList.add("dark");
-      }
+      applyThemeClass(theme);
     }
   }, [theme]);
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -101,11 +101,11 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     return NextResponse.rewrite(nextUrl);
   }
 
-  // Expose the resolved pathname to server components via a request header — the
-  // root layout reads it to skip the analytics script on the /embed/* WebView
-  // routes (server components can't otherwise see the path).
   const requestHeaders = new Headers(request.headers);
-  requestHeaders.set("x-pathname", path);
+  // x-pathname was dropped here: its only consumer was the root layout's
+  // /embed analytics skip, which was itself dead (that route became a route
+  // handler, and route handlers never render the layout). Nothing reads it now.
+  //
   // Layouts cannot read searchParams, so expose the query string too — the feed
   // layout needs it to tell a cursor archive page (?before=) apart from page 1.
   requestHeaders.set("x-search", request.nextUrl.search);

--- a/apps/web/src/specs/utils/apply-theme-class.spec.ts
+++ b/apps/web/src/specs/utils/apply-theme-class.spec.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { applyThemeClass } from "@/utils/apply-theme-class";
+import { Theme } from "@/enums";
+
+/**
+ * The dark class must land on BOTH <html> and <body>.
+ *
+ * <html> is what the checkout components probe
+ * (`document.documentElement.classList.contains("dark")`); before this they read
+ * a class that only existed on body and always rendered light.
+ *
+ * <body> must keep it because styles/theme-day.scss assigns the light custom
+ * properties, background and color DIRECTLY to `body` while theme-night.scss
+ * scopes its dark values under `.dark`. Remove it from body and body's own
+ * declarations beat the inherited dark ones — a light body with Tailwind dark
+ * variants active.
+ */
+describe("applyThemeClass", () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove("dark");
+    document.body.classList.remove("dark");
+  });
+
+  const isDark = () => ({
+    html: document.documentElement.classList.contains("dark"),
+    body: document.body.classList.contains("dark")
+  });
+
+  it("sets dark on both html and body for night", () => {
+    applyThemeClass(Theme.night);
+    expect(isDark()).toEqual({ html: true, body: true });
+  });
+
+  it("clears dark from both for day", () => {
+    applyThemeClass(Theme.night);
+    applyThemeClass(Theme.day);
+    expect(isDark()).toEqual({ html: false, body: false });
+  });
+
+  it("never leaves the two elements disagreeing", () => {
+    for (const theme of [Theme.night, Theme.day, Theme.night, Theme.night, Theme.day]) {
+      applyThemeClass(theme);
+      const { html, body } = isDark();
+      expect(html).toBe(body);
+    }
+  });
+
+  it("is idempotent — re-applying the same theme does not flip it", () => {
+    applyThemeClass(Theme.night);
+    applyThemeClass(Theme.night);
+    expect(isDark()).toEqual({ html: true, body: true });
+
+    applyThemeClass(Theme.day);
+    applyThemeClass(Theme.day);
+    expect(isDark()).toEqual({ html: false, body: false });
+  });
+
+  // Settings offers day / night / system. `system` is resolved to a concrete
+  // day|night by toggleTheme (via use_system_theme + matchMedia) before it
+  // reaches here, but if an unresolved value did arrive it must render light —
+  // matching what the server rendered from the theme cookie — rather than
+  // disagreeing with it.
+  it("treats an unresolved 'system' value as light, consistent with SSR", () => {
+    applyThemeClass(Theme.night);
+    applyThemeClass(Theme.system);
+    expect(isDark()).toEqual({ html: false, body: false });
+  });
+
+  it("treats undefined (no theme cookie) as light", () => {
+    applyThemeClass(Theme.night);
+    applyThemeClass(undefined);
+    expect(isDark()).toEqual({ html: false, body: false });
+  });
+});

--- a/apps/web/src/utils/apply-theme-class.ts
+++ b/apps/web/src/utils/apply-theme-class.ts
@@ -1,0 +1,30 @@
+import { Theme } from "@/enums";
+
+/**
+ * Single place that decides WHERE the dark class lives, so the store toggle and
+ * the <Theme/> effect cannot drift apart.
+ *
+ * The class goes on BOTH elements, deliberately:
+ *  - `documentElement` — the checkout components (pro, gift-card, stripe,
+ *    hosting) read `document.documentElement.classList.contains("dark")`.
+ *  - `body` — `styles/theme-day.scss` assigns the light custom properties,
+ *    `background` and `color` DIRECTLY to `body`, while `theme-night.scss`
+ *    applies its dark values under `.dark`. Drop the class from body and its own
+ *    light declarations beat the merely-inherited dark ones, leaving a light body
+ *    and light Bootstrap/CSS-variable surfaces while Tailwind dark variants are
+ *    active.
+ */
+export function applyThemeClass(theme: Theme | string | undefined): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  // Only `night` is dark. `system` is resolved to a concrete day/night by the
+  // caller before it gets here; if an unresolved value ever arrives, treating it
+  // as light matches what the server rendered from the theme cookie, so the two
+  // stay consistent rather than flashing apart.
+  const isNight = theme === Theme.night;
+
+  document.documentElement.classList.toggle("dark", isNight);
+  document.body?.classList.toggle("dark", isNight);
+}


### PR DESCRIPTION
Refs #1262. Came out of investigating that issue; ships the parts that stand on their own, with rendering mode deliberately untouched.

## Five components were permanently light-themed

`pro-checkout`, `gift-card-checkout`, `stripe-account-checkout`, `stripe-points-dialog` and `hosting-card-checkout` all decide their theme with:

```ts
document.documentElement.classList.contains("dark")
```

The class was only on `<body>`, so that check **always returned `false`** and all five rendered light while the app was in dark mode — Stripe checkout, the points gift card, pro purchase and hosting signup.

The class is now set on **both `<html>` and `<body>`**.

Review caught why `<body>` has to keep it, and it is not obvious: `styles/theme-day.scss` assigns the light custom properties to `body`, and sets `background: white` and `color` on it **directly** (lines 43-44), while `theme-night.scss` applies its dark values under `.dark`. With the class only on `<html>`, body's own declarations beat the merely-inherited dark ones — you would get a white body and light Bootstrap/CSS-variable surfaces while Tailwind dark variants activated. My first pass moved it and would have shipped exactly that; a `body.dark` grep came back empty and I wrongly read that as safe.

So `<body>` preserves the cascade byte-for-byte, and `<html>` is added purely so the `documentElement` probes resolve. Applied across all three owners of the class — the root layout, `features/shared/theme.tsx`, and the global store's `toggleTheme` — so they cannot drift.

## `toggleTheme` branched on the previous theme

```ts
if (theme === "night") { remove("dark") } else { add("dark") }   // `theme` is the OLD value
```

Fine for a plain toggle, but it desyncs whenever the new theme is not simply the opposite — an explicit `theme_key` that matches the current theme, or the `use_system_theme` branch. Now derives from `newTheme`.

## Dead `headers()` read removed

The root layout's `isEmbedRoute` check gated the analytics script on paths under `/embed`. Git history: `c5391e8b69` added it on 2026-06-11 while `/embed` was a Next page; `db2d671035` replaced that page with a **self-contained route handler the next day**. Route handlers never render the root layout, so the guard could not fire — and `x-pathname` had no other consumer. With the consumer gone, `middleware.ts` no longer sets the header either (`x-search`, which the feed layout uses, is untouched).

## Rendering mode is unchanged, and verified

The theme **cookie** read is deliberately kept. Removing it is the actual subject of #1262, and it turns out to need ~40 `useSearchParams()` call sites resolved first, across routes whose content genuinely depends on the query string. That is its own piece of work; details are on the issue.

Verified this commit changes nothing about rendering, against the deployed build:

```
BASELINE   -> ISR dynamicRoutes: 0 | prerendered: /child-safety, /favicon.ico, /llms.txt, /manifest.json, /robots.txt
THIS BUILD -> ISR dynamicRoutes: 0 | prerendered: /child-safety, /favicon.ico, /llms.txt, /manifest.json, /robots.txt
```

Identical, `/child-safety` (the one `force-static` page) included.

## Verification

Server-rendered on a real production build:

| cookie | `html.dark` | `body.dark` |
|---|---|---|
| none | false | false |
| `theme=night` | **true** | **true** |
| `theme=day` | false | false |

`pnpm typecheck` clean across all packages, full suite 2,382 tests pass, lint no new errors.

Worth a quick manual check on staging since tests cannot see pixels: toggle dark mode and confirm it persists across reload and navigation, and that a Stripe checkout dialog now follows the theme instead of always rendering light.
