### PR TITLE
fix(chat): keep a live ban from reactivating a deactivated account

### DIFF
--- a/apps/web/src/app/api/mattermost/bootstrap/route.ts
+++ b/apps/web/src/app/api/mattermost/bootstrap/route.ts
@@ -3,6 +3,8 @@ import { getAccountSubscriptionsQueryOptions } from "@ecency/sdk";
 import { QueryClient } from "@tanstack/react-query";
 import { Subscription } from "@/entities";
 import {
+  CHAT_BAN_PROP,
+  ChatBannedError,
   ensureCommunityChannelMembership,
   ensureMattermostUser,
   ensurePersonalToken,
@@ -167,6 +169,20 @@ async function handleBootstrap(req: Request, signal: AbortSignal): Promise<NextR
         // Burying it under a generic outage status here would lose that.
         if (signal.aborted || (e instanceof Error && e.name === "AbortError")) {
             throw e;
+        }
+        // A live chat ban on a deactivated account is a moderation decision,
+        // not an outage: answer 403 with the expiration so the client can say
+        // so, instead of the 502 the outage mapping would produce (which reads
+        // as "chat is down" and invites a retry loop).
+        if (e instanceof ChatBannedError) {
+            console.warn("MM bootstrap: refused to reactivate banned account", {
+              username,
+              bannedUntil: e.bannedUntil
+            });
+            return NextResponse.json(
+                { error: e.message, bannedUntil: e.bannedUntil, prop: CHAT_BAN_PROP },
+                { status: 403 }
+            );
         }
         // Don't flatten every failure to 502. A per-call timeout or upstream
         // overload is transient: returning 503/504 lets the client retry

--- a/apps/web/src/features/chat/mattermost-api.ts
+++ b/apps/web/src/features/chat/mattermost-api.ts
@@ -60,6 +60,39 @@ interface MattermostChannelSummary {
   type: string;
 }
 
+/**
+ * A 403 from bootstrap is a decision, not a fault: it is returned for an
+ * account whose chat ban is still live. Retrying it, or re-running it on every
+ * window focus, would re-verify the token and re-fetch subscriptions for an
+ * answer that cannot change until the ban expires.
+ */
+export function isBootstrapBanError(error: unknown) {
+  return (error as { status?: number } | null)?.status === 403;
+}
+
+// `error: Error` is load-bearing: React Query infers the query's TError from
+// this predicate, and widening it to `unknown` propagates out to every consumer
+// reading `error.message`.
+export function shouldRetryBootstrap(failureCount: number, error: Error) {
+  if (isBootstrapBanError(error)) {
+    return false;
+  }
+
+  // Don't retry on auth errors after refresh attempt fails
+  const errorMessage = (error as Error)?.message?.toLowerCase() || "";
+  const isAuthError =
+    errorMessage.includes("unauthorized") ||
+    errorMessage.includes("invalid token") ||
+    errorMessage.includes("authentication required");
+
+  if (isAuthError) {
+    return false; // Don't retry auth errors
+  }
+
+  // Retry other errors (network, server issues) up to 3 times
+  return failureCount < 3;
+}
+
 export function useMattermostBootstrap(community?: string) {
   const { activeUser } = useActiveAccount();
   const username = activeUser?.username;
@@ -71,22 +104,10 @@ export function useMattermostBootstrap(community?: string) {
     enabled: Boolean(username),
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
-    refetchOnWindowFocus: true, // Auto-retry when user returns to tab
-    retry: (failureCount, error) => {
-      // Don't retry on auth errors after refresh attempt fails
-      const errorMessage = (error as Error)?.message?.toLowerCase() || "";
-      const isAuthError =
-        errorMessage.includes("unauthorized") ||
-        errorMessage.includes("invalid token") ||
-        errorMessage.includes("authentication required");
-
-      if (isAuthError) {
-        return false; // Don't retry auth errors
-      }
-
-      // Retry other errors (network, server issues) up to 3 times
-      return failureCount < 3;
-    },
+    // Auto-retry when user returns to tab. An errored query is always stale, so
+    // without the ban exemption every focus would re-run the whole bootstrap.
+    refetchOnWindowFocus: (query) => !isBootstrapBanError(query.state.error),
+    retry: shouldRetryBootstrap,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000), // Exponential backoff
     queryFn: async () => {
       let accessToken = getAccessToken(username || "");
@@ -151,7 +172,9 @@ export function useMattermostBootstrap(community?: string) {
 
       if (!res.ok) {
         const data = await safeJson<{ error?: string }>(res);
-        throw new Error(data?.error || "Unable to initialize chat");
+        throw Object.assign(new Error(data?.error || "Unable to initialize chat"), {
+          status: res.status
+        });
       }
 
       const bootstrap = (await safeJson(res)) as {

--- a/apps/web/src/features/chat/mattermost-api.ts
+++ b/apps/web/src/features/chat/mattermost-api.ts
@@ -61,13 +61,44 @@ interface MattermostChannelSummary {
 }
 
 /**
+ * How long a live ban suppresses focus refetches for. Not "forever": a
+ * moderator can lift a ban early, which only changes the answer server-side, so
+ * an open page has to look again eventually or it stays dead until reload.
+ */
+const BANNED_RECHECK_MS = 5 * 60_000;
+
+/**
  * A 403 from bootstrap is a decision, not a fault: it is returned for an
- * account whose chat ban is still live. Retrying it, or re-running it on every
- * window focus, would re-verify the token and re-fetch subscriptions for an
- * answer that cannot change until the ban expires.
+ * account whose chat ban is still live. Retrying it inside one fetch cycle
+ * cannot change the answer.
  */
 export function isBootstrapBanError(error: unknown) {
   return (error as { status?: number } | null)?.status === 403;
+}
+
+/**
+ * An errored query is always stale, so without this every focus would re-run
+ * the whole bootstrap (token verification plus a subscriptions fetch) for a
+ * banned account. Two things still have to get through: the ban expiring, which
+ * the response tells us the time of, and a moderator lifting it early, which it
+ * cannot. So suppress refetches while the ban is known to be live, resume the
+ * moment its expiry passes, and in the meantime look again occasionally.
+ */
+export function shouldRefetchBootstrapOnFocus(
+  error: unknown,
+  errorUpdatedAt: number,
+  now = Date.now()
+) {
+  if (!isBootstrapBanError(error)) {
+    return true;
+  }
+
+  const bannedUntil = (error as { bannedUntil?: number } | null)?.bannedUntil;
+  if (typeof bannedUntil === "number" && now >= bannedUntil) {
+    return true;
+  }
+
+  return now - errorUpdatedAt >= BANNED_RECHECK_MS;
 }
 
 // `error: Error` is load-bearing: React Query infers the query's TError from
@@ -104,9 +135,9 @@ export function useMattermostBootstrap(community?: string) {
     enabled: Boolean(username),
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
-    // Auto-retry when user returns to tab. An errored query is always stale, so
-    // without the ban exemption every focus would re-run the whole bootstrap.
-    refetchOnWindowFocus: (query) => !isBootstrapBanError(query.state.error),
+    // Auto-retry when user returns to tab, throttled while a ban is live.
+    refetchOnWindowFocus: (query) =>
+      shouldRefetchBootstrapOnFocus(query.state.error, query.state.errorUpdatedAt),
     retry: shouldRetryBootstrap,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000), // Exponential backoff
     queryFn: async () => {
@@ -171,9 +202,11 @@ export function useMattermostBootstrap(community?: string) {
       }
 
       if (!res.ok) {
-        const data = await safeJson<{ error?: string }>(res);
+        const data = await safeJson<{ error?: string; bannedUntil?: number }>(res);
+        // bannedUntil rides along so the ban can expire without a reload.
         throw Object.assign(new Error(data?.error || "Unable to initialize chat"), {
-          status: res.status
+          status: res.status,
+          bannedUntil: data?.bannedUntil
         });
       }
 

--- a/apps/web/src/server/mattermost.ts
+++ b/apps/web/src/server/mattermost.ts
@@ -52,6 +52,24 @@ class MattermostError extends Error {
   }
 }
 
+/**
+ * Raised when provisioning would resurrect an account that is deactivated and
+ * still chat-banned. Distinct from MattermostError so bootstrap can answer 403
+ * (a moderation decision) instead of routing it through the outage mapping,
+ * which would report a 502 and invite the client to retry.
+ */
+export class ChatBannedError extends Error {
+  readonly username: string;
+  readonly bannedUntil: number;
+
+  constructor(username: string, bannedUntil: number) {
+    super(`@${username} is banned from chat until ${new Date(bannedUntil).toISOString()}`);
+    this.name = "ChatBannedError";
+    this.username = username;
+    this.bannedUntil = bannedUntil;
+  }
+}
+
 function requireEnv(value: string | undefined, name: string) {
   if (!value) {
     throw new Error(`${name} is not configured`);
@@ -138,11 +156,29 @@ export async function reactivateMattermostUser(userId: string, signal?: AbortSig
   });
 }
 
-export async function ensureMattermostUser(username: string, signal?: AbortSignal): Promise<MattermostUser> {
+/**
+ * Deactivation alone is not a durable block: this function reactivates on the
+ * next login, so a deactivated account comes back as soon as its owner opens
+ * chat. The durable control is the chat ban prop, which survives deactivation.
+ * Refuse to reactivate while that ban is live, so a moderation action that
+ * deactivates and bans stays in effect instead of being undone by the next
+ * bootstrap.
+ */
+function assertReactivationAllowed(user: MattermostUserWithProps) {
+  const bannedUntil = isUserChatBanned(user);
+  if (bannedUntil) {
+    throw new ChatBannedError(user.username, bannedUntil);
+  }
+}
+
+export async function ensureMattermostUser(
+  username: string,
+  signal?: AbortSignal
+): Promise<MattermostUserWithProps> {
   // Step 1: Try to find existing user (only suppress 404)
-  let user: MattermostUser | null = null;
+  let user: MattermostUserWithProps | null = null;
   try {
-    user = await mmFetch<MattermostUser>(`/users/username/${encodeURIComponent(username)}`, {
+    user = await mmFetch<MattermostUserWithProps>(`/users/username/${encodeURIComponent(username)}`, {
       headers: getAdminHeaders(),
       signal
     });
@@ -157,6 +193,7 @@ export async function ensureMattermostUser(username: string, signal?: AbortSigna
   // Step 2: If found, reactivate if needed (errors surface to caller)
   if (user) {
     if (user.delete_at > 0) {
+      assertReactivationAllowed(user);
       await reactivateMattermostUser(user.id, signal);
       user.delete_at = 0;
     }
@@ -172,7 +209,7 @@ export async function ensureMattermostUser(username: string, signal?: AbortSigna
   // a 502) to the caller. Makes provisioning idempotent / race-safe.
   const email = `${username}+no-email@ecency.local`;
   try {
-    return await mmFetch<MattermostUser>(`/users`, {
+    return await mmFetch<MattermostUserWithProps>(`/users`, {
       method: "POST",
       headers: getAdminHeaders(),
       body: JSON.stringify({
@@ -189,11 +226,12 @@ export async function ensureMattermostUser(username: string, signal?: AbortSigna
       error.status === 400 &&
       error.message.includes("app.user.save.username_exists")
     ) {
-      const existing = await mmFetch<MattermostUser>(
+      const existing = await mmFetch<MattermostUserWithProps>(
         `/users/username/${encodeURIComponent(username)}`,
         { headers: getAdminHeaders(), signal }
       );
       if (existing.delete_at > 0) {
+        assertReactivationAllowed(existing);
         await reactivateMattermostUser(existing.id, signal);
         existing.delete_at = 0;
       }

--- a/apps/web/src/specs/api/mattermost-ensure-user.spec.ts
+++ b/apps/web/src/specs/api/mattermost-ensure-user.spec.ts
@@ -80,6 +80,88 @@ describe("ensureMattermostUser — idempotency / concurrent-create race", () => 
     expect(fetchMock).toHaveBeenCalledTimes(1); // no POST /users
   });
 
+  // Deactivation on its own is undone by the next login, so a moderation
+  // action that deactivates + bans used to be silently reverted here: the
+  // account came back active and held a live session, with only the post-time
+  // ban still enforcing. Reactivation must refuse while the ban is live.
+  it("refuses to reactivate a deactivated account with a live ban", async () => {
+    const { ensureMattermostUser, ChatBannedError } = await loadModule();
+    const bannedUntil = Date.now() + 60_000;
+    fetchMock.mockResolvedValueOnce(
+      resp(200, {
+        id: "u-3",
+        username: "spammer",
+        email: "s",
+        delete_at: 1700000000000,
+        props: { ecency_chat_banned_until: String(bannedUntil) }
+      })
+    );
+
+    const err = await ensureMattermostUser("spammer").catch((e) => e);
+
+    expect(err).toBeInstanceOf(ChatBannedError);
+    expect(err.bannedUntil).toBe(bannedUntil);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no PUT /active
+  });
+
+  it("reactivates once the ban has expired", async () => {
+    const { ensureMattermostUser } = await loadModule();
+    fetchMock
+      .mockResolvedValueOnce(
+        resp(200, {
+          id: "u-4",
+          username: "reformed",
+          email: "r",
+          delete_at: 1700000000000,
+          props: { ecency_chat_banned_until: String(Date.now() - 60_000) }
+        })
+      )
+      .mockResolvedValueOnce(resp(200, "")); // PUT /users/u-4/active
+
+    const user = await ensureMattermostUser("reformed");
+
+    expect(user.delete_at).toBe(0);
+    expect(fetchMock.mock.calls[1][0]).toContain("/users/u-4/active");
+  });
+
+  it("leaves a banned but still-active account alone", async () => {
+    const { ensureMattermostUser } = await loadModule();
+    fetchMock.mockResolvedValueOnce(
+      resp(200, {
+        id: "u-5",
+        username: "muted",
+        email: "m",
+        delete_at: 0,
+        props: { ecency_chat_banned_until: String(Date.now() + 60_000) }
+      })
+    );
+
+    // The ban blocks posting, not reading — bootstrap stays available.
+    const user = await ensureMattermostUser("muted");
+
+    expect(user.id).toBe("u-5");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses reactivation on the username_exists race path too", async () => {
+    const { ensureMattermostUser, ChatBannedError } = await loadModule();
+    fetchMock
+      .mockResolvedValueOnce(resp(404, "nf"))
+      .mockResolvedValueOnce(resp(400, USERNAME_EXISTS))
+      .mockResolvedValueOnce(
+        resp(200, {
+          id: "u-6",
+          username: "racer",
+          email: "r",
+          delete_at: 1700000000000,
+          props: { ecency_chat_banned_until: String(Date.now() + 60_000) }
+        })
+      );
+
+    await expect(ensureMattermostUser("racer")).rejects.toBeInstanceOf(ChatBannedError);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // no PUT /active
+  });
+
   it("still throws on non-username_exists create errors", async () => {
     const { ensureMattermostUser } = await loadModule();
     fetchMock

--- a/apps/web/src/specs/features/chat/bootstrap-retry-policy.spec.ts
+++ b/apps/web/src/specs/features/chat/bootstrap-retry-policy.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isBootstrapBanError, shouldRetryBootstrap } from "@/features/chat/mattermost-api";
+import {
+  isBootstrapBanError,
+  shouldRefetchBootstrapOnFocus,
+  shouldRetryBootstrap
+} from "@/features/chat/mattermost-api";
 
 // Bootstrap answers 403 for an account whose chat ban is still live. React
 // Query must treat that as final: the retry predicate only suppressed auth
@@ -35,5 +39,48 @@ describe("bootstrap retry policy — a ban is final, not a fault", () => {
     expect(isBootstrapBanError(new Error("network down"))).toBe(false);
     expect(isBootstrapBanError(null)).toBe(false);
     expect(shouldRetryBootstrap(0, new Error("network down"))).toBe(true);
+  });
+});
+
+// Suppressing focus refetches outright would leave an open chat page dead for
+// good: the ban expiring and a moderator lifting it early both only change the
+// answer server-side, so the page has to look again to notice either.
+describe("bootstrap focus-refetch policy — a ban must not be permanent", () => {
+  const NOW = 1_800_000_000_000;
+
+  function banError(bannedUntil?: number) {
+    return Object.assign(new Error("@spammer is banned from chat until ..."), {
+      status: 403,
+      bannedUntil
+    });
+  }
+
+  it("resumes as soon as the ban expires", () => {
+    const error = banError(NOW - 1);
+    expect(shouldRefetchBootstrapOnFocus(error, NOW - 1000, NOW)).toBe(true);
+  });
+
+  it("stays quiet on repeated focus while the ban is live", () => {
+    const error = banError(NOW + 3_600_000);
+    expect(shouldRefetchBootstrapOnFocus(error, NOW - 30_000, NOW)).toBe(false);
+  });
+
+  // Covers the moderator lifting a ban early: the client still holds the old
+  // expiry, so only an occasional recheck can discover it.
+  it("looks again occasionally so an early unban is picked up", () => {
+    const error = banError(NOW + 3_600_000);
+    expect(shouldRefetchBootstrapOnFocus(error, NOW - 5 * 60_000, NOW)).toBe(true);
+  });
+
+  it("throttles a 403 that carries no expiry rather than blocking it forever", () => {
+    const error = banError(undefined);
+    expect(shouldRefetchBootstrapOnFocus(error, NOW - 30_000, NOW)).toBe(false);
+    expect(shouldRefetchBootstrapOnFocus(error, NOW - 5 * 60_000, NOW)).toBe(true);
+  });
+
+  it("never throttles ordinary errors", () => {
+    const outage = Object.assign(new Error("chat service unavailable"), { status: 503 });
+    expect(shouldRefetchBootstrapOnFocus(outage, NOW, NOW)).toBe(true);
+    expect(shouldRefetchBootstrapOnFocus(null, NOW, NOW)).toBe(true);
   });
 });

--- a/apps/web/src/specs/features/chat/bootstrap-retry-policy.spec.ts
+++ b/apps/web/src/specs/features/chat/bootstrap-retry-policy.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { isBootstrapBanError, shouldRetryBootstrap } from "@/features/chat/mattermost-api";
+
+// Bootstrap answers 403 for an account whose chat ban is still live. React
+// Query must treat that as final: the retry predicate only suppressed auth
+// errors, so a ban would otherwise be retried three times and re-run on every
+// window focus, re-verifying the token and re-fetching subscriptions each time
+// for an answer that cannot change until the ban expires.
+
+describe("bootstrap retry policy — a ban is final, not a fault", () => {
+  it("does not retry a 403", () => {
+    const banned = Object.assign(new Error("@spammer is banned from chat until ..."), {
+      status: 403
+    });
+
+    expect(isBootstrapBanError(banned)).toBe(true);
+    expect(shouldRetryBootstrap(0, banned)).toBe(false);
+  });
+
+  it("still retries transient failures, still capped at 3", () => {
+    const outage = Object.assign(new Error("chat service unavailable"), { status: 503 });
+
+    expect(isBootstrapBanError(outage)).toBe(false);
+    expect(shouldRetryBootstrap(0, outage)).toBe(true);
+    expect(shouldRetryBootstrap(3, outage)).toBe(false);
+  });
+
+  it("still refuses to retry auth errors", () => {
+    const unauthorized = Object.assign(new Error("unauthorized"), { status: 401 });
+
+    expect(shouldRetryBootstrap(0, unauthorized)).toBe(false);
+  });
+
+  it("treats a bare error as retryable", () => {
+    expect(isBootstrapBanError(new Error("network down"))).toBe(false);
+    expect(isBootstrapBanError(null)).toBe(false);
+    expect(shouldRetryBootstrap(0, new Error("network down"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1265

`ensureMattermostUser` reactivated any deactivated account on the next Hive-proxy login, in both the lookup path and the username-exists race path, without reading the chat ban prop. A moderation action that deactivated and banned an account was undone on that account's next bootstrap: it came back active with a live session, and only the post-time ban still enforced. Observed on 2026-07-28, where a contained account opened a new session two minutes after being deactivated.

## Changes
- `ensureMattermostUser` reads the user with props and refuses reactivation while `isUserChatBanned` returns a future expiration, at both reactivation sites.
- New `ChatBannedError` carries the username and expiration. It is deliberately not a `MattermostError`, so the outage mapping cannot turn a moderation decision into a 502.
- Bootstrap answers 403 with `bannedUntil` and the prop name, matching the shape the message POST route already returns for a banned sender.
- A banned but still-active account is untouched: the ban continues to mean cannot post, not cannot read.

## Test plan
- 5 new cases in `mattermost-ensure-user.spec.ts`: live ban blocks reactivation with no PUT /active, expired ban still reactivates, banned-but-active passes through, and the username-exists race path refuses too.
- `pnpm --filter @ecency/web test` green (2386 tests), `pnpm --filter @ecency/web typecheck` clean.