### PR TITLE
fix(hosting-api): reject config saves the server cannot apply, stop leaking driver errors

### DIFF
--- a/apps/self-hosted/hosting/api/src/errors.ts
+++ b/apps/self-hosted/hosting/api/src/errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Errors that are safe to show a caller.
+ *
+ * Everything else that escapes a route is treated as an internal failure and answered with a
+ * fixed message (see middleware/error-handler), because the alternative is echoing whatever a
+ * library threw: a Postgres driver error carries table, column and constraint names, and
+ * sometimes parameter values. A route that wants the caller to see a specific message and
+ * status throws this instead, the same way DomainInUseError lets one path answer with 409.
+ */
+export class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}

--- a/apps/self-hosted/hosting/api/src/index.ts
+++ b/apps/self-hosted/hosting/api/src/index.ts
@@ -14,6 +14,7 @@ import { paymentRoutes } from './routes/payments';
 import { authRoutes } from './routes/auth';
 import { internalRoutes, internalSecret, MIN_INTERNAL_SECRET_LENGTH } from './routes/internal';
 import { rateLimit } from './middleware/rate-limit';
+import { errorHandler } from './middleware/error-handler';
 import { db } from './db/client';
 import { TenantService } from './services/tenant-service';
 import { ConfigService } from './services/config-service';
@@ -78,11 +79,8 @@ app.route('/v1/auth', authRoutes);
 // Service-to-service only (shared-secret guarded); mounted at its own /v1/internal prefix.
 app.route('/v1/internal', internalRoutes);
 
-// Error handling
-app.onError((err, c) => {
-  console.error('API Error:', err);
-  return c.json({ error: err.message || 'Internal server error' }, 500);
-});
+// Error handling. Driver text never reaches the caller; see middleware/error-handler.
+app.onError(errorHandler);
 
 // 404 handler
 app.notFound((c) => c.json({ error: 'Not found' }, 404));

--- a/apps/self-hosted/hosting/api/src/middleware/error-handler.test.ts
+++ b/apps/self-hosted/hosting/api/src/middleware/error-handler.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { errorHandler, GENERIC_ERROR_MESSAGE } from './error-handler';
+import { ApiError } from '../errors';
+
+/**
+ * The handler used to answer `err.message` with a 500, so whatever a library threw was echoed
+ * to the caller. A pg error carries the table, the column and the constraint it failed on, and
+ * its detail can quote parameter values.
+ */
+function appThatThrows(error: unknown) {
+  const app = new Hono();
+  app.onError(errorHandler);
+  app.get('/boom', () => {
+    throw error;
+  });
+  return app;
+}
+
+let errorLog: ReturnType<typeof vi.spyOn>;
+let warnLog: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+  warnLog = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('errorHandler', () => {
+  it('does not leak a driver error to the caller, and logs it in full', async () => {
+    const pgError = Object.assign(
+      new Error(
+        'duplicate key value violates unique constraint "tenants_custom_domain_key"'
+      ),
+      {
+        code: '23505',
+        table: 'tenants',
+        column: 'custom_domain',
+        constraint: 'tenants_custom_domain_key',
+        detail: 'Key (custom_domain)=(example.test) already exists.',
+      }
+    );
+
+    const res = await appThatThrows(pgError).request('http://localhost/boom');
+    const body = (await res.json()) as { error: string };
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe(GENERIC_ERROR_MESSAGE);
+    expect(JSON.stringify(body)).not.toContain('tenants_custom_domain_key');
+    expect(JSON.stringify(body)).not.toContain('custom_domain');
+    // The operator still gets everything: the error object itself is logged.
+    expect(errorLog).toHaveBeenCalled();
+    expect(errorLog.mock.calls[0]).toContain(pgError);
+  });
+
+  it('keeps a message a route deliberately surfaced, with its status', async () => {
+    const res = await appThatThrows(
+      new ApiError(400, 'Invalid configuration document')
+    ).request('http://localhost/boom');
+    const body = (await res.json()) as { error: string };
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Invalid configuration document');
+    expect(errorLog).not.toHaveBeenCalled();
+    expect(warnLog).toHaveBeenCalled();
+  });
+
+  it('answers a framework error with its own status rather than 500', async () => {
+    const res = await appThatThrows(
+      new HTTPException(413, { message: 'Payload too large' })
+    ).request('http://localhost/boom');
+
+    expect(res.status).toBe(413);
+  });
+
+  it('does not echo an unexpected error message even when it looks harmless', async () => {
+    const res = await appThatThrows(new Error('connect ECONNREFUSED 10.0.0.5:5432')).request(
+      'http://localhost/boom'
+    );
+    const body = (await res.json()) as { error: string };
+
+    expect(body.error).toBe(GENERIC_ERROR_MESSAGE);
+    expect(JSON.stringify(body)).not.toContain('ECONNREFUSED');
+  });
+});

--- a/apps/self-hosted/hosting/api/src/middleware/error-handler.ts
+++ b/apps/self-hosted/hosting/api/src/middleware/error-handler.ts
@@ -1,0 +1,44 @@
+/**
+ * Central error handler.
+ *
+ * The previous handler returned `err.message` verbatim with a 500, so anything an underlying
+ * library threw reached the caller. A pg error names the table, the column and the constraint
+ * it failed on, and its `detail` can quote the parameter values, which is a description of the
+ * schema handed to whoever sent the request.
+ *
+ * Two things must survive that, so this maps rather than flattens:
+ *   - a route that has something useful to say throws ApiError(status, message) and that
+ *     message is returned as-is, which is how validation and ownership feedback the owner
+ *     needs stays readable (zod-validator answers its own 400s before reaching here);
+ *   - Hono's own HTTPException already carries a status and a framework-authored message
+ *     (malformed JSON, payload limits), so its response is used unchanged.
+ *
+ * Anything else is logged in full server-side and answered with a fixed body.
+ */
+
+import type { Context } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
+import { ApiError } from '../errors';
+
+export const GENERIC_ERROR_MESSAGE = 'Internal server error';
+
+export function errorHandler(err: Error, c: Context): Response {
+  if (err instanceof HTTPException) {
+    // Framework-generated (bad JSON body, request too large). Status and message are ours.
+    console.warn(`[API] ${c.req.method} ${c.req.path} -> ${err.status}: ${err.message}`);
+    return err.getResponse();
+  }
+
+  if (err instanceof ApiError) {
+    // Deliberately surfaced by a route. Logged at warn so a spike in client errors is still
+    // visible, without the stack of an internal failure.
+    console.warn(`[API] ${c.req.method} ${c.req.path} -> ${err.status}: ${err.message}`);
+    return c.json({ error: err.message }, err.status as ContentfulStatusCode);
+  }
+
+  // Unknown failure: the full error (message, stack, and any driver fields) goes to the log,
+  // never to the response.
+  console.error(`[API] Unhandled error on ${c.req.method} ${c.req.path}:`, err);
+  return c.json({ error: GENERIC_ERROR_MESSAGE }, 500);
+}

--- a/apps/self-hosted/hosting/api/src/routes/tenant-config-patch.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenant-config-patch.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getByUsername: vi.fn(),
+  applyConfigDocument: vi.fn(),
+  updateConfig: vi.fn(),
+  generateConfigFile: vi.fn(),
+}));
+
+vi.mock('../db/client', () => ({ db: { query: vi.fn(), queryOne: vi.fn(), transaction: vi.fn() } }));
+
+vi.mock('../services/tenant-service', () => ({
+  TenantService: {
+    getByUsername: mocks.getByUsername,
+    applyConfigDocument: mocks.applyConfigDocument,
+    updateConfig: mocks.updateConfig,
+    getBlogUrl: () => 'https://alice.example.test',
+  },
+  COMMUNITY_NAME: /^hive-\d+$/,
+  isReregisterableAbandoned: () => false,
+  ABANDONED_REREGISTER_QUARANTINE_HOURS: 1,
+}));
+
+vi.mock('../services/config-service', () => ({
+  ConfigService: { generateConfigFile: mocks.generateConfigFile },
+  isPublishableTenant: (tenant: { subscriptionStatus: string }) =>
+    tenant.subscriptionStatus === 'active',
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: () => Promise<void>) => {
+    c.set('user', { username: 'alice' });
+    await next();
+  },
+}));
+
+vi.mock('../middleware/x402-paywall', () => ({
+  subscriptionPaywall: async (_c: unknown, next: () => Promise<void>) => next(),
+  proUpgradePaywall: async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+vi.mock('../services/audit-service', () => ({
+  AuditService: { log: vi.fn() },
+  parseClientIp: () => null,
+}));
+
+const { tenantRoutes } = await import('./tenants');
+
+const TENANT = {
+  id: 'tenant-1',
+  username: 'alice',
+  owner: 'alice',
+  subscriptionStatus: 'active',
+  subscriptionPlan: 'standard',
+};
+
+function patch(config: unknown) {
+  return tenantRoutes.request('http://localhost/alice', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ config }),
+  });
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset();
+  mocks.getByUsername.mockResolvedValue({ ...TENANT });
+  mocks.applyConfigDocument.mockImplementation(async () => ({
+    tenant: { ...TENANT, config: { version: 1, configuration: {} } },
+    discarded: [],
+  }));
+  mocks.updateConfig.mockImplementation(async () => ({
+    ...TENANT,
+    config: { version: 1, configuration: {} },
+  }));
+  mocks.generateConfigFile.mockResolvedValue(undefined);
+});
+
+/**
+ * The PATCH body used to be validated by a z.union of the full document and the flat keys.
+ * A full document that failed for ANY reason fell through to the flat schema, which is all
+ * optional and therefore matches any object, stripping it to {}. The save then merged nothing
+ * and the route answered 200 "Configuration updated" having stored none of it. Clearing the
+ * Version field in the editor is enough to trigger it: a cleared number input sends null.
+ */
+describe('PATCH /v1/tenants/:username config validation', () => {
+  it('rejects a full document with a null version instead of discarding the save', async () => {
+    const res = await patch({
+      version: null,
+      configuration: { instanceConfiguration: { meta: { title: 'New title' } } },
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; issues: { path: string }[] };
+    expect(body.error).toBe('Invalid configuration');
+    expect(body.issues.map((i) => i.path)).toContain('config.version');
+    // The decisive part: nothing was written and no success was reported.
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('rejects a full document whose configuration is not an object', async () => {
+    const res = await patch({ version: 1, configuration: 'oops' });
+
+    expect(res.status).toBe(400);
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('applies a valid full document', async () => {
+    const doc = {
+      version: 1,
+      configuration: { instanceConfiguration: { meta: { title: 'New title' } } },
+    };
+
+    const res = await patch(doc);
+
+    expect(res.status).toBe(200);
+    expect(mocks.applyConfigDocument).toHaveBeenCalledWith('alice', doc);
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('still accepts the flat key form', async () => {
+    // The flat vocabulary predates the Configuration Editor and shares its shape with
+    // signup; a body with no `configuration` key is unambiguously that form.
+    const res = await patch({ theme: 'dark', title: 'Flat title' });
+
+    expect(res.status).toBe(200);
+    expect(mocks.updateConfig).toHaveBeenCalledWith('alice', { theme: 'dark', title: 'Flat title' });
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid flat value rather than storing part of the body', async () => {
+    const res = await patch({ theme: 'neon' });
+
+    expect(res.status).toBe(400);
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('reports values the server refused to store', async () => {
+    mocks.applyConfigDocument.mockResolvedValue({
+      tenant: { ...TENANT, config: { version: 1, configuration: {} } },
+      discarded: [
+        {
+          path: 'configuration.instanceConfiguration.type',
+          reason: 'the instance type is set when the instance is created and cannot be changed here',
+        },
+      ],
+    });
+
+    const res = await patch({
+      version: 1,
+      configuration: { instanceConfiguration: { type: 'community' } },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { discarded: { path: string }[]; message: string };
+    expect(body.discarded).toHaveLength(1);
+    expect(body.discarded[0].path).toBe('configuration.instanceConfiguration.type');
+    expect(body.message).toContain('not applied');
+  });
+
+  it('reports nothing discarded on an ordinary save', async () => {
+    const res = await patch({ version: 1, configuration: { general: { theme: 'dark' } } });
+
+    const body = (await res.json()) as { discarded: unknown[]; message: string };
+    expect(body.discarded).toEqual([]);
+    expect(body.message).toBe('Configuration updated');
+  });
+});

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -37,13 +37,21 @@ const createTenantSchema = z.object({
 });
 
 // PATCH accepts either the FULL config document (what the instance's Configuration Editor
-// holds: { version, configuration: {...} }) or the legacy flat keys. The union is ordered
-// full-document first: a flat body has no `configuration` key so it falls through, while a
-// full document must never be matched by the flat schema (which would strip everything).
+// holds: { version, configuration: {...} }) or the legacy flat keys.
+//
+// Which one applies is decided by the PRESENCE of `configuration`, NOT by trying both. A
+// z.union does the latter: a full document that fails validation for any reason falls through
+// to the flat schema, and because every flat key is optional that schema matches any object and
+// strips it to {}. The route then merged nothing and answered 200 "Configuration updated" while
+// the save was discarded. Clearing the Version field (the number input sends null, which is not
+// an optional int) was enough to trigger it.
 const fullConfigDocSchema = z.object({
   version: z.number().int().optional(),
   configuration: z.record(z.any()),
 });
+// Kept for callers that send flat keys: create/signup uses this vocabulary, and the PATCH has
+// accepted it since before the Configuration Editor existed. A flat body carries no
+// `configuration` key, so it is unambiguous.
 const flatConfigUpdateSchema = z.object({
   theme: z.enum(['light', 'dark', 'system']).optional(),
   styleTemplate: z.enum(['medium', 'minimal', 'magazine', 'developer', 'modern-gradient']).optional(),
@@ -52,9 +60,18 @@ const flatConfigUpdateSchema = z.object({
   listType: z.enum(['list', 'grid']).optional(),
   sidebarPlacement: z.enum(['left', 'right']).optional(),
 });
+// Only the container is validated here (an object, not an array or a scalar); the branch schema
+// above does the real work once the handler knows which document this is.
 const updateTenantSchema = z.object({
-  config: z.union([fullConfigDocSchema, flatConfigUpdateSchema]).optional(),
+  config: z.record(z.any()).optional(),
 });
+
+/** Whether a PATCH body carries a full config document rather than flat keys. */
+function isFullConfigDocument(config: unknown): boolean {
+  return (
+    !!config && typeof config === 'object' && !Array.isArray(config) && 'configuration' in config
+  );
+}
 
 // Upper bound for a config document; far above any real config, guards the DB row.
 const MAX_CONFIG_BYTES = 64 * 1024;
@@ -566,14 +583,37 @@ tenantRoutes.patch('/:username', authMiddleware, zValidator('json', updateTenant
     return c.json({ error: 'Configuration document too large' }, 413);
   }
 
+  // Validate against the schema for the document this actually is, and answer 400 with the
+  // reason. A body that cannot be understood must never report a successful save.
+  const isFullDoc = isFullConfigDocument(body.config);
+  let configUpdate: any = body.config;
+  if (body.config) {
+    const parsed = isFullDoc
+      ? fullConfigDocSchema.safeParse(body.config)
+      : flatConfigUpdateSchema.safeParse(body.config);
+    if (!parsed.success) {
+      return c.json(
+        {
+          error: 'Invalid configuration',
+          issues: parsed.error.issues.map((issue) => ({
+            path: ['config', ...issue.path].join('.'),
+            message: issue.message,
+          })),
+        },
+        400
+      );
+    }
+    configUpdate = parsed.data;
+  }
+
   // Full document (Configuration Editor) deep-merges into the stored config with identity
   // fields pinned server-side; flat keys are normalized first, then merge the same way.
-  const isFullDoc =
-    !!body.config && typeof body.config === 'object' && 'configuration' in body.config;
-  const updatedTenant = isFullDoc
-    ? await TenantService.applyConfigDocument(username, body.config)
-    : await TenantService.updateConfig(username, body.config);
-  
+  // `discarded` lists what the server refused to store (pinned identity fields, filters the
+  // instance type cannot serve, shape mismatches) so the editor can say so.
+  const { tenant: updatedTenant, discarded } = isFullDoc
+    ? await TenantService.applyConfigDocument(username, configUpdate)
+    : { tenant: await TenantService.updateConfig(username, configUpdate), discarded: [] };
+
   // Publish only for a tenant that is entitled to be served. POST deliberately
   // does not write the file for the same reason: nginx serves any file that
   // exists with no subscription check, so publishing here would put a blog that
@@ -598,8 +638,12 @@ tenantRoutes.patch('/:username', authMiddleware, zValidator('json', updateTenant
     // Tells the editor whether the change is live or only stored, so a saved
     // edit that the visitor cannot see yet is explainable.
     published,
+    // Values the server did not store, with the reason for each. Empty on an ordinary save.
+    discarded,
     message: published
-      ? 'Configuration updated'
+      ? discarded.length > 0
+        ? 'Configuration updated. Some values were not applied.'
+        : 'Configuration updated'
       : 'Configuration saved. It goes live once the subscription is active.',
   });
 });

--- a/apps/self-hosted/hosting/api/src/services/config-document-discards.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-document-discards.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+import { TenantService, type DiscardedField } from './tenant-service';
+
+// Pure config-document handling: no DB, no RPC.
+
+const BLOG_PINS = {
+  version: 1,
+  username: 'alice',
+  owner: 'alice',
+  type: 'blog',
+  communityId: '',
+};
+
+const COMMUNITY_PINS = {
+  version: 1,
+  username: 'hive-125125',
+  owner: 'alice',
+  type: 'community',
+  communityId: 'hive-125125',
+};
+
+function paths(discarded: DiscardedField[]): string[] {
+  return discarded.map((d) => d.path);
+}
+
+/**
+ * Switching the Instance Type in the editor rewrites postsFilters to the other type's list and
+ * sends both. The server pins the type back, so storing the filters left a personal blog asking
+ * bridge.get_account_posts to sort by 'trending': every feed tab on the instance errors.
+ */
+describe('post filters are normalised against the pinned instance type', () => {
+  it('drops community filters from a blog instance and keeps the stored ones', () => {
+    const discarded: DiscardedField[] = [];
+    const clean = TenantService.sanitizeConfigDocument(
+      {
+        configuration: {
+          instanceConfiguration: {
+            type: 'community',
+            features: { postsFilters: ['trending', 'hot', 'new'] },
+          },
+        },
+      },
+      BLOG_PINS,
+      discarded
+    );
+
+    // Nothing valid was left, so the key is gone and the merge keeps the instance's filters.
+    expect(clean.configuration.instanceConfiguration.features.postsFilters).toBeUndefined();
+    expect(paths(discarded)).toEqual([
+      'configuration.instanceConfiguration.type',
+      'configuration.instanceConfiguration.features.postsFilters',
+    ]);
+  });
+
+  it('leaves an instance with a feed when every filter it sent is invalid', async () => {
+    const stored = await TenantService.buildConfig('alice', undefined, 'alice');
+    const clean = TenantService.sanitizeConfigDocument(
+      { configuration: { instanceConfiguration: { features: { postsFilters: ['trending'] } } } },
+      BLOG_PINS
+    );
+    const merged = TenantService.mergeConfigGuarded(stored, clean);
+
+    expect(merged.configuration.instanceConfiguration.features.postsFilters).toEqual([
+      'posts',
+      'blog',
+    ]);
+  });
+
+  it('keeps the valid filters and drops only the rest', () => {
+    const discarded: DiscardedField[] = [];
+    const clean = TenantService.sanitizeConfigDocument(
+      {
+        configuration: {
+          instanceConfiguration: { features: { postsFilters: ['blog', 'trending', 'replies'] } },
+        },
+      },
+      BLOG_PINS,
+      discarded
+    );
+
+    expect(clean.configuration.instanceConfiguration.features.postsFilters).toEqual([
+      'blog',
+      'replies',
+    ]);
+    expect(discarded).toHaveLength(1);
+    expect(discarded[0].reason).toContain('trending');
+  });
+
+  it('accepts community filters on a community instance', () => {
+    const discarded: DiscardedField[] = [];
+    const clean = TenantService.sanitizeConfigDocument(
+      {
+        configuration: {
+          instanceConfiguration: { features: { postsFilters: ['trending', 'hot', 'new'] } },
+        },
+      },
+      COMMUNITY_PINS,
+      discarded
+    );
+
+    expect(clean.configuration.instanceConfiguration.features.postsFilters).toEqual([
+      'trending',
+      'hot',
+      'new',
+    ]);
+    expect(discarded).toEqual([]);
+  });
+
+  it('drops blog filters from a community instance', () => {
+    const discarded: DiscardedField[] = [];
+    TenantService.sanitizeConfigDocument(
+      {
+        configuration: {
+          instanceConfiguration: { features: { postsFilters: ['blog', 'comments'] } },
+        },
+      },
+      COMMUNITY_PINS,
+      discarded
+    );
+
+    expect(paths(discarded)).toEqual([
+      'configuration.instanceConfiguration.features.postsFilters',
+    ]);
+  });
+
+  it('leaves a document that does not mention filters alone', () => {
+    const discarded: DiscardedField[] = [];
+    const clean = TenantService.sanitizeConfigDocument(
+      { configuration: { general: { theme: 'dark' } } },
+      BLOG_PINS,
+      discarded
+    );
+
+    expect(clean.configuration.general.theme).toBe('dark');
+    expect(discarded).toEqual([]);
+  });
+});
+
+/**
+ * The server has always pinned identity fields and dropped shape-mismatched values, but it did
+ * so silently: the editor showed one thing, the stored config held another, and the response
+ * said "Configuration updated" either way.
+ */
+describe('discarded values are reported back', () => {
+  it('reports a pinned identity field only when the client sent something different', () => {
+    const changed: DiscardedField[] = [];
+    TenantService.sanitizeConfigDocument(
+      { configuration: { instanceConfiguration: { owner: 'attacker' } } },
+      BLOG_PINS,
+      changed
+    );
+    expect(paths(changed)).toEqual(['configuration.instanceConfiguration.owner']);
+
+    // The editor loads the served config and sends it back, so matching values are not noise.
+    const echoed: DiscardedField[] = [];
+    TenantService.sanitizeConfigDocument(
+      { version: 1, configuration: { instanceConfiguration: { owner: 'alice', type: 'blog' } } },
+      BLOG_PINS,
+      echoed
+    );
+    expect(echoed).toEqual([]);
+  });
+
+  it('reports a client-supplied config version, which the server owns', () => {
+    const discarded: DiscardedField[] = [];
+    TenantService.sanitizeConfigDocument({ version: 99, configuration: {} }, BLOG_PINS, discarded);
+
+    expect(paths(discarded)).toEqual(['version']);
+  });
+
+  it('reports the full path of a value dropped for disagreeing with the stored shape', async () => {
+    const stored = await TenantService.buildConfig('alice', undefined, 'alice');
+    const discarded: DiscardedField[] = [];
+
+    const merged = TenantService.mergeConfigGuarded(
+      stored,
+      { configuration: { general: { theme: 42 }, instanceConfiguration: { layout: 'oops' } } },
+      { path: '', discarded }
+    );
+
+    expect(merged.configuration.general.theme).toBe('system');
+    expect(paths(discarded).sort()).toEqual([
+      'configuration.general.theme',
+      'configuration.instanceConfiguration.layout',
+    ]);
+  });
+
+  it('still drops mismatched values when no report was asked for', async () => {
+    const stored = await TenantService.buildConfig('alice', undefined, 'alice');
+
+    const merged = TenantService.mergeConfigGuarded(stored, {
+      configuration: { general: { theme: 42 } },
+    });
+
+    expect(merged.configuration.general.theme).toBe('system');
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -5,6 +5,7 @@
 import { db } from '../db/client';
 import { callRPC, config as hiveTxConfig } from '@ecency/sdk/hive';
 import { Tenant, TenantRow, mapTenantFromDb } from '../types';
+import { ApiError } from '../errors';
 
 // Re-export Tenant type for backward compatibility
 export type { Tenant } from '../types';
@@ -32,6 +33,39 @@ const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
 export const COMMUNITY_NAME = /^hive-\d+$/;
 
 const CONTROLLING_COMMUNITY_ROLES = new Set(['owner', 'admin']);
+
+/**
+ * A value the server did not store, reported back to the caller.
+ *
+ * Identity fields are pinned and shape-mismatched values are dropped, both silently: the save
+ * answered 200 while the stored config disagreed with what the editor was showing, and the
+ * owner had no way to find out. Every drop is collected here and returned by the PATCH.
+ */
+export interface DiscardedField {
+  /** Dot path of the value inside the config document the caller sent. */
+  path: string;
+  reason: string;
+}
+
+/** Where the guarded merge currently is, and where to record what it drops. */
+interface MergeReport {
+  path: string;
+  discarded: DiscardedField[];
+}
+
+/**
+ * Post filters each instance type can actually serve.
+ *
+ * A blog instance queries bridge.get_account_posts, whose sort must be one of these; a
+ * community instance queries bridge.get_ranked_posts through the SPA's tab mapping. They do not
+ * overlap except on 'payout', so filters carried over from the other type are not a cosmetic
+ * mismatch: every feed tab on the instance errors. The instance type is pinned server-side, so
+ * filters that contradict the pinned type are dropped rather than stored.
+ */
+export const POSTS_FILTERS_BY_TYPE: Record<'blog' | 'community', readonly string[]> = {
+  blog: ['blog', 'feed', 'posts', 'comments', 'replies', 'payout'],
+  community: ['trending', 'hot', 'created', 'new', 'payout', 'muted'],
+};
 
 // Quiet period after the sweep marks a username 'abandoned' before it can be reserved again. It is
 // a backstop; three enforced guarantees keep a paid-for reservation out of a re-registration:
@@ -234,21 +268,31 @@ export const TenantService = {
    * communityId) are server-owned and pinned from the stored config so a config save can
    * never reassign control or re-type the tenant.
    */
-  async applyConfigDocument(username: string, doc: any): Promise<Tenant> {
+  async applyConfigDocument(
+    username: string,
+    doc: any
+  ): Promise<{ tenant: Tenant; discarded: DiscardedField[] }> {
     const tenant = await this.getByUsername(username);
     if (!tenant) throw new Error('Tenant not found');
 
     const current = tenant.config?.configuration?.instanceConfiguration || {};
+    // Every value the server refuses to store is collected here and returned to the caller, so
+    // the editor can tell the owner instead of showing a save that silently disagreed with it.
+    const discarded: DiscardedField[] = [];
     // Identity comes from the tenant ROW (authorization's source of truth), never from the
     // stored config JSON, which could carry stale values from before the owner column.
-    const clean = this.sanitizeConfigDocument(doc, {
-      version: tenant.config?.version ?? 1,
-      username: tenant.username,
-      owner: tenant.owner,
-      type: current.type ?? 'blog',
-      communityId: current.communityId ?? '',
-    });
-    const newConfig = this.mergeConfigGuarded(tenant.config, clean);
+    const clean = this.sanitizeConfigDocument(
+      doc,
+      {
+        version: tenant.config?.version ?? 1,
+        username: tenant.username,
+        owner: tenant.owner,
+        type: current.type ?? 'blog',
+        communityId: current.communityId ?? '',
+      },
+      discarded
+    );
+    const newConfig = this.mergeConfigGuarded(tenant.config, clean, { path: '', discarded });
 
     const row = await db.queryOne<TenantRow>(
       `UPDATE tenants
@@ -259,7 +303,7 @@ export const TenantService = {
       [username.toLowerCase(), JSON.stringify(newConfig)]
     );
 
-    return mapTenantFromDb(row!);
+    return { tenant: mapTenantFromDb(row!), discarded };
   },
 
   /**
@@ -271,7 +315,7 @@ export const TenantService = {
    * this keeps every known section's runtime shape intact no matter what an authenticated
    * client sends (e.g. `general: "oops"` or `postsFilters: "trending"`).
    */
-  mergeConfigGuarded(base: any, updates: any): any {
+  mergeConfigGuarded(base: any, updates: any, ctx?: MergeReport): any {
     const result = Object.assign(Object.create(null), base);
 
     for (const key of Object.keys(updates)) {
@@ -287,21 +331,24 @@ export const TenantService = {
       const incomingIsPlainObject =
         incoming && typeof incoming === 'object' && !Array.isArray(incoming);
       const incomingIsArray = Array.isArray(incoming);
+      const child = ctx
+        ? { path: ctx.path ? `${ctx.path}.${key}` : key, discarded: ctx.discarded }
+        : undefined;
 
       if (stored === undefined || stored === null) {
         // No stored shape to agree with; take the incoming value.
         result[key] = incomingIsPlainObject
-          ? this.mergeConfigGuarded(Object.create(null), incoming)
+          ? this.mergeConfigGuarded(Object.create(null), incoming, child)
           : incoming;
       } else if (typeof stored === 'object' && !Array.isArray(stored)) {
         if (!incomingIsPlainObject) {
-          console.warn('[TenantService] Dropped type-mismatched config value for key:', key);
+          this.reportTypeMismatch(child, key);
           continue;
         }
-        result[key] = this.mergeConfigGuarded(stored, incoming);
+        result[key] = this.mergeConfigGuarded(stored, incoming, child);
       } else if (Array.isArray(stored)) {
         if (!incomingIsArray || !this.isValidArrayReplacement(stored, incoming)) {
-          console.warn('[TenantService] Dropped type-mismatched config value for key:', key);
+          this.reportTypeMismatch(child, key);
           continue;
         }
         result[key] = incoming;
@@ -309,7 +356,7 @@ export const TenantService = {
         // Stored scalar: only a scalar of the SAME primitive type may replace it, so a
         // string "false" cannot stand in for a boolean, nor 42 for a string.
         if (incomingIsPlainObject || incomingIsArray || typeof incoming !== typeof stored) {
-          console.warn('[TenantService] Dropped type-mismatched config value for key:', key);
+          this.reportTypeMismatch(child, key);
           continue;
         }
         result[key] = incoming;
@@ -317,6 +364,17 @@ export const TenantService = {
     }
 
     return result;
+  },
+
+  /** Log a dropped value and, when the caller asked for a report, record it for the response. */
+  reportTypeMismatch(child: MergeReport | undefined, key: string): void {
+    console.warn('[TenantService] Dropped type-mismatched config value for key:', key);
+    if (child) {
+      child.discarded.push({
+        path: child.path,
+        reason: 'value does not match the type of the stored setting',
+      });
+    }
   },
 
   /**
@@ -360,9 +418,13 @@ export const TenantService = {
    */
   sanitizeConfigDocument(
     doc: any,
-    pins: { version: number; username: string; owner: string; type: string; communityId: string }
+    pins: { version: number; username: string; owner: string; type: string; communityId: string },
+    discarded?: DiscardedField[]
   ): any {
     const clean = this.mergeConfig(Object.create(null), this.stripNulls(doc || {}));
+    if (clean.version !== undefined && clean.version !== pins.version) {
+      discarded?.push({ path: 'version', reason: 'the config version is set by the server' });
+    }
     clean.version = pins.version;
     // Arrays must be rejected, not just non-objects: an array passes typeof === 'object',
     // silently drops any pinned properties when serialized, and would replace the stored
@@ -373,13 +435,31 @@ export const TenantService = {
       Array.isArray(clean.configuration) ||
       Array.isArray(clean.configuration.instanceConfiguration)
     ) {
-      throw new Error('Invalid configuration document');
+      throw new ApiError(400, 'Invalid configuration document');
     }
     const instance = (clean.configuration.instanceConfiguration =
       clean.configuration.instanceConfiguration &&
       typeof clean.configuration.instanceConfiguration === 'object'
         ? clean.configuration.instanceConfiguration
         : Object.create(null));
+
+    // Report a pin only when the client actually sent something different. The editor loads
+    // the served config and sends it back, so the identity fields normally match and produce
+    // no report; a genuine attempt to change one (switching the instance type) does.
+    const pinReasons: Record<string, string> = {
+      username: 'the showcased account is set by the server',
+      owner: 'the controlling account is set by the server',
+      type: 'the instance type is set when the instance is created and cannot be changed here',
+      communityId: 'the community id is set by the server',
+    };
+    for (const key of ['username', 'owner', 'type', 'communityId'] as const) {
+      if (instance[key] !== undefined && instance[key] !== pins[key]) {
+        discarded?.push({
+          path: `configuration.instanceConfiguration.${key}`,
+          reason: pinReasons[key],
+        });
+      }
+    }
 
     instance.username = pins.username;
     instance.owner = pins.owner;
@@ -389,7 +469,45 @@ export const TenantService = {
     // client document into the stored config.
     delete instance.managed;
 
+    // Post filters are checked AFTER the type is pinned, against the pinned type: a document
+    // that switches the instance type carries the other type's filters with it, and storing
+    // those while the type stays put leaves every feed tab querying a sort its API rejects.
+    this.normalizePostsFilters(instance, pins.type, discarded);
+
     return clean;
+  },
+
+  /**
+   * Drop post filters the pinned instance type cannot serve.
+   *
+   * If nothing valid is left the key is removed entirely rather than stored empty, so the merge
+   * keeps whatever the instance already had: an instance with no filters at all has no feed.
+   * Mutates `instance` in place; the caller owns the freshly-sanitized copy.
+   */
+  normalizePostsFilters(instance: any, type: string, discarded?: DiscardedField[]): void {
+    const features = instance?.features;
+    if (!features || typeof features !== 'object' || Array.isArray(features)) return;
+    if (!Array.isArray(features.postsFilters)) return;
+
+    const allowed = POSTS_FILTERS_BY_TYPE[type === 'community' ? 'community' : 'blog'];
+    const kept = features.postsFilters.filter(
+      (filter: unknown) => typeof filter === 'string' && allowed.includes(filter)
+    );
+    if (kept.length === features.postsFilters.length) return;
+
+    const dropped = features.postsFilters.filter((filter: unknown) => !kept.includes(filter));
+    discarded?.push({
+      path: 'configuration.instanceConfiguration.features.postsFilters',
+      reason: `${JSON.stringify(dropped)} cannot be served by a ${
+        type === 'community' ? 'community' : 'blog'
+      } instance`,
+    });
+
+    if (kept.length > 0) {
+      features.postsFilters = kept;
+    } else {
+      delete features.postsFilters;
+    }
   },
   
   /**


### PR DESCRIPTION
Three defects on the managed blog hosting API, all on the request-validation and error surface. Closes #1313.

## 1. Clearing the Version field discarded the whole save

`PATCH /v1/tenants/:username` validated its body with `z.union([fullConfigDocSchema, flatConfigUpdateSchema])`. A full document that failed for any reason fell through to the flat schema, and because every flat key is optional that schema matches any object and strips it to `{}`. The route merged nothing and answered `200 Configuration updated` with none of the edit stored.

The editor's Version input sends `null` when cleared, which is not an optional int, so that alone triggered it.

The form is now decided by the presence of `configuration` and validated against that schema only. An unparseable body answers 400 with the failing paths. The flat key form is kept: it predates the Configuration Editor, shares its vocabulary with signup, and is unambiguous because it carries no `configuration` key.

## 2. Switching Instance Type persisted contradictory filters

Verified in the code first: `sanitizeConfigDocument` pins `type` from the stored config, but `mergeConfigGuarded` accepted the client's `postsFilters` because a string array is a valid replacement for a string array. The editor rewrites `postsFilters` when the type changes, so a personal blog ended up configured with `['trending','hot','new']`, which `bridge.get_account_posts` does not accept as a sort. Every feed tab on the instance errors.

Filters are now checked against the pinned type after pinning and dropped when that type cannot serve them. If nothing valid is left, the key is removed so the merge keeps the instance's stored filters: an instance with no filters has no feed.

The PATCH response now carries a `discarded` array (`{ path, reason }`) listing everything the server refused to store, including pinned identity fields and shape mismatches, both of which were previously dropped silently. The client-side handling of that field is a separate change.

## 3. The error handler returned raw driver messages

`app.onError` returned `err.message` verbatim with a 500, so a Postgres error handed the caller the table, column and constraint it failed on, and `detail` can quote parameter values.

Unknown errors are now logged in full server-side and answered with a fixed message. Two paths stay useful:

- a route that has something to say throws `ApiError(status, message)`, the way `DomainInUseError` already lets one path answer 409; `sanitizeConfigDocument` uses it so an invalid document is a 400 with its reason rather than a 500;
- Hono's own `HTTPException` (malformed JSON, payload limits) keeps its status and framework-authored message instead of collapsing to 500.

zod-validator still answers its own 400s before reaching the handler, so field-level validation feedback is unchanged.

## Behaviour change for existing tenants

A PATCH body that was previously accepted and silently discarded now returns 400. That is the point of the fix, but it does change what a client sees: any caller relying on the 200 will now see an error until it sends a valid document.

Nothing here touches serving, subscriptions or payments, and no schema change is involved.

## Verification

`npm test` and `npm run build` in `apps/self-hosted/hosting/api` (211 tests, typecheck clean). New tests were mutation-checked: restoring the union fallthrough, removing the filter normalisation, storing an empty filter list, reporting every pinned field instead of only changed ones, dropping the merge-path reporting, restoring `err.message` in the handler, and flattening `ApiError` to a 500 each make the relevant test fail for its stated reason.