### PR TITLE
fix(self-hosted): size mention and tag chips, and stop them linking nowhere

### DIFF
--- a/apps/self-hosted/src/styles/blog-markdown.css
+++ b/apps/self-hosted/src/styles/blog-markdown.css
@@ -1545,3 +1545,65 @@
   max-width: 100%;
   border: none;
 }
+
+/* Author (@user) and tag (#tag) chips.
+   renderPostBody's non-app path — the one this SPA uses (forApp = false, see
+   blog-post-body.tsx) — emits a mention as
+   `<a class="er-author er-author-link"><img class="er-author-link-image"/>@user</a>`
+   and a tag as `<a class="er-tag er-tag-link">`; the app path used by decks and
+   other in-app surfaces emits plain `.markdown-author-link` text with no image.
+   The avatar is served at 256x256, so without a size here the generic
+   `.markdown-body img` rule above owns it and renders a 256px block with 29px
+   vertical margins in the middle of the sentence. apps/web carries the
+   equivalent rules in src/styles/_markdown.scss; these mirror them on the
+   theme tokens instead of web's hardcoded palette. Both selectors are scoped
+   under `.markdown-body` so they outrank the generic `img`/`a` rules without
+   needing !important. */
+.markdown-body .er-author-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  vertical-align: middle;
+  max-width: 100%;
+  padding: 0.375rem 0.675rem 0.375rem 0.375rem;
+  border: 1px solid var(--theme-border, rgba(0, 0, 0, 0.1));
+  border-radius: 1rem;
+  color: var(--theme-accent, #357ce6);
+  font-size: 0.875rem;
+  line-height: 1.2;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+.markdown-body .er-author-link .er-author-link-image {
+  display: inline-block;
+  width: 1.5rem;
+  height: 1.5rem;
+  min-width: 1.5rem;
+  margin: 0;
+  border-radius: 1rem;
+  aspect-ratio: auto;
+  object-fit: cover;
+  box-sizing: border-box;
+}
+
+.markdown-body .er-tag-link {
+  display: inline-block;
+  vertical-align: middle;
+  max-width: 100%;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--theme-border, rgba(0, 0, 0, 0.1));
+  border-radius: 1rem;
+  color: var(--theme-accent, #357ce6);
+  font-size: 0.75rem;
+  line-height: 1.2;
+  white-space: nowrap;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+.markdown-body .er-author-link:hover,
+.markdown-body .er-tag-link:hover {
+  color: var(--theme-accent-hover, #1b68da);
+  text-decoration: none;
+}


### PR DESCRIPTION
Fixes #1275

Two changes: the reported sizing bug, then making the chips inert since a blog has no route to send a reader to.

## 1. Sizing (the reported bug)

`renderPostBody`'s non-app path (the one `blog-post-body.tsx` uses) emits `@user` mentions as an avatar chip and `#tag` links as a text chip. `apps/self-hosted/src/styles/blog-markdown.css` had rules for neither, so the generic `.markdown-body img` rule owned the avatar and rendered it as a 256px block with 29px vertical margins in the middle of the sentence.

Adds the chip rules `apps/web` already carries in `src/styles/_markdown.scss`, on the self-hosted theme tokens (`--theme-border`, `--theme-accent`, `--theme-accent-hover`) instead of the hardcoded palette. Scoped under `.markdown-body` so they outrank the generic `img` / `a` rules on specificity, with no `!important`.

## 2. Inert chips

The chip hrefs pointed at routes this SPA does not define. `/@der-prophet` and `/trending/powerup` match nothing in `routeTree.gen.ts`. A self-hosted blog has no profile or tag pages to land on, so rather than adding routes or sending readers to ecency.com, the chips no longer link at all.

Adds `RenderOptions.inertAuthorAndTagChips`. When set, the non-app path emits `<span>` instead of `<a>`, keeping the classes so styling is unchanged. The three self-hosted call sites pass it. CSS hover feedback is scoped to `a.er-author-link` / `a.er-tag-link`, so an inert chip keeps the default text cursor and does not advertise a click that does nothing.

Opted in rather than changed by default: `apps/web` uses the same non-app path and must keep its links.

### Two things this turned up

**The `'a'` ancestor guard in `text.method.ts` was load-bearing.** `traverse()` recurses into the node `text()` inserts, and the chip being an `<a>` was what stopped `linkify` from re-processing the chip's own `@user` label. A `<span>` chip does not trip that guard, so the label expanded into a nested chip on every pass until the render threw and fell back to unenhanced HTML, silently dropping every chip in the body. Now guarded on the chip classes too, matching the class-based already-processed check `a.method.ts` already uses.

**The entry cache key listed only `embedVideosDirectly`** out of `RenderOptions`. Any second flag would have made two callers rendering the same entry with different options serve each other's HTML. The new flag is in the key, with a comment.

## Verification

Rendered the real reported post through `renderPostBody` with the exact arguments each call site passes, loaded it against the real stylesheet in headless Chromium, and measured:

| | avatar box | display | margin | anchor box | tag chip | dead hrefs |
|---|---|---|---|---|---|---|
| before | 256x256 | block | 29px | 800x306 | 64x17 | 8 |
| after | 24x24 | flex item | 0 | 124x38 | 74x28 | 0 |

Before, the avatar is a full-width block that pushes `@der-prophet` onto its own line, splitting the sentence across three lines. After, a single inline pill, sentence intact, all 5 mentions and 3 tags inert.

1240 render-helper tests pass, including 12 new ones covering the inert output, the avatar surviving the sanitizer on a span, the no-recursion guard, the cache key, and the app path being unaffected. The pre-existing snapshot tests pin the default `<a>` output byte for byte, so ecency.com is unchanged.

`pnpm --filter @ecency/self-hosted build` passes, `tsc --noEmit` on render-helper is clean, and biome is clean on the changed files. `packages/render-helper/dist` is rebuilt and committed.
