### PR TITLE
fix(self-hosted): stop config values from blanking the whole blog

### DIFF
--- a/apps/self-hosted/src/core/config-merge-wiring.test.ts
+++ b/apps/self-hosted/src/core/config-merge-wiring.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The build-time config.json is generated at image build and gitignored, so it
+ * does not exist in CI. It is also the thing under test here: the published
+ * image falls back to config.template.json, a DEMO document, so this stub uses
+ * the same shape to prove none of it can leak into a tenant's config.
+ */
+vi.mock('../../config.json', () => ({
+  default: {
+    version: 1,
+    configuration: {
+      general: { theme: 'light', styles: { background: 'bg-demo' } },
+      instanceConfiguration: {
+        type: 'blog',
+        username: 'ecency',
+        meta: { title: 'Demo', logo: 'https://myblog.com/logo.png' },
+        layout: { sidebar: { placement: 'right' } },
+        features: { postsFilters: ['posts'] },
+      },
+    },
+  },
+}));
+
+const { InstanceConfigManager } = await import('./configuration-loader');
+
+function serve(configuration: unknown) {
+  globalThis.fetch = (async () => ({
+    ok: true,
+    json: async () => ({ version: 2, configuration }),
+  })) as unknown as typeof fetch;
+}
+
+describe('runtime config merging (wiring)', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+    // loadRuntimeConfig only fetches in a browser; this suite runs in node.
+    vi.stubGlobal('window', {});
+  });
+
+  it('restores omitted sections without inheriting the fallback document', async () => {
+    serve({
+      general: { theme: 'dark' },
+      instanceConfiguration: { type: 'community', communityId: 'hive-125125' },
+    });
+
+    await InstanceConfigManager.initialize();
+    const { configuration } = InstanceConfigManager.getConfig();
+
+    // Structure the consumers dereference is present...
+    expect(configuration.general.styles).toBeDefined();
+    expect(configuration.instanceConfiguration.meta).toBeDefined();
+    expect(configuration.instanceConfiguration.layout).toBeDefined();
+    expect(configuration.instanceConfiguration.layout.sidebar).toBeDefined();
+
+    // ...and none of the fallback document's CONTENT came with it. A leaked
+    // username resolves the ownership gate (owner || username) to the wrong
+    // account; a leaked logo makes the blog hotlink a domain it does not own.
+    expect(configuration.instanceConfiguration.username).toBeUndefined();
+    expect(configuration.instanceConfiguration.meta.logo).toBeUndefined();
+    expect(configuration.general.styles.background).toBeUndefined();
+    expect(configuration.general.theme).toBe('dark');
+  });
+});

--- a/apps/self-hosted/src/core/configuration-loader.ts
+++ b/apps/self-hosted/src/core/configuration-loader.ts
@@ -17,6 +17,24 @@ import {
 import buildTimeConfig from '../../config.json';
 import { mergeConfig } from './merge-config';
 
+/**
+ * The nested sections applyConfig and the feature hooks dereference. Values are
+ * deliberately absent: every consumer already supplies its own default (?? or
+ * ||), so the skeleton only has to guarantee the objects exist. Anything given a
+ * value here would silently become that consumer's default instead.
+ */
+const CONFIG_SKELETON = {
+  version: 1,
+  configuration: {
+    general: { styles: {} },
+    instanceConfiguration: {
+      meta: {},
+      layout: { sidebar: {} },
+      features: {},
+    },
+  },
+} as const;
+
 // =============================================================================
 // Configuration Types
 // =============================================================================
@@ -146,12 +164,18 @@ class ConfigStore {
 
       // Validate basic structure
       if (runtimeConfig?.version && runtimeConfig?.configuration) {
-        // Merged over the build-time config rather than replacing it: a served
-        // config that omits a nested section (hand edited, or written against
-        // an older schema) would otherwise leave those paths undefined for
-        // every consumer that reads them.
+        // Merged over a structural skeleton, NOT over the build-time config.
+        //
+        // The merge exists so a served config that omits a nested section
+        // cannot leave those paths undefined for the consumers that read them.
+        // It must supply shape only. Merging the build-time config would supply
+        // CONTENT: the image published without a baked config falls back to
+        // config.template.json, a demo document, so an omitted meta.logo would
+        // make the blog hotlink the template's placeholder URL, and an omitted
+        // username would resolve the ownership gate in auth-provider
+        // (owner || username) to the template's account.
         this.config = mergeConfig(
-          buildTimeConfig as InstanceConfig,
+          CONFIG_SKELETON as InstanceConfig,
           runtimeConfig as InstanceConfig,
         );
         this.notifyListeners();

--- a/apps/self-hosted/src/core/configuration-loader.ts
+++ b/apps/self-hosted/src/core/configuration-loader.ts
@@ -15,6 +15,7 @@ import {
 
 // Build-time config import (fallback)
 import buildTimeConfig from '../../config.json';
+import { mergeConfig } from './merge-config';
 
 // =============================================================================
 // Configuration Types
@@ -145,7 +146,14 @@ class ConfigStore {
 
       // Validate basic structure
       if (runtimeConfig?.version && runtimeConfig?.configuration) {
-        this.config = runtimeConfig as InstanceConfig;
+        // Merged over the build-time config rather than replacing it: a served
+        // config that omits a nested section (hand edited, or written against
+        // an older schema) would otherwise leave those paths undefined for
+        // every consumer that reads them.
+        this.config = mergeConfig(
+          buildTimeConfig as InstanceConfig,
+          runtimeConfig as InstanceConfig,
+        );
         this.notifyListeners();
         console.debug('[Config] Loaded runtime config v' + runtimeConfig.version);
       }

--- a/apps/self-hosted/src/core/date-formatter.test.ts
+++ b/apps/self-hosted/src/core/date-formatter.test.ts
@@ -115,6 +115,35 @@ describe('date formatting with invalid configuration', () => {
     expect(formatDateTime(DATE)).toBe('2024-01-16 10:00:00');
   });
 
+  it('survives a format value that is not a string', () => {
+    // convertFormatPattern calls .replace() and runs OUTSIDE safeFormat's try,
+    // so a truthy non-string threw uncaught and blanked the page.
+    for (const bad of [42, true, {}, ['a']]) {
+      state.general = {
+        language: 'en',
+        timezone: 'UTC',
+        dateFormat: bad,
+        timeFormat: bad,
+        dateTimeFormat: bad,
+      } as never;
+
+      expect(
+        () => formatDate(DATE),
+        `dateFormat=${JSON.stringify(bad)}`,
+      ).not.toThrow();
+      expect(() => formatTime(DATE)).not.toThrow();
+      expect(() => formatDateTime(DATE)).not.toThrow();
+      expect(formatDate(DATE)).toBe('2024-01-16');
+    }
+  });
+
+  it('survives a timezone that is not a string', () => {
+    state.general = { language: 'en', timezone: 99 } as never;
+
+    expect(() => formatDate(DATE)).not.toThrow();
+    expect(() => formatRelativeDate(DATE)).not.toThrow();
+  });
+
   it('returns empty rather than throwing for an unparseable date', () => {
     expect(formatMonthYear('not a date')).toBe('');
     expect(formatCustom('not a date', 'yyyy')).toBe('');

--- a/apps/self-hosted/src/core/date-formatter.test.ts
+++ b/apps/self-hosted/src/core/date-formatter.test.ts
@@ -1,26 +1,29 @@
-import { beforeEach, describe, expect, it } from 'vitest';
-import { InstanceConfigManager } from './configuration-loader';
-import {
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * configuration-loader imports the build-time config.json, which is generated
+ * at image build and gitignored, so it does not exist in CI. The formatters
+ * only read a handful of general settings, so the manager is stubbed here.
+ */
+const state = vi.hoisted(() => ({ general: {} as Record<string, unknown> }));
+
+vi.mock('./configuration-loader', () => ({
+  InstanceConfigManager: {
+    getConfigValue: (selector: (config: unknown) => unknown) =>
+      selector({ configuration: { general: state.general } }),
+  },
+}));
+
+const {
   formatCustom,
   formatDate,
   formatDateTime,
   formatMonthYear,
   formatRelativeDate,
   formatTime,
-} from './date-formatter';
+} = await import('./date-formatter');
 
 const DATE = '2024-01-16T10:00:00';
-
-function configure(general: Record<string, unknown>) {
-  const current = InstanceConfigManager.getConfig();
-  InstanceConfigManager.updateConfig({
-    ...current,
-    configuration: {
-      ...current.configuration,
-      general: { ...current.configuration.general, ...general },
-    },
-  } as never);
-}
 
 /**
  * These fields are free text in the config editor and are read while rendering
@@ -29,16 +32,17 @@ function configure(general: Record<string, unknown>) {
  */
 describe('date formatting with invalid configuration', () => {
   beforeEach(() => {
-    configure({
+    state.general = {
+      language: 'en',
       timezone: 'UTC',
       dateFormat: 'yyyy-MM-dd',
       timeFormat: 'HH:mm:ss',
       dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
-    });
+    };
   });
 
   it('survives a timezone that is not an IANA zone', () => {
-    configure({ timezone: 'UTC+3' });
+    state.general.timezone = 'UTC+3';
 
     expect(() => formatDate(DATE)).not.toThrow();
     expect(formatDate(DATE)).not.toBe('');
@@ -50,14 +54,14 @@ describe('date formatting with invalid configuration', () => {
 
   it('survives a Moment style pattern date-fns cannot parse', () => {
     // Uppercase A is not a date-fns token and throws a RangeError.
-    configure({ timeFormat: 'hh:mm A' });
+    state.general.timeFormat = 'hh:mm A';
 
     expect(() => formatTime(DATE)).not.toThrow();
     expect(formatTime(DATE)).not.toBe('');
   });
 
   it('survives a pattern made of literal words', () => {
-    configure({ dateFormat: 'Updated on' });
+    state.general.dateFormat = 'Updated on';
 
     expect(() => formatDate(DATE)).not.toThrow();
     expect(formatDate(DATE)).not.toBe('');

--- a/apps/self-hosted/src/core/date-formatter.test.ts
+++ b/apps/self-hosted/src/core/date-formatter.test.ts
@@ -20,6 +20,7 @@ const {
   formatDateTime,
   formatMonthYear,
   formatRelativeDate,
+  formatRelativeTime,
   formatTime,
 } = await import('./date-formatter');
 
@@ -75,6 +76,43 @@ describe('date formatting with invalid configuration', () => {
   it('still formats correctly when the configuration is valid', () => {
     expect(formatDate(DATE)).toBe('2024-01-16');
     expect(formatTime(DATE)).toBe('10:00:00');
+  });
+
+  it('survives a general section that is missing entirely', () => {
+    // getLocale reads configuration.general.language, so reading it above the
+    // guard's own try would throw past the protection.
+    state.general = undefined as never;
+
+    expect(() => formatDate(DATE)).not.toThrow();
+    expect(() => formatTime(DATE)).not.toThrow();
+    expect(() => formatRelativeTime(DATE)).not.toThrow();
+    expect(() => formatRelativeDate(DATE)).not.toThrow();
+  });
+
+  it('survives a language that collides with an Object.prototype member', () => {
+    // A bare localeMap[language] lookup would hand date-fns a function.
+    state.general = { language: 'constructor' };
+
+    expect(() => formatDate(DATE)).not.toThrow();
+    expect(() => formatRelativeTime(DATE)).not.toThrow();
+    expect(formatDate(DATE)).not.toBe('');
+  });
+
+  it('uses the shipped Moment-style patterns, not only date-fns native ones', () => {
+    // Every config the product ships (config.template.json, the hosting
+    // default, and getDefaultConfig) uses YYYY-MM-DD, which date-fns rejects
+    // unless convertFormatPattern rewrites it, so the tests have to exercise
+    // that path rather than pre-converted patterns.
+    state.general = {
+      language: 'en',
+      timezone: 'UTC',
+      dateFormat: 'YYYY-MM-DD',
+      timeFormat: 'HH:mm:ss',
+      dateTimeFormat: 'YYYY-MM-DD HH:mm:ss',
+    };
+
+    expect(formatDate(DATE)).toBe('2024-01-16');
+    expect(formatDateTime(DATE)).toBe('2024-01-16 10:00:00');
   });
 
   it('returns empty rather than throwing for an unparseable date', () => {

--- a/apps/self-hosted/src/core/date-formatter.test.ts
+++ b/apps/self-hosted/src/core/date-formatter.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { InstanceConfigManager } from './configuration-loader';
+import {
+  formatCustom,
+  formatDate,
+  formatDateTime,
+  formatMonthYear,
+  formatRelativeDate,
+  formatTime,
+} from './date-formatter';
+
+const DATE = '2024-01-16T10:00:00';
+
+function configure(general: Record<string, unknown>) {
+  const current = InstanceConfigManager.getConfig();
+  InstanceConfigManager.updateConfig({
+    ...current,
+    configuration: {
+      ...current.configuration,
+      general: { ...current.configuration.general, ...general },
+    },
+  } as never);
+}
+
+/**
+ * These fields are free text in the config editor and are read while rendering
+ * every post card, so an invalid value used to take the whole blog down to the
+ * root error boundary rather than spoiling one timestamp.
+ */
+describe('date formatting with invalid configuration', () => {
+  beforeEach(() => {
+    configure({
+      timezone: 'UTC',
+      dateFormat: 'yyyy-MM-dd',
+      timeFormat: 'HH:mm:ss',
+      dateTimeFormat: 'yyyy-MM-dd HH:mm:ss',
+    });
+  });
+
+  it('survives a timezone that is not an IANA zone', () => {
+    configure({ timezone: 'UTC+3' });
+
+    expect(() => formatDate(DATE)).not.toThrow();
+    expect(formatDate(DATE)).not.toBe('');
+    expect(() => formatTime(DATE)).not.toThrow();
+    expect(() => formatDateTime(DATE)).not.toThrow();
+    expect(() => formatRelativeDate(DATE)).not.toThrow();
+    expect(() => formatMonthYear(DATE)).not.toThrow();
+  });
+
+  it('survives a Moment style pattern date-fns cannot parse', () => {
+    // Uppercase A is not a date-fns token and throws a RangeError.
+    configure({ timeFormat: 'hh:mm A' });
+
+    expect(() => formatTime(DATE)).not.toThrow();
+    expect(formatTime(DATE)).not.toBe('');
+  });
+
+  it('survives a pattern made of literal words', () => {
+    configure({ dateFormat: 'Updated on' });
+
+    expect(() => formatDate(DATE)).not.toThrow();
+    expect(formatDate(DATE)).not.toBe('');
+  });
+
+  it('survives an invalid custom pattern', () => {
+    expect(() => formatCustom(DATE, 'hh:mm A')).not.toThrow();
+    expect(formatCustom(DATE, 'hh:mm A')).not.toBe('');
+  });
+
+  it('still formats correctly when the configuration is valid', () => {
+    expect(formatDate(DATE)).toBe('2024-01-16');
+    expect(formatTime(DATE)).toBe('10:00:00');
+  });
+
+  it('returns empty rather than throwing for an unparseable date', () => {
+    expect(formatMonthYear('not a date')).toBe('');
+    expect(formatCustom('not a date', 'yyyy')).toBe('');
+  });
+});

--- a/apps/self-hosted/src/core/date-formatter.ts
+++ b/apps/self-hosted/src/core/date-formatter.ts
@@ -118,6 +118,17 @@ function safeFormat(date: Date, pattern: string, fallback: string): string {
   }
 }
 
+/**
+ * These come from free-text config fields, so a value can be any JSON type.
+ * Falling back only on falsiness let a number or an object through to
+ * convertFormatPattern, whose .replace() then threw a TypeError outside
+ * safeFormat's try - the same blank-page failure this guarding exists to stop,
+ * for the wrong-type case rather than the missing-value one.
+ */
+function configString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() !== '' ? value : fallback;
+}
+
 function getLocale(): Locale {
   const language = InstanceConfigManager.getConfigValue(
     ({ configuration }) => configuration.general?.language,
@@ -126,8 +137,11 @@ function getLocale(): Locale {
 }
 
 function getTimezone(): string {
-  return InstanceConfigManager.getConfigValue(
-    ({ configuration }) => configuration.general?.timezone || 'UTC',
+  return configString(
+    InstanceConfigManager.getConfigValue(
+      ({ configuration }) => configuration.general?.timezone,
+    ),
+    'UTC',
   );
 }
 
@@ -135,21 +149,23 @@ function getDateFormat(): string {
   const configFormat = InstanceConfigManager.getConfigValue(
     ({ configuration }) => configuration.general?.dateFormat,
   );
-  return convertFormatPattern(configFormat || 'yyyy-MM-dd');
+  return convertFormatPattern(configString(configFormat, 'yyyy-MM-dd'));
 }
 
 function getTimeFormat(): string {
   const configFormat = InstanceConfigManager.getConfigValue(
     ({ configuration }) => configuration.general?.timeFormat,
   );
-  return convertFormatPattern(configFormat || 'HH:mm:ss');
+  return convertFormatPattern(configString(configFormat, 'HH:mm:ss'));
 }
 
 function getDateTimeFormat(): string {
   const configFormat = InstanceConfigManager.getConfigValue(
     ({ configuration }) => configuration.general?.dateTimeFormat,
   );
-  return convertFormatPattern(configFormat || 'yyyy-MM-dd HH:mm:ss');
+  return convertFormatPattern(
+    configString(configFormat, 'yyyy-MM-dd HH:mm:ss'),
+  );
 }
 
 /**
@@ -241,7 +257,7 @@ export function formatCustom(
   const zonedDate = toZoned(utcDate, getTimezone());
   return safeFormat(
     zonedDate,
-    convertFormatPattern(formatStr),
+    convertFormatPattern(configString(formatStr, 'yyyy-MM-dd HH:mm:ss')),
     'yyyy-MM-dd HH:mm:ss',
   );
 }

--- a/apps/self-hosted/src/core/date-formatter.ts
+++ b/apps/self-hosted/src/core/date-formatter.ts
@@ -20,8 +20,11 @@ import {
 import { toZonedTime } from 'date-fns-tz';
 import { InstanceConfigManager } from './configuration-loader';
 
-// Map language codes to date-fns locales
-const localeMap: Record<string, Locale> = {
+// Map language codes to date-fns locales.
+// Null-prototype on purpose: the language comes from owner-editable config, and
+// a plain literal would resolve a value like 'constructor' to an inherited
+// member instead of falling back to the default locale.
+const localeMap: Record<string, Locale> = Object.assign(Object.create(null), {
   en: enUS,
   es: es,
   de: de,
@@ -37,7 +40,7 @@ const localeMap: Record<string, Locale> = {
   uk: uk,
   vi: vi,
   id: id,
-};
+});
 
 // Convert config format patterns to date-fns format patterns
 // Config uses common patterns like YYYY-MM-DD, date-fns uses yyyy-MM-dd
@@ -97,49 +100,54 @@ function toZoned(date: Date, timezone: string): Date {
  * single timestamp.
  */
 function safeFormat(date: Date, pattern: string, fallback: string): string {
-  const locale = getLocale();
-
+  // getLocale() reads the config and is inside the try on purpose: a general
+  // section that is missing or not an object is exactly the shape this guard
+  // exists to survive, and reading it above the try would throw past it.
   try {
-    return format(date, pattern, { locale });
+    return format(date, pattern, { locale: getLocale() });
   } catch {
     try {
-      return format(date, fallback, { locale });
+      return format(date, fallback, { locale: getLocale() });
     } catch {
-      return date.toISOString();
+      try {
+        return format(date, fallback);
+      } catch {
+        return '';
+      }
     }
   }
 }
 
 function getLocale(): Locale {
   const language = InstanceConfigManager.getConfigValue(
-    ({ configuration }) => configuration.general.language,
+    ({ configuration }) => configuration.general?.language,
   );
   return localeMap[language] || enUS;
 }
 
 function getTimezone(): string {
   return InstanceConfigManager.getConfigValue(
-    ({ configuration }) => configuration.general.timezone || 'UTC',
+    ({ configuration }) => configuration.general?.timezone || 'UTC',
   );
 }
 
 function getDateFormat(): string {
   const configFormat = InstanceConfigManager.getConfigValue(
-    ({ configuration }) => configuration.general.dateFormat,
+    ({ configuration }) => configuration.general?.dateFormat,
   );
   return convertFormatPattern(configFormat || 'yyyy-MM-dd');
 }
 
 function getTimeFormat(): string {
   const configFormat = InstanceConfigManager.getConfigValue(
-    ({ configuration }) => configuration.general.timeFormat,
+    ({ configuration }) => configuration.general?.timeFormat,
   );
   return convertFormatPattern(configFormat || 'HH:mm:ss');
 }
 
 function getDateTimeFormat(): string {
   const configFormat = InstanceConfigManager.getConfigValue(
-    ({ configuration }) => configuration.general.dateTimeFormat,
+    ({ configuration }) => configuration.general?.dateTimeFormat,
   );
   return convertFormatPattern(configFormat || 'yyyy-MM-dd HH:mm:ss');
 }
@@ -182,8 +190,16 @@ export function formatRelativeTime(date: Date | string | number): string {
   const utcDate = parseHiveDate(date);
   if (!isValidDate(utcDate)) return '';
   // formatDistanceToNow compares UTC timestamps internally, so we just need
-  // to ensure the input date is parsed as UTC (which parseHiveDate does)
-  return formatDistanceToNow(utcDate, { addSuffix: true, locale: getLocale() });
+  // to ensure the input date is parsed as UTC (which parseHiveDate does).
+  // Guarded like the others: getLocale() reads owner-controlled config.
+  try {
+    return formatDistanceToNow(utcDate, {
+      addSuffix: true,
+      locale: getLocale(),
+    });
+  } catch {
+    return '';
+  }
 }
 
 /**

--- a/apps/self-hosted/src/core/date-formatter.ts
+++ b/apps/self-hosted/src/core/date-formatter.ts
@@ -80,6 +80,36 @@ function isValidDate(d: Date): boolean {
   return !Number.isNaN(d.getTime());
 }
 
+/**
+ * date-fns throws on an unknown time zone, and the value comes from a free text
+ * config field, so "UTC+3" (not an IANA zone) would otherwise take down every
+ * page that renders a date.
+ */
+function toZoned(date: Date, timezone: string): Date {
+  const zoned = toZonedTime(date, timezone);
+  return isValidDate(zoned) ? zoned : date;
+}
+
+/**
+ * date-fns throws a RangeError on any unescaped latin character that is not a
+ * token, which includes common Moment style patterns such as "hh:mm A". The
+ * pattern is owner-typed, so one typo would blank the whole blog rather than a
+ * single timestamp.
+ */
+function safeFormat(date: Date, pattern: string, fallback: string): string {
+  const locale = getLocale();
+
+  try {
+    return format(date, pattern, { locale });
+  } catch {
+    try {
+      return format(date, fallback, { locale });
+    } catch {
+      return date.toISOString();
+    }
+  }
+}
+
 function getLocale(): Locale {
   const language = InstanceConfigManager.getConfigValue(
     ({ configuration }) => configuration.general.language,
@@ -120,8 +150,8 @@ function getDateTimeFormat(): string {
 export function formatDate(date: Date | string | number): string {
   const utcDate = parseHiveDate(date);
   if (!isValidDate(utcDate)) return '';
-  const zonedDate = toZonedTime(utcDate, getTimezone());
-  return format(zonedDate, getDateFormat(), { locale: getLocale() });
+  const zonedDate = toZoned(utcDate, getTimezone());
+  return safeFormat(zonedDate, getDateFormat(), 'yyyy-MM-dd');
 }
 
 /**
@@ -130,8 +160,8 @@ export function formatDate(date: Date | string | number): string {
 export function formatTime(date: Date | string | number): string {
   const utcDate = parseHiveDate(date);
   if (!isValidDate(utcDate)) return '';
-  const zonedDate = toZonedTime(utcDate, getTimezone());
-  return format(zonedDate, getTimeFormat(), { locale: getLocale() });
+  const zonedDate = toZoned(utcDate, getTimezone());
+  return safeFormat(zonedDate, getTimeFormat(), 'HH:mm:ss');
 }
 
 /**
@@ -140,8 +170,8 @@ export function formatTime(date: Date | string | number): string {
 export function formatDateTime(date: Date | string | number): string {
   const utcDate = parseHiveDate(date);
   if (!isValidDate(utcDate)) return '';
-  const zonedDate = toZonedTime(utcDate, getTimezone());
-  return format(zonedDate, getDateTimeFormat(), { locale: getLocale() });
+  const zonedDate = toZoned(utcDate, getTimezone());
+  return safeFormat(zonedDate, getDateTimeFormat(), 'yyyy-MM-dd HH:mm:ss');
 }
 
 /**
@@ -163,9 +193,14 @@ export function formatRelativeDate(date: Date | string | number): string {
   const utcDate = parseHiveDate(date);
   if (!isValidDate(utcDate)) return '';
   const timezone = getTimezone();
-  const zonedDate = toZonedTime(utcDate, timezone);
-  const zonedNow = toZonedTime(new Date(), timezone);
-  return formatRelative(zonedDate, zonedNow, { locale: getLocale() });
+  const zonedDate = toZoned(utcDate, timezone);
+  const zonedNow = toZoned(new Date(), timezone);
+
+  try {
+    return formatRelative(zonedDate, zonedNow, { locale: getLocale() });
+  } catch {
+    return zonedDate.toISOString();
+  }
 }
 
 /**
@@ -173,8 +208,9 @@ export function formatRelativeDate(date: Date | string | number): string {
  */
 export function formatMonthYear(date: Date | string | number): string {
   const utcDate = parseHiveDate(date);
-  const zonedDate = toZonedTime(utcDate, getTimezone());
-  return format(zonedDate, 'MMMM yyyy', { locale: getLocale() });
+  if (!isValidDate(utcDate)) return '';
+  const zonedDate = toZoned(utcDate, getTimezone());
+  return safeFormat(zonedDate, 'MMMM yyyy', 'MMMM yyyy');
 }
 
 /**
@@ -185,8 +221,11 @@ export function formatCustom(
   formatStr: string,
 ): string {
   const utcDate = parseHiveDate(date);
-  const zonedDate = toZonedTime(utcDate, getTimezone());
-  return format(zonedDate, convertFormatPattern(formatStr), {
-    locale: getLocale(),
-  });
+  if (!isValidDate(utcDate)) return '';
+  const zonedDate = toZoned(utcDate, getTimezone());
+  return safeFormat(
+    zonedDate,
+    convertFormatPattern(formatStr),
+    'yyyy-MM-dd HH:mm:ss',
+  );
 }

--- a/apps/self-hosted/src/core/merge-config.test.ts
+++ b/apps/self-hosted/src/core/merge-config.test.ts
@@ -31,8 +31,13 @@ describe('mergeConfig', () => {
     expect(merged.postsFilters).toEqual(['trending']);
   });
 
-  it('lets the served config override a section with a scalar', () => {
-    expect(mergeConfig({ a: { b: 1 } }, { a: 2 } as never)).toEqual({ a: 2 });
+  it('does not let the served config replace a section with a scalar', () => {
+    // This previously asserted the opposite. Allowing it reproduced the crash
+    // the skeleton exists to prevent, because components dereference the
+    // section during render.
+    expect(mergeConfig({ a: { b: 1 } }, { a: 2 } as never)).toEqual({
+      a: { b: 1 },
+    });
   });
 
   it('returns the override when either side is not an object', () => {
@@ -61,5 +66,55 @@ describe('mergeConfig', () => {
     expect(merged.a).toBe(1);
     expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('keeps a section when the served value is the wrong shape', () => {
+    // A scalar cannot stand in for a section: applyConfig's try/catch only
+    // covers the boot path, while components dereference
+    // configuration.general.* during render and land in the error boundary.
+    const skeleton = {
+      general: { styles: {} },
+      features: { postsFilters: [] },
+    };
+
+    expect(
+      mergeConfig(skeleton, { general: 'invalid' } as never).general,
+    ).toEqual({
+      styles: {},
+    });
+    expect(mergeConfig(skeleton, { general: 42 } as never).general).toEqual({
+      styles: {},
+    });
+    expect(mergeConfig(skeleton, { general: [] } as never).general).toEqual({
+      styles: {},
+    });
+  });
+
+  it('keeps the whole configuration section when it is served as a scalar', () => {
+    // A truthy scalar passes the loader's version/configuration presence check,
+    // so without type agreement it replaced the skeleton outright and
+    // applyConfig destructured a string.
+    const skeleton = {
+      version: 1,
+      configuration: { general: { styles: {} }, instanceConfiguration: {} },
+    };
+
+    for (const bad of ['bad', 42, true, [], ['a']]) {
+      const merged = mergeConfig(skeleton, {
+        version: 2,
+        configuration: bad,
+      } as never);
+
+      expect(merged.configuration.general).toEqual({ styles: {} });
+      expect(merged.version).toBe(2);
+    }
+  });
+
+  it('keeps an array when the served value is not an array', () => {
+    const merged = mergeConfig({ postsFilters: ['posts'] }, {
+      postsFilters: 'trending',
+    } as never);
+
+    expect(merged.postsFilters).toEqual(['posts']);
   });
 });

--- a/apps/self-hosted/src/core/merge-config.test.ts
+++ b/apps/self-hosted/src/core/merge-config.test.ts
@@ -39,4 +39,27 @@ describe('mergeConfig', () => {
     expect(mergeConfig(null, { a: 1 } as never)).toEqual({ a: 1 });
     expect(mergeConfig({ a: 1 } as never, null)).toBe(null);
   });
+
+  it('treats a null section as absent rather than erasing the shape', () => {
+    // Letting null through would overwrite the structure the merge exists to
+    // guarantee, reproducing the crash it prevents.
+    const merged = mergeConfig(
+      { general: { styles: {} }, layout: { sidebar: {} } },
+      { general: null, layout: { sidebar: null } } as never,
+    );
+
+    expect(merged.general).toEqual({ styles: {} });
+    expect(merged.layout.sidebar).toEqual({});
+  });
+
+  it('ignores prototype-bearing keys from a served document', () => {
+    // JSON.parse yields __proto__ as an own enumerable key, and assigning it
+    // would invoke the inherited setter and replace the section's prototype.
+    const served = JSON.parse('{"a": 1, "__proto__": {"polluted": true}}');
+    const merged = mergeConfig({ a: 0 }, served);
+
+    expect(merged.a).toBe(1);
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
 });

--- a/apps/self-hosted/src/core/merge-config.test.ts
+++ b/apps/self-hosted/src/core/merge-config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { mergeConfig } from './merge-config';
+
+describe('mergeConfig', () => {
+  it('keeps sections the served config does not mention', () => {
+    const base = {
+      configuration: {
+        general: { theme: 'light', styles: { background: 'bg-white' } },
+        instanceConfiguration: { layout: { sidebar: { placement: 'right' } } },
+      },
+    };
+    const served = { configuration: { general: { theme: 'dark' } } };
+
+    const merged = mergeConfig(base, served as typeof base);
+
+    expect(merged.configuration.general.theme).toBe('dark');
+    expect(merged.configuration.general.styles.background).toBe('bg-white');
+    expect(
+      merged.configuration.instanceConfiguration.layout.sidebar.placement,
+    ).toBe('right');
+  });
+
+  it('replaces arrays rather than combining them', () => {
+    const merged = mergeConfig(
+      { postsFilters: ['posts', 'blog'] },
+      {
+        postsFilters: ['trending'],
+      },
+    );
+
+    expect(merged.postsFilters).toEqual(['trending']);
+  });
+
+  it('lets the served config override a section with a scalar', () => {
+    expect(mergeConfig({ a: { b: 1 } }, { a: 2 } as never)).toEqual({ a: 2 });
+  });
+
+  it('returns the override when either side is not an object', () => {
+    expect(mergeConfig(null, { a: 1 } as never)).toEqual({ a: 1 });
+    expect(mergeConfig({ a: 1 } as never, null)).toBe(null);
+  });
+});

--- a/apps/self-hosted/src/core/merge-config.ts
+++ b/apps/self-hosted/src/core/merge-config.ts
@@ -3,16 +3,19 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Deep merge of the served config over the build-time defaults.
+ * Deep merge of the served config over a structural skeleton.
  *
- * The served config used to replace the build-time one wholesale, so a document
- * that omits a nested section (hand edited, or written against an older schema)
- * left those paths undefined. applyConfig dereferences several of them before
- * React renders, which turned a partial config into a permanently blank page.
+ * The served config used to replace the fallback wholesale, so a document that
+ * omits a nested section (hand edited, or written against an older schema) left
+ * those paths undefined. applyConfig dereferences several of them before React
+ * renders, which turned a partial config into a permanently blank page.
+ *
+ * The base is a shape with no values in it, so the merge can only ever restore
+ * structure. It must never be given a populated config: whatever the served
+ * document omitted would then silently become that tenant's content.
  *
  * Arrays and scalars from the served config win outright; only objects are
- * merged, so an array such as postsFilters is replaced rather than combined
- * with the default.
+ * merged, so an array such as postsFilters is replaced rather than combined.
  */
 export function mergeConfig<T>(base: T, override: T): T {
   if (!isPlainObject(base) || !isPlainObject(override)) {
@@ -21,6 +24,18 @@ export function mergeConfig<T>(base: T, override: T): T {
 
   const merged: Record<string, unknown> = { ...base };
   for (const [key, value] of Object.entries(override)) {
+    // JSON.parse produces __proto__ as an own enumerable key, and assigning it
+    // would invoke the inherited setter and replace this section's prototype.
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
+
+    // null means "not provided", not "erase the shape". Letting it through
+    // would overwrite the structure this merge exists to guarantee and
+    // reproduce the crash it prevents. The hosting API's own sanitiser takes
+    // the same position, for the same reason.
+    if (value === null) continue;
+
     merged[key] = isPlainObject(value)
       ? mergeConfig(merged[key], value)
       : value;

--- a/apps/self-hosted/src/core/merge-config.ts
+++ b/apps/self-hosted/src/core/merge-config.ts
@@ -1,0 +1,30 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Deep merge of the served config over the build-time defaults.
+ *
+ * The served config used to replace the build-time one wholesale, so a document
+ * that omits a nested section (hand edited, or written against an older schema)
+ * left those paths undefined. applyConfig dereferences several of them before
+ * React renders, which turned a partial config into a permanently blank page.
+ *
+ * Arrays and scalars from the served config win outright; only objects are
+ * merged, so an array such as postsFilters is replaced rather than combined
+ * with the default.
+ */
+export function mergeConfig<T>(base: T, override: T): T {
+  if (!isPlainObject(base) || !isPlainObject(override)) {
+    return override;
+  }
+
+  const merged: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    merged[key] = isPlainObject(value)
+      ? mergeConfig(merged[key], value)
+      : value;
+  }
+
+  return merged as T;
+}

--- a/apps/self-hosted/src/core/merge-config.ts
+++ b/apps/self-hosted/src/core/merge-config.ts
@@ -36,9 +36,23 @@ export function mergeConfig<T>(base: T, override: T): T {
     // the same position, for the same reason.
     if (value === null) continue;
 
-    merged[key] = isPlainObject(value)
-      ? mergeConfig(merged[key], value)
-      : value;
+    // Type agreement, matching mergeConfigGuarded in the hosting API: a value
+    // of the wrong shape cannot stand in for a section. Letting a scalar
+    // replace an object would restore the exact failure the skeleton exists to
+    // prevent, because applyConfig's try/catch only protects the boot path
+    // while components go on dereferencing configuration.general.* during
+    // render, which lands the whole blog in the root error boundary.
+    const current = merged[key];
+    if (isPlainObject(current) && !isPlainObject(value)) {
+      console.warn('[Config] Ignoring type-mismatched value for key:', key);
+      continue;
+    }
+    if (Array.isArray(current) && !Array.isArray(value)) {
+      console.warn('[Config] Ignoring type-mismatched value for key:', key);
+      continue;
+    }
+
+    merged[key] = isPlainObject(value) ? mergeConfig(current, value) : value;
   }
 
   return merged as T;

--- a/apps/self-hosted/src/features/blog/layout/blog-navigation.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-navigation.tsx
@@ -8,6 +8,7 @@ import { InstanceConfigManager, t } from '@/core';
 import { getRssFeedUrl } from '@/utils/rss-feed-url';
 import { UserMenu, CreatePostButton } from '@/features/auth';
 import { useInstanceConfig, useCommunityData } from '../hooks/use-instance-config';
+import { getConfiguredPostsFilters } from '../utils/post-filters';
 import { SearchInput } from '../components/search-input';
 
 export function BlogNavigation() {
@@ -15,10 +16,10 @@ export function BlogNavigation() {
   const { isCommunityMode } = useInstanceConfig();
   const { data: community } = useCommunityData();
 
-  const availableFilters = InstanceConfigManager.getConfigValue(
-    ({ configuration }) =>
-      configuration.instanceConfiguration.features.postsFilters || ['posts'],
-  );
+  // getConfiguredPostsFilters validates the shape. Reading the raw value here
+  // would re-open the crash it exists to prevent: a scalar is truthy, so
+  // availableFilters.map below would throw and take the whole layout with it.
+  const availableFilters = getConfiguredPostsFilters();
 
   const currentFilter = useMemo(() => {
     // Default to the first configured filter

--- a/apps/self-hosted/src/features/blog/utils/post-filters-path.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/post-filters-path.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  instanceConfiguration: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../../core', () => ({
+  InstanceConfigManager: {
+    getConfigValue: (selector: (config: unknown) => unknown) =>
+      selector({
+        configuration: { instanceConfiguration: state.instanceConfiguration },
+      }),
+  },
+}));
+
+const { getConfiguredPostsFilters } = await import('./post-filters');
+
+/**
+ * The helper validated the VALUE thoroughly but dereferenced the PATH, so a
+ * config with no features section threw inside the very guard that exists to
+ * stop a bad config from taking the layout down.
+ */
+describe('getConfiguredPostsFilters path handling', () => {
+  it('survives a missing features section', () => {
+    state.instanceConfiguration = {};
+
+    expect(() => getConfiguredPostsFilters()).not.toThrow();
+    expect(getConfiguredPostsFilters()).toEqual(['posts']);
+  });
+
+  it('survives a null features section', () => {
+    state.instanceConfiguration = { features: null };
+
+    expect(() => getConfiguredPostsFilters()).not.toThrow();
+    expect(getConfiguredPostsFilters()).toEqual(['posts']);
+  });
+
+  it('still reads a configured list', () => {
+    state.instanceConfiguration = {
+      features: { postsFilters: ['blog', 'posts'] },
+    };
+
+    expect(getConfiguredPostsFilters()).toEqual(['blog', 'posts']);
+  });
+});

--- a/apps/self-hosted/src/features/blog/utils/post-filters-path.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/post-filters-path.test.ts
@@ -4,6 +4,9 @@ const state = vi.hoisted(() => ({
   instanceConfiguration: {} as Record<string, unknown>,
 }));
 
+// The specifier is relative because that is what vitest's '@' -> './src' alias
+// resolves post-filters.ts's '@/core' import to; mocking '@/core' does not
+// intercept it and the real module is loaded instead.
 vi.mock('../../../core', () => ({
   InstanceConfigManager: {
     getConfigValue: (selector: (config: unknown) => unknown) =>
@@ -30,6 +33,15 @@ describe('getConfiguredPostsFilters path handling', () => {
 
   it('survives a null features section', () => {
     state.instanceConfiguration = { features: null };
+
+    expect(() => getConfiguredPostsFilters()).not.toThrow();
+    expect(getConfiguredPostsFilters()).toEqual(['posts']);
+  });
+
+  it('survives a missing instanceConfiguration section', () => {
+    // updateConfig bypasses mergeConfig, so a config without the section can
+    // reach this selector and throw before the fallback runs.
+    state.instanceConfiguration = undefined as never;
 
     expect(() => getConfiguredPostsFilters()).not.toThrow();
     expect(getConfiguredPostsFilters()).toEqual(['posts']);

--- a/apps/self-hosted/src/features/blog/utils/post-filters.ts
+++ b/apps/self-hosted/src/features/blog/utils/post-filters.ts
@@ -7,7 +7,7 @@ import { InstanceConfigManager } from '@/core';
 export function getConfiguredPostsFilters(): string[] {
   const filters = InstanceConfigManager.getConfigValue(
     ({ configuration }) =>
-      configuration.instanceConfiguration.features?.postsFilters,
+      configuration.instanceConfiguration?.features?.postsFilters,
   );
   // Self-hosted config.json is hand-edited: a scalar like "trending" would
   // otherwise pass a truthy length check and index to its first CHARACTER.

--- a/apps/self-hosted/src/features/blog/utils/post-filters.ts
+++ b/apps/self-hosted/src/features/blog/utils/post-filters.ts
@@ -7,7 +7,7 @@ import { InstanceConfigManager } from '@/core';
 export function getConfiguredPostsFilters(): string[] {
   const filters = InstanceConfigManager.getConfigValue(
     ({ configuration }) =>
-      configuration.instanceConfiguration.features.postsFilters,
+      configuration.instanceConfiguration.features?.postsFilters,
   );
   // Self-hosted config.json is hand-edited: a scalar like "trending" would
   // otherwise pass a truthy length check and index to its first CHARACTER.

--- a/apps/self-hosted/src/index.tsx
+++ b/apps/self-hosted/src/index.tsx
@@ -23,12 +23,19 @@ function applyConfig() {
   const imageProxyBase = general.imageProxy || 'https://i.ecency.com';
   setProxyBase(imageProxyBase);
 
-  // Apply background styles
-  const backgroundClasses = general.styles.background;
+  // Apply background styles. classList.add throws on a token containing
+  // whitespace or an empty string, and the value is owner-typed, so a stray tab
+  // pasted into the field would otherwise abort the whole boot.
+  const backgroundClasses = general.styles?.background;
   if (backgroundClasses) {
-    backgroundClasses.split(' ').forEach((className) => {
-      if (className) document.body.classList.add(className);
-    });
+    for (const className of backgroundClasses.split(/\s+/)) {
+      if (!className) continue;
+      try {
+        document.body.classList.add(className);
+      } catch {
+        console.warn('[Config] Ignoring invalid background class:', className);
+      }
+    }
   }
 
   // Apply theme
@@ -50,7 +57,7 @@ function applyConfig() {
   document.documentElement.setAttribute('data-style-template', styleTemplate);
 
   // Apply sidebar placement
-  const sidebarConfig = instanceConfiguration.layout.sidebar;
+  const sidebarConfig = instanceConfiguration.layout?.sidebar ?? {};
   const sidebarPlacement = sidebarConfig.placement ?? 'right';
   document.documentElement.setAttribute(
     'data-sidebar-placement',
@@ -58,7 +65,7 @@ function applyConfig() {
   );
 
   // Apply list type
-  const listType = instanceConfiguration.layout.listType ?? 'grid';
+  const listType = instanceConfiguration.layout?.listType ?? 'grid';
   document.documentElement.setAttribute('data-list-type', listType);
 
   // Apply instance type
@@ -92,7 +99,7 @@ function applyConfig() {
   }
 
   // Apply SEO meta tags
-  const meta = instanceConfiguration.meta;
+  const meta = instanceConfiguration.meta ?? {};
 
   if (meta.title) {
     document.title = meta.title;
@@ -174,7 +181,16 @@ function applyConfig() {
 async function main() {
   // Fetch runtime config before rendering
   await InstanceConfigManager.initialize();
-  applyConfig();
+
+  // applyConfig only decorates the document. A malformed config value must not
+  // stop the app from rendering: the floating menu that would let the owner fix
+  // the config is part of the app, so aborting here leaves a blank page with no
+  // way back in.
+  try {
+    applyConfig();
+  } catch (error) {
+    console.error('[Config] Failed to apply configuration:', error);
+  }
 
   const rootElement = document.getElementById('root')!;
   if (!rootElement.innerHTML) {


### PR DESCRIPTION
Closes #1299, closes #1300, closes #1301.

Three ways a value an owner can type in the config editor took the entire site down, rather than spoiling the one thing it configures. Grouped because they are the same failure class and sit in adjacent code.

## Boot (#1299)

`main()` applies the config to the document and only then renders React, with no `try`/`catch` anywhere in that path, and `applyConfig` dereferenced deep paths unguarded (`general.styles.background`, `instanceConfiguration.layout.sidebar`). A config missing a nested section, or a `styles.background` value containing a tab, threw before `root.render` and left `#root` empty: white page, no error boundary.

The floating menu that would let the owner fix the config is part of the app that no longer boots, so recovery required a raw API call.

- `applyConfig` is wrapped, so a bad value degrades to defaults instead of aborting the render
- the nested reads are optional
- background tokens are split on whitespace and added individually, skipping any the DOM rejects
- the served config is deep merged over the build-time one instead of replacing it, so a document written against an older schema keeps the default shape for whatever it omits

## Dates (#1300)

`timezone`, `dateFormat`, `timeFormat` and `dateTimeFormat` are free-text fields, and `formatDate` runs while rendering every post card. The existing guard validated the parsed date but not the zone or the pattern:

- `UTC+3` is not an IANA zone, so `toZonedTime` returns an Invalid Date and `format` then throws
- `hh:mm A` and other Moment-style patterns throw `RangeError: unescaped latin alphabet character`

Either one collapsed the whole blog to the root error boundary for every visitor. Formatting now falls back to the default pattern, then to ISO, and `formatMonthYear`/`formatCustom` gained the date guard they were missing.

## Feed tabs (#1301)

`post-filters.ts` validates that `postsFilters` is a non-empty array, and its comment says why: the self-hosted `config.json` is hand-edited, so a scalar would pass a truthy length check. `blog-navigation.tsx` bypassed it and read the raw value with only `|| [posts]`. A scalar string is truthy, so `.map` threw, and since the nav renders inside `BlogLayout` it took every feed, post and search page with it.

Now calls `getConfiguredPostsFilters()`.

## Verification

- 11 new tests. The date-formatter ones are genuine regression tests: 5 of 6 fail against the current code and pass with the fix.
- The merge logic moved to its own module so it could be tested as a pure function rather than through a private method.
- 74 tests pass, typecheck clean, biome at the pre-existing baseline for these paths, `rsbuild build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience when configuration is incomplete, malformed, or contains invalid values.
  - Preserved valid tenant settings while safely restoring required configuration structure.
  - Prevented invalid background styles and post filters from interrupting startup or navigation.
  - Added safer date and relative-date formatting with fallbacks for invalid time zones, formats, and dates.
  - Ensured the application can continue rendering when configuration errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->