### PR TITLE
fix(self-hosted): key dark: utilities off the instance theme, not the OS

### DIFF
--- a/apps/self-hosted/src/globals.css
+++ b/apps/self-hosted/src/globals.css
@@ -4,6 +4,17 @@
 @source "../config.json";
 /* biome-ignore lint/suspicious/noUnknownAtRules: @source is a Tailwind v4 feature */
 @source "../../../packages/ui/src/**/*.tsx";
+/*
+ * The instance theme is applied as data-theme on <html> from the tenant config,
+ * and every --theme-* token keys off it. Tailwind v4 otherwise compiles `dark:`
+ * to @media (prefers-color-scheme: dark), which made every surface built from
+ * dark: utilities follow the VISITOR'S operating system instead of the theme the
+ * owner configured: a dark blog showed a white editor card on a light-mode
+ * laptop, and a light blog showed gray-800 surfaces on a dark-mode one.
+ */
+/* biome-ignore lint/suspicious/noUnknownAtRules: @custom-variant is a Tailwind v4 feature */
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
 /* biome-ignore lint/correctness/noInvalidPositionAtImportRule: Tailwind v4 requires @source before these imports */
 @import "./styles/themes/index.css";
 /* biome-ignore lint/correctness/noInvalidPositionAtImportRule: Tailwind v4 requires @source before these imports */


### PR DESCRIPTION
Closes #1302.

The instance theme is applied as `data-theme` on `<html>` from the tenant config, and every `--theme-*` token keys off it. Tailwind v4 compiles the default `dark:` variant to `@media (prefers-color-scheme: dark)` unless a custom variant is declared, and none was. So the 69 `dark:` utilities across the publish editor, toolbars, edit editor, comment form, tags selector, login, tipping and payment dialog followed the **visitor’s operating system** instead of the theme the owner configured.

Any visitor whose OS preference differed from the configured theme saw a mix: a dark-configured blog showed a white editor card and light toolbars inside a dark page, and a light-configured blog showed gray-800 surfaces on a light page. Themed and `dark:`-styled elements disagreed on the same screen.

## The change

One declaration in `globals.css`:

```css
@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
```

`theme: "system"` is unaffected: `applyConfig` already resolves it to a concrete `data-theme` value from `matchMedia` at boot, so those instances still follow the OS, through the attribute.

## Verification

Compared the compiled stylesheet before and after, since this is not something tests can see:

- **before**: `dark:bg-gray-800` sits inside an `@media (prefers-color-scheme: dark)` block
- **after**: it compiles to `.dark\:bg-gray-800:where([data-theme=dark],[data-theme=dark] *)`, and all 58 `dark:` rules key off the attribute

The one remaining `prefers-color-scheme` block in the output is a pre-existing rule in `blog-markdown.css`, untouched.

Tests (64) pass and the app builds. Worth a visual pass on a dark-configured instance from a light-mode machine before merge, since the whole point is pixels.