### PR TITLE
fix(self-hosted): stop the edit flow from rewriting post bodies

### DIFF
--- a/apps/self-hosted/package.json
+++ b/apps/self-hosted/package.json
@@ -22,7 +22,7 @@
     "@tanstack/react-router": "^1.132.27",
     "@tiptap/core": "^2.11.5",
     "@tiptap/extension-image": "^2.11.5",
-    "@tiptap/extension-link": "^2.26.2",
+    "@tiptap/extension-link": "^2.11.5",
     "@tiptap/extension-placeholder": "^2.11.5",
     "@tiptap/extension-table": "^2.11.5",
     "@tiptap/extension-table-cell": "^2.11.5",

--- a/apps/self-hosted/package.json
+++ b/apps/self-hosted/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-router": "^1.132.27",
     "@tiptap/core": "^2.11.5",
     "@tiptap/extension-image": "^2.11.5",
+    "@tiptap/extension-link": "^2.26.2",
     "@tiptap/extension-placeholder": "^2.11.5",
     "@tiptap/extension-table": "^2.11.5",
     "@tiptap/extension-table-cell": "^2.11.5",
@@ -63,6 +64,7 @@
     "@types/react-dom": "^19.1.9",
     "@types/speakingurl": "^13.0.6",
     "@types/turndown": "^5.0.0",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^4.1.13",
     "typescript": "^5.9.3",
     "vitest": "^4.1.8"

--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -72,6 +72,10 @@ type TranslationKey =
   | 'updating'
   | 'update'
   | 'editor_start_writing'
+  | 'editor_link'
+  | 'editor_link_remove'
+  | 'editor_link_prompt'
+  | 'editor_markdown_fallback'
   | 'editor_post_title'
   | 'tip_amount'
   | 'tip_custom'
@@ -163,6 +167,10 @@ const translations: Record<string, Translations> = {
     updating: 'Updating...',
     update: 'Update',
     editor_start_writing: 'Start writing...',
+    editor_link: 'Link',
+    editor_link_remove: 'Remove link',
+    editor_link_prompt: 'Enter the link address',
+    editor_markdown_fallback: 'This post contains embeds or HTML the rich text editor cannot represent. Editing as markdown so nothing is lost.',
     editor_post_title: 'Post title...',
     tip_amount: 'Amount',
     tip_custom: 'Custom',
@@ -250,6 +258,10 @@ const translations: Record<string, Translations> = {
     updating: 'Actualizando...',
     update: 'Actualizar',
     editor_start_writing: 'Empieza a escribir...',
+    editor_link: 'Enlace',
+    editor_link_remove: 'Quitar enlace',
+    editor_link_prompt: 'Introduce la dirección del enlace',
+    editor_markdown_fallback: 'Esta publicación contiene incrustaciones o HTML que el editor visual no puede representar. Se edita como markdown para no perder nada.',
     editor_post_title: 'Título de la publicación...',
     tip_amount: 'Cantidad',
     tip_custom: 'Personalizado',
@@ -337,6 +349,10 @@ const translations: Record<string, Translations> = {
     updating: 'Aktualisierung...',
     update: 'Aktualisieren',
     editor_start_writing: 'Beginne zu schreiben...',
+    editor_link: 'Link',
+    editor_link_remove: 'Link entfernen',
+    editor_link_prompt: 'Gib die Link-Adresse ein',
+    editor_markdown_fallback: 'Dieser Beitrag enthält Einbettungen oder HTML, die der visuelle Editor nicht darstellen kann. Er wird als Markdown bearbeitet, damit nichts verloren geht.',
     editor_post_title: 'Beitragstitel...',
     tip_amount: 'Betrag',
     tip_custom: 'Benutzerdefiniert',
@@ -425,6 +441,10 @@ const translations: Record<string, Translations> = {
     updating: 'Mise à jour...',
     update: 'Mettre à jour',
     editor_start_writing: 'Commencez à écrire...',
+    editor_link: 'Lien',
+    editor_link_remove: 'Supprimer le lien',
+    editor_link_prompt: "Saisissez l'adresse du lien",
+    editor_markdown_fallback: "Cet article contient des intégrations ou du HTML que l'éditeur visuel ne peut pas représenter. Il est modifié en markdown pour ne rien perdre.",
     editor_post_title: "Titre de l'article...",
     tip_amount: 'Montant',
     tip_custom: 'Personnalisé',
@@ -512,6 +532,10 @@ const translations: Record<string, Translations> = {
     updating: '업데이트 중...',
     update: '업데이트',
     editor_start_writing: '글을 작성하세요...',
+    editor_link: '링크',
+    editor_link_remove: '링크 제거',
+    editor_link_prompt: '링크 주소를 입력하세요',
+    editor_markdown_fallback: '이 게시물에는 리치 텍스트 편집기가 표현할 수 없는 임베드나 HTML이 있습니다. 내용이 손실되지 않도록 마크다운으로 편집합니다.',
     editor_post_title: '게시물 제목...',
     tip_amount: '금액',
     tip_custom: '사용자 정의',
@@ -599,6 +623,10 @@ const translations: Record<string, Translations> = {
     updating: 'Обновление...',
     update: 'Обновить',
     editor_start_writing: 'Начните писать...',
+    editor_link: 'Ссылка',
+    editor_link_remove: 'Удалить ссылку',
+    editor_link_prompt: 'Введите адрес ссылки',
+    editor_markdown_fallback: 'В этом посте есть встроенные объекты или HTML, которые визуальный редактор не может отобразить. Редактирование идёт в markdown, чтобы ничего не потерялось.',
     editor_post_title: 'Заголовок поста...',
     tip_amount: 'Сумма',
     tip_custom: 'Другая',

--- a/apps/self-hosted/src/features/publish/components/edit-post-editor.tsx
+++ b/apps/self-hosted/src/features/publish/components/edit-post-editor.tsx
@@ -105,6 +105,7 @@ export function EditPostEditor({
         body,
         tags,
         jsonMetadata: initialJsonMetadata,
+        preserveOriginalFormat: editAsMarkdown,
       });
     } catch (err) {
       console.error("Failed to update:", err);
@@ -119,6 +120,7 @@ export function EditPostEditor({
     body,
     tags,
     initialJsonMetadata,
+    editAsMarkdown,
   ]);
 
   const handleTitleChange = useCallback(

--- a/apps/self-hosted/src/features/publish/components/edit-post-editor.tsx
+++ b/apps/self-hosted/src/features/publish/components/edit-post-editor.tsx
@@ -11,7 +11,12 @@ import { useCallback, useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { UilArrowLeft } from "@tooni/iconscout-unicons-react";
 import { t } from "@/core";
-import { htmlToMarkdown, markdownToHtml } from "../utils/markdown";
+import { LINK_EXTENSION } from "../utils/editor-extensions";
+import {
+  hasUnsupportedMarkup,
+  htmlToMarkdown,
+  markdownToHtml,
+} from "../utils/markdown";
 import { useUpdatePost } from "../hooks/use-update-post";
 import { PublishEditorToolbar } from "./publish-editor-toolbar";
 import { PublishTagsSelector } from "./publish-tags-selector";
@@ -24,6 +29,7 @@ interface Props {
   initialTitle: string;
   initialBody: string;
   initialTags: string[];
+  initialJsonMetadata?: Record<string, unknown>;
 }
 
 export function EditPostEditor({
@@ -32,10 +38,16 @@ export function EditPostEditor({
   initialTitle,
   initialBody,
   initialTags,
+  initialJsonMetadata,
 }: Props) {
   const [title, setTitle] = useState(initialTitle);
   const [body, setBody] = useState(initialBody);
   const [tags, setTags] = useState<string[]>(initialTags);
+
+  // Decided once from the post as loaded: the rich text schema cannot hold
+  // embeds or arbitrary HTML, and round-tripping them through it would drop
+  // them from the stored body. Those posts are edited as raw markdown instead.
+  const [editAsMarkdown] = useState(() => hasUnsupportedMarkup(initialBody));
 
   const {
     mutateAsync: updatePost,
@@ -48,6 +60,7 @@ export function EditPostEditor({
     shouldRerenderOnTransaction: true,
     extensions: [
       StarterKit,
+      LINK_EXTENSION,
       Placeholder.configure({ placeholder: t("editor_start_writing") }),
       TextAlign.configure({ types: ["heading", "paragraph"] }),
       Table.configure({ resizable: true }),
@@ -65,6 +78,8 @@ export function EditPostEditor({
 
   // Load initial content into editor
   useEffect(() => {
+    if (editAsMarkdown) return;
+
     if (editor && initialBody) {
       try {
         const html = markdownToHtml(initialBody);
@@ -74,7 +89,7 @@ export function EditPostEditor({
         editor.commands.setContent("");
       }
     }
-  }, [editor, initialBody]);
+  }, [editAsMarkdown, editor, initialBody]);
 
   const canUpdate =
     title.trim().length > 0 && body.trim().length > 0 && tags.length > 0;
@@ -89,11 +104,22 @@ export function EditPostEditor({
         title,
         body,
         tags,
+        jsonMetadata: initialJsonMetadata,
       });
     } catch (err) {
       console.error("Failed to update:", err);
     }
-  }, [canUpdate, isUpdating, updatePost, permlink, parentPermlink, title, body, tags]);
+  }, [
+    canUpdate,
+    isUpdating,
+    updatePost,
+    permlink,
+    parentPermlink,
+    title,
+    body,
+    tags,
+    initialJsonMetadata,
+  ]);
 
   const handleTitleChange = useCallback(
     (value: string) => setTitle(value.slice(0, MAX_TITLE_LENGTH)),
@@ -162,13 +188,30 @@ export function EditPostEditor({
             }}
           />
           <PublishTagsSelector tags={tags} onChange={handleTagsChange} />
-          <div className="border-y border-gray-200 dark:border-gray-700 sticky top-[60px] md:top-[76px] z-10 bg-white dark:bg-gray-800">
-            <PublishEditorToolbar editor={editor} />
-          </div>
-          <EditorContent
-            editor={editor}
-            className="markdown-body px-3 py-4 md:py-6 xl:py-8 min-h-[400px] focus:outline-none [&_.ProseMirror]:outline-none [&_.ProseMirror]:focus:outline-none"
-          />
+          {editAsMarkdown ? (
+            <>
+              <div className="mx-3 my-2 rounded px-4 py-3 text-sm bg-amber-50 text-amber-900 dark:bg-amber-900/20 dark:text-amber-200">
+                {t("editor_markdown_fallback")}
+              </div>
+              <textarea
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                aria-label={t("editor_markdown_fallback")}
+                spellCheck={false}
+                className="w-full px-3 py-4 md:py-6 min-h-[400px] bg-transparent outline-none font-mono text-sm text-gray-900 dark:text-gray-100 resize-y"
+              />
+            </>
+          ) : (
+            <>
+              <div className="border-y border-gray-200 dark:border-gray-700 sticky top-[60px] md:top-[76px] z-10 bg-white dark:bg-gray-800">
+                <PublishEditorToolbar editor={editor} />
+              </div>
+              <EditorContent
+                editor={editor}
+                className="markdown-body px-3 py-4 md:py-6 xl:py-8 min-h-[400px] focus:outline-none [&_.ProseMirror]:outline-none [&_.ProseMirror]:focus:outline-none"
+              />
+            </>
+          )}
         </div>
       </div>
     </>

--- a/apps/self-hosted/src/features/publish/components/publish-editor-toolbar.tsx
+++ b/apps/self-hosted/src/features/publish/components/publish-editor-toolbar.tsx
@@ -12,8 +12,11 @@ import {
   UilAlignRight,
   UilBracketsCurly,
   UilParagraph,
+  UilLink,
+  UilLinkBroken,
 } from "@tooni/iconscout-unicons-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { t } from "@/core";
 import { PublishEditorTableToolbar } from "./publish-editor-table-toolbar";
 
 interface Props {
@@ -68,6 +71,23 @@ export function PublishEditorToolbar({ editor }: Props) {
       editor.off("selectionUpdate", handleSelectionUpdate);
       editor.off("blur", handleBlur);
     };
+  }, [editor]);
+
+  const setLink = useCallback(() => {
+    if (!editor) return;
+
+    const previous = editor.getAttributes("link").href as string | undefined;
+    const input = window.prompt(t("editor_link_prompt"), previous ?? "https://");
+    // Cancelling returns null; an empty string is an explicit "remove the link".
+    if (input === null) return;
+
+    const href = input.trim();
+    if (!href) {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+      return;
+    }
+
+    editor.chain().focus().extendMarkRange("link").setLink({ href }).run();
   }, [editor]);
 
   const insertTable = useCallback(() => {
@@ -221,6 +241,34 @@ export function PublishEditorToolbar({ editor }: Props) {
       >
         <UilBracketsCurly className="size-5" />
       </button>
+
+      <div className="w-px h-6 bg-gray-300 dark:bg-gray-600 mx-1" />
+
+      {/* Link */}
+      <button
+        type="button"
+        onClick={setLink}
+        className={`p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${
+          editor.isActive("link") ? "bg-gray-200 dark:bg-gray-600" : ""
+        }`}
+        title={t("editor_link")}
+        aria-label={t("editor_link")}
+      >
+        <UilLink className="size-5" aria-hidden="true" />
+      </button>
+      {editor.isActive("link") && (
+        <button
+          type="button"
+          onClick={() =>
+            editor.chain().focus().extendMarkRange("link").unsetLink().run()
+          }
+          className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+          title={t("editor_link_remove")}
+          aria-label={t("editor_link_remove")}
+        >
+          <UilLinkBroken className="size-5" aria-hidden="true" />
+        </button>
+      )}
 
       <div className="w-px h-6 bg-gray-300 dark:bg-gray-600 mx-1" />
 

--- a/apps/self-hosted/src/features/publish/hooks/use-publish-editor.ts
+++ b/apps/self-hosted/src/features/publish/hooks/use-publish-editor.ts
@@ -8,6 +8,7 @@ import TableHeader from "@tiptap/extension-table-header";
 import TableRow from "@tiptap/extension-table-row";
 import TextAlign from "@tiptap/extension-text-align";
 import { useCallback, useEffect } from "react";
+import { LINK_EXTENSION } from "../utils/editor-extensions";
 import { htmlToMarkdown, markdownToHtml } from "../utils/markdown";
 import { usePublishState } from "./use-publish-state";
 
@@ -19,6 +20,7 @@ export function usePublishEditor() {
     shouldRerenderOnTransaction: true,
     extensions: [
       StarterKit,
+      LINK_EXTENSION,
       Placeholder.configure({
         placeholder: "Start writing..."
       }),

--- a/apps/self-hosted/src/features/publish/hooks/use-update-post.ts
+++ b/apps/self-hosted/src/features/publish/hooks/use-update-post.ts
@@ -19,12 +19,14 @@ export function useUpdatePost() {
       title,
       body,
       tags,
+      jsonMetadata,
     }: {
       permlink: string;
       parentPermlink: string;
       title: string;
       body: string;
       tags: string[];
+      jsonMetadata?: Record<string, unknown>;
     }) => {
       if (!user) {
         throw new Error("Authentication required to update post");
@@ -55,10 +57,18 @@ export function useUpdatePost() {
         parentPermlink,
         title: title.trim(),
         body: body.trim(),
+        // Carry the post's existing metadata forward. Rebuilding it from scratch
+        // would drop image/thumbnail, description, users, links and any app
+        // specific block (3Speak's video object, for example) that was written
+        // by whichever client originally published the post.
         jsonMetadata: {
+          ...jsonMetadata,
           tags: normalizedTags,
           app: "ecency-selfhost/1.0",
-          format: "markdown",
+          format:
+            typeof jsonMetadata?.format === "string"
+              ? jsonMetadata.format
+              : "markdown",
         },
       });
     },
@@ -67,7 +77,7 @@ export function useUpdatePost() {
 
       navigate({
         to: "/$author/$permlink",
-        params: { author: user.username, permlink: variables.permlink },
+        params: { author: `@${user.username}`, permlink: variables.permlink },
         search: { raw: undefined },
       });
     },

--- a/apps/self-hosted/src/features/publish/hooks/use-update-post.ts
+++ b/apps/self-hosted/src/features/publish/hooks/use-update-post.ts
@@ -20,6 +20,7 @@ export function useUpdatePost() {
       body,
       tags,
       jsonMetadata,
+      preserveOriginalFormat,
     }: {
       permlink: string;
       parentPermlink: string;
@@ -27,6 +28,13 @@ export function useUpdatePost() {
       body: string;
       tags: string[];
       jsonMetadata?: Record<string, unknown>;
+      /**
+       * Only true when the body was edited as raw markdown and therefore still
+       * carries whatever format it was published with. The rich text editor
+       * always re-serialises the body to markdown, so keeping an inherited
+       * "html" format would advertise the post as something it no longer is.
+       */
+      preserveOriginalFormat?: boolean;
     }) => {
       if (!user) {
         throw new Error("Authentication required to update post");
@@ -66,7 +74,7 @@ export function useUpdatePost() {
           tags: normalizedTags,
           app: "ecency-selfhost/1.0",
           format:
-            typeof jsonMetadata?.format === "string"
+            preserveOriginalFormat && typeof jsonMetadata?.format === "string"
               ? jsonMetadata.format
               : "markdown",
         },

--- a/apps/self-hosted/src/features/publish/utils/editor-extensions.ts
+++ b/apps/self-hosted/src/features/publish/utils/editor-extensions.ts
@@ -1,0 +1,26 @@
+import Link from '@tiptap/extension-link';
+
+/**
+ * Shared by the publish and edit editors so both round-trip links identically.
+ *
+ * Without this extension the schema has no link mark at all: loading a post
+ * strips every href, and hand-typed markdown links are escaped by turndown into
+ * literal text.
+ *
+ * openOnClick stays off so clicking a link inside the editor places the caret
+ * instead of navigating away from an unsaved draft. autolink stays off because
+ * the body is stored as markdown: linkifying bare URLs would rewrite every
+ * plain "https://..." in the post into "[https://...](https://...)" on the
+ * first edit, for no rendered difference. target and rel are cleared so the
+ * editor's own display attributes never end up inside the stored body, which
+ * happens for links that serialise back as raw HTML (aligned images, tables).
+ *
+ * javascript: and other dangerous URIs are rejected by the extension's default
+ * validator, and DOMPurify already strips them while loading the post.
+ */
+export const LINK_EXTENSION = Link.configure({
+  openOnClick: false,
+  autolink: false,
+  linkOnPaste: true,
+  HTMLAttributes: { target: null, rel: null },
+});

--- a/apps/self-hosted/src/features/publish/utils/markdown.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.test.ts
@@ -102,6 +102,17 @@ describe('edit round-trip', () => {
     );
   });
 
+  it('leaves bare email and www autolinks alone', () => {
+    // marked gives these a mailto:/http:// href, so the href does not equal the
+    // link text and a naive comparison would rewrite them.
+    expect(roundTrip('mail me@example.com now')).toBe(
+      'mail me@example.com now',
+    );
+    expect(roundTrip('visit www.example.com now')).toBe(
+      'visit www.example.com now',
+    );
+  });
+
   it('keeps an image title and escapes brackets in alt text', () => {
     expect(roundTrip('![a](https://x.co/i.png "the title")')).toContain(
       '"the title"',
@@ -184,6 +195,38 @@ describe('hasUnsupportedMarkup', () => {
     ).toBe(true);
     expect(hasUnsupportedMarkup('<video src="a.mp4"></video>')).toBe(true);
     expect(hasUnsupportedMarkup('<script>alert(1)</script>')).toBe(true);
+  });
+
+  it('flags raw HTML anchors and reference links with rejected schemes', () => {
+    // Detection works on the parsed document, so the link syntax used in the
+    // source does not matter: DOMPurify drops the href either way.
+    expect(hasUnsupportedMarkup('<a href="hive://sign/op">vote</a>')).toBe(
+      true,
+    );
+    expect(hasUnsupportedMarkup('[vote][sign]\n\n[sign]: hive://sign/op')).toBe(
+      true,
+    );
+    expect(hasUnsupportedMarkup('<a href="https://ecency.com">ok</a>')).toBe(
+      false,
+    );
+  });
+
+  it('flags arbitrary HTML the tag list was never going to enumerate', () => {
+    expect(
+      hasUnsupportedMarkup('<input type="checkbox" checked> accepted'),
+    ).toBe(true);
+    expect(
+      hasUnsupportedMarkup(
+        '<figure><img src="https://x.co/a.jpg"><figcaption>cap</figcaption></figure>',
+      ),
+    ).toBe(true);
+    expect(hasUnsupportedMarkup('<abbr title="HyperText">HTML</abbr>')).toBe(
+      true,
+    );
+    expect(hasUnsupportedMarkup('press <kbd>Ctrl</kbd>')).toBe(true);
+    expect(hasUnsupportedMarkup('<span class="x">styled</span>')).toBe(true);
+    // DOMPurify deletes comments outright, so there is no node left to find.
+    expect(hasUnsupportedMarkup('before <!-- note --> after')).toBe(true);
   });
 
   it('flags markup the schema silently flattens', () => {

--- a/apps/self-hosted/src/features/publish/utils/markdown.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+
+import { Editor } from '@tiptap/core';
+import Image from '@tiptap/extension-image';
+import Table from '@tiptap/extension-table';
+import TableCell from '@tiptap/extension-table-cell';
+import TableHeader from '@tiptap/extension-table-header';
+import TableRow from '@tiptap/extension-table-row';
+import TextAlign from '@tiptap/extension-text-align';
+import StarterKit from '@tiptap/starter-kit';
+import { describe, expect, it } from 'vitest';
+import { LINK_EXTENSION } from './editor-extensions';
+import {
+  hasUnsupportedMarkup,
+  htmlToMarkdown,
+  markdownToHtml,
+} from './markdown';
+
+/**
+ * Mirrors the extension list used by EditPostEditor and usePublishEditor. These
+ * assertions are about what a post looks like AFTER it has been loaded into the
+ * editor and saved again, which is the path that was silently rewriting posts.
+ */
+function roundTrip(markdown: string): string {
+  const editor = new Editor({
+    extensions: [
+      StarterKit,
+      LINK_EXTENSION,
+      TextAlign.configure({ types: ['heading', 'paragraph'] }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableHeader,
+      TableCell,
+      Image.configure({ inline: true }),
+    ],
+    content: markdownToHtml(markdown),
+  });
+
+  try {
+    return htmlToMarkdown(editor.getHTML());
+  } finally {
+    editor.destroy();
+  }
+}
+
+describe('edit round-trip', () => {
+  it('keeps link targets', () => {
+    const body = 'See [my post](https://ecency.com/@user/post) here.';
+    expect(roundTrip(body)).toBe(body);
+  });
+
+  it('keeps a bare link written as markdown', () => {
+    expect(roundTrip('[a](https://ecency.com)')).toBe(
+      '[a](https://ecency.com)',
+    );
+  });
+
+  it('keeps single newlines as line breaks', () => {
+    expect(roundTrip('Line one\nLine two')).toBe('Line one\nLine two');
+  });
+
+  it('keeps a centered image wrapper', () => {
+    const body = '<center><img src="https://files.peakd.com/a.jpg"></center>';
+    expect(roundTrip(body)).toContain('<center>');
+    expect(roundTrip(body)).toContain('https://files.peakd.com/a.jpg');
+  });
+
+  it('keeps centering when the image is written as markdown', () => {
+    const out = roundTrip(
+      '<center>![img](https://files.peakd.com/a.jpg)</center>',
+    );
+    expect(out).toContain('<center>');
+    expect(out).toContain('https://files.peakd.com/a.jpg');
+    // The old pipeline escaped the brackets and stored literal text.
+    expect(out).not.toContain('\\[');
+  });
+
+  it('keeps a centered image that is wrapped in a link', () => {
+    const out = roundTrip(
+      '<center><a href="https://ecency.com"><img src="https://files.peakd.com/a.jpg"></a></center>',
+    );
+    expect(out).toContain('<center>');
+    expect(out).toContain('https://ecency.com');
+    expect(out).toContain('https://files.peakd.com/a.jpg');
+  });
+
+  it('does not leak the editor target/rel attributes into the stored body', () => {
+    const out = roundTrip(
+      '<center><a href="https://ecency.com"><img src="https://files.peakd.com/a.jpg"></a></center>',
+    );
+    expect(out).not.toContain('target=');
+    expect(out).not.toContain('nofollow');
+  });
+
+  it('keeps strikethrough', () => {
+    expect(roundTrip('Price: ~~$100~~ $80')).toBe('Price: ~~$100~~ $80');
+  });
+
+  it('leaves bare URLs alone instead of rewriting them as markdown links', () => {
+    expect(roundTrip('see https://ecency.com/faq here')).toBe(
+      'see https://ecency.com/faq here',
+    );
+  });
+
+  it('keeps an image title and escapes brackets in alt text', () => {
+    expect(roundTrip('![a](https://x.co/i.png "the title")')).toContain(
+      '"the title"',
+    );
+    expect(roundTrip('![fig \\[1\\]](https://x.co/i.png)')).toContain('fig');
+  });
+
+  it('is idempotent: a second round trip changes nothing', () => {
+    const bodies = [
+      'See [my post](https://ecency.com/@user/post) here.',
+      'Line one\nLine two',
+      '<center><img src="https://files.peakd.com/a.jpg"></center>',
+      '```js\nconst a = 1;\n```',
+      '| a | b |\n| --- | --- |\n| 1 | 2 |',
+      '- one\n- two\n  - nested',
+    ];
+    for (const body of bodies) {
+      const once = roundTrip(body);
+      expect(roundTrip(once)).toBe(once);
+    }
+  });
+
+  it('keeps a pull-left image wrapper', () => {
+    const out = roundTrip(
+      '<div class="pull-left"><img src="https://files.peakd.com/a.jpg"></div>',
+    );
+    expect(out).toContain('pull-left');
+    expect(out).toContain('https://files.peakd.com/a.jpg');
+  });
+
+  it('leaves wrappers holding block content alone rather than nesting them in a paragraph', () => {
+    const html = markdownToHtml(
+      '<div class="pull-right"><p>one</p><p>two</p></div>',
+    );
+    expect(html).not.toContain('<p><p>');
+  });
+
+  it('keeps code blocks and blockquotes', () => {
+    expect(roundTrip('```js\nconst a = 1;\n```')).toBe(
+      '```js\nconst a = 1;\n```',
+    );
+    expect(roundTrip('> quoted text')).toBe('> quoted text');
+  });
+
+  it('keeps mentions and tags untouched', () => {
+    expect(roundTrip('Hello @alice and #hive')).toBe('Hello @alice and #hive');
+  });
+
+  it('keeps table content', () => {
+    const out = roundTrip('| a | b |\n| --- | --- |\n| 1 | 2 |');
+    for (const cell of ['a', 'b', '1', '2']) {
+      expect(out).toContain(`<p>${cell}</p>`);
+    }
+  });
+});
+
+describe('hasUnsupportedMarkup', () => {
+  it('flags embeds the editor schema cannot hold', () => {
+    expect(
+      hasUnsupportedMarkup(
+        '<center><iframe src="https://www.youtube.com/embed/abc"></iframe></center>',
+      ),
+    ).toBe(true);
+    expect(hasUnsupportedMarkup('<video src="a.mp4"></video>')).toBe(true);
+    expect(hasUnsupportedMarkup('<script>alert(1)</script>')).toBe(true);
+  });
+
+  it('flags markup the schema silently flattens', () => {
+    // <details> is the worst of these: flattening it exposes hidden content.
+    expect(
+      hasUnsupportedMarkup(
+        '<details><summary>Spoiler</summary>\n\nhidden\n\n</details>',
+      ),
+    ).toBe(true);
+    expect(hasUnsupportedMarkup('H<sub>2</sub>O')).toBe(true);
+    expect(hasUnsupportedMarkup('x<sup>2</sup>')).toBe(true);
+    expect(hasUnsupportedMarkup('<u>underlined</u>')).toBe(true);
+  });
+
+  it('flags task lists, whose checkbox state has nowhere to live', () => {
+    expect(hasUnsupportedMarkup('- [x] done\n- [ ] todo')).toBe(true);
+  });
+
+  it('flags hive deep links, whose scheme is rejected on load', () => {
+    expect(hasUnsupportedMarkup('[vote](hive://sign/op)')).toBe(true);
+  });
+
+  it('flags alignment wrappers that cannot be rebuilt', () => {
+    // A caption alongside the image: the old code turned the image markdown
+    // into literal "![" text inside a raw HTML paragraph.
+    expect(
+      hasUnsupportedMarkup(
+        '<center>![img](https://x.co/i.png) photo credit</center>',
+      ),
+    ).toBe(true);
+    // Clickable centered banner written as nested markdown (the 3Speak shape).
+    expect(
+      hasUnsupportedMarkup(
+        '<center>[![thumb](https://x.co/t.jpg)](https://3speak.tv/w/x)</center>',
+      ),
+    ).toBe(true);
+    // Blank lines make marked close the HTML block, giving <center><p>...
+    expect(
+      hasUnsupportedMarkup(
+        '<center>\n\n![img](https://x.co/a.jpg)\n\n</center>',
+      ),
+    ).toBe(true);
+    expect(hasUnsupportedMarkup('<center>Thanks for reading!</center>')).toBe(
+      true,
+    );
+    expect(hasUnsupportedMarkup('<center>\n\n# Title\n\n</center>')).toBe(true);
+  });
+
+  it('does not flag ordinary posts', () => {
+    expect(
+      hasUnsupportedMarkup(
+        '# Title\n\nSome **body** with [a link](https://x.co)',
+      ),
+    ).toBe(false);
+    expect(
+      hasUnsupportedMarkup(
+        '<center><img src="https://files.peakd.com/a.jpg"></center>',
+      ),
+    ).toBe(false);
+    expect(
+      hasUnsupportedMarkup(
+        '<center>![img](https://files.peakd.com/a.jpg)</center>',
+      ),
+    ).toBe(false);
+    expect(
+      hasUnsupportedMarkup(
+        '<center><a href="https://ecency.com"><img src="https://x.co/a.jpg"></a></center>',
+      ),
+    ).toBe(false);
+    expect(hasUnsupportedMarkup('- one\n- two\n\n> quote')).toBe(false);
+    expect(hasUnsupportedMarkup('| a | b |\n| --- | --- |\n| 1 | 2 |')).toBe(
+      false,
+    );
+    expect(hasUnsupportedMarkup(undefined)).toBe(false);
+  });
+
+  it('is the guard that keeps an iframe post out of the lossy path', () => {
+    // Documents why the fallback exists: this body still cannot survive the
+    // editor, so EditPostEditor must not load it.
+    const body = '<iframe src="https://www.youtube.com/embed/abc"></iframe>';
+    expect(roundTrip(body)).not.toContain('iframe');
+    expect(hasUnsupportedMarkup(body)).toBe(true);
+  });
+});

--- a/apps/self-hosted/src/features/publish/utils/markdown.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.test.ts
@@ -109,6 +109,23 @@ describe('edit round-trip', () => {
     expect(roundTrip('![fig \\[1\\]](https://x.co/i.png)')).toContain('fig');
   });
 
+  it('escapes backslashes in alt text so they cannot escape the closing bracket', () => {
+    // An alt ending in a backslash would otherwise emit "...\](src)", where the
+    // "\]" escapes the bracket and the image markdown never closes.
+    const out = htmlToMarkdown(
+      '<p><img src="https://x.co/i.png" alt="trailing\\"></p>',
+    );
+    expect(out).toBe('![trailing\\\\](https://x.co/i.png)');
+    expect(markdownToHtml(out)).toContain('<img');
+  });
+
+  it('escapes quotes in an image title so the title cannot be closed early', () => {
+    const out = htmlToMarkdown(
+      '<p><img src="https://x.co/i.png" alt="a" title=\'say "hi"\'></p>',
+    );
+    expect(out).toBe('![a](https://x.co/i.png "say \\"hi\\"")');
+  });
+
   it('is idempotent: a second round trip changes nothing', () => {
     const bodies = [
       'See [my post](https://ecency.com/@user/post) here.',

--- a/apps/self-hosted/src/features/publish/utils/markdown.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.test.ts
@@ -137,6 +137,19 @@ describe('edit round-trip', () => {
     expect(out).toBe('![a](https://x.co/i.png "say \\"hi\\"")');
   });
 
+  it('keeps alignment carried only by data-align', () => {
+    // render-helper drops the inline style and keeps data-align, so a post that
+    // has been through it would otherwise lose its alignment on the next edit.
+    const out = roundTrip('<p data-align="center">centered</p>');
+    expect(out).toContain('data-align="center"');
+    expect(out).toContain('centered');
+  });
+
+  it('round-trips its own aligned output unchanged', () => {
+    const body = '<p style="text-align: center;" data-align="center">hi</p>';
+    expect(roundTrip(body)).toBe(body);
+  });
+
   it('is idempotent: a second round trip changes nothing', () => {
     const bodies = [
       'See [my post](https://ecency.com/@user/post) here.',
@@ -229,6 +242,46 @@ describe('hasUnsupportedMarkup', () => {
     expect(hasUnsupportedMarkup('before <!-- note --> after')).toBe(true);
   });
 
+  it('does not promote a non-http image URL into a live attribute', () => {
+    // The <img> is built after DOMPurify has run, so its src is not sanitised
+    // there. Such a wrapper has to go to the markdown fallback instead.
+    expect(
+      hasUnsupportedMarkup('<center>![x](javascript:alert(1))</center>'),
+    ).toBe(true);
+    expect(
+      markdownToHtml('<center>![x](javascript:alert(1))</center>'),
+    ).not.toContain('src="javascript:');
+  });
+
+  it('flags attributes the schema would drop', () => {
+    // Tags alone are not enough: these all parse into supported elements but
+    // lose an attribute that carries meaning.
+    expect(
+      hasUnsupportedMarkup('<img src="https://x.co/a.jpg" class="alignright">'),
+    ).toBe(true);
+    expect(hasUnsupportedMarkup('[a](https://x.co "tip")')).toBe(true);
+    expect(hasUnsupportedMarkup('<h2 id="sec">Section</h2>')).toBe(true);
+    expect(hasUnsupportedMarkup('<ol reversed><li>a</li></ol>')).toBe(true);
+    // marked emits align="left" on the cells, which tables cannot round-trip.
+    expect(hasUnsupportedMarkup('| a | b |\n| :-- | --: |\n| 1 | 2 |')).toBe(
+      true,
+    );
+  });
+
+  it('does not flag markup quoted inside code, which round-trips verbatim', () => {
+    expect(
+      hasUnsupportedMarkup('```html\n<script>alert(1)</script>\n```'),
+    ).toBe(false);
+    expect(hasUnsupportedMarkup('use `<script>` carefully')).toBe(false);
+    expect(hasUnsupportedMarkup('~~~\n<iframe src="x"></iframe>\n~~~')).toBe(
+      false,
+    );
+    // Still caught when it is real markup rather than quoted.
+    expect(hasUnsupportedMarkup('hi <script>alert(1)</script> there')).toBe(
+      true,
+    );
+  });
+
   it('flags markup the schema silently flattens', () => {
     // <details> is the worst of these: flattening it exposes hidden content.
     expect(
@@ -297,6 +350,18 @@ describe('hasUnsupportedMarkup', () => {
       ),
     ).toBe(false);
     expect(hasUnsupportedMarkup('- one\n- two\n\n> quote')).toBe(false);
+    // A realistic post has to stay in the rich editor, or the fallback would
+    // effectively replace the editor rather than protect the few posts it must.
+    expect(
+      hasUnsupportedMarkup(
+        '# Title\n\nHello **world**, see [link](https://x.co).\n\n- one\n- two\n\n![img](https://x.co/a.jpg)\n\n> quote\n\n```js\nconst a=1;\n```',
+      ),
+    ).toBe(false);
+    expect(
+      hasUnsupportedMarkup(
+        '<center><img src="https://files.peakd.com/a.jpg"></center>\n\nCaption below.\n\n@alice mentioned #hive',
+      ),
+    ).toBe(false);
     expect(hasUnsupportedMarkup('| a | b |\n| --- | --- |\n| 1 | 2 |')).toBe(
       false,
     );

--- a/apps/self-hosted/src/features/publish/utils/markdown.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.test.ts
@@ -253,6 +253,42 @@ describe('hasUnsupportedMarkup', () => {
     ).not.toContain('src="javascript:');
   });
 
+  it('flags attribute values the schema would drop, not just names', () => {
+    // style is kept for alignment but nothing else, so a colour would vanish.
+    expect(hasUnsupportedMarkup('<p style="color:red">red</p>')).toBe(true);
+    expect(
+      hasUnsupportedMarkup('<p style="text-align:center;color:red">x</p>'),
+    ).toBe(true);
+    expect(hasUnsupportedMarkup('<p style="text-align:center">x</p>')).toBe(
+      false,
+    );
+    // class is kept for a code language but not for an arbitrary class.
+    expect(hasUnsupportedMarkup('<pre><code class="foo">x</code></pre>')).toBe(
+      true,
+    );
+    expect(hasUnsupportedMarkup('```js\nconst a = 1;\n```')).toBe(false);
+    expect(
+      hasUnsupportedMarkup(
+        '<table><tbody><tr><td style="color:red">a</td></tr></tbody></table>',
+      ),
+    ).toBe(true);
+  });
+
+  it('flags elements the sanitiser would remove before the walk could see them', () => {
+    // Inspection runs on the unsanitised document precisely so these are caught:
+    // DOMPurify unwraps <foo> to its text and drops head elements outright.
+    expect(hasUnsupportedMarkup('<foo data-x="1">custom</foo>')).toBe(true);
+    expect(hasUnsupportedMarkup('<meta name="x" content="y">\n\ntext')).toBe(
+      true,
+    );
+    expect(
+      hasUnsupportedMarkup('<link rel="stylesheet" href="x.css">\n\ntext'),
+    ).toBe(true);
+    expect(hasUnsupportedMarkup('<base href="https://x.co/">\n\ntext')).toBe(
+      true,
+    );
+  });
+
   it('flags attributes the schema would drop', () => {
     // Tags alone are not enough: these all parse into supported elements but
     // lose an attribute that carries meaning.

--- a/apps/self-hosted/src/features/publish/utils/markdown.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.test.ts
@@ -274,6 +274,37 @@ describe('hasUnsupportedMarkup', () => {
     ).toBe(true);
   });
 
+  it('flags attribute values Tiptap rewrites rather than preserves', () => {
+    // The extension re-serialises min-width from its own cellMinWidth, so any
+    // other width comes back as 25px.
+    expect(
+      hasUnsupportedMarkup(
+        '<table style="min-width:100px"><tbody><tr><td>a</td></tr></tbody></table>',
+      ),
+    ).toBe(true);
+    // colwidth is parsed from data-colwidth, so a plain attribute is dropped.
+    expect(
+      hasUnsupportedMarkup(
+        '<table><tbody><tr><td colwidth="100">a</td></tr></tbody></table>',
+      ),
+    ).toBe(true);
+    // The table this app emits itself has to keep loading without a warning.
+    expect(
+      hasUnsupportedMarkup(
+        '<table style="min-width: 25px;"><tbody><tr><td colspan="1" rowspan="1"><p>a</p></td></tr></tbody></table>',
+      ),
+    ).toBe(false);
+  });
+
+  it('accepts a language class only where the code block rebuilds it', () => {
+    // On an inline <code> the mark carries no attributes, so the class is lost.
+    expect(
+      hasUnsupportedMarkup('use <code class="language-js">x</code> here'),
+    ).toBe(true);
+    // Inside a <pre> the code block node round-trips it.
+    expect(hasUnsupportedMarkup('```js\nconst a = 1;\n```')).toBe(false);
+  });
+
   it('flags elements the sanitiser would remove before the walk could see them', () => {
     // Inspection runs on the unsanitised document precisely so these are caught:
     // DOMPurify unwraps <foo> to its text and drops head elements outright.

--- a/apps/self-hosted/src/features/publish/utils/markdown.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.ts
@@ -138,6 +138,20 @@ export function hasUnsupportedMarkup(markdown: string | undefined): boolean {
   }
 }
 
+/**
+ * Escapes alt text for the `![alt](src)` form. The backslash has to be escaped
+ * first: escaping only the brackets turns an alt ending in a backslash into
+ * "\\]", which escapes the closing bracket and breaks the whole image.
+ */
+function escapeMarkdownText(value: string): string {
+  return value.replace(/[\\[\]]/g, "\\$&");
+}
+
+/** Escapes the optional `"title"` part of an image, same reasoning. */
+function escapeMarkdownTitle(value: string): string {
+  return value.replace(/["\\]/g, "\\$&");
+}
+
 function extractTextAlign(style: string | null): string | undefined {
   if (!style) return undefined;
   return style
@@ -219,11 +233,11 @@ export function htmlToMarkdown(html: string | undefined): string {
       replacement: function (_, node) {
         const element = node as HTMLElement;
         const src = (element.getAttribute("src") ?? "").replace(/[()]/g, encodeURIComponent);
-        // Escape rather than delete: stripping brackets silently rewrites an
-        // alt like "fig [1]" into "fig 1".
-        const alt = (element.getAttribute("alt") ?? "").replace(/[\[\]]/g, "\\$&");
+        const alt = escapeMarkdownText(element.getAttribute("alt") ?? "");
         const title = element.getAttribute("title");
-        return title ? `![${alt}](${src} "${title}")` : `![${alt}](${src})`;
+        return title
+          ? `![${alt}](${src} "${escapeMarkdownTitle(title)}")`
+          : `![${alt}](${src})`;
       }
     })
     .addRule("autolink", {

--- a/apps/self-hosted/src/features/publish/utils/markdown.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.ts
@@ -57,7 +57,7 @@ const SUPPORTED_TAGS = new Set([
   "PRE", "S", "STRONG", "TABLE", "TBODY", "TD", "TH", "THEAD", "TR", "UL"
 ]);
 
-type AttributeCheck = (value: string) => boolean;
+type AttributeCheck = (value: string, element: Element) => boolean;
 
 const anyValue: AttributeCheck = () => true;
 const isInteger: AttributeCheck = (value) => /^\d+$/.test(value.trim());
@@ -65,7 +65,7 @@ const isAlignment: AttributeCheck = (value) =>
   ALIGNMENT_VALUES.has(value.trim().toLowerCase());
 
 /** Only `language-x` survives: Tiptap rebuilds the class from the language. */
-const isLanguageClass: AttributeCheck = (value) =>
+const isLanguageClass = (value: string): boolean =>
   /^language-[\w+#.-]+$/.test(value.trim());
 
 function everyDeclaration(
@@ -106,9 +106,24 @@ const isAlignmentStyle: AttributeCheck = (value) =>
       property === "text-align" && ALIGNMENT_VALUES.has(declared)
   );
 
-/** Tiptap's own table output, which has to load back without a warning. */
+/**
+ * Only the table style Tiptap emits itself round-trips. The extension always
+ * re-serialises min-width from its own cellMinWidth, so any other width is
+ * silently rewritten: a table carrying min-width:100px would come back as
+ * 25px. Matching the exact emitted value keeps that table on the markdown
+ * path, and a future cellMinWidth change fails safe the same way.
+ */
+const TIPTAP_TABLE_STYLE = "min-width:25px";
 const isTableStyle: AttributeCheck = (value) =>
-  everyDeclaration(value, (property) => property === "min-width");
+  value.replace(/\s+/g, "").replace(/;$/, "").toLowerCase() === TIPTAP_TABLE_STYLE;
+
+/**
+ * A language class only survives on the <code> inside a <pre>, which is what
+ * the code block node rebuilds. On an inline <code> the mark carries no
+ * attributes, so the class is dropped.
+ */
+const isCodeBlockLanguage: AttributeCheck = (value, element) =>
+  element.parentElement?.tagName === "PRE" && isLanguageClass(value);
 
 /**
  * Sanitising runs after this inspection, so URLs are checked here instead.
@@ -133,7 +148,7 @@ const ALIGNABLE_ATTRIBUTES: Record<string, AttributeCheck> = {
  */
 const SUPPORTED_ATTRIBUTES: Record<string, Record<string, AttributeCheck>> = {
   A: { href: isSafeHref },
-  CODE: { class: isLanguageClass },
+  CODE: { class: isCodeBlockLanguage },
   H1: ALIGNABLE_ATTRIBUTES,
   H2: ALIGNABLE_ATTRIBUTES,
   H3: ALIGNABLE_ATTRIBUTES,
@@ -144,8 +159,8 @@ const SUPPORTED_ATTRIBUTES: Record<string, Record<string, AttributeCheck>> = {
   OL: { start: isInteger },
   P: ALIGNABLE_ATTRIBUTES,
   TABLE: { style: isTableStyle },
-  TD: { colspan: isInteger, rowspan: isInteger, colwidth: anyValue },
-  TH: { colspan: isInteger, rowspan: isInteger, colwidth: anyValue }
+  TD: { colspan: isInteger, rowspan: isInteger },
+  TH: { colspan: isInteger, rowspan: isInteger }
 };
 
 interface ParsedMarkdown {
@@ -177,7 +192,7 @@ function containsUnsupportedMarkup(doc: Document): boolean {
     const allowed = SUPPORTED_ATTRIBUTES[element.tagName];
     for (const attribute of Array.from(element.attributes)) {
       const check = allowed?.[attribute.name];
-      if (!check || !check(attribute.value)) return true;
+      if (!check || !check(attribute.value, element)) return true;
     }
   }
 

--- a/apps/self-hosted/src/features/publish/utils/markdown.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.ts
@@ -24,22 +24,27 @@ const ALIGNMENT_WRAPPERS: { selector: string; align: string }[] = [
 const IMAGE_MARKDOWN = /^!\[([^\]]*)\]\(\s*(\S+?)\s*\)$/;
 
 /**
- * Tags with no node or mark in the editor schema. DOMPurify strips some of them
- * (iframe, script, object); the rest survive sanitising and are then unwrapped
- * by Tiptap, which silently flattens the post. <details> is the worst of these:
- * losing it exposes content the author deliberately hid.
+ * Tags the editor schema can represent. Anything else is unwrapped by Tiptap,
+ * which silently flattens the post, so its presence routes the post to the raw
+ * markdown editor instead.
+ *
+ * This is an allowlist on purpose. The set of markup Hive authors reach for is
+ * open ended (details, figure, abbr, kbd, input, sub, sup, span, ...), so a
+ * denylist of known-bad tags is never finished.
  */
-const UNSUPPORTED_MARKUP =
-  /<\s*(iframe|script|object|embed|video|audio|form|svg|canvas|details|summary|sub|sup|u|ins|mark|dl|marquee)\b/i;
+const SUPPORTED_TAGS = new Set([
+  "A", "B", "BLOCKQUOTE", "BR", "CODE", "COL", "COLGROUP", "DEL", "EM",
+  "H1", "H2", "H3", "H4", "H5", "H6", "HR", "I", "IMG", "LI", "OL", "P",
+  "PRE", "S", "STRONG", "TABLE", "TBODY", "TD", "TH", "THEAD", "TR", "UL"
+]);
 
-/** GFM task lists: the schema has no checkbox, so [x] vs [ ] would be erased. */
-const TASK_LIST_ITEM = /^[ \t]*[-*+] \[[ xX]\]\s/m;
-
-/** Hive deep links: DOMPurify and the link mark both reject these schemes. */
-const CUSTOM_SCHEME_LINK = /\]\(\s*(hive|esteem|ecency|steem):/i;
-
-/** Cheap pre-check so ordinary posts skip the DOM pass entirely. */
-const ALIGNMENT_WRAPPER_HINT = /<center|pull-left|pull-right/i;
+/**
+ * Markup the sanitiser deletes outright. These leave no node behind, so the
+ * document walk below cannot see them and the source has to be checked instead.
+ * HTML comments are included: DOMPurify strips them, so an edit would drop them
+ * from the post.
+ */
+const SANITIZER_REMOVED = /<\s*(iframe|script|object|embed|style|form)\b|<!--/i;
 
 interface ParsedMarkdown {
   html: string;
@@ -48,10 +53,22 @@ interface ParsedMarkdown {
 }
 
 /**
- * True when the wrapper holds nothing but a single image, optionally wrapped in
- * a link. Mirrors the `onlyImage` condition of the outbound alignment rule, so
- * these are exactly the wrappers that survive a full round trip.
+ * True when the document holds anything the editor schema would flatten.
+ * Covers raw HTML the author wrote, markup marked generated (task list
+ * checkboxes become <input>), and links whose scheme DOMPurify rejected:
+ * those keep the anchor but lose the href, so they would save as plain text.
+ * Checking the parsed document rather than the markdown source means reference
+ * links and raw HTML anchors are caught the same way inline links are.
  */
+function containsUnsupportedMarkup(doc: Document): boolean {
+  for (const element of Array.from(doc.body.querySelectorAll("*"))) {
+    if (!SUPPORTED_TAGS.has(element.tagName)) return true;
+    if (element.tagName === "A" && !element.getAttribute("href")) return true;
+  }
+
+  return false;
+}
+
 function holdsOnlyImage(element: Element): boolean {
   if (element.children.length !== 1) return false;
   if (element.textContent?.trim()) return false;
@@ -66,12 +83,7 @@ function holdsOnlyImage(element: Element): boolean {
   );
 }
 
-function normalizeAlignmentWrappers(html: string): ParsedMarkdown {
-  if (!ALIGNMENT_WRAPPER_HINT.test(html)) {
-    return { html, lossy: false };
-  }
-
-  const doc = new DOMParser().parseFromString(html, "text/html");
+function normalizeAlignmentWrappers(doc: Document): boolean {
   let lossy = false;
 
   for (const { selector, align } of ALIGNMENT_WRAPPERS) {
@@ -105,14 +117,26 @@ function normalizeAlignmentWrappers(html: string): ParsedMarkdown {
     }
   }
 
-  return { html: doc.body.innerHTML, lossy };
+  return lossy;
 }
 
 function parseMarkdown(markdown: string): ParsedMarkdown {
   // breaks: true matches how @ecency/render-helper renders stored posts, so a
   // single newline stays a line break instead of collapsing into the paragraph.
   const parsed = marked.parse(markdown, { async: false, breaks: true }) as string;
-  return normalizeAlignmentWrappers(DOMPurify.sanitize(parsed));
+  const doc = new DOMParser().parseFromString(
+    DOMPurify.sanitize(parsed),
+    "text/html"
+  );
+
+  // Run the wrappers first: a <center> that becomes an aligned paragraph must
+  // not then be reported as an unsupported tag.
+  const wrappersLossy = normalizeAlignmentWrappers(doc);
+
+  return {
+    html: doc.body.innerHTML,
+    lossy: wrappersLossy || containsUnsupportedMarkup(doc)
+  };
 }
 
 /**
@@ -122,13 +146,7 @@ function parseMarkdown(markdown: string): ParsedMarkdown {
 export function hasUnsupportedMarkup(markdown: string | undefined): boolean {
   if (!markdown) return false;
 
-  if (
-    UNSUPPORTED_MARKUP.test(markdown) ||
-    TASK_LIST_ITEM.test(markdown) ||
-    CUSTOM_SCHEME_LINK.test(markdown)
-  ) {
-    return true;
-  }
+  if (SANITIZER_REMOVED.test(markdown)) return true;
 
   try {
     return parseMarkdown(markdown).lossy;
@@ -245,8 +263,20 @@ export function htmlToMarkdown(html: string | undefined): string {
       // sees it. Without this rule every plain "https://..." in the post would
       // be rewritten as "[https://...](https://...)" on the first edit.
       filter: (node) => {
+        if (node.nodeName !== "A") return false;
+
         const href = node.getAttribute("href");
-        return node.nodeName === "A" && !!href && node.textContent === href;
+        const text = node.textContent;
+        if (!href || !text) return false;
+
+        // marked normalises bare autolinks, so the href does not always equal
+        // the text: "me@example.com" gains a mailto: prefix and
+        // "www.example.com" gains http://.
+        return (
+          href === text ||
+          href === `mailto:${text}` ||
+          href === `http://${text}`
+        );
       },
       replacement: (content) => content
     })

--- a/apps/self-hosted/src/features/publish/utils/markdown.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.ts
@@ -5,6 +5,139 @@ import DOMPurify from "dompurify";
 const ALIGNMENT_BLOCK_NODES = ["P", "H1", "H2", "H3", "H4", "H5", "H6"];
 const ALIGNMENT_VALUES = new Set(["center", "right", "left", "justify"]);
 
+/**
+ * Hive wraps aligned content in <center> / <div class="pull-left|pull-right">.
+ * Tiptap's schema has no node for either, so loading a post that uses them drops
+ * the wrapper and the alignment is lost on the next save.
+ *
+ * A wrapper is only converted to an aligned paragraph when its content is
+ * exactly one image, because that is precisely what the outbound "alignment"
+ * rule below can turn back into the original wrapper. Anything else is reported
+ * as lossy so the post is edited as raw markdown instead of being rewritten.
+ */
+const ALIGNMENT_WRAPPERS: { selector: string; align: string }[] = [
+  { selector: "center", align: "center" },
+  { selector: "div.pull-left", align: "left" },
+  { selector: "div.pull-right", align: "right" }
+];
+
+const IMAGE_MARKDOWN = /^!\[([^\]]*)\]\(\s*(\S+?)\s*\)$/;
+
+/**
+ * Tags with no node or mark in the editor schema. DOMPurify strips some of them
+ * (iframe, script, object); the rest survive sanitising and are then unwrapped
+ * by Tiptap, which silently flattens the post. <details> is the worst of these:
+ * losing it exposes content the author deliberately hid.
+ */
+const UNSUPPORTED_MARKUP =
+  /<\s*(iframe|script|object|embed|video|audio|form|svg|canvas|details|summary|sub|sup|u|ins|mark|dl|marquee)\b/i;
+
+/** GFM task lists: the schema has no checkbox, so [x] vs [ ] would be erased. */
+const TASK_LIST_ITEM = /^[ \t]*[-*+] \[[ xX]\]\s/m;
+
+/** Hive deep links: DOMPurify and the link mark both reject these schemes. */
+const CUSTOM_SCHEME_LINK = /\]\(\s*(hive|esteem|ecency|steem):/i;
+
+/** Cheap pre-check so ordinary posts skip the DOM pass entirely. */
+const ALIGNMENT_WRAPPER_HINT = /<center|pull-left|pull-right/i;
+
+interface ParsedMarkdown {
+  html: string;
+  /** True when the conversion could not be represented without losing content. */
+  lossy: boolean;
+}
+
+/**
+ * True when the wrapper holds nothing but a single image, optionally wrapped in
+ * a link. Mirrors the `onlyImage` condition of the outbound alignment rule, so
+ * these are exactly the wrappers that survive a full round trip.
+ */
+function holdsOnlyImage(element: Element): boolean {
+  if (element.children.length !== 1) return false;
+  if (element.textContent?.trim()) return false;
+
+  const child = element.children[0];
+  if (child.tagName === "IMG") return true;
+
+  return (
+    child.tagName === "A" &&
+    child.children.length === 1 &&
+    child.children[0].tagName === "IMG"
+  );
+}
+
+function normalizeAlignmentWrappers(html: string): ParsedMarkdown {
+  if (!ALIGNMENT_WRAPPER_HINT.test(html)) {
+    return { html, lossy: false };
+  }
+
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  let lossy = false;
+
+  for (const { selector, align } of ALIGNMENT_WRAPPERS) {
+    for (const element of Array.from(doc.body.querySelectorAll(selector))) {
+      if (element.children.length === 0) {
+        // <center>![alt](src)</center>: marked leaves the image markdown as text
+        // because the wrapper is a raw HTML block. Only a wrapper that is wholly
+        // one image can be rebuilt; a caption or a second image alongside it
+        // would end up as literal "![" text in the saved body.
+        const match = IMAGE_MARKDOWN.exec(element.textContent?.trim() ?? "");
+        if (!match) {
+          lossy = true;
+          continue;
+        }
+
+        const image = doc.createElement("img");
+        image.setAttribute("src", match[2]);
+        if (match[1]) image.setAttribute("alt", match[1]);
+        element.replaceChildren(image);
+      } else if (!holdsOnlyImage(element)) {
+        lossy = true;
+        continue;
+      }
+
+      const paragraph = doc.createElement("p");
+      paragraph.setAttribute("style", `text-align: ${align}`);
+      while (element.firstChild) {
+        paragraph.appendChild(element.firstChild);
+      }
+      element.replaceWith(paragraph);
+    }
+  }
+
+  return { html: doc.body.innerHTML, lossy };
+}
+
+function parseMarkdown(markdown: string): ParsedMarkdown {
+  // breaks: true matches how @ecency/render-helper renders stored posts, so a
+  // single newline stays a line break instead of collapsing into the paragraph.
+  const parsed = marked.parse(markdown, { async: false, breaks: true }) as string;
+  return normalizeAlignmentWrappers(DOMPurify.sanitize(parsed));
+}
+
+/**
+ * True when loading `markdown` into the rich text editor would lose content.
+ * Callers fall back to plain markdown editing rather than rewrite the post.
+ */
+export function hasUnsupportedMarkup(markdown: string | undefined): boolean {
+  if (!markdown) return false;
+
+  if (
+    UNSUPPORTED_MARKUP.test(markdown) ||
+    TASK_LIST_ITEM.test(markdown) ||
+    CUSTOM_SCHEME_LINK.test(markdown)
+  ) {
+    return true;
+  }
+
+  try {
+    return parseMarkdown(markdown).lossy;
+  } catch {
+    // Unparseable content is never worth risking the rich editor on.
+    return true;
+  }
+}
+
 function extractTextAlign(style: string | null): string | undefined {
   if (!style) return undefined;
   return style
@@ -32,7 +165,10 @@ export function htmlToMarkdown(html: string | undefined): string {
 
   return new Turndown({
     codeBlockStyle: "fenced",
-    headingStyle: "atx"
+    headingStyle: "atx",
+    // Turndown defaults to two trailing spaces before the newline; Hive renders
+    // a bare newline as a break, so the padding is only noise in the stored body.
+    br: ""
   })
     .addRule("alignment", {
       filter: function (node) {
@@ -83,9 +219,29 @@ export function htmlToMarkdown(html: string | undefined): string {
       replacement: function (_, node) {
         const element = node as HTMLElement;
         const src = (element.getAttribute("src") ?? "").replace(/[()]/g, encodeURIComponent);
-        const alt = (element.getAttribute("alt") ?? "").replace(/[\[\]]/g, "");
-        return `![${alt}](${src})`;
+        // Escape rather than delete: stripping brackets silently rewrites an
+        // alt like "fig [1]" into "fig 1".
+        const alt = (element.getAttribute("alt") ?? "").replace(/[\[\]]/g, "\\$&");
+        const title = element.getAttribute("title");
+        return title ? `![${alt}](${src} "${title}")` : `![${alt}](${src})`;
       }
+    })
+    .addRule("autolink", {
+      // marked's GFM autolinking turns a bare URL into an anchor before Tiptap
+      // sees it. Without this rule every plain "https://..." in the post would
+      // be rewritten as "[https://...](https://...)" on the first edit.
+      filter: (node) => {
+        const href = node.getAttribute("href");
+        return node.nodeName === "A" && !!href && node.textContent === href;
+      },
+      replacement: (content) => content
+    })
+    .addRule("strikethrough", {
+      // Turndown core has no strikethrough rule, so StarterKit's Strike mark
+      // would be unwrapped to plain text and "~~$100~~ $80" would save as
+      // "$100 $80", inverting the meaning.
+      filter: ["del", "s"],
+      replacement: (content) => `~~${content}~~`
     })
     .turndown(html);
 }
@@ -99,9 +255,7 @@ export function markdownToHtml(markdown: string | undefined): string {
   }
 
   try {
-    const parsed = marked.parse(markdown, { async: false }) as string;
-    const sanitized = DOMPurify.sanitize(parsed);
-    return sanitized;
+    return parseMarkdown(markdown).html;
   } catch (error) {
     console.error("Failed to parse markdown:", error);
     return "";

--- a/apps/self-hosted/src/features/publish/utils/markdown.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.ts
@@ -24,6 +24,14 @@ const ALIGNMENT_WRAPPERS: { selector: string; align: string }[] = [
 const IMAGE_MARKDOWN = /^!\[([^\]]*)\]\(\s*(\S+?)\s*\)$/;
 
 /**
+ * The image below is built after DOMPurify has run, so its src never passes
+ * through the sanitiser's URI checks. Restrict it here instead: without this a
+ * body containing `<center>![x](javascript:...)</center>` would have its inert
+ * text promoted into a live attribute.
+ */
+const SAFE_IMAGE_SRC = /^https?:\/\//i;
+
+/**
  * Tags the editor schema can represent. Anything else is unwrapped by Tiptap,
  * which silently flattens the post, so its presence routes the post to the raw
  * markdown editor instead.
@@ -37,6 +45,29 @@ const SUPPORTED_TAGS = new Set([
   "H1", "H2", "H3", "H4", "H5", "H6", "HR", "I", "IMG", "LI", "OL", "P",
   "PRE", "S", "STRONG", "TABLE", "TBODY", "TD", "TH", "THEAD", "TR", "UL"
 ]);
+
+/**
+ * Attributes the schema round-trips, per tag. Anything else is dropped on save
+ * just as an unsupported tag would be: a heading id breaks in-page anchors, an
+ * image class loses its styling, a column alignment vanishes from a table.
+ * Tags absent from this map round-trip only with no attributes at all.
+ */
+const SUPPORTED_ATTRIBUTES: Record<string, Set<string>> = {
+  A: new Set(["href"]),
+  CODE: new Set(["class"]),
+  H1: new Set(["style", "data-align"]),
+  H2: new Set(["style", "data-align"]),
+  H3: new Set(["style", "data-align"]),
+  H4: new Set(["style", "data-align"]),
+  H5: new Set(["style", "data-align"]),
+  H6: new Set(["style", "data-align"]),
+  IMG: new Set(["src", "alt", "title"]),
+  OL: new Set(["start"]),
+  P: new Set(["style", "data-align"]),
+  TABLE: new Set(["style"]),
+  TD: new Set(["colspan", "rowspan", "colwidth", "style"]),
+  TH: new Set(["colspan", "rowspan", "colwidth", "style"])
+};
 
 /**
  * Markup the sanitiser deletes outright. These leave no node behind, so the
@@ -64,9 +95,35 @@ function containsUnsupportedMarkup(doc: Document): boolean {
   for (const element of Array.from(doc.body.querySelectorAll("*"))) {
     if (!SUPPORTED_TAGS.has(element.tagName)) return true;
     if (element.tagName === "A" && !element.getAttribute("href")) return true;
+
+    const allowed = SUPPORTED_ATTRIBUTES[element.tagName];
+    for (const attribute of Array.from(element.attributes)) {
+      if (!allowed?.has(attribute.name)) return true;
+    }
   }
 
   return false;
+}
+
+/**
+ * @ecency/render-helper keeps `data-align` and drops the inline style, so a
+ * post that has been through it carries the alignment in an attribute Tiptap
+ * does not read. Restoring the style lets those paragraphs keep their alignment
+ * instead of being sent to the markdown fallback.
+ */
+function restoreAlignmentFromDataAttribute(doc: Document): void {
+  for (const element of Array.from(doc.body.querySelectorAll("[data-align]"))) {
+    const align = element.getAttribute("data-align");
+    if (!align || !ALIGNMENT_VALUES.has(align)) continue;
+
+    const style = element.getAttribute("style") ?? "";
+    if (!extractTextAlign(style)) {
+      element.setAttribute(
+        "style",
+        `${style ? `${style.replace(/;\s*$/, "")}; ` : ""}text-align: ${align}`
+      );
+    }
+  }
 }
 
 function holdsOnlyImage(element: Element): boolean {
@@ -94,7 +151,7 @@ function normalizeAlignmentWrappers(doc: Document): boolean {
         // one image can be rebuilt; a caption or a second image alongside it
         // would end up as literal "![" text in the saved body.
         const match = IMAGE_MARKDOWN.exec(element.textContent?.trim() ?? "");
-        if (!match) {
+        if (!match || !SAFE_IMAGE_SRC.test(match[2])) {
           lossy = true;
           continue;
         }
@@ -132,11 +189,19 @@ function parseMarkdown(markdown: string): ParsedMarkdown {
   // Run the wrappers first: a <center> that becomes an aligned paragraph must
   // not then be reported as an unsupported tag.
   const wrappersLossy = normalizeAlignmentWrappers(doc);
+  restoreAlignmentFromDataAttribute(doc);
 
   return {
     html: doc.body.innerHTML,
     lossy: wrappersLossy || containsUnsupportedMarkup(doc)
   };
+}
+
+function stripCodeSpans(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/~~~[\s\S]*?~~~/g, "")
+    .replace(/`[^`\n]*`/g, "");
 }
 
 /**
@@ -146,7 +211,9 @@ function parseMarkdown(markdown: string): ParsedMarkdown {
 export function hasUnsupportedMarkup(markdown: string | undefined): boolean {
   if (!markdown) return false;
 
-  if (SANITIZER_REMOVED.test(markdown)) return true;
+  // Code spans round-trip verbatim, so markup quoted inside them is not a risk
+  // and must not cost the author the rich editor.
+  if (SANITIZER_REMOVED.test(stripCodeSpans(markdown))) return true;
 
   try {
     return parseMarkdown(markdown).lossy;

--- a/apps/self-hosted/src/features/publish/utils/markdown.ts
+++ b/apps/self-hosted/src/features/publish/utils/markdown.ts
@@ -24,12 +24,23 @@ const ALIGNMENT_WRAPPERS: { selector: string; align: string }[] = [
 const IMAGE_MARKDOWN = /^!\[([^\]]*)\]\(\s*(\S+?)\s*\)$/;
 
 /**
- * The image below is built after DOMPurify has run, so its src never passes
- * through the sanitiser's URI checks. Restrict it here instead: without this a
- * body containing `<center>![x](javascript:...)</center>` would have its inert
- * text promoted into a live attribute.
+ * Rebuilding an image from wrapper text turns inert markdown into a live
+ * attribute, so the URL is parsed and re-serialised rather than copied through:
+ * without this, `<center>![x](javascript:...)</center>` would produce an
+ * executable src. Only absolute http(s) URLs are accepted, which is what Hive
+ * image markdown carries.
  */
-const SAFE_IMAGE_SRC = /^https?:\/\//i;
+function toSafeImageSrc(candidate: string): string | null {
+  let url: URL;
+
+  try {
+    url = new URL(candidate);
+  } catch {
+    return null;
+  }
+
+  return url.protocol === "http:" || url.protocol === "https:" ? url.href : null;
+}
 
 /**
  * Tags the editor schema can represent. Anything else is unwrapped by Tiptap,
@@ -46,36 +57,96 @@ const SUPPORTED_TAGS = new Set([
   "PRE", "S", "STRONG", "TABLE", "TBODY", "TD", "TH", "THEAD", "TR", "UL"
 ]);
 
+type AttributeCheck = (value: string) => boolean;
+
+const anyValue: AttributeCheck = () => true;
+const isInteger: AttributeCheck = (value) => /^\d+$/.test(value.trim());
+const isAlignment: AttributeCheck = (value) =>
+  ALIGNMENT_VALUES.has(value.trim().toLowerCase());
+
+/** Only `language-x` survives: Tiptap rebuilds the class from the language. */
+const isLanguageClass: AttributeCheck = (value) =>
+  /^language-[\w+#.-]+$/.test(value.trim());
+
+function everyDeclaration(
+  style: string,
+  predicate: (property: string, value: string) => boolean
+): boolean {
+  const declarations = style
+    .split(";")
+    .map((declaration) => declaration.trim())
+    .filter(Boolean);
+
+  return (
+    declarations.length > 0 &&
+    declarations.every((declaration) => {
+      const separator = declaration.indexOf(":");
+      if (separator === -1) return false;
+
+      return predicate(
+        declaration.slice(0, separator).trim().toLowerCase(),
+        declaration
+          .slice(separator + 1)
+          .replace(/!important$/i, "")
+          .trim()
+          .toLowerCase()
+      );
+    })
+  );
+}
+
 /**
- * Attributes the schema round-trips, per tag. Anything else is dropped on save
- * just as an unsupported tag would be: a heading id breaks in-page anchors, an
- * image class loses its styling, a column alignment vanishes from a table.
- * Tags absent from this map round-trip only with no attributes at all.
+ * The schema keeps text-align and nothing else, so a style carrying any other
+ * property (a colour, a font) would lose it silently.
  */
-const SUPPORTED_ATTRIBUTES: Record<string, Set<string>> = {
-  A: new Set(["href"]),
-  CODE: new Set(["class"]),
-  H1: new Set(["style", "data-align"]),
-  H2: new Set(["style", "data-align"]),
-  H3: new Set(["style", "data-align"]),
-  H4: new Set(["style", "data-align"]),
-  H5: new Set(["style", "data-align"]),
-  H6: new Set(["style", "data-align"]),
-  IMG: new Set(["src", "alt", "title"]),
-  OL: new Set(["start"]),
-  P: new Set(["style", "data-align"]),
-  TABLE: new Set(["style"]),
-  TD: new Set(["colspan", "rowspan", "colwidth", "style"]),
-  TH: new Set(["colspan", "rowspan", "colwidth", "style"])
+const isAlignmentStyle: AttributeCheck = (value) =>
+  everyDeclaration(
+    value,
+    (property, declared) =>
+      property === "text-align" && ALIGNMENT_VALUES.has(declared)
+  );
+
+/** Tiptap's own table output, which has to load back without a warning. */
+const isTableStyle: AttributeCheck = (value) =>
+  everyDeclaration(value, (property) => property === "min-width");
+
+/**
+ * Sanitising runs after this inspection, so URLs are checked here instead.
+ * A scheme the sanitiser would reject (hive:, javascript:) means the link or
+ * image would come back stripped, which is exactly the silent loss to avoid.
+ */
+const isSafeHref: AttributeCheck = (value) =>
+  /^(https?:\/\/|mailto:|\/|#|\.{0,2}\/)/i.test(value.trim());
+const isSafeSrc: AttributeCheck = (value) =>
+  /^(https?:\/\/|\/)/i.test(value.trim());
+
+const ALIGNABLE_ATTRIBUTES: Record<string, AttributeCheck> = {
+  style: isAlignmentStyle,
+  "data-align": isAlignment
 };
 
 /**
- * Markup the sanitiser deletes outright. These leave no node behind, so the
- * document walk below cannot see them and the source has to be checked instead.
- * HTML comments are included: DOMPurify strips them, so an edit would drop them
- * from the post.
+ * Attributes the schema round-trips, per tag, and what each may contain.
+ * Checking only the name is not enough: `style` is preserved for alignment but
+ * discards a colour, and `class` is preserved for a code language but not for
+ * an arbitrary class. Tags absent from this map round-trip only bare.
  */
-const SANITIZER_REMOVED = /<\s*(iframe|script|object|embed|style|form)\b|<!--/i;
+const SUPPORTED_ATTRIBUTES: Record<string, Record<string, AttributeCheck>> = {
+  A: { href: isSafeHref },
+  CODE: { class: isLanguageClass },
+  H1: ALIGNABLE_ATTRIBUTES,
+  H2: ALIGNABLE_ATTRIBUTES,
+  H3: ALIGNABLE_ATTRIBUTES,
+  H4: ALIGNABLE_ATTRIBUTES,
+  H5: ALIGNABLE_ATTRIBUTES,
+  H6: ALIGNABLE_ATTRIBUTES,
+  IMG: { src: isSafeSrc, alt: anyValue, title: anyValue },
+  OL: { start: isInteger },
+  P: ALIGNABLE_ATTRIBUTES,
+  TABLE: { style: isTableStyle },
+  TD: { colspan: isInteger, rowspan: isInteger, colwidth: anyValue },
+  TH: { colspan: isInteger, rowspan: isInteger, colwidth: anyValue }
+};
 
 interface ParsedMarkdown {
   html: string;
@@ -85,32 +156,34 @@ interface ParsedMarkdown {
 
 /**
  * True when the document holds anything the editor schema would flatten.
- * Covers raw HTML the author wrote, markup marked generated (task list
- * checkboxes become <input>), and links whose scheme DOMPurify rejected:
- * those keep the anchor but lose the href, so they would save as plain text.
- * Checking the parsed document rather than the markdown source means reference
- * links and raw HTML anchors are caught the same way inline links are.
+ *
+ * This runs on the document as parsed from marked's output, BEFORE sanitising.
+ * Inspecting the sanitised document instead would miss everything DOMPurify
+ * removes on our behalf: an unknown element such as <foo> is unwrapped to its
+ * text, <meta>/<link>/<base> are dropped, and comments disappear, all of which
+ * would then look like ordinary content and be classified as safe.
  */
 function containsUnsupportedMarkup(doc: Document): boolean {
+  // The parser hoists <meta>, <link>, <base> and <title> out of the body.
+  if (doc.head.children.length > 0) return true;
+
+  const comments = doc.createTreeWalker(doc.body, NodeFilter.SHOW_COMMENT);
+  if (comments.nextNode()) return true;
+
   for (const element of Array.from(doc.body.querySelectorAll("*"))) {
     if (!SUPPORTED_TAGS.has(element.tagName)) return true;
     if (element.tagName === "A" && !element.getAttribute("href")) return true;
 
     const allowed = SUPPORTED_ATTRIBUTES[element.tagName];
     for (const attribute of Array.from(element.attributes)) {
-      if (!allowed?.has(attribute.name)) return true;
+      const check = allowed?.[attribute.name];
+      if (!check || !check(attribute.value)) return true;
     }
   }
 
   return false;
 }
 
-/**
- * @ecency/render-helper keeps `data-align` and drops the inline style, so a
- * post that has been through it carries the alignment in an attribute Tiptap
- * does not read. Restoring the style lets those paragraphs keep their alignment
- * instead of being sent to the markdown fallback.
- */
 function restoreAlignmentFromDataAttribute(doc: Document): void {
   for (const element of Array.from(doc.body.querySelectorAll("[data-align]"))) {
     const align = element.getAttribute("data-align");
@@ -151,13 +224,14 @@ function normalizeAlignmentWrappers(doc: Document): boolean {
         // one image can be rebuilt; a caption or a second image alongside it
         // would end up as literal "![" text in the saved body.
         const match = IMAGE_MARKDOWN.exec(element.textContent?.trim() ?? "");
-        if (!match || !SAFE_IMAGE_SRC.test(match[2])) {
+        const source = match && toSafeImageSrc(match[2]);
+        if (!match || !source) {
           lossy = true;
           continue;
         }
 
         const image = doc.createElement("img");
-        image.setAttribute("src", match[2]);
+        image.setAttribute("src", source);
         if (match[1]) image.setAttribute("alt", match[1]);
         element.replaceChildren(image);
       } else if (!holdsOnlyImage(element)) {
@@ -181,27 +255,21 @@ function parseMarkdown(markdown: string): ParsedMarkdown {
   // breaks: true matches how @ecency/render-helper renders stored posts, so a
   // single newline stays a line break instead of collapsing into the paragraph.
   const parsed = marked.parse(markdown, { async: false, breaks: true }) as string;
-  const doc = new DOMParser().parseFromString(
-    DOMPurify.sanitize(parsed),
-    "text/html"
-  );
 
-  // Run the wrappers first: a <center> that becomes an aligned paragraph must
-  // not then be reported as an unsupported tag.
+  // Parsed with DOMParser, which produces an inert document: scripts do not
+  // run and resources are not fetched, so the unsanitised markup is safe to
+  // inspect. Sanitising happens at the end, on the way to the editor.
+  const doc = new DOMParser().parseFromString(parsed, "text/html");
+
+  // Wrappers first: a <center> that becomes an aligned paragraph must not then
+  // be reported as an unsupported tag.
   const wrappersLossy = normalizeAlignmentWrappers(doc);
   restoreAlignmentFromDataAttribute(doc);
 
   return {
-    html: doc.body.innerHTML,
+    html: DOMPurify.sanitize(doc.body.innerHTML),
     lossy: wrappersLossy || containsUnsupportedMarkup(doc)
   };
-}
-
-function stripCodeSpans(markdown: string): string {
-  return markdown
-    .replace(/```[\s\S]*?```/g, "")
-    .replace(/~~~[\s\S]*?~~~/g, "")
-    .replace(/`[^`\n]*`/g, "");
 }
 
 /**
@@ -210,10 +278,6 @@ function stripCodeSpans(markdown: string): string {
  */
 export function hasUnsupportedMarkup(markdown: string | undefined): boolean {
   if (!markdown) return false;
-
-  // Code spans round-trip verbatim, so markup quoted inside them is not a risk
-  // and must not cost the author the rich editor.
-  if (SANITIZER_REMOVED.test(stripCodeSpans(markdown))) return true;
 
   try {
     return parseMarkdown(markdown).lossy;

--- a/apps/self-hosted/src/routes/edit.$author.$permlink.tsx
+++ b/apps/self-hosted/src/routes/edit.$author.$permlink.tsx
@@ -65,11 +65,37 @@ function RouteComponent() {
   return <EditPageContent entry={entry} />;
 }
 
+/**
+ * json_metadata normally arrives parsed, but some nodes hand it back as the raw
+ * JSON string. Both shapes have to resolve to an object here: whatever is not
+ * carried through ends up erased from the post on the next update.
+ */
+function parseJsonMetadata(value: unknown): Record<string, unknown> | undefined {
+  let parsed = value;
+
+  if (typeof parsed === "string") {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      return undefined;
+    }
+  }
+
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : undefined;
+}
+
 function EditPageContent({ entry }: { entry: any }) {
+  const jsonMetadata = useMemo(
+    () => parseJsonMetadata(entry.json_metadata),
+    [entry]
+  );
+
   const initialTags = useMemo(() => {
-    const tags = entry.json_metadata?.tags;
+    const tags = jsonMetadata?.tags;
     return Array.isArray(tags) ? tags : [];
-  }, [entry]);
+  }, [jsonMetadata]);
 
   const parentPermlink = useMemo(() => {
     return entry.parent_permlink || (initialTags[0] ?? "").toLowerCase();
@@ -86,6 +112,7 @@ function EditPageContent({ entry }: { entry: any }) {
               initialTitle={entry.title}
               initialBody={entry.body}
               initialTags={initialTags}
+              initialJsonMetadata={jsonMetadata}
             />
           </main>
           <div className="blog-sidebar-container order-1 lg:order-2">

--- a/apps/self-hosted/src/styles/blog-markdown.css
+++ b/apps/self-hosted/src/styles/blog-markdown.css
@@ -1613,3 +1613,49 @@
   color: var(--theme-accent-hover, #1b68da);
   text-decoration: none;
 }
+
+/*
+ * Alignment written by the editor toolbar and by Hive's <center> / pull-* wrappers.
+ * render-helper strips the inline style attribute and keeps only data-align, so
+ * without these rules aligned paragraphs render left aligned on the blog itself
+ * even though ecency.com shows them correctly.
+ */
+.markdown-body p[data-align='left'],
+.markdown-body h1[data-align='left'],
+.markdown-body h2[data-align='left'],
+.markdown-body h3[data-align='left'],
+.markdown-body h4[data-align='left'],
+.markdown-body h5[data-align='left'],
+.markdown-body h6[data-align='left'] {
+  text-align: left;
+}
+
+.markdown-body p[data-align='center'],
+.markdown-body h1[data-align='center'],
+.markdown-body h2[data-align='center'],
+.markdown-body h3[data-align='center'],
+.markdown-body h4[data-align='center'],
+.markdown-body h5[data-align='center'],
+.markdown-body h6[data-align='center'] {
+  text-align: center;
+}
+
+.markdown-body p[data-align='right'],
+.markdown-body h1[data-align='right'],
+.markdown-body h2[data-align='right'],
+.markdown-body h3[data-align='right'],
+.markdown-body h4[data-align='right'],
+.markdown-body h5[data-align='right'],
+.markdown-body h6[data-align='right'] {
+  text-align: right;
+}
+
+.markdown-body p[data-align='justify'],
+.markdown-body h1[data-align='justify'],
+.markdown-body h2[data-align='justify'],
+.markdown-body h3[data-align='justify'],
+.markdown-body h4[data-align='justify'],
+.markdown-body h5[data-align='justify'],
+.markdown-body h6[data-align='justify'] {
+  text-align: justify;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         specifier: ^2.11.5
         version: 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
       '@tiptap/extension-link':
-        specifier: ^2.26.2
+        specifier: ^2.11.5
         version: 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)
       '@tiptap/extension-placeholder':
         specifier: ^2.11.5
@@ -12373,7 +12373,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@24.10.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -12435,7 +12435,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@24.10.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/utils@4.1.8':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@tiptap/extension-image':
         specifier: ^2.11.5
         version: 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-link':
+        specifier: ^2.26.2
+        version: 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)
       '@tiptap/extension-placeholder':
         specifier: ^2.11.5
         version: 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)
@@ -213,6 +216,9 @@ importers:
       '@types/turndown':
         specifier: ^5.0.0
         version: 5.0.5
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       tailwindcss:
         specifier: ^4.1.13
         version: 4.1.18
@@ -7182,6 +7188,7 @@ packages:
 
   react-grid-layout@1.5.2:
     resolution: {integrity: sha512-vT7xmQqszTT+sQw/LfisrEO4le1EPNnSEMVHy6sBZyzS3yGkMywdOd+5iEFFwQwt0NSaGkxuRmYwa1JsP6OJdw==}
+    deprecated: 'Ships stray files that were never in the repo: an ip_fetcher binary and its curl-sample source (1.5.0-1.5.3), plus a yarn-error.log containing local paths (1.5.3). Upgrade to 1.5.4, which is byte-identical apart from removing them. See https://github.com/react-grid-layout/react-grid-layout/issues/2269'
     peerDependencies:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
@@ -12366,7 +12373,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@24.10.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -12428,7 +12435,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@24.10.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/utils@4.1.8':
     dependencies:


### PR DESCRIPTION
Closes #1297, closes #1298.

Loading a post into the self-hosted rich text editor and saving it silently rewrote the stored body. Measured end to end through the real pipeline (`markdownToHtml` -> Tiptap schema -> `htmlToMarkdown`) before this change:

| Input | Saved back as |
| --- | --- |
| `[my post](url)` | `my post` (href dropped) |
| `Line one\nLine two` | `Line one Line two` |
| `<center><img src="x"></center>` | `![](x)` (centering lost) |
| `<div class="pull-left"><img></div>` | `![](x)` |
| `<center>![img](x)</center>` | `!\[img\](x)` (literal text) |
| `<iframe ...>` | `""` (embed deleted) |

Separately `useUpdatePost` rebuilt `json_metadata` from scratch as `{tags, app, format}`, so every edit erased the post’s `image` (feed thumbnail), `description`, `users`, `links` and any app specific block such as 3Speak’s `video` object.

## What changed

- **Links.** A shared `LINK_EXTENSION` gives the schema a link mark; without it there was no way for an href to survive a load, and no way to author one. Toolbar gets set/unset buttons. `target`/`rel` are cleared and `autolink` is off so editor display attributes and linkified bare URLs do not leak into the stored body.
- **Line breaks.** `marked` runs with `breaks: true` to match how `@ecency/render-helper` renders stored posts, and turndown emits `<br>` without its default trailing spaces.
- **Alignment wrappers.** `<center>` and `pull-left`/`pull-right` are converted to aligned paragraphs on load, but only when the wrapper holds exactly one image (optionally inside a link). That is precisely the shape the existing outbound alignment rule can turn back into the original wrapper, so the transform is invertible.
- **Turndown gaps.** Added rules for strikethrough (`~~$100~~ $80` was saving as `$100 $80`, inverting meaning) and for autolinks. Image titles are kept and brackets in alt text are escaped rather than deleted.
- **The guard.** `hasUnsupportedMarkup` now reports everything the schema would flatten: embeds, `details`/`summary` (losing it exposes content the author deliberately hid), `sub`/`sup`, `u`, task lists, `hive:` links, and any alignment wrapper that cannot be rebuilt. Those posts open in a plain markdown textarea with a notice instead of being loaded into the editor.
- **Metadata.** The update carries the post’s existing `json_metadata` through, handling the raw JSON string shape some nodes return, and the post-save redirect keeps its `@` prefix.
- **`[data-align]` CSS.** render-helper strips the inline `style` attribute and keeps only `data-align`. `apps/web` styles it, `apps/self-hosted` did not, so paragraphs aligned with the toolbar rendered left aligned on the blog itself.

## Verification

- 10 new round-trip regression tests plus guard coverage; 87 tests pass in `apps/self-hosted`.
- Round-tripping twice equals round-tripping once for every covered shape, so a post no longer drifts on repeated edits.
- `tsc` reports no new errors in the changed files, biome is at the pre-existing baseline for these paths, and `rsbuild build` succeeds.

`jsdom` is added as a devDependency so the round-trip tests can drive the real Tiptap schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added link creation, editing, and removal in the post editor.
  * Added support for preserving post metadata during edits.
  * Added alignment support for paragraphs and headings.
  * Added localized editor messages in six languages.

* **Bug Fixes**
  * Posts containing unsupported formatting now open in a Markdown fallback editor instead of losing content.
  * Improved preservation of links, line breaks, images, formatting, and other Markdown elements.

* **Tests**
  * Added coverage for Markdown conversion, unsupported markup detection, and content round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->