### PR TITLE
self-hosted: single config to DOM contract, fix save and instance type

### DIFF
--- a/apps/self-hosted/src/core/apply-config-dom.test.ts
+++ b/apps/self-hosted/src/core/apply-config-dom.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyConfigDom,
+  CONFIG_DOM_DECLARATION,
+  type ConfigDomDeclaration,
+  restoreConfigDom,
+  snapshotConfigDom,
+} from './apply-config-dom';
+
+function background(value: string) {
+  return { configuration: { general: { styles: { background: value } } } };
+}
+
+const FULL_CONFIG = {
+  configuration: {
+    general: {
+      theme: 'dark',
+      styleTemplate: 'magazine',
+      language: 'fr',
+      styles: { background: 'bg-slate-900 from-black to-slate-800' },
+    },
+    instanceConfiguration: {
+      type: 'community',
+      meta: { title: 'A community' },
+      layout: {
+        listType: 'list',
+        sidebar: {
+          placement: 'left',
+          followers: { enabled: false },
+          following: { enabled: true },
+          hiveInformation: {},
+        },
+      },
+    },
+  },
+};
+
+beforeEach(() => {
+  // Flush the module's record of the classes it applied, then wipe the
+  // document so each test starts from a page that carries nothing from config.
+  applyConfigDom({});
+  const root = document.documentElement;
+  for (const attribute of Array.from(root.attributes)) {
+    root.removeAttribute(attribute.name);
+  }
+  document.body.className = '';
+  document.title = 'Ecency Blog';
+  // jsdom does not implement matchMedia; tests that need it install a stub.
+  (window as { matchMedia?: unknown }).matchMedia = undefined;
+});
+
+describe('applyConfigDom', () => {
+  it('applies every declared attribute, the background and the title', () => {
+    applyConfigDom(FULL_CONFIG);
+
+    const root = document.documentElement;
+    expect(root.getAttribute('data-theme')).toBe('dark');
+    expect(root.getAttribute('data-style-template')).toBe('magazine');
+    expect(root.getAttribute('lang')).toBe('fr');
+    expect(root.getAttribute('data-language')).toBe('fr');
+    expect(root.getAttribute('data-sidebar-placement')).toBe('left');
+    expect(root.getAttribute('data-list-type')).toBe('list');
+    expect(root.getAttribute('data-instance-type')).toBe('community');
+    expect(root.getAttribute('data-show-followers')).toBe('false');
+    expect(root.getAttribute('data-show-following')).toBe('true');
+    expect(root.getAttribute('data-show-hive-info')).toBe('true');
+    expect(Array.from(document.body.classList).sort()).toEqual([
+      'bg-slate-900',
+      'from-black',
+      'to-slate-800',
+    ]);
+    expect(document.title).toBe('A community');
+  });
+
+  it('uses one set of defaults for missing and blank values', () => {
+    // The boot path used ?? and the preview path used ||, so an empty string
+    // reached the DOM on boot (matching no stylesheet) while preview showed
+    // the default. A missing theme reached the DOM as the string "undefined".
+    applyConfigDom({
+      configuration: {
+        general: { styleTemplate: '', language: '   ' },
+        instanceConfiguration: { type: '', layout: { listType: '' } },
+      },
+    });
+
+    const root = document.documentElement;
+    expect(root.getAttribute('data-theme')).toBe('light');
+    expect(root.getAttribute('data-style-template')).toBe('medium');
+    expect(root.getAttribute('lang')).toBe('en');
+    expect(root.getAttribute('data-language')).toBe('en');
+    expect(root.getAttribute('data-sidebar-placement')).toBe('right');
+    expect(root.getAttribute('data-list-type')).toBe('grid');
+    expect(root.getAttribute('data-instance-type')).toBe('blog');
+    expect(root.getAttribute('data-show-followers')).toBe('true');
+  });
+
+  it('resolves the system theme against the OS preference', () => {
+    (window as { matchMedia?: unknown }).matchMedia = () => ({
+      matches: true,
+      addEventListener() {},
+      removeEventListener() {},
+    });
+
+    applyConfigDom({ configuration: { general: { theme: 'system' } } });
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('replaces config owned background classes instead of stacking them', () => {
+    document.body.className = 'app-shell';
+
+    applyConfigDom(background('bg-white from-white to-gray-100'));
+    applyConfigDom(background('bg-black'));
+
+    expect(Array.from(document.body.classList).sort()).toEqual([
+      'app-shell',
+      'bg-black',
+    ]);
+  });
+
+  it('keeps the current title when the config carries none', () => {
+    applyConfigDom({
+      configuration: { instanceConfiguration: { meta: { title: '' } } },
+    });
+
+    expect(document.title).toBe('Ecency Blog');
+  });
+});
+
+describe('snapshotConfigDom / restoreConfigDom', () => {
+  it('restores the exact pre preview state, including absent attributes', () => {
+    // A booted page carries no data-language, and only some of the declared
+    // attributes. Restoring by writing a default back left the preview's
+    // attributes on the document forever.
+    document.documentElement.setAttribute('data-theme', 'light');
+    document.body.className = 'app-shell';
+    document.title = 'Owner blog';
+
+    const snapshot = snapshotConfigDom();
+    applyConfigDom(FULL_CONFIG);
+    expect(document.documentElement.getAttribute('data-language')).toBe('fr');
+
+    restoreConfigDom(snapshot);
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    for (const { attribute } of CONFIG_DOM_DECLARATION.attributes) {
+      if (attribute === 'data-theme') continue;
+      expect(
+        `${attribute}=${document.documentElement.getAttribute(attribute)}`,
+      ).toBe(`${attribute}=null`);
+    }
+    expect(Array.from(document.body.classList)).toEqual(['app-shell']);
+    expect(document.title).toBe('Owner blog');
+  });
+
+  it('restores the previous value of an attribute that was present', () => {
+    applyConfigDom({
+      configuration: {
+        general: { theme: 'light', styleTemplate: 'minimal' },
+        instanceConfiguration: { layout: { listType: 'grid' } },
+      },
+    });
+
+    const snapshot = snapshotConfigDom();
+    applyConfigDom(FULL_CONFIG);
+    restoreConfigDom(snapshot);
+
+    const root = document.documentElement;
+    expect(root.getAttribute('data-theme')).toBe('light');
+    expect(root.getAttribute('data-style-template')).toBe('minimal');
+    expect(root.getAttribute('data-list-type')).toBe('grid');
+  });
+
+  it('replaces a background class that carries no declared prefix', () => {
+    applyConfigDom(background('owner-skin'));
+    const snapshot = snapshotConfigDom();
+    applyConfigDom(background('preview-skin'));
+    restoreConfigDom(snapshot);
+
+    applyConfigDom(background('next-skin'));
+
+    expect(Array.from(document.body.classList)).toEqual(['next-skin']);
+  });
+});
+
+describe('declared CSS variables', () => {
+  // Nothing is driven by an inline custom property yet, so the declaration is
+  // exercised here with the shape a future knob (accent color, font preset)
+  // will take.
+  const declaration: ConfigDomDeclaration = {
+    ...CONFIG_DOM_DECLARATION,
+    cssVariables: [
+      {
+        variable: '--instance-accent',
+        resolve: (read) => {
+          const value = read('configuration.general.styles.accent');
+          return typeof value === 'string' && value.length > 0 ? value : null;
+        },
+      },
+    ],
+  };
+
+  const accent = (value: string) => ({
+    configuration: { general: { styles: { accent: value } } },
+  });
+
+  it('sets the property and removes it again when it was not set before', () => {
+    const snapshot = snapshotConfigDom(declaration);
+
+    applyConfigDom(accent('#ff0000'), { declaration });
+    expect(
+      document.documentElement.style.getPropertyValue('--instance-accent'),
+    ).toBe('#ff0000');
+
+    restoreConfigDom(snapshot);
+    expect(
+      document.documentElement.style.getPropertyValue('--instance-accent'),
+    ).toBe('');
+  });
+
+  it('restores the value the property had before preview', () => {
+    document.documentElement.style.setProperty('--instance-accent', '#0000ff');
+
+    const snapshot = snapshotConfigDom(declaration);
+    applyConfigDom(accent('#ff0000'), { declaration });
+    restoreConfigDom(snapshot);
+
+    expect(
+      document.documentElement.style.getPropertyValue('--instance-accent'),
+    ).toBe('#0000ff');
+  });
+});

--- a/apps/self-hosted/src/core/apply-config-dom.test.ts
+++ b/apps/self-hosted/src/core/apply-config-dom.test.ts
@@ -4,9 +4,14 @@ import {
   applyConfigDom,
   CONFIG_DOM_DECLARATION,
   type ConfigDomDeclaration,
+  resetConfigDomBaseline,
   restoreConfigDom,
   snapshotConfigDom,
 } from './apply-config-dom';
+
+function configWithTitle(title: string) {
+  return { configuration: { instanceConfiguration: { meta: { title } } } };
+}
 
 function background(value: string) {
   return { configuration: { general: { styles: { background: value } } } };
@@ -119,7 +124,12 @@ describe('applyConfigDom', () => {
     ]);
   });
 
-  it('keeps the current title when the config carries none', () => {
+  it('shows the boot title when the config carries none', () => {
+    // The baseline is captured on the first apply, so this states which title
+    // the document booted with rather than relying on an earlier test's state.
+    resetConfigDomBaseline();
+    document.title = 'Ecency Blog';
+
     applyConfigDom({
       configuration: { instanceConfiguration: { meta: { title: '' } } },
     });
@@ -229,5 +239,42 @@ describe('declared CSS variables', () => {
     expect(
       document.documentElement.style.getPropertyValue('--instance-accent'),
     ).toBe('#0000ff');
+  });
+});
+
+describe('document title round trip', () => {
+  beforeEach(() => {
+    resetConfigDomBaseline();
+    document.title = 'Ecency Blog';
+  });
+
+  /**
+   * An empty configured title means the owner cleared it, which is not the same
+   * as "leave whatever is on the document". Returning early left the old title
+   * on screen, so the change could not be previewed and read as a failed save.
+   */
+  it('falls back to the boot title when the owner clears it', () => {
+    applyConfigDom(configWithTitle('My Blog'));
+    expect(document.title).toBe('My Blog');
+
+    applyConfigDom(configWithTitle(''));
+    expect(document.title).toBe('Ecency Blog');
+  });
+
+  it('does not adopt a configured title as the baseline', () => {
+    // The first apply carries a title, so the baseline must still be the one
+    // the document booted with, not the configured one.
+    applyConfigDom(configWithTitle('My Blog'));
+    applyConfigDom(configWithTitle('Renamed'));
+    applyConfigDom(configWithTitle(''));
+
+    expect(document.title).toBe('Ecency Blog');
+  });
+
+  it('applies a title on every apply, not only the first', () => {
+    applyConfigDom(configWithTitle('One'));
+    applyConfigDom(configWithTitle('Two'));
+
+    expect(document.title).toBe('Two');
   });
 });

--- a/apps/self-hosted/src/core/apply-config-dom.ts
+++ b/apps/self-hosted/src/core/apply-config-dom.ts
@@ -209,6 +209,26 @@ export const CONFIG_DOM_DECLARATION: ConfigDomDeclaration = {
 // =============================================================================
 
 /**
+ * The document title before configuration first touched it, which is what an
+ * instance with no configured title falls back to. Captured lazily on the first
+ * apply, which is boot, so preview cannot capture a configured title as if it
+ * were the baseline.
+ */
+let originalDocumentTitle: string | null = null;
+
+function baselineDocumentTitle(): string {
+  if (originalDocumentTitle === null) {
+    originalDocumentTitle = document.title;
+  }
+  return originalDocumentTitle;
+}
+
+/** Test seam: the baseline otherwise leaks between cases. */
+export function resetConfigDomBaseline(): void {
+  originalDocumentTitle = null;
+}
+
+/**
  * Classes this module added on the previous apply. Cleared alongside the
  * declared prefixes so a background class that carries no declared prefix is
  * still replaced rather than accumulated.
@@ -300,10 +320,18 @@ export function applyConfigDom(
 
   applyBodyClasses(read, declaration.bodyClasses);
 
+  // null means the config carries no title, which is not the same as "leave
+  // whatever is on the document". Clearing the title in the editor produced
+  // null, so the old title stayed on screen: the change could not be previewed
+  // and looked like the save had failed. Falling back to the title the document
+  // booted with makes clearing round-trip and stay deterministic.
+  // Captured before the assignment, and unconditionally: reading it only in the
+  // fallback branch would mean the first apply with a configured title never
+  // captures, and a later clear would then adopt that configured title as the
+  // baseline.
+  const baseline = baselineDocumentTitle();
   const title = declaration.documentTitle(read);
-  if (title !== null) {
-    document.title = title;
-  }
+  document.title = title ?? baseline;
 
   if (options.syncSystemTheme) {
     syncSystemTheme(text(read(PATHS.theme), DEFAULT_THEME) === 'system');

--- a/apps/self-hosted/src/core/apply-config-dom.ts
+++ b/apps/self-hosted/src/core/apply-config-dom.ts
@@ -1,0 +1,378 @@
+/**
+ * The single config -> DOM contract for the instance.
+ *
+ * Every visual knob the configuration drives is declared once in
+ * CONFIG_DOM_DECLARATION. Boot (src/index.tsx) and the Configuration Editor's
+ * preview both apply it through applyConfigDom, and the editor's
+ * snapshot/restore is generated from the same declaration, so preview cannot
+ * drift from what a save actually produces and adding a knob (accent color,
+ * font preset, theme gallery) is a one-file change here.
+ *
+ * The config document is read by path rather than by type because the two call
+ * sites hold it differently: boot has the typed InstanceConfig, the editor
+ * holds the raw JSON document it is editing.
+ */
+
+export type ConfigReader = (path: string) => unknown;
+
+export interface ConfigDomAttribute {
+  /** Attribute name set on the <html> element. */
+  attribute: string;
+  /** Resolved value, or null to remove the attribute entirely. */
+  resolve: (read: ConfigReader) => string | null;
+}
+
+export interface ConfigDomCssVariable {
+  /** Custom property name, e.g. '--instance-accent'. */
+  variable: string;
+  /** Resolved value, or null to leave the property unset. */
+  resolve: (read: ConfigReader) => string | null;
+}
+
+export interface ConfigDomBodyClasses {
+  /**
+   * Class prefixes owned by the configuration. Every matching class is cleared
+   * from <body> before the configured ones are added, so re-applying a config
+   * replaces the previous background instead of stacking on top of it.
+   */
+  prefixes: readonly string[];
+  resolve: (read: ConfigReader) => readonly string[];
+}
+
+export interface ConfigDomDeclaration {
+  attributes: readonly ConfigDomAttribute[];
+  cssVariables: readonly ConfigDomCssVariable[];
+  bodyClasses: ConfigDomBodyClasses;
+  /** Document title, or null to keep whatever title the document already has. */
+  documentTitle: (read: ConfigReader) => string | null;
+}
+
+export interface ConfigDomSnapshot {
+  /** null means the attribute was absent and must be removed on restore. */
+  attributes: Record<string, string | null>;
+  /** null means the property was not set inline and must be removed on restore. */
+  cssVariables: Record<string, string | null>;
+  bodyClasses: string[];
+  /**
+   * The subset of bodyClasses this module applied from config at capture time.
+   * Restoring it keeps a later apply able to replace a configured class that
+   * carries none of the declared prefixes.
+   */
+  ownedBodyClasses: string[];
+  documentTitle: string;
+}
+
+export interface ApplyConfigDomOptions {
+  declaration?: ConfigDomDeclaration;
+  /**
+   * Keep data-theme in step with the operating system while the configured
+   * theme is 'system'. Only the paths that establish a new baseline (boot, a
+   * successful save) ask for this; preview must not, so a keystroke in the
+   * editor cannot register a listener per render.
+   */
+  syncSystemTheme?: boolean;
+}
+
+// =============================================================================
+// Config reading helpers
+// =============================================================================
+
+export function readConfigPath(config: unknown, path: string): unknown {
+  let current: unknown = config;
+  for (const key of path.split('.')) {
+    if (typeof current !== 'object' || current === null) return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+export function createConfigReader(config: unknown): ConfigReader {
+  return (path: string) => readConfigPath(config, path);
+}
+
+/**
+ * A blank or non-string value means "not configured". An empty string must not
+ * reach the DOM: `data-style-template=""` matches no stylesheet, which is how
+ * the boot path used to render an unstyled page where preview showed the
+ * default template.
+ */
+function text(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+/** Sidebar sections are opt-out: anything but an explicit false is enabled. */
+function flag(value: unknown): string {
+  return value === false ? 'false' : 'true';
+}
+
+function prefersDarkColorScheme(): boolean {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return false;
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+// =============================================================================
+// The declaration
+// =============================================================================
+
+const PATHS = {
+  theme: 'configuration.general.theme',
+  styleTemplate: 'configuration.general.styleTemplate',
+  language: 'configuration.general.language',
+  background: 'configuration.general.styles.background',
+  instanceType: 'configuration.instanceConfiguration.type',
+  title: 'configuration.instanceConfiguration.meta.title',
+  listType: 'configuration.instanceConfiguration.layout.listType',
+  sidebarPlacement:
+    'configuration.instanceConfiguration.layout.sidebar.placement',
+  followers:
+    'configuration.instanceConfiguration.layout.sidebar.followers.enabled',
+  following:
+    'configuration.instanceConfiguration.layout.sidebar.following.enabled',
+  hiveInformation:
+    'configuration.instanceConfiguration.layout.sidebar.hiveInformation.enabled',
+} as const;
+
+export const DEFAULT_THEME = 'light';
+
+function resolveTheme(read: ConfigReader): string {
+  const configured = text(read(PATHS.theme), DEFAULT_THEME);
+  if (configured === 'system') {
+    return prefersDarkColorScheme() ? 'dark' : 'light';
+  }
+  return configured;
+}
+
+export const CONFIG_DOM_DECLARATION: ConfigDomDeclaration = {
+  attributes: [
+    { attribute: 'data-theme', resolve: resolveTheme },
+    {
+      attribute: 'data-style-template',
+      resolve: (read) => text(read(PATHS.styleTemplate), 'medium'),
+    },
+    { attribute: 'lang', resolve: (read) => text(read(PATHS.language), 'en') },
+    {
+      attribute: 'data-language',
+      resolve: (read) => text(read(PATHS.language), 'en'),
+    },
+    {
+      attribute: 'data-sidebar-placement',
+      resolve: (read) => text(read(PATHS.sidebarPlacement), 'right'),
+    },
+    {
+      attribute: 'data-list-type',
+      resolve: (read) => text(read(PATHS.listType), 'grid'),
+    },
+    {
+      attribute: 'data-instance-type',
+      resolve: (read) => text(read(PATHS.instanceType), 'blog'),
+    },
+    {
+      attribute: 'data-show-followers',
+      resolve: (read) => flag(read(PATHS.followers)),
+    },
+    {
+      attribute: 'data-show-following',
+      resolve: (read) => flag(read(PATHS.following)),
+    },
+    {
+      attribute: 'data-show-hive-info',
+      resolve: (read) => flag(read(PATHS.hiveInformation)),
+    },
+  ],
+  // Nothing is driven by an inline custom property yet: the style templates
+  // declare their variables in CSS. This is where accent color and font
+  // presets attach, and the apply/snapshot/restore machinery already covers
+  // them.
+  cssVariables: [],
+  bodyClasses: {
+    prefixes: ['bg-', 'from-', 'via-', 'to-'],
+    resolve: (read) =>
+      text(read(PATHS.background), '')
+        .split(/\s+/)
+        .filter((className) => className.length > 0),
+  },
+  documentTitle: (read) => {
+    const title = text(read(PATHS.title), '');
+    return title.length > 0 ? title : null;
+  },
+};
+
+// =============================================================================
+// Apply
+// =============================================================================
+
+/**
+ * Classes this module added on the previous apply. Cleared alongside the
+ * declared prefixes so a background class that carries no declared prefix is
+ * still replaced rather than accumulated.
+ */
+let appliedBodyClasses: string[] = [];
+
+let systemThemeQuery: MediaQueryList | null = null;
+let systemThemeListener: ((event: MediaQueryListEvent) => void) | null = null;
+
+function syncSystemTheme(enabled: boolean): void {
+  if (systemThemeQuery && systemThemeListener) {
+    systemThemeQuery.removeEventListener('change', systemThemeListener);
+  }
+  systemThemeQuery = null;
+  systemThemeListener = null;
+
+  if (
+    !enabled ||
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return;
+  }
+
+  systemThemeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  systemThemeListener = (event) => {
+    document.documentElement.setAttribute(
+      'data-theme',
+      event.matches ? 'dark' : 'light',
+    );
+  };
+  systemThemeQuery.addEventListener('change', systemThemeListener);
+}
+
+function applyBodyClasses(
+  read: ConfigReader,
+  declaration: ConfigDomBodyClasses,
+): void {
+  const body = document.body;
+  if (!body) return;
+
+  for (const className of Array.from(body.classList)) {
+    const owned =
+      appliedBodyClasses.includes(className) ||
+      declaration.prefixes.some((prefix) => className.startsWith(prefix));
+    if (owned) body.classList.remove(className);
+  }
+
+  const next: string[] = [];
+  for (const className of declaration.resolve(read)) {
+    // classList.add throws on a token containing whitespace or an empty
+    // string, and the value is owner-typed, so a stray tab pasted into the
+    // field must not abort the rest of the apply.
+    try {
+      body.classList.add(className);
+      next.push(className);
+    } catch {
+      console.warn('[Config] Ignoring invalid background class:', className);
+    }
+  }
+  appliedBodyClasses = next;
+}
+
+export function applyConfigDom(
+  config: unknown,
+  options: ApplyConfigDomOptions = {},
+): void {
+  const declaration = options.declaration ?? CONFIG_DOM_DECLARATION;
+  const read = createConfigReader(config);
+  const root = document.documentElement;
+
+  for (const { attribute, resolve } of declaration.attributes) {
+    const value = resolve(read);
+    if (value === null) {
+      root.removeAttribute(attribute);
+    } else {
+      root.setAttribute(attribute, value);
+    }
+  }
+
+  for (const { variable, resolve } of declaration.cssVariables) {
+    const value = resolve(read);
+    if (value === null) {
+      root.style.removeProperty(variable);
+    } else {
+      root.style.setProperty(variable, value);
+    }
+  }
+
+  applyBodyClasses(read, declaration.bodyClasses);
+
+  const title = declaration.documentTitle(read);
+  if (title !== null) {
+    document.title = title;
+  }
+
+  if (options.syncSystemTheme) {
+    syncSystemTheme(text(read(PATHS.theme), DEFAULT_THEME) === 'system');
+  }
+}
+
+// =============================================================================
+// Snapshot / restore
+// =============================================================================
+
+/**
+ * Capture everything the declaration is allowed to touch, so leaving preview
+ * puts the document back exactly as it was, including attributes and custom
+ * properties that were ABSENT before preview started.
+ */
+export function snapshotConfigDom(
+  declaration: ConfigDomDeclaration = CONFIG_DOM_DECLARATION,
+): ConfigDomSnapshot {
+  const root = document.documentElement;
+
+  const attributes: Record<string, string | null> = {};
+  for (const { attribute } of declaration.attributes) {
+    attributes[attribute] = root.getAttribute(attribute);
+  }
+
+  const cssVariables: Record<string, string | null> = {};
+  for (const { variable } of declaration.cssVariables) {
+    // getPropertyValue returns '' both for "unset" and for an empty value; an
+    // empty inline value is not a state the declaration can produce, so '' is
+    // recorded as "was not set".
+    const value = root.style.getPropertyValue(variable);
+    cssVariables[variable] = value === '' ? null : value;
+  }
+
+  return {
+    attributes,
+    cssVariables,
+    bodyClasses: document.body ? Array.from(document.body.classList) : [],
+    ownedBodyClasses: [...appliedBodyClasses],
+    documentTitle: document.title,
+  };
+}
+
+export function restoreConfigDom(snapshot: ConfigDomSnapshot): void {
+  const root = document.documentElement;
+
+  for (const [attribute, value] of Object.entries(snapshot.attributes)) {
+    if (value === null) {
+      root.removeAttribute(attribute);
+    } else {
+      root.setAttribute(attribute, value);
+    }
+  }
+
+  for (const [variable, value] of Object.entries(snapshot.cssVariables)) {
+    if (value === null) {
+      root.style.removeProperty(variable);
+    } else {
+      root.style.setProperty(variable, value);
+    }
+  }
+
+  if (document.body) {
+    document.body.className = '';
+    for (const className of snapshot.bodyClasses) {
+      document.body.classList.add(className);
+    }
+  }
+  appliedBodyClasses = [...snapshot.ownedBodyClasses];
+
+  document.title = snapshot.documentTitle;
+}

--- a/apps/self-hosted/src/core/index.ts
+++ b/apps/self-hosted/src/core/index.ts
@@ -1,3 +1,5 @@
+export * from './apply-config-dom';
 export * from './configuration-loader';
 export * from './date-formatter';
 export * from './i18n';
+export * from './instance-type-filters';

--- a/apps/self-hosted/src/core/instance-type-filters.test.ts
+++ b/apps/self-hosted/src/core/instance-type-filters.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defaultPostsFiltersFor,
+  sanitizePostsFiltersFor,
+  toInstanceType,
+  withPinnedInstanceType,
+} from './instance-type-filters';
+
+function makeDocument(type: string, postsFilters?: unknown) {
+  return {
+    version: 1,
+    configuration: {
+      general: { theme: 'light' },
+      instanceConfiguration: {
+        type,
+        username: 'owner',
+        features:
+          postsFilters === undefined
+            ? { likes: { enabled: true } }
+            : { likes: { enabled: true }, postsFilters },
+      },
+    },
+  };
+}
+
+describe('sanitizePostsFiltersFor', () => {
+  it('drops community sorts from a blog instance', () => {
+    expect(
+      sanitizePostsFiltersFor('blog', ['posts', 'trending', 'hot', 'replies']),
+    ).toEqual(['posts', 'replies']);
+  });
+
+  it('drops blog sorts from a community instance', () => {
+    expect(
+      sanitizePostsFiltersFor('community', ['blog', 'trending', 'replies']),
+    ).toEqual(['trending']);
+  });
+
+  it('falls back to the defaults when nothing valid is left', () => {
+    // An instance with no usable filter has no feed at all, and
+    // resolvePostsFilter would clamp every request to the broken first entry.
+    expect(sanitizePostsFiltersFor('blog', ['trending', 'hot', 'new'])).toEqual(
+      defaultPostsFiltersFor('blog'),
+    );
+    expect(sanitizePostsFiltersFor('community', 'trending')).toEqual(
+      defaultPostsFiltersFor('community'),
+    );
+  });
+
+  it('only offers sorts the feed APIs accept', () => {
+    // bridge.get_account_posts has no 'new'; bridge.get_ranked_posts has no
+    // 'blog'. The editor used to auto-fill ['trending','hot','new'].
+    expect(defaultPostsFiltersFor('community')).not.toContain('new');
+    for (const filter of defaultPostsFiltersFor('community')) {
+      expect(sanitizePostsFiltersFor('community', [filter])).toEqual([filter]);
+    }
+    for (const filter of defaultPostsFiltersFor('blog')) {
+      expect(sanitizePostsFiltersFor('blog', [filter])).toEqual([filter]);
+    }
+  });
+});
+
+describe('withPinnedInstanceType', () => {
+  it('pins the type back and repairs the filters the editor auto-filled', () => {
+    const document = makeDocument('community', ['trending', 'hot', 'new']);
+
+    const pinned = withPinnedInstanceType(document, 'blog');
+
+    expect(pinned.configuration.instanceConfiguration.type).toBe('blog');
+    expect(
+      pinned.configuration.instanceConfiguration.features.postsFilters,
+    ).toEqual(defaultPostsFiltersFor('blog'));
+  });
+
+  it('keeps the filters that the pinned type can fetch', () => {
+    const pinned = withPinnedInstanceType(
+      makeDocument('community', ['posts', 'trending', 'comments']),
+      'blog',
+    );
+
+    expect(
+      pinned.configuration.instanceConfiguration.features.postsFilters,
+    ).toEqual(['posts', 'comments']);
+  });
+
+  it('leaves an already consistent document untouched', () => {
+    const document = makeDocument('blog', ['posts', 'replies']);
+
+    expect(withPinnedInstanceType(document, 'blog')).toBe(document);
+  });
+
+  it('does not invent filters a document does not carry', () => {
+    const pinned = withPinnedInstanceType(makeDocument('community'), 'blog');
+
+    expect(pinned.configuration.instanceConfiguration.type).toBe('blog');
+    expect(
+      pinned.configuration.instanceConfiguration.features,
+    ).not.toHaveProperty('postsFilters');
+  });
+
+  it('does not mutate the document it is given', () => {
+    const document = makeDocument('community', ['trending']);
+
+    withPinnedInstanceType(document, 'blog');
+
+    expect(document.configuration.instanceConfiguration.type).toBe('community');
+    expect(
+      document.configuration.instanceConfiguration.features.postsFilters,
+    ).toEqual(['trending']);
+  });
+
+  it('returns a document it cannot understand unchanged', () => {
+    const document = { version: 1 };
+    expect(withPinnedInstanceType(document, 'blog')).toBe(document);
+  });
+});
+
+describe('toInstanceType', () => {
+  it('treats anything but community as a blog', () => {
+    expect(toInstanceType('community')).toBe('community');
+    expect(toInstanceType('blog')).toBe('blog');
+    expect(toInstanceType(undefined)).toBe('blog');
+    expect(toInstanceType('Community')).toBe('blog');
+  });
+});

--- a/apps/self-hosted/src/core/instance-type-filters.ts
+++ b/apps/self-hosted/src/core/instance-type-filters.ts
@@ -1,0 +1,134 @@
+/**
+ * Post filters are only meaningful for one instance type: a blog feed calls
+ * bridge.get_account_posts, a community feed calls bridge.get_ranked_posts, and
+ * the two APIs accept different sorts. Mixing them produces an instance whose
+ * every tab errors, and resolvePostsFilter then clamps even an explicit
+ * ?filter=... to the broken first entry.
+ *
+ * The hosting API pins instanceConfiguration.type from the stored config
+ * (TenantService.applyConfigDocument) but persists whatever postsFilters the
+ * client sends, so the editor must not save filters that contradict the type
+ * the server is going to keep.
+ */
+
+export type InstanceType = 'blog' | 'community';
+
+/** Sorts bridge.get_account_posts accepts. */
+export const BLOG_POSTS_FILTERS: readonly string[] = [
+  'blog',
+  'feed',
+  'posts',
+  'comments',
+  'replies',
+  'payout',
+];
+
+/** Sorts bridge.get_ranked_posts accepts. */
+export const COMMUNITY_POSTS_FILTERS: readonly string[] = [
+  'trending',
+  'hot',
+  'created',
+  'promoted',
+  'payout',
+  'muted',
+];
+
+/** What the editor fills in when the instance type changes. */
+export const DEFAULT_POSTS_FILTERS: Record<InstanceType, readonly string[]> = {
+  blog: ['blog', 'posts', 'comments', 'replies'],
+  community: ['trending', 'hot', 'created'],
+};
+
+export function toInstanceType(value: unknown): InstanceType {
+  return value === 'community' ? 'community' : 'blog';
+}
+
+export function defaultPostsFiltersFor(type: InstanceType): string[] {
+  return [...DEFAULT_POSTS_FILTERS[type]];
+}
+
+function supportedFiltersFor(type: InstanceType): readonly string[] {
+  return type === 'community' ? COMMUNITY_POSTS_FILTERS : BLOG_POSTS_FILTERS;
+}
+
+/**
+ * Keep only the filters the given instance type can actually fetch. An empty
+ * result would leave the instance with no feed at all, so it falls back to the
+ * defaults for that type.
+ */
+export function sanitizePostsFiltersFor(
+  type: InstanceType,
+  filters: unknown,
+): string[] {
+  const supported = supportedFiltersFor(type);
+  const valid = Array.isArray(filters)
+    ? filters.filter(
+        (filter): filter is string =>
+          typeof filter === 'string' && supported.includes(filter),
+      )
+    : [];
+  return valid.length > 0 ? valid : defaultPostsFiltersFor(type);
+}
+
+function sameFilters(a: readonly unknown[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+/**
+ * Force a config document to agree with the instance type the server owns:
+ * the type is set back to the pinned value and any filter that type cannot
+ * fetch is dropped. postsFilters is left alone when the document does not
+ * carry it, so a save never invents settings the owner did not have.
+ *
+ * Returns the original document when it is already consistent.
+ */
+export function withPinnedInstanceType<T>(
+  document: T,
+  pinnedType: InstanceType,
+): T {
+  const doc = document as unknown as Record<string, unknown>;
+  const configuration = doc?.configuration;
+  if (typeof configuration !== 'object' || configuration === null) {
+    return document;
+  }
+
+  const configurationRecord = configuration as Record<string, unknown>;
+  const instance = configurationRecord.instanceConfiguration;
+  if (typeof instance !== 'object' || instance === null) {
+    return document;
+  }
+
+  const instanceRecord = instance as Record<string, unknown>;
+  const features = instanceRecord.features;
+  const featuresRecord =
+    typeof features === 'object' && features !== null
+      ? (features as Record<string, unknown>)
+      : null;
+  const currentFilters = featuresRecord?.postsFilters;
+
+  const typeMatches = instanceRecord.type === pinnedType;
+  const nextFilters = Array.isArray(currentFilters)
+    ? sanitizePostsFiltersFor(pinnedType, currentFilters)
+    : null;
+  const filtersMatch =
+    nextFilters === null ||
+    sameFilters(currentFilters as unknown[], nextFilters);
+
+  if (typeMatches && filtersMatch) return document;
+
+  const nextInstance: Record<string, unknown> = {
+    ...instanceRecord,
+    type: pinnedType,
+  };
+  if (nextFilters !== null && featuresRecord) {
+    nextInstance.features = { ...featuresRecord, postsFilters: nextFilters };
+  }
+
+  return {
+    ...doc,
+    configuration: {
+      ...configurationRecord,
+      instanceConfiguration: nextInstance,
+    },
+  } as unknown as T;
+}

--- a/apps/self-hosted/src/features/floating-menu/components/floating-menu-window.tsx
+++ b/apps/self-hosted/src/features/floating-menu/components/floating-menu-window.tsx
@@ -1,5 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { InstanceConfigManager } from '@/core';
+import {
+  applyConfigDom,
+  type ConfigDomSnapshot,
+  defaultPostsFiltersFor,
+  type InstanceConfig,
+  InstanceConfigManager,
+  type InstanceType,
+  restoreConfigDom,
+  snapshotConfigDom,
+  toInstanceType,
+  withPinnedInstanceType,
+} from '@/core';
 import {
   clearHostingToken,
   getHostingToken,
@@ -39,162 +50,40 @@ function getTenantUsername(): string | null {
   );
 }
 
-interface OriginalState {
-  theme: string;
-  styleTemplate: string;
-  sidebarPlacement: string;
-  /** Complete snapshot of all body classes at capture time */
-  allBodyClasses: string[];
-  pageTitle: string;
-  language: string;
-  instanceType: string;
-  showFollowers: string;
-  showFollowing: string;
-  showHiveInfo: string;
-  listType: string | null;
-}
+const INSTANCE_TYPE_PATH = 'configuration.instanceConfiguration.type';
+const POSTS_FILTERS_PATH =
+  'configuration.instanceConfiguration.features.postsFilters';
 
-function applyPreviewConfig(config: Record<string, ConfigValue>) {
-  const configuration = config.configuration as Record<string, ConfigValue>;
-  const general = configuration?.general as Record<string, ConfigValue>;
-  const instanceConfiguration = configuration?.instanceConfiguration as Record<
-    string,
-    ConfigValue
-  >;
-
-  if (!general) return;
-
-  // Apply theme
-  const theme = (general.theme as string) || 'light';
-  if (theme === 'system') {
-    const prefersDark = window.matchMedia(
-      '(prefers-color-scheme: dark)',
-    ).matches;
-    document.documentElement.setAttribute(
-      'data-theme',
-      prefersDark ? 'dark' : 'light',
-    );
-  } else {
-    document.documentElement.setAttribute('data-theme', theme);
-  }
-
-  // Apply style template
-  const styleTemplate = (general.styleTemplate as string) || 'medium';
-  document.documentElement.setAttribute('data-style-template', styleTemplate);
-
-  // Apply language
-  const language = (general.language as string) || 'en';
-  document.documentElement.setAttribute('lang', language);
-  document.documentElement.setAttribute('data-language', language);
-
-  // Apply sidebar placement
-  const layout = instanceConfiguration?.layout as Record<string, ConfigValue>;
-  const sidebar = layout?.sidebar as Record<string, ConfigValue>;
-  const sidebarPlacement = (sidebar?.placement as string) || 'right';
-  document.documentElement.setAttribute(
-    'data-sidebar-placement',
-    sidebarPlacement,
-  );
-
-  // Apply list type
-  const listType = (layout?.listType as string) || 'grid';
-  document.documentElement.setAttribute('data-list-type', listType);
-
-  // Apply meta title to page
-  const meta = instanceConfiguration?.meta as Record<string, ConfigValue>;
-  const title = (meta?.title as string) || '';
-  if (title) {
-    document.title = title;
-  }
-
-  // Apply background styles
-  const styles = general.styles as Record<string, ConfigValue>;
-  const background = (styles?.background as string) || '';
-
-  // Remove old background classes and add new ones
-  const bodyClasses = Array.from(document.body.classList);
-  for (const c of bodyClasses) {
-    if (c.startsWith('bg-') || c.startsWith('from-') || c.startsWith('to-')) {
-      document.body.classList.remove(c);
-    }
-  }
-
-  if (background) {
-    for (const className of background.split(' ')) {
-      if (className) document.body.classList.add(className);
-    }
-  }
-
-  // Apply instance type
-  const instanceType = (instanceConfiguration?.type as string) || 'blog';
-  document.documentElement.setAttribute('data-instance-type', instanceType);
-
-  // Apply sidebar section visibility
-  const followers = sidebar?.followers as Record<string, ConfigValue>;
-  const following = sidebar?.following as Record<string, ConfigValue>;
-  const hiveInfo = sidebar?.hiveInformation as Record<string, ConfigValue>;
-
-  document.documentElement.setAttribute(
-    'data-show-followers',
-    followers?.enabled !== false ? 'true' : 'false',
-  );
-  document.documentElement.setAttribute(
-    'data-show-following',
-    following?.enabled !== false ? 'true' : 'false',
-  );
-  document.documentElement.setAttribute(
-    'data-show-hive-info',
-    hiveInfo?.enabled !== false ? 'true' : 'false',
+/**
+ * The instance type the hosting API will keep no matter what this document
+ * says: applyConfigDocument pins it from the stored config. Null when the site
+ * is not on managed hosting, where the edited document is what the owner
+ * deploys.
+ */
+function getPinnedInstanceType(): InstanceType | null {
+  if (!isManagedHosting()) return null;
+  return toInstanceType(
+    InstanceConfigManager.getConfigValue(
+      ({ configuration }) => configuration.instanceConfiguration.type,
+    ),
   );
 }
 
-function restoreOriginalState(original: OriginalState) {
-  // Restore theme
-  document.documentElement.setAttribute('data-theme', original.theme);
-
-  // Restore style template
-  document.documentElement.setAttribute(
-    'data-style-template',
-    original.styleTemplate,
-  );
-
-  // Restore sidebar placement
-  document.documentElement.setAttribute(
-    'data-sidebar-placement',
-    original.sidebarPlacement,
-  );
-
-  // Restore language
-  document.documentElement.setAttribute('lang', original.language);
-  document.documentElement.setAttribute('data-language', original.language);
-
-  // Restore page title
-  document.title = original.pageTitle;
-
-  // Restore all body classes to original state
-  // Remove all current classes and restore the original snapshot
-  const currentClasses = Array.from(document.body.classList);
-  for (const c of currentClasses) {
-    document.body.classList.remove(c);
+/**
+ * The config the server actually stored, which is authoritative: it pins the
+ * identity fields and drops values that disagree with the stored shape.
+ */
+function readSavedConfig(payload: unknown): Record<string, ConfigValue> | null {
+  const saved = (payload as { config?: unknown } | null)?.config;
+  if (
+    saved &&
+    typeof saved === 'object' &&
+    !Array.isArray(saved) &&
+    'configuration' in saved
+  ) {
+    return saved as Record<string, ConfigValue>;
   }
-  for (const c of original.allBodyClasses) {
-    document.body.classList.add(c);
-  }
-
-  // Restore instance type
-  document.documentElement.setAttribute('data-instance-type', original.instanceType);
-
-  // Restore sidebar section visibility
-  document.documentElement.setAttribute('data-show-followers', original.showFollowers);
-  document.documentElement.setAttribute('data-show-following', original.showFollowing);
-  document.documentElement.setAttribute('data-show-hive-info', original.showHiveInfo);
-
-  // Restore list type
-  if (original.listType !== null) {
-    document.documentElement.setAttribute('data-list-type', original.listType);
-  } else {
-    document.documentElement.removeAttribute('data-list-type');
-  }
+  return null;
 }
 
 interface FloatingMenuWindowProps {
@@ -213,7 +102,8 @@ export function FloatingMenuWindow({
   const [isSaving, setIsSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [saveError, setSaveError] = useState<string | null>(null);
-  const originalStateRef = useRef<OriginalState | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const originalStateRef = useRef<ConfigDomSnapshot | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
   const managed = useMemo(() => isManagedHosting(), []);
 
@@ -225,18 +115,34 @@ export function FloatingMenuWindow({
   }, [isOpen]);
 
   const handleUpdate = useCallback((path: string, value: ConfigValue) => {
-    setConfig((prev) => {
-      let updated = updateNestedPath(prev, path, value);
+    const isTypeChange = path === INSTANCE_TYPE_PATH;
 
-      // Auto-fill postsFilters when instance type changes
-      if (path === 'configuration.instanceConfiguration.type') {
-        const blogFilters = ['blog', 'posts', 'comments', 'replies'];
-        const communityFilters = ['trending', 'hot', 'new'];
-        const filters = value === 'community' ? communityFilters : blogFilters;
-        updated = updateNestedPath(
+    if (isTypeChange) {
+      // The hosting API pins the instance type from the stored config, so a
+      // switch made here is never persisted while the filters auto-filled
+      // beside it are. That combination is what leaves a blog instance whose
+      // only filters are community sorts, and every feed tab then errors.
+      const pinnedType = getPinnedInstanceType();
+      if (pinnedType && value !== pinnedType) {
+        setNotice(
+          'Instance type is set when the site is created and cannot be changed from the editor.',
+        );
+        return;
+      }
+    }
+    setNotice(null);
+
+    setConfig((prev) => {
+      const updated = updateNestedPath(prev, path, value);
+
+      // Auto-fill postsFilters when instance type changes. Only sorts the new
+      // type can actually fetch: a blog feed calls bridge.get_account_posts, a
+      // community feed calls bridge.get_ranked_posts.
+      if (isTypeChange) {
+        return updateNestedPath(
           updated,
-          'configuration.instanceConfiguration.features.postsFilters',
-          filters,
+          POSTS_FILTERS_PATH,
+          defaultPostsFiltersFor(toInstanceType(value)),
         );
       }
 
@@ -259,6 +165,13 @@ export function FloatingMenuWindow({
     setIsSaving(true);
     setSaveStatus('idle');
     setSaveError(null);
+    // Last line of defence for a document that already carries filters from
+    // before this was fixed, or one edited outside the editor and pasted back:
+    // what goes out must agree with the type the server keeps.
+    const pinnedType = getPinnedInstanceType();
+    const outgoing = pinnedType
+      ? withPinnedInstanceType(config, pinnedType)
+      : config;
     try {
       const saveWith = (token: string) =>
         fetch(`${HOSTING_API_URL}/v1/tenants/${encodeURIComponent(username)}`, {
@@ -267,7 +180,7 @@ export function FloatingMenuWindow({
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,
           },
-          body: JSON.stringify({ config }),
+          body: JSON.stringify({ config: outgoing }),
           signal: AbortSignal.timeout(HOSTING_FETCH_TIMEOUT_MS),
         });
 
@@ -287,6 +200,19 @@ export function FloatingMenuWindow({
           (data as { error?: string }).error || `Save failed (${response.status})`,
         );
       }
+      // A save becomes the new baseline. Without this the PATCH landed but the
+      // running app kept the old config, and leaving preview restored the
+      // pre-save snapshot, so the owner watched the saved change revert and
+      // concluded the save had failed.
+      const saved = readSavedConfig(await response.json().catch(() => null));
+      const baseline = saved ?? outgoing;
+      setConfig(baseline);
+      InstanceConfigManager.updateConfig(baseline as unknown as InstanceConfig);
+      applyConfigDom(baseline, { syncSystemTheme: true });
+      // Re-take the restore point so exiting preview cannot roll back what was
+      // just saved.
+      originalStateRef.current = snapshotConfigDom();
+
       setSaveStatus('success');
       setTimeout(() => setSaveStatus('idle'), 3000);
     } catch (e) {
@@ -304,33 +230,13 @@ export function FloatingMenuWindow({
   const handleTogglePreview = useCallback(() => {
     setIsPreviewMode((prev) => {
       if (!prev) {
-        // Entering preview mode - save original state
-        originalStateRef.current = {
-          theme: document.documentElement.getAttribute('data-theme') || 'light',
-          styleTemplate:
-            document.documentElement.getAttribute('data-style-template') ||
-            'medium',
-          sidebarPlacement:
-            document.documentElement.getAttribute('data-sidebar-placement') ||
-            'right',
-          allBodyClasses: Array.from(document.body.classList),
-          pageTitle: document.title,
-          language: document.documentElement.getAttribute('lang') || 'en',
-          instanceType:
-            document.documentElement.getAttribute('data-instance-type') || 'blog',
-          showFollowers:
-            document.documentElement.getAttribute('data-show-followers') || 'true',
-          showFollowing:
-            document.documentElement.getAttribute('data-show-following') || 'true',
-          showHiveInfo:
-            document.documentElement.getAttribute('data-show-hive-info') || 'true',
-          listType: document.documentElement.getAttribute('data-list-type'),
-        };
-        applyPreviewConfig(config);
+        // Entering preview mode - capture everything the config can touch
+        originalStateRef.current = snapshotConfigDom();
+        applyConfigDom(config);
       } else {
         // Exiting preview mode - restore original state
         if (originalStateRef.current) {
-          restoreOriginalState(originalStateRef.current);
+          restoreConfigDom(originalStateRef.current);
           originalStateRef.current = null;
         }
       }
@@ -348,7 +254,7 @@ export function FloatingMenuWindow({
     // Cleanup: restore original state only when exiting preview mode
     return () => {
       if (originalStateRef.current) {
-        restoreOriginalState(originalStateRef.current);
+        restoreConfigDom(originalStateRef.current);
       }
     };
   }, [isPreviewMode]);
@@ -357,13 +263,13 @@ export function FloatingMenuWindow({
   // This effect has NO cleanup to avoid restore/reapply flicker
   useEffect(() => {
     if (isPreviewMode) {
-      applyPreviewConfig(config);
+      applyConfigDom(config);
     }
   }, [config, isPreviewMode]);
 
   const handleExitPreview = useCallback(() => {
     if (originalStateRef.current) {
-      restoreOriginalState(originalStateRef.current);
+      restoreConfigDom(originalStateRef.current);
       originalStateRef.current = null;
     }
     setIsPreviewMode(false);
@@ -573,6 +479,16 @@ export function FloatingMenuWindow({
             >
               {saveError}
             </div>
+          )}
+
+          {/* Field the server owns, rejected before it can be edited */}
+          {notice && (
+            <output
+              className="block px-4 py-2 text-sm font-sans text-gray-300 border-b shrink-0"
+              style={{ borderColor: FLOATING_MENU_THEME.borderColor }}
+            >
+              {notice}
+            </output>
           )}
 
           {/* Content */}

--- a/apps/self-hosted/src/features/floating-menu/components/floating-menu-window.tsx
+++ b/apps/self-hosted/src/features/floating-menu/components/floating-menu-window.tsx
@@ -18,6 +18,11 @@ import {
 } from '@/features/auth/utils/hosting-token';
 import { configFieldsMap } from '../config-fields';
 import { FLOATING_MENU_THEME } from '../constants';
+import {
+  readDiscarded,
+  readSavedConfig,
+  withServedOnlyMarkers,
+} from '../save-response';
 import type { ConfigValue } from '../types';
 import { downloadJson, updateNestedPath } from '../utils';
 import { ConfigEditor } from './config-editor';
@@ -69,23 +74,6 @@ function getPinnedInstanceType(): InstanceType | null {
   );
 }
 
-/**
- * The config the server actually stored, which is authoritative: it pins the
- * identity fields and drops values that disagree with the stored shape.
- */
-function readSavedConfig(payload: unknown): Record<string, ConfigValue> | null {
-  const saved = (payload as { config?: unknown } | null)?.config;
-  if (
-    saved &&
-    typeof saved === 'object' &&
-    !Array.isArray(saved) &&
-    'configuration' in saved
-  ) {
-    return saved as Record<string, ConfigValue>;
-  }
-  return null;
-}
-
 interface FloatingMenuWindowProps {
   isOpen: boolean;
   onClose: () => void;
@@ -96,11 +84,16 @@ export function FloatingMenuWindow({
   onClose,
 }: FloatingMenuWindowProps) {
   const [config, setConfig] = useState<Record<string, ConfigValue>>(() => {
-    return InstanceConfigManager.getConfig() as unknown as Record<string, ConfigValue>;
+    return InstanceConfigManager.getConfig() as unknown as Record<
+      string,
+      ConfigValue
+    >;
   });
   const [isPreviewMode, setIsPreviewMode] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>(
+    'idle',
+  );
   const [saveError, setSaveError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const originalStateRef = useRef<ConfigDomSnapshot | null>(null);
@@ -197,21 +190,34 @@ export function FloatingMenuWindow({
         }
         const data = await response.json().catch(() => ({}));
         throw new Error(
-          (data as { error?: string }).error || `Save failed (${response.status})`,
+          (data as { error?: string }).error ||
+            `Save failed (${response.status})`,
         );
       }
       // A save becomes the new baseline. Without this the PATCH landed but the
       // running app kept the old config, and leaving preview restored the
       // pre-save snapshot, so the owner watched the saved change revert and
       // concluded the save had failed.
-      const saved = readSavedConfig(await response.json().catch(() => null));
-      const baseline = saved ?? outgoing;
+      const payload = await response.json().catch(() => null);
+      const saved = readSavedConfig(payload);
+      // Read before updateConfig replaces what isManagedHosting() consults.
+      const managed = InstanceConfigManager.getConfigValue(
+        ({ configuration }) => configuration.instanceConfiguration.managed,
+      );
+      const baseline = saved ? withServedOnlyMarkers(saved, managed) : outgoing;
       setConfig(baseline);
       InstanceConfigManager.updateConfig(baseline as unknown as InstanceConfig);
       applyConfigDom(baseline, { syncSystemTheme: true });
       // Re-take the restore point so exiting preview cannot roll back what was
       // just saved.
       originalStateRef.current = snapshotConfigDom();
+
+      const discarded = readDiscarded(payload);
+      setNotice(
+        discarded.length > 0
+          ? `Saved, but the server did not store: ${discarded.join(', ')}. The editor now shows what was stored.`
+          : null,
+      );
 
       setSaveStatus('success');
       setTimeout(() => setSaveStatus('idle'), 3000);
@@ -370,7 +376,10 @@ export function FloatingMenuWindow({
               borderColor: FLOATING_MENU_THEME.borderColor,
             }}
           >
-            <h2 id="config-editor-title" className="text-sm font-semibold font-sans text-white">
+            <h2
+              id="config-editor-title"
+              className="text-sm font-semibold font-sans text-white"
+            >
               Configuration Editor
             </h2>
             <div className="flex items-center gap-2">
@@ -431,7 +440,13 @@ export function FloatingMenuWindow({
                   type="button"
                   aria-label="Save configuration"
                 >
-                  {isSaving ? 'Saving...' : saveStatus === 'success' ? 'Saved!' : saveStatus === 'error' ? 'Failed' : 'Save'}
+                  {isSaving
+                    ? 'Saving...'
+                    : saveStatus === 'success'
+                      ? 'Saved!'
+                      : saveStatus === 'error'
+                        ? 'Failed'
+                        : 'Save'}
                 </button>
               ) : (
                 <button

--- a/apps/self-hosted/src/features/floating-menu/save-response.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/save-response.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  readDiscarded,
+  readSavedConfig,
+  withServedOnlyMarkers,
+} from './save-response';
+
+const savedConfig = {
+  version: 1,
+  configuration: {
+    instanceConfiguration: { type: 'blog', username: 'alice' },
+  },
+} as never;
+
+/**
+ * ConfigService injects `managed` when it serves the file and TenantService
+ * deletes it before storing, so the save response never carries it. On a custom
+ * domain that flag is the only signal the app has, so adopting the response
+ * verbatim made the next save refuse with "This site is not on managed hosting".
+ */
+describe('adopting the saved config', () => {
+  it('keeps the managed marker the server strips before storing', () => {
+    const adopted = withServedOnlyMarkers(savedConfig, true);
+
+    expect(
+      (adopted.configuration as never as Record<string, Record<string, unknown>>)
+        .instanceConfiguration.managed,
+    ).toBe(true);
+  });
+
+  it('does not invent the marker for a true self-hosted instance', () => {
+    const adopted = withServedOnlyMarkers(savedConfig, undefined);
+
+    expect(
+      (adopted.configuration as never as Record<string, Record<string, unknown>>)
+        .instanceConfiguration.managed,
+    ).toBeUndefined();
+  });
+
+  it('leaves a response with no configuration alone', () => {
+    expect(withServedOnlyMarkers({ version: 1 } as never, true)).toEqual({
+      version: 1,
+    });
+  });
+
+  it('reads the stored config back, and nothing else', () => {
+    expect(readSavedConfig({ config: savedConfig })).toBe(savedConfig);
+    expect(readSavedConfig({ config: { version: 1 } })).toBe(null);
+    expect(readSavedConfig({ config: [] })).toBe(null);
+    expect(readSavedConfig(null)).toBe(null);
+  });
+});
+
+/**
+ * A save can succeed while parts of it are dropped, because the server pins
+ * identity fields and refuses filters the pinned type cannot serve. The editor
+ * reported "Saved!" and kept displaying the rejected value.
+ */
+describe('discarded fields', () => {
+  it('lists what the server refused to store', () => {
+    const paths = readDiscarded({
+      discarded: [
+        { path: 'instanceConfiguration.type', reason: 'pinned' },
+        { path: 'instanceConfiguration.postsFilters', reason: 'invalid sort' },
+      ],
+    });
+
+    expect(paths).toEqual([
+      'instanceConfiguration.type',
+      'instanceConfiguration.postsFilters',
+    ]);
+  });
+
+  it('is empty for a save that stored everything', () => {
+    expect(readDiscarded({ config: savedConfig })).toEqual([]);
+  });
+
+  it('ignores a malformed discarded field rather than throwing mid-save', () => {
+    expect(readDiscarded({ discarded: 'nope' })).toEqual([]);
+    expect(readDiscarded({ discarded: [null, 42, { reason: 'no path' }] })).toEqual(
+      [],
+    );
+  });
+});

--- a/apps/self-hosted/src/features/floating-menu/save-response.ts
+++ b/apps/self-hosted/src/features/floating-menu/save-response.ts
@@ -1,0 +1,67 @@
+import type { ConfigValue } from './types';
+
+/**
+ * Fields the server refused to store, from the PATCH response.
+ *
+ * A save can succeed while parts of it are dropped: the server pins identity
+ * fields such as the instance type, and drops post filters the pinned type
+ * cannot serve. Without reading this the editor reported "Saved!" while still
+ * displaying the value that was thrown away.
+ */
+export function readDiscarded(payload: unknown): string[] {
+  const discarded = (payload as { discarded?: unknown } | null)?.discarded;
+  if (!Array.isArray(discarded)) return [];
+  return discarded
+    .map((entry) => (entry as { path?: unknown })?.path)
+    .filter((path): path is string => typeof path === 'string');
+}
+
+/**
+ * The config the server actually stored, which is authoritative: it pins the
+ * identity fields and drops values that disagree with the stored shape.
+ */
+export function readSavedConfig(
+  payload: unknown,
+): Record<string, ConfigValue> | null {
+  const saved = (payload as { config?: unknown } | null)?.config;
+  if (
+    saved &&
+    typeof saved === 'object' &&
+    !Array.isArray(saved) &&
+    'configuration' in saved
+  ) {
+    return saved as Record<string, ConfigValue>;
+  }
+  return null;
+}
+
+/**
+ * Carry over the markers the server strips before storing.
+ *
+ * ConfigService injects instanceConfiguration.managed when it serves the file,
+ * and TenantService deletes it again before storing, so it is absent from the
+ * save response. Adopting that response verbatim tells the running app it is
+ * not on managed hosting, and on a custom domain that flag is the only signal
+ * there is, so the next save in the same page would refuse with "This site is
+ * not on managed hosting".
+ */
+export function withServedOnlyMarkers(
+  saved: Record<string, ConfigValue>,
+  managed: boolean | undefined,
+): Record<string, ConfigValue> {
+  if (managed !== true) return saved;
+  const configuration = saved.configuration as
+    | Record<string, ConfigValue>
+    | undefined;
+  const instance = configuration?.instanceConfiguration as
+    | Record<string, ConfigValue>
+    | undefined;
+  if (!configuration || !instance) return saved;
+  return {
+    ...saved,
+    configuration: {
+      ...configuration,
+      instanceConfiguration: { ...instance, managed: true },
+    },
+  };
+}

--- a/apps/self-hosted/src/index.tsx
+++ b/apps/self-hosted/src/index.tsx
@@ -3,7 +3,7 @@ import { createRouter, RouterProvider } from '@tanstack/react-router';
 import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import './globals.css';
-import { InstanceConfigManager } from './core';
+import { applyConfigDom, InstanceConfigManager } from './core';
 import { getRssFeedUrl } from './utils/rss-feed-url';
 import { routeTree } from './routeTree.gen';
 
@@ -23,87 +23,15 @@ function applyConfig() {
   const imageProxyBase = general.imageProxy || 'https://i.ecency.com';
   setProxyBase(imageProxyBase);
 
-  // Apply background styles. classList.add throws on a token containing
-  // whitespace or an empty string, and the value is owner-typed, so a stray tab
-  // pasted into the field would otherwise abort the whole boot.
-  const backgroundClasses = general.styles?.background;
-  if (backgroundClasses) {
-    for (const className of backgroundClasses.split(/\s+/)) {
-      if (!className) continue;
-      try {
-        document.body.classList.add(className);
-      } catch {
-        console.warn('[Config] Ignoring invalid background class:', className);
-      }
-    }
-  }
+  // Every attribute, custom property, body class and the document title the
+  // config drives live in one declaration, which the Configuration Editor's
+  // preview applies through the same function. See core/apply-config-dom.ts.
+  applyConfigDom(config, { syncSystemTheme: true });
 
-  // Apply theme
-  const configuredTheme = general.theme;
-  if (configuredTheme === 'system') {
-    const prefersDark = window.matchMedia(
-      '(prefers-color-scheme: dark)',
-    ).matches;
-    document.documentElement.setAttribute(
-      'data-theme',
-      prefersDark ? 'dark' : 'light',
-    );
-  } else {
-    document.documentElement.setAttribute('data-theme', configuredTheme);
-  }
-
-  // Apply style template
-  const styleTemplate = general.styleTemplate ?? 'medium';
-  document.documentElement.setAttribute('data-style-template', styleTemplate);
-
-  // Apply sidebar placement
-  const sidebarConfig = instanceConfiguration.layout?.sidebar ?? {};
-  const sidebarPlacement = sidebarConfig.placement ?? 'right';
-  document.documentElement.setAttribute(
-    'data-sidebar-placement',
-    sidebarPlacement,
-  );
-
-  // Apply list type
-  const listType = instanceConfiguration.layout?.listType ?? 'grid';
-  document.documentElement.setAttribute('data-list-type', listType);
-
-  // Apply instance type
   const instanceType = instanceConfiguration.type ?? 'blog';
-  document.documentElement.setAttribute('data-instance-type', instanceType);
-
-  // Apply sidebar section visibility
-  document.documentElement.setAttribute(
-    'data-show-followers',
-    sidebarConfig.followers?.enabled !== false ? 'true' : 'false',
-  );
-  document.documentElement.setAttribute(
-    'data-show-following',
-    sidebarConfig.following?.enabled !== false ? 'true' : 'false',
-  );
-  document.documentElement.setAttribute(
-    'data-show-hive-info',
-    sidebarConfig.hiveInformation?.enabled !== false ? 'true' : 'false',
-  );
-
-  // Listen for system theme changes when theme is set to "system"
-  if (configuredTheme === 'system') {
-    window
-      .matchMedia('(prefers-color-scheme: dark)')
-      .addEventListener('change', (e) => {
-        document.documentElement.setAttribute(
-          'data-theme',
-          e.matches ? 'dark' : 'light',
-        );
-      });
-  }
 
   // Apply SEO meta tags
   const meta = instanceConfiguration.meta ?? {};
-
-  if (meta.title) {
-    document.title = meta.title;
-  }
 
   if (meta.description) {
     let descriptionMeta = document.querySelector('meta[name="description"]');


### PR DESCRIPTION
## What was broken

Every visual knob the instance config drives was applied to the DOM in four
places: `applyConfig()` in `src/index.tsx`, and the preview triple in
`floating-menu-window.tsx` (`applyPreviewConfig`, the snapshot it took, and
`restoreOriginalState`). The defaults in the boot path and the preview path had
drifted apart, so preview did not represent what a save produces:

| knob | boot | preview | now |
| --- | --- | --- | --- |
| `data-theme` when theme is missing | `setAttribute('data-theme', undefined)`, i.e. the literal string `undefined`, which matches neither `[data-theme="dark"]` nor the `:root:not([data-theme])` fallback | `light` | `light` |
| `data-style-template`, `data-sidebar-placement`, `data-list-type`, `data-instance-type` when the value is an empty string | `??`, so `""` reached the DOM and matched no stylesheet | `\|\|`, so the default was used | blank or non-string means unset, default is used |
| `lang` / `data-language` | never set | set from `general.language` | set on both paths |
| background classes | added, never removed, so a re-apply stacked them | `bg-`/`from-`/`to-` cleared first (not `via-`) | declared prefixes `bg-`/`from-`/`via-`/`to-` plus whatever the previous apply added are cleared first |
| restore of an attribute that was absent before preview | n/a | written back with a hardcoded default, so `data-language` stayed on the document after a preview round trip; only `data-list-type` handled absence | every declared attribute is restored to absent if it was absent |
| meta tags, favicon, RSS link, image proxy base | applied | not applied | unchanged, still boot only |

## What changed

`src/core/apply-config-dom.ts` declares, once, the attributes, CSS variables,
body classes and document title the config drives. `applyConfigDom`,
`snapshotConfigDom` and `restoreConfigDom` are generic over that declaration, so
boot and preview cannot diverge and a new knob is a one-file change. This is the
enabler for the customization roadmap (theme gallery, accent color, font
presets): the CSS variable list is empty today because the style templates
declare their variables in CSS, and it is where those knobs attach. The
system-theme media listener moved into the module and is now rebound
idempotently, so only the paths that establish a baseline (boot, a successful
save) register it.

Save did not apply. `handleSave` PATCHed the config but never called
`InstanceConfigManager.updateConfig` (which had zero callers) and never
re-applied the DOM. Since the natural flow is preview, save, exit preview, and
exiting restored the pre-save snapshot, the owner watched the saved change
revert. A successful save now adopts the config the server actually stored,
updates the in-memory config, re-applies the DOM and re-takes the restore point.

Instance Type broke every feed tab. Switching blog to community auto-filled
`postsFilters: ['trending','hot','new']`. `TenantService.applyConfigDocument`
pins `type` from the stored config but merges the filters, so the tenant stayed
a blog whose only filters are sorts `bridge.get_account_posts` rejects, and
`resolvePostsFilter` then clamps even an explicit `?filter=posts` to the broken
first entry. The editor no longer writes a type the server will not keep (it
says so instead of silently reverting), the auto-filled defaults are limited to
sorts the feed APIs accept (`created`, not `new`), and a save pins the outgoing
document to the server-owned type and drops filters that type cannot fetch. The
server-side counterpart is separate.

## Tests

New: `src/core/apply-config-dom.test.ts` (jsdom) and
`src/core/instance-type-filters.test.ts`. Each assertion was mutation-verified
by breaking the fix and confirming the intended test fails: restore skipping
absent attributes, `text()` keeping empty strings, `lang`/`data-language`
dropped from the declaration, body classes not cleared before apply, restore
forgetting which classes came from config, the custom property not removed on
restore, the system theme not resolved, an empty title overwriting the document
title, the filter sanitizer as a passthrough, the community defaults back to
`new`, the pinned type not written back, and filters invented for a document
that carries none.

The editor component itself has no test: the app has no React testing library
and its `@/` alias does not resolve under vitest, so the logic lives in the two
core modules that are covered.