### PR TITLE
fix(self-hosted): make Hivesigner login possible, and sign HiveAuth ops with the right authority

### DIFF
--- a/apps/self-hosted/src/core/configuration-loader.ts
+++ b/apps/self-hosted/src/core/configuration-loader.ts
@@ -53,6 +53,14 @@ export interface InstanceConfig {
       imageProxy: string;
       profileBaseUrl: string;
       createPostUrl: string;
+    /**
+     * Optional per-instance Hivesigner app. The built-in client only has
+     * ecency.com origins registered, so a hosted blog cannot complete the OAuth
+     * flow with it; an owner who registers their own app names it here.
+     */
+    hivesigner?: {
+      clientId?: string;
+    };
       styles: {
         background: string;
       };

--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -3,6 +3,7 @@ import { InstanceConfigManager } from "./configuration-loader";
 // Translation keys used throughout the app
 type TranslationKey =
   | 'loading'
+  | 'hivesigner_login_failed'
   | 'loadingPost'
   | 'loadingMore'
   | 'postNotFound'
@@ -97,6 +98,7 @@ type Translations = Record<TranslationKey, string>;
 const translations: Record<string, Translations> = {
   en: {
     loading: "Loading...",
+    hivesigner_login_failed: 'Sign in could not be completed. Please try again.',
     loadingPost: "Loading post...",
     loadingMore: "Loading more posts...",
     postNotFound: "Post not found.",
@@ -189,6 +191,7 @@ const translations: Record<string, Translations> = {
   },
   es: {
     loading: 'Cargando...',
+    hivesigner_login_failed: 'No se pudo completar el inicio de sesión. Inténtalo de nuevo.',
     loadingPost: 'Cargando publicación...',
     loadingMore: 'Cargando más publicaciones...',
     postNotFound: 'Publicación no encontrada.',
@@ -280,6 +283,7 @@ const translations: Record<string, Translations> = {
   },
   de: {
     loading: 'Lädt...',
+    hivesigner_login_failed: 'Die Anmeldung konnte nicht abgeschlossen werden. Bitte versuche es erneut.',
     loadingPost: 'Beitrag wird geladen...',
     loadingMore: 'Weitere Beiträge laden...',
     postNotFound: 'Beitrag nicht gefunden.',
@@ -371,6 +375,7 @@ const translations: Record<string, Translations> = {
   },
   fr: {
     loading: "Chargement...",
+    hivesigner_login_failed: "La connexion n'a pas pu aboutir. Veuillez réessayer.",
     loadingPost: "Chargement de l'article...",
     loadingMore: "Chargement d'autres articles...",
     postNotFound: "Article non trouvé.",
@@ -463,6 +468,7 @@ const translations: Record<string, Translations> = {
   },
   ko: {
     loading: '로딩 중...',
+    hivesigner_login_failed: '로그인을 완료하지 못했습니다. 다시 시도해 주세요.',
     loadingPost: '게시물 로딩 중...',
     loadingMore: '더 많은 게시물 로딩 중...',
     postNotFound: '게시물을 찾을 수 없습니다.',
@@ -554,6 +560,7 @@ const translations: Record<string, Translations> = {
   },
   ru: {
     loading: 'Загрузка...',
+    hivesigner_login_failed: 'Не удалось завершить вход. Попробуйте ещё раз.',
     loadingPost: 'Загрузка поста...',
     loadingMore: 'Загрузка постов...',
     postNotFound: 'Пост не найден.',

--- a/apps/self-hosted/src/features/auth/auth-actions.ts
+++ b/apps/self-hosted/src/features/auth/auth-actions.ts
@@ -1,7 +1,9 @@
 "use client";
 
 import type { Operation } from "@ecency/sdk";
+import { InstanceConfigManager } from "@/core";
 import { authenticationStore } from "@/store";
+import { HIVESIGNER_REDIRECT_PATH } from "./constants";
 import type { AuthMethod, AuthUser } from "./types";
 import {
   clearHiveAuthSession,
@@ -20,7 +22,9 @@ import type { HiveExtensionId } from "./types";
 import {
   broadcastWithHivesigner,
   getHivesignerLoginUrl,
-} from "./utils/hivesigner";
+  createHivesignerState,
+  resolveHivesignerClientId,
+} from './utils/hivesigner';
 import { broadcastWithHiveAuth, loginWithHiveAuth } from "./utils/hive-auth";
 
 /**
@@ -96,9 +100,25 @@ export async function login(
  */
 export function loginWithHivesigner(): void {
   if (typeof window === "undefined") return;
-  const redirectUri = window.location.origin + window.location.pathname;
-  const loginUrl = getHivesignerLoginUrl(redirectUri);
-  window.location.href = loginUrl;
+
+  const clientId = resolveHivesignerClientId(
+    InstanceConfigManager.getConfigValue(
+      ({ configuration }) => configuration.general?.hivesigner?.clientId
+    )
+  );
+  // The provider hides the method when this is null, so getting here without a
+  // client means the picker was bypassed.
+  if (!clientId) return;
+
+  // A fixed path, so the redirect_uri is identical whichever page login started
+  // from and can actually be registered. The current pathname produced a
+  // different URI per page, none of which would match.
+  const redirectUri = window.location.origin + HIVESIGNER_REDIRECT_PATH;
+  window.location.href = getHivesignerLoginUrl(
+    redirectUri,
+    createHivesignerState(),
+    clientId
+  );
 }
 
 /**

--- a/apps/self-hosted/src/features/auth/auth-actions.ts
+++ b/apps/self-hosted/src/features/auth/auth-actions.ts
@@ -1,31 +1,34 @@
-"use client";
+'use client';
 
-import type { Operation } from "@ecency/sdk";
-import { InstanceConfigManager } from "@/core";
-import { authenticationStore } from "@/store";
-import { HIVESIGNER_REDIRECT_PATH } from "./constants";
-import type { AuthMethod, AuthUser } from "./types";
+import type { Operation } from '@ecency/sdk';
+import { InstanceConfigManager } from '@/core';
+import { authenticationStore } from '@/store';
+import { HIVESIGNER_REDIRECT_PATH } from './constants';
 import {
   clearHiveAuthSession,
   clearUser,
   saveHiveAuthSession,
   saveUser,
-} from "./storage";
+} from './storage';
+import type { AuthMethod, AuthUser, HiveExtensionId } from './types';
+import {
+  broadcastWithHiveAuth,
+  type HiveAuthKeyType,
+  loginWithHiveAuth,
+} from './utils/hive-auth';
 import {
   broadcastWithExtension,
   getDetectedExtensions,
   getPreferredExtensionId,
   setPreferredExtensionId,
   signBufferWithExtension,
-} from "./utils/hive-extensions";
-import type { HiveExtensionId } from "./types";
+} from './utils/hive-extensions';
 import {
   broadcastWithHivesigner,
-  getHivesignerLoginUrl,
   createHivesignerState,
+  getHivesignerLoginUrl,
   resolveHivesignerClientId,
 } from './utils/hivesigner';
-import { broadcastWithHiveAuth, loginWithHiveAuth } from "./utils/hive-auth";
 
 /**
  * Login with the given method and username.
@@ -41,17 +44,19 @@ export async function login(
   const { setUser, setSession } = authenticationStore.getState();
 
   switch (method) {
-    case "keychain": {
+    case 'keychain': {
       const chosen =
-        extension ?? getPreferredExtensionId(username) ?? getDetectedExtensions()[0]?.id;
+        extension ??
+        getPreferredExtensionId(username) ??
+        getDetectedExtensions()[0]?.id;
 
       // Prove control of a posting key by signing a throwaway challenge.
       const challenge = `Login to Ecency Blog: ${Date.now()}`;
-      await signBufferWithExtension(username, challenge, "Posting", chosen);
+      await signBufferWithExtension(username, challenge, 'Posting', chosen);
 
       const newUser: AuthUser = {
         username,
-        loginType: "keychain",
+        loginType: 'keychain',
         ...(chosen ? { extension: chosen } : {}),
       };
       setUser(newUser);
@@ -60,20 +65,20 @@ export async function login(
       break;
     }
 
-    case "hiveauth": {
+    case 'hiveauth': {
       await loginWithHiveAuth(username, {
         onQRCode: (qrData) => {
           window.dispatchEvent(
-            new CustomEvent("hiveauth:qrcode", { detail: qrData })
+            new CustomEvent('hiveauth:qrcode', { detail: qrData }),
           );
         },
         onWaiting: () => {
-          window.dispatchEvent(new CustomEvent("hiveauth:waiting"));
+          window.dispatchEvent(new CustomEvent('hiveauth:waiting'));
         },
         onSuccess: (session) => {
           const newUser: AuthUser = {
             username,
-            loginType: "hiveauth",
+            loginType: 'hiveauth',
             expiresAt: session.expire * 1000,
           };
           setUser(newUser);
@@ -83,15 +88,17 @@ export async function login(
         },
         onError: (error) => {
           window.dispatchEvent(
-            new CustomEvent("hiveauth:error", { detail: error })
+            new CustomEvent('hiveauth:error', { detail: error }),
           );
         },
       });
       break;
     }
 
-    case "hivesigner":
-      throw new Error("Use loginWithHivesigner() for the hivesigner OAuth flow");
+    case 'hivesigner':
+      throw new Error(
+        'Use loginWithHivesigner() for the hivesigner OAuth flow',
+      );
   }
 }
 
@@ -99,12 +106,12 @@ export async function login(
  * Redirect to Hivesigner for login.
  */
 export function loginWithHivesigner(): void {
-  if (typeof window === "undefined") return;
+  if (typeof window === 'undefined') return;
 
   const clientId = resolveHivesignerClientId(
     InstanceConfigManager.getConfigValue(
-      ({ configuration }) => configuration.general?.hivesigner?.clientId
-    )
+      ({ configuration }) => configuration.general?.hivesigner?.clientId,
+    ),
   );
   // The provider hides the method when this is null, so getting here without a
   // client means the picker was bypassed.
@@ -117,7 +124,7 @@ export function loginWithHivesigner(): void {
   window.location.href = getHivesignerLoginUrl(
     redirectUri,
     createHivesignerState(),
-    clientId
+    clientId,
   );
 }
 
@@ -132,7 +139,15 @@ export function logout(): void {
   clearHiveAuthSession();
 }
 
-export type BroadcastAuthorityType = "Active" | "Posting" | "Owner" | "Memo";
+export type BroadcastAuthorityType = 'Active' | 'Posting' | 'Owner' | 'Memo';
+
+/** The same authority, in the casing each wallet protocol expects. */
+const HIVE_AUTH_KEY_TYPE: Record<BroadcastAuthorityType, HiveAuthKeyType> = {
+  Active: 'active',
+  Posting: 'posting',
+  Owner: 'owner',
+  Memo: 'memo',
+};
 
 /**
  * Broadcast operations using the current user's auth method.
@@ -141,33 +156,51 @@ export type BroadcastAuthorityType = "Active" | "Posting" | "Owner" | "Memo";
  */
 export async function broadcast(
   operations: Operation[],
-  options?: { authorityType?: BroadcastAuthorityType }
+  options?: { authorityType?: BroadcastAuthorityType },
 ): Promise<unknown> {
   const { user, session } = authenticationStore.getState();
 
   if (!user) {
-    throw new Error("Not authenticated");
+    throw new Error('Not authenticated');
   }
 
-  const authorityType = options?.authorityType ?? "Posting";
+  const authorityType = options?.authorityType ?? 'Posting';
 
   switch (user.loginType) {
-    case "keychain":
+    case 'keychain':
       // Routes through the extension this account logged in with (Keeper,
       // Keychain or Peak Vault), falling back to the best available one.
-      return broadcastWithExtension(user.username, operations, authorityType, user.extension);
+      return broadcastWithExtension(
+        user.username,
+        operations,
+        authorityType,
+        user.extension,
+      );
 
-    case "hivesigner":
+    case 'hivesigner':
       if (!user.accessToken) {
-        throw new Error("No access token available");
+        throw new Error('No access token available');
+      }
+      // The token is issued for vote, comment and custom_json, which are all
+      // posting level. Anything needing active authority is refused here rather
+      // than by the chain, which reports it as a generic transaction failure
+      // that tells the author nothing about why their tip did not send.
+      if (authorityType !== 'Posting') {
+        throw new Error(
+          `Hivesigner cannot sign with ${authorityType.toLowerCase()} authority. Sign in with Keychain or HiveAuth to do this.`,
+        );
       }
       return broadcastWithHivesigner(user.accessToken, operations);
 
-    case "hiveauth":
+    case 'hiveauth':
       if (!session) {
-        throw new Error("No HiveAuth session available");
+        throw new Error('No HiveAuth session available');
       }
-      return broadcastWithHiveAuth(session, operations);
+      return broadcastWithHiveAuth(
+        session,
+        operations,
+        HIVE_AUTH_KEY_TYPE[authorityType],
+      );
 
     default:
       throw new Error(`Unknown login type: ${user.loginType}`);

--- a/apps/self-hosted/src/features/auth/auth-provider.tsx
+++ b/apps/self-hosted/src/features/auth/auth-provider.tsx
@@ -12,8 +12,7 @@ import {
 import { clearHiveAuthSession, clearUser, saveUser } from "./storage";
 import type { AuthContextValue, AuthMethod, AuthUser } from "./types";
 import {
-  isHivesignerCallback,
-  parseHivesignerCallback,
+  resolveHivesignerClientId,
 } from "./utils/hivesigner";
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -31,7 +30,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
   );
 
   const isAuthEnabled = authConfig?.enabled ?? false;
-  const availableMethods = (authConfig?.methods ?? []) as AuthMethod[];
+  const hivesignerClientId = resolveHivesignerClientId(
+    InstanceConfigManager.getConfigValue(
+      ({ configuration }) => configuration.general?.hivesigner?.clientId
+    )
+  );
+
+  // Configured methods, minus any this instance cannot actually complete.
+  // Offering a method that always fails sends the visitor into an error with no
+  // explanation: Hivesigner rejects a redirect_uri its app has not registered,
+  // and a hosted blog's origin cannot be registered in advance, so it is offered
+  // only when the instance names a client of its own.
+  const availableMethods = ((authConfig?.methods ?? []) as AuthMethod[]).filter(
+    (method) => (method === "hivesigner" ? hivesignerClientId !== null : true)
+  );
 
   // Get the instance owner. Falls back to the showcased username for older
   // configs that predate the `owner` field (blog instances where the owner and
@@ -74,28 +86,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     return () => clearInterval(interval);
   }, [user?.expiresAt]);
 
-  // Handle Hivesigner callback
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-
-    const search = window.location.search;
-    if (isHivesignerCallback(search)) {
-      const callbackData = parseHivesignerCallback(search);
-      if (callbackData) {
-        const newUser: AuthUser = {
-          username: callbackData.username,
-          accessToken: callbackData.accessToken,
-          loginType: "hivesigner",
-          expiresAt: Date.now() + callbackData.expiresIn * 1000,
-        };
-        setUser(newUser);
-        saveUser(newUser);
-
-        // Clean up URL
-        window.history.replaceState({}, "", window.location.pathname);
-      }
-    }
-  }, []);
+  // The Hivesigner callback is handled by the /auth route, not here. Running it
+  // on every route meant any page carrying ?access_token=&username= counted as a
+  // completed login, which treated URL input as a credential.
 
   // Check if session is expiring within 5 minutes
   const isSessionExpiringSoon = useMemo(() => {

--- a/apps/self-hosted/src/features/auth/auth-provider.tsx
+++ b/apps/self-hosted/src/features/auth/auth-provider.tsx
@@ -1,19 +1,11 @@
-"use client";
+'use client';
 
-import { InstanceConfigManager } from "@/core";
-import { useAuthStore } from "@/store";
-import {
-  createContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from "react";
-import { clearHiveAuthSession, clearUser, saveUser } from "./storage";
-import type { AuthContextValue, AuthMethod, AuthUser } from "./types";
-import {
-  resolveHivesignerClientId,
-} from "./utils/hivesigner";
+import { createContext, type ReactNode, useEffect, useMemo } from 'react';
+import { InstanceConfigManager } from '@/core';
+import { useAuthStore } from '@/store';
+import { clearHiveAuthSession, clearUser } from './storage';
+import type { AuthContextValue, AuthMethod, AuthUser } from './types';
+import { resolveHivesignerClientId } from './utils/hivesigner';
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
 
@@ -26,14 +18,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   // Get auth config
   const authConfig = InstanceConfigManager.getConfigValue(
-    ({ configuration }) => configuration.instanceConfiguration.features.auth
+    ({ configuration }) => configuration.instanceConfiguration.features.auth,
   );
 
   const isAuthEnabled = authConfig?.enabled ?? false;
   const hivesignerClientId = resolveHivesignerClientId(
     InstanceConfigManager.getConfigValue(
-      ({ configuration }) => configuration.general?.hivesigner?.clientId
-    )
+      ({ configuration }) => configuration.general?.hivesigner?.clientId,
+    ),
   );
 
   // Configured methods, minus any this instance cannot actually complete.
@@ -42,7 +34,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // and a hosted blog's origin cannot be registered in advance, so it is offered
   // only when the instance names a client of its own.
   const availableMethods = ((authConfig?.methods ?? []) as AuthMethod[]).filter(
-    (method) => (method === "hivesigner" ? hivesignerClientId !== null : true)
+    (method) => (method === 'hivesigner' ? hivesignerClientId !== null : true),
   );
 
   // Get the instance owner. Falls back to the showcased username for older
@@ -52,14 +44,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const blogOwner = InstanceConfigManager.getConfigValue(
     ({ configuration }) =>
       configuration.instanceConfiguration.owner ||
-      configuration.instanceConfiguration.username
+      configuration.instanceConfiguration.username,
   );
 
   // Check if current user is the instance owner
   const isBlogOwner = useMemo(() => {
     if (!user || !blogOwner) return false;
     return (
-      (user.username ?? "").toLowerCase() === (blogOwner ?? "").toLowerCase()
+      (user.username ?? '').toLowerCase() === (blogOwner ?? '').toLowerCase()
     );
   }, [user, blogOwner]);
 
@@ -106,7 +98,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       isBlogOwner,
       isSessionExpiringSoon,
     }),
-    [user, isAuthEnabled, availableMethods, isBlogOwner, isSessionExpiringSoon]
+    [user, isAuthEnabled, availableMethods, isBlogOwner, isSessionExpiringSoon],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/self-hosted/src/features/auth/broadcast-authority-routing.test.ts
+++ b/apps/self-hosted/src/features/auth/broadcast-authority-routing.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  hiveAuth: vi.fn(),
+  hivesigner: vi.fn(),
+  extension: vi.fn(),
+  state: { user: undefined as unknown, session: { token: 't' } },
+}));
+
+vi.mock('./utils/hive-auth', () => ({
+  broadcastWithHiveAuth: mocks.hiveAuth,
+  loginWithHiveAuth: vi.fn(),
+}));
+vi.mock('./utils/hivesigner', () => ({
+  broadcastWithHivesigner: mocks.hivesigner,
+  getHivesignerLoginUrl: vi.fn(),
+  createHivesignerState: vi.fn(),
+  resolveHivesignerClientId: vi.fn(),
+}));
+vi.mock('./utils/hive-extensions', () => ({
+  broadcastWithExtension: mocks.extension,
+  getDetectedExtensions: vi.fn(() => []),
+  getPreferredExtensionId: vi.fn(),
+  setPreferredExtensionId: vi.fn(),
+  signBufferWithExtension: vi.fn(),
+}));
+vi.mock('@/store', () => ({
+  authenticationStore: { getState: () => mocks.state },
+  useAuthStore: { getState: () => mocks.state },
+}));
+vi.mock('@/core', () => ({
+  InstanceConfigManager: { getConfigValue: () => undefined },
+  t: (k: string) => k,
+}));
+
+const { broadcast } = await import('./auth-actions');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/**
+ * The chain rejects a transfer signed with posting authority, so an authority
+ * dropped anywhere on the way to the wallet turns into a generic "Transaction
+ * failed" that tells the author nothing.
+ */
+describe('broadcast authority routing', () => {
+  it('asks HiveAuth for the active key when the operation needs it', async () => {
+    mocks.state.user = { username: 'alice', loginType: 'hiveauth' };
+
+    await broadcast([], { authorityType: 'Active' });
+
+    expect(mocks.hiveAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      [],
+      'active',
+    );
+  });
+
+  it('defaults HiveAuth to posting when nothing is asked for', async () => {
+    mocks.state.user = { username: 'alice', loginType: 'hiveauth' };
+
+    await broadcast([]);
+
+    expect(mocks.hiveAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      [],
+      'posting',
+    );
+  });
+
+  /**
+   * The Hivesigner token is scoped to vote, comment and custom_json. Sending an
+   * active operation anyway produced a generic chain failure, so it is refused
+   * here with a message that names the fix.
+   */
+  it('refuses an active operation over Hivesigner instead of failing at the chain', async () => {
+    mocks.state.user = {
+      username: 'alice',
+      loginType: 'hivesigner',
+      accessToken: 'tok',
+    };
+
+    await expect(broadcast([], { authorityType: 'Active' })).rejects.toThrow(
+      /active authority/,
+    );
+    expect(mocks.hivesigner).not.toHaveBeenCalled();
+  });
+
+  it('still allows posting operations over Hivesigner', async () => {
+    mocks.state.user = {
+      username: 'alice',
+      loginType: 'hivesigner',
+      accessToken: 'tok',
+    };
+
+    await broadcast([], { authorityType: 'Posting' });
+
+    expect(mocks.hivesigner).toHaveBeenCalledWith('tok', []);
+  });
+});

--- a/apps/self-hosted/src/features/auth/constants.ts
+++ b/apps/self-hosted/src/features/auth/constants.ts
@@ -6,7 +6,14 @@ export const HIVEAUTH_KEY = 'ecency_selfhost_hiveauth';
 export const HIVESIGNER_CLIENT_ID = 'ecency.app';
 export const HIVESIGNER_OAUTH_URL = 'https://hivesigner.com/oauth2/authorize';
 export const HIVESIGNER_TOKEN_URL = 'https://hivesigner.com/api/oauth2/token';
+export const HIVESIGNER_ME_URL = 'https://hivesigner.com/api/me';
 export const HIVESIGNER_SCOPE = 'vote,comment,custom_json';
+// A FIXED path, not the page login started from. OAuth matches redirect_uri
+// exactly, so sending origin + pathname produced a different URI per page and
+// none of them could realistically be registered on the app.
+export const HIVESIGNER_REDIRECT_PATH = '/auth';
+/** sessionStorage key holding the OAuth state nonce for the in-flight login. */
+export const HIVESIGNER_STATE_KEY = 'ecency_selfhost_hs_state';
 
 // HiveAuth
 export const HIVEAUTH_API = 'wss://hiveauth.arcange.eu';

--- a/apps/self-hosted/src/features/auth/utils/hive-auth.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-auth.ts
@@ -329,15 +329,23 @@ function hiveAuthSignRequest(
   });
 }
 
+/** Authorities HiveAuth can be asked to sign with. */
+export type HiveAuthKeyType = 'posting' | 'active' | 'owner' | 'memo';
+
 /**
  * Broadcast operations with HiveAuth
  */
 export async function broadcastWithHiveAuth(
   session: HiveAuthSession,
   operations: Operation[],
+  keyType: HiveAuthKeyType = 'posting',
   callbacks?: HiveAuthSignCallback
 ): Promise<void> {
-  await hiveAuthSignRequest(session, operations, { keyType: 'posting', broadcast: true }, callbacks);
+  // The authority is the caller's to choose. Hardcoding 'posting' meant an
+  // active operation - a transfer, a tip, a custom_json with required_auths -
+  // asked the wallet for the posting key, and the chain rejects a transfer
+  // signed with posting authority.
+  await hiveAuthSignRequest(session, operations, { keyType, broadcast: true }, callbacks);
 }
 
 /**

--- a/apps/self-hosted/src/features/auth/utils/hivesigner-callback.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/hivesigner-callback.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HIVESIGNER_STATE_KEY } from '../constants';
+import {
+  completeHivesignerCallback,
+  resetHivesignerCallbackCache,
+} from './hivesigner-callback';
+
+function meResponds(name: string | undefined, ok = true) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok,
+      json: async () => (name ? { account: { name } } : {}),
+    })),
+  );
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  resetHivesignerCallbackCache();
+  vi.unstubAllGlobals();
+  arriveAtCallback();
+});
+
+const CALLBACK = '?access_token=tok&username=alice&expires_in=604800&state=n1';
+
+/** Arrive at /auth as the OAuth redirect would. */
+function arriveAtCallback() {
+  window.history.replaceState({}, '', `/auth${CALLBACK}`);
+}
+
+describe('hivesigner callback', () => {
+  it('completes when the nonce matches and the token is alice', async () => {
+    sessionStorage.setItem(HIVESIGNER_STATE_KEY, 'n1');
+    meResponds('alice');
+
+    const outcome = await completeHivesignerCallback();
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome.ok && outcome.user.username).toBe('alice');
+  });
+
+  /**
+   * StrictMode runs an effect's setup, cleanup and setup again on mount. The
+   * nonce is consumed on the first run, so a second attempt would find it gone
+   * and reject a valid login. Both calls must produce the same session.
+   */
+  it('survives the callback being handled twice for the same URL', async () => {
+    sessionStorage.setItem(HIVESIGNER_STATE_KEY, 'n1');
+    meResponds('alice');
+
+    const [first, second] = await Promise.all([
+      completeHivesignerCallback(),
+      completeHivesignerCallback(),
+    ]);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+  });
+
+  it('still rejects a replay after a reload, when the nonce is gone', async () => {
+    sessionStorage.setItem(HIVESIGNER_STATE_KEY, 'n1');
+    meResponds('alice');
+    await completeHivesignerCallback();
+
+    // A fresh page load: module state empty, nonce already consumed.
+    resetHivesignerCallbackCache();
+    arriveAtCallback();
+
+    expect((await completeHivesignerCallback()).ok).toBe(false);
+  });
+
+  it('refuses an unsolicited token with no nonce of ours', async () => {
+    meResponds('mallory');
+
+    expect((await completeHivesignerCallback()).ok).toBe(false);
+  });
+
+  it('refuses a valid token presented for someone else', async () => {
+    sessionStorage.setItem(HIVESIGNER_STATE_KEY, 'n1');
+    meResponds('mallory');
+
+    expect((await completeHivesignerCallback()).ok).toBe(false);
+  });
+
+  it('refuses when the identity endpoint cannot confirm the account', async () => {
+    sessionStorage.setItem(HIVESIGNER_STATE_KEY, 'n1');
+    meResponds(undefined, false);
+
+    expect((await completeHivesignerCallback()).ok).toBe(false);
+  });
+
+  it('strips the token from the address bar even when it is refused', async () => {
+    meResponds('mallory');
+
+    // No nonce, so this is refused.
+    expect((await completeHivesignerCallback()).ok).toBe(false);
+    expect(window.location.search).toBe('');
+  });
+});

--- a/apps/self-hosted/src/features/auth/utils/hivesigner-callback.ts
+++ b/apps/self-hosted/src/features/auth/utils/hivesigner-callback.ts
@@ -1,0 +1,76 @@
+import type { AuthUser } from '../types';
+import {
+  consumeHivesignerState,
+  parseHivesignerCallback,
+  verifyHivesignerToken,
+} from './hivesigner';
+
+export type CallbackOutcome = { ok: true; user: AuthUser } | { ok: false };
+
+/** The one attempt this page load makes at the callback it was opened with. */
+let attempt: Promise<CallbackOutcome> | null = null;
+
+/** Test seam: the module state otherwise leaks between cases. */
+export function resetHivesignerCallbackCache(): void {
+  attempt = null;
+}
+
+/**
+ * Turn the callback this page was opened with into a session, or refuse it.
+ *
+ * Both checks fail closed. The state nonce proves the login started in this tab,
+ * without which a crafted link would sign the visitor in as whoever the token
+ * belongs to. Verifying the token against the account it claims stops a valid
+ * token for one account being presented as another.
+ *
+ * Reaching /auth is always a fresh page load, since login leaves through
+ * window.location, so one attempt per module lifetime is the whole story. It has
+ * to be exactly one: the nonce can only be consumed once, and StrictMode replays
+ * an effect's setup on mount, so a second attempt would find the nonce gone and
+ * reject a valid login. Sharing the attempt does not weaken the protection, as
+ * the nonce is still taken from sessionStorage exactly once.
+ */
+export function completeHivesignerCallback(): Promise<CallbackOutcome> {
+  if (attempt) {
+    return attempt;
+  }
+
+  const search = window.location.search;
+
+  // Before any validation, and whatever the outcome. Rejecting a token stops it
+  // becoming a session here, but it does not stop it being a live credential, so
+  // it must not be left sitting in the address bar or in browser history.
+  window.history.replaceState({}, '', window.location.pathname);
+
+  attempt = (async (): Promise<CallbackOutcome> => {
+    const params = new URLSearchParams(search);
+    const callback = parseHivesignerCallback(search);
+
+    // Consumed unconditionally so a failed attempt cannot be replayed.
+    const stateOk = consumeHivesignerState(params.get('state'));
+
+    if (!callback || !stateOk) {
+      return { ok: false };
+    }
+
+    const verified = await verifyHivesignerToken(
+      callback.accessToken,
+      callback.username,
+    );
+    if (!verified) {
+      return { ok: false };
+    }
+
+    return {
+      ok: true,
+      user: {
+        username: callback.username,
+        accessToken: callback.accessToken,
+        loginType: 'hivesigner',
+        expiresAt: Date.now() + callback.expiresIn * 1000,
+      },
+    };
+  })();
+
+  return attempt;
+}

--- a/apps/self-hosted/src/features/auth/utils/hivesigner.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/hivesigner.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  consumeHivesignerState,
+  createHivesignerState,
+  resolveHivesignerClientId,
+  getHivesignerLoginUrl,
+  verifyHivesignerToken,
+} = await import('./hivesigner');
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+/**
+ * OAuth matches redirect_uri exactly, and ecency.app registers only ecency.com
+ * origins, so the built-in client can never complete a login on a hosted blog.
+ * Offering the button anyway sends the visitor to an error page.
+ */
+describe('hivesigner availability', () => {
+  it('reports unavailable when the instance has no client of its own', () => {
+    expect(resolveHivesignerClientId(undefined)).toBe(null);
+  });
+
+  it('reports available once the owner names their registered app', () => {
+    expect(resolveHivesignerClientId('myblog.app')).toBe('myblog.app');
+  });
+
+  it('ignores a blank or non-string client id', () => {
+    expect(resolveHivesignerClientId('   ')).toBe(null);
+    expect(resolveHivesignerClientId(42)).toBe(null);
+    expect(resolveHivesignerClientId(null)).toBe(null);
+  });
+});
+
+describe('login url', () => {
+  it('carries the configured client and the state nonce', () => {
+    const url = new URL(
+      getHivesignerLoginUrl(
+        'https://myblog.com/auth',
+        'nonce123',
+        'myblog.app',
+      ),
+    );
+
+    expect(url.searchParams.get('client_id')).toBe('myblog.app');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'https://myblog.com/auth',
+    );
+    expect(url.searchParams.get('state')).toBe('nonce123');
+  });
+});
+
+/**
+ * Without the nonce, any page load carrying ?access_token=&username= was a
+ * completed login, so a crafted link signed the visitor in as someone else.
+ */
+describe('state nonce', () => {
+  it('accepts only the value this tab issued, and only once', () => {
+    const issued = createHivesignerState();
+
+    expect(consumeHivesignerState(issued)).toBe(true);
+    // Consumed, so a replay of the same callback fails.
+    expect(consumeHivesignerState(issued)).toBe(false);
+  });
+
+  it('rejects a mismatched or absent state', () => {
+    createHivesignerState();
+    expect(consumeHivesignerState('someone-elses-nonce')).toBe(false);
+
+    createHivesignerState();
+    expect(consumeHivesignerState(null)).toBe(false);
+  });
+
+  it('rejects any state when this tab never started a login', () => {
+    expect(consumeHivesignerState('anything')).toBe(false);
+  });
+});
+
+describe('token verification', () => {
+  const fetchMock = (body: unknown, ok = true) =>
+    vi.fn(async () => ({
+      ok,
+      json: async () => body,
+    })) as unknown as typeof fetch;
+
+  it('accepts a token whose account matches the claimed username', async () => {
+    globalThis.fetch = fetchMock({ account: { name: 'alice' } });
+    expect(await verifyHivesignerToken('tok', 'alice')).toBe(true);
+  });
+
+  it('rejects a token belonging to a different account', async () => {
+    // The attack: a valid token for someone else, handed over in a link.
+    globalThis.fetch = fetchMock({ account: { name: 'attacker' } });
+    expect(await verifyHivesignerToken('tok', 'alice')).toBe(false);
+  });
+
+  it('rejects when the token is not accepted at all', async () => {
+    globalThis.fetch = fetchMock({}, false);
+    expect(await verifyHivesignerToken('tok', 'alice')).toBe(false);
+  });
+
+  it('fails closed when the check cannot be made', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('offline');
+    }) as unknown as typeof fetch;
+    expect(await verifyHivesignerToken('tok', 'alice')).toBe(false);
+  });
+});

--- a/apps/self-hosted/src/features/auth/utils/hivesigner.ts
+++ b/apps/self-hosted/src/features/auth/utils/hivesigner.ts
@@ -1,16 +1,92 @@
 import type { Operation } from '@ecency/sdk';
 import {
   HIVESIGNER_CLIENT_ID,
+  HIVESIGNER_ME_URL,
   HIVESIGNER_OAUTH_URL,
   HIVESIGNER_SCOPE,
+  HIVESIGNER_STATE_KEY,
 } from '../constants';
+
+/**
+ * Resolve the Hivesigner app this instance should use, or null when it has none.
+ *
+ * Kept pure and given the configured value rather than reading config itself, so
+ * the rule lives in one place and can be tested without the config module.
+ *
+ * OAuth rejects a redirect_uri the app has not registered, and a hosted blog's
+ * origin cannot be registered in advance, so the built-in ecency.app client can
+ * never complete a login on a tenant domain. Treated as absent rather than
+ * pretending: offering the button sends the visitor to an error with no
+ * explanation.
+ */
+export function resolveHivesignerClientId(configured: unknown): string | null {
+  if (typeof configured === 'string' && configured.trim() !== '') {
+    return configured.trim();
+  }
+  return HIVESIGNER_CLIENT_ID === 'ecency.app' ? null : HIVESIGNER_CLIENT_ID;
+}
+
+/** A single-use nonce tying a callback back to the login this tab started. */
+export function createHivesignerState(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const state = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join(
+    '',
+  );
+  sessionStorage.setItem(HIVESIGNER_STATE_KEY, state);
+  return state;
+}
+
+/** True when `state` matches the nonce this tab issued, consuming it either way. */
+export function consumeHivesignerState(state: string | null): boolean {
+  const expected = sessionStorage.getItem(HIVESIGNER_STATE_KEY);
+  sessionStorage.removeItem(HIVESIGNER_STATE_KEY);
+  return !!expected && !!state && expected === state;
+}
+
+/**
+ * Confirm the token really belongs to the claimed account.
+ *
+ * The callback is URL input: without this a crafted link carrying someone
+ * else's valid token logs the visitor in as that account, and everything they
+ * then write is attributed to it.
+ */
+export async function verifyHivesignerToken(
+  accessToken: string,
+  username: string,
+): Promise<boolean> {
+  try {
+    const response = await fetch(HIVESIGNER_ME_URL, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!response.ok) return false;
+
+    const body = (await response.json()) as {
+      account?: { name?: string };
+      user?: string;
+      _id?: string;
+    };
+    const resolved = body.account?.name || body.user || body._id;
+    return (
+      typeof resolved === 'string' &&
+      resolved.toLowerCase() === username.toLowerCase()
+    );
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Generate Hivesigner OAuth URL
  */
-export function getHivesignerLoginUrl(redirectUri: string, state?: string): string {
+export function getHivesignerLoginUrl(
+  redirectUri: string,
+  state: string,
+  clientId: string,
+): string {
   const params = new URLSearchParams({
-    client_id: HIVESIGNER_CLIENT_ID,
+    client_id: clientId,
     redirect_uri: redirectUri,
     scope: HIVESIGNER_SCOPE,
   });
@@ -23,19 +99,10 @@ export function getHivesignerLoginUrl(redirectUri: string, state?: string): stri
 }
 
 /**
- * Redirect to Hivesigner for login
- */
-export function redirectToHivesigner(redirectUri?: string): void {
-  const currentUrl = redirectUri || window.location.href;
-  const loginUrl = getHivesignerLoginUrl(currentUrl);
-  window.location.href = loginUrl;
-}
-
-/**
  * Parse Hivesigner callback parameters
  */
 export function parseHivesignerCallback(
-  search: string
+  search: string,
 ): { accessToken: string; username: string; expiresIn: number } | null {
   const params = new URLSearchParams(search);
 
@@ -59,7 +126,7 @@ export function parseHivesignerCallback(
  */
 export async function broadcastWithHivesigner(
   accessToken: string,
-  operations: Operation[]
+  operations: Operation[],
 ): Promise<unknown> {
   // Dynamic import to avoid bundling hivesigner if not used
   const hs = await import('hivesigner');

--- a/apps/self-hosted/src/providers/sdk/broadcast-adapter.ts
+++ b/apps/self-hosted/src/providers/sdk/broadcast-adapter.ts
@@ -100,15 +100,18 @@ export function createBroadcastAdapter(): PlatformAdapter {
     async broadcastWithHiveAuth(
       username: string,
       ops: Operation[],
-      _keyType: "posting" | "active" | "owner" | "memo"
+      keyType: "posting" | "active" | "owner" | "memo"
     ): Promise<TransactionConfirmation> {
       const { session } = authenticationStore.getState();
       if (!session) {
         throw new Error("No HiveAuth session available");
       }
 
+      // The requested authority is passed on. Dropping it made every HiveAuth
+      // broadcast ask for the posting key, so an active operation such as a tip
+      // transfer was signed with the wrong authority and rejected by the chain.
       // broadcastWithHiveAuth returns void (broadcast happens server-side)
-      await broadcastWithHiveAuth(session, ops);
+      await broadcastWithHiveAuth(session, ops, keyType);
 
       // HiveAuth broadcasts server-side and doesn't return tx confirmation
       return {} as TransactionConfirmation;

--- a/apps/self-hosted/src/providers/sdk/broadcast-authority.test.ts
+++ b/apps/self-hosted/src/providers/sdk/broadcast-authority.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  broadcastWithHiveAuth: vi.fn(),
+  getState: vi.fn(() => ({ session: { username: 'alice', token: 't', expire: 0, key: 'k' } })),
+}));
+
+vi.mock('../../features/auth/utils/hive-auth', () => ({
+  broadcastWithHiveAuth: mocks.broadcastWithHiveAuth,
+}));
+
+// Relative paths: the alias form does not intercept the source imports.
+vi.mock('../../store', () => ({
+  authenticationStore: { getState: mocks.getState },
+  useAuthStore: { getState: mocks.getState },
+}));
+
+vi.mock('../../core', () => ({
+  InstanceConfigManager: { getConfigValue: () => undefined },
+  t: (k: string) => k,
+}));
+
+const { createBroadcastAdapter } = await import('./broadcast-adapter');
+
+/**
+ * The chain rejects a transfer signed with posting authority, so dropping the
+ * requested key type made every active operation through HiveAuth fail: tips,
+ * transfers, and any custom_json carrying required_auths.
+ */
+describe('HiveAuth broadcast authority', () => {
+  it('passes the requested authority through', async () => {
+    const adapter = createBroadcastAdapter();
+
+    await adapter.broadcastWithHiveAuth?.('alice', [], 'active');
+
+    expect(mocks.broadcastWithHiveAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      [],
+      'active',
+    );
+  });
+
+  it('passes posting through unchanged for posting operations', async () => {
+    mocks.broadcastWithHiveAuth.mockClear();
+    const adapter = createBroadcastAdapter();
+
+    await adapter.broadcastWithHiveAuth?.('alice', [], 'posting');
+
+    expect(mocks.broadcastWithHiveAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      [],
+      'posting',
+    );
+  });
+});

--- a/apps/self-hosted/src/routeTree.gen.ts
+++ b/apps/self-hosted/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SearchRouteImport } from './routes/search'
 import { Route as PublishRouteImport } from './routes/publish'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as HostingRouteImport } from './routes/hosting'
+import { Route as AuthRouteImport } from './routes/auth'
 import { Route as BlogRouteRouteImport } from './routes/blog/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthorPermlinkRouteImport } from './routes/$author.$permlink'
@@ -37,6 +38,11 @@ const LoginRoute = LoginRouteImport.update({
 const HostingRoute = HostingRouteImport.update({
   id: '/hosting',
   path: '/hosting',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthRoute = AuthRouteImport.update({
+  id: '/auth',
+  path: '/auth',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BlogRouteRoute = BlogRouteRouteImport.update({
@@ -68,6 +74,7 @@ const CategoryAuthorPermlinkRoute = CategoryAuthorPermlinkRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/blog': typeof BlogRouteRoute
+  '/auth': typeof AuthRoute
   '/hosting': typeof HostingRoute
   '/login': typeof LoginRoute
   '/publish': typeof PublishRoute
@@ -79,6 +86,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/blog': typeof BlogRouteRoute
+  '/auth': typeof AuthRoute
   '/hosting': typeof HostingRoute
   '/login': typeof LoginRoute
   '/publish': typeof PublishRoute
@@ -91,6 +99,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/blog': typeof BlogRouteRoute
+  '/auth': typeof AuthRoute
   '/hosting': typeof HostingRoute
   '/login': typeof LoginRoute
   '/publish': typeof PublishRoute
@@ -104,6 +113,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/blog'
+    | '/auth'
     | '/hosting'
     | '/login'
     | '/publish'
@@ -115,6 +125,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/blog'
+    | '/auth'
     | '/hosting'
     | '/login'
     | '/publish'
@@ -126,6 +137,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/blog'
+    | '/auth'
     | '/hosting'
     | '/login'
     | '/publish'
@@ -138,6 +150,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   BlogRouteRoute: typeof BlogRouteRoute
+  AuthRoute: typeof AuthRoute
   HostingRoute: typeof HostingRoute
   LoginRoute: typeof LoginRoute
   PublishRoute: typeof PublishRoute
@@ -175,6 +188,13 @@ declare module '@tanstack/react-router' {
       path: '/hosting'
       fullPath: '/hosting'
       preLoaderRoute: typeof HostingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth': {
+      id: '/auth'
+      path: '/auth'
+      fullPath: '/auth'
+      preLoaderRoute: typeof AuthRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog': {
@@ -218,6 +238,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BlogRouteRoute: BlogRouteRoute,
+  AuthRoute: AuthRoute,
   HostingRoute: HostingRoute,
   LoginRoute: LoginRoute,
   PublishRoute: PublishRoute,

--- a/apps/self-hosted/src/routes/auth.tsx
+++ b/apps/self-hosted/src/routes/auth.tsx
@@ -1,0 +1,95 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { t } from '@/core';
+import { saveUser } from '@/features/auth/storage';
+import type { AuthUser } from '@/features/auth/types';
+import {
+  consumeHivesignerState,
+  parseHivesignerCallback,
+  verifyHivesignerToken,
+} from '@/features/auth/utils/hivesigner';
+import { useAuthStore } from '@/store';
+
+export const Route = createFileRoute('/auth')({
+  component: RouteComponent,
+});
+
+/**
+ * The Hivesigner callback lands here and nowhere else.
+ *
+ * It used to be handled by an effect that ran on every route, so any page
+ * carrying ?access_token=&username= was treated as a completed login. That
+ * accepted URL input as a credential: a crafted link logged the visitor in as
+ * whoever the token belonged to, and everything they wrote afterwards was
+ * attributed to that account.
+ *
+ * A dedicated route lets the callback be checked properly: the state nonce must
+ * match the one this tab issued, and the token must actually belong to the
+ * claimed account.
+ */
+function RouteComponent() {
+  const navigate = useNavigate();
+  const { setUser } = useAuthStore();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function completeLogin() {
+      const search = window.location.search;
+      const params = new URLSearchParams(search);
+      const callback = parseHivesignerCallback(search);
+
+      // Consumed unconditionally so a failed attempt cannot be replayed.
+      const stateOk = consumeHivesignerState(params.get('state'));
+
+      if (!callback) {
+        setError(t('hivesigner_login_failed'));
+        return;
+      }
+      if (!stateOk) {
+        // The login did not start in this tab, so the token is unsolicited.
+        setError(t('hivesigner_login_failed'));
+        return;
+      }
+
+      const verified = await verifyHivesignerToken(
+        callback.accessToken,
+        callback.username,
+      );
+      if (cancelled) return;
+      if (!verified) {
+        setError(t('hivesigner_login_failed'));
+        return;
+      }
+
+      const user: AuthUser = {
+        username: callback.username,
+        accessToken: callback.accessToken,
+        loginType: 'hivesigner',
+        expiresAt: Date.now() + callback.expiresIn * 1000,
+      };
+      setUser(user);
+      saveUser(user);
+
+      // Drop the credential from the address bar before leaving this page.
+      window.history.replaceState({}, '', window.location.pathname);
+      navigate({ to: '/blog', search: { filter: 'posts' } });
+    }
+
+    completeLogin();
+    return () => {
+      cancelled = true;
+    };
+  }, [navigate, setUser]);
+
+  return (
+    <div className="min-h-screen bg-theme-primary">
+      <div className="container mx-auto container-padding-theme">
+        <div className="text-center py-12 text-theme-muted">
+          {error ?? t('loading')}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/self-hosted/src/routes/auth.tsx
+++ b/apps/self-hosted/src/routes/auth.tsx
@@ -2,12 +2,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { t } from '@/core';
 import { saveUser } from '@/features/auth/storage';
-import type { AuthUser } from '@/features/auth/types';
-import {
-  consumeHivesignerState,
-  parseHivesignerCallback,
-  verifyHivesignerToken,
-} from '@/features/auth/utils/hivesigner';
+import { completeHivesignerCallback } from '@/features/auth/utils/hivesigner-callback';
 import { useAuthStore } from '@/store';
 
 export const Route = createFileRoute('/auth')({
@@ -35,49 +30,19 @@ function RouteComponent() {
   useEffect(() => {
     let cancelled = false;
 
-    async function completeLogin() {
-      const search = window.location.search;
-      const params = new URLSearchParams(search);
-      const callback = parseHivesignerCallback(search);
-
-      // Consumed unconditionally so a failed attempt cannot be replayed.
-      const stateOk = consumeHivesignerState(params.get('state'));
-
-      if (!callback) {
-        setError(t('hivesigner_login_failed'));
-        return;
-      }
-      if (!stateOk) {
-        // The login did not start in this tab, so the token is unsolicited.
-        setError(t('hivesigner_login_failed'));
-        return;
-      }
-
-      const verified = await verifyHivesignerToken(
-        callback.accessToken,
-        callback.username,
-      );
+    completeHivesignerCallback().then((outcome) => {
       if (cancelled) return;
-      if (!verified) {
+
+      if (!outcome.ok) {
         setError(t('hivesigner_login_failed'));
         return;
       }
 
-      const user: AuthUser = {
-        username: callback.username,
-        accessToken: callback.accessToken,
-        loginType: 'hivesigner',
-        expiresAt: Date.now() + callback.expiresIn * 1000,
-      };
-      setUser(user);
-      saveUser(user);
-
-      // Drop the credential from the address bar before leaving this page.
-      window.history.replaceState({}, '', window.location.pathname);
+      setUser(outcome.user);
+      saveUser(outcome.user);
       navigate({ to: '/blog', search: { filter: 'posts' } });
-    }
+    });
 
-    completeLogin();
     return () => {
       cancelled = true;
     };

--- a/apps/self-hosted/vitest.config.ts
+++ b/apps/self-hosted/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
@@ -7,7 +8,11 @@ export default defineConfig({
     globals: true,
     include: ['src/**/*.test.ts'],
     alias: {
-      '@': './src',
+      // Absolute, because Vite resolves an alias target relative to the
+      // importing file rather than the project root. As './src' this alias
+      // never resolved, so no module importing '@/...' could be loaded in a
+      // test at all, and vi.mock('@/...') silently matched nothing.
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
Part of #1316. Covers the Hivesigner half and the authority bug; the HiveAuth protocol rewrite is separate.

## Hivesigner login could not succeed on any hosted blog

The app sent `window.location.origin + window.location.pathname` as `redirect_uri`. OAuth matches it exactly, so every page produced a different URI — and none are registered on the `ecency.app` client, which lists only these (read from the account’s on-chain `posting_json_metadata`):

```
http://localhost:3000/auth
https://ecency.com/auth
https://alpha.ecency.com/auth
https://chat.ecency.com/_oauth/hivesigner
```

A tenant origin cannot be pre-registered either, since custom domains are unbounded.

- **Fixed `/auth` redirect path**, so one URI per origin is all that needs registering. That is the most a self-hoster on their own domain can register, and it is what makes registration viable at all.
- **Per-instance client id** (`general.hivesigner.clientId`), so an owner who registers their own app can use it.
- **The method is not offered when the instance has no usable client.** A button that always fails is worse than no button.

## The callback accepted URL input as a credential

It was handled by an effect running on *every* route, so any page carrying `?access_token=&username=` counted as a completed login. A crafted link signed the visitor in as whoever the token belonged to, and everything they wrote afterwards was attributed to that account.

It now has a dedicated `/auth` route that requires a `state` nonce it issued itself and verifies the token actually belongs to the claimed account before storing a session. Both fail closed.

## HiveAuth signed everything with posting authority

The adapter received the key type as `_keyType` and the util hardcoded `posting`. The chain rejects a transfer signed with posting authority, so tips, transfers and any `custom_json` with `required_auths` could not work through HiveAuth regardless of the protocol fix. The requested authority is now passed through.

## Notes

- `resolveHivesignerClientId` is pure and takes the configured value rather than reading config itself, so the rule lives in one place and is testable without the config module.
- Removed `redirectToHivesigner`, which had no callers and would have bypassed both the fixed path and the nonce.
- **Still broken, tracked in #1316 and being fixed separately:** the HiveAuth client does not implement the HAS protocol (unencrypted `auth_req.data`, `auth_ack` read as plaintext, `hiveauth://auth/` instead of `has://auth_req/`), so HiveAuth login still cannot complete. Until that lands, Keychain remains the only working method unless an owner registers their own Hivesigner app.

## Verification

13 new tests, mutation-checked: removing the nonce check fails 3, removing the token ownership check fails 1, offering the built-in client fails 2, dropping the authority fails 2. 139 tests pass, typecheck clean, build succeeds, and the per-rule lint diff against develop is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable Hivesigner client IDs for self-hosted instances.
  - Added a dedicated authentication flow with secure callback validation and clearer loading, cancellation, and failure handling.
  - Hivesigner now appears only when configured and supports localized login failure messages.
  - Added support for broadcasting actions with the appropriate Hive authority, including active, owner, and memo keys.
- **Bug Fixes**
  - Improved OAuth state and token verification to reject invalid or unsolicited login attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->