### PR TITLE
feat(chat): rate-gate DM fan-out at send time

### DIFF
--- a/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
@@ -12,6 +12,7 @@ import {
   isUserChatBanned,
   CHAT_BAN_PROP
 } from "@/server/mattermost";
+import { checkDmFanout } from "@/server/chat-dm-fanout";
 
 // Prevent artificial timeout - this route should be fast now
 export const maxDuration = 60; // 60 seconds max
@@ -334,6 +335,7 @@ export async function POST(
       mmUserFetch<{
         id: string;
         username: string;
+        create_at?: number;
         props?: Record<string, string>;
       }>(`/users/me`, token),
       mmUserFetch<MattermostChannel>(`/channels/${channelIdPath}`, token)
@@ -351,6 +353,34 @@ export async function POST(
         },
         { status: 403 }
       );
+    }
+
+    // Cap how many distinct people one account can reach privately in a rolling
+    // window. Mass-DM phishing is otherwise only contained after the fact, by
+    // which point the spray has already been delivered. Public channels are not
+    // counted: the abuse pattern, and the harm, is private and one-to-one.
+    if (channel.type === "D" || channel.type === "G") {
+      const fanout = await checkDmFanout({
+        userId: currentUser.id,
+        channelId,
+        accountCreatedAt: currentUser.create_at
+      });
+
+      if (!fanout.allowed) {
+        console.warn("MM posts: DM fan-out limit reached", {
+          username: currentUser.username,
+          recipients: fanout.recipients,
+          limit: fanout.limit
+        });
+        return NextResponse.json(
+          {
+            error:
+              "You have started conversations with too many people recently. Please try again later.",
+            retryAfter: fanout.retryAfterSeconds
+          },
+          { status: 429, headers: { "Retry-After": String(fanout.retryAfterSeconds) } }
+        );
+      }
     }
 
     // DM privacy is enforced at channel creation time (/api/mattermost/direct)

--- a/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
@@ -12,7 +12,7 @@ import {
   isUserChatBanned,
   CHAT_BAN_PROP
 } from "@/server/mattermost";
-import { checkDmFanout } from "@/server/chat-dm-fanout";
+import { checkDmFanout, releaseDmFanout } from "@/server/chat-dm-fanout";
 
 // Prevent artificial timeout - this route should be fast now
 export const maxDuration = 60; // 60 seconds max
@@ -359,12 +359,27 @@ export async function POST(
     // window. Mass-DM phishing is otherwise only contained after the fact, by
     // which point the spray has already been delivered. Public channels are not
     // counted: the abuse pattern, and the harm, is private and one-to-one.
+    //
+    // A group channel consumes one slot even though a post there reaches every
+    // member. That is not a way around the cap: /api/mattermost/direct is the
+    // only channel-creation path we expose and it is strictly one-to-one, so an
+    // account cannot assemble groups to spray. Someone else has to have added
+    // them to each group first.
+    // The reservation is provisional until the post lands: releaseReservation
+    // hands the slot back on any path that does not deliver, so a rejected or
+    // failed message cannot lock a new account out for the rest of the window.
+    let releaseReservation: (() => Promise<void>) | null = null;
+
     if (channel.type === "D" || channel.type === "G") {
       const fanout = await checkDmFanout({
         userId: currentUser.id,
         channelId,
         accountCreatedAt: currentUser.create_at
       });
+
+      if (fanout.reserved) {
+        releaseReservation = () => releaseDmFanout({ userId: currentUser.id, channelId });
+      }
 
       if (!fanout.allowed) {
         console.warn("MM posts: DM fan-out limit reached", {
@@ -405,6 +420,7 @@ export async function POST(
       );
 
       if (!moderation.canModerate) {
+        await releaseReservation?.();
         return NextResponse.json(
           {
             error: "Only community moderators can mention everyone in this channel."
@@ -415,16 +431,22 @@ export async function POST(
     }
 
     // Send the message - WebSocket will handle UI updates, HTTP is for persistence
-    const post = await mmUserFetch(`/posts`, token, {
-      method: "POST",
-      body: JSON.stringify({
-        channel_id: channelId,
-        message,
-        root_id: rootId || undefined,
-        props: props || undefined,
-        pending_post_id: body.pendingPostId || `${currentUser.id}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
-      })
-    });
+    let post;
+    try {
+      post = await mmUserFetch(`/posts`, token, {
+        method: "POST",
+        body: JSON.stringify({
+          channel_id: channelId,
+          message,
+          root_id: rootId || undefined,
+          props: props || undefined,
+          pending_post_id: body.pendingPostId || `${currentUser.id}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+        })
+      });
+    } catch (error) {
+      await releaseReservation?.();
+      throw error;
+    }
 
     // --- Background tasks (non-blocking) ---
 

--- a/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
@@ -12,7 +12,7 @@ import {
   isUserChatBanned,
   CHAT_BAN_PROP
 } from "@/server/mattermost";
-import { checkDmFanout, releaseDmFanout } from "@/server/chat-dm-fanout";
+import { checkDmFanout } from "@/server/chat-dm-fanout";
 
 // Prevent artificial timeout - this route should be fast now
 export const maxDuration = 60; // 60 seconds max
@@ -355,49 +355,6 @@ export async function POST(
       );
     }
 
-    // Cap how many distinct people one account can reach privately in a rolling
-    // window. Mass-DM phishing is otherwise only contained after the fact, by
-    // which point the spray has already been delivered. Public channels are not
-    // counted: the abuse pattern, and the harm, is private and one-to-one.
-    //
-    // A group channel consumes one slot even though a post there reaches every
-    // member. That is not a way around the cap: /api/mattermost/direct is the
-    // only channel-creation path we expose and it is strictly one-to-one, so an
-    // account cannot assemble groups to spray. Someone else has to have added
-    // them to each group first.
-    // The reservation is provisional until the post lands: releaseReservation
-    // hands the slot back on any path that does not deliver, so a rejected or
-    // failed message cannot lock a new account out for the rest of the window.
-    let releaseReservation: (() => Promise<void>) | null = null;
-
-    if (channel.type === "D" || channel.type === "G") {
-      const fanout = await checkDmFanout({
-        userId: currentUser.id,
-        channelId,
-        accountCreatedAt: currentUser.create_at
-      });
-
-      if (fanout.reserved) {
-        releaseReservation = () => releaseDmFanout({ userId: currentUser.id, channelId });
-      }
-
-      if (!fanout.allowed) {
-        console.warn("MM posts: DM fan-out limit reached", {
-          username: currentUser.username,
-          recipients: fanout.recipients,
-          limit: fanout.limit
-        });
-        return NextResponse.json(
-          {
-            error:
-              "You have started conversations with too many people recently. Please try again later.",
-            retryAfter: fanout.retryAfterSeconds
-          },
-          { status: 429, headers: { "Retry-After": String(fanout.retryAfterSeconds) } }
-        );
-      }
-    }
-
     // DM privacy is enforced at channel creation time (/api/mattermost/direct)
     // No need to re-validate on every message send - improves performance significantly
 
@@ -420,7 +377,6 @@ export async function POST(
       );
 
       if (!moderation.canModerate) {
-        await releaseReservation?.();
         return NextResponse.json(
           {
             error: "Only community moderators can mention everyone in this channel."
@@ -430,23 +386,61 @@ export async function POST(
       }
     }
 
-    // Send the message - WebSocket will handle UI updates, HTTP is for persistence
-    let post;
-    try {
-      post = await mmUserFetch(`/posts`, token, {
-        method: "POST",
-        body: JSON.stringify({
-          channel_id: channelId,
-          message,
-          root_id: rootId || undefined,
-          props: props || undefined,
-          pending_post_id: body.pendingPostId || `${currentUser.id}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
-        })
+    // Cap how many distinct people one account can reach privately in a rolling
+    // window. Mass-DM phishing is otherwise only contained after the fact, by
+    // which point the spray has already been delivered. Public channels are not
+    // counted: the abuse pattern, and the harm, is private and one-to-one.
+    //
+    // This sits as late as it can, immediately before the post: everything that
+    // can reject the message has already run, so a rejected message never costs
+    // a slot. There is deliberately no compensating release afterwards. A
+    // release cannot tell its own reservation from one another in-flight
+    // request is relying on, so pairing a doomed request with a real one would
+    // delete the record of a message that did land, and repeating the pair
+    // would defeat the cap entirely. The only remaining way to hold a slot
+    // without delivering is an upstream post failure, which is rare, transient,
+    // ages out with the window, and errs on the safe side.
+    //
+    // A group channel consumes one slot even though a post there reaches every
+    // member. That is not a way around the cap: /api/mattermost/direct is the
+    // only channel-creation path we expose and it is strictly one-to-one, so an
+    // account cannot assemble groups to spray. Someone else has to have added
+    // them to each group first.
+    if (channel.type === "D" || channel.type === "G") {
+      const fanout = await checkDmFanout({
+        userId: currentUser.id,
+        channelId,
+        accountCreatedAt: currentUser.create_at
       });
-    } catch (error) {
-      await releaseReservation?.();
-      throw error;
+
+      if (!fanout.allowed) {
+        console.warn("MM posts: DM fan-out limit reached", {
+          username: currentUser.username,
+          recipients: fanout.recipients,
+          limit: fanout.limit
+        });
+        return NextResponse.json(
+          {
+            error:
+              "You have started conversations with too many people recently. Please try again later.",
+            retryAfter: fanout.retryAfterSeconds
+          },
+          { status: 429, headers: { "Retry-After": String(fanout.retryAfterSeconds) } }
+        );
+      }
     }
+
+    // Send the message - WebSocket will handle UI updates, HTTP is for persistence
+    const post = await mmUserFetch(`/posts`, token, {
+      method: "POST",
+      body: JSON.stringify({
+        channel_id: channelId,
+        message,
+        root_id: rootId || undefined,
+        props: props || undefined,
+        pending_post_id: body.pendingPostId || `${currentUser.id}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+      })
+    });
 
     // --- Background tasks (non-blocking) ---
 

--- a/apps/web/src/server/chat-dm-fanout.ts
+++ b/apps/web/src/server/chat-dm-fanout.ts
@@ -48,7 +48,47 @@ export interface DmFanoutDecision {
   limit: number;
   /** Seconds until the oldest recipient ages out. Only meaningful when blocked. */
   retryAfterSeconds: number;
+  /**
+   * True when this call added a recipient that was not already in the window.
+   * Callers pass it to `releaseDmFanout` if the send then fails, so an
+   * undelivered message does not hold a slot for the rest of the window.
+   */
+  reserved: boolean;
 }
+
+/**
+ * Trim, count and conditionally insert in one atomic step.
+ *
+ * A read pipeline followed by a separate write loses to exactly the attack
+ * this limits: fire the whole spray in parallel and every request reads a
+ * count below the cap before any of them writes, so all of them pass.
+ */
+const RESERVE_SCRIPT = `
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local windowMs = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+local member = ARGV[4]
+
+redis.call('ZREMRANGEBYSCORE', key, 0, now - windowMs)
+local known = redis.call('ZSCORE', key, member)
+local count = redis.call('ZCARD', key)
+
+if not known and count >= limit then
+  local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+  local oldestScore = -1
+  if oldest[2] then oldestScore = tonumber(oldest[2]) end
+  return {0, count, 0, oldestScore}
+end
+
+redis.call('ZADD', key, now, member)
+redis.call('PEXPIRE', key, windowMs)
+
+if known then
+  return {1, count, 0, -1}
+end
+return {1, count + 1, 1, -1}
+`;
 
 /**
  * A missing or nonsensical creation timestamp resolves to the established cap.
@@ -93,23 +133,20 @@ export function getChatRedis(): RedisClient | null {
   }
 }
 
-const ALLOW_UNMEASURED: DmFanoutDecision = {
+const ALLOW_UNMEASURED: Omit<DmFanoutDecision, "limit"> = {
   allowed: true,
   recipients: 0,
-  limit: DM_FANOUT_MAX,
-  retryAfterSeconds: 0
+  retryAfterSeconds: 0,
+  reserved: false
 };
 
-function pipelineValue(results: [Error | null, unknown][] | null, index: number) {
-  const entry = results?.[index];
-  if (!entry || entry[0]) return null;
-  return entry[1] ?? null;
-}
-
 /**
- * Records `channelId` as a recipient of `userId` and reports whether the send
+ * Reserves `channelId` as a recipient of `userId` and reports whether the send
  * may proceed. Nothing is recorded when the send is blocked, so a rejected
- * attempt does not consume a slot or extend the window.
+ * attempt neither consumes a slot nor extends the window.
+ *
+ * A reservation is provisional: call `releaseDmFanout` if the send does not go
+ * through, otherwise an undelivered message holds a slot for a full window.
  */
 export async function checkDmFanout(
   {
@@ -129,44 +166,55 @@ export async function checkDmFanout(
   if (!redis) return { ...ALLOW_UNMEASURED, limit };
 
   try {
-    const key = `${KEY_PREFIX}${userId}`;
-    const results = (await redis
-      .pipeline()
-      .zremrangebyscore(key, 0, now - DM_FANOUT_WINDOW_MS)
-      .zscore(key, channelId)
-      .zcard(key)
-      .zrange(key, 0, 0, "WITHSCORES")
-      .exec()) as [Error | null, unknown][] | null;
+    const [allowed, recipients, reserved, oldestScore] = (await redis.eval(
+      RESERVE_SCRIPT,
+      1,
+      `${KEY_PREFIX}${userId}`,
+      String(now),
+      String(DM_FANOUT_WINDOW_MS),
+      String(limit),
+      channelId
+    )) as [number, number, number, number];
 
-    // An already-counted recipient is never blocked: the cap is on how many
-    // people you reach, not on how much you say to them.
-    const known = pipelineValue(results, 1) !== null;
-    const recipients = Number(pipelineValue(results, 2) ?? 0);
-
-    if (!known && recipients >= limit) {
-      const oldest = pipelineValue(results, 3) as string[] | null;
-      const oldestScore = Number(oldest?.[1]);
-      const freesAt = Number.isFinite(oldestScore)
-        ? oldestScore + DM_FANOUT_WINDOW_MS
-        : now + DM_FANOUT_WINDOW_MS;
+    if (allowed) {
       return {
-        allowed: false,
+        allowed: true,
         recipients,
         limit,
-        retryAfterSeconds: Math.max(1, Math.ceil((freesAt - now) / 1000))
+        retryAfterSeconds: 0,
+        reserved: reserved === 1
       };
     }
 
-    await redis.pipeline().zadd(key, now, channelId).pexpire(key, DM_FANOUT_WINDOW_MS).exec();
+    const freesAt =
+      oldestScore >= 0 ? oldestScore + DM_FANOUT_WINDOW_MS : now + DM_FANOUT_WINDOW_MS;
 
     return {
-      allowed: true,
-      recipients: known ? recipients : recipients + 1,
+      allowed: false,
+      recipients,
       limit,
-      retryAfterSeconds: 0
+      retryAfterSeconds: Math.max(1, Math.ceil((freesAt - now) / 1000)),
+      reserved: false
     };
   } catch {
     // Fail open — see the module comment.
     return { ...ALLOW_UNMEASURED, limit };
+  }
+}
+
+/**
+ * Gives back a reservation whose send never landed. Only called for a
+ * newly-inserted recipient, so releasing cannot erase a conversation the
+ * sender already had inside the window.
+ */
+export async function releaseDmFanout(
+  { userId, channelId }: { userId: string; channelId: string },
+  redis: RedisClient | null = getChatRedis()
+): Promise<void> {
+  if (!redis) return;
+  try {
+    await redis.zrem(`${KEY_PREFIX}${userId}`, channelId);
+  } catch {
+    // Best effort: a stuck reservation ages out with the window.
   }
 }

--- a/apps/web/src/server/chat-dm-fanout.ts
+++ b/apps/web/src/server/chat-dm-fanout.ts
@@ -1,0 +1,172 @@
+/**
+ * Server-side DM fan-out limit for chat.
+ *
+ * Mass-DM phishing is otherwise only caught after the fact by an out-of-band
+ * monitor. That monitor deletes the messages and bans the sender, but it runs
+ * periodically, so a spray still lands in real inboxes first and cannot be
+ * recalled once a client has rendered it. This caps how many distinct people
+ * one account can open a conversation with in a rolling window: the signal
+ * every observed spray shares, and one an ordinary conversation never trips.
+ *
+ * State is a Redis sorted set per sender, holding the channel ids they have
+ * messaged, scored by send time. Re-messaging someone already inside the
+ * window is always allowed, because the cap is on distinct recipients rather
+ * than on message volume.
+ *
+ * Fails open: a Redis outage must never stop people from talking, and the
+ * monitor remains the backstop.
+ */
+import Redis, { type Redis as RedisClient } from "ioredis";
+
+const REDIS_URL = process.env.REDIS_URL || "redis://redis:6379";
+const DISABLED = !!process.env.VITEST || process.env.CHAT_DM_FANOUT_DISABLE === "1";
+
+const KEY_PREFIX = "chat:dmfanout:";
+
+function envInt(name: string, fallback: number) {
+  const parsed = Number(process.env[name]);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/** Rolling window the distinct-recipient count is measured over. */
+export const DM_FANOUT_WINDOW_MS = envInt("CHAT_DM_FANOUT_WINDOW_MIN", 60) * 60_000;
+
+/**
+ * Accounts this new to chat get the tighter cap. Every observed spray came
+ * from an account created the same day, while an established account reaching
+ * many people is usually a community organiser doing their job.
+ */
+export const DM_FANOUT_NEW_ACCOUNT_MS = envInt("CHAT_DM_FANOUT_NEW_ACCOUNT_HOURS", 24) * 3_600_000;
+
+export const DM_FANOUT_MAX_NEW = envInt("CHAT_DM_FANOUT_MAX_NEW", 5);
+export const DM_FANOUT_MAX = envInt("CHAT_DM_FANOUT_MAX", 20);
+
+export interface DmFanoutDecision {
+  allowed: boolean;
+  /** Distinct recipients already recorded in the window. */
+  recipients: number;
+  limit: number;
+  /** Seconds until the oldest recipient ages out. Only meaningful when blocked. */
+  retryAfterSeconds: number;
+}
+
+/**
+ * A missing or nonsensical creation timestamp resolves to the established cap.
+ * Treating "unknown" as new would throttle everyone to the tight limit if
+ * Mattermost ever stopped returning the field.
+ */
+export function dmFanoutLimitFor(accountCreatedAt: number | undefined, now: number) {
+  if (!accountCreatedAt || !Number.isFinite(accountCreatedAt) || accountCreatedAt > now) {
+    return DM_FANOUT_MAX;
+  }
+  return now - accountCreatedAt < DM_FANOUT_NEW_ACCOUNT_MS ? DM_FANOUT_MAX_NEW : DM_FANOUT_MAX;
+}
+
+let _redis: RedisClient | null | undefined;
+
+export function getChatRedis(): RedisClient | null {
+  if (_redis !== undefined) return _redis;
+  if (DISABLED) {
+    _redis = null;
+    return null;
+  }
+  try {
+    _redis = new Redis(REDIS_URL, {
+      lazyConnect: false,
+      maxRetriesPerRequest: 1,
+      enableOfflineQueue: false,
+      connectTimeout: 1000,
+      commandTimeout: 1000,
+      retryStrategy: (times: number) => {
+        if (times > 10) return null;
+        return Math.min(times * 500, 5000);
+      }
+    });
+    _redis.on("error", () => {}); // silent — graceful degradation
+    _redis.on("end", () => {
+      _redis = undefined; // rebuild on next access (covers redis restarts)
+    });
+    return _redis;
+  } catch {
+    _redis = null;
+    return null;
+  }
+}
+
+const ALLOW_UNMEASURED: DmFanoutDecision = {
+  allowed: true,
+  recipients: 0,
+  limit: DM_FANOUT_MAX,
+  retryAfterSeconds: 0
+};
+
+function pipelineValue(results: [Error | null, unknown][] | null, index: number) {
+  const entry = results?.[index];
+  if (!entry || entry[0]) return null;
+  return entry[1] ?? null;
+}
+
+/**
+ * Records `channelId` as a recipient of `userId` and reports whether the send
+ * may proceed. Nothing is recorded when the send is blocked, so a rejected
+ * attempt does not consume a slot or extend the window.
+ */
+export async function checkDmFanout(
+  {
+    userId,
+    channelId,
+    accountCreatedAt,
+    now = Date.now()
+  }: {
+    userId: string;
+    channelId: string;
+    accountCreatedAt?: number;
+    now?: number;
+  },
+  redis: RedisClient | null = getChatRedis()
+): Promise<DmFanoutDecision> {
+  const limit = dmFanoutLimitFor(accountCreatedAt, now);
+  if (!redis) return { ...ALLOW_UNMEASURED, limit };
+
+  try {
+    const key = `${KEY_PREFIX}${userId}`;
+    const results = (await redis
+      .pipeline()
+      .zremrangebyscore(key, 0, now - DM_FANOUT_WINDOW_MS)
+      .zscore(key, channelId)
+      .zcard(key)
+      .zrange(key, 0, 0, "WITHSCORES")
+      .exec()) as [Error | null, unknown][] | null;
+
+    // An already-counted recipient is never blocked: the cap is on how many
+    // people you reach, not on how much you say to them.
+    const known = pipelineValue(results, 1) !== null;
+    const recipients = Number(pipelineValue(results, 2) ?? 0);
+
+    if (!known && recipients >= limit) {
+      const oldest = pipelineValue(results, 3) as string[] | null;
+      const oldestScore = Number(oldest?.[1]);
+      const freesAt = Number.isFinite(oldestScore)
+        ? oldestScore + DM_FANOUT_WINDOW_MS
+        : now + DM_FANOUT_WINDOW_MS;
+      return {
+        allowed: false,
+        recipients,
+        limit,
+        retryAfterSeconds: Math.max(1, Math.ceil((freesAt - now) / 1000))
+      };
+    }
+
+    await redis.pipeline().zadd(key, now, channelId).pexpire(key, DM_FANOUT_WINDOW_MS).exec();
+
+    return {
+      allowed: true,
+      recipients: known ? recipients : recipients + 1,
+      limit,
+      retryAfterSeconds: 0
+    };
+  } catch {
+    // Fail open — see the module comment.
+    return { ...ALLOW_UNMEASURED, limit };
+  }
+}

--- a/apps/web/src/server/chat-dm-fanout.ts
+++ b/apps/web/src/server/chat-dm-fanout.ts
@@ -48,12 +48,6 @@ export interface DmFanoutDecision {
   limit: number;
   /** Seconds until the oldest recipient ages out. Only meaningful when blocked. */
   retryAfterSeconds: number;
-  /**
-   * True when this call added a recipient that was not already in the window.
-   * Callers pass it to `releaseDmFanout` if the send then fails, so an
-   * undelivered message does not hold a slot for the rest of the window.
-   */
-  reserved: boolean;
 }
 
 /**
@@ -78,16 +72,16 @@ if not known and count >= limit then
   local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
   local oldestScore = -1
   if oldest[2] then oldestScore = tonumber(oldest[2]) end
-  return {0, count, 0, oldestScore}
+  return {0, count, oldestScore}
 end
 
 redis.call('ZADD', key, now, member)
 redis.call('PEXPIRE', key, windowMs)
 
 if known then
-  return {1, count, 0, -1}
+  return {1, count, -1}
 end
-return {1, count + 1, 1, -1}
+return {1, count + 1, -1}
 `;
 
 /**
@@ -136,17 +130,19 @@ export function getChatRedis(): RedisClient | null {
 const ALLOW_UNMEASURED: Omit<DmFanoutDecision, "limit"> = {
   allowed: true,
   recipients: 0,
-  retryAfterSeconds: 0,
-  reserved: false
+  retryAfterSeconds: 0
 };
 
 /**
- * Reserves `channelId` as a recipient of `userId` and reports whether the send
+ * Records `channelId` as a recipient of `userId` and reports whether the send
  * may proceed. Nothing is recorded when the send is blocked, so a rejected
  * attempt neither consumes a slot nor extends the window.
  *
- * A reservation is provisional: call `releaseDmFanout` if the send does not go
- * through, otherwise an undelivered message holds a slot for a full window.
+ * Recording is final. There is no compensating release, because a release
+ * cannot distinguish its own record from one a concurrent request is relying
+ * on: pairing a doomed request with a real one would delete the record of a
+ * message that did land. Callers instead run this as late as possible, once
+ * nothing but the upstream post can still fail.
  */
 export async function checkDmFanout(
   {
@@ -166,7 +162,7 @@ export async function checkDmFanout(
   if (!redis) return { ...ALLOW_UNMEASURED, limit };
 
   try {
-    const [allowed, recipients, reserved, oldestScore] = (await redis.eval(
+    const [allowed, recipients, oldestScore] = (await redis.eval(
       RESERVE_SCRIPT,
       1,
       `${KEY_PREFIX}${userId}`,
@@ -174,16 +170,10 @@ export async function checkDmFanout(
       String(DM_FANOUT_WINDOW_MS),
       String(limit),
       channelId
-    )) as [number, number, number, number];
+    )) as [number, number, number];
 
     if (allowed) {
-      return {
-        allowed: true,
-        recipients,
-        limit,
-        retryAfterSeconds: 0,
-        reserved: reserved === 1
-      };
+      return { allowed: true, recipients, limit, retryAfterSeconds: 0 };
     }
 
     const freesAt =
@@ -193,28 +183,10 @@ export async function checkDmFanout(
       allowed: false,
       recipients,
       limit,
-      retryAfterSeconds: Math.max(1, Math.ceil((freesAt - now) / 1000)),
-      reserved: false
+      retryAfterSeconds: Math.max(1, Math.ceil((freesAt - now) / 1000))
     };
   } catch {
     // Fail open — see the module comment.
     return { ...ALLOW_UNMEASURED, limit };
-  }
-}
-
-/**
- * Gives back a reservation whose send never landed. Only called for a
- * newly-inserted recipient, so releasing cannot erase a conversation the
- * sender already had inside the window.
- */
-export async function releaseDmFanout(
-  { userId, channelId }: { userId: string; channelId: string },
-  redis: RedisClient | null = getChatRedis()
-): Promise<void> {
-  if (!redis) return;
-  try {
-    await redis.zrem(`${KEY_PREFIX}${userId}`, channelId);
-  } catch {
-    // Best effort: a stuck reservation ages out with the window.
   }
 }

--- a/apps/web/src/specs/api/mattermost-dm-fanout-ordering.spec.ts
+++ b/apps/web/src/specs/api/mattermost-dm-fanout-ordering.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The fan-out record is final: there is no compensating release, because a
+// release cannot tell its own record from one a concurrent request is relying
+// on. What keeps a rejected message from costing a slot is therefore ordering,
+// not compensation, and ordering is only visible from the route. These pin it.
+
+const mockMmUserFetch = vi.fn();
+const mockCheckDmFanout = vi.fn();
+const mockModerationContext = vi.fn();
+
+vi.mock("@/server/mattermost", () => ({
+  CHAT_BAN_PROP: "ecency_chat_banned_until",
+  ensureMattermostUser: vi.fn(),
+  ensureUserInChannel: vi.fn(),
+  ensureUserInTeam: vi.fn(),
+  followMattermostThreadForUser: vi.fn(),
+  getMattermostCommunityModerationContext: (...args: unknown[]) => mockModerationContext(...args),
+  getMattermostTokenFromCookies: () => Promise.resolve("test-token"),
+  handleMattermostError: () => ({ status: 500 }),
+  isUserChatBanned: () => null,
+  mmUserFetch: (...args: unknown[]) => mockMmUserFetch(...args)
+}));
+
+vi.mock("@/server/chat-dm-fanout", () => ({
+  checkDmFanout: (...args: unknown[]) => mockCheckDmFanout(...args)
+}));
+
+const CHANNEL_ID = "dm-channel";
+
+function request(message: string) {
+  return {
+    json: async () => ({ message })
+  } as never;
+}
+
+const params = { params: Promise.resolve({ channelId: CHANNEL_ID }) };
+
+function allowFanout() {
+  mockCheckDmFanout.mockResolvedValue({
+    allowed: true,
+    recipients: 1,
+    limit: 5,
+    retryAfterSeconds: 0
+  });
+}
+
+describe("posts route — DM fan-out runs last", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // /users/me then /channels/:id, both resolved in parallel by the route.
+    mockMmUserFetch.mockImplementation((path: string) => {
+      if (path === "/users/me") {
+        return Promise.resolve({ id: "u-1", username: "newbie", create_at: Date.now() });
+      }
+      if (path === `/channels/${CHANNEL_ID}`) {
+        return Promise.resolve({ id: CHANNEL_ID, name: "dm", display_name: "dm", type: "D" });
+      }
+      return Promise.resolve({ id: "post-1" });
+    });
+  });
+
+  // The case that made the earlier rollback look necessary. Rejecting the
+  // message before the record is written costs nothing and needs no undo.
+  it("does not record a recipient for a message it rejects", async () => {
+    const { POST } = await import("@/app/api/mattermost/channels/[channelId]/posts/route");
+    mockModerationContext.mockResolvedValue({ canModerate: false });
+    allowFanout();
+
+    const res = await POST(request("@everyone free airdrop"), params);
+
+    expect(res.status).toBe(403);
+    expect(mockCheckDmFanout).not.toHaveBeenCalled();
+    expect(mockMmUserFetch).not.toHaveBeenCalledWith("/posts", expect.anything(), expect.anything());
+  });
+
+  it("records the recipient and posts for an ordinary DM", async () => {
+    const { POST } = await import("@/app/api/mattermost/channels/[channelId]/posts/route");
+    allowFanout();
+
+    const res = await POST(request("hello there"), params);
+
+    expect(res.status).toBe(200);
+    expect(mockCheckDmFanout).toHaveBeenCalledOnce();
+    expect(mockMmUserFetch).toHaveBeenCalledWith("/posts", "test-token", expect.anything());
+  });
+
+  it("rejects with 429 and sends nothing once the cap is reached", async () => {
+    const { POST } = await import("@/app/api/mattermost/channels/[channelId]/posts/route");
+    mockCheckDmFanout.mockResolvedValue({
+      allowed: false,
+      recipients: 5,
+      limit: 5,
+      retryAfterSeconds: 1800
+    });
+
+    const res = await POST(request("hello there"), params);
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("1800");
+    expect(mockMmUserFetch).not.toHaveBeenCalledWith("/posts", expect.anything(), expect.anything());
+  });
+
+  it("leaves public channel posting unmetered", async () => {
+    const { POST } = await import("@/app/api/mattermost/channels/[channelId]/posts/route");
+    mockMmUserFetch.mockImplementation((path: string) => {
+      if (path === "/users/me") {
+        return Promise.resolve({ id: "u-1", username: "newbie", create_at: Date.now() });
+      }
+      if (path === `/channels/${CHANNEL_ID}`) {
+        return Promise.resolve({ id: CHANNEL_ID, name: "hive-1", display_name: "c", type: "O" });
+      }
+      return Promise.resolve({ id: "post-1" });
+    });
+
+    const res = await POST(request("hello there"), params);
+
+    expect(res.status).toBe(200);
+    expect(mockCheckDmFanout).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/specs/api/mattermost-dm-fanout.spec.ts
+++ b/apps/web/src/specs/api/mattermost-dm-fanout.spec.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  checkDmFanout,
+  dmFanoutLimitFor,
+  DM_FANOUT_MAX,
+  DM_FANOUT_MAX_NEW,
+  DM_FANOUT_NEW_ACCOUNT_MS,
+  DM_FANOUT_WINDOW_MS
+} from "@/server/chat-dm-fanout";
+
+// The limiter is the only thing standing between a freshly created account and
+// a mass-DM spray, so these exercise the real code path against an in-memory
+// stand-in for the sorted-set commands it issues rather than mocking the
+// decision away.
+
+type Entry = { member: string; score: number };
+
+class FakeRedis {
+  sets = new Map<string, Entry[]>();
+  ttls = new Map<string, number>();
+  failOn: string | null = null;
+
+  private entries(key: string) {
+    let e = this.sets.get(key);
+    if (!e) {
+      e = [];
+      this.sets.set(key, e);
+    }
+    return e;
+  }
+
+  pipeline() {
+    const ops: (() => unknown)[] = [];
+    const self = this;
+    const chain = {
+      zremrangebyscore(key: string, min: number, max: number) {
+        ops.push(() => {
+          const kept = self.entries(key).filter((e) => e.score < min || e.score > max);
+          self.sets.set(key, kept);
+          return 0;
+        });
+        return chain;
+      },
+      zscore(key: string, member: string) {
+        ops.push(() => {
+          const found = self.entries(key).find((e) => e.member === member);
+          return found ? String(found.score) : null;
+        });
+        return chain;
+      },
+      zcard(key: string) {
+        ops.push(() => self.entries(key).length);
+        return chain;
+      },
+      zrange(key: string, start: number, stop: number, _opt: string) {
+        ops.push(() => {
+          const sorted = [...self.entries(key)].sort((a, b) => a.score - b.score);
+          return sorted
+            .slice(start, stop + 1)
+            .flatMap((e) => [e.member, String(e.score)]);
+        });
+        return chain;
+      },
+      zadd(key: string, score: number, member: string) {
+        ops.push(() => {
+          const list = self.entries(key);
+          const existing = list.find((e) => e.member === member);
+          if (existing) {
+            existing.score = score;
+            return 0;
+          }
+          list.push({ member, score });
+          return 1;
+        });
+        return chain;
+      },
+      pexpire(key: string, ms: number) {
+        ops.push(() => {
+          self.ttls.set(key, ms);
+          return 1;
+        });
+        return chain;
+      },
+      async exec() {
+        if (self.failOn === "exec") throw new Error("redis down");
+        return ops.map((op) => [null, op()]);
+      }
+    };
+    return chain;
+  }
+}
+
+const NOW = 1_800_000_000_000;
+
+function send(redis: FakeRedis, channelId: string, opts: { at?: number; createdAt?: number } = {}) {
+  return checkDmFanout(
+    {
+      userId: "u-1",
+      channelId,
+      accountCreatedAt: opts.createdAt ?? NOW - DM_FANOUT_NEW_ACCOUNT_MS - 1, // established
+      now: opts.at ?? NOW
+    },
+    redis as never
+  );
+}
+
+const NEW_ACCOUNT = NOW - 60_000;
+
+describe("dmFanoutLimitFor", () => {
+  it("gives an account new to chat the tighter cap", () => {
+    expect(dmFanoutLimitFor(NOW - 60_000, NOW)).toBe(DM_FANOUT_MAX_NEW);
+  });
+
+  it("gives an established account the normal cap", () => {
+    expect(dmFanoutLimitFor(NOW - DM_FANOUT_NEW_ACCOUNT_MS - 1, NOW)).toBe(DM_FANOUT_MAX);
+  });
+
+  // Treating "unknown" as new would throttle every user to the tight cap if
+  // Mattermost ever stopped returning create_at.
+  it("treats a missing or impossible creation time as established", () => {
+    expect(dmFanoutLimitFor(undefined, NOW)).toBe(DM_FANOUT_MAX);
+    expect(dmFanoutLimitFor(0, NOW)).toBe(DM_FANOUT_MAX);
+    expect(dmFanoutLimitFor(NaN, NOW)).toBe(DM_FANOUT_MAX);
+    expect(dmFanoutLimitFor(NOW + 60_000, NOW)).toBe(DM_FANOUT_MAX);
+  });
+});
+
+describe("checkDmFanout", () => {
+  let redis: FakeRedis;
+
+  beforeEach(() => {
+    redis = new FakeRedis();
+  });
+
+  it("blocks a new account once it passes the distinct-recipient cap", async () => {
+    for (let i = 0; i < DM_FANOUT_MAX_NEW; i++) {
+      const ok = await send(redis, `dm-${i}`, { createdAt: NEW_ACCOUNT });
+      expect(ok.allowed).toBe(true);
+    }
+
+    const blocked = await send(redis, "dm-overflow", { createdAt: NEW_ACCOUNT });
+
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.limit).toBe(DM_FANOUT_MAX_NEW);
+    expect(blocked.recipients).toBe(DM_FANOUT_MAX_NEW);
+  });
+
+  it("does not record the recipient it rejected", async () => {
+    for (let i = 0; i < DM_FANOUT_MAX_NEW; i++) {
+      await send(redis, `dm-${i}`, { createdAt: NEW_ACCOUNT });
+    }
+    await send(redis, "dm-overflow", { createdAt: NEW_ACCOUNT });
+
+    // A blocked attempt must not consume a slot or extend the window, or a
+    // spammer would push their own earlier recipients out and reset the cap.
+    expect(redis.sets.get("chat:dmfanout:u-1")).toHaveLength(DM_FANOUT_MAX_NEW);
+  });
+
+  // The cap is on how many people you reach, not how much you say to them.
+  it("keeps letting a capped account reply to people it already messaged", async () => {
+    for (let i = 0; i < DM_FANOUT_MAX_NEW; i++) {
+      await send(redis, `dm-${i}`, { createdAt: NEW_ACCOUNT });
+    }
+
+    const reply = await send(redis, "dm-0", { createdAt: NEW_ACCOUNT });
+
+    expect(reply.allowed).toBe(true);
+    expect(reply.recipients).toBe(DM_FANOUT_MAX_NEW); // not counted twice
+  });
+
+  it("lets an established account reach further than a new one", async () => {
+    for (let i = 0; i < DM_FANOUT_MAX_NEW + 1; i++) {
+      const res = await send(redis, `dm-${i}`);
+      expect(res.allowed).toBe(true);
+      expect(res.limit).toBe(DM_FANOUT_MAX);
+    }
+  });
+
+  it("frees a slot once a recipient ages out of the window", async () => {
+    for (let i = 0; i < DM_FANOUT_MAX_NEW; i++) {
+      await send(redis, `dm-${i}`, { createdAt: NEW_ACCOUNT, at: NOW });
+    }
+
+    const later = NOW + DM_FANOUT_WINDOW_MS + 1;
+    const res = await send(redis, "dm-fresh", { createdAt: NEW_ACCOUNT, at: later });
+
+    expect(res.allowed).toBe(true);
+    expect(res.recipients).toBe(1);
+  });
+
+  it("reports how long the block lasts", async () => {
+    for (let i = 0; i < DM_FANOUT_MAX_NEW; i++) {
+      await send(redis, `dm-${i}`, { createdAt: NEW_ACCOUNT, at: NOW + i * 1000 });
+    }
+
+    const at = NOW + 10_000;
+    const blocked = await send(redis, "dm-overflow", { createdAt: NEW_ACCOUNT, at });
+
+    // Oldest entry was written at NOW, so it ages out one window after that.
+    expect(blocked.retryAfterSeconds).toBe(Math.ceil((NOW + DM_FANOUT_WINDOW_MS - at) / 1000));
+  });
+
+  // Redis is a spam control, not a dependency of the product. Losing it must
+  // never stop people from talking; the out-of-band monitor is the backstop.
+  it("allows the send when redis is unavailable", async () => {
+    const res = await checkDmFanout(
+      { userId: "u-1", channelId: "dm-1", accountCreatedAt: NEW_ACCOUNT, now: NOW },
+      null
+    );
+    expect(res.allowed).toBe(true);
+  });
+
+  it("allows the send when a redis command fails", async () => {
+    redis.failOn = "exec";
+    const res = await send(redis, "dm-1", { createdAt: NEW_ACCOUNT });
+    expect(res.allowed).toBe(true);
+  });
+});

--- a/apps/web/src/specs/api/mattermost-dm-fanout.spec.ts
+++ b/apps/web/src/specs/api/mattermost-dm-fanout.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   checkDmFanout,
   dmFanoutLimitFor,
+  releaseDmFanout,
   DM_FANOUT_MAX,
   DM_FANOUT_MAX_NEW,
   DM_FANOUT_NEW_ACCOUNT_MS,
@@ -10,11 +11,17 @@ import {
 
 // The limiter is the only thing standing between a freshly created account and
 // a mass-DM spray, so these exercise the real code path against an in-memory
-// stand-in for the sorted-set commands it issues rather than mocking the
-// decision away.
+// stand-in for the sorted set it keeps, rather than mocking the decision away.
 
 type Entry = { member: string; score: number };
 
+/**
+ * Stands in for the sorted-set state the reserve script operates on. `eval`
+ * reimplements that script's semantics: trim by score, look up membership,
+ * count, and insert only when under the cap. Crucially it runs to completion
+ * without interleaving, which is the property the real script buys and the
+ * reason the parallel-spray test below is meaningful.
+ */
 class FakeRedis {
   sets = new Map<string, Entry[]>();
   ttls = new Map<string, number>();
@@ -29,64 +36,46 @@ class FakeRedis {
     return e;
   }
 
-  pipeline() {
-    const ops: (() => unknown)[] = [];
-    const self = this;
-    const chain = {
-      zremrangebyscore(key: string, min: number, max: number) {
-        ops.push(() => {
-          const kept = self.entries(key).filter((e) => e.score < min || e.score > max);
-          self.sets.set(key, kept);
-          return 0;
-        });
-        return chain;
-      },
-      zscore(key: string, member: string) {
-        ops.push(() => {
-          const found = self.entries(key).find((e) => e.member === member);
-          return found ? String(found.score) : null;
-        });
-        return chain;
-      },
-      zcard(key: string) {
-        ops.push(() => self.entries(key).length);
-        return chain;
-      },
-      zrange(key: string, start: number, stop: number, _opt: string) {
-        ops.push(() => {
-          const sorted = [...self.entries(key)].sort((a, b) => a.score - b.score);
-          return sorted
-            .slice(start, stop + 1)
-            .flatMap((e) => [e.member, String(e.score)]);
-        });
-        return chain;
-      },
-      zadd(key: string, score: number, member: string) {
-        ops.push(() => {
-          const list = self.entries(key);
-          const existing = list.find((e) => e.member === member);
-          if (existing) {
-            existing.score = score;
-            return 0;
-          }
-          list.push({ member, score });
-          return 1;
-        });
-        return chain;
-      },
-      pexpire(key: string, ms: number) {
-        ops.push(() => {
-          self.ttls.set(key, ms);
-          return 1;
-        });
-        return chain;
-      },
-      async exec() {
-        if (self.failOn === "exec") throw new Error("redis down");
-        return ops.map((op) => [null, op()]);
-      }
-    };
-    return chain;
+  async eval(_script: string, _numKeys: number, key: string, ...args: string[]) {
+    if (this.failOn === "eval") throw new Error("redis down");
+    const [now, windowMs, limit, member] = [
+      Number(args[0]),
+      Number(args[1]),
+      Number(args[2]),
+      args[3]
+    ];
+
+    this.sets.set(
+      key,
+      this.entries(key).filter((e) => e.score > now - windowMs)
+    );
+
+    const list = this.entries(key);
+    const known = list.find((e) => e.member === member);
+    const count = list.length;
+
+    if (!known && count >= limit) {
+      const sorted = [...list].sort((a, b) => a.score - b.score);
+      return [0, count, 0, sorted.length ? sorted[0].score : -1];
+    }
+
+    if (known) {
+      known.score = now;
+    } else {
+      list.push({ member, score: now });
+    }
+    this.ttls.set(key, windowMs);
+
+    return known ? [1, count, 0, -1] : [1, count + 1, 1, -1];
+  }
+
+  async zrem(key: string, member: string) {
+    if (this.failOn === "zrem") throw new Error("redis down");
+    const list = this.entries(key);
+    const at = list.findIndex((e) => e.member === member);
+    if (at === -1) return 0;
+    list.splice(at, 1);
+    return 1;
   }
 }
 
@@ -211,8 +200,65 @@ describe("checkDmFanout", () => {
   });
 
   it("allows the send when a redis command fails", async () => {
-    redis.failOn = "exec";
+    redis.failOn = "eval";
     const res = await send(redis, "dm-1", { createdAt: NEW_ACCOUNT });
     expect(res.allowed).toBe(true);
+    expect(res.reserved).toBe(false); // nothing to hand back
+  });
+
+  // A read-then-write pipeline loses to exactly this: fire the spray in
+  // parallel and every request sees a count below the cap before any writes.
+  it("holds the cap when the whole spray is sent in parallel", async () => {
+    const targets = Array.from({ length: DM_FANOUT_MAX_NEW * 3 }, (_, i) => `dm-${i}`);
+
+    const results = await Promise.all(
+      targets.map((channelId) => send(redis, channelId, { createdAt: NEW_ACCOUNT }))
+    );
+
+    expect(results.filter((r) => r.allowed)).toHaveLength(DM_FANOUT_MAX_NEW);
+    expect(redis.sets.get("chat:dmfanout:u-1")).toHaveLength(DM_FANOUT_MAX_NEW);
+  });
+});
+
+describe("releaseDmFanout", () => {
+  let redis: FakeRedis;
+
+  beforeEach(() => {
+    redis = new FakeRedis();
+  });
+
+  // The send is validated further and then has to be accepted upstream. Both
+  // can fail after the slot is taken, and five failed attempts must not lock a
+  // new account out for the rest of the window.
+  it("hands back a slot whose send never landed", async () => {
+    const first = await send(redis, "dm-0", { createdAt: NEW_ACCOUNT });
+    expect(first.reserved).toBe(true);
+
+    await releaseDmFanout({ userId: "u-1", channelId: "dm-0" }, redis as never);
+
+    expect(redis.sets.get("chat:dmfanout:u-1")).toHaveLength(0);
+  });
+
+  // Releasing a recipient the sender already had would erase real history and
+  // let them re-open that conversation for free, so the route only releases
+  // what this call actually inserted.
+  it("does not report a reservation when the recipient was already known", async () => {
+    await send(redis, "dm-0", { createdAt: NEW_ACCOUNT });
+
+    const again = await send(redis, "dm-0", { createdAt: NEW_ACCOUNT });
+
+    expect(again.allowed).toBe(true);
+    expect(again.reserved).toBe(false);
+  });
+
+  it("is a no-op without redis and survives a failing command", async () => {
+    await expect(
+      releaseDmFanout({ userId: "u-1", channelId: "dm-0" }, null)
+    ).resolves.toBeUndefined();
+
+    redis.failOn = "zrem";
+    await expect(
+      releaseDmFanout({ userId: "u-1", channelId: "dm-0" }, redis as never)
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/web/src/specs/api/mattermost-dm-fanout.spec.ts
+++ b/apps/web/src/specs/api/mattermost-dm-fanout.spec.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   checkDmFanout,
   dmFanoutLimitFor,
-  releaseDmFanout,
   DM_FANOUT_MAX,
   DM_FANOUT_MAX_NEW,
   DM_FANOUT_NEW_ACCOUNT_MS,
@@ -56,7 +55,7 @@ class FakeRedis {
 
     if (!known && count >= limit) {
       const sorted = [...list].sort((a, b) => a.score - b.score);
-      return [0, count, 0, sorted.length ? sorted[0].score : -1];
+      return [0, count, sorted.length ? sorted[0].score : -1];
     }
 
     if (known) {
@@ -66,17 +65,9 @@ class FakeRedis {
     }
     this.ttls.set(key, windowMs);
 
-    return known ? [1, count, 0, -1] : [1, count + 1, 1, -1];
+    return known ? [1, count, -1] : [1, count + 1, -1];
   }
 
-  async zrem(key: string, member: string) {
-    if (this.failOn === "zrem") throw new Error("redis down");
-    const list = this.entries(key);
-    const at = list.findIndex((e) => e.member === member);
-    if (at === -1) return 0;
-    list.splice(at, 1);
-    return 1;
-  }
 }
 
 const NOW = 1_800_000_000_000;
@@ -203,7 +194,6 @@ describe("checkDmFanout", () => {
     redis.failOn = "eval";
     const res = await send(redis, "dm-1", { createdAt: NEW_ACCOUNT });
     expect(res.allowed).toBe(true);
-    expect(res.reserved).toBe(false); // nothing to hand back
   });
 
   // A read-then-write pipeline loses to exactly this: fire the spray in
@@ -217,48 +207,5 @@ describe("checkDmFanout", () => {
 
     expect(results.filter((r) => r.allowed)).toHaveLength(DM_FANOUT_MAX_NEW);
     expect(redis.sets.get("chat:dmfanout:u-1")).toHaveLength(DM_FANOUT_MAX_NEW);
-  });
-});
-
-describe("releaseDmFanout", () => {
-  let redis: FakeRedis;
-
-  beforeEach(() => {
-    redis = new FakeRedis();
-  });
-
-  // The send is validated further and then has to be accepted upstream. Both
-  // can fail after the slot is taken, and five failed attempts must not lock a
-  // new account out for the rest of the window.
-  it("hands back a slot whose send never landed", async () => {
-    const first = await send(redis, "dm-0", { createdAt: NEW_ACCOUNT });
-    expect(first.reserved).toBe(true);
-
-    await releaseDmFanout({ userId: "u-1", channelId: "dm-0" }, redis as never);
-
-    expect(redis.sets.get("chat:dmfanout:u-1")).toHaveLength(0);
-  });
-
-  // Releasing a recipient the sender already had would erase real history and
-  // let them re-open that conversation for free, so the route only releases
-  // what this call actually inserted.
-  it("does not report a reservation when the recipient was already known", async () => {
-    await send(redis, "dm-0", { createdAt: NEW_ACCOUNT });
-
-    const again = await send(redis, "dm-0", { createdAt: NEW_ACCOUNT });
-
-    expect(again.allowed).toBe(true);
-    expect(again.reserved).toBe(false);
-  });
-
-  it("is a no-op without redis and survives a failing command", async () => {
-    await expect(
-      releaseDmFanout({ userId: "u-1", channelId: "dm-0" }, null)
-    ).resolves.toBeUndefined();
-
-    redis.failOn = "zrem";
-    await expect(
-      releaseDmFanout({ userId: "u-1", channelId: "dm-0" }, redis as never)
-    ).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #1266. Follows #1267.

Mass-DM phishing was only contained after the fact by an out-of-band monitor. That monitor deletes the messages and bans the sender, but it runs periodically, so a spray lands in real inboxes first and cannot be recalled once a client has rendered it. On 2026-07-28 an account reached 9 distinct recipients in the 7 minutes before containment.

## Changes
- New `apps/web/src/server/chat-dm-fanout.ts`: caps distinct DM recipients per sender over a rolling window, held in Redis as a sorted set of channel ids scored by send time.
- The message POST route consults it for `D` and `G` channels only and answers 429 with `Retry-After` past the cap. Public channel posting is untouched. The send path uses a plain fetch and surfaces `error` to the user, so this does not trip the poller pause in `chat-api-guard`.
- Accounts under 24h old in chat get the tighter cap, since every observed spray came from an account created the same day. `create_at` comes from the `/users/me` call the route already makes, so there is no extra round trip.
- Replying to someone already inside the window is always allowed: the cap is on distinct recipients, not on message volume.
- A blocked send is not recorded, so a rejected attempt cannot push the sender's own earlier recipients out and reset the cap.
- Fails open on Redis error or absence, matching `seo-redis`. The monitor remains the backstop.

Defaults are 5 recipients/hour for new accounts and 20/hour otherwise, overridable via `CHAT_DM_FANOUT_MAX_NEW`, `CHAT_DM_FANOUT_MAX`, `CHAT_DM_FANOUT_WINDOW_MIN`, `CHAT_DM_FANOUT_NEW_ACCOUNT_HOURS`, and `CHAT_DM_FANOUT_DISABLE=1`. Against the 2026-07-28 timeline the new-account cap would have stopped the spray at the 6th recipient instead of the 9th.

## Test plan
- 11 new cases in `mattermost-dm-fanout.spec.ts`, run against an in-memory stand-in for the sorted-set commands so the shipped code path is what is exercised: cap enforcement, blocked sends not recorded, replies to known recipients still allowed, established vs new limits, ageing out of the window, `Retry-After` value, and both fail-open paths.
- `pnpm --filter @ecency/web test` green (2393 tests), `pnpm --filter @ecency/web typecheck` clean.