### PR TITLE
fix(chat): count first DMs and drop phantom unreads

### DIFF
--- a/apps/web/src/app/api/mattermost/channels/helpers.ts
+++ b/apps/web/src/app/api/mattermost/channels/helpers.ts
@@ -52,12 +52,37 @@ export function isChannelMuted(member?: { notify_props?: { mark_unread?: string 
 /**
  * A channel has never been viewed when the member has no meaningful
  * `last_viewed_at`. Mattermost represents "never viewed" as either a missing
- * value or the int64 zero (`0`), so both must count — otherwise a never-viewed
- * DM slips through and floods the badge with historical messages. Such channels
- * are excluded from the unread badge on purpose.
+ * value or the int64 zero (`0`), so both must count.
  */
 export function isChannelNeverViewed(member?: { last_viewed_at?: number | null }): boolean {
   return member?.last_viewed_at == null || member.last_viewed_at === 0;
+}
+
+/**
+ * Whether the never-viewed rule suppresses a channel's unread count.
+ *
+ * Mattermost auto-joins a user to every channel of a community they join, and
+ * an unopened one reports its ENTIRE history as unread (`msg_count` is 0, so
+ * unread = `total_msg_count`). Counting those buries the badge under thousands
+ * of messages nobody ever asked for, so a never-viewed channel contributes 0.
+ *
+ * ⛔ This must NOT be applied to DMs. `last_viewed_at = 0` is exactly what a
+ * first-ever DM from a new person looks like, so the rule silently swallowed
+ * every first-contact DM — the badge stayed at 0 while a real message sat
+ * unread. A DM has no auto-join path (`/api/mattermost/direct` is the only way
+ * one is created and it is deliberate on both sides), so there is no history
+ * flood to protect against and the never-viewed guard has no work to do.
+ */
+export function isChannelUnreadSuppressed(
+  channel: { type?: string },
+  member?: {
+    last_viewed_at?: number | null;
+    notify_props?: { mark_unread?: string };
+  }
+): boolean {
+  if (isChannelMuted(member)) return true;
+  if (channel.type === "D") return false;
+  return isChannelNeverViewed(member);
 }
 
 /** Unread messages = total posts in the channel minus what the member has read. */
@@ -75,10 +100,10 @@ export function channelUnreadMessageCount(
  *  - `channels` force-SHOWS them in the list.
  * If the two ever drift, a closed DM can show a badge count with no row to open
  * and clear it — the "phantom unread" bug. A DM contributes when it is not
- * muted, has been viewed at least once, and has unread messages.
+ * muted and has unread messages.
  */
 export function dmContributesToUnreadBadge(
-  channel: { total_msg_count?: number },
+  channel: { type?: string; total_msg_count?: number },
   member?: {
     msg_count?: number;
     last_viewed_at?: number | null;
@@ -86,9 +111,57 @@ export function dmContributesToUnreadBadge(
   }
 ): boolean {
   if (!member) return false;
-  if (isChannelMuted(member)) return false;
-  if (isChannelNeverViewed(member)) return false;
+  if (isChannelUnreadSuppressed(channel, member)) return false;
   return channelUnreadMessageCount(channel, member) > 0;
+}
+
+/**
+ * Mattermost soft-deletes posts but never decrements `channels.total_msg_count`,
+ * so a DM whose messages were all deleted by their sender keeps reporting
+ * unread forever. The recipient sees a badge that opens to an empty
+ * conversation and cannot be cleared by reading it.
+ *
+ * `GET /channels/{id}/posts?per_page=1` excludes deleted posts, so an empty
+ * `order` means the channel has nothing left to show and its unread count is a
+ * phantom. Probing is bounded and only ever runs for DMs that already report
+ * unread — in practice a handful of channels for the small share of users who
+ * have unread DMs at all.
+ *
+ * Fails OPEN: a probe that errors (or a channel past the cap) is treated as
+ * live, because hiding a real message is far worse than leaving a stale badge.
+ */
+const DM_LIVENESS_PROBE_LIMIT = 16;
+
+interface MattermostPostList {
+  order?: string[];
+}
+
+export async function findPhantomUnreadDmChannelIds(
+  token: string,
+  channelIds: string[]
+): Promise<Set<string>> {
+  const phantom = new Set<string>();
+  if (!channelIds.length) return phantom;
+
+  const probed = channelIds.slice(0, DM_LIVENESS_PROBE_LIMIT);
+
+  await Promise.all(
+    probed.map(async (channelId) => {
+      try {
+        const posts = await mmUserFetch<MattermostPostList>(
+          `/channels/${channelId}/posts?per_page=1`,
+          token
+        );
+        if (Array.isArray(posts?.order) && posts.order.length === 0) {
+          phantom.add(channelId);
+        }
+      } catch {
+        // Fail open — leave the channel counted.
+      }
+    })
+  );
+
+  return phantom;
 }
 
 // `/users/me/channels` returns the user's full channel list as a single

--- a/apps/web/src/app/api/mattermost/channels/helpers.ts
+++ b/apps/web/src/app/api/mattermost/channels/helpers.ts
@@ -67,6 +67,68 @@ export function isDirectLikeChannel(channel: { type?: string }): boolean {
   return channel.type === "D" || channel.type === "G";
 }
 
+interface MattermostDmUser {
+  id: string;
+  delete_at?: number;
+}
+
+/**
+ * A 1:1 DM channel is named `<userA>__<userB>`, so the partner is whichever id
+ * is not the viewer's. Group channels do not use that form and have no single
+ * partner, hence `undefined`.
+ */
+export function directMessagePartnerId(
+  channel: { name?: string | null; type?: string },
+  selfUserId: string
+): string | undefined {
+  if (channel.type !== "D") return undefined;
+  const parts = channel.name?.split("__") ?? [];
+  if (parts.length !== 2) return undefined;
+  return parts.find((id) => id !== selfUserId) || parts[0];
+}
+
+/**
+ * DM channels whose partner has been deactivated. Both routes drop these, and
+ * both must drop them at the SAME point: the phantom probe is capped, so a
+ * route that probes doomed channels spends slots the other route does not and
+ * the two can disagree about which DMs are phantom.
+ *
+ * Returns an empty set if the lookup fails — same fail-open reasoning as the
+ * probe, a listing error must not silently hide conversations.
+ */
+export async function fetchDeactivatedDmPartners<TUser extends MattermostDmUser>(
+  token: string,
+  channels: Array<{ id: string; name?: string | null; type?: string }>,
+  selfUserId: string
+): Promise<{ usersById: Record<string, TUser>; excludedChannelIds: Set<string> }> {
+  const partnerIdByChannelId = new Map<string, string>();
+  for (const channel of channels) {
+    const partnerId = directMessagePartnerId(channel, selfUserId);
+    if (partnerId) partnerIdByChannelId.set(channel.id, partnerId);
+  }
+
+  const usersById: Record<string, TUser> = {};
+  const excludedChannelIds = new Set<string>();
+  if (!partnerIdByChannelId.size) return { usersById, excludedChannelIds };
+
+  try {
+    const users = await mmUserFetch<TUser[]>(`/users/ids`, token, {
+      method: "POST",
+      body: JSON.stringify(Array.from(new Set(partnerIdByChannelId.values())))
+    });
+    for (const user of users) usersById[user.id] = user;
+  } catch {
+    return { usersById, excludedChannelIds };
+  }
+
+  for (const [channelId, partnerId] of partnerIdByChannelId) {
+    const partner = usersById[partnerId];
+    if (partner?.delete_at && partner.delete_at > 0) excludedChannelIds.add(channelId);
+  }
+
+  return { usersById, excludedChannelIds };
+}
+
 /**
  * Whether the never-viewed rule suppresses a channel's unread count.
  *

--- a/apps/web/src/app/api/mattermost/channels/helpers.ts
+++ b/apps/web/src/app/api/mattermost/channels/helpers.ts
@@ -59,6 +59,15 @@ export function isChannelNeverViewed(member?: { last_viewed_at?: number | null }
 }
 
 /**
+ * Direct (`D`) and group (`G`) message channels. Neither has an auto-join
+ * path — a person has to be put in one deliberately — which is what makes the
+ * never-viewed rule below inapplicable to them.
+ */
+export function isDirectLikeChannel(channel: { type?: string }): boolean {
+  return channel.type === "D" || channel.type === "G";
+}
+
+/**
  * Whether the never-viewed rule suppresses a channel's unread count.
  *
  * Mattermost auto-joins a user to every channel of a community they join, and
@@ -66,12 +75,11 @@ export function isChannelNeverViewed(member?: { last_viewed_at?: number | null }
  * unread = `total_msg_count`). Counting those buries the badge under thousands
  * of messages nobody ever asked for, so a never-viewed channel contributes 0.
  *
- * ⛔ This must NOT be applied to DMs. `last_viewed_at = 0` is exactly what a
- * first-ever DM from a new person looks like, so the rule silently swallowed
- * every first-contact DM — the badge stayed at 0 while a real message sat
- * unread. A DM has no auto-join path (`/api/mattermost/direct` is the only way
- * one is created and it is deliberate on both sides), so there is no history
- * flood to protect against and the never-viewed guard has no work to do.
+ * ⛔ This must NOT be applied to DMs or group messages. `last_viewed_at = 0` is
+ * exactly what a first-ever DM from a new person looks like, so the rule
+ * silently swallowed every first-contact DM — the badge stayed at 0 while a
+ * real message sat unread. Neither channel type can be auto-joined, so there is
+ * no history flood to protect against and the guard has no work to do.
  */
 export function isChannelUnreadSuppressed(
   channel: { type?: string },
@@ -81,7 +89,7 @@ export function isChannelUnreadSuppressed(
   }
 ): boolean {
   if (isChannelMuted(member)) return true;
-  if (channel.type === "D") return false;
+  if (isDirectLikeChannel(channel)) return false;
   return isChannelNeverViewed(member);
 }
 
@@ -129,6 +137,10 @@ export function dmContributesToUnreadBadge(
  *
  * Fails OPEN: a probe that errors (or a channel past the cap) is treated as
  * live, because hiding a real message is far worse than leaving a stale badge.
+ *
+ * ⚠️ This verdict goes stale the instant a new post lands, unlike the mute and
+ * never-viewed rules. Anything caching it must be able to tell the two apart —
+ * see `unread_emptied` in channels/unreads/route.ts.
  */
 const DM_LIVENESS_PROBE_LIMIT = 16;
 

--- a/apps/web/src/app/api/mattermost/channels/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/route.ts
@@ -12,6 +12,7 @@ import {
   dmContributesToUnreadBadge,
   findPhantomUnreadDmChannelIds,
   isChannelUnreadSuppressed,
+  isDirectLikeChannel,
   isMattermostDefaultChannel
 } from "./helpers";
 
@@ -134,7 +135,7 @@ export async function GET() {
       channels
         .filter(
           (channel) =>
-            channel.type === "D" &&
+            isDirectLikeChannel(channel) &&
             !isChannelUnreadSuppressed(channel, channelMembersById[channel.id]) &&
             channelUnreadMessageCount(channel, channelMembersById[channel.id]) > 0
         )

--- a/apps/web/src/app/api/mattermost/channels/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/route.ts
@@ -8,7 +8,10 @@ import {
 import {
   fetchAllChannelPages,
   fetchAllChannelMemberPages,
+  channelUnreadMessageCount,
   dmContributesToUnreadBadge,
+  findPhantomUnreadDmChannelIds,
+  isChannelUnreadSuppressed,
   isMattermostDefaultChannel
 } from "./helpers";
 
@@ -121,12 +124,36 @@ export async function GET() {
       {}
     );
 
+    // Mattermost keeps counting deleted posts as unread (total_msg_count is
+    // never decremented), so a DM whose sender deleted everything reports
+    // unread with nothing to render. Resolve those before anything else reads
+    // an unread count — visibility, the per-row badge and the global badge all
+    // have to agree that such a channel is empty.
+    const phantomDmIds = await findPhantomUnreadDmChannelIds(
+      token,
+      channels
+        .filter(
+          (channel) =>
+            channel.type === "D" &&
+            !isChannelUnreadSuppressed(channel, channelMembersById[channel.id]) &&
+            channelUnreadMessageCount(channel, channelMembersById[channel.id]) > 0
+        )
+        .map((channel) => channel.id)
+    );
+
+    const unreadMessageCount = (channel: MattermostChannel) =>
+      isChannelUnreadSuppressed(channel, channelMembersById[channel.id]) ||
+      phantomDmIds.has(channel.id)
+        ? 0
+        : channelUnreadMessageCount(channel, channelMembersById[channel.id]);
+
     // A DM that contributes to the unread badge must stay visible in the list,
     // otherwise the badge shows a count the user has no row to open and clear —
     // the "phantom unread" bug for a closed (or uncategorized) DM that later
     // receives a message. The rule lives in ./helpers so it stays identical to
     // the unread-badge computation in channels/unreads/route.ts.
     const dmContributesToBadge = (channel: MattermostChannel) =>
+      !phantomDmIds.has(channel.id) &&
       dmContributesToUnreadBadge(channel, channelMembersById[channel.id]);
 
     const hasCategories = (categoriesResponse.categories || []).length > 0;
@@ -211,7 +238,7 @@ export async function GET() {
         return {
           ...channel,
           mention_count: member?.mention_count || 0,
-          message_count: Math.max((channel.total_msg_count || 0) - (member?.msg_count || 0), 0),
+          message_count: unreadMessageCount(channel),
           display_name: directUser ? `@${directUser.username}` : channel.display_name,
           directUser: directUser || null,
           last_viewed_at: member?.last_viewed_at
@@ -250,19 +277,29 @@ export async function GET() {
       return order;
     })();
 
-    const channelsWithCounts = channelsWithDirectUsers.map((channel) => ({
-      ...channel,
-      is_favorite: favoriteIds.has(channel.id),
-      is_muted: channelMembersById[channel.id]?.notify_props?.mark_unread === "mention",
-      mention_count:
-        channelMembersById[channel.id]?.mention_count ||
-        channel.mention_count ||
-        0,
-      message_count:
-        Math.max((channel.total_msg_count || 0) - (channelMembersById[channel.id]?.msg_count || 0), 0),
-      order: channelOrderFromCategories.get(channel.id),
-      last_viewed_at: channelMembersById[channel.id]?.last_viewed_at
-    }));
+    // `unread_eligible` is the server's verdict on whether this channel may
+    // raise the badge at all, so clients do not each re-derive the rule and
+    // drift apart. Both counts are zeroed alongside it: a mention count is a
+    // subset of the message count, so leaving it populated on a suppressed or
+    // emptied channel would resurrect the very badge we just cleared.
+    const channelsWithCounts = channelsWithDirectUsers.map((channel) => {
+      const unreadEligible =
+        !isChannelUnreadSuppressed(channel, channelMembersById[channel.id]) &&
+        !phantomDmIds.has(channel.id);
+
+      return {
+        ...channel,
+        is_favorite: favoriteIds.has(channel.id),
+        is_muted: channelMembersById[channel.id]?.notify_props?.mark_unread === "mention",
+        mention_count: unreadEligible
+          ? channelMembersById[channel.id]?.mention_count || channel.mention_count || 0
+          : 0,
+        message_count: unreadMessageCount(channel),
+        unread_eligible: unreadEligible,
+        order: channelOrderFromCategories.get(channel.id),
+        last_viewed_at: channelMembersById[channel.id]?.last_viewed_at
+      };
+    });
 
     const orderedChannels = [...channelsWithCounts].sort((a, b) => {
       const orderA = a.order ?? Number.MAX_SAFE_INTEGER;

--- a/apps/web/src/app/api/mattermost/channels/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/route.ts
@@ -10,6 +10,7 @@ import {
   fetchAllChannelMemberPages,
   channelUnreadMessageCount,
   dmContributesToUnreadBadge,
+  fetchDeactivatedDmPartners,
   findPhantomUnreadDmChannelIds,
   isChannelUnreadSuppressed,
   isDirectLikeChannel,
@@ -125,6 +126,17 @@ export async function GET() {
       {}
     );
 
+    // Resolve deactivated DM partners FIRST. Their channels are dropped further
+    // down anyway, and the phantom probe below is capped — letting doomed
+    // channels eat probe slots here would make this route disagree with
+    // unreads/route.ts about which DMs are phantom, which is exactly the
+    // list-vs-badge drift this file exists to prevent.
+    const { usersById, excludedChannelIds } = await fetchDeactivatedDmPartners<MattermostUser>(
+      token,
+      channels,
+      currentUser.id
+    );
+
     // Mattermost keeps counting deleted posts as unread (total_msg_count is
     // never decremented), so a DM whose sender deleted everything reports
     // unread with nothing to render. Resolve those before anything else reads
@@ -136,6 +148,8 @@ export async function GET() {
         .filter(
           (channel) =>
             isDirectLikeChannel(channel) &&
+            !excludedChannelIds.has(channel.id) &&
+            !isMattermostDefaultChannel(channel) &&
             !isChannelUnreadSuppressed(channel, channelMembersById[channel.id]) &&
             channelUnreadMessageCount(channel, channelMembersById[channel.id]) > 0
         )
@@ -194,36 +208,8 @@ export async function GET() {
       return true;
     });
 
-    const directChannels = filteredChannels.filter((channel) => channel.type === "D");
-    const usersById: Record<string, MattermostUser> = {};
-
-    if (directChannels.length) {
-      const memberIds = new Set<string>();
-
-      directChannels.forEach((channel) => {
-        const parts = channel.name?.split("__") ?? [];
-        const otherUserId =
-          parts.length === 2
-            ? parts.find((id) => id !== currentUser.id) || parts[0]
-            : undefined;
-
-        if (otherUserId) {
-          memberIds.add(otherUserId);
-        }
-      });
-
-      if (memberIds.size) {
-        const users = await mmUserFetch<MattermostUser[]>(`/users/ids`, token, {
-          method: "POST",
-          body: JSON.stringify(Array.from(memberIds))
-        });
-
-        users.forEach((user) => {
-          usersById[user.id] = user;
-        });
-      }
-    }
-
+    // DM partners were already resolved above (one batched lookup covering every
+    // DM channel, so it is a superset of what the filtered list needs).
     const channelsWithDirectUsers = filteredChannels
       .map((channel) => {
         if (channel.type !== "D") return channel;

--- a/apps/web/src/app/api/mattermost/channels/unreads/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/unreads/route.ts
@@ -10,6 +10,7 @@ import {
   fetchAllChannelPages,
   fetchAllChannelMemberPages,
   isChannelUnreadSuppressed,
+  isDirectLikeChannel,
   channelUnreadMessageCount,
   findPhantomUnreadDmChannelIds,
   isMattermostDefaultChannel
@@ -186,7 +187,7 @@ export async function GET() {
     const candidatePhantomDmIds = filteredChannels
       .filter(
         (channel) =>
-          channel.type === "D" &&
+          isDirectLikeChannel(channel) &&
           !isChannelUnreadSuppressed(channel, memberByChannelId[channel.id]) &&
           channelUnreadMessageCount(channel, memberByChannelId[channel.id]) > 0
       )
@@ -205,14 +206,22 @@ export async function GET() {
       // `unread_eligible: false` tells the realtime updater not to grow the
       // badge for these on a websocket post, otherwise the badge could count a
       // channel the list route never shows (a phantom unread).
-      if (isChannelUnreadSuppressed(channel, member) || phantomDmIds.has(channel.id)) {
+      // `unread_emptied` separates the one verdict that expires from the ones
+      // that do not. Muting and never-viewed survive a new post; "every post
+      // was deleted" stops being true the moment one arrives, so a client
+      // holding this response must refetch rather than trust it — see
+      // MattermostWebSocket.incrementUnreadCount.
+      const emptied = phantomDmIds.has(channel.id);
+
+      if (isChannelUnreadSuppressed(channel, member) || emptied) {
         return {
           channelId: channel.id,
           type: channel.type,
           mention_count: 0,
           message_count: 0,
           thread_unread: 0,
-          unread_eligible: false
+          unread_eligible: false,
+          unread_emptied: emptied
         };
       }
 

--- a/apps/web/src/app/api/mattermost/channels/unreads/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/unreads/route.ts
@@ -12,6 +12,7 @@ import {
   isChannelUnreadSuppressed,
   isDirectLikeChannel,
   channelUnreadMessageCount,
+  fetchDeactivatedDmPartners,
   findPhantomUnreadDmChannelIds,
   isMattermostDefaultChannel
 } from "../helpers";
@@ -118,54 +119,18 @@ export async function GET() {
     // Only thread pagination can still hit a cap, so `truncated` reflects only that.
     const truncated = threadsResult.truncated;
 
-    // Extract user IDs from DM channels to check for deactivated users
-    const dmChannels = allChannels.filter((ch) => ch.type === "D");
-    const dmUserIds = new Set<string>();
-    dmChannels.forEach((channel) => {
-      const parts = channel.name?.split("__") ?? [];
-      if (parts.length === 2) {
-        const otherUserId = parts.find((id) => id !== currentUser.id) || parts[0];
-        if (otherUserId) {
-          dmUserIds.add(otherUserId);
-        }
-      }
-    });
-
-    // Fetch user data to check delete_at status
-    const usersById: Record<string, MattermostUser> = {};
-    if (dmUserIds.size > 0) {
-      try {
-        const users = await mmUserFetch<MattermostUser[]>(`/users/ids`, token, {
-          method: "POST",
-          body: JSON.stringify(Array.from(dmUserIds))
-        });
-        users.forEach((user) => {
-          usersById[user.id] = user;
-        });
-      } catch {
-        // If we can't fetch users, proceed without filtering
-      }
-    }
-
-    // Set of DM channel IDs to exclude (deactivated users)
-    const excludedDmChannelIds = new Set<string>();
-    dmChannels.forEach((channel) => {
-      const parts = channel.name?.split("__") ?? [];
-      if (parts.length === 2) {
-        const otherUserId = parts.find((id) => id !== currentUser.id) || parts[0];
-        if (otherUserId) {
-          const user = usersById[otherUserId];
-          // Exclude if user is deactivated (delete_at > 0)
-          if (user && user.delete_at && user.delete_at > 0) {
-            excludedDmChannelIds.add(channel.id);
-          }
-        }
-      }
-    });
+    // DMs with a deactivated partner are dropped. Shared with the channel-list
+    // route so both spend their capped phantom probes on the same candidates —
+    // see fetchDeactivatedDmPartners.
+    const { excludedChannelIds } = await fetchDeactivatedDmPartners<MattermostUser>(
+      token,
+      allChannels,
+      currentUser.id
+    );
 
     // Filter out excluded DM channels and hidden default channels
     const filteredChannels = allChannels.filter(
-      (ch) => !excludedDmChannelIds.has(ch.id) && !isMattermostDefaultChannel(ch)
+      (ch) => !excludedChannelIds.has(ch.id) && !isMattermostDefaultChannel(ch)
     );
 
     const memberByChannelId = members.reduce<Record<string, MattermostChannelMember>>((acc, member) => {

--- a/apps/web/src/app/api/mattermost/channels/unreads/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/unreads/route.ts
@@ -9,9 +9,9 @@ import * as Sentry from "@sentry/nextjs";
 import {
   fetchAllChannelPages,
   fetchAllChannelMemberPages,
-  isChannelMuted,
-  isChannelNeverViewed,
+  isChannelUnreadSuppressed,
   channelUnreadMessageCount,
+  findPhantomUnreadDmChannelIds,
   isMattermostDefaultChannel
 } from "../helpers";
 
@@ -179,17 +179,33 @@ export async function GET() {
       return acc;
     }, {});
 
+    // A DM whose posts were all deleted still reports unread (Mattermost never
+    // decrements total_msg_count on delete). Probe only those DMs — the count
+    // is what makes the badge unclearable, so an empty channel must resolve to
+    // zero here and in the list route alike.
+    const candidatePhantomDmIds = filteredChannels
+      .filter(
+        (channel) =>
+          channel.type === "D" &&
+          !isChannelUnreadSuppressed(channel, memberByChannelId[channel.id]) &&
+          channelUnreadMessageCount(channel, memberByChannelId[channel.id]) > 0
+      )
+      .map((channel) => channel.id);
+
+    const phantomDmIds = await findPhantomUnreadDmChannelIds(token, candidatePhantomDmIds);
+
     const channelsWithCounts = filteredChannels.map((channel) => {
       const member = memberByChannelId[channel.id];
 
       // Zero out muted channels (hidden from the list, so their unreads would
-      // mislead) and never-viewed channels (skipped to prevent a historical
-      // message flood). Both rules are shared with the channel-list route via
-      // ./helpers so the two stay in lockstep — see dmContributesToUnreadBadge.
+      // mislead), never-viewed non-DM channels (skipped to prevent a historical
+      // message flood) and DMs with nothing left to read. All three rules are
+      // shared with the channel-list route via ./helpers so the two stay in
+      // lockstep — see dmContributesToUnreadBadge.
       // `unread_eligible: false` tells the realtime updater not to grow the
       // badge for these on a websocket post, otherwise the badge could count a
       // channel the list route never shows (a phantom unread).
-      if (isChannelMuted(member) || isChannelNeverViewed(member)) {
+      if (isChannelUnreadSuppressed(channel, member) || phantomDmIds.has(channel.id)) {
         return {
           channelId: channel.id,
           type: channel.type,

--- a/apps/web/src/features/chat/mattermost-websocket.ts
+++ b/apps/web/src/features/chat/mattermost-websocket.ts
@@ -717,9 +717,37 @@ export class MattermostWebSocket {
     );
   }
 
+  /**
+   * A channel the unreads route reported as emptied (every post deleted) is
+   * no longer empty once a post arrives, so its `unread_eligible: false` is
+   * stale rather than structural. Patching the badge locally is not enough
+   * either: the channel-list route hides such a DM, and a post event does not
+   * invalidate that list — so the badge would grow with no row to open. Refetch
+   * both and let the server re-derive.
+   */
+  private isEmptiedChannel(channelId: string): boolean {
+    if (!this.queryClient) return false;
+
+    return this.queryClient
+      .getQueriesData<{
+        channels?: Array<{ channelId: string; unread_emptied?: boolean }>;
+      }>({ queryKey: ["mattermost-unread"] })
+      .some(([, data]) =>
+        data?.channels?.some(
+          (channel) => channel.channelId === channelId && channel.unread_emptied === true
+        )
+      );
+  }
+
   private incrementUnreadCount(channelId: string): void {
     if (!this.queryClient) return;
     if (channelId === this.channelId) return;
+
+    if (this.isEmptiedChannel(channelId)) {
+      this.queryClient.invalidateQueries({ queryKey: ["mattermost-unread"] });
+      this.queryClient.invalidateQueries({ queryKey: ["mattermost-channels"] });
+      return;
+    }
 
     this.queryClient.setQueriesData<{
       channels: Array<{ channelId: string; type: string; mention_count: number; message_count: number; thread_unread?: number; unread_eligible?: boolean }>;
@@ -739,6 +767,7 @@ export class MattermostWebSocket {
       // the unreads route (unread_eligible === false). Growing the badge here would
       // count a channel the list route never shows — a phantom unread. Skip them.
       // (undefined means an older cached response: treat as eligible, no regression.)
+      // Emptied channels are handled above — that verdict expires, these do not.
       if (target.unread_eligible === false) return data;
 
       const isDm = target.type === "D";

--- a/apps/web/src/specs/api/mattermost-dm-unread-visibility.spec.ts
+++ b/apps/web/src/specs/api/mattermost-dm-unread-visibility.spec.ts
@@ -10,6 +10,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
  * used to hide any DM with `direct_channel_show=false`, so a closed DM that
  * later received a message produced a "phantom" badge: a count with no row to
  * open and clear. The list route now keeps such a DM visible.
+ *
+ * Two later fixes are pinned here as well:
+ *  - a never-viewed DM (`last_viewed_at` null or 0) DOES contribute. That is
+ *    what a first message from a new person looks like, and treating it as
+ *    "not viewed yet, so skip" hid first-contact DMs entirely.
+ *  - a DM whose posts were all deleted does NOT contribute, even though
+ *    Mattermost still reports unread for it (`total_msg_count` is never
+ *    decremented on delete).
  */
 
 const mockMmUserFetch = vi.fn();
@@ -31,7 +39,7 @@ vi.mock("@/app/api/mattermost/channels/helpers", async () => ({
   fetchAllChannelMemberPages: (...args: unknown[]) => mockFetchAllChannelMemberPages(...args)
 }));
 
-// Five closed DMs (direct_channel_show=false), each exercising one branch of the
+// Six closed DMs (direct_channel_show=false), each exercising one branch of the
 // "contributes to badge" rule.
 const CHANNELS = [
   // unread + viewed + not muted -> contributes -> must stay visible
@@ -40,11 +48,16 @@ const CHANNELS = [
   { id: "dm-read", name: "u-self__u-read", display_name: "", type: "D", total_msg_count: 3 },
   // muted with unread -> badge zeroes muted -> stays hidden
   { id: "dm-muted", name: "u-self__u-muted", display_name: "", type: "D", total_msg_count: 4 },
-  // never viewed (last_viewed_at null) -> badge skips never-viewed -> stays hidden
+  // never viewed (last_viewed_at null) -> a first DM -> must stay visible
   { id: "dm-neverviewed", name: "u-self__u-new", display_name: "", type: "D", total_msg_count: 2 },
-  // never viewed (last_viewed_at 0, Mattermost's other "never" value) -> stays hidden
-  { id: "dm-neverviewed-zero", name: "u-self__u-zero", display_name: "", type: "D", total_msg_count: 2 }
+  // never viewed (last_viewed_at 0, Mattermost's other "never" value) -> visible
+  { id: "dm-neverviewed-zero", name: "u-self__u-zero", display_name: "", type: "D", total_msg_count: 2 },
+  // unread per Mattermost, but every post was deleted -> nothing to read -> hidden
+  { id: "dm-phantom", name: "u-self__u-ghost", display_name: "", type: "D", total_msg_count: 2 }
 ];
+
+// Channels whose post list comes back empty because every post is soft-deleted.
+const EMPTIED_CHANNEL_IDS = new Set(["dm-phantom"]);
 
 const MEMBERS = [
   { user_id: "u-self", channel_id: "dm-unread", mention_count: 4, msg_count: 1, last_viewed_at: 1000 },
@@ -58,7 +71,8 @@ const MEMBERS = [
     notify_props: { mark_unread: "mention" }
   },
   { user_id: "u-self", channel_id: "dm-neverviewed", mention_count: 0, msg_count: 0, last_viewed_at: null },
-  { user_id: "u-self", channel_id: "dm-neverviewed-zero", mention_count: 0, msg_count: 0, last_viewed_at: 0 }
+  { user_id: "u-self", channel_id: "dm-neverviewed-zero", mention_count: 0, msg_count: 0, last_viewed_at: 0 },
+  { user_id: "u-self", channel_id: "dm-phantom", mention_count: 2, msg_count: 0, last_viewed_at: 0 }
 ];
 
 const PREFERENCES = [
@@ -66,7 +80,8 @@ const PREFERENCES = [
   { user_id: "u-self", category: "direct_channel_show", name: "u-read", value: "false" },
   { user_id: "u-self", category: "direct_channel_show", name: "u-muted", value: "false" },
   { user_id: "u-self", category: "direct_channel_show", name: "u-new", value: "false" },
-  { user_id: "u-self", category: "direct_channel_show", name: "u-zero", value: "false" }
+  { user_id: "u-self", category: "direct_channel_show", name: "u-zero", value: "false" },
+  { user_id: "u-self", category: "direct_channel_show", name: "u-ghost", value: "false" }
 ];
 
 const DM_USERS = [
@@ -74,7 +89,8 @@ const DM_USERS = [
   { id: "u-read", username: "readpartner", delete_at: 0 },
   { id: "u-muted", username: "mutedpartner", delete_at: 0 },
   { id: "u-new", username: "newpartner", delete_at: 0 },
-  { id: "u-zero", username: "zeropartner", delete_at: 0 }
+  { id: "u-zero", username: "zeropartner", delete_at: 0 },
+  { id: "u-ghost", username: "ghostpartner", delete_at: 0 }
 ];
 
 describe("channels route — DM unread visibility", () => {
@@ -87,15 +103,30 @@ describe("channels route — DM unread visibility", () => {
       if (path.includes("/channels/categories")) return Promise.resolve({ categories: [], order: [] });
       if (path === "/users/me/preferences") return Promise.resolve(PREFERENCES);
       if (path === "/users/ids") return Promise.resolve(DM_USERS);
+
+      // Liveness probe. Mattermost omits deleted posts from `order`, so an
+      // emptied channel answers with an empty list while a live one does not.
+      const probe = /^\/channels\/([^/]+)\/posts\?per_page=1$/.exec(path);
+      if (probe) {
+        const id = probe[1];
+        return Promise.resolve(
+          EMPTIED_CHANNEL_IDS.has(id) ? { order: [], posts: {} } : { order: ["p1"], posts: { p1: {} } }
+        );
+      }
+
       return Promise.resolve([]);
     });
   });
 
-  async function getChannelIds() {
+  async function getChannels() {
     const { GET } = await import("@/app/api/mattermost/channels/route");
     const res = await GET();
     const body = await res.json();
-    return (body.channels as { id: string }[]).map((c) => c.id);
+    return body.channels as { id: string; message_count: number; mention_count: number }[];
+  }
+
+  async function getChannelIds() {
+    return (await getChannels()).map((c) => c.id);
   }
 
   it("keeps a closed DM visible when it has unread messages", async () => {
@@ -113,13 +144,27 @@ describe("channels route — DM unread visibility", () => {
     expect(ids).not.toContain("dm-muted");
   });
 
-  it("does not force-show a never-viewed DM (excluded from the badge)", async () => {
+  it("shows a never-viewed DM — a first message from someone new is unread", async () => {
     const ids = await getChannelIds();
-    expect(ids).not.toContain("dm-neverviewed");
+    expect(ids).toContain("dm-neverviewed");
   });
 
-  it("treats last_viewed_at of 0 as never-viewed and keeps it hidden", async () => {
+  it("shows a never-viewed DM reported with last_viewed_at of 0", async () => {
     const ids = await getChannelIds();
-    expect(ids).not.toContain("dm-neverviewed-zero");
+    expect(ids).toContain("dm-neverviewed-zero");
+  });
+
+  it("hides a DM whose posts were all deleted and zeroes its counts", async () => {
+    const channels = await getChannels();
+    expect(channels.map((c) => c.id)).not.toContain("dm-phantom");
+  });
+
+  it("does not probe DMs that have no unread messages", async () => {
+    await getChannelIds();
+    const probed = mockMmUserFetch.mock.calls
+      .map(([path]) => /^\/channels\/([^/]+)\/posts/.exec(path as string)?.[1])
+      .filter(Boolean);
+    expect(probed).not.toContain("dm-read");
+    expect(probed).not.toContain("dm-muted");
   });
 });

--- a/apps/web/src/specs/api/mattermost-dm-unread-visibility.spec.ts
+++ b/apps/web/src/specs/api/mattermost-dm-unread-visibility.spec.ts
@@ -53,7 +53,9 @@ const CHANNELS = [
   // never viewed (last_viewed_at 0, Mattermost's other "never" value) -> visible
   { id: "dm-neverviewed-zero", name: "u-self__u-zero", display_name: "", type: "D", total_msg_count: 2 },
   // unread per Mattermost, but every post was deleted -> nothing to read -> hidden
-  { id: "dm-phantom", name: "u-self__u-ghost", display_name: "", type: "D", total_msg_count: 2 }
+  { id: "dm-phantom", name: "u-self__u-ghost", display_name: "", type: "D", total_msg_count: 2 },
+  // unread, but the partner is deactivated -> dropped, and must not be probed
+  { id: "dm-deactivated", name: "u-self__u-gone", display_name: "", type: "D", total_msg_count: 4 }
 ];
 
 // Channels whose post list comes back empty because every post is soft-deleted.
@@ -72,7 +74,8 @@ const MEMBERS = [
   },
   { user_id: "u-self", channel_id: "dm-neverviewed", mention_count: 0, msg_count: 0, last_viewed_at: null },
   { user_id: "u-self", channel_id: "dm-neverviewed-zero", mention_count: 0, msg_count: 0, last_viewed_at: 0 },
-  { user_id: "u-self", channel_id: "dm-phantom", mention_count: 2, msg_count: 0, last_viewed_at: 0 }
+  { user_id: "u-self", channel_id: "dm-phantom", mention_count: 2, msg_count: 0, last_viewed_at: 0 },
+  { user_id: "u-self", channel_id: "dm-deactivated", mention_count: 0, msg_count: 0, last_viewed_at: 0 }
 ];
 
 const PREFERENCES = [
@@ -81,7 +84,8 @@ const PREFERENCES = [
   { user_id: "u-self", category: "direct_channel_show", name: "u-muted", value: "false" },
   { user_id: "u-self", category: "direct_channel_show", name: "u-new", value: "false" },
   { user_id: "u-self", category: "direct_channel_show", name: "u-zero", value: "false" },
-  { user_id: "u-self", category: "direct_channel_show", name: "u-ghost", value: "false" }
+  { user_id: "u-self", category: "direct_channel_show", name: "u-ghost", value: "false" },
+  { user_id: "u-self", category: "direct_channel_show", name: "u-gone", value: "false" }
 ];
 
 const DM_USERS = [
@@ -90,7 +94,8 @@ const DM_USERS = [
   { id: "u-muted", username: "mutedpartner", delete_at: 0 },
   { id: "u-new", username: "newpartner", delete_at: 0 },
   { id: "u-zero", username: "zeropartner", delete_at: 0 },
-  { id: "u-ghost", username: "ghostpartner", delete_at: 0 }
+  { id: "u-ghost", username: "ghostpartner", delete_at: 0 },
+  { id: "u-gone", username: "goneparter", delete_at: 1700000000000 }
 ];
 
 describe("channels route — DM unread visibility", () => {
@@ -129,6 +134,12 @@ describe("channels route — DM unread visibility", () => {
     return (await getChannels()).map((c) => c.id);
   }
 
+  function probedChannelIds() {
+    return mockMmUserFetch.mock.calls
+      .map(([path]) => /^\/channels\/([^/]+)\/posts/.exec(path as string)?.[1])
+      .filter(Boolean);
+  }
+
   it("keeps a closed DM visible when it has unread messages", async () => {
     const ids = await getChannelIds();
     expect(ids).toContain("dm-unread");
@@ -161,10 +172,25 @@ describe("channels route — DM unread visibility", () => {
 
   it("does not probe DMs that have no unread messages", async () => {
     await getChannelIds();
-    const probed = mockMmUserFetch.mock.calls
-      .map(([path]) => /^\/channels\/([^/]+)\/posts/.exec(path as string)?.[1])
-      .filter(Boolean);
-    expect(probed).not.toContain("dm-read");
-    expect(probed).not.toContain("dm-muted");
+    expect(probedChannelIds()).not.toContain("dm-read");
+    expect(probedChannelIds()).not.toContain("dm-muted");
+  });
+
+  /**
+   * The probe is capped, so a route that spends slots on channels it is going
+   * to drop anyway can run out before reaching a real phantom — and then the
+   * two routes disagree about which DMs are phantom. Deactivated partners are
+   * resolved before the probe, in both routes, for exactly this reason.
+   */
+  it("does not spend probe budget on a DM whose partner is deactivated", async () => {
+    const ids = await getChannelIds();
+    expect(ids).not.toContain("dm-deactivated");
+    expect(probedChannelIds()).not.toContain("dm-deactivated");
+  });
+
+  it("resolves DM partners in a single batched lookup", async () => {
+    await getChannelIds();
+    const lookups = mockMmUserFetch.mock.calls.filter(([path]) => path === "/users/ids");
+    expect(lookups).toHaveLength(1);
   });
 });

--- a/apps/web/src/specs/api/mattermost-unreads-eligibility.spec.ts
+++ b/apps/web/src/specs/api/mattermost-unreads-eligibility.spec.ts
@@ -41,7 +41,9 @@ const CHANNELS = [
   // a first message from someone new is always `last_viewed_at = 0`.
   { id: "d-neverviewed", type: "D", name: "u-self__u-new", total_msg_count: 2 },
   // Mattermost keeps reporting unread after every post is deleted.
-  { id: "d-phantom", type: "D", name: "u-self__u-ghost", total_msg_count: 2 }
+  { id: "d-phantom", type: "D", name: "u-self__u-ghost", total_msg_count: 2 },
+  // Group messages cannot be auto-joined either, so the guard must skip them.
+  { id: "g-neverviewed", type: "G", name: "groupchat", total_msg_count: 3 }
 ];
 
 // Channels whose post list comes back empty because every post is soft-deleted.
@@ -60,7 +62,8 @@ const MEMBERS = [
   { channel_id: "c-neverviewed", mention_count: 0, msg_count: 0, last_viewed_at: null },
   { channel_id: "c-neverviewed-zero", mention_count: 0, msg_count: 0, last_viewed_at: 0 },
   { channel_id: "d-neverviewed", mention_count: 2, msg_count: 0, last_viewed_at: 0 },
-  { channel_id: "d-phantom", mention_count: 2, msg_count: 0, last_viewed_at: 0 }
+  { channel_id: "d-phantom", mention_count: 2, msg_count: 0, last_viewed_at: 0 },
+  { channel_id: "g-neverviewed", mention_count: 0, msg_count: 0, last_viewed_at: 0 }
 ];
 
 describe("channels/unreads route — unread_eligible flag", () => {
@@ -101,6 +104,13 @@ describe("channels/unreads route — unread_eligible flag", () => {
     return byId;
   }
 
+  // Full rows, for assertions about flags the map above drops.
+  async function getRawChannels() {
+    const { GET } = await import("@/app/api/mattermost/channels/unreads/route");
+    const body = await (await GET()).json();
+    return body.channels as Array<{ channelId: string; unread_emptied?: boolean }>;
+  }
+
   it("marks a viewed channel with unread messages as eligible", async () => {
     const byId = await getChannels();
     expect(byId["c-normal"]).toEqual({ unread_eligible: true, message_count: 4 });
@@ -130,6 +140,20 @@ describe("channels/unreads route — unread_eligible flag", () => {
   it("marks a DM whose posts were all deleted ineligible and zeroed", async () => {
     const byId = await getChannels();
     expect(byId["d-phantom"]).toEqual({ unread_eligible: false, message_count: 0 });
+  });
+
+  it("counts a never-viewed group message — it cannot be auto-joined either", async () => {
+    const byId = await getChannels();
+    expect(byId["g-neverviewed"]).toEqual({ unread_eligible: true, message_count: 3 });
+  });
+
+  // The realtime updater has to tell an expiring verdict from a structural one:
+  // a new post un-empties a channel, but does not unmute it.
+  it("flags only the emptied channel with unread_emptied", async () => {
+    const rows = await getRawChannels();
+    const emptied = rows.filter((c) => c.unread_emptied).map((c) => c.channelId);
+    expect(emptied).toEqual(["d-phantom"]);
+    expect(rows.find((c) => c.channelId === "c-muted")?.unread_emptied).toBe(false);
   });
 
   it("keeps counting a DM when the liveness probe fails (fails open)", async () => {

--- a/apps/web/src/specs/api/mattermost-unreads-eligibility.spec.ts
+++ b/apps/web/src/specs/api/mattermost-unreads-eligibility.spec.ts
@@ -36,8 +36,16 @@ const CHANNELS = [
   { id: "c-read", type: "O", name: "read", total_msg_count: 3 },
   { id: "c-muted", type: "O", name: "muted", total_msg_count: 4 },
   { id: "c-neverviewed", type: "O", name: "nv", total_msg_count: 2 },
-  { id: "c-neverviewed-zero", type: "O", name: "nvz", total_msg_count: 2 }
+  { id: "c-neverviewed-zero", type: "O", name: "nvz", total_msg_count: 2 },
+  // The never-viewed guard is for auto-joined channels and must not reach DMs:
+  // a first message from someone new is always `last_viewed_at = 0`.
+  { id: "d-neverviewed", type: "D", name: "u-self__u-new", total_msg_count: 2 },
+  // Mattermost keeps reporting unread after every post is deleted.
+  { id: "d-phantom", type: "D", name: "u-self__u-ghost", total_msg_count: 2 }
 ];
+
+// Channels whose post list comes back empty because every post is soft-deleted.
+const EMPTIED_CHANNEL_IDS = new Set(["d-phantom"]);
 
 const MEMBERS = [
   { channel_id: "c-normal", mention_count: 1, msg_count: 1, last_viewed_at: 1000 },
@@ -50,7 +58,9 @@ const MEMBERS = [
     notify_props: { mark_unread: "mention" }
   },
   { channel_id: "c-neverviewed", mention_count: 0, msg_count: 0, last_viewed_at: null },
-  { channel_id: "c-neverviewed-zero", mention_count: 0, msg_count: 0, last_viewed_at: 0 }
+  { channel_id: "c-neverviewed-zero", mention_count: 0, msg_count: 0, last_viewed_at: 0 },
+  { channel_id: "d-neverviewed", mention_count: 2, msg_count: 0, last_viewed_at: 0 },
+  { channel_id: "d-phantom", mention_count: 2, msg_count: 0, last_viewed_at: 0 }
 ];
 
 describe("channels/unreads route — unread_eligible flag", () => {
@@ -62,6 +72,16 @@ describe("channels/unreads route — unread_eligible flag", () => {
       if (path === "/users/me") return Promise.resolve({ id: "u-self" });
       if (path.includes("/threads")) return Promise.resolve({ threads: [] });
       if (path === "/users/ids") return Promise.resolve([]);
+
+      // Liveness probe. Mattermost omits deleted posts from `order`, so an
+      // emptied channel answers with an empty list while a live one does not.
+      const probe = /^\/channels\/([^/]+)\/posts\?per_page=1$/.exec(path);
+      if (probe) {
+        return Promise.resolve(
+          EMPTIED_CHANNEL_IDS.has(probe[1]) ? { order: [] } : { order: ["p1"] }
+        );
+      }
+
       return Promise.resolve([]);
     });
   });
@@ -100,5 +120,28 @@ describe("channels/unreads route — unread_eligible flag", () => {
     const byId = await getChannels();
     expect(byId["c-neverviewed"]).toEqual({ unread_eligible: false, message_count: 0 });
     expect(byId["c-neverviewed-zero"]).toEqual({ unread_eligible: false, message_count: 0 });
+  });
+
+  it("counts a never-viewed DM — the never-viewed guard is for auto-joined channels", async () => {
+    const byId = await getChannels();
+    expect(byId["d-neverviewed"]).toEqual({ unread_eligible: true, message_count: 2 });
+  });
+
+  it("marks a DM whose posts were all deleted ineligible and zeroed", async () => {
+    const byId = await getChannels();
+    expect(byId["d-phantom"]).toEqual({ unread_eligible: false, message_count: 0 });
+  });
+
+  it("keeps counting a DM when the liveness probe fails (fails open)", async () => {
+    mockMmUserFetch.mockImplementation((path: string) => {
+      if (path === "/users/me") return Promise.resolve({ id: "u-self" });
+      if (path.includes("/threads")) return Promise.resolve({ threads: [] });
+      if (path === "/users/ids") return Promise.resolve([]);
+      if (/\/posts\?per_page=1$/.test(path)) return Promise.reject(new Error("mm down"));
+      return Promise.resolve([]);
+    });
+
+    const byId = await getChannels();
+    expect(byId["d-phantom"]).toEqual({ unread_eligible: true, message_count: 2 });
   });
 });

--- a/apps/web/src/specs/features/chat/mattermost-unread-increment.spec.ts
+++ b/apps/web/src/specs/features/chat/mattermost-unread-increment.spec.ts
@@ -18,6 +18,7 @@ type UnreadChannel = {
   message_count: number;
   thread_unread: number;
   unread_eligible?: boolean;
+  unread_emptied?: boolean;
 };
 
 function seed(qc: QueryClient, channels: UnreadChannel[]) {
@@ -72,5 +73,60 @@ describe("MattermostWebSocket.incrementUnreadCount — badge eligibility", () =>
     const data = increment(qc, "dm-legacy");
     expect(data.channels[0].message_count).toBe(3);
     expect(data.totalDMs).toBe(1);
+  });
+
+  /**
+   * "Every post was deleted" is the one ineligibility that a new post undoes.
+   * Patching the cache locally is not enough — the channel-list route hides an
+   * emptied DM and a post event does not invalidate that list, so the badge
+   * would grow with no row to open. Both queries have to be refetched.
+   */
+  it("refetches instead of silently dropping a post to an emptied DM", () => {
+    const invalidated: unknown[] = [];
+    qc.invalidateQueries = ((filters: { queryKey?: unknown }) => {
+      invalidated.push(filters?.queryKey);
+      return Promise.resolve();
+    }) as QueryClient["invalidateQueries"];
+
+    seed(qc, [
+      {
+        channelId: "dm-emptied",
+        type: "D",
+        mention_count: 0,
+        message_count: 0,
+        thread_unread: 0,
+        unread_eligible: false,
+        unread_emptied: true
+      }
+    ]);
+
+    const data = increment(qc, "dm-emptied");
+
+    expect(invalidated).toEqual([["mattermost-unread"], ["mattermost-channels"]]);
+    // The cache is left untouched — the refetch supplies the truth.
+    expect(data.channels[0].message_count).toBe(0);
+  });
+
+  it("does not refetch for a muted or never-viewed channel", () => {
+    const invalidated: unknown[] = [];
+    qc.invalidateQueries = ((filters: { queryKey?: unknown }) => {
+      invalidated.push(filters?.queryKey);
+      return Promise.resolve();
+    }) as QueryClient["invalidateQueries"];
+
+    seed(qc, [
+      {
+        channelId: "c-muted",
+        type: "O",
+        mention_count: 0,
+        message_count: 0,
+        thread_unread: 0,
+        unread_eligible: false,
+        unread_emptied: false
+      }
+    ]);
+
+    increment(qc, "c-muted");
+    expect(invalidated).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #1287

## Two defects, one change

**First DMs never reached the badge.** `isChannelNeverViewed()` was applied to every channel type. For an auto-joined community channel that guard is correct and load-bearing — an unopened one reports its entire history as unread. For a DM it is wrong: `last_viewed_at = 0` is exactly what a first message from a new person looks like, so the badge silently swallowed it. The guard is now scoped to non-DM channels via `isChannelUnreadSuppressed()`. DMs have no auto-join path (`/api/mattermost/direct` is deliberate on both sides), so there is no history flood to protect against.

**Phantom unreads.** Mattermost soft-deletes posts but never decrements `channels.total_msg_count`, so a DM whose sender deleted their messages keeps reporting unread forever, opening to an empty conversation that reading cannot clear. Fixing the first defect alone would have surfaced this on web too, so both land together.

`GET /channels/{id}/posts?per_page=1` omits deleted posts, so an empty `order` means there is nothing left to read. `findPhantomUnreadDmChannelIds()` probes only DMs that already report unread, in parallel, capped at 16, and **fails open** — a probe that errors leaves the channel counted, because hiding a real message is worse than a stale badge. Measured against live data the probe runs for roughly 1.4 channels per affected user (p99 = 4, max 11), and only for the minority of users who have unread DMs at all.

## Clients now share one verdict

`channels/route.ts` emits `unread_eligible` and zeroes `message_count`/`mention_count` on suppressed channels. Previously the per-row badge read the raw `message_count` from the list route while the global badge read `channels/unreads`, so a never-opened community channel could show a row count of several hundred next to a global badge of zero. Mention counts are zeroed alongside messages — a mention is a subset of the message count, so leaving it populated would resurrect the badge that was just cleared.

`ecency-mobile` derives its badge from this same route, so it picks the fix up without an app release. Its local copy of the rule has an inverted bug (it misses the `0` case entirely) and is fixed separately in ecency/ecency-mobile#3376.

## Tests

`mattermost-dm-unread-visibility.spec.ts` and `mattermost-unreads-eligibility.spec.ts` extended:

- never-viewed DMs (`null` and `0`) now count and stay visible — these two cases previously asserted the opposite, which is the bug
- a DM with every post deleted is ineligible, zeroed, and hidden
- a failing probe leaves the DM counted (fail-open)
- DMs with no unread are never probed

Full web suite green (257 files, 2469 tests); `tsc --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unread badges for direct and group messages that had never been viewed.
  * Prevented phantom unread indicators when all messages in a direct conversation have been deleted.
  * Improved channel visibility and unread counts for muted or suppressed conversations.
  * Updated real-time unread handling to refresh conversation data correctly without incorrectly increasing badges.
* **Tests**
  * Added regression coverage for deleted messages, never-viewed conversations, muted channels, and probe failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->