### PR TITLE
fix(self-hosted): speak the HAS protocol for HiveAuth login

### DIFF
--- a/apps/self-hosted/package.json
+++ b/apps/self-hosted/package.json
@@ -37,6 +37,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "dompurify": "^3.4.12",
+    "hive-auth-wrapper": "^1.0.0",
     "hivesigner": "^4.0.0",
     "marked": "^12.0.0",
     "qrcode": "^1.5.4",

--- a/apps/self-hosted/src/features/auth/constants.ts
+++ b/apps/self-hosted/src/features/auth/constants.ts
@@ -16,7 +16,9 @@ export const HIVESIGNER_REDIRECT_PATH = '/auth';
 export const HIVESIGNER_STATE_KEY = 'ecency_selfhost_hs_state';
 
 // HiveAuth
-export const HIVEAUTH_API = 'wss://hiveauth.arcange.eu';
+// The HAS server. `hiveauth.arcange.eu` does not resolve, so the socket could
+// never open and login failed before the protocol was even reached.
+export const HIVEAUTH_API = 'wss://hive-auth.arcange.eu';
 export const HIVEAUTH_APP = 'ecency.selfhost';
 export const HIVEAUTH_KEY_PREFIX = 'ecency_ha_';
 

--- a/apps/self-hosted/src/features/auth/types.ts
+++ b/apps/self-hosted/src/features/auth/types.ts
@@ -54,7 +54,13 @@ export interface KeychainSignTxResponse {
 
 export interface HiveAuthSession {
   username: string;
-  token: string;
+  /**
+   * Deprecated in HAS and omitted entirely by protocol v1 acknowledgements, so
+   * a compliant wallet establishes a session without one. Kept optional rather
+   * than removed, because pre-v1 wallets still send it and the wrapper still
+   * accepts it.
+   */
+  token?: string;
   expire: number;
   key: string;
 }

--- a/apps/self-hosted/src/features/auth/utils/hive-auth.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-auth.test.ts
@@ -334,4 +334,48 @@ describe('HAS host', () => {
     // hiveauth.arcange.eu is NXDOMAIN, so the socket never opened.
     expect(HIVEAUTH_API).toBe('wss://hive-auth.arcange.eu');
   });
+
+  /**
+   * HAS deprecated the session token and protocol v1 acknowledgements omit it
+   * entirely, so requiring one rejected an authentication the wallet had
+   * already approved. The key and the expiry establish the session.
+   */
+  it('accepts a protocol v1 approval that carries no token', () => {
+    const session = toHiveAuthSession('alice', {
+      expire: 1_800_000_000_000,
+      key: 'the-auth-key',
+    } as never);
+
+    expect(session).toEqual({
+      username: 'alice',
+      expire: 1_800_000_000,
+      key: 'the-auth-key',
+    });
+    expect('token' in session).toBe(false);
+  });
+
+  it('still carries a pre-v1 token through when the wallet sends one', () => {
+    const session = toHiveAuthSession('alice', {
+      token: 'legacy-token',
+      expire: 1_800_000_000_000,
+      key: 'the-auth-key',
+    } as never);
+
+    expect(session.token).toBe('legacy-token');
+  });
+
+  it('rebuilds credentials without a token for a v1 session', () => {
+    const credentials = toHiveAuthCredentials({
+      username: 'alice',
+      expire: 1_800_000_000,
+      key: 'the-auth-key',
+    });
+
+    expect(credentials).toEqual({
+      username: 'alice',
+      expire: 1_800_000_000_000,
+      key: 'the-auth-key',
+    });
+    expect('token' in credentials).toBe(false);
+  });
 });

--- a/apps/self-hosted/src/features/auth/utils/hive-auth.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-auth.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * HiveAuth (HAS) is an encrypted protocol, not a plain JSON exchange: the app
+ * AES-encrypts every request `data` field with a per-session auth key and the
+ * wallet replies encrypted with the same key, which it learns only by scanning
+ * the QR. These tests cover the parts that can be exercised without a live HAS
+ * server: the QR payload the wallet has to scan, the data handed to the
+ * protocol library, and the session shape the rest of the app persists.
+ */
+
+const has = vi.hoisted(() => ({
+  setOptions: vi.fn(),
+  authenticate: vi.fn(),
+  broadcast: vi.fn(),
+}));
+
+vi.mock('hive-auth-wrapper', () => ({ default: has }));
+
+const {
+  broadcastWithHiveAuth,
+  buildHiveAuthQrPayload,
+  buildLoginChallenge,
+  describeHiveAuthError,
+  isHiveAuthSessionValid,
+  loginWithHiveAuth,
+  toHiveAuthCredentials,
+  toHiveAuthSession,
+} = await import('./hive-auth');
+
+const { HIVEAUTH_API, HIVEAUTH_APP } = await import('../constants');
+
+const QR_PREFIX = 'has://auth_req/';
+
+function decodeQr(qr: string) {
+  expect(qr.startsWith(QR_PREFIX)).toBe(true);
+  return JSON.parse(atob(qr.slice(QR_PREFIX.length)));
+}
+
+/** A successful authenticate(): fills the credentials the wrapper mutates. */
+function approveAuth(expireMs: number) {
+  return async (
+    auth: { token?: string; expire?: number; key?: string },
+    _app: unknown,
+    _challenge: unknown,
+    cbWait?: (evt: {
+      cmd: string;
+      uuid: string;
+      expire: number;
+      key?: string;
+    }) => void,
+  ) => {
+    cbWait?.({
+      cmd: 'auth_wait',
+      uuid: 'req-uuid',
+      expire: expireMs,
+      key: 'auth-key',
+    });
+    auth.token = 'session-token';
+    auth.expire = expireMs;
+    auth.key = 'auth-key';
+    return { cmd: 'auth_ack' };
+  };
+}
+
+beforeEach(() => {
+  has.setOptions.mockClear();
+  has.authenticate.mockReset();
+  has.broadcast.mockReset();
+});
+
+/**
+ * `hiveauth://auth/` is registered by no wallet, so the previous QR scanned as
+ * unknown text and the login could never be approved.
+ */
+describe('QR payload', () => {
+  it('uses the has:// auth_req scheme wallets register', () => {
+    const qr = buildHiveAuthQrPayload({
+      account: 'alice',
+      uuid: 'req-uuid',
+      key: 'auth-key',
+      host: 'wss://has.example',
+    });
+
+    expect(qr.startsWith(QR_PREFIX)).toBe(true);
+  });
+
+  it('carries the account, request uuid, auth key and host as base64 json', () => {
+    const qr = buildHiveAuthQrPayload({
+      account: 'alice',
+      uuid: 'req-uuid',
+      key: 'auth-key',
+      host: 'wss://has.example',
+    });
+
+    expect(decodeQr(qr)).toEqual({
+      account: 'alice',
+      uuid: 'req-uuid',
+      key: 'auth-key',
+      host: 'wss://has.example',
+    });
+  });
+});
+
+describe('login', () => {
+  it('emits a scannable QR built from the auth_wait uuid and the auth key', async () => {
+    has.authenticate.mockImplementation(approveAuth(Date.now() + 3_600_000));
+    const onQRCode = vi.fn();
+    const onWaiting = vi.fn();
+
+    await loginWithHiveAuth('alice', { onQRCode, onWaiting });
+
+    expect(onQRCode).toHaveBeenCalledTimes(1);
+    expect(decodeQr(onQRCode.mock.calls[0][0])).toEqual({
+      account: 'alice',
+      uuid: 'req-uuid',
+      // Without the key in the QR the wallet cannot decrypt the request.
+      key: 'auth-key',
+      host: HIVEAUTH_API,
+    });
+    expect(onWaiting).toHaveBeenCalled();
+  });
+
+  it('hands the app data and challenge to the protocol library unencrypted', async () => {
+    has.authenticate.mockImplementation(approveAuth(Date.now() + 3_600_000));
+
+    await loginWithHiveAuth('alice', {});
+
+    const [, appData, challenge] = has.authenticate.mock.calls[0];
+    expect(appData.name).toBe(HIVEAUTH_APP);
+    // The library encrypts these into auth_req.data. Sending them ready-made
+    // as the request body, as the hand-rolled client did, is what the PKSA
+    // cannot read.
+    expect(challenge.key_type).toBe('posting');
+    expect(JSON.parse(challenge.challenge)).toMatchObject({ login: 'alice' });
+  });
+
+  it('connects to the configured HAS host', async () => {
+    has.authenticate.mockImplementation(approveAuth(Date.now() + 3_600_000));
+
+    await loginWithHiveAuth('alice', {});
+
+    expect(has.setOptions).toHaveBeenCalledWith({ host: HIVEAUTH_API });
+  });
+
+  it('reports a rejected authentication instead of an undefined message', async () => {
+    has.authenticate.mockRejectedValue({ cmd: 'auth_nack', uuid: 'req-uuid' });
+    const onError = vi.fn();
+
+    await expect(loginWithHiveAuth('alice', { onError })).rejects.toThrow(
+      'Authentication rejected',
+    );
+    expect(onError).toHaveBeenCalledWith('Authentication rejected');
+  });
+});
+
+describe('login challenge', () => {
+  it('asks for a posting-key signature over a timestamped login string', () => {
+    const challenge = buildLoginChallenge('alice');
+
+    expect(challenge.key_type).toBe('posting');
+    const body = JSON.parse(challenge.challenge);
+    expect(body.login).toBe('alice');
+    expect(typeof body.ts).toBe('number');
+  });
+});
+
+/**
+ * HAS reports expiry in milliseconds while storage.ts, isHiveAuthSessionValid
+ * and auth-actions all multiply the stored value by 1000. Storing the raw HAS
+ * value pushes every expiry check thousands of years out, so a revoked session
+ * would look live forever.
+ */
+describe('session shape', () => {
+  it('stores the HAS expiry in seconds', () => {
+    const session = toHiveAuthSession('alice', {
+      username: 'alice',
+      token: 'session-token',
+      expire: 1_893_456_000_000,
+      key: 'auth-key',
+    });
+
+    expect(session).toEqual({
+      username: 'alice',
+      token: 'session-token',
+      expire: 1_893_456_000,
+      key: 'auth-key',
+    });
+  });
+
+  it('is still valid an hour before it expires', () => {
+    const session = toHiveAuthSession('alice', {
+      username: 'alice',
+      token: 'session-token',
+      expire: Date.now() + 3_600_000,
+      key: 'auth-key',
+    });
+
+    expect(isHiveAuthSessionValid(session)).toBe(true);
+  });
+
+  it('is expired once the HAS expiry has passed', () => {
+    const session = toHiveAuthSession('alice', {
+      username: 'alice',
+      token: 'session-token',
+      expire: Date.now() - 60_000,
+      key: 'auth-key',
+    });
+
+    expect(isHiveAuthSessionValid(session)).toBe(false);
+  });
+
+  it('round-trips back to the credentials the protocol library expects', () => {
+    const expire = 1_893_456_000_000;
+    const session = toHiveAuthSession('alice', {
+      username: 'alice',
+      token: 'session-token',
+      expire,
+      key: 'auth-key',
+    });
+
+    expect(toHiveAuthCredentials(JSON.parse(JSON.stringify(session)))).toEqual({
+      username: 'alice',
+      token: 'session-token',
+      expire,
+      key: 'auth-key',
+    });
+  });
+
+  it('refuses a session without the auth key needed to sign later', () => {
+    expect(() =>
+      toHiveAuthSession('alice', { username: 'alice', token: 't', expire: 1 }),
+    ).toThrow(/encryption key/);
+  });
+
+  it('reaches login callers as a complete session', async () => {
+    const expire = Date.now() + 3_600_000;
+    has.authenticate.mockImplementation(approveAuth(expire));
+    const onSuccess = vi.fn();
+
+    await loginWithHiveAuth('alice', { onSuccess });
+
+    expect(onSuccess).toHaveBeenCalledWith({
+      username: 'alice',
+      token: 'session-token',
+      expire: Math.floor(expire / 1000),
+      key: 'auth-key',
+    });
+  });
+});
+
+/**
+ * The chain rejects a transfer signed with posting authority, so dropping the
+ * requested key type made every active operation through HiveAuth fail.
+ */
+describe('broadcast', () => {
+  const session = {
+    username: 'alice',
+    token: 'session-token',
+    expire: 1_893_456_000,
+    key: 'auth-key',
+  };
+  const op = ['vote', { voter: 'alice' }] as never;
+
+  it('signs with the requested authority', async () => {
+    has.broadcast.mockResolvedValue({ cmd: 'sign_ack', data: 'tx-id' });
+
+    await broadcastWithHiveAuth(session, [op], 'active');
+
+    expect(has.broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({ username: 'alice', key: 'auth-key' }),
+      'active',
+      [op],
+      expect.any(Function),
+    );
+  });
+
+  it('defaults to posting when the caller does not ask for an authority', async () => {
+    has.broadcast.mockResolvedValue({ cmd: 'sign_ack' });
+
+    await broadcastWithHiveAuth(session, [op]);
+
+    expect(has.broadcast.mock.calls[0][1]).toBe('posting');
+  });
+
+  it('signs with the stored auth key, so the wallet can decrypt the ops', async () => {
+    has.broadcast.mockResolvedValue({ cmd: 'sign_ack' });
+
+    await broadcastWithHiveAuth(session, [op], 'posting');
+
+    expect(has.broadcast.mock.calls[0][0].key).toBe('auth-key');
+  });
+
+  it('reports a rejected transaction instead of an undefined message', async () => {
+    has.broadcast.mockRejectedValue({ cmd: 'sign_nack', uuid: 'req-uuid' });
+    const onError = vi.fn();
+
+    await expect(
+      broadcastWithHiveAuth(session, [op], 'active', { onError }),
+    ).rejects.toThrow('Transaction rejected');
+    expect(onError).toHaveBeenCalledWith('Transaction rejected');
+  });
+});
+
+describe('error descriptions', () => {
+  it('names the protocol rejections', () => {
+    expect(describeHiveAuthError({ cmd: 'auth_nack' })).toBe(
+      'Authentication rejected',
+    );
+    expect(describeHiveAuthError({ cmd: 'sign_nack' })).toBe(
+      'Transaction rejected',
+    );
+  });
+
+  it('prefers the server-supplied error text', () => {
+    expect(
+      describeHiveAuthError({ cmd: 'auth_err', error: 'unknown account' }),
+    ).toBe('unknown account');
+  });
+
+  it('spells out the wrapper timeout', () => {
+    expect(describeHiveAuthError(new Error('expired'))).toBe(
+      'HiveAuth request expired',
+    );
+  });
+
+  it('falls back rather than returning undefined', () => {
+    expect(describeHiveAuthError(undefined)).toBe('HiveAuth request failed');
+  });
+});
+
+describe('HAS host', () => {
+  it('points at a host that resolves', () => {
+    // hiveauth.arcange.eu is NXDOMAIN, so the socket never opened.
+    expect(HIVEAUTH_API).toBe('wss://hive-auth.arcange.eu');
+  });
+});

--- a/apps/self-hosted/src/features/auth/utils/hive-auth.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-auth.ts
@@ -1,27 +1,20 @@
 import type { Operation } from '@ecency/sdk';
-import CryptoJS from 'crypto-js';
+import HAS, { type HasAuth, type HasChallengeData } from 'hive-auth-wrapper';
 import { HIVEAUTH_API, HIVEAUTH_APP } from '../constants';
 import type { HiveAuthSession } from '../types';
 
-interface HiveAuthChallenge {
-  key_type: string;
-  challenge: string;
-}
-
-interface HiveAuthAuthResponse {
-  cmd: 'auth_ack' | 'auth_nack' | 'auth_wait' | 'auth_err';
-  uuid?: string;
-  expire?: number;
-  token?: string;
-  error?: string;
-}
-
-interface HiveAuthSignResponse {
-  cmd: 'sign_ack' | 'sign_nack' | 'sign_wait' | 'sign_err';
-  broadcast?: boolean;
-  error?: string;
-  data?: string;
-}
+/**
+ * HiveAuth (HAS) client.
+ *
+ * The protocol is not a plain JSON exchange: everything an app sends in a
+ * request `data` field is AES encrypted with a per-session auth key, and the
+ * PKSA replies encrypted with the same key. The key never travels over the
+ * socket; it reaches the wallet out of band, in the QR payload the user scans.
+ * A hand-rolled client that sends `auth_req.data` in the clear, reads
+ * `auth_ack.data` as plain JSON, or emits a QR under a scheme no wallet
+ * registers cannot complete a login, so the crypto and the socket lifecycle are
+ * delegated to the official wrapper instead of being reimplemented here.
+ */
 
 type HiveAuthCallback = {
   onQRCode?: (qrData: string) => void;
@@ -36,341 +29,206 @@ type HiveAuthSignCallback = {
   onError?: (error: string) => void;
 };
 
-/**
- * Generate a random encryption key for HiveAuth
- */
-function generateKey(): string {
-  const array = new Uint8Array(32);
-  crypto.getRandomValues(array);
-  return Array.from(array, (b) => b.toString(16).padStart(2, '0')).join('');
-}
-
-/**
- * Encrypt challenge using AES-CBC with EVP_BytesToKey derivation
- * This matches HiveAuth's expected encryption format
- */
-function encryptChallenge(challenge: string, key: string): string {
-  // CryptoJS.AES.encrypt with a string key uses EVP_BytesToKey internally
-  // which derives the AES key and IV using MD5 - this is what HiveAuth expects
-  return CryptoJS.AES.encrypt(challenge, key).toString();
-}
-
-/**
- * Generate QR code data for HiveAuth login
- */
-function generateQRData(
-  username: string,
-  uuid: string,
-  key: string,
-  challenge: HiveAuthChallenge
-): string {
-  const authData = {
-    account: username,
-    uuid,
-    key,
-    host: HIVEAUTH_API,
-    ...challenge,
-  };
-
-  return `hiveauth://auth/${btoa(JSON.stringify(authData))}`;
-}
-
-/**
- * HiveAuth login flow
- */
-export async function loginWithHiveAuth(
-  username: string,
-  callbacks: HiveAuthCallback
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const ws = new WebSocket(HIVEAUTH_API);
-    const key = generateKey();
-    let uuid: string | null = null;
-    let authTimeout: ReturnType<typeof setTimeout> | null = null;
-    let settled = false;
-
-    // Create challenge once to ensure consistent timestamps between auth_req and QR data
-    const challenge: HiveAuthChallenge = {
-      key_type: 'posting',
-      challenge: JSON.stringify({
-        login: true,
-        ts: Date.now(),
-      }),
-    };
-
-    const cleanup = () => {
-      if (authTimeout) {
-        clearTimeout(authTimeout);
-        authTimeout = null;
-      }
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.close();
-      }
-    };
-
-    const safeReject = (error: Error) => {
-      if (!settled) {
-        settled = true;
-        reject(error);
-      }
-    };
-
-    const safeResolve = () => {
-      if (!settled) {
-        settled = true;
-        resolve();
-      }
-    };
-
-    ws.onopen = () => {
-      // Send auth request using the pre-created challenge
-      const authReq = {
-        cmd: 'auth_req',
-        account: username,
-        data: {
-          app: {
-            name: HIVEAUTH_APP,
-          },
-          challenge: encryptChallenge(challenge.challenge, key),
-          key_type: challenge.key_type,
-        },
-      };
-
-      ws.send(JSON.stringify(authReq));
-    };
-
-    ws.onmessage = (event) => {
-      try {
-        const msg = JSON.parse(event.data) as HiveAuthAuthResponse;
-
-        switch (msg.cmd) {
-          case 'auth_wait':
-            if (msg.uuid) {
-              uuid = msg.uuid;
-              // Reuse the same challenge for QR data
-              const qrData = generateQRData(username, uuid, key, challenge);
-              callbacks.onQRCode?.(qrData);
-              callbacks.onWaiting?.();
-            }
-            break;
-
-          case 'auth_ack':
-            if (msg.token && msg.expire) {
-              const session: HiveAuthSession = {
-                username,
-                token: msg.token,
-                expire: msg.expire,
-                key,
-              };
-              callbacks.onSuccess?.(session);
-              cleanup();
-              safeResolve();
-            }
-            break;
-
-          case 'auth_nack':
-            callbacks.onError?.('Authentication rejected');
-            cleanup();
-            safeReject(new Error('Authentication rejected'));
-            break;
-
-          case 'auth_err':
-            callbacks.onError?.(msg.error || 'Authentication error');
-            cleanup();
-            safeReject(new Error(msg.error || 'Authentication error'));
-            break;
-        }
-      } catch (error) {
-        callbacks.onError?.('Failed to parse response');
-        cleanup();
-        safeReject(error instanceof Error ? error : new Error('Failed to parse response'));
-      }
-    };
-
-    ws.onerror = () => {
-      callbacks.onError?.('WebSocket connection error');
-      cleanup();
-      safeReject(new Error('WebSocket connection error'));
-    };
-
-    ws.onclose = () => {
-      // Connection closed - ensure timeout is cleared
-      if (authTimeout) {
-        clearTimeout(authTimeout);
-        authTimeout = null;
-      }
-      // Reject if the Promise hasn't been settled yet
-      if (!settled) {
-        callbacks.onError?.('WebSocket closed before authentication completed');
-        safeReject(new Error('WebSocket closed before authentication completed'));
-      }
-    };
-
-    // Timeout after 5 minutes
-    authTimeout = setTimeout(() => {
-      if (ws.readyState === WebSocket.OPEN) {
-        callbacks.onError?.('Authentication timeout');
-        cleanup();
-        safeReject(new Error('Authentication timeout'));
-      }
-    }, 5 * 60 * 1000);
-  });
-}
-
-/**
- * Internal helper: sends a sign_req via HiveAuth WebSocket and resolves with
- * the sign_ack data string (or undefined if broadcast-only).
- */
-function hiveAuthSignRequest(
-  session: HiveAuthSession,
-  operations: Operation[],
-  opts: { keyType: string; broadcast: boolean },
-  callbacks?: HiveAuthSignCallback
-): Promise<string | undefined> {
-  return new Promise((resolve, reject) => {
-    const ws = new WebSocket(HIVEAUTH_API);
-    let signTimeout: ReturnType<typeof setTimeout> | null = null;
-    let settled = false;
-
-    const cleanup = () => {
-      if (signTimeout) {
-        clearTimeout(signTimeout);
-        signTimeout = null;
-      }
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.close();
-      }
-    };
-
-    const safeReject = (error: Error) => {
-      if (!settled) {
-        settled = true;
-        reject(error);
-      }
-    };
-
-    ws.onopen = () => {
-      const signReq = {
-        cmd: 'sign_req',
-        account: session.username,
-        token: session.token,
-        data: {
-          key_type: opts.keyType,
-          ops: operations,
-          broadcast: opts.broadcast,
-        },
-      };
-
-      ws.send(JSON.stringify(signReq));
-      callbacks?.onWaiting?.();
-    };
-
-    ws.onmessage = (event) => {
-      try {
-        const msg = JSON.parse(event.data) as HiveAuthSignResponse;
-
-        switch (msg.cmd) {
-          case 'sign_wait':
-            callbacks?.onWaiting?.();
-            break;
-
-          case 'sign_ack':
-            if (!settled) {
-              settled = true;
-              callbacks?.onSuccess?.(msg.data);
-              cleanup();
-              resolve(msg.data);
-            }
-            break;
-
-          case 'sign_nack':
-            callbacks?.onError?.('Transaction rejected');
-            cleanup();
-            safeReject(new Error('Transaction rejected'));
-            break;
-
-          case 'sign_err':
-            callbacks?.onError?.(msg.error || 'Signing error');
-            cleanup();
-            safeReject(new Error(msg.error || 'Signing error'));
-            break;
-        }
-      } catch (error) {
-        callbacks?.onError?.('Failed to parse response');
-        cleanup();
-        safeReject(error instanceof Error ? error : new Error('Failed to parse response'));
-      }
-    };
-
-    ws.onerror = () => {
-      callbacks?.onError?.('WebSocket connection error');
-      cleanup();
-      safeReject(new Error('WebSocket connection error'));
-    };
-
-    ws.onclose = () => {
-      if (signTimeout) {
-        clearTimeout(signTimeout);
-        signTimeout = null;
-      }
-      if (!settled) {
-        callbacks?.onError?.('WebSocket closed before signing completed');
-        safeReject(new Error('WebSocket closed before signing completed'));
-      }
-    };
-
-    signTimeout = setTimeout(() => {
-      if (ws.readyState === WebSocket.OPEN) {
-        callbacks?.onError?.('Signing timeout');
-        cleanup();
-        safeReject(new Error('Signing timeout'));
-      }
-    }, 2 * 60 * 1000);
-  });
-}
-
 /** Authorities HiveAuth can be asked to sign with. */
 export type HiveAuthKeyType = 'posting' | 'active' | 'owner' | 'memo';
 
+/** Shown by the wallet when it asks the user to approve the request. */
+const APP_META = {
+  name: HIVEAUTH_APP,
+  description: 'Ecency self-hosted blog',
+};
+
 /**
- * Broadcast operations with HiveAuth
+ * The payload a HiveAuth wallet expects to scan. `has://auth_req/` is the
+ * scheme wallets register; anything else produces a QR that scans as unknown
+ * text. `key` is the AES key for the rest of the exchange, which is why it
+ * travels here and not over the websocket.
+ */
+export function buildHiveAuthQrPayload(params: {
+  account: string;
+  uuid: string;
+  key: string;
+  host: string;
+}): string {
+  const payload = {
+    account: params.account,
+    uuid: params.uuid,
+    key: params.key,
+    host: params.host,
+  };
+
+  return `has://auth_req/${btoa(JSON.stringify(payload))}`;
+}
+
+/**
+ * Challenge the wallet signs to prove it holds the account's posting key.
+ * Sent as plain data; the wrapper encrypts it with the auth key.
+ */
+export function buildLoginChallenge(username: string): HasChallengeData {
+  return {
+    key_type: 'posting',
+    challenge: JSON.stringify({ login: username, ts: Date.now() }),
+  };
+}
+
+/**
+ * HAS reports token expiry as an epoch in milliseconds. The stored session
+ * keeps seconds, which is what `storage.ts`, `isHiveAuthSessionValid` and
+ * auth-actions' `session.expire * 1000` all assume. Storing the raw HAS value
+ * would push every expiry check thousands of years out.
+ */
+export function toHiveAuthSession(
+  username: string,
+  auth: HasAuth,
+): HiveAuthSession {
+  if (!auth.key) {
+    throw new Error('HiveAuth returned no encryption key');
+  }
+  if (!auth.token) {
+    throw new Error('HiveAuth returned no session token');
+  }
+  if (!auth.expire) {
+    throw new Error('HiveAuth returned no session expiry');
+  }
+
+  return {
+    username,
+    token: auth.token,
+    expire: Math.floor(auth.expire / 1000),
+    key: auth.key,
+  };
+}
+
+/** Rebuild the wrapper's credentials from a stored session, expiry back in ms. */
+export function toHiveAuthCredentials(session: HiveAuthSession): HasAuth {
+  return {
+    username: session.username,
+    token: session.token,
+    expire: session.expire * 1000,
+    key: session.key,
+  };
+}
+
+/**
+ * HAS rejects with either an Error or a raw protocol message, so a plain
+ * `error.message` read turns half the failures into "undefined".
+ */
+export function describeHiveAuthError(reason: unknown): string {
+  if (reason instanceof Error) {
+    return reason.message === 'expired'
+      ? 'HiveAuth request expired'
+      : reason.message;
+  }
+
+  if (reason && typeof reason === 'object') {
+    const message = reason as { cmd?: string; error?: string };
+    if (typeof message.error === 'string' && message.error) {
+      return message.error;
+    }
+    switch (message.cmd) {
+      case 'auth_nack':
+        return 'Authentication rejected';
+      case 'auth_err':
+        return 'Authentication error';
+      case 'sign_nack':
+        return 'Transaction rejected';
+      case 'sign_err':
+        return 'Signing error';
+    }
+  }
+
+  return 'HiveAuth request failed';
+}
+
+/**
+ * HiveAuth login flow. Resolves once the wallet has approved; `onSuccess`
+ * carries the session the caller has to persist.
+ */
+export async function loginWithHiveAuth(
+  username: string,
+  callbacks: HiveAuthCallback,
+): Promise<void> {
+  HAS.setOptions({ host: HIVEAUTH_API });
+
+  // The wrapper fills token, expire and key into this object on success.
+  const auth: HasAuth = { username };
+
+  try {
+    await HAS.authenticate(
+      auth,
+      APP_META,
+      buildLoginChallenge(username),
+      (evt) => {
+        // evt.key is the auth key the wrapper generated for this request. The
+        // wallet cannot decrypt anything until it reads the key from the QR.
+        callbacks.onQRCode?.(
+          buildHiveAuthQrPayload({
+            account: username,
+            uuid: evt.uuid,
+            key: evt.key ?? auth.key ?? '',
+            host: HIVEAUTH_API,
+          }),
+        );
+        callbacks.onWaiting?.();
+      },
+    );
+  } catch (error) {
+    const message = describeHiveAuthError(error);
+    callbacks.onError?.(message);
+    throw new Error(message);
+  }
+
+  let session: HiveAuthSession;
+  try {
+    session = toHiveAuthSession(username, auth);
+  } catch (error) {
+    const message = describeHiveAuthError(error);
+    callbacks.onError?.(message);
+    throw new Error(message);
+  }
+
+  callbacks.onSuccess?.(session);
+}
+
+/**
+ * Broadcast operations with HiveAuth.
+ *
+ * The authority is the caller's to choose. Hardcoding 'posting' meant an
+ * active operation - a transfer, a tip, a custom_json with required_auths -
+ * asked the wallet for the posting key, and the chain rejects a transfer
+ * signed with posting authority.
  */
 export async function broadcastWithHiveAuth(
   session: HiveAuthSession,
   operations: Operation[],
   keyType: HiveAuthKeyType = 'posting',
-  callbacks?: HiveAuthSignCallback
+  callbacks?: HiveAuthSignCallback,
 ): Promise<void> {
-  // The authority is the caller's to choose. Hardcoding 'posting' meant an
-  // active operation - a transfer, a tip, a custom_json with required_auths -
-  // asked the wallet for the posting key, and the chain rejects a transfer
-  // signed with posting authority.
-  await hiveAuthSignRequest(session, operations, { keyType, broadcast: true }, callbacks);
-}
+  HAS.setOptions({ host: HIVEAUTH_API });
 
-/**
- * Sign operations with HiveAuth without broadcasting (for x402 payments).
- * Uses key_type: 'active' and broadcast: false to get signed tx data back.
- *
- * Note: HiveAuth may not support broadcast:false with active keys.
- * If unsupported, this will reject with an error.
- */
-export async function signWithHiveAuth(
-  session: HiveAuthSession,
-  operations: Operation[],
-  callbacks?: HiveAuthSignCallback
-): Promise<string> {
-  const data = await hiveAuthSignRequest(session, operations, { keyType: 'active', broadcast: false }, callbacks);
-  if (!data) {
-    throw new Error('HiveAuth signing failed: no data returned');
+  try {
+    const response = await HAS.broadcast(
+      toHiveAuthCredentials(session),
+      keyType,
+      operations,
+      () => callbacks?.onWaiting?.(),
+    );
+    callbacks?.onSuccess?.(
+      typeof response?.data === 'string' ? response.data : undefined,
+    );
+  } catch (error) {
+    const message = describeHiveAuthError(error);
+    callbacks?.onError?.(message);
+    throw new Error(message);
   }
-  return data;
 }
 
 /**
  * Check if HiveAuth session is valid
  */
-export function isHiveAuthSessionValid(session: HiveAuthSession | null): boolean {
+export function isHiveAuthSessionValid(
+  session: HiveAuthSession | null,
+): boolean {
   if (!session) return false;
   return Date.now() < session.expire * 1000;
 }

--- a/apps/self-hosted/src/features/auth/utils/hive-auth.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-auth.ts
@@ -84,16 +84,17 @@ export function toHiveAuthSession(
   if (!auth.key) {
     throw new Error('HiveAuth returned no encryption key');
   }
-  if (!auth.token) {
-    throw new Error('HiveAuth returned no session token');
-  }
+  // No token check. HAS deprecated it and protocol v1 acknowledgements omit it,
+  // so requiring one rejects an authentication the wallet already approved. The
+  // key and the expiry are what establish the session; the token is carried
+  // through only when a pre-v1 wallet sends one.
   if (!auth.expire) {
     throw new Error('HiveAuth returned no session expiry');
   }
 
   return {
     username,
-    token: auth.token,
+    ...(auth.token ? { token: auth.token } : {}),
     expire: Math.floor(auth.expire / 1000),
     key: auth.key,
   };
@@ -103,7 +104,7 @@ export function toHiveAuthSession(
 export function toHiveAuthCredentials(session: HiveAuthSession): HasAuth {
   return {
     username: session.username,
-    token: session.token,
+    ...(session.token ? { token: session.token } : {}),
     expire: session.expire * 1000,
     key: session.key,
   };

--- a/apps/self-hosted/src/types/hive-auth-wrapper.d.ts
+++ b/apps/self-hosted/src/types/hive-auth-wrapper.d.ts
@@ -1,0 +1,84 @@
+/**
+ * `hive-auth-wrapper` ships no type declarations, so the surface this app uses
+ * is declared here. Shapes follow the HAS protocol documented at
+ * https://docs.hiveauth.com and the wrapper's own JSDoc.
+ */
+declare module 'hive-auth-wrapper' {
+  /**
+   * Credentials the wrapper reads from and writes back to. `authenticate()`
+   * mutates this object in place on success, filling in `token`, `expire` and
+   * the generated `key`.
+   */
+  export interface HasAuth {
+    username: string;
+    /** Session token issued by the PKSA. */
+    token?: string;
+    /** Token expiry as an epoch in MILLISECONDS. */
+    expire?: number;
+    /** AES key shared with the PKSA out of band, through the QR payload. */
+    key?: string;
+  }
+
+  export interface HasAppMeta {
+    name: string;
+    description?: string;
+    icon?: string;
+  }
+
+  export interface HasChallengeData {
+    /** posting, active, owner or memo. */
+    key_type: string;
+    /** Plain string for the PKSA to sign. The wrapper encrypts it. */
+    challenge: string;
+  }
+
+  /** `auth_wait` / `sign_wait`: the request is queued for the PKSA to approve. */
+  export interface HasWaitEvent {
+    cmd: string;
+    uuid: string;
+    expire: number;
+    account?: string;
+    /** Only on `auth_wait`, injected by the wrapper so the app can build the QR. */
+    key?: string;
+  }
+
+  export interface HasResponse {
+    cmd: string;
+    uuid?: string;
+    data?: unknown;
+    error?: string;
+    broadcast?: boolean;
+  }
+
+  export interface HasOptions {
+    host?: string;
+    auth_key_secret?: string;
+  }
+
+  const HAS: {
+    setOptions(options: HasOptions): void;
+    status(): { host: string; connected: boolean; timeout: number };
+    connect(): Promise<boolean>;
+    traceOn(): void;
+    traceOff(): void;
+    authenticate(
+      auth: HasAuth,
+      appData: HasAppMeta,
+      challengeData?: HasChallengeData,
+      cbWait?: (evt: HasWaitEvent) => void,
+    ): Promise<HasResponse>;
+    broadcast(
+      auth: HasAuth,
+      keyType: string,
+      ops: unknown[],
+      cbWait?: (evt: HasWaitEvent) => void,
+    ): Promise<HasResponse>;
+    challenge(
+      auth: HasAuth,
+      challengeData: HasChallengeData,
+      cbWait?: (evt: HasWaitEvent) => void,
+    ): Promise<HasResponse>;
+  };
+
+  export default HAS;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       dompurify:
         specifier: ^3.4.12
         version: 3.4.12
+      hive-auth-wrapper:
+        specifier: ^1.0.0
+        version: 1.0.0
       hivesigner:
         specifier: ^4.0.0
         version: 4.0.0
@@ -4574,6 +4577,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -5758,6 +5764,9 @@ packages:
   highcharts@12.4.0:
     resolution: {integrity: sha512-o6UxxfChSUrvrZUbWrAuqL1HO/+exhAUPcZY6nnqLsadZQlnP16d082sg7DnXKZCk1gtfkyfkp6g3qkIZ9miZg==}
 
+  hive-auth-wrapper@1.0.0:
+    resolution: {integrity: sha512-HHWKCXO7gT8Zvo+bFwfYWqeUZVk+8fhi1UM27z5hV1zrl/Fe6Fzt/NGhojlNaKDNrIa5VZclnUr21qFZYFYHzQ==}
+
   hive-uri@0.2.8:
     resolution: {integrity: sha512-z04c+XiIxn8LmLyZD/26T5vBhR+EptIIxTnQYu5sODMskY1SjkpVZr6QaHb+6N4vWGVuOtLnK1A89NfyJ7OFfA==}
 
@@ -5885,6 +5894,10 @@ packages:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
     engines: {node: '>=12.22.0'}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -5950,6 +5963,10 @@ packages:
 
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
 
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
@@ -6736,6 +6753,10 @@ packages:
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
     engines: {node: '>= 0.4'}
 
   object-keys@1.1.1:
@@ -8407,6 +8428,9 @@ packages:
 
   util@0.10.4:
     resolution: {integrity: sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
@@ -12373,7 +12397,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@24.10.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -12435,7 +12459,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@24.10.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/utils@4.1.8':
     dependencies:
@@ -12715,6 +12739,14 @@ snapshots:
       is-array-buffer: 3.0.5
 
   asap@2.0.6: {}
+
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.8
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
 
   assertion-error@2.0.1: {}
 
@@ -14070,6 +14102,12 @@ snapshots:
 
   highcharts@12.4.0: {}
 
+  hive-auth-wrapper@1.0.0:
+    dependencies:
+      assert: 2.1.0
+      crypto-js: 4.2.0
+      uuid: 11.1.1
+
   hive-uri@0.2.8:
     dependencies:
       url-parse: 1.5.10
@@ -14216,6 +14254,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -14287,6 +14330,11 @@ snapshots:
   is-map@2.0.3: {}
 
   is-module@1.0.0: {}
+
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   is-negative-zero@2.0.3: {}
 
@@ -15016,6 +15064,11 @@ snapshots:
   object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
@@ -16841,6 +16894,14 @@ snapshots:
   util@0.10.4:
     dependencies:
       inherits: 2.0.3
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.19
 
   uuid@11.1.1: {}
 


### PR DESCRIPTION
Stacked on #1317, which already touches `hive-auth.ts`. Retarget this to `develop` once #1317 merges. Part of #1316.

## What was broken

`apps/self-hosted/src/features/auth/utils/hive-auth.ts` was a hand-rolled websocket client that did not implement HAS, so HiveAuth login could not complete on any instance. Every one of these is independently fatal:

- `auth_req.data` was sent as plaintext JSON. HAS requires the whole `data` object to be AES encrypted with a per-session auth key, so the wallet had nothing it could decrypt.
- `auth_ack` was read as plaintext, and `token` / `expire` were read off the message envelope, where they do not live. The reply is encrypted with the same auth key and carries those fields inside `data`, so even an approved login produced no session.
- The QR carried a `hiveauth://auth/` deep link. HAS wallets register `has://auth_req/`, so the code scanned as unknown text.
- The auth key was never handed to the wallet at all. The QR is the only channel it travels on, which is the whole point of scanning it.
- `HIVEAUTH_API` pointed at `hiveauth.arcange.eu`, which does not resolve. The socket never opened in the first place.

## What changed

The protocol, the crypto and the socket lifecycle now come from the official `hive-auth-wrapper` (1.0.0, deps: assert, crypto-js, uuid). Nothing about HAS encryption is reimplemented here.

The module keeps its existing exports. `loginWithHiveAuth` emits `has://auth_req/<base64 json>` carrying account, request uuid, auth key and host, which is what the existing `hiveauth:qrcode` listener and `QRCodeSVG` already render, so no UI change was needed. `broadcastWithHiveAuth` still takes the caller's `keyType` and passes it to the sign request, preserving the authority fix from #1317.

Session expiry is normalised on the way in. HAS reports an epoch in milliseconds, while `storage.ts`, `isHiveAuthSessionValid` and `auth-actions` all multiply the stored value by 1000. Storing the raw HAS value would have made every session look valid for millennia, so it is converted to seconds and back again when rebuilding credentials for a broadcast.

`signWithHiveAuth` is dropped. It had no callers anywhere in the repo, `broadcast: false` is not something the wrapper exposes, and keeping it would have meant keeping the raw plaintext socket path it was built on.

## Verification

22 new tests cover the parts reachable without a live HAS server: QR scheme and payload contents, the data handed to the protocol library, session shape and expiry semantics, authority passthrough, and error descriptions. Each was mutation-checked by breaking the fix and confirming the specific test fails (QR scheme reverted, auth key dropped from the payload, authority hardcoded to posting, expiry left in milliseconds, host reverted, challenge pre-encrypted, `setOptions` removed, `onSuccess` suppressed).

Full self-hosted suite passes (161 tests), typecheck shows only the pre-existing `config.json` error, and `rsbuild build` succeeds with the wrapper bundled.

Not covered: the encrypted exchange itself needs a real HAS server and a wallet, so the end-to-end approval round trip has not been exercised.