### PR TITLE
fix(community): gate avatar and cover edit on the active user

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
@@ -5,7 +5,6 @@ import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import { Button } from "@ui/button";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
-import { useGlobalStore } from "@/core/global-store";
 import { Account, Community, FullAccount, roleMap, ROLES } from "@/entities";
 import i18next from "i18next";
 import { UserAvatar } from "@/features/shared";
@@ -26,7 +25,6 @@ interface Props {
 
 export function CommunityCard({ community, account }: Props) {
   const { activeUser } = useActiveAccount();
-  const users = useGlobalStore((state) => state.users);
 
   const [info, setInfo] = useState<DialogInfo>();
   const [settings, setSettings] = useState(false);
@@ -38,9 +36,14 @@ export function CommunityCard({ community, account }: Props) {
     [activeUser?.username, community.team]
   );
   const roleInTeam = useMemo(() => (role ? role[1] : null), [role]);
+  // The edit affordance is shown for one account but `useUpdateProfile` signs
+  // for the ACTIVE user, so this has to be the active user actually being the
+  // community account. Checking the saved-accounts list instead meant that
+  // signing in as @alice with @hive-x merely saved showed the pencil, and
+  // uploading rewrote *alice's* own profile image.
   const canUpdatePic = useMemo(
-    () => activeUser && !!users.find((x: { username: string }) => x.username === community.name),
-    [activeUser, community.name, users]
+    () => activeUser?.username === community.name,
+    [activeUser?.username, community.name]
   );
   const canEditCommunity = useMemo(
     () => !!(roleInTeam && [ROLES.OWNER.toString(), ROLES.ADMIN.toString()].includes(roleInTeam)),

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-cover/index.tsx
@@ -26,7 +26,6 @@ interface Props {
 
 export function CommunityCover({ community, account }: Props) {
   const { activeUser } = useActiveAccount();
-  const users = useGlobalStore((state) => state.users);
   const theme = useGlobalStore((state) => state.theme);
   const { data: channelData } = useQuery({
     queryKey: ["private-api", "get-community-channel", community.name],
@@ -66,9 +65,12 @@ export function CommunityCover({ community, account }: Props) {
     () => formattedNumber(community.num_authors, { fractionDigits: 0 }),
     [community.num_authors]
   );
+  // Same as the avatar: `useUpdateProfile` signs for the ACTIVE user, so
+  // showing this because the community is merely in the saved-accounts list
+  // let it overwrite the signed-in user's own cover image.
   const canUpdateCoverImage = useMemo(
-    () => activeUser && !!users.find((x: { username: string }) => x.username === community.name),
-    [activeUser, users, community.name]
+    () => activeUser?.username === community.name,
+    [activeUser?.username, community.name]
   );
 
   return (


### PR DESCRIPTION
Closes #1290

Both the community avatar and cover edit affordances were gated on the community account merely existing in the **saved-accounts** list, while `useUpdateProfile` signs for the **active** user.

Signed in as `@alice` with `@hive-125125` saved but not active, the pencil appeared on the community avatar - with no community role required at all - and uploading overwrote **alice's own** `profile_image` via an `account_update2` broadcast for alice.

```ts
// before
const canUpdatePic = useMemo(
  () => activeUser && !!users.find((x: { username: string }) => x.username === community.name),
  [activeUser, community.name, users]
);
```

The chain: `community-card-edit-pic.tsx:21` passes the *community's* account to `useUpdateProfile`, `api/mutations/update-profile.ts:36` ignores it for signing, and `api/sdk-mutations/use-update-profile-mutation.ts:64-70` resolves `useActiveUsername()`.

### The cover had it too

The issue flagged this as worth checking, and it is the same defect: `community-cover/index.tsx` used an identical gate and the same `useUpdateProfile` call, so it could overwrite alice's own cover image the same way. Both are fixed.

Both now require the active user to actually **be** the community account, which is the only case where the broadcast does what the button implies. That also makes the gate stricter in the right direction: previously no community role was checked at all.

The saved-accounts selector is unused in each file afterwards, so it is removed, along with the `useGlobalStore` import in `community-card` which it was the last consumer of.

### Not addressed here

The issue also noted two smaller things in the same path: `community-card-edit-pic.tsx:37` mutates the passed `account.profile` in place, and the invalidation targets `QueryKeys.accounts.full(account.name)` - the community account - while the write lands on the active user. With this fix those two are now consistent, since the only case that reaches them is the active user *being* the community account. Worth a separate tidy, but no longer a correctness bug.

### Testing

- `pnpm --filter @ecency/web typecheck`: clean.
- `pnpm --filter @ecency/web test`: 2508 passed, 263 files.
- `pnpm --filter @ecency/web lint`: no new errors.

No SDK change, so no label needed on this one.

Manual check: sign in as a normal account with a community account also saved, open that community, and confirm no edit affordance appears on either the avatar or the cover. Then sign in *as* the community account and confirm both appear and work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated community avatar and cover editing permissions.
  * Editing is now available only when the active account’s username exactly matches the community name.
  * Removed reliance on previously saved account membership, providing more consistent access control for community branding updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->