### PR TITLE
fix(self-hosted): custom domain ownership, verification races and squatting

### DIFF
--- a/apps/self-hosted/hosting/api/src/routes/domain-ownership.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/domain-ownership.test.ts
@@ -69,6 +69,7 @@ beforeEach(() => {
     expiresAt: new Date().toISOString(),
   });
   mocks.isDomainClaimed.mockResolvedValue(false);
+  mocks.setCustomDomain.mockResolvedValue({ ...COMMUNITY, customDomainVerified: false });
 });
 
 describe('custom domains for a community instance', () => {
@@ -234,24 +235,53 @@ describe('tenant targeting', () => {
 });
 
 describe('re-submitting a domain the tenant already holds', () => {
-  it('leaves the verification intact', async () => {
-    // setCustomDomain clears the verified flag, and the origin sync drops the
-    // vhost and certificate for anything that leaves the verified set.
+  it('does not re-issue verification, which would drop the live certificate', () =>
+    (async () => {
+      mocks.getByUsername.mockResolvedValue({
+        ...COMMUNITY,
+        username: 'alice',
+        customDomain: 'mine.example.com',
+        customDomainVerified: true,
+      });
+      // The statement preserves the flag only for an unchanged domain, so a
+      // still-verified result means nothing was reset.
+      mocks.setCustomDomain.mockResolvedValue({
+        ...COMMUNITY,
+        customDomain: 'mine.example.com',
+        customDomainVerified: true,
+      });
+
+      const res = await request('/', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ domain: 'mine.example.com' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mocks.createVerification).not.toHaveBeenCalled();
+    })());
+
+  it('still issues verification for a domain that is new to the tenant', async () => {
     mocks.getByUsername.mockResolvedValue({
       ...COMMUNITY,
       username: 'alice',
-      customDomain: 'mine.example.com',
+      customDomain: 'old.example.com',
       customDomainVerified: true,
+    });
+    mocks.setCustomDomain.mockResolvedValue({
+      ...COMMUNITY,
+      customDomain: 'new.example.com',
+      customDomainVerified: false,
     });
 
     const res = await request('/', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ domain: 'mine.example.com' }),
+      body: JSON.stringify({ domain: 'new.example.com' }),
     });
 
-    expect(res.status).toBe(200);
-    expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+    expect(res.status).toBe(201);
+    expect(mocks.createVerification).toHaveBeenCalled();
   });
 });
 

--- a/apps/self-hosted/hosting/api/src/routes/domain-ownership.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/domain-ownership.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getByUsername: vi.fn(),
+  isDomainClaimed: vi.fn(),
+  setCustomDomain: vi.fn(),
+  verifyCustomDomain: vi.fn(),
+  removeCustomDomain: vi.fn(),
+  getByDomain: vi.fn(),
+  createVerification: vi.fn(),
+  verifyDomain: vi.fn(),
+  markVerified: vi.fn(),
+}));
+
+class DomainInUseError extends Error {}
+
+vi.mock('../services/tenant-service', () => ({
+  TenantService: {
+    getByUsername: mocks.getByUsername,
+    isDomainClaimed: mocks.isDomainClaimed,
+    setCustomDomain: mocks.setCustomDomain,
+    verifyCustomDomain: mocks.verifyCustomDomain,
+    removeCustomDomain: mocks.removeCustomDomain,
+    getByDomain: mocks.getByDomain,
+  },
+  DomainInUseError,
+}));
+
+vi.mock('../services/domain-service', () => ({
+  DomainService: {
+    createVerification: mocks.createVerification,
+    verifyDomain: mocks.verifyDomain,
+    markVerified: mocks.markVerified,
+  },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('user', { username: 'alice' });
+    await next();
+  },
+}));
+
+vi.mock('../services/audit-service', () => ({
+  AuditService: { log: vi.fn() },
+  parseClientIp: () => null,
+}));
+
+vi.mock('../utils/cors-domains', () => ({ addVerifiedDomainOrigin: vi.fn() }));
+
+const { domainRoutes } = await import('./domains');
+
+const COMMUNITY = {
+  id: 'tenant-community',
+  username: 'hive-125125',
+  owner: 'alice',
+  subscriptionPlan: 'pro',
+  customDomain: null as string | null,
+};
+
+function request(path: string, init?: RequestInit) {
+  return domainRoutes.request(`http://localhost${path}`, init);
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset();
+  mocks.createVerification.mockResolvedValue({
+    verificationMethod: 'cname',
+    expiresAt: new Date().toISOString(),
+  });
+  mocks.isDomainClaimed.mockResolvedValue(false);
+});
+
+describe('custom domains for a community instance', () => {
+  it('addresses the community tenant rather than the caller name', async () => {
+    // A community tenant is username hive-NNNN with a separate owner, so
+    // resolving by the caller's own name could only reach a personal blog.
+    mocks.getByUsername.mockImplementation(async (name: string) =>
+      name === 'hive-125125' ? { ...COMMUNITY } : null,
+    );
+    mocks.setCustomDomain.mockResolvedValue({ ...COMMUNITY });
+
+    const res = await request('/?tenant=hive-125125', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ domain: 'blog.example.com' }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(mocks.setCustomDomain).toHaveBeenCalledWith(
+      'hive-125125',
+      'blog.example.com',
+    );
+  });
+
+  it('still refuses a tenant the caller does not own', async () => {
+    mocks.getByUsername.mockResolvedValue({ ...COMMUNITY, owner: 'bob' });
+
+    const res = await request('/?tenant=hive-125125', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ domain: 'blog.example.com' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+  });
+});
+
+describe('domain occupancy', () => {
+  it('rejects a domain another tenant reserved but never verified', async () => {
+    // getByDomain matches verified rows only, but the column is UNIQUE either
+    // way, so an unverified reservation still blocks everyone else.
+    mocks.getByUsername.mockResolvedValue({ ...COMMUNITY, username: 'alice' });
+    mocks.isDomainClaimed.mockResolvedValue(true);
+
+    const res = await request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ domain: 'taken.example.com' }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+  });
+
+  it('answers a lost race with a conflict rather than a server error', async () => {
+    mocks.getByUsername.mockResolvedValue({ ...COMMUNITY, username: 'alice' });
+    mocks.setCustomDomain.mockRejectedValue(new DomainInUseError('x'));
+
+    const res = await request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ domain: 'raced.example.com' }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('domain verification', () => {
+  it('applies the result to the domain that was checked', async () => {
+    mocks.getByUsername.mockResolvedValue({
+      ...COMMUNITY,
+      username: 'alice',
+      customDomain: 'mine.example.com',
+    });
+    mocks.verifyDomain.mockResolvedValue(true);
+    mocks.verifyCustomDomain.mockResolvedValue({ ...COMMUNITY });
+
+    const res = await request('/verify', { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    expect(mocks.verifyCustomDomain).toHaveBeenCalledWith(
+      'alice',
+      'mine.example.com',
+    );
+    expect(mocks.markVerified).toHaveBeenCalledWith('alice', 'mine.example.com');
+  });
+
+  it('does not report success when the domain changed mid-check', async () => {
+    // The conditional update matched no row, so the DNS result describes a
+    // domain the tenant no longer holds.
+    mocks.getByUsername.mockResolvedValue({
+      ...COMMUNITY,
+      username: 'alice',
+      customDomain: 'mine.example.com',
+    });
+    mocks.verifyDomain.mockResolvedValue(true);
+    mocks.verifyCustomDomain.mockResolvedValue(null);
+
+    const res = await request('/verify', { method: 'POST' });
+    const body = (await res.json()) as { verified: boolean };
+
+    expect(body.verified).toBe(false);
+    expect(mocks.markVerified).not.toHaveBeenCalled();
+  });
+});
+
+describe('removing a custom domain', () => {
+  it('removes it from the community tenant, not the caller name', async () => {
+    mocks.getByUsername.mockImplementation(async (name: string) =>
+      name === 'hive-125125' ? { ...COMMUNITY } : null,
+    );
+    mocks.removeCustomDomain.mockResolvedValue(undefined);
+
+    const res = await request('/?tenant=hive-125125', { method: 'DELETE' });
+
+    expect(res.status).toBe(200);
+    expect(mocks.removeCustomDomain).toHaveBeenCalledWith('hive-125125');
+  });
+
+  it('refuses to strip the domain off a tenant the caller does not own', async () => {
+    // Destructive and newly reachable for other tenants, so the ownership check
+    // is asserted rather than assumed.
+    mocks.getByUsername.mockResolvedValue({ ...COMMUNITY, owner: 'bob' });
+
+    const res = await request('/?tenant=hive-125125', { method: 'DELETE' });
+
+    expect(res.status).toBe(403);
+    expect(mocks.removeCustomDomain).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing tenant rather than removing anything', async () => {
+    mocks.getByUsername.mockResolvedValue(null);
+
+    const res = await request('/?tenant=hive-999999', { method: 'DELETE' });
+
+    expect(res.status).toBe(404);
+    expect(mocks.removeCustomDomain).not.toHaveBeenCalled();
+  });
+});
+
+describe('tenant targeting', () => {
+  it('rejects a malformed tenant parameter before touching the database', async () => {
+    const res = await request('/?tenant=NOT%20A%20NAME', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ domain: 'blog.example.com' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mocks.getByUsername).not.toHaveBeenCalled();
+  });
+
+  it('defaults to the caller when no tenant is given', async () => {
+    mocks.getByUsername.mockResolvedValue({ ...COMMUNITY, username: 'alice' });
+    mocks.removeCustomDomain.mockResolvedValue(undefined);
+
+    await request('/', { method: 'DELETE' });
+
+    expect(mocks.getByUsername).toHaveBeenCalledWith('alice');
+  });
+});
+
+describe('re-submitting a domain the tenant already holds', () => {
+  it('leaves the verification intact', async () => {
+    // setCustomDomain clears the verified flag, and the origin sync drops the
+    // vhost and certificate for anything that leaves the verified set.
+    mocks.getByUsername.mockResolvedValue({
+      ...COMMUNITY,
+      username: 'alice',
+      customDomain: 'mine.example.com',
+      customDomainVerified: true,
+    });
+
+    const res = await request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ domain: 'mine.example.com' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+  });
+});
+
+describe('availability check', () => {
+  it('reports a domain reserved but never verified as unavailable', async () => {
+    // The verified-only lookup used to call this free, right up until the add
+    // call refused it with a conflict.
+    mocks.isDomainClaimed.mockResolvedValue(true);
+    mocks.getByDomain.mockResolvedValue(null);
+
+    const res = await request('/check/squat.example.com');
+    const body = (await res.json()) as { available: boolean; registeredTo: string | null };
+
+    expect(body.available).toBe(false);
+    // Unproven claims do not name their holder to unauthenticated callers.
+    expect(body.registeredTo).toBe(null);
+  });
+
+  it('reports a free domain as available', async () => {
+    mocks.isDomainClaimed.mockResolvedValue(false);
+
+    const res = await request('/check/free.example.com');
+    const body = (await res.json()) as { available: boolean };
+
+    expect(body.available).toBe(true);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/routes/domains.ts
+++ b/apps/self-hosted/hosting/api/src/routes/domains.ts
@@ -3,15 +3,54 @@
  */
 
 import { Hono } from 'hono';
+import type { Context } from 'hono';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
-import { TenantService } from '../services/tenant-service';
+import { DomainInUseError, TenantService } from '../services/tenant-service';
+import type { Tenant } from '../types';
 import { DomainService } from '../services/domain-service';
 import { authMiddleware } from '../middleware/auth';
 import { AuditService, parseClientIp } from '../services/audit-service';
 import { addVerifiedDomainOrigin } from '../utils/cors-domains';
 
+/** Hive account names, the same shape the internal rail validates. */
+const HIVE_USERNAME = /^[a-z][a-z0-9.-]{2,15}$/;
+
 export const domainRoutes = new Hono();
+
+/**
+ * Resolves the tenant a domain request is about.
+ *
+ * A community tenant is stored as username 'hive-NNNN' with a separate owner,
+ * so resolving by the caller's own name could only ever reach a personal blog
+ * and a community owner got 404 for the domain their Pro plan paid for. The
+ * target is explicit, and authorisation stays on tenant.owner.
+ */
+type OwnedTenant =
+  | { tenant: Tenant; actor: string; response: null }
+  | { tenant: null; actor: null; response: Response };
+
+async function resolveOwnedTenant(c: Context): Promise<OwnedTenant> {
+  const authUser = c.get('user');
+  const requested = (c.req.query('tenant') || '').trim().toLowerCase();
+
+  // Shape-checked before it reaches the database, matching every sibling path.
+  // Authorisation keys on tenant.owner rather than on this value, so it is not
+  // a bypass, but an unbounded free-text lookup is not worth leaving open.
+  if (requested && !HIVE_USERNAME.test(requested)) {
+    return { tenant: null, actor: null, response: c.json({ error: 'Invalid tenant' }, 400) };
+  }
+
+  const tenant = await TenantService.getByUsername(requested || authUser.username);
+  if (!tenant) {
+    return { tenant: null, actor: null, response: c.json({ error: 'Tenant not found' }, 404) };
+  }
+  if (authUser.username !== tenant.owner) {
+    return { tenant: null, actor: null, response: c.json({ error: 'Unauthorized' }, 403) };
+  }
+
+  return { tenant, actor: authUser.username, response: null };
+}
 
 // Validation schemas
 const addDomainSchema = z.object({
@@ -24,42 +63,51 @@ const addDomainSchema = z.object({
 // POST /v1/domains - Add custom domain to tenant
 domainRoutes.post('/', authMiddleware, zValidator('json', addDomainSchema), async (c) => {
   const { domain } = c.req.valid('json');
-  const authUser = c.get('user');
-  const username = authUser.username;
-
-  // Get tenant
-  const tenant = await TenantService.getByUsername(username);
-  if (!tenant) {
-    return c.json({ error: 'Tenant not found' }, 404);
-  }
-
-  // Authorize the controlling owner, not the showcased account.
-  if (authUser.username !== tenant.owner) {
-    return c.json({ error: 'Unauthorized' }, 403);
-  }
+  const { tenant, actor, response } = await resolveOwnedTenant(c);
+  if (!tenant) return response;
+  const username = tenant.username;
 
   // Check if Pro plan
   if (tenant.subscriptionPlan !== 'pro') {
     return c.json({ error: 'Custom domains require Pro plan' }, 402);
   }
 
-  // Check if domain is already in use
-  const existingTenant = await TenantService.getByDomain(domain);
-  if (existingTenant && existingTenant.username !== username) {
+  // Occupancy covers unverified reservations too: the column is UNIQUE either
+  // way, so an unverified row still blocks everyone else.
+  if (await TenantService.isDomainClaimed(domain, username)) {
     return c.json({ error: 'Domain already in use' }, 409);
   }
 
-  // Set domain and generate verification
-  await TenantService.setCustomDomain(username, domain);
-  const verification = await DomainService.createVerification(username, domain);
+  // Re-submitting the domain this tenant already has verified must not run the
+  // write below: setCustomDomain clears the verified flag, and the origin sync
+  // removes the vhost and certificate for anything that leaves the verified
+  // set, so a repeat submit would take a live blog off its own hostname.
+  if (tenant.customDomainVerified && tenant.customDomain === domain.toLowerCase()) {
+    return c.json({ domain, verified: true, message: 'Domain already verified' });
+  }
 
+  // Set domain and generate verification
+  try {
+    await TenantService.setCustomDomain(username, domain);
+  } catch (error) {
+    if (error instanceof DomainInUseError) {
+      return c.json({ error: 'Domain already in use' }, 409);
+    }
+    throw error;
+  }
+  // Recorded as soon as the tenant row changes, before the verification record
+  // it does not depend on, matching internal.ts: setCustomDomain also clears
+  // custom_domain_verified, so a throw from createVerification would otherwise
+  // leave the domain state changed with nothing in the trail to say what did it.
   void AuditService.log({
     tenantId: tenant.id,
     eventType: 'domain.added',
-    eventData: { domain, username },
+    eventData: { domain, username, actor },
     ipAddress: parseClientIp(c.req.header('x-forwarded-for')),
     userAgent: c.req.header('user-agent'),
   });
+
+  const verification = await DomainService.createVerification(username, domain);
 
   // The record NAME must be the domain itself: verification resolves the domain's CNAME
   // (and serving requires it too). The internal verification token is bookkeeping only.
@@ -78,77 +126,71 @@ domainRoutes.post('/', authMiddleware, zValidator('json', addDomainSchema), asyn
 
 // POST /v1/domains/verify - Verify domain ownership
 domainRoutes.post('/verify', authMiddleware, async (c) => {
-  const authUser = c.get('user');
-  const username = authUser.username;
-
-  // Get tenant
-  const tenant = await TenantService.getByUsername(username);
-  if (!tenant) {
-    return c.json({ error: 'Tenant not found' }, 404);
-  }
-
-  // Authorize the controlling owner, not the showcased account.
-  if (authUser.username !== tenant.owner) {
-    return c.json({ error: 'Unauthorized' }, 403);
-  }
+  const { tenant, actor, response } = await resolveOwnedTenant(c);
+  if (!tenant) return response;
+  const username = tenant.username;
 
   if (!tenant.customDomain) {
     return c.json({ error: 'No custom domain configured' }, 400);
   }
 
+  // Captured before the DNS round trip so the result is applied to the domain
+  // that was actually checked.
+  const checkedDomain = tenant.customDomain;
+
   // Check DNS
-  const isVerified = await DomainService.verifyDomain(tenant.customDomain, username);
+  const isVerified = await DomainService.verifyDomain(checkedDomain, username);
 
   if (!isVerified) {
     return c.json({
       verified: false,
-      domain: tenant.customDomain,
+      domain: checkedDomain,
       message: 'DNS verification failed. Please check your CNAME record.',
     });
   }
 
-  // Mark as verified
-  await TenantService.verifyCustomDomain(username);
-  await DomainService.markVerified(username, tenant.customDomain);
-  addVerifiedDomainOrigin(tenant.customDomain);
+  // Mark as verified. Null means the tenant's domain changed while DNS was
+  // being checked, so this result no longer describes the stored domain.
+  const verifiedTenant = await TenantService.verifyCustomDomain(username, checkedDomain);
+  if (!verifiedTenant) {
+    return c.json({
+      verified: false,
+      domain: checkedDomain,
+      message: 'The custom domain changed during verification. Please verify again.',
+    });
+  }
+
+  await DomainService.markVerified(username, checkedDomain);
+  addVerifiedDomainOrigin(checkedDomain);
 
   void AuditService.log({
     tenantId: tenant.id,
     eventType: 'domain.verified',
-    eventData: { domain: tenant.customDomain, username },
+    eventData: { domain: checkedDomain, username, actor },
     ipAddress: parseClientIp(c.req.header('x-forwarded-for')),
     userAgent: c.req.header('user-agent'),
   });
 
   return c.json({
     verified: true,
-    domain: tenant.customDomain,
+    domain: checkedDomain,
     message: 'Domain verified successfully!',
   });
 });
 
 // DELETE /v1/domains - Remove custom domain
 domainRoutes.delete('/', authMiddleware, async (c) => {
-  const authUser = c.get('user');
-  const username = authUser.username;
-
   try {
-    const tenant = await TenantService.getByUsername(username);
-    if (!tenant) {
-      return c.json({ error: 'Tenant not found' }, 404);
-    }
-
-    // Authorize the controlling owner, not the showcased account.
-    if (authUser.username !== tenant.owner) {
-      return c.json({ error: 'Unauthorized' }, 403);
-    }
+    const { tenant, actor, response } = await resolveOwnedTenant(c);
+    if (!tenant) return response;
+    const username = tenant.username;
 
     await TenantService.removeCustomDomain(username);
 
     void AuditService.log({
       tenantId: tenant?.id ?? null,
       eventType: 'domain.removed',
-      eventData: { username },
+      eventData: { username, actor },
       ipAddress: parseClientIp(c.req.header('x-forwarded-for')),
       userAgent: c.req.header('user-agent'),
     });
@@ -167,12 +209,19 @@ domainRoutes.delete('/', authMiddleware, async (c) => {
 domainRoutes.get('/check/:domain', async (c) => {
   const domain = c.req.param('domain');
 
-  const tenant = await TenantService.getByDomain(domain);
+  // Availability has to answer the same question POST / enforces. Asking the
+  // verified-only lookup reported a domain another tenant had reserved but not
+  // verified as free, right up until the add call refused it with a conflict.
+  const claimed = await TenantService.isDomainClaimed(domain);
+  // registeredTo stays on the verified lookup: an unverified reservation is
+  // unproven, so naming its holder to an unauthenticated caller would disclose
+  // a claim nobody has demonstrated.
+  const verifiedHolder = claimed ? await TenantService.getByDomain(domain) : null;
 
   return c.json({
     domain,
-    available: !tenant,
-    registeredTo: tenant ? tenant.username : null,
+    available: !claimed,
+    registeredTo: verifiedHolder ? verifiedHolder.username : null,
   });
 });
 

--- a/apps/self-hosted/hosting/api/src/routes/domains.ts
+++ b/apps/self-hosted/hosting/api/src/routes/domains.ts
@@ -78,23 +78,24 @@ domainRoutes.post('/', authMiddleware, zValidator('json', addDomainSchema), asyn
     return c.json({ error: 'Domain already in use' }, 409);
   }
 
-  // Re-submitting the domain this tenant already has verified must not run the
-  // write below: setCustomDomain clears the verified flag, and the origin sync
-  // removes the vhost and certificate for anything that leaves the verified
-  // set, so a repeat submit would take a live blog off its own hostname.
-  if (tenant.customDomainVerified && tenant.customDomain === domain.toLowerCase()) {
-    return c.json({ domain, verified: true, message: 'Domain already verified' });
-  }
-
   // Set domain and generate verification
+  let updated: Awaited<ReturnType<typeof TenantService.setCustomDomain>>;
   try {
-    await TenantService.setCustomDomain(username, domain);
+    updated = await TenantService.setCustomDomain(username, domain);
   } catch (error) {
     if (error instanceof DomainInUseError) {
       return c.json({ error: 'Domain already in use' }, 409);
     }
     throw error;
   }
+  // The statement preserves the flag only when the domain was unchanged, so a
+  // still-verified row here means this was a repeat submit of a live domain.
+  // Re-issuing the verification would delete its record and the origin sync
+  // would drop the vhost and certificate.
+  if (updated.customDomainVerified) {
+    return c.json({ domain, verified: true, message: 'Domain already verified' });
+  }
+
   // Recorded as soon as the tenant row changes, before the verification record
   // it does not depend on, matching internal.ts: setCustomDomain also clears
   // custom_domain_verified, so a throw from createVerification would otherwise

--- a/apps/self-hosted/hosting/api/src/routes/internal.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.test.ts
@@ -182,7 +182,10 @@ describe('internal endpoint audit trail', () => {
     mocks.buildConfig.mockReset().mockResolvedValue({ version: 1 });
     mocks.getBlogUrl.mockReset().mockReturnValue('https://alice.blogs.ecency.com');
     mocks.isDomainClaimed.mockReset().mockResolvedValue(false);
-    mocks.setCustomDomain.mockReset().mockResolvedValue(undefined);
+    mocks.setCustomDomain.mockReset().mockResolvedValue({
+      id: 'tenant-1',
+      customDomainVerified: false,
+    });
     mocks.verifyCustomDomain.mockReset().mockResolvedValue({ id: 'tenant-1' });
     mocks.createVerification.mockReset().mockResolvedValue({ verificationMethod: 'cname' });
     mocks.verifyDomain.mockReset().mockResolvedValue(true);
@@ -246,10 +249,16 @@ describe('internal endpoint audit trail', () => {
       expect(response.status).toBe(409);
     });
 
-    it('does not clear verification when the same domain is submitted again', async () => {
+    it('does not re-issue verification when the same domain is submitted again', async () => {
       mocks.getByUsername.mockResolvedValue({
         ...proTenant,
         customDomain: 'mine.example.com',
+        customDomainVerified: true,
+      });
+      // The statement preserves the flag only when the stored domain already
+      // equals the requested one, so a still-verified result means no reset.
+      mocks.setCustomDomain.mockResolvedValue({
+        id: 'tenant-1',
         customDomainVerified: true,
       });
 
@@ -259,9 +268,9 @@ describe('internal endpoint audit trail', () => {
       });
 
       expect(response.status).toBe(200);
-      // setCustomDomain would reset custom_domain_verified and cost the tenant
-      // its vhost and certificate until it verified again.
-      expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+      // Re-issuing would delete the live verification record, and the origin
+      // sync would drop the vhost and certificate with it.
+      expect(mocks.createVerification).not.toHaveBeenCalled();
     });
 
     it('verifies against the domain that was checked', async () => {

--- a/apps/self-hosted/hosting/api/src/routes/internal.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.test.ts
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => ({
   auditLog: vi.fn(),
   buildConfig: vi.fn(),
   getBlogUrl: vi.fn(),
-  getByDomain: vi.fn(),
+  isDomainClaimed: vi.fn(),
   setCustomDomain: vi.fn(),
   verifyCustomDomain: vi.fn(),
   createVerification: vi.fn(),
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   markVerified: vi.fn(),
   addVerifiedDomainOrigin: vi.fn(),
 }));
+
+class DomainInUseError extends Error {}
 
 vi.mock('../db/client', () => ({
   db: { transaction: mocks.transaction },
@@ -25,12 +27,13 @@ vi.mock('../services/tenant-service', () => ({
     getByUsername: mocks.getByUsername,
     buildConfig: mocks.buildConfig,
     getBlogUrl: mocks.getBlogUrl,
-    getByDomain: mocks.getByDomain,
+    isDomainClaimed: mocks.isDomainClaimed,
     setCustomDomain: mocks.setCustomDomain,
     verifyCustomDomain: mocks.verifyCustomDomain,
   },
   ABANDONED_REREGISTER_QUARANTINE_HOURS: 24,
   CAUGHT_UP_SQL: 'TRUE',
+  DomainInUseError,
 }));
 
 vi.mock('../services/config-service', () => ({
@@ -178,9 +181,9 @@ describe('internal endpoint audit trail', () => {
     mocks.generateConfigFile.mockReset().mockResolvedValue('/configs/alice.json');
     mocks.buildConfig.mockReset().mockResolvedValue({ version: 1 });
     mocks.getBlogUrl.mockReset().mockReturnValue('https://alice.blogs.ecency.com');
-    mocks.getByDomain.mockReset().mockResolvedValue(null);
+    mocks.isDomainClaimed.mockReset().mockResolvedValue(false);
     mocks.setCustomDomain.mockReset().mockResolvedValue(undefined);
-    mocks.verifyCustomDomain.mockReset().mockResolvedValue(undefined);
+    mocks.verifyCustomDomain.mockReset().mockResolvedValue({ id: 'tenant-1' });
     mocks.createVerification.mockReset().mockResolvedValue({ verificationMethod: 'cname' });
     mocks.verifyDomain.mockReset().mockResolvedValue(true);
     mocks.markVerified.mockReset().mockResolvedValue(undefined);
@@ -207,6 +210,94 @@ describe('internal endpoint audit trail', () => {
     order_id: 'order-1',
     amount_usd: 24,
   };
+
+  describe('custom domain integrity', () => {
+    const proTenant = {
+      id: 'tenant-1',
+      username: 'alice',
+      subscriptionStatus: 'active',
+      subscriptionPlan: 'pro',
+      customDomain: null as string | null,
+      customDomainVerified: false,
+    };
+
+    it('refuses a domain another tenant holds without verifying it', async () => {
+      mocks.getByUsername.mockResolvedValue({ ...proTenant });
+      mocks.isDomainClaimed.mockResolvedValue(true);
+
+      const response = await post('/domain', {
+        username: 'alice',
+        domain: 'taken.example.com',
+      });
+
+      expect(response.status).toBe(409);
+      expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+    });
+
+    it('answers a lost unique race with a conflict, not a server error', async () => {
+      mocks.getByUsername.mockResolvedValue({ ...proTenant });
+      mocks.setCustomDomain.mockRejectedValue(new DomainInUseError('raced'));
+
+      const response = await post('/domain', {
+        username: 'alice',
+        domain: 'raced.example.com',
+      });
+
+      expect(response.status).toBe(409);
+    });
+
+    it('does not clear verification when the same domain is submitted again', async () => {
+      mocks.getByUsername.mockResolvedValue({
+        ...proTenant,
+        customDomain: 'mine.example.com',
+        customDomainVerified: true,
+      });
+
+      const response = await post('/domain', {
+        username: 'alice',
+        domain: 'mine.example.com',
+      });
+
+      expect(response.status).toBe(200);
+      // setCustomDomain would reset custom_domain_verified and cost the tenant
+      // its vhost and certificate until it verified again.
+      expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+    });
+
+    it('verifies against the domain that was checked', async () => {
+      mocks.getByUsername.mockResolvedValue({
+        ...proTenant,
+        customDomain: 'mine.example.com',
+      });
+
+      const response = await post('/domain/verify', { username: 'alice' });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ verified: true });
+      expect(mocks.verifyCustomDomain).toHaveBeenCalledWith('alice', 'mine.example.com');
+      expect(mocks.markVerified).toHaveBeenCalledWith('alice', 'mine.example.com');
+    });
+
+    it('does not report success when the domain changed during the DNS check', async () => {
+      mocks.getByUsername.mockResolvedValue({
+        ...proTenant,
+        customDomain: 'mine.example.com',
+      });
+      // The conditional update matched no row: the DNS result describes a domain
+      // the tenant no longer holds.
+      mocks.verifyCustomDomain.mockResolvedValue(null);
+
+      const response = await post('/domain/verify', { username: 'alice' });
+
+      expect(await response.json()).toEqual({ verified: false });
+      expect(mocks.markVerified).not.toHaveBeenCalled();
+      expect(mocks.addVerifiedDomainOrigin).not.toHaveBeenCalled();
+      const verifiedEvents = mocks.auditLog.mock.calls.filter(
+        (call) => (call[0] as { eventType?: string })?.eventType === 'domain.verified',
+      );
+      expect(verifiedEvents).toHaveLength(0);
+    });
+  });
 
   it('records a card activation with its order, term and rail', async () => {
     const response = await post('/activate', activateBody);

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -9,6 +9,7 @@ import { Hono, type Context } from 'hono';
 import { db } from '../db/client';
 import {
   TenantService,
+  DomainInUseError,
   ABANDONED_REREGISTER_QUARANTINE_HOURS,
   CAUGHT_UP_SQL,
 } from '../services/tenant-service';
@@ -317,13 +318,26 @@ internalRoutes.post('/domain', async (c) => {
     return c.json({ error: 'custom_domain_requires_pro' }, 402);
   }
 
-  // Refuse a domain already verified by a different tenant.
-  const existing = await TenantService.getByDomain(domain);
-  if (existing && existing.username !== username) {
+  // Refuse a domain another tenant already holds, verified or not: the column is
+  // UNIQUE either way, so an unverified reservation still blocks everyone else.
+  if (await TenantService.isDomainClaimed(domain, username)) {
     return c.json({ error: 'domain_in_use' }, 409);
   }
 
-  await TenantService.setCustomDomain(username, domain);
+  // Re-submitting an already-verified domain would clear the verified flag and
+  // cost the tenant its vhost and certificate until it verified again.
+  if (tenant.customDomainVerified && tenant.customDomain === domain) {
+    return c.json({ domain, verified: true }, 200);
+  }
+
+  try {
+    await TenantService.setCustomDomain(username, domain);
+  } catch (error) {
+    if (error instanceof DomainInUseError) {
+      return c.json({ error: 'domain_in_use' }, 409);
+    }
+    throw error;
+  }
   // Recorded as soon as the tenant row changes, before the verification record it does not depend
   // on: setCustomDomain also clears custom_domain_verified, so if createVerification then threw,
   // the tenant's domain state would have changed with nothing in the trail to say what changed it.
@@ -376,23 +390,30 @@ internalRoutes.post('/domain/verify', async (c) => {
     return c.json({ verified: true }, 200);
   }
 
-  const ok = await DomainService.verifyDomain(tenant.customDomain, username);
+  // Captured before the DNS round trip so the result is applied to the domain
+  // that was actually checked, not to whatever the row holds afterwards.
+  const checkedDomain = tenant.customDomain;
+
+  const ok = await DomainService.verifyDomain(checkedDomain, username);
   if (!ok) {
     return c.json({ verified: false }, 200);
   }
 
-  await TenantService.verifyCustomDomain(username);
+  // Null means the domain changed while DNS was being checked.
+  if (!(await TenantService.verifyCustomDomain(username, checkedDomain))) {
+    return c.json({ verified: false }, 200);
+  }
   // Recorded here, not after the bookkeeping below: the tenant is already verified at this point,
   // and the idempotent early return above means a retry would never reach a later audit call. If
   // markVerified threw, the event would be lost permanently for a domain that IS verified.
   auditInternal(c, tenant.id, 'domain.verified', {
-    domain: tenant.customDomain,
+    domain: checkedDomain,
     username,
     via: 'internal',
   });
 
-  await DomainService.markVerified(username, tenant.customDomain);
-  addVerifiedDomainOrigin(tenant.customDomain);
+  await DomainService.markVerified(username, checkedDomain);
+  addVerifiedDomainOrigin(checkedDomain);
 
   return c.json({ verified: true }, 200);
 });

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -324,14 +324,9 @@ internalRoutes.post('/domain', async (c) => {
     return c.json({ error: 'domain_in_use' }, 409);
   }
 
-  // Re-submitting an already-verified domain would clear the verified flag and
-  // cost the tenant its vhost and certificate until it verified again.
-  if (tenant.customDomainVerified && tenant.customDomain === domain) {
-    return c.json({ domain, verified: true }, 200);
-  }
-
+  let updated: Awaited<ReturnType<typeof TenantService.setCustomDomain>>;
   try {
-    await TenantService.setCustomDomain(username, domain);
+    updated = await TenantService.setCustomDomain(username, domain);
   } catch (error) {
     if (error instanceof DomainInUseError) {
       return c.json({ error: 'domain_in_use' }, 409);
@@ -341,6 +336,12 @@ internalRoutes.post('/domain', async (c) => {
   // Recorded as soon as the tenant row changes, before the verification record it does not depend
   // on: setCustomDomain also clears custom_domain_verified, so if createVerification then threw,
   // the tenant's domain state would have changed with nothing in the trail to say what changed it.
+  // Still verified means the statement matched the domain already stored, so
+  // this was a repeat submit of a live domain and nothing was reset.
+  if (updated.customDomainVerified) {
+    return c.json({ domain, verified: true }, 200);
+  }
+
   auditInternal(c, tenant.id, 'domain.added', { domain, username, via: 'internal' });
 
   await DomainService.createVerification(username, domain);

--- a/apps/self-hosted/hosting/api/src/services/set-custom-domain.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/set-custom-domain.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ queryOne: vi.fn() }));
+
+vi.mock('../db/client', () => ({ db: { queryOne: mocks.queryOne } }));
+vi.mock('@ecency/sdk/hive', () => ({ callRPC: vi.fn(), config: { set: vi.fn() } }));
+
+const { TenantService, DomainInUseError } = await import('./tenant-service');
+
+/**
+ * Whether a re-submitted domain keeps its verification is decided inside the
+ * UPDATE, not by the route, because a route-level guard would be check-then-act
+ * on a read that a concurrent update can invalidate. There is no database in
+ * this suite, so the statement is pinned here directly: if the conditional ever
+ * turns back into an unconditional reset, a live blog loses its vhost and
+ * certificate on a harmless repeat submit.
+ */
+describe('setCustomDomain', () => {
+  beforeEach(() => {
+    mocks.queryOne.mockReset().mockResolvedValue({ id: 't1', username: 'alice' });
+  });
+
+  it('preserves verification only when the stored domain is unchanged', async () => {
+    await TenantService.setCustomDomain('alice', 'mine.example.com');
+
+    const [sql, params] = mocks.queryOne.mock.calls[0];
+    const normalised = sql.replace(/\s+/g, ' ');
+
+    expect(normalised).toContain(
+      'custom_domain_verified = CASE WHEN custom_domain = $2 THEN custom_domain_verified ELSE false END',
+    );
+    expect(normalised).toContain(
+      'custom_domain_verified_at = CASE WHEN custom_domain = $2 THEN custom_domain_verified_at ELSE NULL END',
+    );
+    expect(params).toEqual(['alice', 'mine.example.com']);
+  });
+
+  it('lowercases both the tenant and the domain', async () => {
+    await TenantService.setCustomDomain('Alice', 'Mine.Example.COM');
+
+    expect(mocks.queryOne.mock.calls[0][1]).toEqual(['alice', 'mine.example.com']);
+  });
+
+  it('reports a unique violation as a domain conflict', async () => {
+    mocks.queryOne.mockRejectedValue(Object.assign(new Error('dup'), { code: '23505' }));
+
+    await expect(
+      TenantService.setCustomDomain('alice', 'taken.example.com'),
+    ).rejects.toBeInstanceOf(DomainInUseError);
+  });
+
+  it('does not swallow an unrelated database error', async () => {
+    mocks.queryOne.mockRejectedValue(Object.assign(new Error('boom'), { code: '08006' }));
+
+    await expect(
+      TenantService.setCustomDomain('alice', 'x.example.com'),
+    ).rejects.toThrow('boom');
+  });
+
+  it('reports a missing tenant', async () => {
+    mocks.queryOne.mockResolvedValue(null);
+
+    await expect(
+      TenantService.setCustomDomain('nobody', 'x.example.com'),
+    ).rejects.toThrow('Tenant not found');
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -11,6 +11,16 @@ export type { Tenant } from '../types';
 
 // Configure hive-tx nodes
 hiveTxConfig.nodes = process.env.HIVE_API_URL?.split(',') || ['https://api.hive.blog'];
+const UNIQUE_VIOLATION = '23505';
+
+/** Raised when another tenant already holds the requested custom domain. */
+export class DomainInUseError extends Error {
+  constructor(public readonly domain: string) {
+    super('Domain already in use');
+    this.name = 'DomainInUseError';
+  }
+}
+
 const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
 
 // Quiet period after the sweep marks a username 'abandoned' before it can be reserved again. It is
@@ -376,16 +386,28 @@ export const TenantService = {
    * Set custom domain
    */
   async setCustomDomain(username: string, domain: string): Promise<Tenant> {
-    const row = await db.queryOne<TenantRow>(
-      `UPDATE tenants
-       SET custom_domain = $2,
-           custom_domain_verified = false,
-           custom_domain_verified_at = NULL,
-           updated_at = NOW()
-       WHERE username = $1
-       RETURNING *`,
-      [username.toLowerCase(), domain.toLowerCase()]
-    );
+    let row: TenantRow | null;
+
+    try {
+      row = await db.queryOne<TenantRow>(
+        `UPDATE tenants
+         SET custom_domain = $2,
+             custom_domain_verified = false,
+             custom_domain_verified_at = NULL,
+             updated_at = NOW()
+         WHERE username = $1
+         RETURNING *`,
+        [username.toLowerCase(), domain.toLowerCase()]
+      );
+    } catch (error) {
+      // custom_domain is UNIQUE. Losing the race to another tenant is a
+      // conflict, not a server error: without this the raw Postgres message
+      // surfaced as a 500 and the caller could not tell why.
+      if ((error as { code?: string }).code === UNIQUE_VIOLATION) {
+        throw new DomainInUseError(domain);
+      }
+      throw error;
+    }
 
     if (!row) throw new Error('Tenant not found');
     return mapTenantFromDb(row);
@@ -394,19 +416,47 @@ export const TenantService = {
   /**
    * Verify custom domain
    */
-  async verifyCustomDomain(username: string): Promise<Tenant> {
+  /**
+   * Marks the domain that was actually checked, not whatever the row holds now.
+   *
+   * Verification does a DNS round trip between reading the tenant and writing
+   * the flag. Keying the update on the username alone let a domain swap during
+   * that window inherit the result of a check performed against the previous
+   * domain, which also added it to the CORS allowlist and blocked its rightful
+   * owner. Returns null when the row moved on, so the caller can ask the user
+   * to verify again.
+   */
+  async verifyCustomDomain(username: string, domain: string): Promise<Tenant | null> {
     const row = await db.queryOne<TenantRow>(
       `UPDATE tenants
        SET custom_domain_verified = true,
            custom_domain_verified_at = NOW(),
            updated_at = NOW()
-       WHERE username = $1
+       WHERE username = $1 AND custom_domain = $2
        RETURNING *`,
-      [username.toLowerCase()]
+      [username.toLowerCase(), domain.toLowerCase()]
     );
 
-    if (!row) throw new Error('Tenant not found');
-    return mapTenantFromDb(row);
+    return row ? mapTenantFromDb(row) : null;
+  },
+
+  /**
+   * Whether any tenant holds this domain, verified or not.
+   *
+   * getByDomain deliberately matches verified rows only, because that is what
+   * serving a request by host means. Occupancy is a different question: the
+   * column is UNIQUE regardless of the flag, so an unverified reservation still
+   * blocks everyone else, and checking only verified rows let the insert fail
+   * on the constraint instead of returning a clean conflict.
+   */
+  async isDomainClaimed(domain: string, excludeUsername?: string): Promise<boolean> {
+    const row = await db.queryOne<{ username: string }>(
+      'SELECT username FROM tenants WHERE custom_domain = $1',
+      [domain.toLowerCase()]
+    );
+
+    if (!row) return false;
+    return row.username.toLowerCase() !== excludeUsername?.toLowerCase();
   },
 
   /**

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -389,11 +389,18 @@ export const TenantService = {
     let row: TenantRow | null;
 
     try {
+      // Re-submitting the domain the tenant already holds keeps its verification.
+      // Decided inside the statement rather than from an earlier read: a route
+      // level guard would be check-then-act, and a concurrent update could make
+      // the read stale between the two. Setting a DIFFERENT domain still clears
+      // the flag, which is what re-verification exists for.
       row = await db.queryOne<TenantRow>(
         `UPDATE tenants
          SET custom_domain = $2,
-             custom_domain_verified = false,
-             custom_domain_verified_at = NULL,
+             custom_domain_verified =
+               CASE WHEN custom_domain = $2 THEN custom_domain_verified ELSE false END,
+             custom_domain_verified_at =
+               CASE WHEN custom_domain = $2 THEN custom_domain_verified_at ELSE NULL END,
              updated_at = NOW()
          WHERE username = $1
          RETURNING *`,


### PR DESCRIPTION
Three defects in the custom-domain lifecycle, plus one found while reviewing them. Grouped because they are all in the same two routes and the fixes interlock.

## Verification race

The route read the tenant’s domain, ran an async DNS check, then flipped `custom_domain_verified` with an UPDATE keyed on the **username alone**, never naming the domain that was checked. A domain swap during that window inherited the result of a check performed against the previous domain, which also added it to the CORS allowlist and blocked its rightful owner. The internal rail had the identical bug.

`verifyCustomDomain(username, domain)` now updates `WHERE username = $1 AND custom_domain = $2` and returns `Tenant | null`; `null` means the row moved on, and both rails report not-verified instead of success.

## Squatting

Occupancy was asked with `getByDomain`, whose SQL is `custom_domain = $1 AND custom_domain_verified = true`, while the UNIQUE constraint applies regardless of the flag. An unverified reservation was invisible to the check, and the rightful owner’s write then raised an unhandled `23505` that surfaced as a 500 with the raw driver message.

New `isDomainClaimed` asks the question the constraint actually enforces, and `setCustomDomain` converts `23505` into a typed `DomainInUseError` that both rails answer with 409.

`GET /v1/domains/check/:domain` now answers from the same predicate. I originally left it on the verified-only lookup and said in review that `getByDomain` could stay as-is because `auth.ts` resolves a tenant by request host; that was wrong, there are two callers and this one asks the occupancy question. It reported a squatted domain as free right up until the add route refused it. `registeredTo` still comes from the verified lookup, since an unverified claim is unproven and this endpoint is unauthenticated.

## Community instances

All three public routes resolved the tenant with `getByUsername(authUser.username)`. A community tenant is `hive-NNNN` with a separate owner, so a community owner got 404 for the domain their Pro plan paid for. A shared `resolveOwnedTenant` takes an optional `?tenant=`, shape-checked before it reaches the database, with authorization still keyed on `tenant.owner` rather than on the parameter.

## Found while reviewing: re-submitting your own domain took the blog offline

Both occupancy checks deliberately let the caller’s own row through, so re-POSTing a domain you already have verified fell straight into `setCustomDomain`, which clears `custom_domain_verified` unconditionally. The origin sync removes the vhost and certificate for anything leaving the verified set, so a repeat submit took a live blog off its own hostname until the customer noticed. Both rails now treat it as a no-op. This one is pre-existing rather than introduced here, but it is a one-line guard in a function this PR was already changing.

## Smaller items in the same pass

- Audit events record the acting account alongside the tenant, which matters now that the two can differ.
- `domain.added` is written before the verification record it does not depend on, matching the ordering the internal rail already documents and tests.
- The shared helper is typed against Hono’s `Context` with a discriminated return, rather than `any`.

## Verification

139 tests pass, typecheck clean. The new coverage is mutation-tested rather than assumed: reverting the internal verification guard fails 1 test, reverting the DELETE ownership check fails 2, and reverting the availability fix fails 1. That check was prompted by review finding that the entire internal-rail half of the change and the whole DELETE route could be deleted with the suite still green.

Follow-ups filed separately: #1311 (nothing releases an unverified domain claim, and the CORS origin set never drops a removed domain), #1312 (a lapsed subscription keeps its Pro custom-domain capabilities), #1313 (the error handler returns raw driver messages).