### PR TITLE
fix(self-hosted): tighten tenant creation and config publication

### DIFF
--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -7,7 +7,7 @@
 
 import { callRPC, setNodes } from '@ecency/sdk/hive';
 import { db } from './db/client';
-import { TenantService } from './services/tenant-service';
+import { COMMUNITY_NAME, TenantService } from './services/tenant-service';
 import { ConfigService } from './services/config-service';
 import { parseMemo, mapTenantFromDb, type ParsedMemo } from './types';
 import { AuditService } from './services/audit-service';
@@ -339,6 +339,20 @@ export class PaymentListener {
         // row — including one the sweep marked 'abandoned' — skips this block and is revived in
         // place by the activation in step 4, preserving its stored owner + config.
         if (!row) {
+          // A community instance may only exist if it was reserved through
+          // POST /v1/tenants, which verifies the claimed owner administers the
+          // community on chain. Auto-creating one here would set owner =
+          // username, i.e. the community account itself, and permanently occupy
+          // the subdomain: the create upsert only revives an abandoned row or a
+          // same-owner inactive one, so the real team could never take it back.
+          // A community account IS a real Hive account, so the existence check
+          // below does not stop this on its own.
+          if (COMMUNITY_NAME.test(username)) {
+            throw Object.assign(
+              new Error('Community instances must be reserved before payment'),
+              { permanent: true }
+            );
+          }
           if (!(await TenantService.accountExistsStrict(username))) {
             throw Object.assign(new Error('Hive account not found'), { permanent: true });
           }

--- a/apps/self-hosted/hosting/api/src/routes/tenant-validation.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenant-validation.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  accounts: new Set<string>(),
+  controlled: new Map<string, string[]>(),
+}));
+
+vi.mock('../services/tenant-service', () => ({
+  TenantService: {
+    verifyHiveAccount: async (name: string) => state.accounts.has(name),
+    verifyCommunityControlledBy: async (community: string, account: string) =>
+      (state.controlled.get(community) ?? []).includes(account),
+  },
+}));
+
+const { resolveAndValidateTenant } = await import('./tenants');
+
+function seed() {
+  state.accounts = new Set(['alice', 'attacker', 'hive-125125']);
+  state.controlled = new Map([['hive-125125', ['alice']]]);
+}
+
+/**
+ * Whether a request is a community claim has to be decided from the subdomain,
+ * not from the caller-supplied config.type. A community account is a real Hive
+ * account, so omitting the type used to route the request through the personal
+ * blog branch, which only requires owner === username, and let anyone capture a
+ * community's subdomain with no ownership check.
+ */
+describe('resolveAndValidateTenant', () => {
+  it('rejects a community name claimed without declaring a type', async () => {
+    seed();
+
+    const result = await resolveAndValidateTenant({ username: 'hive-125125' });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a community name claimed as a personal blog', async () => {
+    seed();
+
+    const result = await resolveAndValidateTenant({
+      username: 'hive-125125',
+      config: { type: 'blog' },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a community claim by an account that does not administer it', async () => {
+    seed();
+
+    const result = await resolveAndValidateTenant({
+      username: 'hive-125125',
+      owner: 'attacker',
+      config: { type: 'community', communityId: 'hive-125125' },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts a community claim by an administrator', async () => {
+    seed();
+
+    const result = await resolveAndValidateTenant({
+      username: 'hive-125125',
+      owner: 'alice',
+      config: { type: 'community', communityId: 'hive-125125' },
+    });
+
+    expect(result).toEqual({ ok: true, owner: 'alice' });
+  });
+
+  it('accepts a community claim that omits the redundant communityId', async () => {
+    seed();
+
+    const result = await resolveAndValidateTenant({
+      username: 'hive-125125',
+      owner: 'alice',
+      config: { type: 'community' },
+    });
+
+    expect(result).toEqual({ ok: true, owner: 'alice' });
+  });
+
+  it('rejects a community id that does not match the subdomain', async () => {
+    seed();
+    state.accounts.add('hive-999999');
+
+    const result = await resolveAndValidateTenant({
+      username: 'hive-999999',
+      owner: 'alice',
+      config: { type: 'community', communityId: 'hive-125125' },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('still accepts an ordinary personal blog', async () => {
+    seed();
+
+    expect(await resolveAndValidateTenant({ username: 'alice' })).toEqual({
+      ok: true,
+      owner: 'alice',
+    });
+  });
+
+  it('still rejects a personal blog assigned to a different owner', async () => {
+    seed();
+
+    const result = await resolveAndValidateTenant({
+      username: 'alice',
+      owner: 'attacker',
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/routes/tenant-validation.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenant-validation.test.ts
@@ -6,6 +6,9 @@ const state = vi.hoisted(() => ({
 }));
 
 vi.mock('../services/tenant-service', () => ({
+  // Shared with the payment listener so both recognise a community claim the
+  // same way; the real pattern is used here rather than a stub of it.
+  COMMUNITY_NAME: /^hive-\d+$/,
   TenantService: {
     verifyHiveAccount: async (name: string) => state.accounts.has(name),
     verifyCommunityControlledBy: async (community: string, account: string) =>

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -8,6 +8,7 @@ import { zValidator } from '@hono/zod-validator';
 import { db } from '../db/client';
 import {
   TenantService,
+  COMMUNITY_NAME,
   isReregisterableAbandoned,
   ABANDONED_REREGISTER_QUARANTINE_HOURS,
 } from '../services/tenant-service';
@@ -130,9 +131,6 @@ tenantRoutes.get('/:username/config', async (c) => {
 // username) so a direct API call cannot assign someone else as controller of a blog; and that a
 // COMMUNITY has a real, separate owner account plus a valid, existing community id equal to the
 // subdomain. Returns the resolved owner or a client error.
-/** Hive names a community account hive-NNNN; the subdomain must match it. */
-const COMMUNITY_NAME = /^hive-\d+$/;
-
 export async function resolveAndValidateTenant(
   body: any
 ): Promise<{ ok: true; owner: string } | { ok: false; status: 400; error: string }> {

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -157,8 +157,12 @@ async function resolveAndValidateTenant(
     if (!body.owner || owner === communityId) {
       return { ok: false, status: 400, error: 'A community instance requires a separate owner account' };
     }
-    if (!(await TenantService.verifyCommunity(communityId))) {
-      return { ok: false, status: 400, error: 'Community not found' };
+    if (!(await TenantService.verifyCommunityControlledBy(communityId, owner))) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'Community not found, or the owner account does not administer it',
+      };
     }
   } else if (owner !== username) {
     // A personal blog is always controlled by its own account; reject an attempt to assign a

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -130,12 +130,21 @@ tenantRoutes.get('/:username/config', async (c) => {
 // username) so a direct API call cannot assign someone else as controller of a blog; and that a
 // COMMUNITY has a real, separate owner account plus a valid, existing community id equal to the
 // subdomain. Returns the resolved owner or a client error.
-async function resolveAndValidateTenant(
+/** Hive names a community account hive-NNNN; the subdomain must match it. */
+const COMMUNITY_NAME = /^hive-\d+$/;
+
+export async function resolveAndValidateTenant(
   body: any
 ): Promise<{ ok: true; owner: string } | { ok: false; status: 400; error: string }> {
   const username = body.username.toLowerCase();
   const owner = (body.owner || body.username).toLowerCase();
-  const isCommunity = body.config?.type === 'community';
+  // Derived from the subdomain being claimed, never from the caller-supplied
+  // type. Trusting body.config.type let a caller omit it, take the personal
+  // blog branch (which only requires owner === username) and capture a
+  // community's subdomain with no ownership check at all. A community account
+  // is a real Hive account, so the account existence check does not stop it.
+  const isCommunity =
+    COMMUNITY_NAME.test(username) || body.config?.type === 'community';
 
   if (!(await TenantService.verifyHiveAccount(username))) {
     return { ok: false, status: 400, error: 'Hive account not found' };
@@ -145,8 +154,8 @@ async function resolveAndValidateTenant(
   }
 
   if (isCommunity) {
-    const communityId = (body.config.communityId || '').toLowerCase();
-    if (!/^hive-\d+$/.test(communityId)) {
+    const communityId = (body.config?.communityId || username).toLowerCase();
+    if (!COMMUNITY_NAME.test(communityId)) {
       return { ok: false, status: 400, error: 'Community id must look like hive-NNNN' };
     }
     if (username !== communityId) {

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -13,7 +13,7 @@ import {
 } from '../services/tenant-service';
 import { mapTenantFromDb } from '../types';
 import { PAYMENT_ACCOUNT, MONTHLY_PRICE_HBD, PRO_UPGRADE_PRICE_HBD, hbd } from '../pricing';
-import { ConfigService } from '../services/config-service';
+import { ConfigService, isPublishableTenant } from '../services/config-service';
 import { authMiddleware } from '../middleware/auth';
 import { subscriptionPaywall, proUpgradePaywall } from '../middleware/x402-paywall';
 import { withPaymentTargetLock } from '../middleware/payment-target-lock';
@@ -567,8 +567,15 @@ tenantRoutes.patch('/:username', authMiddleware, zValidator('json', updateTenant
     ? await TenantService.applyConfigDocument(username, body.config)
     : await TenantService.updateConfig(username, body.config);
   
-  // Regenerate config file
-  await ConfigService.generateConfigFile(updatedTenant);
+  // Publish only for a tenant that is entitled to be served. POST deliberately
+  // does not write the file for the same reason: nginx serves any file that
+  // exists with no subscription check, so publishing here would put a blog that
+  // has never been paid for live until the next sweep removes it. The config
+  // itself is always persisted, so the edit is not lost.
+  const published = isPublishableTenant(updatedTenant);
+  if (published) {
+    await ConfigService.generateConfigFile(updatedTenant);
+  }
   
   void AuditService.log({
     tenantId: updatedTenant.id,
@@ -581,7 +588,12 @@ tenantRoutes.patch('/:username', authMiddleware, zValidator('json', updateTenant
   return c.json({
     username: updatedTenant.username,
     config: updatedTenant.config,
-    message: 'Configuration updated',
+    // Tells the editor whether the change is live or only stored, so a saved
+    // edit that the visitor cannot see yet is explainable.
+    published,
+    message: published
+      ? 'Configuration updated'
+      : 'Configuration saved. It goes live once the subscription is active.',
   });
 });
 

--- a/apps/self-hosted/hosting/api/src/services/community-name.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/community-name.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { COMMUNITY_NAME } from './tenant-service';
+
+/**
+ * Every path that can bring a tenant into existence has to recognise a
+ * community claim identically. The public route derives it from the subdomain;
+ * the payment listener refuses to auto-create one, because doing so would set
+ * owner = the community account and permanently occupy the subdomain with no
+ * ownership check and no way for the real team to reclaim it.
+ */
+describe('COMMUNITY_NAME', () => {
+  it('matches the community account shape', () => {
+    for (const name of ['hive-1', 'hive-125125', 'hive-140217']) {
+      expect(COMMUNITY_NAME.test(name)).toBe(true);
+    }
+  });
+
+  it('does not match ordinary accounts or near misses', () => {
+    for (const name of ['alice', 'hive', 'hive-', 'hive-abc', 'hive-12a', 'xhive-1', 'hive-1x']) {
+      expect(COMMUNITY_NAME.test(name), name).toBe(false);
+    }
+  });
+
+  it('is anchored so it cannot match a substring', () => {
+    expect(COMMUNITY_NAME.test('not-hive-125125')).toBe(false);
+    expect(COMMUNITY_NAME.test('hive-125125-blog')).toBe(false);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/config-publication.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-publication.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { isPublishableTenant } from './config-service';
+
+/**
+ * nginx serves any file that exists in the config directory with no
+ * subscription check, so publishing for a tenant that has never paid puts a
+ * free blog live until the next sweep removes it. POST /v1/tenants already
+ * avoids writing the file for that reason; every other publication path has to
+ * agree with the rule syncAllConfigs uses.
+ */
+describe('isPublishableTenant', () => {
+  it('publishes for an active subscription', () => {
+    expect(isPublishableTenant({ subscriptionStatus: 'active' })).toBe(true);
+  });
+
+  it('does not publish for a tenant that has never been activated', () => {
+    expect(isPublishableTenant({ subscriptionStatus: 'inactive' })).toBe(false);
+    expect(isPublishableTenant({ subscriptionStatus: 'abandoned' })).toBe(false);
+  });
+
+  it('does not republish for a lapsed subscription', () => {
+    // These keep whatever file they already have (accepted grace behaviour),
+    // but nothing re-publishes them, matching syncAllConfigs.
+    expect(isPublishableTenant({ subscriptionStatus: 'expired' })).toBe(false);
+    expect(isPublishableTenant({ subscriptionStatus: 'suspended' })).toBe(false);
+  });
+
+  it('does not publish for an unrecognised status', () => {
+    expect(isPublishableTenant({ subscriptionStatus: 'something-new' as never })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/config-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-service.ts
@@ -43,6 +43,19 @@ export function withTenantWriteLock<T>(username: string, fn: () => Promise<T>): 
   return run;
 }
 
+/**
+ * Whether a tenant's config may be published to the served directory.
+ *
+ * nginx serves any file that exists with no subscription check, so publishing
+ * for a tenant that has never paid puts a free blog live until the next sweep
+ * removes it. syncAllConfigs writes only for 'active'; every other publication
+ * path has to agree with it, which is why this predicate is shared rather than
+ * repeated.
+ */
+export function isPublishableTenant(tenant: Pick<Tenant, 'subscriptionStatus'>): boolean {
+  return tenant.subscriptionStatus === 'active';
+}
+
 export const ConfigService = {
   /**
    * Generate config file for a tenant. Writes are serialized per tenant (see
@@ -234,7 +247,7 @@ export const ConfigService = {
         // that window). The unlocked writer is used because the lock is not reentrant.
         await withTenantWriteLock(tenant.username, async () => {
           const fresh = await TenantService.getByUsername(tenant.username);
-          if (!fresh || fresh.subscriptionStatus !== 'active') return;
+          if (!fresh || !isPublishableTenant(fresh)) return;
           await this.writeConfigFile(fresh);
         });
       } catch (err) {

--- a/apps/self-hosted/hosting/api/src/services/tenant-service-community-role.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service-community-role.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  response: null as unknown,
+  shouldThrow: false,
+}));
+
+vi.mock('@ecency/sdk/hive', () => ({
+  callRPC: async () => {
+    if (state.shouldThrow) throw new Error('rpc down');
+    return state.response;
+  },
+  config: { set: () => {} },
+  setNodes: () => {},
+}));
+
+const { TenantService } = await import('./tenant-service');
+
+function community(team: unknown) {
+  return { name: 'hive-125125', team };
+}
+
+/**
+ * Verifying only that the community exists let any account pay for, and then
+ * permanently hold, the instance of a community it has no part in: every later
+ * mutation authorises against tenants.owner, so the real team could never
+ * reclaim it.
+ */
+describe('verifyCommunityControlledBy', () => {
+  it('accepts an admin of the community', async () => {
+    state.response = community([
+      ['hive-125125', 'owner', ''],
+      ['alice', 'admin', ''],
+    ]);
+
+    expect(
+      await TenantService.verifyCommunityControlledBy('hive-125125', 'alice'),
+    ).toBe(true);
+  });
+
+  it('accepts an account holding the owner role', async () => {
+    state.response = community([['alice', 'owner', '']]);
+
+    expect(
+      await TenantService.verifyCommunityControlledBy('hive-125125', 'alice'),
+    ).toBe(true);
+  });
+
+  it('is case insensitive on the account name', async () => {
+    state.response = community([['Alice', 'Admin', '']]);
+
+    expect(
+      await TenantService.verifyCommunityControlledBy('hive-125125', 'alice'),
+    ).toBe(true);
+  });
+
+  it('rejects an account with no role in the community', async () => {
+    state.response = community([
+      ['hive-125125', 'owner', ''],
+      ['bob', 'admin', ''],
+    ]);
+
+    expect(
+      await TenantService.verifyCommunityControlledBy('hive-125125', 'attacker'),
+    ).toBe(false);
+  });
+
+  it('rejects a mod, a member and a muted account', async () => {
+    for (const role of ['mod', 'member', 'guest', 'muted']) {
+      state.response = community([['alice', role, '']]);
+
+      expect(
+        await TenantService.verifyCommunityControlledBy('hive-125125', 'alice'),
+      ).toBe(false);
+    }
+  });
+
+  it('rejects when the community does not exist or the name does not match', async () => {
+    state.response = null;
+    expect(
+      await TenantService.verifyCommunityControlledBy('hive-125125', 'alice'),
+    ).toBe(false);
+
+    state.response = { name: 'hive-999999', team: [['alice', 'admin', '']] };
+    expect(
+      await TenantService.verifyCommunityControlledBy('hive-125125', 'alice'),
+    ).toBe(false);
+  });
+
+  it('rejects when the team is missing or malformed', async () => {
+    for (const team of [undefined, null, 'admin', [null], [['alice']], [{ 0: 'alice' }]]) {
+      state.response = community(team);
+
+      expect(
+        await TenantService.verifyCommunityControlledBy('hive-125125', 'alice'),
+      ).toBe(false);
+    }
+  });
+
+  it('fails closed when the node call throws', async () => {
+    state.shouldThrow = true;
+
+    try {
+      expect(
+        await TenantService.verifyCommunityControlledBy('hive-125125', 'alice'),
+      ).toBe(false);
+    } finally {
+      state.shouldThrow = false;
+    }
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -15,6 +15,12 @@ const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
 
 // Roles that may claim a community's hosted instance. Mods moderate content but
 // do not control the community's identity, so they are deliberately excluded.
+/**
+ * Hive names a community account hive-NNNN. Shared so every path that can bring
+ * a tenant into existence recognises a community claim the same way.
+ */
+export const COMMUNITY_NAME = /^hive-\d+$/;
+
 const CONTROLLING_COMMUNITY_ROLES = new Set(['owner', 'admin']);
 
 // Quiet period after the sweep marks a username 'abandoned' before it can be reserved again. It is

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -13,6 +13,10 @@ export type { Tenant } from '../types';
 hiveTxConfig.nodes = process.env.HIVE_API_URL?.split(',') || ['https://api.hive.blog'];
 const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
 
+// Roles that may claim a community's hosted instance. Mods moderate content but
+// do not control the community's identity, so they are deliberately excluded.
+const CONTROLLING_COMMUNITY_ROLES = new Set(['owner', 'admin']);
+
 // Quiet period after the sweep marks a username 'abandoned' before it can be reserved again. It is
 // a backstop; three enforced guarantees keep a paid-for reservation out of a re-registration:
 //   1. create() refreshes the grace clock on every checkout re-entry, so an actively-paid
@@ -559,11 +563,36 @@ export const TenantService = {
   /**
    * Verify a Hive community exists (not merely an account named hive-NNNNN).
    */
-  async verifyCommunity(communityId: string): Promise<boolean> {
+  /**
+   * A community instance may only be claimed by an account that controls the
+   * community on chain. Verifying that the community merely exists would let
+   * any account pay for, and permanently hold, the instance of a community it
+   * has no part in: every later mutation authorises against tenants.owner, so
+   * the real team could never take it back.
+   *
+   * `team` carries [account, role, title] tuples for the community's owner,
+   * admins and mods. Only owner and admin are accepted, matching who can change
+   * the community's own settings on chain.
+   */
+  async verifyCommunityControlledBy(communityId: string, account: string): Promise<boolean> {
     try {
       const community = await callRPC('bridge.get_community', { name: communityId, observer: '' }) as any;
-      return !!community && community.name === communityId;
+      if (!community || community.name !== communityId) return false;
+
+      const team = community.team;
+      if (!Array.isArray(team)) return false;
+
+      const claimant = account.toLowerCase();
+      return team.some(
+        (member: unknown) =>
+          Array.isArray(member) &&
+          typeof member[0] === 'string' &&
+          member[0].toLowerCase() === claimant &&
+          typeof member[1] === 'string' &&
+          CONTROLLING_COMMUNITY_ROLES.has(member[1].toLowerCase())
+      );
     } catch {
+      // Fail closed: an RPC failure must not hand out a community instance.
       return false;
     }
   },


### PR DESCRIPTION
Two authorization gaps in the hosting API tenant lifecycle. Grouped because they touch the same routes and both concern which tenant state a caller can bring about.

## Community instance creation

Creating a community tenant verified that the community existed, that its id matched the subdomain, and that a separate Hive account was named as owner. It never checked that the named owner had any standing in the community.

`verifyCommunity` is replaced by `verifyCommunityControlledBy`, which reads the community `team` from the same `bridge.get_community` call and requires the claimed owner to hold the `owner` or `admin` role. That matches who can change the community’s own settings on chain. Mods are excluded: they moderate content but do not control the community’s identity.

The check fails closed, so a node error refuses the claim rather than granting it. This matters because ownership is not recoverable after the fact: every later mutation authorizes against `tenants.owner`, and the create upsert only re-enters an `abandoned` row or a same-owner `inactive` one.

Note `team` carries `[account, role, title]` tuples, not objects, and the tests cover the malformed shapes.

## Config publication

`POST /v1/tenants` deliberately does not write the served config file, with a comment explaining why: nginx serves any file that exists with no subscription check. `PATCH /v1/tenants/:username` broke that invariant by regenerating the file unconditionally, so a tenant that had never been activated could be served, and the periodic sweep that removes such files could be undone by saving again.

Publication is now gated on the same rule `syncAllConfigs` already applies (status `active`), extracted as `isPublishableTenant` so the two paths cannot drift.

The config is still persisted for any status, so an edit is never lost. The response reports whether it went live, which also gives the config editor something to say when a saved change is not yet visible.

## Verification

- 12 new tests covering roles, case handling, malformed team data, node failure, and each subscription status.
- 132 hosting API tests pass, typecheck clean.
- No client changes: `apps/web`’s signup already sends `owner`, and a community owner who administers the community is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Community tenant validation now confirms the requesting account is an owner or administrator of the specified community.
  * Configuration files are published only for tenants with active subscriptions.
  * Tenant updates now indicate whether configuration was published, including a distinct response for inactive subscriptions.

* **Bug Fixes**
  * Invalid, unauthorized, missing, or malformed community data is handled safely without granting access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->