### PR TITLE
fix: keep vertical videos vertical on hosted blogs and ecency.com

### DIFF
--- a/apps/self-hosted/src/features/blog/components/blog-post-page.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-page.tsx
@@ -6,6 +6,7 @@ import { useParams, useSearch } from '@tanstack/react-router';
 import { useMemo } from 'react';
 import { InstanceConfigManager, t } from '@/core';
 import { useDocumentMeta } from '@/utils/use-document-meta';
+import { useThreeSpeakOrientation } from '../hooks/use-three-speak-orientation';
 import { BlogLayout } from '../layout/blog-layout';
 import { BlogPostBody } from './blog-post-body';
 import { BlogPostDiscussion } from './blog-post-discussion';
@@ -33,6 +34,10 @@ export function BlogPostPage() {
     error,
     refetch,
   } = useQuery(getPostQueryOptions(author, permlink));
+
+  // Installed here rather than in BlogPostBody so one listener serves both the
+  // post body and the comment bodies below it.
+  useThreeSpeakOrientation();
 
   // Extract first image from post body for OG image
   const ogImage = useMemo(() => {

--- a/apps/self-hosted/src/features/blog/hooks/use-three-speak-orientation.test.ts
+++ b/apps/self-hosted/src/features/blog/hooks/use-three-speak-orientation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSpeakOrientationClass } from './use-three-speak-orientation';
+
+const ORIGIN = 'https://play.3speak.tv';
+
+function playerReady(data: Record<string, unknown>, origin = ORIGIN) {
+  return { origin, data: { type: '3speak-player-ready', ...data } };
+}
+
+describe('resolveSpeakOrientationClass', () => {
+  it('marks a vertical clip as portrait', () => {
+    expect(
+      resolveSpeakOrientationClass(
+        playerReady({
+          isVertical: true,
+          width: 1080,
+          height: 1920,
+          aspectRatio: 1080 / 1920,
+        }),
+      ),
+    ).toBe('speak-portrait');
+  });
+
+  it('marks a square clip as square', () => {
+    expect(
+      resolveSpeakOrientationClass(
+        playerReady({
+          isVertical: false,
+          width: 720,
+          height: 720,
+          aspectRatio: 1,
+        }),
+      ),
+    ).toBe('speak-square');
+  });
+
+  it('leaves a landscape clip on the default 16:9 box', () => {
+    expect(
+      resolveSpeakOrientationClass(
+        playerReady({
+          isVertical: false,
+          width: 1920,
+          height: 1080,
+          aspectRatio: 1920 / 1080,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('ignores a message from another origin', () => {
+    expect(
+      resolveSpeakOrientationClass(
+        playerReady({ isVertical: true }, 'https://evil.example'),
+      ),
+    ).toBeNull();
+  });
+
+  it('ignores an unrelated message from the player', () => {
+    expect(
+      resolveSpeakOrientationClass({
+        origin: ORIGIN,
+        data: { type: '3speak-player-progress', isVertical: true },
+      }),
+    ).toBeNull();
+  });
+
+  it('ignores a message with no data', () => {
+    expect(
+      resolveSpeakOrientationClass({ origin: ORIGIN, data: undefined }),
+    ).toBeNull();
+  });
+});

--- a/apps/self-hosted/src/features/blog/hooks/use-three-speak-orientation.ts
+++ b/apps/self-hosted/src/features/blog/hooks/use-three-speak-orientation.ts
@@ -1,0 +1,84 @@
+import { useEffect } from 'react';
+
+const THREE_SPEAK_EMBED_ORIGIN = 'https://play.3speak.tv';
+
+export type SpeakOrientationClass = 'speak-portrait' | 'speak-square';
+
+/**
+ * Read the orientation out of a `3speak-player-ready` message, or null when the
+ * message is not one (wrong origin, wrong type) or the clip is landscape and
+ * the default 16:9 box is already right.
+ */
+export function resolveSpeakOrientationClass(
+  event: Pick<MessageEvent, 'origin' | 'data'>,
+): SpeakOrientationClass | null {
+  if (
+    event.origin !== THREE_SPEAK_EMBED_ORIGIN ||
+    event.data?.type !== '3speak-player-ready'
+  ) {
+    return null;
+  }
+
+  if (event.data.isVertical) {
+    return 'speak-portrait';
+  }
+
+  const { aspectRatio } = event.data;
+  if (typeof aspectRatio === 'number' && Math.abs(aspectRatio - 1) < 0.1) {
+    return 'speak-square';
+  }
+
+  return null;
+}
+
+/**
+ * Post bodies here are rendered with `embedVideosDirectly`, so none of the web
+ * app's client-side video enhancers run and every 3Speak embed sits in the
+ * fixed 16:9 box from blog-markdown.css. A vertical (9:16) clip then plays
+ * pillarboxed between two wide black bars.
+ *
+ * Once the player knows the real dimensions it reports them to the parent
+ * window as `{ type: '3speak-player-ready', isVertical, aspectRatio }`. Turn
+ * that into the `speak-portrait` / `speak-square` class the CSS overrides look
+ * for, which is what `EcencyRenderer` does on ecency.com.
+ *
+ * A single document-level listener covers the post body and every comment body
+ * at once: the message carries the source window, which is matched back to the
+ * iframe that sent it.
+ */
+export function useThreeSpeakOrientation() {
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      // Bail before touching any class for the player's other messages, so a
+      // correct verdict is not cleared by an unrelated event.
+      if (
+        event.origin !== THREE_SPEAK_EMBED_ORIGIN ||
+        event.data?.type !== '3speak-player-ready'
+      ) {
+        return;
+      }
+
+      const iframe = Array.from(
+        document.querySelectorAll<HTMLIFrameElement>('iframe.speak-iframe'),
+      ).find(
+        (el) => el.contentWindow !== null && el.contentWindow === event.source,
+      );
+      const container = iframe?.closest('.markdown-video-link-speak');
+      if (!container) {
+        return;
+      }
+
+      // The player re-reports when the source changes, so drop any earlier
+      // verdict instead of stacking classes.
+      container.classList.remove('speak-portrait', 'speak-square');
+
+      const orientation = resolveSpeakOrientationClass(event);
+      if (orientation) {
+        container.classList.add(orientation);
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+}

--- a/apps/self-hosted/src/features/blog/hooks/use-three-speak-orientation.ts
+++ b/apps/self-hosted/src/features/blog/hooks/use-three-speak-orientation.ts
@@ -63,18 +63,22 @@ export function useThreeSpeakOrientation() {
       ).find(
         (el) => el.contentWindow !== null && el.contentWindow === event.source,
       );
-      const container = iframe?.closest('.markdown-video-link-speak');
-      if (!container) {
+      if (!iframe) {
         return;
       }
 
+      // A link the renderer expanded sits in a .markdown-video-link-speak box
+      // that owns the aspect ratio. An <iframe> the author pasted is sized
+      // directly by the standalone-iframe rule, so it carries the class itself.
+      const target = iframe.closest('.markdown-video-link-speak') ?? iframe;
+
       // The player re-reports when the source changes, so drop any earlier
       // verdict instead of stacking classes.
-      container.classList.remove('speak-portrait', 'speak-square');
+      target.classList.remove('speak-portrait', 'speak-square');
 
       const orientation = resolveSpeakOrientationClass(event);
       if (orientation) {
-        container.classList.add(orientation);
+        target.classList.add(orientation);
       }
     };
 

--- a/apps/self-hosted/src/styles/blog-markdown.css
+++ b/apps/self-hosted/src/styles/blog-markdown.css
@@ -1482,6 +1482,21 @@
   max-width: 600px;
 }
 
+/* A 3Speak <iframe> pasted by the author has no wrapper anchor, so the class
+   lands on the iframe itself and overrides the standalone-iframe rule below.
+   width/margin/display carry over from it, which keeps the player centred. */
+.markdown-body iframe.speak-iframe.speak-portrait {
+  aspect-ratio: 3 / 5;
+  height: auto;
+  max-width: 450px;
+}
+
+.markdown-body iframe.speak-iframe.speak-square {
+  aspect-ratio: 1 / 1;
+  height: auto;
+  max-width: 600px;
+}
+
 /* Truvvl stories are always 9:16; render-helper marks their iframe
    portrait-embed, which the 16:9 fallback below would otherwise stretch. */
 .markdown-body iframe.portrait-embed {

--- a/apps/self-hosted/src/styles/blog-markdown.css
+++ b/apps/self-hosted/src/styles/blog-markdown.css
@@ -1463,16 +1463,49 @@
   display: block;
 }
 
+/* Vertical and square 3Speak clips. The 16:9 box above would pillarbox them
+   between two wide black bars, so use-three-speak-orientation.ts tags the
+   container from the player's own `3speak-player-ready` report. Ratios and max
+   widths match ecency.com (apps/web/.../ecency-renderer.scss) so a post looks
+   the same on a hosted blog. */
+.markdown-body .markdown-video-link-speak.speak-portrait {
+  padding-bottom: 0;
+  aspect-ratio: 3 / 5;
+  height: auto;
+  max-width: 450px;
+}
+
+.markdown-body .markdown-video-link-speak.speak-square {
+  padding-bottom: 0;
+  aspect-ratio: 1 / 1;
+  height: auto;
+  max-width: 600px;
+}
+
+/* Truvvl stories are always 9:16; render-helper marks their iframe
+   portrait-embed, which the 16:9 fallback below would otherwise stretch. */
+.markdown-body iframe.portrait-embed {
+  max-width: 360px;
+  width: 100%;
+  aspect-ratio: 9 / 16;
+  height: auto;
+  border: none;
+  display: block;
+  margin: 1rem auto 0.5rem;
+}
+
 /* Standalone iframe embeds (raw author-pasted <iframe> — the sanitizer strips
    width/height, so without this they render at the 300x150 default). Kept
    responsive 16:9. :where() holds this at zero added specificity so the
    provider container rules above (and the audio overrides below) always win;
-   audio hosts are excluded so they are not stretched into video boxes. */
+   audio hosts are excluded so they are not stretched into video boxes, and
+   portrait embeds keep their own 9:16 rule. */
 .markdown-body
   iframe:where(
     :not(
         .markdown-audio-link *,
         .speak-audio-iframe,
+        .portrait-embed,
         [src*="open.spotify.com"],
         [src*="soundcloud.com"]
       )

--- a/apps/web/src/features/post-renderer/components/ecency-renderer.tsx
+++ b/apps/web/src/features/post-renderer/components/ecency-renderer.tsx
@@ -45,9 +45,14 @@ export function EcencyRenderer({
 }: HTMLProps<HTMLDivElement> & Props) {
   const ref = useRef<HTMLDivElement>(null);
 
-  // Lightweight postMessage listener for 3Speak orientation when videos are embedded directly
+  // Lightweight postMessage listener for 3Speak orientation. ThreeSpeakVideoExtension
+  // owns this for the players it builds, but it only enhances
+  // .markdown-video-link-speak anchors - an <iframe> the author pasted is normalized
+  // to a bare iframe.speak-iframe with no wrapper, so nothing ever sized it by
+  // orientation and a 9:16 clip stayed in a 16:9 box. Those are handled here, along
+  // with every player when embedVideosDirectly skips the extensions entirely.
   useEffect(() => {
-    if (!renderOptions?.embedVideosDirectly) return;
+    const embedsDirectly = renderOptions?.embedVideosDirectly ?? false;
 
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== "https://play.3speak.tv" || event.data?.type !== "3speak-player-ready") return;
@@ -55,13 +60,20 @@ export function EcencyRenderer({
       const iframes = ref.current?.querySelectorAll<HTMLIFrameElement>(".speak-iframe");
       iframes?.forEach((iframe) => {
         if (iframe.contentWindow == null || iframe.contentWindow !== event.source) return;
+
         const container = iframe.closest(".markdown-video-link-speak");
-        if (!container) return;
+        // A wrapped player belongs to the extension whenever one is running.
+        if (container && !embedsDirectly) return;
+
+        // The player re-reports when the source changes, so drop any earlier
+        // verdict instead of stacking classes.
+        const target = container ?? iframe;
+        target.classList.remove("speak-portrait", "speak-square");
 
         if (event.data.isVertical) {
-          container.classList.add("speak-portrait");
+          target.classList.add("speak-portrait");
         } else if (event.data.aspectRatio && Math.abs(event.data.aspectRatio - 1) < 0.1) {
-          container.classList.add("speak-square");
+          target.classList.add("speak-square");
         }
       });
     };

--- a/apps/web/src/features/post-renderer/ecency-renderer.scss
+++ b/apps/web/src/features/post-renderer/ecency-renderer.scss
@@ -478,6 +478,31 @@ $xxxl-break: "1600px";
     display: block;
   }
 
+  // A 3Speak <iframe> the author pasted has no .markdown-video-link-speak
+  // wrapper to size it, and .speak-iframe is excluded from both the fallback
+  // below and the one in _markdown.scss, so without this it renders at the
+  // 300x150 browser default (the sanitizer drops width/height). Orientation
+  // classes come from the listener in EcencyRenderer.
+  iframe.speak-iframe:where(:not(.markdown-video-link-speak *)) {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    aspect-ratio: 16 / 9;
+    height: auto;
+    border: none;
+    margin: 1rem auto 0.5rem;
+
+    &.speak-portrait {
+      aspect-ratio: 3 / 5;
+      max-width: 450px;
+    }
+
+    &.speak-square {
+      aspect-ratio: 1 / 1;
+      max-width: 600px;
+    }
+  }
+
   // Fallback for standalone iframes not inside video containers.
   // Use :where() to keep specificity at (0,0,1) so video container rules
   // (.markdown-video-link-* iframe) win by specificity and aren't shadowed.

--- a/apps/web/src/specs/features/post-renderer/three-speak-orientation.spec.tsx
+++ b/apps/web/src/specs/features/post-renderer/three-speak-orientation.spec.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { renderPostBody } from "@ecency/render-helper";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EcencyRenderer } from "@/features/post-renderer/components/ecency-renderer";
+
+// renderPostBody is stubbed so each case can pin the exact markup the listener
+// has to cope with. The contract test at the bottom uses the real one.
+vi.mock("@ecency/render-helper", async () => ({
+  ...(await vi.importActual<typeof import("@ecency/render-helper")>("@ecency/render-helper")),
+  renderPostBody: vi.fn()
+}));
+
+const PLAYER_ORIGIN = "https://play.3speak.tv";
+const SPEAK_SRC = "https://play.3speak.tv/watch?v=alice/abc123&mode=iframe";
+
+const STANDALONE_IFRAME = `<iframe class="speak-iframe" src="${SPEAK_SRC}"></iframe>`;
+const WRAPPED_IFRAME =
+  `<a class="markdown-video-link markdown-video-link-speak er-speak">` +
+  `<span class="er-speak-frame"><iframe class="speak-iframe" src="${SPEAK_SRC}"></iframe></span></a>`;
+
+function playerReady(data: Record<string, unknown>, source: Window | null, origin = PLAYER_ORIGIN) {
+  return new MessageEvent("message", {
+    origin,
+    data: { type: "3speak-player-ready", ...data },
+    source
+  });
+}
+
+describe("EcencyRenderer 3Speak orientation", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.mocked(renderPostBody).mockReset();
+  });
+
+  function mount(html: string, embedVideosDirectly?: boolean) {
+    vi.mocked(renderPostBody).mockReturnValue(html);
+    const { container: root } = render(
+      <EcencyRenderer
+        value="body"
+        pure
+        renderOptions={embedVideosDirectly ? { embedVideosDirectly: true } : undefined}
+      />,
+      { container }
+    );
+    return root.querySelector<HTMLIFrameElement>("iframe.speak-iframe")!;
+  }
+
+  it("sizes an author-pasted iframe that has no video-link wrapper", async () => {
+    const iframe = mount(STANDALONE_IFRAME);
+    expect(iframe.closest(".markdown-video-link-speak")).toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(
+        playerReady({ isVertical: true, aspectRatio: 1080 / 1920 }, iframe.contentWindow)
+      );
+    });
+
+    expect(iframe.classList.contains("speak-portrait")).toBe(true);
+  });
+
+  it("marks a square author-pasted iframe", async () => {
+    const iframe = mount(STANDALONE_IFRAME);
+
+    await act(async () => {
+      window.dispatchEvent(
+        playerReady({ isVertical: false, aspectRatio: 1 }, iframe.contentWindow)
+      );
+    });
+
+    expect(iframe.classList.contains("speak-square")).toBe(true);
+  });
+
+  it("leaves a landscape clip alone", async () => {
+    const iframe = mount(STANDALONE_IFRAME);
+
+    await act(async () => {
+      window.dispatchEvent(
+        playerReady({ isVertical: false, aspectRatio: 1920 / 1080 }, iframe.contentWindow)
+      );
+    });
+
+    expect(iframe.classList.contains("speak-portrait")).toBe(false);
+    expect(iframe.classList.contains("speak-square")).toBe(false);
+  });
+
+  it("ignores a message from another origin", async () => {
+    const iframe = mount(STANDALONE_IFRAME);
+
+    await act(async () => {
+      window.dispatchEvent(
+        playerReady({ isVertical: true }, iframe.contentWindow, "https://evil.example")
+      );
+    });
+
+    expect(iframe.classList.contains("speak-portrait")).toBe(false);
+  });
+
+  it("classes the wrapper, not the iframe, when videos are embedded directly", async () => {
+    const iframe = mount(WRAPPED_IFRAME, true);
+    const wrapper = iframe.closest(".markdown-video-link-speak")!;
+
+    await act(async () => {
+      window.dispatchEvent(playerReady({ isVertical: true }, iframe.contentWindow));
+    });
+
+    expect(wrapper.classList.contains("speak-portrait")).toBe(true);
+    expect(iframe.classList.contains("speak-portrait")).toBe(false);
+  });
+
+  it("leaves a wrapped player to ThreeSpeakVideoExtension outside direct-embed mode", async () => {
+    const iframe = mount(WRAPPED_IFRAME);
+    const wrapper = iframe.closest(".markdown-video-link-speak")!;
+
+    await act(async () => {
+      window.dispatchEvent(playerReady({ isVertical: true }, iframe.contentWindow));
+    });
+
+    expect(wrapper.classList.contains("speak-portrait")).toBe(false);
+    expect(iframe.classList.contains("speak-portrait")).toBe(false);
+  });
+
+  it("render-helper really does leave a pasted 3Speak iframe unwrapped", async () => {
+    const { renderPostBody: actualRenderPostBody } =
+      await vi.importActual<typeof import("@ecency/render-helper")>("@ecency/render-helper");
+
+    const host = document.createElement("div");
+    host.innerHTML = actualRenderPostBody(
+      `<iframe src="https://3speak.tv/embed?v=alice/abc123"></iframe>`,
+      false,
+      false,
+      "ecency.com"
+    );
+
+    const iframe = host.querySelector("iframe.speak-iframe");
+    expect(iframe).toBeTruthy();
+    expect(iframe!.closest(".markdown-video-link-speak")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1269

Vertical (9:16) clips were pillarboxed on hosted/self-hosted blogs: post bodies render with `embedVideosDirectly`, so no client-side video enhancer runs and `blog-markdown.css` locked every 3Speak embed into a fixed 16:9 box.

**Self-hosted**
- `use-three-speak-orientation.ts`: one document-level listener for the player's `3speak-player-ready` message (`isVertical` / `aspectRatio`), matching the source window back to its iframe and tagging the container `speak-portrait` / `speak-square`. Installed from `BlogPostPage` so it covers the post body and every comment body. Same signal `EcencyRenderer` uses on ecency.com.
- `blog-markdown.css`: portrait and square overrides with the aspect ratios and max widths from `ecency-renderer.scss`, so a post looks the same on a hosted blog.
- Truvvl stories had the same symptom for a different reason: render-helper marks them `iframe.portrait-embed`, which the generic 16:9 iframe fallback did not exclude. Excluded, plus a 9:16 rule.

**ecency.com (same bug via the other authoring path)**

An author-pasted `<iframe>` is normalized by render-helper to a bare `iframe.speak-iframe` with no `.markdown-video-link-speak` wrapper. `ThreeSpeakVideoExtension` only enhances the anchors, and the `EcencyRenderer` listener ran only under `embedVideosDirectly` and gave up when there was no wrapper, so nothing applied an orientation. Since `.speak-iframe` is excluded from both generic iframe rules it also fell back to the 300x150 browser default (the sanitizer drops `width`/`height`).
- The listener now runs in both modes and classes the iframe itself when it has no wrapper; wrapped players still belong to the extension.
- `ecency-renderer.scss` gives the standalone case a responsive 16:9 default with 3:5 / 1:1 overrides.

Not covered: YouTube Shorts also embed at 16:9, but that needs a shorts marker from render-helper.

Verified: self-hosted build passes with the portrait/square/portrait-embed rules in the built CSS and the listener in the JS bundle; `ecency-renderer.scss` compiles to the expected selectors; biome, eslint and tsc clean on both apps; self-hosted vitest 45/45; web post-renderer + 3speak specs 177/177, including 7 new cases. Two of the new cases fail against the pre-fix renderer, so they bite.
