### PR TITLE
fix(self-hosted): rate limit /v1/internal and require a strong shared secret

### DIFF
--- a/apps/self-hosted/hosting/.env.example
+++ b/apps/self-hosted/hosting/.env.example
@@ -53,6 +53,11 @@ X402_FACILITATOR_URL=https://x402.ecency.com
 # endpoint (POST /v1/internal/activate) after a paid order, authenticated by this
 # shared secret (same pattern as ePoints' STRIPE_INTERNAL_SECRET). Empty = card
 # activation disabled (the endpoint fails closed).
+#
+# MUST be at least 32 characters. These routes activate subscriptions, attach
+# custom domains and grant free Pro terms, and this secret is the only thing in
+# front of them, so a shorter value is refused exactly as an empty one is. The
+# same value has to be set on the ePoints side, so rotate both together.
 # =============================================================================
 HOSTING_INTERNAL_SECRET=
 # Show/hide the card option in the signup UI + the price it displays (200 = $2.00).

--- a/apps/self-hosted/hosting/api/src/index.ts
+++ b/apps/self-hosted/hosting/api/src/index.ts
@@ -12,7 +12,7 @@ import { tenantRoutes } from './routes/tenants';
 import { domainRoutes } from './routes/domains';
 import { paymentRoutes } from './routes/payments';
 import { authRoutes } from './routes/auth';
-import { internalRoutes } from './routes/internal';
+import { internalRoutes, internalSecret, MIN_INTERNAL_SECRET_LENGTH } from './routes/internal';
 import { rateLimit } from './middleware/rate-limit';
 import { db } from './db/client';
 import { TenantService } from './services/tenant-service';
@@ -55,15 +55,20 @@ app.get('/health', (c) => c.json({ status: 'ok', timestamp: new Date().toISOStri
 // Per-IP rate limiting. A general budget on all public routes caps the unauthenticated
 // tenant-creation + RPC-amplification abuse; a tighter budget on /v1/auth throttles the
 // challenge/verify/hivesigner endpoints, which each spend an RPC or external call per hit.
-// The shared-secret /v1/internal routes (called by ePoints, not end users) are NOT IP-limited.
+// /v1/internal is reachable from the public internet and its only gate is a shared secret,
+// so it gets a budget too: generous enough that ePoints' fulfillment never notices, tight
+// enough that the secret cannot be guessed online and that each attempt cannot keep opening
+// a database transaction.
 const generalLimit = rateLimit({ name: 'api', limit: 180, windowMs: 60_000 });
 const authLimit = rateLimit({ name: 'auth', limit: 30, windowMs: 60_000 });
+const internalLimit = rateLimit({ name: 'internal', limit: 600, windowMs: 60_000 });
 app.use('/v1/tenants/*', generalLimit);
 app.use('/v1/tenants', generalLimit);
 app.use('/v1/domains/*', generalLimit);
 app.use('/v1/payments/*', generalLimit);
 app.use('/v1/auth/*', generalLimit);
 app.use('/v1/auth/*', authLimit);
+app.use('/v1/internal/*', internalLimit);
 
 // API Routes
 app.route('/v1/tenants', tenantRoutes);
@@ -107,6 +112,19 @@ async function syncTenantConfigs(): Promise<void> {
   } finally {
     configSyncRunning = false;
   }
+}
+
+// Say once, at boot, what state the internal shared secret is in. Without this the two
+// misconfigurations are indistinguishable in production: both simply reject every call,
+// one because the operator meant to disable card activation and one because the value
+// they chose is too weak to accept.
+if (!process.env.HOSTING_INTERNAL_SECRET) {
+  console.log('[Startup] HOSTING_INTERNAL_SECRET is not set; /v1/internal is disabled');
+} else if (!internalSecret()) {
+  console.error(
+    `[Startup] HOSTING_INTERNAL_SECRET is shorter than ${MIN_INTERNAL_SECRET_LENGTH} characters` +
+      ' and will be refused; /v1/internal is disabled until it is replaced'
+  );
 }
 
 // Warm request-critical state BEFORE accepting traffic, bounded so a slow or down DB

--- a/apps/self-hosted/hosting/api/src/routes/card-availability.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/card-availability.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db/client', () => ({ db: { query: vi.fn(), queryOne: vi.fn() } }));
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
+  adminMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+const { paymentRoutes } = await import('./payments');
+const { MIN_INTERNAL_SECRET_LENGTH } = await import('./internal');
+
+const STRONG = 'a'.repeat(MIN_INTERNAL_SECRET_LENGTH);
+const original = process.env.HOSTING_INTERNAL_SECRET;
+
+afterEach(() => {
+  if (original === undefined) delete process.env.HOSTING_INTERNAL_SECRET;
+  else process.env.HOSTING_INTERNAL_SECRET = original;
+});
+
+async function cardEnabled(): Promise<boolean> {
+  const res = await paymentRoutes.request('http://localhost/methods');
+  const body = (await res.json()) as { card: { enabled: boolean } };
+  return body.card.enabled;
+}
+
+/**
+ * The signup UI must not offer a rail whose fulfilment will be refused: the
+ * customer would be charged and the activation would 403. Advertisement and
+ * acceptance therefore have to be decided by the same predicate.
+ */
+describe('card rail availability', () => {
+  it('is offered when the secret is strong enough to accept', async () => {
+    process.env.HOSTING_INTERNAL_SECRET = STRONG;
+
+    expect(await cardEnabled()).toBe(true);
+  });
+
+  it('is not offered when the secret is absent', async () => {
+    delete process.env.HOSTING_INTERNAL_SECRET;
+
+    expect(await cardEnabled()).toBe(false);
+  });
+
+  it('is not offered when the secret is present but too weak to accept', async () => {
+    // The state this fix introduced: activation refuses it, so advertising the
+    // option would take a payment that can never be fulfilled.
+    process.env.HOSTING_INTERNAL_SECRET = 'short-secret';
+
+    expect(await cardEnabled()).toBe(false);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/routes/internal-secret.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal-secret.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  internalSecret,
+  internalSecretOk,
+  MIN_INTERNAL_SECRET_LENGTH,
+} from './internal';
+
+const STRONG = 'a'.repeat(MIN_INTERNAL_SECRET_LENGTH);
+const original = process.env.HOSTING_INTERNAL_SECRET;
+
+afterEach(() => {
+  if (original === undefined) delete process.env.HOSTING_INTERNAL_SECRET;
+  else process.env.HOSTING_INTERNAL_SECRET = original;
+});
+
+/**
+ * These routes activate subscriptions, attach custom domains and grant free Pro
+ * terms, and this secret is the only thing in front of them. JWT_SECRET is
+ * floored at 32 characters; this one had no floor, so a short operator-chosen
+ * value was accepted and could be guessed.
+ */
+describe('internal shared secret', () => {
+  it('accepts a secret of the required length', () => {
+    process.env.HOSTING_INTERNAL_SECRET = STRONG;
+
+    expect(internalSecret()).toBe(STRONG);
+    expect(internalSecretOk(STRONG)).toBe(true);
+  });
+
+  it('refuses a secret shorter than the floor, even when it matches', () => {
+    const weak = 'short-secret';
+    process.env.HOSTING_INTERNAL_SECRET = weak;
+
+    expect(internalSecret()).toBe(null);
+    expect(internalSecretOk(weak)).toBe(false);
+  });
+
+  it('refuses a secret one character below the floor', () => {
+    const almost = 'a'.repeat(MIN_INTERNAL_SECRET_LENGTH - 1);
+    process.env.HOSTING_INTERNAL_SECRET = almost;
+
+    expect(internalSecretOk(almost)).toBe(false);
+  });
+
+  it('fails closed when the secret is unset', () => {
+    delete process.env.HOSTING_INTERNAL_SECRET;
+
+    expect(internalSecret()).toBe(null);
+    expect(internalSecretOk('')).toBe(false);
+    expect(internalSecretOk(undefined)).toBe(false);
+    expect(internalSecretOk(STRONG)).toBe(false);
+  });
+
+  it('rejects a wrong secret of the right length', () => {
+    process.env.HOSTING_INTERNAL_SECRET = STRONG;
+
+    expect(internalSecretOk('b'.repeat(MIN_INTERNAL_SECRET_LENGTH))).toBe(false);
+  });
+
+  it('rejects a value that is merely a prefix of the secret', () => {
+    process.env.HOSTING_INTERNAL_SECRET = STRONG;
+
+    expect(internalSecretOk(STRONG.slice(0, -1))).toBe(false);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/routes/internal-secret.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal-secret.test.ts
@@ -57,6 +57,21 @@ describe('internal shared secret', () => {
     expect(internalSecretOk('b'.repeat(MIN_INTERNAL_SECRET_LENGTH))).toBe(false);
   });
 
+  it('rejects a multi-byte value of the same string length without throwing', () => {
+    // timingSafeEqual throws on a byte-length mismatch, and two strings of equal
+    // length can encode to different byte counts, which would turn a rejected
+    // secret into a 500 rather than a 403.
+    process.env.HOSTING_INTERNAL_SECRET = STRONG;
+    const sameLengthDifferentBytes = `${'a'.repeat(MIN_INTERNAL_SECRET_LENGTH - 1)}\u00e9`;
+
+    expect(sameLengthDifferentBytes.length).toBe(STRONG.length);
+    expect(Buffer.from(sameLengthDifferentBytes).length).not.toBe(
+      Buffer.from(STRONG).length,
+    );
+    expect(() => internalSecretOk(sameLengthDifferentBytes)).not.toThrow();
+    expect(internalSecretOk(sameLengthDifferentBytes)).toBe(false);
+  });
+
   it('rejects a value that is merely a prefix of the secret', () => {
     process.env.HOSTING_INTERNAL_SECRET = STRONG;
 

--- a/apps/self-hosted/hosting/api/src/routes/internal.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.test.ts
@@ -16,6 +16,9 @@ const mocks = vi.hoisted(() => ({
   addVerifiedDomainOrigin: vi.fn(),
 }));
 
+// Must satisfy MIN_INTERNAL_SECRET_LENGTH, which the routes now enforce.
+const INTERNAL_SECRET = 'test-internal-secret-of-32-chars!!';
+
 vi.mock('../db/client', () => ({
   db: { transaction: mocks.transaction },
 }));
@@ -62,7 +65,7 @@ const { internalRoutes } = await import('./internal');
 
 describe('POST /activate config publication', () => {
   beforeEach(() => {
-    process.env.HOSTING_INTERNAL_SECRET = 'test-secret';
+    process.env.HOSTING_INTERNAL_SECRET = INTERNAL_SECRET;
     mocks.transaction.mockReset().mockResolvedValue({
       status: 200,
       tenantId: 'tenant-1',
@@ -82,7 +85,7 @@ describe('POST /activate config publication', () => {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'x-internal-secret': 'test-secret',
+        'x-internal-secret': INTERNAL_SECRET,
       },
       body: JSON.stringify({
         username: 'alice',
@@ -163,7 +166,7 @@ describe('POST /activate config publication', () => {
 
 describe('internal endpoint audit trail', () => {
   beforeEach(() => {
-    process.env.HOSTING_INTERNAL_SECRET = 'test-secret';
+    process.env.HOSTING_INTERNAL_SECRET = INTERNAL_SECRET;
     mocks.transaction.mockReset().mockResolvedValue({
       status: 200,
       tenantId: 'tenant-1',
@@ -193,7 +196,7 @@ describe('internal endpoint audit trail', () => {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'x-internal-secret': 'test-secret',
+        'x-internal-secret': INTERNAL_SECRET,
         'x-forwarded-for': '203.0.113.9, 10.0.0.2',
         'user-agent': 'epoints-fulfillment/1.0',
       },

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -6,6 +6,7 @@
  */
 
 import { Hono, type Context } from 'hono';
+import { timingSafeEqual } from 'node:crypto';
 import { db } from '../db/client';
 import {
   TenantService,
@@ -65,13 +66,18 @@ export function internalSecret(): string | null {
 // Fails CLOSED when the secret is unset OR too short, so neither a missing value nor a
 // weak one can activate blogs. Rejecting rather than refusing to boot keeps an
 // otherwise healthy deploy serving; the startup log says which case applies.
+// Constant-time check of the shared service-to-service secret (ePoints -> hosting).
+// Fails CLOSED when the secret is unset OR too short, so neither a missing value nor a
+// weak one can activate blogs. Refusing rather than refusing to boot keeps an
+// otherwise healthy deploy serving; the startup log says which case applies.
 export function internalSecretOk(provided: string | undefined): boolean {
-  const secret = internalSecret() ?? '';
-  const given = provided || '';
+  const secret = Buffer.from(internalSecret() ?? '');
+  const given = Buffer.from(provided || '');
+  // Compared on BYTE length, not string length: timingSafeEqual throws on a
+  // mismatch, and two strings of equal length can encode to different byte
+  // counts, which would turn a rejected secret into a 500.
   if (secret.length === 0 || given.length !== secret.length) return false;
-  let diff = 0;
-  for (let i = 0; i < secret.length; i++) diff |= given.charCodeAt(i) ^ secret.charCodeAt(i);
-  return diff === 0;
+  return timingSafeEqual(given, secret);
 }
 
 // POST /v1/internal/activate - service-to-service activation (NOT public).

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -47,10 +47,26 @@ function auditInternal(
   });
 }
 
-// Constant-time check of the shared service-to-service secret (ePoints -> hosting).
-// Fails CLOSED when the secret is unset, so a misconfigured deploy cannot activate blogs.
-export function internalSecretOk(provided: string | undefined): boolean {
+/**
+ * These routes activate subscriptions, attach custom domains and grant free Pro
+ * terms, and the shared secret is the only thing in front of them. JWT_SECRET is
+ * already floored at 32 characters; this one had no requirement at all, so a
+ * short operator-chosen value was accepted.
+ */
+export const MIN_INTERNAL_SECRET_LENGTH = 32;
+
+/** The configured secret, or null when it is absent or too weak to accept. */
+export function internalSecret(): string | null {
   const secret = process.env.HOSTING_INTERNAL_SECRET || '';
+  return secret.length >= MIN_INTERNAL_SECRET_LENGTH ? secret : null;
+}
+
+// Constant-time check of the shared service-to-service secret (ePoints -> hosting).
+// Fails CLOSED when the secret is unset OR too short, so neither a missing value nor a
+// weak one can activate blogs. Rejecting rather than refusing to boot keeps an
+// otherwise healthy deploy serving; the startup log says which case applies.
+export function internalSecretOk(provided: string | undefined): boolean {
+  const secret = internalSecret() ?? '';
   const given = provided || '';
   if (secret.length === 0 || given.length !== secret.length) return false;
   let diff = 0;

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -64,12 +64,9 @@ export function internalSecret(): string | null {
 
 // Constant-time check of the shared service-to-service secret (ePoints -> hosting).
 // Fails CLOSED when the secret is unset OR too short, so neither a missing value nor a
-// weak one can activate blogs. Rejecting rather than refusing to boot keeps an
-// otherwise healthy deploy serving; the startup log says which case applies.
-// Constant-time check of the shared service-to-service secret (ePoints -> hosting).
-// Fails CLOSED when the secret is unset OR too short, so neither a missing value nor a
-// weak one can activate blogs. Refusing rather than refusing to boot keeps an
-// otherwise healthy deploy serving; the startup log says which case applies.
+// weak one can activate blogs. Rejecting the call rather than refusing to boot keeps an
+// otherwise healthy deploy serving the rest of its routes; the startup log distinguishes
+// "not configured" from "configured too weakly", which look identical from outside.
 export function internalSecretOk(provided: string | undefined): boolean {
   const secret = Buffer.from(internalSecret() ?? '');
   const given = Buffer.from(provided || '');

--- a/apps/self-hosted/hosting/api/src/routes/payments.ts
+++ b/apps/self-hosted/hosting/api/src/routes/payments.ts
@@ -3,6 +3,7 @@
  */
 
 import { Hono } from 'hono';
+import { internalSecret } from './internal';
 import { db } from '../db/client';
 import { authMiddleware, adminMiddleware } from '../middleware/auth';
 import { TenantService } from '../services/tenant-service';
@@ -24,9 +25,11 @@ paymentRoutes.get('/methods', async (c) => {
   const facilitator = process.env.X402_FACILITATOR_URL || '';
   // Card requires the internal secret (ePoints -> hosting activation). Without it, a paid
   // card order can only get a 403 from /v1/internal/activate, so never advertise the option.
+  // Asked through internalSecret() rather than by re-testing the variable, so that a secret
+  // the activation endpoint refuses is also one the signup UI does not offer: a value that
+  // is present but too weak would otherwise take the payment and fail the fulfilment.
   const cardEnabled =
-    (process.env.HOSTING_CARD_ENABLED || 'true') === 'true' &&
-    (process.env.HOSTING_INTERNAL_SECRET || '').length > 0;
+    (process.env.HOSTING_CARD_ENABLED || 'true') === 'true' && internalSecret() !== null;
   return c.json({
     hbd: {
       enabled: true,


### PR DESCRIPTION
> [!IMPORTANT]
> **Read the operational note before merging.** `HOSTING_INTERNAL_SECRET` comes from CI secrets and its current length is not visible from the repo. If it is under 32 characters, card activation stops working on deploy until it is rotated, on this side **and** on the ePoints side that sends it. Please check the value first; if it is short, rotate both before merging.

The `/v1/internal` routes activate subscriptions, attach custom domains and grant free Pro terms. They are reachable from the public internet through the api vhost, and the shared secret is the only thing in front of them.

## Rate limiting

They were deliberately excluded from the limiter, with a comment noting they are called by ePoints rather than end users. That is true of the intended caller, but not of an unintended one: the secret could be guessed online as fast as the network allowed, and each attempt opened a database transaction.

They now get their own bucket at 600 requests per minute per IP. That is far above anything fulfillment does, and far below what guessing needs. The limiter fails open on a Redis outage, which is the existing and correct trade-off for this API.

## Secret strength

`JWT_SECRET` is validated at 32 characters or longer. `HOSTING_INTERNAL_SECRET` had no requirement at all, so a short operator-chosen value was accepted.

A value below the floor is now refused exactly as an empty one is, so a weak secret cannot authorize anything. I chose to refuse rather than fail to boot: this API also serves tenant management and config saves, and taking it down entirely is a worse failure than disabling one rail. A startup line distinguishes "not configured" from "configured too weakly", which are otherwise indistinguishable from the outside since both simply reject every call.

## Verification

126 tests pass, typecheck clean. Mutation-checked rather than assumed: removing the strength floor fails two of the new tests.

Note the existing `internal.test.ts` fixture used an 11-character secret and had to be updated. That is the change doing its job, and it is the same signal the operational note above is about.

`.env.example` now states the requirement and that both sides must be rotated together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enforced a minimum 32-character length for the hosting internal secret.
  * Disabled internal routes and card payment availability when the secret is missing or too short.
  * Added rate limiting for internal endpoints.
  * Added startup warnings for invalid secret configuration.
  * Improved protection for secret verification.

* **Bug Fixes**
  * Prevented card payments from being advertised when internal authentication cannot succeed.

* **Documentation**
  * Documented secret-sharing and rotation requirements in the environment configuration example.

* **Tests**
  * Added coverage for secret validation, authentication, rate limiting, and card availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->