### PR TITLE
test(self-hosted): scope link exemptions per file and tighten identifier resolution

### DIFF
--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -32,16 +32,27 @@ const SRC = join(__dirname, '..');
 /**
  * Dynamic `href` / `to` values this test cannot resolve statically.
  * Adding an entry is a deliberate act: say why it is safe.
+ *
+ * Keyed by `file:identifier`, never by identifier alone. `to` in particular is a
+ * very common name (it is also a plain prop on the tipping components), so a
+ * bare-name exemption would silently wave through a real `<a href={to}>` added
+ * anywhere in the app later.
  */
 const DYNAMIC_LINKS: Record<string, string> = {
-  SIGNUP_URL: 'absolute https://ecency.com/hosting constant',
-  claimHref: 'built from HOSTING_URL, absolute',
-  rssUrl: 'getRssFeedUrl() returns an absolute ecency.com URL',
-  createPostUrl: 'runtime config general.createPostUrl, may be internal or absolute',
-  websiteUrl: 'account metadata, arbitrary external site',
-  'link.url': 'wallet/extension install links, external',
-  to: 'not a link: TippingStepCurrency prop naming the tip recipient',
-  recipientUsername: 'not a link: TippingPopover prop naming the tip recipient',
+  'src/routes/hosting.tsx:SIGNUP_URL': 'absolute https://ecency.com/hosting constant',
+  'src/features/claim/claim-landing.tsx:claimHref': 'built from HOSTING_URL, absolute',
+  'src/features/blog/layout/blog-navigation.tsx:rssUrl':
+    'getRssFeedUrl() returns an absolute ecency.com URL',
+  'src/features/auth/components/create-post-button.tsx:createPostUrl':
+    'runtime config general.createPostUrl, may be internal or absolute',
+  'src/features/blog/layout/blog-sidebar.tsx:websiteUrl':
+    'account metadata, arbitrary external site',
+  'src/features/auth/components/extension-login.tsx:link.url':
+    'wallet/extension install links, external',
+  'src/features/tipping/components/tipping-popover.tsx:to':
+    'not a link: TippingStepCurrency prop naming the tip recipient',
+  'src/features/tipping/components/tip-button.tsx:recipientUsername':
+    'not a link: TippingPopover prop naming the tip recipient',
 };
 
 function walk(dir: string): string[] {
@@ -61,14 +72,31 @@ function declaredRoutes(): string[] {
 const LINK_RE =
   /\b(?:href|to)=(?:"([^"]*)"|\{`([^`]*)`\}|\{'([^']*)'\}|\{([A-Za-z_$][\w$.]*)\})/g;
 
-/** First string literal assigned to `name` in this file, if it is a simple const. */
+/**
+ * The literal assigned to `name`, for the two forms the app actually uses:
+ *
+ *   const NAME = '/literal'
+ *   const NAME = useMemo(() => `/literal`, [deps])   (comments before the arrow ok)
+ *
+ * Anything else returns null and becomes an unclassified link, which fails the
+ * suite. Deliberately strict: an earlier version scanned for the first string
+ * within 400 characters of the declaration, which for `const target = getUrl()`
+ * happily returned a className or even a word from a type annotation. A wrong
+ * literal that does not start with "/" is treated as external and the real link
+ * is dropped from the check without a sound, which is the worst outcome for a
+ * test whose whole job is to not miss links.
+ */
 function resolveIdentifier(source: string, name: string): string | null {
-  const root = name.split('.')[0];
-  const at = source.search(new RegExp(`\\bconst\\s+${root}\\s*=`));
-  if (at === -1) return null;
-  const window = source.slice(at, at + 400).replace(/\/\/[^\n]*/g, '');
-  const lit = window.match(/[`'"]([^`'"]*)[`'"]/);
-  return lit ? lit[1] : null;
+  const root = name.split('.')[0].replace(/[^\w$]/g, '');
+  if (!root) return null;
+
+  const direct = new RegExp(`\\bconst\\s+${root}\\s*=\\s*(['"\`])([^'"\`]*)\\1`);
+  const viaMemo = new RegExp(
+    `\\bconst\\s+${root}\\s*=\\s*useMemo\\(\\s*(?:\\/\\/[^\\n]*\\n\\s*)*\\(\\s*\\)\\s*=>\\s*(['"\`])([^'"\`]*)\\1`
+  );
+
+  const m = source.match(viaMemo) ?? source.match(direct);
+  return m ? m[2] : null;
 }
 
 const isInternal = (v: string) => v.startsWith('/') && !v.startsWith('//');
@@ -111,7 +139,8 @@ function collect() {
       }
 
       const ident = m[4];
-      if (ident in DYNAMIC_LINKS) continue; // classified, see the map above
+      // Scoped to this file: a same-named identifier elsewhere is not exempt.
+      if (`${rel}:${ident}` in DYNAMIC_LINKS) continue;
 
       const resolved = resolveIdentifier(source, ident);
       if (resolved === null) {
@@ -151,6 +180,30 @@ describe('internal links resolve to declared routes', () => {
   it('leaves no dynamic link unclassified', () => {
     const missing = unresolved.map((l) => `${l.where} -> ${l.value}`);
     expect(missing).toEqual([]);
+  });
+
+  it('scopes every exemption to a file, so common names stay checked', () => {
+    // A bare `to` key would exempt any future `<a href={to}>` in any file.
+    for (const key of Object.keys(DYNAMIC_LINKS)) {
+      expect(key).toMatch(/^src\/.+\.tsx:[\w$.]+$/);
+    }
+    // and each exemption must still point at a file that exists
+    for (const key of Object.keys(DYNAMIC_LINKS)) {
+      const file = join(SRC, '..', key.split(':')[0]);
+      expect(() => readFileSync(file, 'utf8')).not.toThrow();
+    }
+  });
+
+  it('resolves only real literal assignments, never a nearby string', () => {
+    const memo = "const entryLink = useMemo(\n  // note\n  () => `/@${a}/${b}`,\n  [a],\n);";
+    expect(resolveIdentifier(memo, 'entryLink')).toBe('/@${a}/${b}');
+    expect(resolveIdentifier("const x = '/blog';", 'x')).toBe('/blog');
+    // the mis-resolution this replaced: a call expression must not borrow a
+    // later string such as a className or a word from a type annotation
+    const call = 'const target = getUrl();\nconst cls = "totally-unrelated";';
+    expect(resolveIdentifier(call, 'target')).toBeNull();
+    const annotated = 'function P({ to }: { to: string }) {\n  const target = getUrl();';
+    expect(resolveIdentifier(annotated, 'target')).toBeNull();
   });
 
   it('recognises the shapes the app actually uses', () => {

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -298,7 +298,67 @@ function collect() {
     const lineOf = (n: ts.Node) =>
       sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1;
 
+    /** Records one destination, whether it came from an attribute or a spread. */
+    const record = (where: string, expr: ts.Expression | undefined) => {
+      // Source text of the expression, so a template with no identifier can
+      // still be classified. For a plain identifier this is just its name,
+      // which keeps the exemption keys readable.
+      const ident = expr ? expr.getText(sf).replace(/\s+/g, ' ') : undefined;
+      const key = ident ? `${rel}:${ident}` : undefined;
+
+      // Resolve first. An exemption may only absorb a link that is genuinely
+      // unknowable, so if the identifier later becomes a plain literal the link
+      // is validated and the now-stale exemption fails its occurrence count
+      // instead of quietly covering for it.
+      const value = staticValue(expr);
+      if (value === null) {
+        if (key && key in DYNAMIC_LINKS) {
+          exemptionHits[key] = (exemptionHits[key] ?? 0) + 1;
+        } else {
+          unresolved.push({ where, value: ident ?? '<expression>' });
+        }
+      } else if (isInternal(value)) {
+        checked.push({ where, value, via: ident });
+      }
+    };
+
+    /** Can this element carry a destination at all? */
+    const navigable = (tag: string) =>
+      /^[a-z]/.test(tag) || NAVIGATION_COMPONENTS.has(tag);
+
     const visit = (node: ts.Node) => {
+      // `<a {...{ href: '/dead' }}>` and `<Link {...props}>` are attributes too,
+      // just not JsxAttribute nodes. Without this they produce no entry at all,
+      // so a dead link inside a spread is invisible rather than merely
+      // unresolved.
+      if (ts.isJsxSpreadAttribute(node)) {
+        const owner = node.parent.parent as ts.JsxOpeningLikeElement;
+        const tag = owner.tagName.getText(sf);
+        const where = `${rel}:${lineOf(node)}`;
+
+        if (navigable(tag)) {
+          const spread = node.expression;
+          if (ts.isObjectLiteralExpression(spread)) {
+            // a literal tells us exactly whether it carries a destination
+            for (const prop of spread.properties) {
+              if (
+                ts.isPropertyAssignment(prop) &&
+                (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)) &&
+                (prop.name.text === 'href' || prop.name.text === 'to')
+              ) {
+                record(where, prop.initializer);
+              }
+            }
+          } else {
+            // an opaque spread may or may not carry one; it has to be classified
+            unresolved.push({
+              where,
+              value: `{...${spread.getText(sf).replace(/\s+/g, ' ')}}`,
+            });
+          }
+        }
+      }
+
       if (ts.isJsxAttribute(node) && ts.isIdentifier(node.name)) {
         const attr = node.name.text;
         if (attr === 'href' || attr === 'to') {
@@ -315,33 +375,12 @@ function collect() {
             componentProps.push({ where, key: `${tag}.${attr}` });
           } else {
             const init = node.initializer;
-            const expr =
+            record(
+              where,
               init && ts.isJsxExpression(init)
                 ? init.expression
-                : (init as ts.Expression | undefined);
-
-            // Source text of the expression, so a template with no identifier
-            // can still be classified. For a plain identifier this is just its
-            // name, which keeps the exemption keys readable.
-            const ident = expr
-              ? expr.getText(sf).replace(/\s+/g, ' ')
-              : undefined;
-
-            const key = ident ? `${rel}:${ident}` : undefined;
-            // Resolve first. An exemption may only absorb a link that is
-            // genuinely unknowable, so if the identifier later becomes a plain
-            // literal the link is validated and the now-stale exemption fails
-            // its occurrence count instead of quietly covering for it.
-            const value = staticValue(expr);
-            if (value === null) {
-              if (key && key in DYNAMIC_LINKS) {
-                exemptionHits[key] = (exemptionHits[key] ?? 0) + 1;
-              } else {
-                unresolved.push({ where, value: ident ?? '<expression>' });
-              }
-            } else if (isInternal(value)) {
-              checked.push({ where, value, via: ident });
-            }
+                : (init as ts.Expression | undefined),
+            );
           }
         }
       }
@@ -558,6 +597,39 @@ describe('internal links resolve to declared routes', () => {
         ].join('\n'),
       ),
     ).toEqual(['/blog']);
+  });
+
+  it('sees destinations passed through a JSX spread', () => {
+    // A spread is a JsxSpreadAttribute, not a JsxAttribute, so an
+    // attribute-only visitor produces no entry at all and a dead link inside
+    // one is invisible rather than merely unresolved.
+    const inSpread = (code: string) => {
+      const sf = ts.createSourceFile(
+        'spread.tsx',
+        code,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TSX,
+      );
+      const out: string[] = [];
+      const visit = (n: ts.Node) => {
+        if (ts.isJsxSpreadAttribute(n)) out.push(n.expression.getText(sf));
+        ts.forEachChild(n, visit);
+      };
+      visit(sf);
+      return out;
+    };
+
+    // the shapes exist and are reachable as spread attributes
+    expect(
+      inSpread("const E = () => <a {...{ href: '/dead' }}>x</a>;"),
+    ).toEqual(["{ href: '/dead' }"]);
+    expect(inSpread('const E = () => <a {...props}>x</a>;')).toEqual(['props']);
+
+    // and the collector classifies them: object literals resolve, opaque
+    // spreads are unresolved, and non-navigable components are ignored.
+    // Exercised end to end by the probe cases in the PR description.
+    expect(NAVIGATION_COMPONENTS.has('Link')).toBe(true);
   });
 
   it('recognises the shapes the app actually uses', () => {

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 /**
@@ -7,20 +8,17 @@ import { describe, expect, it } from 'vitest';
  *
  * The SPA serves index.html for unmatched paths, so a link to a route that does
  * not exist renders "Page not found" with HTTP 200. It never appears as a 404 in
- * logs, and nothing in the type system catches it because these are raw `href`
- * strings rather than typed `<Link to>`. A commenter's name pointed at `/@user`
- * this way and shipped.
+ * logs, and nothing in the type system catches a raw `href` string. A
+ * commenter's name pointed at `/@user` this way and shipped.
  *
- * Scope, stated precisely rather than as "every link":
- *   1. literal values        - `href="/blog"`, `` href={`/@${a}/${b}`} ``  -> checked
- *   2. same-file identifiers - `href={entryLink}` where entryLink is a const
- *                              or useMemo returning a literal              -> resolved, then checked
- *   3. anything else dynamic - config values, API-derived URLs, and props
- *                              that merely share the name `to`             -> must appear in
- *                              DYNAMIC_LINKS with a reason
- *
- * (3) exists so the blind spot is visible: a new unresolvable link fails this
- * test until someone classifies it, instead of silently escaping the check.
+ * This walks the TypeScript AST rather than matching source text. An earlier
+ * regex version kept finding new ways to under-report: it could not tell an
+ * `<a href>` from a component that happens to take a prop named `to`, it
+ * resolved identifiers by proximity rather than by scope, and it preferred one
+ * declaration form over another regardless of source order. Each of those
+ * silently dropped links from validation. The AST settles all three
+ * structurally: element identity, real lexical scope, and the actual
+ * initializer of the declaration that is in view.
  *
  * Lives under src/routes with a `-` prefix, TanStack Router's convention for a
  * non-route file in the routes directory. Without it the generator warns on
@@ -29,29 +27,28 @@ import { describe, expect, it } from 'vitest';
 
 const SRC = join(__dirname, '..');
 
+/** Router components whose `to` really is navigation. */
+const NAVIGATION_COMPONENTS = new Set(['Link', 'Navigate']);
+
 /**
- * Dynamic `href` / `to` values this test cannot resolve statically.
+ * Components taking a `to` / `href` prop that is not a link at all. Listed so a
+ * new component with a link-shaped prop name must be classified rather than
+ * quietly assumed to be one or the other.
+ */
+const NON_LINK_COMPONENT_PROPS: Record<string, string> = {
+  'TippingPopover.to': 'tip recipient username, not a destination',
+  'TippingStepCurrency.to': 'tip recipient username, not a destination',
+};
+
+/**
+ * Real links whose destination is not statically knowable.
  * Adding an entry is a deliberate act: say why it is safe.
  *
- * Keyed by `file:identifier`, never by identifier alone. `to` in particular is a
- * very common name (it is also a plain prop on the tipping components), so a
- * bare-name exemption would silently wave through a real `<a href={to}>` added
- * anywhere in the app later.
- *
- * `occurrences` pins how many matches the entry is allowed to absorb in that
- * file. Keying by file alone still covers every same-named occurrence in it, so
- * adding a real `<a href={to}>` beside the tipping prop would inherit its
- * exemption; the count turns that into a failure instead.
+ * `occurrences` pins how many links the entry may account for, so a second link
+ * through the same identifier in the same file fails rather than inheriting the
+ * exemption, and a stale entry matching nothing fails too.
  */
 const DYNAMIC_LINKS: Record<string, { occurrences: number; reason: string }> = {
-  'src/routes/hosting.tsx:SIGNUP_URL': {
-    occurrences: 1,
-    reason: 'absolute https://ecency.com/hosting constant',
-  },
-  'src/features/claim/claim-landing.tsx:claimHref': {
-    occurrences: 1,
-    reason: 'built from HOSTING_URL, absolute',
-  },
   'src/features/blog/layout/blog-navigation.tsx:rssUrl': {
     occurrences: 1,
     reason: 'getRssFeedUrl() returns an absolute ecency.com URL',
@@ -68,15 +65,10 @@ const DYNAMIC_LINKS: Record<string, { occurrences: number; reason: string }> = {
     occurrences: 1,
     reason: 'wallet/extension install links, external',
   },
-  'src/features/tipping/components/tipping-popover.tsx:to': {
-    occurrences: 1,
-    reason: 'not a link: TippingStepCurrency prop naming the tip recipient',
-  },
-  'src/features/tipping/components/tip-button.tsx:recipientUsername': {
-    occurrences: 1,
-    reason: 'not a link: TippingPopover prop naming the tip recipient',
-  },
 };
+
+/** Stands in for an interpolated segment, so `/@${a}` compares as `/@*`. */
+const HOLE = '*';
 
 function walk(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
@@ -86,95 +78,118 @@ function walk(dir: string): string[] {
   });
 }
 
-/** Route paths declared by the generated route tree, e.g. /$author/$permlink. */
-function declaredRoutes(): string[] {
-  const tree = readFileSync(join(SRC, 'routeTree.gen.ts'), 'utf8');
-  return [...new Set(Array.from(tree.matchAll(/'(\/[^']*)'/g), (m) => m[1]))];
-}
-
-const LINK_RE =
-  /\b(?:href|to)=(?:"([^"]*)"|\{`([^`]*)`\}|\{'([^']*)'\}|\{([A-Za-z_$][\w$.]*)\})/g;
-
-/**
- * The literal assigned to `name`, for the two forms the app actually uses:
- *
- *   const NAME = '/literal'
- *   const NAME = useMemo(() => `/literal`, [deps])   (comments before the arrow ok)
- *
- * Anything else returns null and becomes an unclassified link, which fails the
- * suite. Deliberately strict: an earlier version scanned for the first string
- * within 400 characters of the declaration, which for `const target = getUrl()`
- * happily returned a className or even a word from a type annotation. A wrong
- * literal that does not start with "/" is treated as external and the real link
- * is dropped from the check without a sound, which is the worst outcome for a
- * test whose whole job is to not miss links.
- *
- * Resolution is positional: the declaration nearest *above* the link wins. Two
- * component scopes in one file can reuse a name, and preferring one syntactic
- * form globally would let a later `useMemo(() => 'https://external')` answer for
- * an earlier `const target = '/missing'`, reclassifying a real internal link as
- * external. This is not scope analysis (that wants an AST), but nearest
- * preceding declaration matches how these components are actually written.
- */
-function declarationsOf(
-  source: string,
-  name: string,
-): { at: number; value: string | null }[] {
-  const root = name.split('.')[0].replace(/[^\w$]/g, '');
-  if (!root) return [];
-
-  // Every `const NAME =`, whatever the right-hand side. Collecting only the
-  // shapes we can read would let an unreadable declaration be skipped over, so
-  // a later `const target = getUrl()` would silently inherit an earlier
-  // component's `const target = '/blog'`.
-  const anyDecl = new RegExp(`\\bconst\\s+${root}\\s*=`, 'g');
-  const direct = new RegExp(`^const\\s+${root}\\s*=\\s*(['"\`])([^'"\`]*)\\1`);
-  const viaMemo = new RegExp(
-    `^const\\s+${root}\\s*=\\s*useMemo\\(\\s*(?:\\/\\/[^\\n]*\\n\\s*)*\\(\\s*\\)\\s*=>\\s*(['"\`])([^'"\`]*)\\1`,
+function parse(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX,
   );
+}
 
-  return Array.from(source.matchAll(anyDecl), (m) => {
-    const tail = source.slice(m.index);
-    const lit = tail.match(viaMemo) ?? tail.match(direct);
-    return { at: m.index, value: lit ? lit[2] : null };
-  });
+/** Route paths exactly as the generator declares them in FileRoutesByFullPath. */
+function declaredRoutes(): string[] {
+  const sf = parse(join(SRC, 'routeTree.gen.ts'));
+  const found: string[] = [];
+  const visit = (n: ts.Node) => {
+    if (
+      ts.isInterfaceDeclaration(n) &&
+      n.name.text === 'FileRoutesByFullPath'
+    ) {
+      for (const member of n.members) {
+        if (member.name && ts.isStringLiteral(member.name)) {
+          found.push(member.name.text);
+        }
+      }
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(sf);
+  return found;
 }
 
 /**
- * Nearest declaration above `usedAt`, resolved only if that declaration itself
- * has a readable literal. An unreadable one yields null, i.e. unclassified,
- * rather than deferring to some other declaration of the same name.
+ * The nearest `const <name>` visible from `from`, honouring lexical scope, so an
+ * identifier declared in a sibling component is not in view.
  */
-function resolveIdentifier(
-  source: string,
+function declarationInScope(
+  from: ts.Node,
   name: string,
-  usedAt: number,
-): string | null {
-  const above = declarationsOf(source, name).filter((d) => d.at < usedAt);
-  return above.length > 0 ? above[above.length - 1].value : null;
+): ts.Expression | undefined {
+  for (let n: ts.Node | undefined = from; n; n = n.parent) {
+    const statements = ts.isSourceFile(n)
+      ? n.statements
+      : ts.isBlock(n) || ts.isModuleBlock(n)
+        ? n.statements
+        : undefined;
+    if (!statements) continue;
+
+    for (const statement of statements) {
+      if (!ts.isVariableStatement(statement)) continue;
+      for (const decl of statement.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name) && decl.name.text === name) {
+          return decl.initializer;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+/** `useMemo(() => X, deps)` -> X; any other call -> undefined. */
+function unwrapUseMemo(call: ts.CallExpression): ts.Expression | undefined {
+  if (!ts.isIdentifier(call.expression) || call.expression.text !== 'useMemo') {
+    return undefined;
+  }
+  const [factory] = call.arguments;
+  if (!factory || !ts.isArrowFunction(factory)) return undefined;
+  return ts.isBlock(factory.body) ? undefined : factory.body;
 }
 
 /**
- * Builds the literal text `${name}` for fixtures, without writing `${` inside a
- * plain string. Biome's noTemplateCurlyInString flags that, correctly in general
- * (it usually means a missing backtick), and here the placeholder text is the
- * thing under test rather than a mistake.
+ * Static value of `expr`, with interpolations collapsed to HOLE.
+ * Returns null when the value cannot be known without running the app.
  */
-const ph = (name: string) => `$\u007B${name}\u007D`;
+function staticValue(
+  expr: ts.Expression | undefined,
+  depth = 0,
+): string | null {
+  if (!expr || depth > 8) return null;
+
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) {
+    return expr.text;
+  }
+  if (ts.isTemplateExpression(expr)) {
+    return (
+      expr.head.text +
+      expr.templateSpans.map((span) => HOLE + span.literal.text).join('')
+    );
+  }
+  if (ts.isIdentifier(expr)) {
+    return staticValue(declarationInScope(expr, expr.text), depth + 1);
+  }
+  if (ts.isCallExpression(expr)) {
+    return staticValue(unwrapUseMemo(expr), depth + 1);
+  }
+  if (ts.isParenthesizedExpression(expr)) {
+    return staticValue(expr.expression, depth + 1);
+  }
+  return null;
+}
 
 const isInternal = (v: string) => v.startsWith('/') && !v.startsWith('//');
 
-/** `/@${a}/${b}` -> ['@*', '*'] so interpolations compare as wildcards. */
 function segments(path: string): string[] {
-  const clean = path.split(/[?#]/)[0].replace(/\$\{[^}]*\}/g, '*');
-  return clean.split('/').filter(Boolean);
+  return path.split(/[?#]/)[0].split('/').filter(Boolean);
 }
 
 function matches(link: string, route: string): boolean {
   const l = segments(link);
   const r = segments(route);
   if (l.length !== r.length) return false;
-  return r.every((rs, i) => rs.startsWith('$') || rs === l[i]);
+  // a route param matches anything; a HOLE in the link matches any route segment
+  return r.every((rs, i) => rs.startsWith('$') || l[i] === HOLE || rs === l[i]);
 }
 
 interface FoundLink {
@@ -186,56 +201,100 @@ interface FoundLink {
 function collect() {
   const checked: FoundLink[] = [];
   const unresolved: FoundLink[] = [];
+  const componentProps: { where: string; key: string }[] = [];
   const exemptionHits: Record<string, number> = {};
 
   for (const file of walk(SRC)) {
-    const source = readFileSync(file, 'utf8');
+    const sf = parse(file);
     const rel = file.replace(SRC, 'src');
+    const lineOf = (n: ts.Node) =>
+      sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1;
 
-    for (const m of source.matchAll(LINK_RE)) {
-      const line = source.slice(0, m.index).split('\n').length;
-      const where = `${rel}:${line}`;
-      const literal = m[1] ?? m[2] ?? m[3];
+    const visit = (node: ts.Node) => {
+      if (ts.isJsxAttribute(node) && ts.isIdentifier(node.name)) {
+        const attr = node.name.text;
+        if (attr === 'href' || attr === 'to') {
+          const owner = node.parent.parent as ts.JsxOpeningLikeElement;
+          const tag = owner.tagName.getText(sf);
+          const where = `${rel}:${lineOf(node)}`;
+          // lowercase tags are DOM elements, so href is genuinely a link;
+          // capitalised ones are components and only the router's navigate
+          const isLink = /^[a-z]/.test(tag)
+            ? attr === 'href'
+            : NAVIGATION_COMPONENTS.has(tag);
 
-      if (literal !== undefined) {
-        if (isInternal(literal)) checked.push({ where, value: literal });
-        continue;
+          if (!isLink) {
+            componentProps.push({ where, key: `${tag}.${attr}` });
+          } else {
+            const init = node.initializer;
+            const expr =
+              init && ts.isJsxExpression(init)
+                ? init.expression
+                : (init as ts.Expression | undefined);
+
+            const ident =
+              expr && ts.isIdentifier(expr)
+                ? expr.text
+                : expr && ts.isPropertyAccessExpression(expr)
+                  ? expr.getText(sf)
+                  : undefined;
+
+            const key = ident ? `${rel}:${ident}` : undefined;
+            if (key && key in DYNAMIC_LINKS) {
+              exemptionHits[key] = (exemptionHits[key] ?? 0) + 1;
+            } else {
+              const value = staticValue(expr);
+              if (value === null) {
+                unresolved.push({ where, value: ident ?? '<expression>' });
+              } else if (isInternal(value)) {
+                checked.push({ where, value, via: ident });
+              }
+            }
+          }
+        }
       }
-
-      const ident = m[4];
-      // Scoped to this file: a same-named identifier elsewhere is not exempt.
-      const key = `${rel}:${ident}`;
-      if (key in DYNAMIC_LINKS) {
-        exemptionHits[key] = (exemptionHits[key] ?? 0) + 1;
-        continue;
-      }
-
-      const resolved = resolveIdentifier(source, ident, m.index);
-      if (resolved === null) {
-        unresolved.push({ where, value: ident });
-      } else if (isInternal(resolved)) {
-        checked.push({ where, value: resolved, via: ident });
-      }
-    }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
   }
-  return { checked, unresolved, exemptionHits };
+
+  return { checked, unresolved, componentProps, exemptionHits };
+}
+
+/** Parses a snippet and returns every `href` value the resolver produces. */
+function hrefValuesIn(code: string): (string | null)[] {
+  const sf = ts.createSourceFile(
+    'snippet.tsx',
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const out: (string | null)[] = [];
+  const visit = (n: ts.Node) => {
+    if (
+      ts.isJsxAttribute(n) &&
+      ts.isIdentifier(n.name) &&
+      n.name.text === 'href' &&
+      n.initializer &&
+      ts.isJsxExpression(n.initializer)
+    ) {
+      out.push(staticValue(n.initializer.expression));
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(sf);
+  return out;
 }
 
 describe('internal links resolve to declared routes', () => {
   const routes = declaredRoutes();
-  const { checked, unresolved, exemptionHits } = collect();
+  const { checked, unresolved, componentProps, exemptionHits } = collect();
 
-  it('finds the route tree and links to check', () => {
-    expect(routes.length).toBeGreaterThan(0);
+  it('reads the route tree and finds links to check', () => {
+    expect(routes).toContain('/blog');
+    expect(routes).toContain('/$author/$permlink');
     expect(checked.length).toBeGreaterThan(0);
-  });
-
-  it('resolves identifier-backed links, not only inline literals', () => {
-    // blog-discussion-item's `href={entryLink}` is a useMemo returning a template
-    // literal; an inline-literal-only scan would not see it at all.
-    const viaIdentifier = checked.filter((l) => l.via);
-    expect(viaIdentifier.length).toBeGreaterThan(0);
-    expect(viaIdentifier.some((l) => l.via === 'entryLink')).toBe(true);
   });
 
   it('has no link pointing at an undeclared route', () => {
@@ -245,109 +304,86 @@ describe('internal links resolve to declared routes', () => {
     expect(dead).toEqual([]);
   });
 
-  it('leaves no dynamic link unclassified', () => {
-    const missing = unresolved.map((l) => `${l.where} -> ${l.value}`);
-    expect(missing).toEqual([]);
+  it('leaves no real link unclassified', () => {
+    expect(unresolved.map((l) => `${l.where} -> ${l.value}`)).toEqual([]);
   });
 
   it('consumes each exemption exactly as many times as declared', () => {
-    // File-scoped keys still cover every same-named occurrence in that file, so
-    // a real <a href={to}> added beside the tipping prop would inherit its
-    // exemption. Pinning the count makes that a failure. A stale entry that
-    // matches nothing fails here too.
     const expected = Object.fromEntries(
       Object.entries(DYNAMIC_LINKS).map(([k, v]) => [k, v.occurrences]),
     );
     expect(exemptionHits).toEqual(expected);
   });
 
-  it('scopes every exemption to a file, so common names stay checked', () => {
-    // A bare `to` key would exempt any future `<a href={to}>` in any file.
-    for (const [key, entry] of Object.entries(DYNAMIC_LINKS)) {
-      expect(key).toMatch(/^src\/.+\.tsx:[\w$.]+$/);
-      expect(entry.reason.length).toBeGreaterThan(0);
-    }
-    // and each exemption must still point at a file that exists
-    for (const key of Object.keys(DYNAMIC_LINKS)) {
-      const file = join(SRC, '..', key.split(':')[0]);
-      expect(() => readFileSync(file, 'utf8')).not.toThrow();
-    }
+  it('classifies every component prop that merely looks like a link', () => {
+    const unclassified = componentProps
+      .filter((p) => !(p.key in NON_LINK_COMPONENT_PROPS))
+      .map((p) => `${p.where} -> ${p.key}`);
+    expect(unclassified).toEqual([]);
   });
 
-  it('resolves only real literal assignments, never a nearby string', () => {
-    const interpolated = `/@${ph('a')}/${ph('b')}`;
-    const memo = `const entryLink = useMemo(\n  // note\n  () => \`${interpolated}\`,\n  [a],\n);`;
-    expect(resolveIdentifier(memo, 'entryLink', memo.length)).toBe(
-      interpolated,
+  it('resolves identifiers by scope, not proximity', () => {
+    // Both hazards the regex version fell into, now decided by the AST: a
+    // sibling component's declaration is not in view, and the declaration that
+    // is in view is used whatever form it takes.
+    const values = hrefValuesIn(
+      [
+        'function A() {',
+        "  const target = '/blog';",
+        '  return <a href={target}>a</a>;',
+        '}',
+        'function B() {',
+        '  const target = getUrl();',
+        '  return <a href={target}>b</a>;',
+        '}',
+        'function C() {',
+        "  const target = useMemo(() => '/search', []);",
+        '  return <a href={target}>c</a>;',
+        '}',
+      ].join('\n'),
     );
-    const plain = "const x = '/blog';";
-    expect(resolveIdentifier(plain, 'x', plain.length)).toBe('/blog');
-    // the mis-resolution this replaced: a call expression must not borrow a
-    // later string such as a className or a word from a type annotation
-    const call = 'const target = getUrl();\nconst cls = "totally-unrelated";';
-    expect(resolveIdentifier(call, 'target', call.length)).toBeNull();
-    const annotated =
-      'function P({ to }: { to: string }) {\n  const target = getUrl();';
-    expect(resolveIdentifier(annotated, 'target', annotated.length)).toBeNull();
+    // B's getUrl() is unknowable and must not borrow A's '/blog'
+    expect(values).toEqual(['/blog', null, '/search']);
   });
 
-  it('uses the declaration above the link when a name is reused in one file', () => {
-    // Two component scopes reusing `target`. Preferring the useMemo form globally
-    // answered the first link with the second declaration's external URL, so a
-    // real internal link was reclassified as external and never validated.
-    const src = [
-      'function A() {',
-      "  const target = '/missing';",
-      '  return <a href={target}>a</a>;',
-      '}',
-      'function B() {',
-      "  const target = useMemo(() => 'https://external', []);",
-      '  return <a href={target}>b</a>;',
-      '}',
-    ].join('\n');
-
-    const firstLink = src.indexOf('href={target}');
-    const secondLink = src.indexOf('href={target}', firstLink + 1);
-
-    expect(resolveIdentifier(src, 'target', firstLink)).toBe('/missing');
-    expect(resolveIdentifier(src, 'target', secondLink)).toBe(
-      'https://external',
+  it('prefers an inner declaration over an outer one', () => {
+    const values = hrefValuesIn(
+      [
+        "const target = '/blog';",
+        'function A() {',
+        "  const target = '/search';",
+        '  return <a href={target}>a</a>;',
+        '}',
+      ].join('\n'),
     );
-    // nothing declared above the very top of the file
-    expect(resolveIdentifier(src, 'target', 0)).toBeNull();
+    expect(values).toEqual(['/search']);
   });
 
-  it('does not let an unreadable declaration inherit an earlier literal', () => {
-    const src = [
-      'function A() {',
-      "  const target = '/blog';",
-      '  return <a href={target}>a</a>;',
-      '}',
-      'function B() {',
-      '  const target = getUrl();',
-      '  return <a href={target}>b</a>;',
-      '}',
-    ].join('\n');
-
-    const first = src.indexOf('href={target}');
-    const second = src.indexOf('href={target}', first + 1);
-
-    expect(resolveIdentifier(src, 'target', first)).toBe('/blog');
-    // nearest declaration above the second link is getUrl(), which we cannot
-    // read, so it must be unclassified rather than borrowing '/blog'
-    expect(resolveIdentifier(src, 'target', second)).toBeNull();
+  it('collapses interpolation to a wildcard that matches a route param', () => {
+    // template literal with escaped placeholders: keeps a literal `${` out of a
+    // plain string, which noTemplateCurlyInString flags (rightly, in general)
+    const [value] = hrefValuesIn(
+      `const E = () => <a href={\`/@\${a}/\${b}\`}>x</a>;`,
+    );
+    expect(value).toBe(`/@${HOLE}/${HOLE}`);
+    expect(matches(`/@${HOLE}/${HOLE}`, '/$author/$permlink')).toBe(true);
+    expect(matches(`/@${HOLE}`, '/$author/$permlink')).toBe(false);
+    // a template that starts with an interpolation is not an internal path
+    const [absolute] = hrefValuesIn(
+      `const E = () => <a href={\`\${base}/x\`}>x</a>;`,
+    );
+    expect(isInternal(absolute ?? '')).toBe(false);
   });
 
   it('recognises the shapes the app actually uses', () => {
-    // guards the matcher itself, so a broken matcher cannot silently pass the above
     expect(matches('/blog', '/blog')).toBe(true);
-    expect(matches(`/@${ph('a')}/${ph('b')}`, '/$author/$permlink')).toBe(true);
     expect(matches('/edit/$author/$permlink', '/edit/$author/$permlink')).toBe(
       true,
     );
     expect(matches('/blog', '/$author/$permlink')).toBe(false);
     expect(isInternal('//evil.com')).toBe(false);
+    expect(isInternal('https://ecency.com/blog')).toBe(false);
     // the regression this test exists for
-    expect(routes.some((r) => matches(`/@${ph('author')}`, r))).toBe(false);
+    expect(routes.some((r) => matches(`/@${HOLE}`, r))).toBe(false);
   });
 });

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -37,22 +37,45 @@ const SRC = join(__dirname, '..');
  * very common name (it is also a plain prop on the tipping components), so a
  * bare-name exemption would silently wave through a real `<a href={to}>` added
  * anywhere in the app later.
+ *
+ * `occurrences` pins how many matches the entry is allowed to absorb in that
+ * file. Keying by file alone still covers every same-named occurrence in it, so
+ * adding a real `<a href={to}>` beside the tipping prop would inherit its
+ * exemption; the count turns that into a failure instead.
  */
-const DYNAMIC_LINKS: Record<string, string> = {
-  'src/routes/hosting.tsx:SIGNUP_URL': 'absolute https://ecency.com/hosting constant',
-  'src/features/claim/claim-landing.tsx:claimHref': 'built from HOSTING_URL, absolute',
-  'src/features/blog/layout/blog-navigation.tsx:rssUrl':
-    'getRssFeedUrl() returns an absolute ecency.com URL',
-  'src/features/auth/components/create-post-button.tsx:createPostUrl':
-    'runtime config general.createPostUrl, may be internal or absolute',
-  'src/features/blog/layout/blog-sidebar.tsx:websiteUrl':
-    'account metadata, arbitrary external site',
-  'src/features/auth/components/extension-login.tsx:link.url':
-    'wallet/extension install links, external',
-  'src/features/tipping/components/tipping-popover.tsx:to':
-    'not a link: TippingStepCurrency prop naming the tip recipient',
-  'src/features/tipping/components/tip-button.tsx:recipientUsername':
-    'not a link: TippingPopover prop naming the tip recipient',
+const DYNAMIC_LINKS: Record<string, { occurrences: number; reason: string }> = {
+  'src/routes/hosting.tsx:SIGNUP_URL': {
+    occurrences: 1,
+    reason: 'absolute https://ecency.com/hosting constant',
+  },
+  'src/features/claim/claim-landing.tsx:claimHref': {
+    occurrences: 1,
+    reason: 'built from HOSTING_URL, absolute',
+  },
+  'src/features/blog/layout/blog-navigation.tsx:rssUrl': {
+    occurrences: 1,
+    reason: 'getRssFeedUrl() returns an absolute ecency.com URL',
+  },
+  'src/features/auth/components/create-post-button.tsx:createPostUrl': {
+    occurrences: 1,
+    reason: 'runtime config general.createPostUrl, may be internal or absolute',
+  },
+  'src/features/blog/layout/blog-sidebar.tsx:websiteUrl': {
+    occurrences: 1,
+    reason: 'account metadata, arbitrary external site',
+  },
+  'src/features/auth/components/extension-login.tsx:link.url': {
+    occurrences: 1,
+    reason: 'wallet/extension install links, external',
+  },
+  'src/features/tipping/components/tipping-popover.tsx:to': {
+    occurrences: 1,
+    reason: 'not a link: TippingStepCurrency prop naming the tip recipient',
+  },
+  'src/features/tipping/components/tip-button.tsx:recipientUsername': {
+    occurrences: 1,
+    reason: 'not a link: TippingPopover prop naming the tip recipient',
+  },
 };
 
 function walk(dir: string): string[] {
@@ -93,28 +116,51 @@ const LINK_RE =
  * external. This is not scope analysis (that wants an AST), but nearest
  * preceding declaration matches how these components are actually written.
  */
-function declarationsOf(source: string, name: string): { at: number; value: string }[] {
+function declarationsOf(
+  source: string,
+  name: string,
+): { at: number; value: string | null }[] {
   const root = name.split('.')[0].replace(/[^\w$]/g, '');
   if (!root) return [];
 
-  // `direct` needs a quote straight after `=`, so it never also matches the useMemo form.
-  const forms = [
-    new RegExp(`\\bconst\\s+${root}\\s*=\\s*(['"\`])([^'"\`]*)\\1`, 'g'),
-    new RegExp(
-      `\\bconst\\s+${root}\\s*=\\s*useMemo\\(\\s*(?:\\/\\/[^\\n]*\\n\\s*)*\\(\\s*\\)\\s*=>\\s*(['"\`])([^'"\`]*)\\1`,
-      'g'
-    ),
-  ];
+  // Every `const NAME =`, whatever the right-hand side. Collecting only the
+  // shapes we can read would let an unreadable declaration be skipped over, so
+  // a later `const target = getUrl()` would silently inherit an earlier
+  // component's `const target = '/blog'`.
+  const anyDecl = new RegExp(`\\bconst\\s+${root}\\s*=`, 'g');
+  const direct = new RegExp(`^const\\s+${root}\\s*=\\s*(['"\`])([^'"\`]*)\\1`);
+  const viaMemo = new RegExp(
+    `^const\\s+${root}\\s*=\\s*useMemo\\(\\s*(?:\\/\\/[^\\n]*\\n\\s*)*\\(\\s*\\)\\s*=>\\s*(['"\`])([^'"\`]*)\\1`,
+  );
 
-  return forms
-    .flatMap((re) => Array.from(source.matchAll(re), (m) => ({ at: m.index, value: m[2] })))
-    .sort((a, b) => a.at - b.at);
+  return Array.from(source.matchAll(anyDecl), (m) => {
+    const tail = source.slice(m.index);
+    const lit = tail.match(viaMemo) ?? tail.match(direct);
+    return { at: m.index, value: lit ? lit[2] : null };
+  });
 }
 
-function resolveIdentifier(source: string, name: string, usedAt: number): string | null {
+/**
+ * Nearest declaration above `usedAt`, resolved only if that declaration itself
+ * has a readable literal. An unreadable one yields null, i.e. unclassified,
+ * rather than deferring to some other declaration of the same name.
+ */
+function resolveIdentifier(
+  source: string,
+  name: string,
+  usedAt: number,
+): string | null {
   const above = declarationsOf(source, name).filter((d) => d.at < usedAt);
   return above.length > 0 ? above[above.length - 1].value : null;
 }
+
+/**
+ * Builds the literal text `${name}` for fixtures, without writing `${` inside a
+ * plain string. Biome's noTemplateCurlyInString flags that, correctly in general
+ * (it usually means a missing backtick), and here the placeholder text is the
+ * thing under test rather than a mistake.
+ */
+const ph = (name: string) => `$\u007B${name}\u007D`;
 
 const isInternal = (v: string) => v.startsWith('/') && !v.startsWith('//');
 
@@ -140,6 +186,7 @@ interface FoundLink {
 function collect() {
   const checked: FoundLink[] = [];
   const unresolved: FoundLink[] = [];
+  const exemptionHits: Record<string, number> = {};
 
   for (const file of walk(SRC)) {
     const source = readFileSync(file, 'utf8');
@@ -157,7 +204,11 @@ function collect() {
 
       const ident = m[4];
       // Scoped to this file: a same-named identifier elsewhere is not exempt.
-      if (`${rel}:${ident}` in DYNAMIC_LINKS) continue;
+      const key = `${rel}:${ident}`;
+      if (key in DYNAMIC_LINKS) {
+        exemptionHits[key] = (exemptionHits[key] ?? 0) + 1;
+        continue;
+      }
 
       const resolved = resolveIdentifier(source, ident, m.index);
       if (resolved === null) {
@@ -167,12 +218,12 @@ function collect() {
       }
     }
   }
-  return { checked, unresolved };
+  return { checked, unresolved, exemptionHits };
 }
 
 describe('internal links resolve to declared routes', () => {
   const routes = declaredRoutes();
-  const { checked, unresolved } = collect();
+  const { checked, unresolved, exemptionHits } = collect();
 
   it('finds the route tree and links to check', () => {
     expect(routes.length).toBeGreaterThan(0);
@@ -199,10 +250,22 @@ describe('internal links resolve to declared routes', () => {
     expect(missing).toEqual([]);
   });
 
+  it('consumes each exemption exactly as many times as declared', () => {
+    // File-scoped keys still cover every same-named occurrence in that file, so
+    // a real <a href={to}> added beside the tipping prop would inherit its
+    // exemption. Pinning the count makes that a failure. A stale entry that
+    // matches nothing fails here too.
+    const expected = Object.fromEntries(
+      Object.entries(DYNAMIC_LINKS).map(([k, v]) => [k, v.occurrences]),
+    );
+    expect(exemptionHits).toEqual(expected);
+  });
+
   it('scopes every exemption to a file, so common names stay checked', () => {
     // A bare `to` key would exempt any future `<a href={to}>` in any file.
-    for (const key of Object.keys(DYNAMIC_LINKS)) {
+    for (const [key, entry] of Object.entries(DYNAMIC_LINKS)) {
       expect(key).toMatch(/^src\/.+\.tsx:[\w$.]+$/);
+      expect(entry.reason.length).toBeGreaterThan(0);
     }
     // and each exemption must still point at a file that exists
     for (const key of Object.keys(DYNAMIC_LINKS)) {
@@ -212,15 +275,19 @@ describe('internal links resolve to declared routes', () => {
   });
 
   it('resolves only real literal assignments, never a nearby string', () => {
-    const memo = "const entryLink = useMemo(\n  // note\n  () => `/@${a}/${b}`,\n  [a],\n);";
-    expect(resolveIdentifier(memo, 'entryLink', memo.length)).toBe('/@${a}/${b}');
+    const interpolated = `/@${ph('a')}/${ph('b')}`;
+    const memo = `const entryLink = useMemo(\n  // note\n  () => \`${interpolated}\`,\n  [a],\n);`;
+    expect(resolveIdentifier(memo, 'entryLink', memo.length)).toBe(
+      interpolated,
+    );
     const plain = "const x = '/blog';";
     expect(resolveIdentifier(plain, 'x', plain.length)).toBe('/blog');
     // the mis-resolution this replaced: a call expression must not borrow a
     // later string such as a className or a word from a type annotation
     const call = 'const target = getUrl();\nconst cls = "totally-unrelated";';
     expect(resolveIdentifier(call, 'target', call.length)).toBeNull();
-    const annotated = 'function P({ to }: { to: string }) {\n  const target = getUrl();';
+    const annotated =
+      'function P({ to }: { to: string }) {\n  const target = getUrl();';
     expect(resolveIdentifier(annotated, 'target', annotated.length)).toBeNull();
   });
 
@@ -243,19 +310,44 @@ describe('internal links resolve to declared routes', () => {
     const secondLink = src.indexOf('href={target}', firstLink + 1);
 
     expect(resolveIdentifier(src, 'target', firstLink)).toBe('/missing');
-    expect(resolveIdentifier(src, 'target', secondLink)).toBe('https://external');
+    expect(resolveIdentifier(src, 'target', secondLink)).toBe(
+      'https://external',
+    );
     // nothing declared above the very top of the file
     expect(resolveIdentifier(src, 'target', 0)).toBeNull();
+  });
+
+  it('does not let an unreadable declaration inherit an earlier literal', () => {
+    const src = [
+      'function A() {',
+      "  const target = '/blog';",
+      '  return <a href={target}>a</a>;',
+      '}',
+      'function B() {',
+      '  const target = getUrl();',
+      '  return <a href={target}>b</a>;',
+      '}',
+    ].join('\n');
+
+    const first = src.indexOf('href={target}');
+    const second = src.indexOf('href={target}', first + 1);
+
+    expect(resolveIdentifier(src, 'target', first)).toBe('/blog');
+    // nearest declaration above the second link is getUrl(), which we cannot
+    // read, so it must be unclassified rather than borrowing '/blog'
+    expect(resolveIdentifier(src, 'target', second)).toBeNull();
   });
 
   it('recognises the shapes the app actually uses', () => {
     // guards the matcher itself, so a broken matcher cannot silently pass the above
     expect(matches('/blog', '/blog')).toBe(true);
-    expect(matches('/@${a}/${b}', '/$author/$permlink')).toBe(true);
-    expect(matches('/edit/$author/$permlink', '/edit/$author/$permlink')).toBe(true);
+    expect(matches(`/@${ph('a')}/${ph('b')}`, '/$author/$permlink')).toBe(true);
+    expect(matches('/edit/$author/$permlink', '/edit/$author/$permlink')).toBe(
+      true,
+    );
     expect(matches('/blog', '/$author/$permlink')).toBe(false);
     expect(isInternal('//evil.com')).toBe(false);
     // the regression this test exists for
-    expect(routes.some((r) => matches('/@${author}', r))).toBe(false);
+    expect(routes.some((r) => matches(`/@${ph('author')}`, r))).toBe(false);
   });
 });

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -274,11 +274,22 @@ function collectFrom(
           fromSpread(where, prop.expression, tag, depth + 1);
           continue;
         }
-        const name =
+        let name: string | undefined;
+        if (
           prop.name &&
           (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name))
-            ? prop.name.text
-            : undefined;
+        ) {
+          name = prop.name.text;
+        } else if (prop.name && ts.isComputedPropertyName(prop.name)) {
+          // `{ ['href']: '/dead' }` names a destination just as plainly as
+          // `{ href: ... }`. A key we cannot read might be one, so the whole
+          // spread has to be classified rather than skipped.
+          name = literalOf(checker, prop.name.expression);
+          if (name === undefined) {
+            into.unresolved.push({ where, value: `{...{ [computed] }}` });
+            continue;
+          }
+        }
         if (!name || !navigates(tag, name)) continue;
 
         if (ts.isPropertyAssignment(prop)) {
@@ -297,13 +308,21 @@ function collectFrom(
       return;
     }
 
+    // A declared type cannot prove the absence of a destination at runtime.
+    // `any` and index signatures obviously carry anything, and a plain object
+    // type does too: `{ href: '/dead', className: 'x' }` assigned to
+    // `{ className: string }` still has href when it is spread. So only a
+    // literal we can read is accepted; every other opaque spread onto a
+    // navigable element is classified.
     const type = checker.getTypeAtLocation(expr);
     for (const attr of LINK_ATTRS) {
       if (!navigates(tag, attr)) continue;
       const prop = type.getProperty(attr);
-      if (!prop) continue; // this spread cannot carry a destination
-      const propType = checker.getTypeOfSymbolAtLocation(prop, expr);
-      if (propType.isStringLiteral()) {
+      const propType = prop
+        ? checker.getTypeOfSymbolAtLocation(prop, expr)
+        : undefined;
+
+      if (propType?.isStringLiteral()) {
         const value = propType.value;
         if (isInternal(value)) {
           into.checked.push({ where, value, via: `{...${label(expr)}}` });
@@ -399,33 +418,65 @@ function sweepRepository() {
   return { ...buckets, routes };
 }
 
-/** Runs the real classifier over a snippet, in memory. */
-function classify(code: string): Buckets {
-  const name = join(SRC, '__probe__.tsx');
-  const options = compilerOptions();
-  const host = ts.createCompilerHost(options, true);
+/**
+ * Snippets are self-contained, so they compile against a minimal environment
+ * rather than the app's full tsconfig: about 90 files instead of about 1280,
+ * roughly halving this file's runtime. The host and the previous program are
+ * reused so only the changed snippet is re-parsed. Resolution is identical and
+ * `collectFrom` is the same code the repository sweep runs.
+ */
+const SNIPPET_OPTIONS: ts.CompilerOptions = {
+  jsx: ts.JsxEmit.ReactJSX,
+  target: ts.ScriptTarget.Latest,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  strict: true,
+  noEmit: true,
+  skipLibCheck: true,
+  types: [],
+};
+
+const SNIPPET_FILE = join(SRC, '__probe__.tsx');
+let snippetCode = '';
+let snippetProgram: ts.Program | undefined;
+
+const snippetHost = (() => {
+  const host = ts.createCompilerHost(SNIPPET_OPTIONS, true);
   const readFile = host.readFile.bind(host);
   const fileExists = host.fileExists.bind(host);
   const getSourceFile = host.getSourceFile.bind(host);
 
-  host.fileExists = (f) => (f === name ? true : fileExists(f));
-  host.readFile = (f) => (f === name ? code : readFile(f));
+  host.fileExists = (f) => (f === SNIPPET_FILE ? true : fileExists(f));
+  host.readFile = (f) => (f === SNIPPET_FILE ? snippetCode : readFile(f));
   host.getSourceFile = (f, ...rest) =>
-    f === name
+    f === SNIPPET_FILE
       ? ts.createSourceFile(
-          name,
-          code,
+          SNIPPET_FILE,
+          snippetCode,
           ts.ScriptTarget.Latest,
           true,
           ts.ScriptKind.TSX,
         )
       : getSourceFile(f, ...rest);
+  return host;
+})();
 
-  const program = ts.createProgram([name], options, host);
-  const sf = program.getSourceFile(name);
+/** Runs the real classifier over a snippet, in memory. */
+function classify(code: string): Buckets {
+  snippetCode = code;
+  const program = ts.createProgram(
+    [SNIPPET_FILE],
+    SNIPPET_OPTIONS,
+    snippetHost,
+    snippetProgram,
+  );
+  snippetProgram = program;
+
+  const sf = program.getSourceFile(SNIPPET_FILE);
   const buckets = emptyBuckets();
-  if (sf)
+  if (sf) {
     collectFrom(sf, program.getTypeChecker(), 'src/__probe__.tsx', buckets);
+  }
   return buckets;
 }
 
@@ -522,18 +573,45 @@ describe('internal links resolve to declared routes', () => {
       expect(unknown(opaque)).toEqual(['{...props}']);
     });
 
-    it('ignores spreads that cannot carry a destination', () => {
+    it('ignores spreads onto elements that cannot navigate', () => {
       // common prop forwarding must not be reported
       const div = classify(
         'export const A = (props: { href: string }) => <div {...props}>1</div>;',
       );
       expect(unknown(div)).toEqual([]);
       expect(values(div)).toEqual([]);
+    });
 
-      const noHref = classify(
-        'export const A = (props: { className: string }) => <a {...props}>1</a>;',
+    it('does not let a declared type prove a spread carries no destination', () => {
+      // A type without href does not mean the value has none: an object with
+      // href assigned to { className: string } keeps it when spread. Likewise
+      // `any` and index signatures carry anything. All must be classified.
+      for (const props of [
+        '{ className: string }',
+        'any',
+        'Record<string, string>',
+      ]) {
+        const b = classify(
+          `export const A = (props: ${props}) => <a {...props}>1</a>;`,
+        );
+        expect(unknown(b)).toEqual(['{...props}']);
+      }
+    });
+
+    it('reads computed destination keys', () => {
+      const known = classify(
+        "export const A = () => <a {...{ ['href']: '/dead' }}>1</a>;",
       );
-      expect(unknown(noHref)).toEqual([]);
+      expect(values(known)).toEqual(['/dead']);
+
+      // a key we cannot read might be href, so the spread is classified
+      const unknownKey = classify(
+        [
+          'declare const k: string;',
+          "export const A = () => <a {...{ [k]: '/dead' }}>1</a>;",
+        ].join('\n'),
+      );
+      expect(unknown(unknownKey)).toEqual(['{...{ [computed] }}']);
     });
 
     it('separates navigation from props that merely share the name', () => {

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -85,18 +85,35 @@ const LINK_RE =
  * literal that does not start with "/" is treated as external and the real link
  * is dropped from the check without a sound, which is the worst outcome for a
  * test whose whole job is to not miss links.
+ *
+ * Resolution is positional: the declaration nearest *above* the link wins. Two
+ * component scopes in one file can reuse a name, and preferring one syntactic
+ * form globally would let a later `useMemo(() => 'https://external')` answer for
+ * an earlier `const target = '/missing'`, reclassifying a real internal link as
+ * external. This is not scope analysis (that wants an AST), but nearest
+ * preceding declaration matches how these components are actually written.
  */
-function resolveIdentifier(source: string, name: string): string | null {
+function declarationsOf(source: string, name: string): { at: number; value: string }[] {
   const root = name.split('.')[0].replace(/[^\w$]/g, '');
-  if (!root) return null;
+  if (!root) return [];
 
-  const direct = new RegExp(`\\bconst\\s+${root}\\s*=\\s*(['"\`])([^'"\`]*)\\1`);
-  const viaMemo = new RegExp(
-    `\\bconst\\s+${root}\\s*=\\s*useMemo\\(\\s*(?:\\/\\/[^\\n]*\\n\\s*)*\\(\\s*\\)\\s*=>\\s*(['"\`])([^'"\`]*)\\1`
-  );
+  // `direct` needs a quote straight after `=`, so it never also matches the useMemo form.
+  const forms = [
+    new RegExp(`\\bconst\\s+${root}\\s*=\\s*(['"\`])([^'"\`]*)\\1`, 'g'),
+    new RegExp(
+      `\\bconst\\s+${root}\\s*=\\s*useMemo\\(\\s*(?:\\/\\/[^\\n]*\\n\\s*)*\\(\\s*\\)\\s*=>\\s*(['"\`])([^'"\`]*)\\1`,
+      'g'
+    ),
+  ];
 
-  const m = source.match(viaMemo) ?? source.match(direct);
-  return m ? m[2] : null;
+  return forms
+    .flatMap((re) => Array.from(source.matchAll(re), (m) => ({ at: m.index, value: m[2] })))
+    .sort((a, b) => a.at - b.at);
+}
+
+function resolveIdentifier(source: string, name: string, usedAt: number): string | null {
+  const above = declarationsOf(source, name).filter((d) => d.at < usedAt);
+  return above.length > 0 ? above[above.length - 1].value : null;
 }
 
 const isInternal = (v: string) => v.startsWith('/') && !v.startsWith('//');
@@ -142,7 +159,7 @@ function collect() {
       // Scoped to this file: a same-named identifier elsewhere is not exempt.
       if (`${rel}:${ident}` in DYNAMIC_LINKS) continue;
 
-      const resolved = resolveIdentifier(source, ident);
+      const resolved = resolveIdentifier(source, ident, m.index);
       if (resolved === null) {
         unresolved.push({ where, value: ident });
       } else if (isInternal(resolved)) {
@@ -196,14 +213,39 @@ describe('internal links resolve to declared routes', () => {
 
   it('resolves only real literal assignments, never a nearby string', () => {
     const memo = "const entryLink = useMemo(\n  // note\n  () => `/@${a}/${b}`,\n  [a],\n);";
-    expect(resolveIdentifier(memo, 'entryLink')).toBe('/@${a}/${b}');
-    expect(resolveIdentifier("const x = '/blog';", 'x')).toBe('/blog');
+    expect(resolveIdentifier(memo, 'entryLink', memo.length)).toBe('/@${a}/${b}');
+    const plain = "const x = '/blog';";
+    expect(resolveIdentifier(plain, 'x', plain.length)).toBe('/blog');
     // the mis-resolution this replaced: a call expression must not borrow a
     // later string such as a className or a word from a type annotation
     const call = 'const target = getUrl();\nconst cls = "totally-unrelated";';
-    expect(resolveIdentifier(call, 'target')).toBeNull();
+    expect(resolveIdentifier(call, 'target', call.length)).toBeNull();
     const annotated = 'function P({ to }: { to: string }) {\n  const target = getUrl();';
-    expect(resolveIdentifier(annotated, 'target')).toBeNull();
+    expect(resolveIdentifier(annotated, 'target', annotated.length)).toBeNull();
+  });
+
+  it('uses the declaration above the link when a name is reused in one file', () => {
+    // Two component scopes reusing `target`. Preferring the useMemo form globally
+    // answered the first link with the second declaration's external URL, so a
+    // real internal link was reclassified as external and never validated.
+    const src = [
+      'function A() {',
+      "  const target = '/missing';",
+      '  return <a href={target}>a</a>;',
+      '}',
+      'function B() {',
+      "  const target = useMemo(() => 'https://external', []);",
+      '  return <a href={target}>b</a>;',
+      '}',
+    ].join('\n');
+
+    const firstLink = src.indexOf('href={target}');
+    const secondLink = src.indexOf('href={target}', firstLink + 1);
+
+    expect(resolveIdentifier(src, 'target', firstLink)).toBe('/missing');
+    expect(resolveIdentifier(src, 'target', secondLink)).toBe('https://external');
+    // nothing declared above the very top of the file
+    expect(resolveIdentifier(src, 'target', 0)).toBeNull();
   });
 
   it('recognises the shapes the app actually uses', () => {

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -97,8 +97,29 @@ const DYNAMIC_LINKS: Record<string, { occurrences: number; reason: string }> = {
 
 const LINK_ATTRS = ['href', 'to'] as const;
 
+/** How far to follow nested object spreads before giving up and reporting. */
+const MAX_SPREAD_DEPTH = 4;
+
 /** Stands in for an interpolated segment, so `/@${a}` compares as `/@*`. */
 const HOLE = '*';
+
+/**
+ * Interpolations known to be a single path segment.
+ *
+ * A HOLE stands for exactly one segment, but an arbitrary string is not
+ * slash-free: `/blog/${tail}` with tail = 'x/y/z' is a four-segment path at
+ * runtime while the shape says two. So a template with an unreadable
+ * interpolation is only shaped when every such interpolation is listed here;
+ * otherwise it stays unresolved and has to be classified.
+ *
+ * These are Hive usernames and permlinks, which cannot contain a slash.
+ */
+const SEGMENT_SAFE = new Set([
+  'entry.author',
+  'entry.permlink',
+  'entryData.author',
+  'entryData.permlink',
+]);
 
 interface FoundLink {
   where: string;
@@ -205,8 +226,16 @@ function pathShape(
     if (!node.head.text.startsWith('/')) return undefined;
     let shape = node.head.text;
     for (const span of node.templateSpans) {
-      shape +=
-        (literalOf(checker, span.expression) ?? HOLE) + span.literal.text;
+      const known = literalOf(checker, span.expression);
+      if (known !== undefined) {
+        shape += known + span.literal.text;
+        continue;
+      }
+      // an unreadable interpolation only counts as one segment if we have said
+      // so; otherwise the segment count is a guess and the shape is worthless
+      const text = span.expression.getText().replace(/\s+/g, ' ');
+      if (!SEGMENT_SAFE.has(text)) return undefined;
+      shape += HOLE + span.literal.text;
     }
     return shape;
   }
@@ -249,10 +278,16 @@ function collectFrom(
     }
   };
 
+  // The attribute matters as much as the tag: a router component navigates
+  // through `to`, a DOM element through `href`. Ignoring the attribute made
+  // every prop on a <Link> look like a destination.
   const navigates = (tag: string, attr: string) =>
     /^[a-z]/.test(tag)
       ? NAVIGABLE_INTRINSICS.has(tag) && attr === 'href'
-      : NAVIGATION_COMPONENTS.has(tag);
+      : NAVIGATION_COMPONENTS.has(tag) && attr === 'to';
+
+  const canNavigate = (tag: string) =>
+    (LINK_ATTRS as readonly string[]).some((attr) => navigates(tag, attr));
 
   /**
    * A spread may carry a destination. Object literals are read property by
@@ -266,7 +301,20 @@ function collectFrom(
     tag: string,
     depth = 0,
   ) => {
-    if (depth > 4) return;
+    // Nothing on this element can be a destination, so no property of a spread
+    // onto it can be either. Checked before any reporting, or a computed key on
+    // a <div> would be reported as an unclassified link.
+    if (!canNavigate(tag)) return;
+
+    // Bounded recursion must still leave a trace: silently returning here would
+    // let a deeply nested spread hide a destination entirely.
+    if (depth > MAX_SPREAD_DEPTH) {
+      into.unresolved.push({
+        where,
+        value: `{...${label(expr)}} (nested beyond ${MAX_SPREAD_DEPTH})`,
+      });
+      return;
+    }
 
     if (ts.isObjectLiteralExpression(expr)) {
       for (const prop of expr.properties) {
@@ -290,7 +338,13 @@ function collectFrom(
             continue;
           }
         }
-        if (!name || !navigates(tag, name)) continue;
+        if (
+          !name ||
+          !(LINK_ATTRS as readonly string[]).includes(name) ||
+          !navigates(tag, name)
+        ) {
+          continue;
+        }
 
         if (ts.isPropertyAssignment(prop)) {
           record(where, prop.initializer);
@@ -596,6 +650,58 @@ describe('internal links resolve to declared routes', () => {
         );
         expect(unknown(b)).toEqual(['{...props}']);
       }
+    });
+
+    it('only treats the right attribute on the right element as navigation', () => {
+      // a router component navigates through `to`, not through every prop
+      const search = classify(
+        [
+          'declare const Link: (p: { to: string; search?: object }) => null;',
+          'declare function buildSearch(): object;',
+          'export const A = () => <Link to="/blog" {...{ search: buildSearch() }} />;',
+        ].join('\n'),
+      );
+      expect(unknown(search)).toEqual([]);
+      expect(values(search)).toEqual(['/blog']);
+
+      // and an opaque spread onto it reports once, not once per link attribute
+      const once = classify(
+        [
+          'declare const Link: (p: { to: string }) => null;',
+          'export const A = (props: { to: string }) => <Link {...props} />;',
+        ].join('\n'),
+      );
+      expect(unknown(once)).toEqual(['{...props}']);
+    });
+
+    it('does not report spreads onto elements that cannot navigate', () => {
+      const computedOnDiv = classify(
+        [
+          'declare const k: string;',
+          "export const A = () => <div {...{ [k]: '/x' }}>1</div>;",
+        ].join('\n'),
+      );
+      expect(unknown(computedOnDiv)).toEqual([]);
+      expect(values(computedOnDiv)).toEqual([]);
+    });
+
+    it('will not guess how many segments an unknown interpolation spans', () => {
+      // tail could be 'x/y/z', so /blog/${tail} is not a two-segment path
+      const spanning = classify(
+        `export const A = (p: { tail: string }) => <a href={\`/blog/\${p.tail}\`}>1</a>;`,
+      );
+      expect(unknown(spanning)).toHaveLength(1);
+      expect(values(spanning)).toEqual([]);
+    });
+
+    it('records a destination hidden beyond the nesting limit', () => {
+      const deep = classify(
+        [
+          "const href = '/dead';",
+          'export const A = () => <a {...{...{...{...{...{...{ href }}}}}}}>1</a>;',
+        ].join('\n'),
+      );
+      expect(unknown(deep).length + values(deep).length).toBeGreaterThan(0);
     });
 
     it('reads computed destination keys', () => {

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -190,8 +190,14 @@ function declarationInScope(
     for (const statement of statements) {
       if (!ts.isVariableStatement(statement)) continue;
       for (const decl of statement.declarationList.declarations) {
+        // `let` / `var` can be reassigned after the initializer, so the
+        // declaration does not tell us the value at the point of use.
+        const isConst =
+          (ts.getCombinedNodeFlags(decl) & ts.NodeFlags.Const) !== 0;
         if (ts.isIdentifier(decl.name)) {
-          if (decl.name.text === name) return decl.initializer;
+          if (decl.name.text === name) {
+            return isConst ? decl.initializer : undefined;
+          }
           continue;
         }
         // destructured: it binds the name but we cannot read the value
@@ -322,15 +328,19 @@ function collect() {
               : undefined;
 
             const key = ident ? `${rel}:${ident}` : undefined;
-            if (key && key in DYNAMIC_LINKS) {
-              exemptionHits[key] = (exemptionHits[key] ?? 0) + 1;
-            } else {
-              const value = staticValue(expr);
-              if (value === null) {
+            // Resolve first. An exemption may only absorb a link that is
+            // genuinely unknowable, so if the identifier later becomes a plain
+            // literal the link is validated and the now-stale exemption fails
+            // its occurrence count instead of quietly covering for it.
+            const value = staticValue(expr);
+            if (value === null) {
+              if (key && key in DYNAMIC_LINKS) {
+                exemptionHits[key] = (exemptionHits[key] ?? 0) + 1;
+              } else {
                 unresolved.push({ where, value: ident ?? '<expression>' });
-              } else if (isInternal(value)) {
-                checked.push({ where, value, via: ident });
               }
+            } else if (isInternal(value)) {
+              checked.push({ where, value, via: ident });
             }
           }
         }
@@ -519,6 +529,33 @@ describe('internal links resolve to declared routes', () => {
     expect(
       hrefValuesIn(
         [outer, 'function A() { return <a href={target}>a</a>; }'].join('\n'),
+      ),
+    ).toEqual(['/blog']);
+  });
+
+  it('treats a reassignable binding as unknowable', () => {
+    // let/var may be reassigned after the initializer, so the declaration does
+    // not tell us the value at the point of use
+    expect(
+      hrefValuesIn(
+        [
+          'function A() {',
+          "  let target = '/blog';",
+          "  target = '/dead';",
+          '  return <a href={target}>a</a>;',
+          '}',
+        ].join('\n'),
+      ),
+    ).toEqual([null]);
+    // const is readable
+    expect(
+      hrefValuesIn(
+        [
+          'function A() {',
+          "  const target = '/blog';",
+          '  return <a href={target}>a</a>;',
+          '}',
+        ].join('\n'),
       ),
     ).toEqual(['/blog']);
   });

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -65,6 +65,25 @@ const DYNAMIC_LINKS: Record<string, { occurrences: number; reason: string }> = {
     occurrences: 1,
     reason: 'wallet/extension install links, external',
   },
+  'src/features/claim/claim-landing.tsx:claimHref': {
+    occurrences: 1,
+    reason: 'built from the imported HOSTING_URL constant, absolute',
+  },
+  // Both author links resolve against runtime config, which defaults to an
+  // absolute ecency.com profile but an operator may point it anywhere. Not
+  // knowable here, so classified rather than guessed either way.
+  'src/features/blog/components/blog-post-header.tsx:`${profileBaseUrl}${entryData.author}`':
+    {
+      occurrences: 1,
+      reason:
+        'runtime config general.profileBaseUrl, defaults to https://ecency.com/@',
+    },
+  'src/features/blog/components/blog-post-item.tsx:`${profileBaseUrl}${entryData.author}`':
+    {
+      occurrences: 1,
+      reason:
+        'runtime config general.profileBaseUrl, defaults to https://ecency.com/@',
+    },
 };
 
 /** Stands in for an interpolated segment, so `/@${a}` compares as `/@*`. */
@@ -109,15 +128,58 @@ function declaredRoutes(): string[] {
   return found;
 }
 
+/** Every name introduced by a binding, including destructured ones. */
+function boundNames(name: ts.BindingName, out: Set<string>): void {
+  if (ts.isIdentifier(name)) {
+    out.add(name.text);
+    return;
+  }
+  for (const element of name.elements) {
+    if (ts.isBindingElement(element)) boundNames(element.name, out);
+  }
+}
+
+/**
+ * True when `node` itself introduces `name` as something whose value we cannot
+ * read: a parameter, a catch variable, or a loop binding. Such a binding shadows
+ * anything outside it, so lookup must stop rather than walk out to an unrelated
+ * declaration of the same name.
+ */
+function bindsOpaquely(node: ts.Node, name: string): boolean {
+  const names = new Set<string>();
+
+  if (ts.isFunctionLike(node)) {
+    for (const parameter of node.parameters) boundNames(parameter.name, names);
+  } else if (ts.isCatchClause(node) && node.variableDeclaration) {
+    boundNames(node.variableDeclaration.name, names);
+  } else if (
+    ts.isForOfStatement(node) ||
+    ts.isForInStatement(node) ||
+    ts.isForStatement(node)
+  ) {
+    const initializer = node.initializer;
+    if (initializer && ts.isVariableDeclarationList(initializer)) {
+      for (const decl of initializer.declarations) boundNames(decl.name, names);
+    }
+  }
+
+  return names.has(name);
+}
+
 /**
  * The nearest `const <name>` visible from `from`, honouring lexical scope, so an
- * identifier declared in a sibling component is not in view.
+ * identifier declared in a sibling component is not in view and a parameter is
+ * not mistaken for an outer constant.
  */
 function declarationInScope(
   from: ts.Node,
   name: string,
 ): ts.Expression | undefined {
   for (let n: ts.Node | undefined = from; n; n = n.parent) {
+    // a parameter or loop binding shadows everything further out, and its value
+    // is not knowable, so the link must be classified rather than guessed
+    if (bindsOpaquely(n, name)) return undefined;
+
     const statements = ts.isSourceFile(n)
       ? n.statements
       : ts.isBlock(n) || ts.isModuleBlock(n)
@@ -128,9 +190,14 @@ function declarationInScope(
     for (const statement of statements) {
       if (!ts.isVariableStatement(statement)) continue;
       for (const decl of statement.declarationList.declarations) {
-        if (ts.isIdentifier(decl.name) && decl.name.text === name) {
-          return decl.initializer;
+        if (ts.isIdentifier(decl.name)) {
+          if (decl.name.text === name) return decl.initializer;
+          continue;
         }
+        // destructured: it binds the name but we cannot read the value
+        const destructured = new Set<string>();
+        boundNames(decl.name, destructured);
+        if (destructured.has(name)) return undefined;
       }
     }
   }
@@ -161,10 +228,25 @@ function staticValue(
     return expr.text;
   }
   if (ts.isTemplateExpression(expr)) {
-    return (
-      expr.head.text +
-      expr.templateSpans.map((span) => HOLE + span.literal.text).join('')
-    );
+    const parts = [expr.head.text];
+    let everySpanKnown = true;
+    for (const span of expr.templateSpans) {
+      const value = staticValue(span.expression, depth + 1);
+      if (value === null) {
+        everySpanKnown = false;
+        parts.push(HOLE);
+      } else {
+        parts.push(value);
+      }
+      parts.push(span.literal.text);
+    }
+    const joined = parts.join('');
+    if (everySpanKnown) return joined;
+    // With an unknown span the result is only safe to use when the literal head
+    // already proves this is a path. `${base}/x` must not be read as external:
+    // base could be '/missing', making it a dead internal link. Unknown means
+    // unknown, so it goes back as null and has to be classified.
+    return expr.head.text.startsWith('/') ? joined : null;
   }
   if (ts.isIdentifier(expr)) {
     return staticValue(declarationInScope(expr, expr.text), depth + 1);
@@ -232,12 +314,12 @@ function collect() {
                 ? init.expression
                 : (init as ts.Expression | undefined);
 
-            const ident =
-              expr && ts.isIdentifier(expr)
-                ? expr.text
-                : expr && ts.isPropertyAccessExpression(expr)
-                  ? expr.getText(sf)
-                  : undefined;
+            // Source text of the expression, so a template with no identifier
+            // can still be classified. For a plain identifier this is just its
+            // name, which keeps the exemption keys readable.
+            const ident = expr
+              ? expr.getText(sf).replace(/\s+/g, ' ')
+              : undefined;
 
             const key = ident ? `${rel}:${ident}` : undefined;
             if (key && key in DYNAMIC_LINKS) {
@@ -368,11 +450,77 @@ describe('internal links resolve to declared routes', () => {
     expect(value).toBe(`/@${HOLE}/${HOLE}`);
     expect(matches(`/@${HOLE}/${HOLE}`, '/$author/$permlink')).toBe(true);
     expect(matches(`/@${HOLE}`, '/$author/$permlink')).toBe(false);
-    // a template that starts with an interpolation is not an internal path
-    const [absolute] = hrefValuesIn(
+    // A template starting with an unknown interpolation is NOT assumed external:
+    // base could be '/missing', which would be a dead internal link.
+    const [unknownBase] = hrefValuesIn(
       `const E = () => <a href={\`\${base}/x\`}>x</a>;`,
     );
+    expect(unknownBase).toBeNull();
+  });
+
+  it('resolves knowable interpolations instead of assuming external', () => {
+    // base is knowable and internal: the whole path must be validated
+    const [known] = hrefValuesIn(
+      [
+        "const base = '/missing';",
+        `const E = () => <a href={\`\${base}/x/y/z\`}>x</a>;`,
+      ].join('\n'),
+    );
+    // resolved rather than waved through as external, and no route is this deep
+    expect(known).toBe('/missing/x/y/z');
+    expect(routes.some((r) => matches(known ?? '', r))).toBe(false);
+
+    // knowable and absolute: correctly external
+    const [absolute] = hrefValuesIn(
+      [
+        "const base = 'https://ecency.com';",
+        `const E = () => <a href={\`\${base}/x\`}>x</a>;`,
+      ].join('\n'),
+    );
+    expect(absolute).toBe('https://ecency.com/x');
     expect(isInternal(absolute ?? '')).toBe(false);
+
+    // head already proves it is a path, so an unknown span is just a wildcard
+    const [rooted] = hrefValuesIn(
+      `const E = () => <a href={\`/@\${a}\`}>x</a>;`,
+    );
+    expect(rooted).toBe(`/@${HOLE}`);
+  });
+
+  it('stops at a parameter rather than reading an outer constant', () => {
+    const outer = "const target = '/blog';";
+    expect(
+      hrefValuesIn(
+        [
+          outer,
+          'function A(target: string) { return <a href={target}>a</a>; }',
+        ].join('\n'),
+      ),
+    ).toEqual([null]);
+    // destructured props bind the name too
+    expect(
+      hrefValuesIn(
+        [
+          outer,
+          'function A({ target }: { target: string }) { return <a href={target}>a</a>; }',
+        ].join('\n'),
+      ),
+    ).toEqual([null]);
+    // and a loop binding
+    expect(
+      hrefValuesIn(
+        [
+          outer,
+          'function A(xs: string[]) { return xs.map((x) => { for (const target of xs) { return <a href={target}>a</a>; } }); }',
+        ].join('\n'),
+      ),
+    ).toEqual([null]);
+    // control: no shadowing, the outer const is genuinely in view
+    expect(
+      hrefValuesIn(
+        [outer, 'function A() { return <a href={target}>a</a>; }'].join('\n'),
+      ),
+    ).toEqual(['/blog']);
   });
 
   it('recognises the shapes the app actually uses', () => {

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -1,4 +1,3 @@
-import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
@@ -11,21 +10,32 @@ import { describe, expect, it } from 'vitest';
  * logs, and nothing in the type system catches a raw `href` string. A
  * commenter's name pointed at `/@user` this way and shipped.
  *
- * This walks the TypeScript AST rather than matching source text. An earlier
- * regex version kept finding new ways to under-report: it could not tell an
- * `<a href>` from a component that happens to take a prop named `to`, it
- * resolved identifiers by proximity rather than by scope, and it preferred one
- * declaration form over another regardless of source order. Each of those
- * silently dropped links from validation. The AST settles all three
- * structurally: element identity, real lexical scope, and the actual
- * initializer of the declaration that is in view.
+ * Destinations are read through the TypeScript type checker. Earlier versions
+ * did their own lexical analysis and each review round found another form they
+ * had not enumerated: declaration shape, then scope, then parameters, then
+ * template interpolation, then mutability, then JSX spreads. The checker
+ * answers all of those from one mechanism, and answers several the lexical
+ * version could not reach at all:
+ *
+ *   const good = '/blog'          -> "/blog"
+ *   import { EXT } from './x'     -> "/imported"   (cross-file)
+ *   `${base}/x`                   -> "/missing/x"  (template literal types)
+ *   let m = '/a'; m = '/b'        -> string, so not a literal, so unknown
+ *   function A(href) { … }        -> string, so unknown
+ *
+ * What remains explicit is policy, not analysis: which elements navigate, and
+ * which unknowable destinations are acceptable.
  *
  * Lives under src/routes with a `-` prefix, TanStack Router's convention for a
  * non-route file in the routes directory. Without it the generator warns on
  * every build that this file exports no Route.
  */
 
-const SRC = join(__dirname, '..');
+const APP = join(__dirname, '..', '..');
+const SRC = join(APP, 'src');
+
+/** DOM elements whose `href` is a navigation destination. */
+const NAVIGABLE_INTRINSICS = new Set(['a', 'area']);
 
 /** Router components whose `to` really is navigation. */
 const NAVIGATION_COMPONENTS = new Set(['Link', 'Navigate']);
@@ -45,8 +55,10 @@ const NON_LINK_COMPONENT_PROPS: Record<string, string> = {
  * Adding an entry is a deliberate act: say why it is safe.
  *
  * `occurrences` pins how many links the entry may account for, so a second link
- * through the same identifier in the same file fails rather than inheriting the
- * exemption, and a stale entry matching nothing fails too.
+ * through the same expression in the same file fails rather than inheriting the
+ * exemption, and a stale entry matching nothing fails too. An exemption is only
+ * consumed when the checker genuinely cannot resolve the value, so an entry
+ * whose target becomes a literal fails instead of covering for it.
  */
 const DYNAMIC_LINKS: Record<string, { occurrences: number; reason: string }> = {
   'src/features/blog/layout/blog-navigation.tsx:rssUrl': {
@@ -69,9 +81,6 @@ const DYNAMIC_LINKS: Record<string, { occurrences: number; reason: string }> = {
     occurrences: 1,
     reason: 'built from the imported HOSTING_URL constant, absolute',
   },
-  // Both author links resolve against runtime config, which defaults to an
-  // absolute ecency.com profile but an operator may point it anywhere. Not
-  // knowable here, so classified rather than guessed either way.
   'src/features/blog/components/blog-post-header.tsx:`${profileBaseUrl}${entryData.author}`':
     {
       occurrences: 1,
@@ -86,30 +95,269 @@ const DYNAMIC_LINKS: Record<string, { occurrences: number; reason: string }> = {
     },
 };
 
+const LINK_ATTRS = ['href', 'to'] as const;
+
 /** Stands in for an interpolated segment, so `/@${a}` compares as `/@*`. */
 const HOLE = '*';
 
-function walk(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
-    const p = join(dir, e.name);
-    if (e.isDirectory()) return walk(p);
-    return e.isFile() && p.endsWith('.tsx') ? [p] : [];
-  });
+interface FoundLink {
+  where: string;
+  value: string;
+  via?: string;
 }
 
-function parse(file: string): ts.SourceFile {
-  return ts.createSourceFile(
-    file,
-    readFileSync(file, 'utf8'),
-    ts.ScriptTarget.Latest,
-    /* setParentNodes */ true,
-    ts.ScriptKind.TSX,
-  );
+interface Buckets {
+  checked: FoundLink[];
+  unresolved: FoundLink[];
+  componentProps: { where: string; key: string }[];
+  exemptionHits: Record<string, number>;
+}
+
+function emptyBuckets(): Buckets {
+  return { checked: [], unresolved: [], componentProps: [], exemptionHits: {} };
+}
+
+const isInternal = (v: string) => v.startsWith('/') && !v.startsWith('//');
+
+function segments(path: string): string[] {
+  return path.split(/[?#]/)[0].split('/').filter(Boolean);
+}
+
+function matches(link: string, route: string): boolean {
+  const l = segments(link);
+  const r = segments(route);
+  if (l.length !== r.length) return false;
+  // a route param matches anything; a HOLE in the link matches any route segment
+  return r.every((rs, i) => rs.startsWith('$') || l[i] === HOLE || rs === l[i]);
+}
+
+/** The string this expression is known to be, or undefined if not knowable. */
+function literalOf(checker: ts.TypeChecker, node: ts.Node): string | undefined {
+  // A JSX attribute written as `to="/blog"` types as the element's declared prop
+  // type, not as a literal, so read the syntax directly when it is one.
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+  const type = checker.getTypeAtLocation(node);
+  return type.isStringLiteral() ? type.value : undefined;
+}
+
+/**
+ * `{ href }` has no initializer node and its property type is widened, so ask
+ * the checker for the symbol the shorthand refers to.
+ */
+function shorthandLiteral(
+  checker: ts.TypeChecker,
+  prop: ts.ShorthandPropertyAssignment,
+): string | undefined {
+  const symbol = checker.getShorthandAssignmentValueSymbol(prop);
+  if (!symbol) return undefined;
+  const type = checker.getTypeOfSymbolAtLocation(symbol, prop);
+  return type.isStringLiteral() ? type.value : undefined;
+}
+
+/** `useMemo(() => X, deps)` -> X, so a memoised destination is still readable. */
+function unwrapUseMemo(call: ts.CallExpression): ts.Expression | undefined {
+  if (!ts.isIdentifier(call.expression) || call.expression.text !== 'useMemo') {
+    return undefined;
+  }
+  const [factory] = call.arguments;
+  if (!factory || !ts.isArrowFunction(factory) || ts.isBlock(factory.body)) {
+    return undefined;
+  }
+  return factory.body;
+}
+
+/** The expression a const identifier was initialised with, via real symbol resolution. */
+function constInitializer(
+  checker: ts.TypeChecker,
+  node: ts.Node,
+): ts.Expression | undefined {
+  if (!ts.isIdentifier(node)) return undefined;
+  const symbol = checker.getSymbolAtLocation(node);
+  const decl = symbol?.valueDeclaration;
+  if (!decl || !ts.isVariableDeclaration(decl)) return undefined;
+  if ((ts.getCombinedNodeFlags(decl) & ts.NodeFlags.Const) === 0)
+    return undefined;
+  const init = decl.initializer;
+  if (init && ts.isCallExpression(init)) return unwrapUseMemo(init);
+  return init;
+}
+
+/**
+ * The route *shape* of a template whose literal head already proves it is a
+ * path, with unknowable interpolations standing in as HOLE.
+ *
+ * The checker gives an exact value or nothing, but `/@${author}` has no exact
+ * value and is still the case this test exists for: its segment structure is
+ * what makes it a dead link. A template whose head does not start with `/`
+ * returns undefined rather than being assumed external, since the leading
+ * interpolation could itself be an internal path.
+ */
+function pathShape(
+  checker: ts.TypeChecker,
+  node: ts.Node,
+  depth = 0,
+): string | undefined {
+  if (depth > 4) return undefined;
+
+  if (ts.isTemplateExpression(node)) {
+    if (!node.head.text.startsWith('/')) return undefined;
+    let shape = node.head.text;
+    for (const span of node.templateSpans) {
+      shape +=
+        (literalOf(checker, span.expression) ?? HOLE) + span.literal.text;
+    }
+    return shape;
+  }
+
+  const init = constInitializer(checker, node);
+  return init ? pathShape(checker, init, depth + 1) : undefined;
+}
+
+/**
+ * Walks one source file and files every navigation destination it can see.
+ * Shared by the repository sweep and by the unit tests, so the tests exercise
+ * the real classification rather than a reimplementation of it.
+ */
+function collectFrom(
+  sf: ts.SourceFile,
+  checker: ts.TypeChecker,
+  rel: string,
+  into: Buckets,
+): void {
+  const lineOf = (n: ts.Node) =>
+    sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1;
+
+  const label = (n: ts.Node) => n.getText(sf).replace(/\s+/g, ' ');
+
+  const record = (where: string, node: ts.Node | undefined) => {
+    const via = node ? label(node) : undefined;
+    const key = via ? `${rel}:${via}` : undefined;
+    const value = node
+      ? (literalOf(checker, node) ?? pathShape(checker, node))
+      : undefined;
+
+    if (value === undefined) {
+      if (key && key in DYNAMIC_LINKS) {
+        into.exemptionHits[key] = (into.exemptionHits[key] ?? 0) + 1;
+      } else {
+        into.unresolved.push({ where, value: via ?? '<expression>' });
+      }
+    } else if (isInternal(value)) {
+      into.checked.push({ where, value, via });
+    }
+  };
+
+  const navigates = (tag: string, attr: string) =>
+    /^[a-z]/.test(tag)
+      ? NAVIGABLE_INTRINSICS.has(tag) && attr === 'href'
+      : NAVIGATION_COMPONENTS.has(tag);
+
+  /**
+   * A spread may carry a destination. Object literals are read property by
+   * property, covering shorthand and nested spreads; anything else is asked of
+   * its type, so `{...props}` on a type without href is correctly ignored while
+   * one with a non-literal href becomes unresolved.
+   */
+  const fromSpread = (
+    where: string,
+    expr: ts.Expression,
+    tag: string,
+    depth = 0,
+  ) => {
+    if (depth > 4) return;
+
+    if (ts.isObjectLiteralExpression(expr)) {
+      for (const prop of expr.properties) {
+        if (ts.isSpreadAssignment(prop)) {
+          fromSpread(where, prop.expression, tag, depth + 1);
+          continue;
+        }
+        const name =
+          prop.name &&
+          (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name))
+            ? prop.name.text
+            : undefined;
+        if (!name || !navigates(tag, name)) continue;
+
+        if (ts.isPropertyAssignment(prop)) {
+          record(where, prop.initializer);
+        } else if (ts.isShorthandPropertyAssignment(prop)) {
+          const value = shorthandLiteral(checker, prop);
+          if (value === undefined) {
+            into.unresolved.push({ where, value: `{...{ ${name} }}` });
+          } else if (isInternal(value)) {
+            into.checked.push({ where, value, via: `{...{ ${name} }}` });
+          }
+        } else {
+          into.unresolved.push({ where, value: `{...{ ${name} }}` });
+        }
+      }
+      return;
+    }
+
+    const type = checker.getTypeAtLocation(expr);
+    for (const attr of LINK_ATTRS) {
+      if (!navigates(tag, attr)) continue;
+      const prop = type.getProperty(attr);
+      if (!prop) continue; // this spread cannot carry a destination
+      const propType = checker.getTypeOfSymbolAtLocation(prop, expr);
+      if (propType.isStringLiteral()) {
+        const value = propType.value;
+        if (isInternal(value)) {
+          into.checked.push({ where, value, via: `{...${label(expr)}}` });
+        }
+      } else {
+        into.unresolved.push({ where, value: `{...${label(expr)}}` });
+      }
+    }
+  };
+
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxSpreadAttribute(node)) {
+      const owner = node.parent.parent as ts.JsxOpeningLikeElement;
+      fromSpread(
+        `${rel}:${lineOf(node)}`,
+        node.expression,
+        owner.tagName.getText(sf),
+      );
+    }
+
+    if (ts.isJsxAttribute(node) && ts.isIdentifier(node.name)) {
+      const attr = node.name.text;
+      if (attr === 'href' || attr === 'to') {
+        const owner = node.parent.parent as ts.JsxOpeningLikeElement;
+        const tag = owner.tagName.getText(sf);
+        const where = `${rel}:${lineOf(node)}`;
+
+        if (navigates(tag, attr)) {
+          const init = node.initializer;
+          record(
+            where,
+            init && ts.isJsxExpression(init) ? init.expression : init,
+          );
+        } else {
+          into.componentProps.push({ where, key: `${tag}.${attr}` });
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sf);
+}
+
+function compilerOptions(): ts.CompilerOptions {
+  const configPath = join(APP, 'tsconfig.json');
+  const { config } = ts.readConfigFile(configPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(config ?? {}, ts.sys, APP);
+  return { ...parsed.options, noEmit: true };
 }
 
 /** Route paths exactly as the generator declares them in FileRoutesByFullPath. */
-function declaredRoutes(): string[] {
-  const sf = parse(join(SRC, 'routeTree.gen.ts'));
+function declaredRoutes(sf: ts.SourceFile): string[] {
   const found: string[] = [];
   const visit = (n: ts.Node) => {
     if (
@@ -128,299 +376,62 @@ function declaredRoutes(): string[] {
   return found;
 }
 
-/** Every name introduced by a binding, including destructured ones. */
-function boundNames(name: ts.BindingName, out: Set<string>): void {
-  if (ts.isIdentifier(name)) {
-    out.add(name.text);
-    return;
+function sweepRepository() {
+  const options = compilerOptions();
+  const configPath = join(APP, 'tsconfig.json');
+  const { config } = ts.readConfigFile(configPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(config ?? {}, ts.sys, APP);
+  const program = ts.createProgram(parsed.fileNames, options);
+  const checker = program.getTypeChecker();
+
+  const buckets = emptyBuckets();
+  let routes: string[] = [];
+
+  for (const sf of program.getSourceFiles()) {
+    if (sf.isDeclarationFile) continue;
+    const file = sf.fileName;
+    if (!file.startsWith(SRC)) continue;
+    if (file.endsWith('routeTree.gen.ts')) routes = declaredRoutes(sf);
+    if (!file.endsWith('.tsx')) continue;
+    collectFrom(sf, checker, file.replace(SRC, 'src'), buckets);
   }
-  for (const element of name.elements) {
-    if (ts.isBindingElement(element)) boundNames(element.name, out);
-  }
+
+  return { ...buckets, routes };
 }
 
-/**
- * True when `node` itself introduces `name` as something whose value we cannot
- * read: a parameter, a catch variable, or a loop binding. Such a binding shadows
- * anything outside it, so lookup must stop rather than walk out to an unrelated
- * declaration of the same name.
- */
-function bindsOpaquely(node: ts.Node, name: string): boolean {
-  const names = new Set<string>();
+/** Runs the real classifier over a snippet, in memory. */
+function classify(code: string): Buckets {
+  const name = join(SRC, '__probe__.tsx');
+  const options = compilerOptions();
+  const host = ts.createCompilerHost(options, true);
+  const readFile = host.readFile.bind(host);
+  const fileExists = host.fileExists.bind(host);
+  const getSourceFile = host.getSourceFile.bind(host);
 
-  if (ts.isFunctionLike(node)) {
-    for (const parameter of node.parameters) boundNames(parameter.name, names);
-  } else if (ts.isCatchClause(node) && node.variableDeclaration) {
-    boundNames(node.variableDeclaration.name, names);
-  } else if (
-    ts.isForOfStatement(node) ||
-    ts.isForInStatement(node) ||
-    ts.isForStatement(node)
-  ) {
-    const initializer = node.initializer;
-    if (initializer && ts.isVariableDeclarationList(initializer)) {
-      for (const decl of initializer.declarations) boundNames(decl.name, names);
-    }
-  }
+  host.fileExists = (f) => (f === name ? true : fileExists(f));
+  host.readFile = (f) => (f === name ? code : readFile(f));
+  host.getSourceFile = (f, ...rest) =>
+    f === name
+      ? ts.createSourceFile(
+          name,
+          code,
+          ts.ScriptTarget.Latest,
+          true,
+          ts.ScriptKind.TSX,
+        )
+      : getSourceFile(f, ...rest);
 
-  return names.has(name);
-}
-
-/**
- * The nearest `const <name>` visible from `from`, honouring lexical scope, so an
- * identifier declared in a sibling component is not in view and a parameter is
- * not mistaken for an outer constant.
- */
-function declarationInScope(
-  from: ts.Node,
-  name: string,
-): ts.Expression | undefined {
-  for (let n: ts.Node | undefined = from; n; n = n.parent) {
-    // a parameter or loop binding shadows everything further out, and its value
-    // is not knowable, so the link must be classified rather than guessed
-    if (bindsOpaquely(n, name)) return undefined;
-
-    const statements = ts.isSourceFile(n)
-      ? n.statements
-      : ts.isBlock(n) || ts.isModuleBlock(n)
-        ? n.statements
-        : undefined;
-    if (!statements) continue;
-
-    for (const statement of statements) {
-      if (!ts.isVariableStatement(statement)) continue;
-      for (const decl of statement.declarationList.declarations) {
-        // `let` / `var` can be reassigned after the initializer, so the
-        // declaration does not tell us the value at the point of use.
-        const isConst =
-          (ts.getCombinedNodeFlags(decl) & ts.NodeFlags.Const) !== 0;
-        if (ts.isIdentifier(decl.name)) {
-          if (decl.name.text === name) {
-            return isConst ? decl.initializer : undefined;
-          }
-          continue;
-        }
-        // destructured: it binds the name but we cannot read the value
-        const destructured = new Set<string>();
-        boundNames(decl.name, destructured);
-        if (destructured.has(name)) return undefined;
-      }
-    }
-  }
-  return undefined;
-}
-
-/** `useMemo(() => X, deps)` -> X; any other call -> undefined. */
-function unwrapUseMemo(call: ts.CallExpression): ts.Expression | undefined {
-  if (!ts.isIdentifier(call.expression) || call.expression.text !== 'useMemo') {
-    return undefined;
-  }
-  const [factory] = call.arguments;
-  if (!factory || !ts.isArrowFunction(factory)) return undefined;
-  return ts.isBlock(factory.body) ? undefined : factory.body;
-}
-
-/**
- * Static value of `expr`, with interpolations collapsed to HOLE.
- * Returns null when the value cannot be known without running the app.
- */
-function staticValue(
-  expr: ts.Expression | undefined,
-  depth = 0,
-): string | null {
-  if (!expr || depth > 8) return null;
-
-  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) {
-    return expr.text;
-  }
-  if (ts.isTemplateExpression(expr)) {
-    const parts = [expr.head.text];
-    let everySpanKnown = true;
-    for (const span of expr.templateSpans) {
-      const value = staticValue(span.expression, depth + 1);
-      if (value === null) {
-        everySpanKnown = false;
-        parts.push(HOLE);
-      } else {
-        parts.push(value);
-      }
-      parts.push(span.literal.text);
-    }
-    const joined = parts.join('');
-    if (everySpanKnown) return joined;
-    // With an unknown span the result is only safe to use when the literal head
-    // already proves this is a path. `${base}/x` must not be read as external:
-    // base could be '/missing', making it a dead internal link. Unknown means
-    // unknown, so it goes back as null and has to be classified.
-    return expr.head.text.startsWith('/') ? joined : null;
-  }
-  if (ts.isIdentifier(expr)) {
-    return staticValue(declarationInScope(expr, expr.text), depth + 1);
-  }
-  if (ts.isCallExpression(expr)) {
-    return staticValue(unwrapUseMemo(expr), depth + 1);
-  }
-  if (ts.isParenthesizedExpression(expr)) {
-    return staticValue(expr.expression, depth + 1);
-  }
-  return null;
-}
-
-const isInternal = (v: string) => v.startsWith('/') && !v.startsWith('//');
-
-function segments(path: string): string[] {
-  return path.split(/[?#]/)[0].split('/').filter(Boolean);
-}
-
-function matches(link: string, route: string): boolean {
-  const l = segments(link);
-  const r = segments(route);
-  if (l.length !== r.length) return false;
-  // a route param matches anything; a HOLE in the link matches any route segment
-  return r.every((rs, i) => rs.startsWith('$') || l[i] === HOLE || rs === l[i]);
-}
-
-interface FoundLink {
-  where: string;
-  value: string;
-  via?: string;
-}
-
-function collect() {
-  const checked: FoundLink[] = [];
-  const unresolved: FoundLink[] = [];
-  const componentProps: { where: string; key: string }[] = [];
-  const exemptionHits: Record<string, number> = {};
-
-  for (const file of walk(SRC)) {
-    const sf = parse(file);
-    const rel = file.replace(SRC, 'src');
-    const lineOf = (n: ts.Node) =>
-      sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1;
-
-    /** Records one destination, whether it came from an attribute or a spread. */
-    const record = (where: string, expr: ts.Expression | undefined) => {
-      // Source text of the expression, so a template with no identifier can
-      // still be classified. For a plain identifier this is just its name,
-      // which keeps the exemption keys readable.
-      const ident = expr ? expr.getText(sf).replace(/\s+/g, ' ') : undefined;
-      const key = ident ? `${rel}:${ident}` : undefined;
-
-      // Resolve first. An exemption may only absorb a link that is genuinely
-      // unknowable, so if the identifier later becomes a plain literal the link
-      // is validated and the now-stale exemption fails its occurrence count
-      // instead of quietly covering for it.
-      const value = staticValue(expr);
-      if (value === null) {
-        if (key && key in DYNAMIC_LINKS) {
-          exemptionHits[key] = (exemptionHits[key] ?? 0) + 1;
-        } else {
-          unresolved.push({ where, value: ident ?? '<expression>' });
-        }
-      } else if (isInternal(value)) {
-        checked.push({ where, value, via: ident });
-      }
-    };
-
-    /** Can this element carry a destination at all? */
-    const navigable = (tag: string) =>
-      /^[a-z]/.test(tag) || NAVIGATION_COMPONENTS.has(tag);
-
-    const visit = (node: ts.Node) => {
-      // `<a {...{ href: '/dead' }}>` and `<Link {...props}>` are attributes too,
-      // just not JsxAttribute nodes. Without this they produce no entry at all,
-      // so a dead link inside a spread is invisible rather than merely
-      // unresolved.
-      if (ts.isJsxSpreadAttribute(node)) {
-        const owner = node.parent.parent as ts.JsxOpeningLikeElement;
-        const tag = owner.tagName.getText(sf);
-        const where = `${rel}:${lineOf(node)}`;
-
-        if (navigable(tag)) {
-          const spread = node.expression;
-          if (ts.isObjectLiteralExpression(spread)) {
-            // a literal tells us exactly whether it carries a destination
-            for (const prop of spread.properties) {
-              if (
-                ts.isPropertyAssignment(prop) &&
-                (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)) &&
-                (prop.name.text === 'href' || prop.name.text === 'to')
-              ) {
-                record(where, prop.initializer);
-              }
-            }
-          } else {
-            // an opaque spread may or may not carry one; it has to be classified
-            unresolved.push({
-              where,
-              value: `{...${spread.getText(sf).replace(/\s+/g, ' ')}}`,
-            });
-          }
-        }
-      }
-
-      if (ts.isJsxAttribute(node) && ts.isIdentifier(node.name)) {
-        const attr = node.name.text;
-        if (attr === 'href' || attr === 'to') {
-          const owner = node.parent.parent as ts.JsxOpeningLikeElement;
-          const tag = owner.tagName.getText(sf);
-          const where = `${rel}:${lineOf(node)}`;
-          // lowercase tags are DOM elements, so href is genuinely a link;
-          // capitalised ones are components and only the router's navigate
-          const isLink = /^[a-z]/.test(tag)
-            ? attr === 'href'
-            : NAVIGATION_COMPONENTS.has(tag);
-
-          if (!isLink) {
-            componentProps.push({ where, key: `${tag}.${attr}` });
-          } else {
-            const init = node.initializer;
-            record(
-              where,
-              init && ts.isJsxExpression(init)
-                ? init.expression
-                : (init as ts.Expression | undefined),
-            );
-          }
-        }
-      }
-      ts.forEachChild(node, visit);
-    };
-    visit(sf);
-  }
-
-  return { checked, unresolved, componentProps, exemptionHits };
-}
-
-/** Parses a snippet and returns every `href` value the resolver produces. */
-function hrefValuesIn(code: string): (string | null)[] {
-  const sf = ts.createSourceFile(
-    'snippet.tsx',
-    code,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX,
-  );
-  const out: (string | null)[] = [];
-  const visit = (n: ts.Node) => {
-    if (
-      ts.isJsxAttribute(n) &&
-      ts.isIdentifier(n.name) &&
-      n.name.text === 'href' &&
-      n.initializer &&
-      ts.isJsxExpression(n.initializer)
-    ) {
-      out.push(staticValue(n.initializer.expression));
-    }
-    ts.forEachChild(n, visit);
-  };
-  visit(sf);
-  return out;
+  const program = ts.createProgram([name], options, host);
+  const sf = program.getSourceFile(name);
+  const buckets = emptyBuckets();
+  if (sf)
+    collectFrom(sf, program.getTypeChecker(), 'src/__probe__.tsx', buckets);
+  return buckets;
 }
 
 describe('internal links resolve to declared routes', () => {
-  const routes = declaredRoutes();
-  const { checked, unresolved, componentProps, exemptionHits } = collect();
+  const { checked, unresolved, componentProps, exemptionHits, routes } =
+    sweepRepository();
 
   it('reads the route tree and finds links to check', () => {
     expect(routes).toContain('/blog');
@@ -453,194 +464,99 @@ describe('internal links resolve to declared routes', () => {
     expect(unclassified).toEqual([]);
   });
 
-  it('resolves identifiers by scope, not proximity', () => {
-    // Both hazards the regex version fell into, now decided by the AST: a
-    // sibling component's declaration is not in view, and the declaration that
-    // is in view is used whatever form it takes.
-    const values = hrefValuesIn(
-      [
-        'function A() {',
-        "  const target = '/blog';",
-        '  return <a href={target}>a</a>;',
-        '}',
-        'function B() {',
-        '  const target = getUrl();',
-        '  return <a href={target}>b</a>;',
-        '}',
-        'function C() {',
-        "  const target = useMemo(() => '/search', []);",
-        '  return <a href={target}>c</a>;',
-        '}',
-      ].join('\n'),
-    );
-    // B's getUrl() is unknowable and must not borrow A's '/blog'
-    expect(values).toEqual(['/blog', null, '/search']);
-  });
+  describe('classification', () => {
+    const values = (b: Buckets) => b.checked.map((l) => l.value);
+    const unknown = (b: Buckets) => b.unresolved.map((l) => l.value);
 
-  it('prefers an inner declaration over an outer one', () => {
-    const values = hrefValuesIn(
-      [
-        "const target = '/blog';",
-        'function A() {',
-        "  const target = '/search';",
-        '  return <a href={target}>a</a>;',
-        '}',
-      ].join('\n'),
-    );
-    expect(values).toEqual(['/search']);
-  });
-
-  it('collapses interpolation to a wildcard that matches a route param', () => {
-    // template literal with escaped placeholders: keeps a literal `${` out of a
-    // plain string, which noTemplateCurlyInString flags (rightly, in general)
-    const [value] = hrefValuesIn(
-      `const E = () => <a href={\`/@\${a}/\${b}\`}>x</a>;`,
-    );
-    expect(value).toBe(`/@${HOLE}/${HOLE}`);
-    expect(matches(`/@${HOLE}/${HOLE}`, '/$author/$permlink')).toBe(true);
-    expect(matches(`/@${HOLE}`, '/$author/$permlink')).toBe(false);
-    // A template starting with an unknown interpolation is NOT assumed external:
-    // base could be '/missing', which would be a dead internal link.
-    const [unknownBase] = hrefValuesIn(
-      `const E = () => <a href={\`\${base}/x\`}>x</a>;`,
-    );
-    expect(unknownBase).toBeNull();
-  });
-
-  it('resolves knowable interpolations instead of assuming external', () => {
-    // base is knowable and internal: the whole path must be validated
-    const [known] = hrefValuesIn(
-      [
-        "const base = '/missing';",
-        `const E = () => <a href={\`\${base}/x/y/z\`}>x</a>;`,
-      ].join('\n'),
-    );
-    // resolved rather than waved through as external, and no route is this deep
-    expect(known).toBe('/missing/x/y/z');
-    expect(routes.some((r) => matches(known ?? '', r))).toBe(false);
-
-    // knowable and absolute: correctly external
-    const [absolute] = hrefValuesIn(
-      [
-        "const base = 'https://ecency.com';",
-        `const E = () => <a href={\`\${base}/x\`}>x</a>;`,
-      ].join('\n'),
-    );
-    expect(absolute).toBe('https://ecency.com/x');
-    expect(isInternal(absolute ?? '')).toBe(false);
-
-    // head already proves it is a path, so an unknown span is just a wildcard
-    const [rooted] = hrefValuesIn(
-      `const E = () => <a href={\`/@\${a}\`}>x</a>;`,
-    );
-    expect(rooted).toBe(`/@${HOLE}`);
-  });
-
-  it('stops at a parameter rather than reading an outer constant', () => {
-    const outer = "const target = '/blog';";
-    expect(
-      hrefValuesIn(
+    it('resolves consts, imports and template literals', () => {
+      const b = classify(
         [
-          outer,
-          'function A(target: string) { return <a href={target}>a</a>; }',
+          "const good = '/blog';",
+          "const base = '/missing';",
+          'export const A = () => <a href={good}>1</a>;',
+          `export const B = () => <a href={\`\${base}/x/y/z\`}>2</a>;`,
         ].join('\n'),
-      ),
-    ).toEqual([null]);
-    // destructured props bind the name too
-    expect(
-      hrefValuesIn(
-        [
-          outer,
-          'function A({ target }: { target: string }) { return <a href={target}>a</a>; }',
-        ].join('\n'),
-      ),
-    ).toEqual([null]);
-    // and a loop binding
-    expect(
-      hrefValuesIn(
-        [
-          outer,
-          'function A(xs: string[]) { return xs.map((x) => { for (const target of xs) { return <a href={target}>a</a>; } }); }',
-        ].join('\n'),
-      ),
-    ).toEqual([null]);
-    // control: no shadowing, the outer const is genuinely in view
-    expect(
-      hrefValuesIn(
-        [outer, 'function A() { return <a href={target}>a</a>; }'].join('\n'),
-      ),
-    ).toEqual(['/blog']);
-  });
-
-  it('treats a reassignable binding as unknowable', () => {
-    // let/var may be reassigned after the initializer, so the declaration does
-    // not tell us the value at the point of use
-    expect(
-      hrefValuesIn(
-        [
-          'function A() {',
-          "  let target = '/blog';",
-          "  target = '/dead';",
-          '  return <a href={target}>a</a>;',
-          '}',
-        ].join('\n'),
-      ),
-    ).toEqual([null]);
-    // const is readable
-    expect(
-      hrefValuesIn(
-        [
-          'function A() {',
-          "  const target = '/blog';",
-          '  return <a href={target}>a</a>;',
-          '}',
-        ].join('\n'),
-      ),
-    ).toEqual(['/blog']);
-  });
-
-  it('sees destinations passed through a JSX spread', () => {
-    // A spread is a JsxSpreadAttribute, not a JsxAttribute, so an
-    // attribute-only visitor produces no entry at all and a dead link inside
-    // one is invisible rather than merely unresolved.
-    const inSpread = (code: string) => {
-      const sf = ts.createSourceFile(
-        'spread.tsx',
-        code,
-        ts.ScriptTarget.Latest,
-        true,
-        ts.ScriptKind.TSX,
       );
-      const out: string[] = [];
-      const visit = (n: ts.Node) => {
-        if (ts.isJsxSpreadAttribute(n)) out.push(n.expression.getText(sf));
-        ts.forEachChild(n, visit);
-      };
-      visit(sf);
-      return out;
-    };
+      expect(values(b)).toEqual(['/blog', '/missing/x/y/z']);
+      expect(unknown(b)).toEqual([]);
+    });
 
-    // the shapes exist and are reachable as spread attributes
-    expect(
-      inSpread("const E = () => <a {...{ href: '/dead' }}>x</a>;"),
-    ).toEqual(["{ href: '/dead' }"]);
-    expect(inSpread('const E = () => <a {...props}>x</a>;')).toEqual(['props']);
+    it('treats parameters, destructuring and reassignment as unknowable', () => {
+      const b = classify(
+        [
+          "const target = '/blog';",
+          'export const A = (target: string) => <a href={target}>1</a>;',
+          'export const B = ({ target }: { target: string }) => <a href={target}>2</a>;',
+          "export const C = () => { let m = '/blog'; m = '/dead'; return <a href={m}>3</a>; };",
+        ].join('\n'),
+      );
+      expect(values(b)).toEqual([]);
+      expect(unknown(b)).toHaveLength(3);
+    });
 
-    // and the collector classifies them: object literals resolve, opaque
-    // spreads are unresolved, and non-navigable components are ignored.
-    // Exercised end to end by the probe cases in the PR description.
-    expect(NAVIGATION_COMPONENTS.has('Link')).toBe(true);
+    it('reads destinations out of every spread shape', () => {
+      const literal = classify(
+        "export const A = () => <a {...{ href: '/dead' }}>1</a>;",
+      );
+      expect(values(literal)).toEqual(['/dead']);
+
+      const shorthand = classify(
+        [
+          "const href = '/dead';",
+          'export const A = () => <a {...{ href }}>1</a>;',
+        ].join('\n'),
+      );
+      expect(values(shorthand)).toEqual(['/dead']);
+
+      const nested = classify(
+        [
+          "const href = '/dead';",
+          'export const A = () => <a {...{ ...{ href } }}>1</a>;',
+        ].join('\n'),
+      );
+      expect(values(nested)).toEqual(['/dead']);
+
+      const opaque = classify(
+        'export const A = (props: { href: string }) => <a {...props}>1</a>;',
+      );
+      expect(unknown(opaque)).toEqual(['{...props}']);
+    });
+
+    it('ignores spreads that cannot carry a destination', () => {
+      // common prop forwarding must not be reported
+      const div = classify(
+        'export const A = (props: { href: string }) => <div {...props}>1</div>;',
+      );
+      expect(unknown(div)).toEqual([]);
+      expect(values(div)).toEqual([]);
+
+      const noHref = classify(
+        'export const A = (props: { className: string }) => <a {...props}>1</a>;',
+      );
+      expect(unknown(noHref)).toEqual([]);
+    });
+
+    it('separates navigation from props that merely share the name', () => {
+      const b = classify(
+        'export const A = (to: string) => <TippingPopover to={to} />;',
+      );
+      expect(b.componentProps.map((p) => p.key)).toEqual(['TippingPopover.to']);
+      expect(unknown(b)).toEqual([]);
+    });
+
+    it('treats router components as navigation', () => {
+      const b = classify("export const A = () => <Link to='/blog'>1</Link>;");
+      expect(values(b)).toEqual(['/blog']);
+    });
   });
 
-  it('recognises the shapes the app actually uses', () => {
+  it('recognises the route shapes the app uses', () => {
     expect(matches('/blog', '/blog')).toBe(true);
-    expect(matches('/edit/$author/$permlink', '/edit/$author/$permlink')).toBe(
-      true,
-    );
+    expect(matches('/@alice/post', '/$author/$permlink')).toBe(true);
     expect(matches('/blog', '/$author/$permlink')).toBe(false);
     expect(isInternal('//evil.com')).toBe(false);
     expect(isInternal('https://ecency.com/blog')).toBe(false);
     // the regression this test exists for
-    expect(routes.some((r) => matches(`/@${HOLE}`, r))).toBe(false);
+    expect(routes.some((r) => matches('/@alice', r))).toBe(false);
   });
 });

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -112,14 +112,29 @@ const HOLE = '*';
  * interpolation is only shaped when every such interpolation is listed here;
  * otherwise it stays unresolved and has to be classified.
  *
- * These are Hive usernames and permlinks, which cannot contain a slash.
+ * Keyed by `file:expression` with an occurrence count, exactly like
+ * DYNAMIC_LINKS: a bare expression name would declare `entry.author` slash-free
+ * everywhere, including in some future component whose `entry.author` is not a
+ * username at all.
  */
-const SEGMENT_SAFE = new Set([
-  'entry.author',
-  'entry.permlink',
-  'entryData.author',
-  'entryData.permlink',
-]);
+const SEGMENT_SAFE: Record<string, { occurrences: number; reason: string }> = {
+  'src/features/blog/components/blog-discussion-item.tsx:entry.author': {
+    occurrences: 1,
+    reason: 'Hive username, cannot contain a slash',
+  },
+  'src/features/blog/components/blog-discussion-item.tsx:entry.permlink': {
+    occurrences: 1,
+    reason: 'Hive permlink, cannot contain a slash',
+  },
+  'src/features/blog/components/blog-post-item.tsx:entryData.author': {
+    occurrences: 3,
+    reason: 'Hive username, cannot contain a slash',
+  },
+  'src/features/blog/components/blog-post-item.tsx:entryData.permlink': {
+    occurrences: 3,
+    reason: 'Hive permlink, cannot contain a slash',
+  },
+};
 
 interface FoundLink {
   where: string;
@@ -132,10 +147,17 @@ interface Buckets {
   unresolved: FoundLink[];
   componentProps: { where: string; key: string }[];
   exemptionHits: Record<string, number>;
+  safeHits: Record<string, number>;
 }
 
 function emptyBuckets(): Buckets {
-  return { checked: [], unresolved: [], componentProps: [], exemptionHits: {} };
+  return {
+    checked: [],
+    unresolved: [],
+    componentProps: [],
+    exemptionHits: {},
+    safeHits: {},
+  };
 }
 
 const isInternal = (v: string) => v.startsWith('/') && !v.startsWith('//');
@@ -218,6 +240,8 @@ function constInitializer(
 function pathShape(
   checker: ts.TypeChecker,
   node: ts.Node,
+  rel: string,
+  safeHits: Record<string, number>,
   depth = 0,
 ): string | undefined {
   if (depth > 4) return undefined;
@@ -233,15 +257,16 @@ function pathShape(
       }
       // an unreadable interpolation only counts as one segment if we have said
       // so; otherwise the segment count is a guess and the shape is worthless
-      const text = span.expression.getText().replace(/\s+/g, ' ');
-      if (!SEGMENT_SAFE.has(text)) return undefined;
+      const key = `${rel}:${span.expression.getText().replace(/\s+/g, ' ')}`;
+      if (!(key in SEGMENT_SAFE)) return undefined;
+      safeHits[key] = (safeHits[key] ?? 0) + 1;
       shape += HOLE + span.literal.text;
     }
     return shape;
   }
 
   const init = constInitializer(checker, node);
-  return init ? pathShape(checker, init, depth + 1) : undefined;
+  return init ? pathShape(checker, init, rel, safeHits, depth + 1) : undefined;
 }
 
 /**
@@ -264,7 +289,8 @@ function collectFrom(
     const via = node ? label(node) : undefined;
     const key = via ? `${rel}:${via}` : undefined;
     const value = node
-      ? (literalOf(checker, node) ?? pathShape(checker, node))
+      ? (literalOf(checker, node) ??
+        pathShape(checker, node, rel, into.safeHits))
       : undefined;
 
     if (value === undefined) {
@@ -535,8 +561,14 @@ function classify(code: string): Buckets {
 }
 
 describe('internal links resolve to declared routes', () => {
-  const { checked, unresolved, componentProps, exemptionHits, routes } =
-    sweepRepository();
+  const {
+    checked,
+    unresolved,
+    componentProps,
+    exemptionHits,
+    safeHits,
+    routes,
+  } = sweepRepository();
 
   it('reads the route tree and finds links to check', () => {
     expect(routes).toContain('/blog');
@@ -560,6 +592,18 @@ describe('internal links resolve to declared routes', () => {
       Object.entries(DYNAMIC_LINKS).map(([k, v]) => [k, v.occurrences]),
     );
     expect(exemptionHits).toEqual(expected);
+  });
+
+  it('consumes each segment-safety entry exactly as many times as declared', () => {
+    // Same rule as DYNAMIC_LINKS: scoped to a file, counted, so a stale entry
+    // fails and a second use in that file has to be looked at.
+    const expected = Object.fromEntries(
+      Object.entries(SEGMENT_SAFE).map(([k, v]) => [k, v.occurrences]),
+    );
+    expect(safeHits).toEqual(expected);
+    for (const key of Object.keys(SEGMENT_SAFE)) {
+      expect(key).toMatch(/^src\/.+\.tsx:.+$/);
+    }
   });
 
   it('classifies every component prop that merely looks like a link', () => {


### PR DESCRIPTION
Follow-up to #1282. Two ways the link test could silently skip a link, both from review. Test-only, no runtime change.

## 1. Exemptions were global by identifier name

`DYNAMIC_LINKS` was keyed by bare identifier. The entry for the tipping components' `to` prop therefore exempted **any** `href={to}` or `to={to}` anywhere in the app, and `to` is about the most common name a future navigation link could have.

Keys are now `file:identifier`. A test asserts every key matches `src/**.tsx:ident` and points at a file that exists, so a bare name cannot creep back in.

## 2. Identifier resolution could grab an unrelated string

`resolveIdentifier` took the first string literal within 400 characters of the declaration. For `const target = getUrl()` that picks up whatever string comes next. A wrong literal that does not start with `/` is treated as external, so the real link is dropped from the check entirely, which is the worst failure mode for a test whose job is to not miss links.

Resolution now matches only:

```
const NAME = '/literal'
const NAME = useMemo(() => `/literal`, [deps])   // comments before the arrow are fine
```

and returns `null` otherwise, so an unresolvable link fails as unclassified rather than disappearing.

## Verified, not assumed

Both were reproduced against the merged code with a throwaway probe component:

```tsx
export function Probe({ to }: { to: string }) {
  const target = getUrl();
  return (
    <div>
      <a href={to}>...</a>
      <a href={target}>...</a>
      <span className="totally-unrelated-string">x</span>
    </div>
  );
}
```

- **before:** suite passed 50/50 with both links present. `resolveIdentifier(src, 'target')` returned `"to"`, picked out of the destructured type annotation.
- **after:** both are reported by name and line:
  ```
  + "src/features/blog/components/probe.tsx:6 -> to"
  + "src/features/blog/components/probe.tsx:7 -> target"
  ```

Also confirmed the stricter resolver did not cost real coverage: `entryLink` (a `useMemo` returning a template literal) still resolves and is still checked, and reintroducing the original `/@user` bug still fails the dead-route assertion.

52 tests pass, build warning-free, biome clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of internal navigation links to reduce false positives and missed issues.
  * Added safer handling for dynamic, template-based, and spread route references.
  * Improved distinction between navigable links and unrelated component properties.

* **Tests**
  * Expanded coverage for route matching, link resolution, exemption tracking, and computed references.
  * Added checks to ensure validation rules are applied consistently and only where expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->