### PR TITLE
fix(self-hosted): mount the tenant config volume in the payment listener

### DIFF
--- a/apps/self-hosted/hosting/api/src/db/advisory-lock.test.ts
+++ b/apps/self-hosted/hosting/api/src/db/advisory-lock.test.ts
@@ -87,6 +87,21 @@ describe('withAdvisoryLock client handling', () => {
     expect(c.release).toHaveBeenCalledWith(true);
   });
 
+  it('destroys the client when the advisory lock cannot be released', async () => {
+    // Advisory locks are session scoped: handing this connection back to the
+    // pool would keep the lock held for the life of the connection and block
+    // every later writer for that tenant.
+    const c = client('pg_advisory_unlock');
+    mocks.connect.mockResolvedValue(c);
+
+    await withAdvisoryLock(1, 2, async () => 'ok');
+    await flush();
+
+    expect(c.release).toHaveBeenCalledWith(true);
+    // The reset is pointless on a connection being destroyed.
+    expect(c.queries).not.toContain('RESET lock_timeout');
+  });
+
   it('releases the client even when the work throws', async () => {
     const c = client();
     mocks.connect.mockResolvedValue(c);

--- a/apps/self-hosted/hosting/api/src/db/advisory-lock.test.ts
+++ b/apps/self-hosted/hosting/api/src/db/advisory-lock.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ connect: vi.fn() }));
+
+vi.mock('pg', () => ({
+  default: { Pool: class { connect = mocks.connect; on() {} query() {} } },
+}));
+
+process.env.DATABASE_URL = 'postgres://test';
+const { withAdvisoryLock } = await import('./client');
+
+function client(failOn?: string) {
+  const release = vi.fn();
+  const queries: string[] = [];
+  return {
+    release,
+    queries,
+    query: vi.fn(async (sql: string) => {
+      queries.push(sql);
+      if (failOn && sql.includes(failOn)) throw new Error(`${failOn} failed`);
+      return { rows: [] };
+    }),
+  };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => mocks.connect.mockReset());
+afterEach(() => vi.restoreAllMocks());
+
+/**
+ * The lock holds a pooled connection for the duration of the work, so every
+ * exit path has to hand it back. A leak here is invisible until repeated
+ * failures exhaust the 20-client pool and unrelated queries start timing out.
+ */
+describe('withAdvisoryLock client handling', () => {
+  it('releases the client when the lock cannot be acquired', async () => {
+    const c = client('pg_advisory_lock');
+    mocks.connect.mockResolvedValue(c);
+
+    const result = await withAdvisoryLock(1, 2, async () => 'ran anyway');
+    await flush();
+
+    expect(result).toBe('ran anyway');
+    expect(c.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the client when setting the timeout fails', async () => {
+    const c = client('SET lock_timeout');
+    mocks.connect.mockResolvedValue(c);
+
+    await withAdvisoryLock(1, 2, async () => 'ok');
+    await flush();
+
+    expect(c.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not try to release when the connection itself failed', async () => {
+    mocks.connect.mockRejectedValue(new Error('pool exhausted'));
+
+    await expect(withAdvisoryLock(1, 2, async () => 'ok')).resolves.toBe('ok');
+  });
+
+  it('resets the session timeout before handing the client back', async () => {
+    const c = client();
+    mocks.connect.mockResolvedValue(c);
+
+    await withAdvisoryLock(1, 2, async () => 'ok');
+    await flush();
+
+    // SET without LOCAL outlives the checkout, and pooled clients are reused.
+    expect(c.queries).toContain('RESET lock_timeout');
+    expect(c.queries.indexOf('RESET lock_timeout')).toBeGreaterThan(
+      c.queries.findIndex((q) => q.includes('pg_advisory_unlock')),
+    );
+    expect(c.release).toHaveBeenCalledWith();
+  });
+
+  it('discards the connection when the reset fails', async () => {
+    const c = client('RESET lock_timeout');
+    mocks.connect.mockResolvedValue(c);
+
+    await withAdvisoryLock(1, 2, async () => 'ok');
+    await flush();
+
+    // A session whose state cannot be established must not be reused.
+    expect(c.release).toHaveBeenCalledWith(true);
+  });
+
+  it('releases the client even when the work throws', async () => {
+    const c = client();
+    mocks.connect.mockResolvedValue(c);
+
+    await expect(
+      withAdvisoryLock(1, 2, async () => {
+        throw new Error('work failed');
+      }),
+    ).rejects.toThrow('work failed');
+    await flush();
+
+    expect(c.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/db/client.ts
+++ b/apps/self-hosted/hosting/api/src/db/client.ts
@@ -58,4 +58,55 @@ export const db = {
   },
 };
 
+/**
+ * Serialize an operation across PROCESSES on a Postgres advisory lock.
+ *
+ * The hosting API and the payment listener are separate containers, so the
+ * per-tenant promise chain in config-service, which is a process-local Map,
+ * cannot order their writes against each other. An advisory lock is held on one
+ * session, so the work runs on a dedicated pooled client for its duration.
+ *
+ * Degrades rather than blocks: if the lock cannot be taken the operation still
+ * runs, ordered only within this process. That is the behaviour before this
+ * existed, so a database problem cannot make config publication worse than it
+ * already was, and the served file self-heals on the next periodic sync.
+ */
+const ADVISORY_LOCK_TIMEOUT_MS = 5000;
+
+export async function withAdvisoryLock<T>(
+  namespace: number,
+  key: number,
+  fn: () => Promise<T>
+): Promise<T> {
+  // No database configured (unit tests): nothing to coordinate with.
+  if (!process.env.DATABASE_URL) return fn();
+
+  let client: pg.PoolClient;
+  try {
+    client = await pool.connect();
+    // Advisory waits honour lock_timeout, so a stuck holder cannot wedge the
+    // periodic sync; the timeout surfaces as an error and we degrade below.
+    await client.query(`SET lock_timeout = ${ADVISORY_LOCK_TIMEOUT_MS}`);
+    await client.query('SELECT pg_advisory_lock($1, $2)', [namespace, key]);
+  } catch (error) {
+    console.warn(
+      '[Db] Advisory lock unavailable, continuing without cross-process ordering:',
+      (error as Error).message
+    );
+    return fn();
+  }
+
+  try {
+    return await fn();
+  } finally {
+    try {
+      await client.query('SELECT pg_advisory_unlock($1, $2)', [namespace, key]);
+    } catch (error) {
+      // The lock is session scoped, so releasing the client drops it anyway.
+      console.error('[Db] Failed to release advisory lock:', (error as Error).message);
+    }
+    client.release();
+  }
+}
+
 export default db;

--- a/apps/self-hosted/hosting/api/src/db/client.ts
+++ b/apps/self-hosted/hosting/api/src/db/client.ts
@@ -103,13 +103,15 @@ export async function withAdvisoryLock<T>(
   try {
     return await fn();
   } finally {
+    let stillLocked = false;
     try {
       await client.query('SELECT pg_advisory_unlock($1, $2)', [namespace, key]);
     } catch (error) {
-      // The lock is session scoped, so destroying the client below drops it.
+      // The unlock did not run, so this session may still hold the lock.
+      stillLocked = true;
       console.error('[Db] Failed to release advisory lock:', (error as Error).message);
     }
-    releaseLockClient(client);
+    releaseLockClient(client, stillLocked);
   }
 }
 
@@ -121,7 +123,17 @@ export async function withAdvisoryLock<T>(
  * queries. If the reset itself fails the connection is destroyed instead, since
  * a session whose state cannot be established must not be reused.
  */
-function releaseLockClient(client: pg.PoolClient): void {
+function releaseLockClient(client: pg.PoolClient, stillLocked = false): void {
+  if (stillLocked) {
+    // Advisory locks live for the session, so returning this connection to the
+    // pool would keep the lock held for the life of the connection and block
+    // every later writer for that tenant. Destroy it instead: ending the
+    // backend session is what actually drops the lock.
+    console.error('[Db] Discarding lock client that may still hold its advisory lock');
+    client.release(true);
+    return;
+  }
+
   client
     .query('RESET lock_timeout')
     .then(() => client.release())

--- a/apps/self-hosted/hosting/api/src/db/client.ts
+++ b/apps/self-hosted/hosting/api/src/db/client.ts
@@ -81,7 +81,7 @@ export async function withAdvisoryLock<T>(
   // No database configured (unit tests): nothing to coordinate with.
   if (!process.env.DATABASE_URL) return fn();
 
-  let client: pg.PoolClient;
+  let client: pg.PoolClient | undefined;
   try {
     client = await pool.connect();
     // Advisory waits honour lock_timeout, so a stuck holder cannot wedge the
@@ -89,6 +89,10 @@ export async function withAdvisoryLock<T>(
     await client.query(`SET lock_timeout = ${ADVISORY_LOCK_TIMEOUT_MS}`);
     await client.query('SELECT pg_advisory_lock($1, $2)', [namespace, key]);
   } catch (error) {
+    // The connection may already be checked out: a lock timeout throws AFTER
+    // connect succeeded. Returning without releasing would leak one client per
+    // failure and exhaust the pool under repeated timeouts.
+    if (client) releaseLockClient(client);
     console.warn(
       '[Db] Advisory lock unavailable, continuing without cross-process ordering:',
       (error as Error).message
@@ -102,11 +106,29 @@ export async function withAdvisoryLock<T>(
     try {
       await client.query('SELECT pg_advisory_unlock($1, $2)', [namespace, key]);
     } catch (error) {
-      // The lock is session scoped, so releasing the client drops it anyway.
+      // The lock is session scoped, so destroying the client below drops it.
       console.error('[Db] Failed to release advisory lock:', (error as Error).message);
     }
-    client.release();
+    releaseLockClient(client);
   }
+}
+
+/**
+ * Return a lock client to the pool with the session state it was given wiped.
+ *
+ * SET without LOCAL lives for the whole session, and pooled connections are
+ * reused, so a client handed back as-is would carry lock_timeout to unrelated
+ * queries. If the reset itself fails the connection is destroyed instead, since
+ * a session whose state cannot be established must not be reused.
+ */
+function releaseLockClient(client: pg.PoolClient): void {
+  client
+    .query('RESET lock_timeout')
+    .then(() => client.release())
+    .catch((error) => {
+      console.error('[Db] Failed to reset lock client, discarding it:', (error as Error).message);
+      client.release(true);
+    });
 }
 
 export default db;

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -400,7 +400,16 @@ export class PaymentListener {
       // (which regenerates every active tenant), so log and move on.
       if (updatedTenant) {
         try {
-          await ConfigService.generateConfigFile(updatedTenant);
+          // Re-read rather than publishing the snapshot this transaction returned.
+          // The API and this listener are separate processes, so the per-tenant
+          // write lock in config-service cannot serialize them: an owner who
+          // edits their config while the payment is being processed would
+          // otherwise have that edit overwritten by a tenant row read before it
+          // was saved. Reading at write time keeps the published file from
+          // rolling back to a version older than what is committed.
+          const current =
+            (await TenantService.getByUsername(username)) ?? updatedTenant;
+          await ConfigService.generateConfigFile(current);
         } catch (err) {
           console.error(
             `[PaymentListener] Config generation failed post-commit for ${username} (periodic sync will retry):`,

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -400,16 +400,12 @@ export class PaymentListener {
       // (which regenerates every active tenant), so log and move on.
       if (updatedTenant) {
         try {
-          // Re-read rather than publishing the snapshot this transaction returned.
-          // The API and this listener are separate processes, so the per-tenant
-          // write lock in config-service cannot serialize them: an owner who
-          // edits their config while the payment is being processed would
-          // otherwise have that edit overwritten by a tenant row read before it
-          // was saved. Reading at write time keeps the published file from
-          // rolling back to a version older than what is committed.
-          const current =
-            (await TenantService.getByUsername(username)) ?? updatedTenant;
-          await ConfigService.generateConfigFile(current);
+          // Publishes from the row as it stands inside the write lock, which is
+          // now a cross-process advisory lock. Passing the snapshot this
+          // transaction returned, or even re-reading just before the call,
+          // leaves a window where the API can commit and publish an owner's
+          // newer config and have this write roll it back.
+          await ConfigService.publishConfigFile(username);
         } catch (err) {
           console.error(
             `[PaymentListener] Config generation failed post-commit for ${username} (periodic sync will retry):`,

--- a/apps/self-hosted/hosting/api/src/services/config-publish-lock.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-publish-lock.test.ts
@@ -1,0 +1,105 @@
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+process.env.CONFIG_DIR = mkdtempSync(path.join(tmpdir(), 'hosting-lock-'));
+
+const mocks = vi.hoisted(() => ({
+  getByUsername: vi.fn(),
+  withAdvisoryLock: vi.fn(),
+}));
+
+vi.mock('../db/client', () => ({
+  db: {},
+  withAdvisoryLock: mocks.withAdvisoryLock,
+}));
+
+vi.mock('./tenant-service', () => ({
+  TenantService: { getByUsername: mocks.getByUsername },
+}));
+
+const { ConfigService } = await import('./config-service');
+
+const tenant = (title: string, status = 'active') =>
+  ({
+    username: 'alice',
+    subscriptionStatus: status,
+    config: {
+      version: 1,
+      configuration: {
+        general: {},
+        instanceConfiguration: { username: 'alice', meta: { title } },
+      },
+    },
+  }) as never;
+
+beforeEach(() => {
+  mocks.getByUsername.mockReset();
+  // Pass-through by default so the ordering assertions below are about the
+  // callback, not about the lock implementation.
+  mocks.withAdvisoryLock.mockReset().mockImplementation(
+    async (_ns: number, _key: number, fn: () => Promise<unknown>) => fn(),
+  );
+});
+
+/**
+ * The listener and the API are separate containers, so the per-tenant promise
+ * chain cannot order their writes. Publication therefore has to take a lock
+ * that spans processes AND read the tenant inside it: reading before the lock
+ * leaves a window where the other process commits a newer config that this
+ * write then rolls back.
+ */
+describe('publishConfigFile', () => {
+  it('reads the tenant inside the lock, not before it', async () => {
+    const order: string[] = [];
+    mocks.withAdvisoryLock.mockImplementation(
+      async (_ns: number, _key: number, fn: () => Promise<unknown>) => {
+        order.push('lock-acquired');
+        const result = await fn();
+        order.push('lock-released');
+        return result;
+      },
+    );
+    mocks.getByUsername.mockImplementation(async () => {
+      order.push('tenant-read');
+      return tenant('Fresh');
+    });
+
+    await ConfigService.publishConfigFile('alice');
+
+    expect(order).toEqual(['lock-acquired', 'tenant-read', 'lock-released']);
+  });
+
+  it('takes the same lock coordinates for the same tenant regardless of case', async () => {
+    mocks.getByUsername.mockResolvedValue(tenant('T'));
+
+    await ConfigService.publishConfigFile('alice');
+    await ConfigService.publishConfigFile('ALICE');
+
+    const [firstNs, firstKey] = mocks.withAdvisoryLock.mock.calls[0];
+    const [secondNs, secondKey] = mocks.withAdvisoryLock.mock.calls[1];
+    expect(secondNs).toBe(firstNs);
+    expect(secondKey).toBe(firstKey);
+    expect(Number.isInteger(firstKey)).toBe(true);
+  });
+
+  it('uses different lock coordinates for different tenants', async () => {
+    mocks.getByUsername.mockResolvedValue(tenant('T'));
+
+    await ConfigService.publishConfigFile('alice');
+    await ConfigService.publishConfigFile('bob');
+
+    expect(mocks.withAdvisoryLock.mock.calls[0][1]).not.toBe(
+      mocks.withAdvisoryLock.mock.calls[1][1],
+    );
+  });
+
+  it('publishes nothing when the tenant is gone or not serving', async () => {
+    mocks.getByUsername.mockResolvedValue(null);
+    await expect(ConfigService.publishConfigFile('alice')).resolves.toBeUndefined();
+
+    mocks.getByUsername.mockResolvedValue(tenant('T', 'inactive'));
+    await expect(ConfigService.publishConfigFile('alice')).resolves.toBeUndefined();
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/config-publish-lock.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-publish-lock.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'fs';
+import { existsSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -96,10 +96,40 @@ describe('publishConfigFile', () => {
   });
 
   it('publishes nothing when the tenant is gone or not serving', async () => {
-    mocks.getByUsername.mockResolvedValue(null);
-    await expect(ConfigService.publishConfigFile('alice')).resolves.toBeUndefined();
+    // Asserting the resolved value proves nothing: publishConfigFile returns
+    // Promise<void>, so it resolves to undefined on the writing path too. The
+    // absence of the served file is the thing that matters, because nginx
+    // serves any file that exists with no subscription check.
+    // A name no other test in this file publishes, so a file here can only
+    // have come from this call.
+    const served = path.join(process.env.CONFIG_DIR as string, 'carol.json');
+    const meta = path.join(process.env.CONFIG_DIR as string, 'carol.meta.html');
 
-    mocks.getByUsername.mockResolvedValue(tenant('T', 'inactive'));
-    await expect(ConfigService.publishConfigFile('alice')).resolves.toBeUndefined();
+    mocks.getByUsername.mockResolvedValue(null);
+    await ConfigService.publishConfigFile('carol');
+    expect(existsSync(served)).toBe(false);
+    expect(existsSync(meta)).toBe(false);
+
+    mocks.getByUsername.mockResolvedValue({
+      ...(tenant('T', 'inactive') as unknown as Record<string, unknown>),
+      username: 'carol',
+    } as never);
+    await ConfigService.publishConfigFile('carol');
+    expect(existsSync(served)).toBe(false);
+    expect(existsSync(meta)).toBe(false);
+  });
+
+  it('does write the served file for an active tenant', async () => {
+    // The counterpart, so the assertion above cannot pass simply because
+    // nothing in this suite ever writes.
+    const served = path.join(process.env.CONFIG_DIR as string, 'bob.json');
+    mocks.getByUsername.mockResolvedValue({
+      ...(tenant('Live') as unknown as Record<string, unknown>),
+      username: 'bob',
+    } as never);
+
+    await ConfigService.publishConfigFile('bob');
+
+    expect(existsSync(served)).toBe(true);
   });
 });

--- a/apps/self-hosted/hosting/api/src/services/config-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-service.ts
@@ -6,6 +6,7 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
+import { withAdvisoryLock } from '../db/client';
 import { TenantService, type Tenant } from './tenant-service';
 
 const CONFIG_DIR = process.env.CONFIG_DIR || '/app/configs';
@@ -29,10 +30,30 @@ const writeChains = new Map<string, Promise<void>>();
  * Serialize an async operation per tenant. The next operation runs regardless of whether
  * the previous one failed; the caller still sees its own operation's result or error.
  */
+// Advisory lock coordinates: a fixed namespace plus a stable hash of the tenant,
+// so both containers derive the same lock for the same tenant without depending
+// on a Postgres internal like hashtext().
+const CONFIG_LOCK_NAMESPACE = 0x6563;
+
+function tenantLockKey(username: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < username.length; i++) {
+    hash ^= username.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash | 0;
+}
+
 export function withTenantWriteLock<T>(username: string, fn: () => Promise<T>): Promise<T> {
   const key = username.toLowerCase();
+  // The in-process chain orders this process's own writes; the advisory lock
+  // orders them against the other container. Both are needed: the chain alone
+  // cannot see across processes, and taking only the advisory lock would let
+  // two writes from THIS process interleave while one waits on the database.
+  const guarded = () =>
+    withAdvisoryLock(CONFIG_LOCK_NAMESPACE, tenantLockKey(key), fn);
   const prev = writeChains.get(key) ?? Promise.resolve();
-  const run = prev.then(fn, fn);
+  const run = prev.then(guarded, guarded);
   writeChains.set(
     key,
     run.then(
@@ -218,6 +239,22 @@ export const ConfigService = {
   /**
    * Sync all tenant configs to disk
    */
+  /**
+   * Publish a tenant's served config from the row as it stands INSIDE the lock.
+   *
+   * Callers that hold a tenant object read it before doing other work, so
+   * publishing that snapshot can overwrite a newer config another process
+   * committed in between. Re-reading under the lock removes the window instead
+   * of narrowing it.
+   */
+  async publishConfigFile(username: string): Promise<void> {
+    return withTenantWriteLock(username, async () => {
+      const fresh = await TenantService.getByUsername(username);
+      if (!fresh || fresh.subscriptionStatus !== 'active') return;
+      await this.writeConfigFile(fresh);
+    });
+  },
+
   async syncAllConfigs(activeTenants: Tenant[]): Promise<void> {
     console.log('[ConfigService] Syncing', activeTenants.length, 'active configs to disk...');
 

--- a/apps/self-hosted/hosting/docker-compose.yml
+++ b/apps/self-hosted/hosting/docker-compose.yml
@@ -79,6 +79,12 @@ services:
       - PAYMENT_ACCOUNT=${PAYMENT_ACCOUNT:-ecency.hosting}
       - MONTHLY_PRICE_HBD=${MONTHLY_PRICE_HBD:-2.000}
       - PRO_UPGRADE_PRICE_HBD=${PRO_UPGRADE_PRICE_HBD:-5.000}
+    volumes:
+      # Activating a subscription writes the tenant's served config. Without
+      # this mount that write lands in the container's own layer and never
+      # reaches the volume nginx serves, so a paying customer gets default.json
+      # until the API's periodic sync repairs it.
+      - "tenant-configs:/app/configs"
     networks:
       - ecency-hosting
     depends_on:


### PR DESCRIPTION
Closes #1303.

`hosting-api` mounts the shared volume:

```yaml
volumes:
  - "tenant-configs:/app/configs"
```

`payment-listener`, which reuses the same image with a different entrypoint, declared no `volumes:` at all. Activating an HBD subscription calls `ConfigService.generateConfigFile`, and `CONFIG_DIR` is baked to `/app/configs` in the image, so that write landed in the listener container’s own writable layer and never reached the volume nginx serves. The write succeeds, so nothing is logged and the post-commit catch never fires.

nginx `try_files` then falls through to `default.json`, whose `instanceConfiguration.username` is `ecency`. A customer who has just paid sees the generic demo blog, and its unfurl metadata, until the API’s periodic config sync regenerates the file. This is deterministic for every new HBD signup, which is the rail the shipped signup UI uses.

## Notes

- One line plus a comment. `CONFIG_DIR` is already correct in the image, and `config-service.ts` reads no other environment, so the mount is the only thing missing. `BASE_DOMAIN` is deliberately not added: it is only read by `tenant-service.getBlogUrl`, which nothing in the listener path calls.
- The alternative would be to have the listener publish activation over Redis and let the API own every config write, so only one container ever touches the volume. That is the better long-term shape, but it is a behavioural change rather than a fix, so it is not in this PR.

## Verification

Compose file parses and both services now resolve `tenant-configs` against the same top-level volume. No application code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved tenant configuration publishing during subscription activation.
  * Prevented outdated or inactive tenant configurations from being published.
  * Coordinated configuration updates across multiple application processes to avoid conflicts.
  * Ensured generated configuration files are written to the shared location used by the hosting service.
* **Bug Fixes**
  * Improved cleanup and recovery when configuration updates or database operations fail.
* **Tests**
  * Added coverage for concurrent updates, tenant matching, failures, and configuration publication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->