### PR TITLE
chore(web): bump version to 4.4.1

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecency/web",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "private": true,
   "packageManager": "pnpm@11.5.0",
   "sideEffects": [


### PR DESCRIPTION
Bumps `@ecency/web` from 4.4.0 to 4.4.1 ahead of next week's release.

`@ecency/web` is in the `.changeset/config.json` `ignore` list, so its version is not managed by the versioning bot and is bumped by hand. This is a one-line change to `apps/web/package.json`; no lockfile change (`pnpm install --lockfile-only` produced no diff, since the package is private and not depended on).

### What the version actually drives

Worth knowing, since it is not purely cosmetic:

- **Post app signature.** `src/utils/temp-entry.ts:41` writes `app: ecency/${appPackage.version}-vision` into post metadata, so new posts will carry `ecency/4.4.1-vision` on chain.
- **Sentry release.** `next.config.js` falls back to `appPackage.version` when `SENTRY_RELEASE` is unset, so this opens a new release bucket in local/dev builds. CI sets the commit SHA, so deployed builds are unaffected.

The `4.4.0` strings in `waves-list-item-header-badge.spec.tsx` and `ecency-source-badge.spec.tsx` are fixtures for parsing an app signature, not the live version, and are deliberately left alone.

### Testing

- `pnpm --filter @ecency/web test`: 2501 passed, 262 files.
