### PR TITLE
fix(self-hosted): reader-facing UI and content-filtering defects

### DIFF
--- a/apps/self-hosted/src/core/dmca.test.ts
+++ b/apps/self-hosted/src/core/dmca.test.ts
@@ -155,4 +155,38 @@ describe('loadDmcaLists', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(setDmcaLists).toHaveBeenCalledTimes(1);
   });
+
+  /**
+   * The fetch is not awaited, so a post query can resolve against an empty
+   * configuration and cache the unfiltered result. Without a refetch the listed
+   * content stays on screen for the rest of the session.
+   */
+  it('refetches post queries once the lists land', async () => {
+    vi.stubGlobal('fetch', respond(FULL));
+    const loadDmcaLists = await importLoader();
+    const invalidateQueries = vi.fn();
+
+    await loadDmcaLists({ invalidateQueries } as never);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['posts'] });
+  });
+
+  it('does not refetch when the lists came back empty', async () => {
+    vi.stubGlobal(
+      'fetch',
+      respond({
+        'dmca-accounts.json': { accounts: [] },
+        'dmca-tags.json': { tags: [] },
+        'dmca-posts.json': { posts: [] },
+      }),
+    );
+    const loadDmcaLists = await importLoader();
+    const invalidateQueries = vi.fn();
+
+    await loadDmcaLists({ invalidateQueries } as never);
+
+    // Nothing to filter, so the refetch would cost every visitor a round of
+    // requests for no change whenever the lists are unreachable.
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
 });

--- a/apps/self-hosted/src/core/dmca.test.ts
+++ b/apps/self-hosted/src/core/dmca.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setDmcaLists = vi.fn();
+
+vi.mock('@ecency/sdk', () => ({
+  ConfigManager: {
+    setDmcaLists: (...args: unknown[]) => setDmcaLists(...args),
+  },
+}));
+
+type Payload = Record<string, unknown>;
+
+function respond(payloads: Record<string, Payload>) {
+  return vi.fn(async (url: string) => {
+    const file = url.split('/').pop() as string;
+    const payload = payloads[file];
+    if (!payload) {
+      throw new Error(`unexpected request for ${file}`);
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    } as unknown as Response;
+  });
+}
+
+const FULL = {
+  'dmca-accounts.json': { accounts: ['@baduser'] },
+  'dmca-tags.json': { tags: ['badtag'] },
+  'dmca-posts.json': { posts: ['@baduser/stolen-post'] },
+};
+
+/** Fresh module each time, so the memoised promise does not leak between tests. */
+async function importLoader() {
+  vi.resetModules();
+  return (await import('./dmca')).loadDmcaLists;
+}
+
+beforeEach(() => {
+  setDmcaLists.mockClear();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('loadDmcaLists', () => {
+  it('applies the fetched lists to the SDK config', async () => {
+    vi.stubGlobal('fetch', respond(FULL));
+    const loadDmcaLists = await importLoader();
+
+    await loadDmcaLists();
+
+    // Without this call the SDK's dmca patterns stay empty and every
+    // filterDmcaEntry in the query path is a no-op, which is the defect.
+    expect(setDmcaLists).toHaveBeenCalledTimes(1);
+    expect(setDmcaLists).toHaveBeenCalledWith({
+      accounts: ['@baduser'],
+      tags: ['badtag'],
+      posts: ['@baduser/stolen-post'],
+    });
+  });
+
+  it('requests the three published list files', async () => {
+    const fetchMock = respond(FULL);
+    vi.stubGlobal('fetch', fetchMock);
+    const loadDmcaLists = await importLoader();
+
+    await loadDmcaLists();
+
+    const requested = fetchMock.mock.calls.map(([url]) => url as string).sort();
+    expect(requested).toEqual([
+      'https://ecency.com/dmca/dmca-accounts.json',
+      'https://ecency.com/dmca/dmca-posts.json',
+      'https://ecency.com/dmca/dmca-tags.json',
+    ]);
+  });
+
+  it('fails open when the network is unreachable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      }),
+    );
+    const loadDmcaLists = await importLoader();
+
+    // Must resolve, not reject: this runs at bootstrap and a rejection there
+    // would surface as an unhandled rejection on every load.
+    await expect(loadDmcaLists()).resolves.toBeUndefined();
+    expect(setDmcaLists).toHaveBeenCalledWith({
+      accounts: [],
+      tags: [],
+      posts: [],
+    });
+  });
+
+  it('keeps the lists that loaded when one of them fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.endsWith('dmca-tags.json')) {
+          return { ok: false, status: 503 } as unknown as Response;
+        }
+        const file = url.split('/').pop() as string;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => FULL[file as keyof typeof FULL],
+        } as unknown as Response;
+      }),
+    );
+    const loadDmcaLists = await importLoader();
+
+    await loadDmcaLists();
+
+    expect(setDmcaLists).toHaveBeenCalledWith({
+      accounts: ['@baduser'],
+      tags: [],
+      posts: ['@baduser/stolen-post'],
+    });
+  });
+
+  it('drops entries that are not strings and tolerates a missing key', async () => {
+    vi.stubGlobal(
+      'fetch',
+      respond({
+        'dmca-accounts.json': { accounts: ['@baduser', 42, null] },
+        'dmca-tags.json': {},
+        'dmca-posts.json': { posts: 'not-an-array' },
+      }),
+    );
+    const loadDmcaLists = await importLoader();
+
+    await loadDmcaLists();
+
+    expect(setDmcaLists).toHaveBeenCalledWith({
+      accounts: ['@baduser'],
+      tags: [],
+      posts: [],
+    });
+  });
+
+  it('fetches once however many callers ask', async () => {
+    const fetchMock = respond(FULL);
+    vi.stubGlobal('fetch', fetchMock);
+    const loadDmcaLists = await importLoader();
+
+    await Promise.all([loadDmcaLists(), loadDmcaLists()]);
+    await loadDmcaLists();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(setDmcaLists).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/self-hosted/src/core/dmca.ts
+++ b/apps/self-hosted/src/core/dmca.ts
@@ -1,4 +1,5 @@
 import { ConfigManager } from '@ecency/sdk';
+import type { QueryClient } from '@tanstack/react-query';
 
 /**
  * DMCA filtering lists.
@@ -61,10 +62,27 @@ let pending: Promise<void> | undefined;
 /**
  * Loads the lists into the SDK config. Memoised: repeated calls share the first
  * request. Always resolves, and always applies whatever it managed to fetch.
+ *
+ * Post queries are refetched once the lists land. Nothing about rendering may
+ * wait on a remote origin, so the fetch is not awaited, which leaves a window
+ * where a query resolves first: filterDmcaEntry runs against an empty
+ * configuration, and the unfiltered result is cached and displayed for the rest
+ * of the session. Refetching closes it. Every post key starts with "posts", so
+ * one invalidation reaches them all.
+ *
+ * Skipped when nothing was loaded, since there is then nothing to filter and
+ * the refetch would be pure cost for every visitor whenever the lists are
+ * unreachable.
  */
-export function loadDmcaLists(): Promise<void> {
+export function loadDmcaLists(queryClient?: QueryClient): Promise<void> {
   pending ??= fetchLists().then((lists) => {
     ConfigManager.setDmcaLists(lists);
+
+    const listed =
+      lists.accounts.length + lists.tags.length + lists.posts.length;
+    if (listed > 0 && queryClient) {
+      queryClient.invalidateQueries({ queryKey: ['posts'] });
+    }
   });
   return pending;
 }

--- a/apps/self-hosted/src/core/dmca.ts
+++ b/apps/self-hosted/src/core/dmca.ts
@@ -1,0 +1,70 @@
+import { ConfigManager } from '@ecency/sdk';
+
+/**
+ * DMCA filtering lists.
+ *
+ * The SDK's post queries all run their results through filterDmcaEntry, but it
+ * reads lists that stay empty until ConfigManager.setDmcaLists is called. That
+ * call was missing here, so takedown-listed content was served unfiltered on
+ * every instance. apps/web loads the same three files, bundled from its own
+ * public/dmca; this app is a static bundle deployed independently of them, so
+ * it reads them over the network instead and picks up updates without a
+ * rebuild.
+ *
+ * Failure is not fatal. A blocked or unreachable fetch leaves that list empty
+ * and the page still renders, which is the same state the app was already in.
+ */
+const DMCA_LIST_BASE = 'https://ecency.com/dmca';
+
+const DMCA_LIST_SOURCES = [
+  { file: 'dmca-accounts.json', key: 'accounts' },
+  { file: 'dmca-tags.json', key: 'tags' },
+  { file: 'dmca-posts.json', key: 'posts' },
+] as const;
+
+/** Bounded so a hanging response cannot keep the request open indefinitely. */
+const FETCH_TIMEOUT_MS = 10_000;
+
+async function fetchList(file: string, key: string): Promise<string[]> {
+  const response = await fetch(`${DMCA_LIST_BASE}/${file}`, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`${file} responded ${response.status}`);
+  }
+
+  const payload = (await response.json()) as Record<string, unknown>;
+  const list = payload?.[key];
+
+  return Array.isArray(list)
+    ? list.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+async function fetchLists() {
+  const [accounts, tags, posts] = await Promise.all(
+    DMCA_LIST_SOURCES.map(({ file, key }) =>
+      fetchList(file, key).catch((error) => {
+        // One unreachable list must not discard the two that did load.
+        console.warn(`[DMCA] Could not load ${file}:`, error);
+        return [] as string[];
+      }),
+    ),
+  );
+
+  return { accounts, tags, posts };
+}
+
+let pending: Promise<void> | undefined;
+
+/**
+ * Loads the lists into the SDK config. Memoised: repeated calls share the first
+ * request. Always resolves, and always applies whatever it managed to fetch.
+ */
+export function loadDmcaLists(): Promise<void> {
+  pending ??= fetchLists().then((lists) => {
+    ConfigManager.setDmcaLists(lists);
+  });
+  return pending;
+}

--- a/apps/self-hosted/src/features/blog/components/blog-post-header.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-header.tsx
@@ -7,36 +7,11 @@ import { Link } from '@tanstack/react-router';
 import { formatRelativeTime, InstanceConfigManager, t } from '@/core';
 import { UserAvatar } from '@/features/shared/user-avatar';
 import { useIsBlogOwner } from '@/features/auth/hooks';
+import { stripHtmlAndMarkdown } from '../utils/strip-markdown';
 import { TextToSpeechButton } from './text-to-speech-button';
 
 interface Props {
   entry: Entry;
-}
-
-function stripHtmlAndMarkdown(text: string): string {
-  return text
-    // Remove HTML tags
-    .replace(/<[^>]*>/g, ' ')
-    // Remove Markdown images ![alt](url)
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
-    // Remove Markdown links [text](url) - keep the text
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-    // Remove Markdown bold/italic **text**, *text*, __text__, _text_
-    .replace(/(\*\*|__)(.*?)\1/g, '$2')
-    .replace(/(\*|_)(.*?)\1/g, '$2')
-    // Remove Markdown headings # ## ### etc.
-    .replace(/^#{1,6}\s+/gm, '')
-    // Remove Markdown blockquotes >
-    .replace(/^>\s*/gm, '')
-    // Remove Markdown code blocks ```...```
-    .replace(/```[\s\S]*?```/g, '')
-    // Remove inline code `text`
-    .replace(/`([^`]*)`/g, '$1')
-    // Remove horizontal rules ---, ***, ___
-    .replace(/^[-*_]{3,}\s*$/gm, '')
-    // Remove extra whitespace
-    .replace(/\s+/g, ' ')
-    .trim();
 }
 
 function countWords(text: string): number {

--- a/apps/self-hosted/src/features/blog/components/blog-post-header.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-header.tsx
@@ -6,7 +6,8 @@ import { useMemo } from 'react';
 import { Link } from '@tanstack/react-router';
 import { formatRelativeTime, InstanceConfigManager, t } from '@/core';
 import { UserAvatar } from '@/features/shared/user-avatar';
-import { useIsBlogOwner } from '@/features/auth/hooks';
+import { useAuth } from '@/features/auth/hooks';
+import { canEditEntry } from '@/features/publish/utils/can-edit-entry';
 import { stripHtmlAndMarkdown } from '../utils/strip-markdown';
 import { TextToSpeechButton } from './text-to-speech-button';
 
@@ -28,7 +29,7 @@ function calculateReadTime(body: string): number {
 }
 
 export function BlogPostHeader({ entry }: Props) {
-  const isBlogOwner = useIsBlogOwner();
+  const { user } = useAuth();
   const entryData = entry.original_entry || entry;
   const instanceType = InstanceConfigManager.getConfigValue(
     ({ configuration }) => configuration.instanceConfiguration.type ?? 'blog',
@@ -108,7 +109,7 @@ export function BlogPostHeader({ entry }: Props) {
             text={entryData.body}
             title={entryData.title}
           />
-          {isBlogOwner && (
+          {canEditEntry(user?.username, entryData.author) && (
             <Link
               to="/edit/$author/$permlink"
               params={{ author: entryData.author, permlink: entryData.permlink }}

--- a/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
@@ -90,7 +90,10 @@ export function BlogPostItem({ entry }: Props) {
   // away the query cache the feed had just filled. The route param carries the
   // bare username; the post page accepts it with or without the @ prefix.
   const postParams = useMemo(
-    () => ({ author: entryData.author, permlink: entryData.permlink }),
+    // The '@' is part of the canonical post URL, and the router is configured to
+    // leave it unencoded, so these links keep the shape the rest of the Hive
+    // ecosystem uses instead of dropping to /author/permlink.
+    () => ({ author: `@${entryData.author}`, permlink: entryData.permlink }),
     [entryData.author, entryData.permlink],
   );
 

--- a/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
@@ -4,6 +4,7 @@ import {
   renderPostBody,
 } from '@ecency/render-helper';
 import type { Entry } from '@ecency/sdk';
+import { Link } from '@tanstack/react-router';
 import {
   UilComment,
   UilHeart,
@@ -84,6 +85,20 @@ export function BlogPostItem({ entry }: Props) {
     return catchPostImage(entryData, 800, 600) || null;
   }, [entryData]);
 
+  // Router navigation, not a document load: an <a href> here tore down the SPA
+  // on every feed-to-post click, refetching the instance config and throwing
+  // away the query cache the feed had just filled. The route param carries the
+  // bare username; the post page accepts it with or without the @ prefix.
+  const postParams = useMemo(
+    () => ({ author: entryData.author, permlink: entryData.permlink }),
+    [entryData.author, entryData.permlink],
+  );
+
+  // The post route declares `raw` as a search param, so the type demands the
+  // key. An undefined value is dropped when the href is built, so the link is
+  // still the bare post path.
+  const postSearch = { raw: undefined };
+
   const contentSection = (
     <>
       <div className="mb-2">
@@ -100,25 +115,21 @@ export function BlogPostItem({ entry }: Props) {
       </div>
 
       <h2 className="text-xl sm:text-2xl font-bold mb-3 transition-theme hover:opacity-70 heading-theme leading-[1.15]">
-        <a
-          href={`/@${entryData.author}/${entryData.permlink}`}
-        >
+        <Link to="/$author/$permlink" params={postParams} search={postSearch}>
           {entryData.title}
-        </a>
+        </Link>
       </h2>
 
       {listType === 'grid' && imageUrl && (
         <div className="mb-4 overflow-hidden">
-          <a
-            href={`/@${entryData.author}/${entryData.permlink}`}
-          >
+          <Link to="/$author/$permlink" params={postParams} search={postSearch}>
             <img
               src={imageUrl}
               alt={entryData.title}
               className="w-full object-cover post-card-image-theme"
               loading="lazy"
             />
-          </a>
+          </Link>
         </div>
       )}
 
@@ -197,8 +208,10 @@ export function BlogPostItem({ entry }: Props) {
         <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
           <div className="flex-1">{contentSection}</div>
           <div className="shrink-0 w-full sm:w-48">
-            <a
-              href={`/@${entryData.author}/${entryData.permlink}`}
+            <Link
+              to="/$author/$permlink"
+              params={postParams}
+              search={postSearch}
             >
               <img
                 src={imageUrl}
@@ -206,7 +219,7 @@ export function BlogPostItem({ entry }: Props) {
                 className="w-full h-48 sm:h-32 object-cover rounded-theme"
                 loading="lazy"
               />
-            </a>
+            </Link>
           </div>
         </div>
       ) : (

--- a/apps/self-hosted/src/features/blog/components/blog-posts-list.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-posts-list.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { getAccountPostsInfiniteQueryOptions } from '@ecency/sdk';
+import {
+  getAccountPostsInfiniteQueryOptions,
+  getPostsRankedInfiniteQueryOptions,
+} from '@ecency/sdk';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef } from 'react';
 import { t } from '@/core';
 import { BlogPostItem } from './blog-post-item';
 import { DetectBottom } from './detect-bottom';
 import { useInstanceConfig } from '../hooks/use-instance-config';
-import { getCommunityPostsInfiniteQueryOptions } from '../queries/community-queries';
 import { ErrorMessage } from '@/features/shared/error-message';
 
 interface Props {
@@ -41,7 +43,16 @@ export function BlogPostsList({ filter = 'posts', limit = 20 }: Props) {
 
   // Get query options and preserve their built-in enabled guards
   const accountOptions = getAccountPostsInfiniteQueryOptions(username, filter, limit);
-  const communityOptions = getCommunityPostsInfiniteQueryOptions(communityId, communitySort, limit);
+  // The SDK's ranked-posts query, not a local bridge call: it is the path that
+  // applies DMCA post filtering and drops a tag that is itself listed. A
+  // bespoke get_ranked_posts call here served takedown-listed content.
+  const communityOptions = getPostsRankedInfiniteQueryOptions(
+    communitySort,
+    communityId,
+    limit,
+    '',
+    !!communityId && isCommunityMode,
+  );
 
   const blogQuery = useInfiniteQuery({
     ...accountOptions,
@@ -52,7 +63,6 @@ export function BlogPostsList({ filter = 'posts', limit = 20 }: Props) {
   const communityQuery = useInfiniteQuery({
     ...communityOptions,
     select: selectPosts,
-    enabled: communityOptions.enabled && isCommunityMode,
   });
 
   const { data = [], fetchNextPage, isFetching, hasNextPage, isError, refetch } = isCommunityMode

--- a/apps/self-hosted/src/features/blog/components/text-to-speech-button.tsx
+++ b/apps/self-hosted/src/features/blog/components/text-to-speech-button.tsx
@@ -4,6 +4,7 @@ import { UilPlay, UilPause, UilStopCircle } from '@tooni/iconscout-unicons-react
 import { useCallback, useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { InstanceConfigManager, t } from '@/core';
+import { stripHtmlAndMarkdown } from '../utils/strip-markdown';
 
 interface Props {
   text: string;
@@ -51,11 +52,10 @@ export function TextToSpeechButton({ text, title, className }: Props) {
     // Cancel any existing speech
     window.speechSynthesis.cancel();
 
-    // Strip HTML and prepare text
-    const cleanText = text
-      .replace(/<[^>]*>/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim();
+    // `text` is the raw post body: markdown, not rendered HTML. Stripping tags
+    // alone left image URLs, link targets and `#`/`*` markers in the string,
+    // and the speech synthesiser read every one of them out loud.
+    const cleanText = stripHtmlAndMarkdown(text);
 
     const fullText = title ? `${title}. ${cleanText}` : cleanText;
 

--- a/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
@@ -102,7 +102,7 @@ function BlogSidebarContent({ username }: { username: string }) {
           <TipButton
             recipientUsername={username}
             variant="general"
-            className="w-full flex items-center justify-center gap-2 py-2 rounded-md border border-theme bg-theme-bg text-theme-primary hover:bg-theme-tertiary text-sm"
+            className="w-full flex items-center justify-center gap-2 py-2 rounded-md border border-theme bg-theme-primary text-theme-primary hover:bg-theme-tertiary text-sm"
           />
         </div>
       )}

--- a/apps/self-hosted/src/features/blog/queries/community-queries.ts
+++ b/apps/self-hosted/src/features/blog/queries/community-queries.ts
@@ -1,8 +1,5 @@
-import { callRPC, type Entry } from '@ecency/sdk';
-import {
-  infiniteQueryOptions,
-  queryOptions,
-} from '@tanstack/react-query';
+import { callRPC } from '@ecency/sdk';
+import { queryOptions } from '@tanstack/react-query';
 import type { Community } from './types';
 
 export type { Community };
@@ -24,41 +21,12 @@ export function getCommunityQueryOptions(communityId: string) {
   });
 }
 
-/**
- * Get community posts (ranked posts with community tag)
+/*
+ * The community feed used to be a bespoke bridge.get_ranked_posts call here. It
+ * bypassed the SDK's DMCA post filtering and tag sanitisation entirely, so
+ * takedown-listed content was served. Use getPostsRankedInfiniteQueryOptions
+ * from @ecency/sdk instead; see blog-posts-list.
  */
-export function getCommunityPostsInfiniteQueryOptions(
-  communityId: string,
-  sort: string = 'created',
-  limit: number = 20
-) {
-  return infiniteQueryOptions({
-    queryKey: ['community-posts', communityId, sort, limit],
-    enabled: !!communityId,
-    initialPageParam: { start_author: '', start_permlink: '' },
-    queryFn: async ({ pageParam }) => {
-      const result = await callRPC('bridge.get_ranked_posts', {
-        sort,
-        tag: communityId,
-        start_author: pageParam.start_author,
-        start_permlink: pageParam.start_permlink,
-        limit,
-        observer: '',
-      });
-      return (result as Entry[]) || [];
-    },
-    getNextPageParam: (lastPage) => {
-      if (!lastPage || lastPage.length < limit) {
-        return undefined;
-      }
-      const lastPost = lastPage[lastPage.length - 1];
-      return {
-        start_author: lastPost.author,
-        start_permlink: lastPost.permlink,
-      };
-    },
-  });
-}
 
 /**
  * Get community subscribers count

--- a/apps/self-hosted/src/features/blog/queries/ranked-posts-source.test.ts
+++ b/apps/self-hosted/src/features/blog/queries/ranked-posts-source.test.ts
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The community feed must go through the SDK's ranked-posts query.
+ *
+ * That query is where DMCA post filtering and tag sanitisation happen. This app
+ * used to call bridge.get_ranked_posts itself, which skipped both, so
+ * takedown-listed content was served on instances Ecency operates. Nothing in
+ * the type system distinguishes the two, so the direct call is checked for
+ * here: it is a one-line change to reintroduce and nothing else would notice.
+ */
+
+const SRC = join(__dirname, '..', '..', '..');
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    if (!/\.tsx?$/.test(entry.name)) return [];
+    if (entry.name.endsWith('.test.ts')) return [];
+    return [path];
+  });
+}
+
+/** The method name as it appears in a call, so prose about it does not match. */
+const DIRECT_CALL = /['"`]bridge\.get_ranked_posts['"`]/;
+
+describe('community feed data source', () => {
+  it('makes no ranked-posts bridge call of its own', () => {
+    const offenders = sourceFiles(SRC)
+      .filter((file) => DIRECT_CALL.test(readFileSync(file, 'utf8')))
+      .map((file) => file.replace(SRC, 'src'));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('reads real source files', () => {
+    // Guards the sweep itself: a broken path would make the check above pass
+    // over an empty list forever.
+    const files = sourceFiles(SRC);
+    expect(files.length).toBeGreaterThan(20);
+    expect(files.some((file) => file.endsWith('blog-posts-list.tsx'))).toBe(
+      true,
+    );
+  });
+});

--- a/apps/self-hosted/src/features/blog/utils/strip-markdown.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/strip-markdown.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { stripHtmlAndMarkdown } from './strip-markdown';
+
+describe('stripHtmlAndMarkdown', () => {
+  it('drops image markup instead of reading the URL out', () => {
+    const result = stripHtmlAndMarkdown(
+      'Look at this ![a cat on a roof](https://images.example.com/cat.png) picture.',
+    );
+    expect(result).toBe('Look at this picture.');
+    expect(result).not.toContain('https');
+    expect(result).not.toContain('png');
+  });
+
+  it('keeps link text and drops the target', () => {
+    const result = stripHtmlAndMarkdown(
+      'Read [the announcement](https://example.com/blog/post-1) today.',
+    );
+    expect(result).toBe('Read the announcement today.');
+    expect(result).not.toContain('example.com');
+  });
+
+  it('drops heading and emphasis markers', () => {
+    expect(stripHtmlAndMarkdown('## Chapter one\nIt was **very** quiet.')).toBe(
+      'Chapter one It was very quiet.',
+    );
+    expect(stripHtmlAndMarkdown('_soft_ and __loud__')).toBe('soft and loud');
+  });
+
+  it('drops blockquote markers, code fences and inline code', () => {
+    expect(stripHtmlAndMarkdown('> quoted line')).toBe('quoted line');
+    expect(stripHtmlAndMarkdown('before\n```\nconst x = 1;\n```\nafter')).toBe(
+      'before after',
+    );
+    expect(stripHtmlAndMarkdown('run `npm test` now')).toBe('run npm test now');
+  });
+
+  it('drops horizontal rules', () => {
+    expect(stripHtmlAndMarkdown('one\n---\ntwo')).toBe('one two');
+  });
+
+  it('still strips HTML tags', () => {
+    expect(stripHtmlAndMarkdown('<p>hello <b>there</b></p>')).toBe(
+      'hello there',
+    );
+  });
+
+  it('collapses whitespace and trims', () => {
+    expect(stripHtmlAndMarkdown('  a\n\n\tb  ')).toBe('a b');
+  });
+});

--- a/apps/self-hosted/src/features/blog/utils/strip-markdown.ts
+++ b/apps/self-hosted/src/features/blog/utils/strip-markdown.ts
@@ -1,0 +1,35 @@
+/**
+ * Reduces a post body to plain prose.
+ *
+ * Post bodies arrive as raw markdown that may also contain HTML, so anything
+ * that reads or measures the text has to strip both. Stripping HTML alone left
+ * image URLs, link targets, `#` and `*` in the string, which the read-time
+ * estimate counted as words and the text-to-speech button read out loud.
+ */
+export function stripHtmlAndMarkdown(text: string): string {
+  return (
+    text
+      // Remove HTML tags
+      .replace(/<[^>]*>/g, ' ')
+      // Remove Markdown images ![alt](url)
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+      // Remove Markdown links [text](url) - keep the text
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      // Remove Markdown bold/italic **text**, *text*, __text__, _text_
+      .replace(/(\*\*|__)(.*?)\1/g, '$2')
+      .replace(/(\*|_)(.*?)\1/g, '$2')
+      // Remove Markdown headings # ## ### etc.
+      .replace(/^#{1,6}\s+/gm, '')
+      // Remove Markdown blockquotes >
+      .replace(/^>\s*/gm, '')
+      // Remove Markdown code blocks ```...```
+      .replace(/```[\s\S]*?```/g, '')
+      // Remove inline code `text`
+      .replace(/`([^`]*)`/g, '$1')
+      // Remove horizontal rules ---, ***, ___
+      .replace(/^[-*_]{3,}\s*$/gm, '')
+      // Remove extra whitespace
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}

--- a/apps/self-hosted/src/features/publish/utils/can-edit-entry.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/can-edit-entry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { canEditEntry } from './can-edit-entry';
+
+describe('canEditEntry', () => {
+  it('lets an author edit their own post', () => {
+    expect(canEditEntry('alice', 'alice')).toBe(true);
+  });
+
+  it('lets a community member edit their own post on an instance they do not own', () => {
+    // The regression: the route required `isBlogOwner && username === author`,
+    // so on a community instance, where any authenticated user can publish,
+    // the author of a post could never reopen it.
+    expect(canEditEntry('member', 'member')).toBe(true);
+  });
+
+  it("does not let the instance owner edit someone else's post", () => {
+    // The Edit control used to render on ownership alone and then bounced the
+    // owner back to /blog, because an edit is broadcast as the post's author.
+    expect(canEditEntry('owner', 'someone-else')).toBe(false);
+  });
+
+  it('rejects a signed-out visitor', () => {
+    expect(canEditEntry(undefined, 'alice')).toBe(false);
+    expect(canEditEntry(null, 'alice')).toBe(false);
+    expect(canEditEntry('', 'alice')).toBe(false);
+  });
+
+  it('rejects a missing author rather than matching an empty username', () => {
+    expect(canEditEntry(undefined, undefined)).toBe(false);
+    expect(canEditEntry('', '')).toBe(false);
+    expect(canEditEntry('alice', undefined)).toBe(false);
+  });
+
+  it('accepts the @-prefixed form the route param carries', () => {
+    expect(canEditEntry('alice', '@alice')).toBe(true);
+    expect(canEditEntry('@alice', 'alice')).toBe(true);
+  });
+
+  it('ignores case and surrounding whitespace', () => {
+    expect(canEditEntry('Alice', ' alice ')).toBe(true);
+  });
+
+  it('does not treat a prefix as a match', () => {
+    expect(canEditEntry('alice', 'alice2')).toBe(false);
+    expect(canEditEntry('alice', 'ali')).toBe(false);
+  });
+});

--- a/apps/self-hosted/src/features/publish/utils/can-edit-entry.ts
+++ b/apps/self-hosted/src/features/publish/utils/can-edit-entry.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether the signed-in user is allowed to edit a post.
+ *
+ * Authorship is the only rule. An edit is a comment operation broadcast under
+ * the post's own author account, so nobody else can produce a valid one: the
+ * instance owner seeing an Edit control on someone else's post only ever led to
+ * a redirect. On a community instance any member can publish, and gating on
+ * ownership instead of authorship locked those members out of their own posts.
+ *
+ * Author values reach this from two places: the route param, which carries the
+ * `@` prefix used in post URLs, and `entry.author`, which does not.
+ */
+export function canEditEntry(
+  username: string | null | undefined,
+  author: string | null | undefined,
+): boolean {
+  const normalize = (value: string | null | undefined) =>
+    (value ?? '').trim().replace(/^@/, '').toLowerCase();
+
+  const user = normalize(username);
+  return user.length > 0 && user === normalize(author);
+}

--- a/apps/self-hosted/src/features/tipping/components/tipping-step-currency.tsx
+++ b/apps/self-hosted/src/features/tipping/components/tipping-step-currency.tsx
@@ -112,7 +112,7 @@ export function TippingStepCurrency({
           <button
             type="button"
             disabled={!canSubmit}
-            className="px-3 py-2 rounded-md border border-theme text-theme-contrast text-sm hover:bg-theme-tertiary disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-3 py-2 rounded-md border border-theme text-theme-primary text-sm hover:bg-theme-tertiary disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={onSubmit}
           >
             {t(getTipSubmitLabelKey(user?.username, loading))}

--- a/apps/self-hosted/src/features/tipping/components/tipping-step-currency.tsx
+++ b/apps/self-hosted/src/features/tipping/components/tipping-step-currency.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { isExternalWalletAsset } from "../types";
 import { TippingCurrencyCards } from "./tipping-currency-cards";
 import { TippingWalletQr } from "./tipping-wallet-qr";
+import { getTipSubmitLabelKey } from "../utils/tip-submit-label";
 import { useAuth } from "@/features/auth";
 
 interface TippingStepCurrencyProps {
@@ -114,8 +115,7 @@ export function TippingStepCurrency({
             className="px-3 py-2 rounded-md border border-theme text-theme-contrast text-sm hover:bg-theme-tertiary disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={onSubmit}
           >
-            {!user?.username && t("tip_login_to_send")}
-            {user?.username && loading ? t("tip_sending") : t("tip_send")}
+            {t(getTipSubmitLabelKey(user?.username, loading))}
           </button>
         )}
       </div>

--- a/apps/self-hosted/src/features/tipping/utils/tip-submit-label.test.ts
+++ b/apps/self-hosted/src/features/tipping/utils/tip-submit-label.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { getTipSubmitLabelKey } from './tip-submit-label';
+
+describe('getTipSubmitLabelKey', () => {
+  it('prompts a logged-out visitor to sign in, whether or not a send is in flight', () => {
+    expect(getTipSubmitLabelKey(undefined, false)).toBe('tip_login_to_send');
+    // The regression: `username && loading ? sending : send` evaluated the
+    // `&&` first, so a logged-out visitor fell into the send branch and the
+    // button rendered the prompt and the send label together.
+    expect(getTipSubmitLabelKey(undefined, true)).toBe('tip_login_to_send');
+    expect(getTipSubmitLabelKey(null, true)).toBe('tip_login_to_send');
+    expect(getTipSubmitLabelKey('', true)).toBe('tip_login_to_send');
+  });
+
+  it('shows the send label to a signed-in user', () => {
+    expect(getTipSubmitLabelKey('alice', false)).toBe('tip_send');
+  });
+
+  it('shows the in-flight label while a signed-in user is sending', () => {
+    expect(getTipSubmitLabelKey('alice', true)).toBe('tip_sending');
+  });
+
+  it('never returns more than one label for a state', () => {
+    const states: Array<[string | undefined, boolean]> = [
+      [undefined, false],
+      [undefined, true],
+      ['alice', false],
+      ['alice', true],
+    ];
+    for (const [username, loading] of states) {
+      const key = getTipSubmitLabelKey(username, loading);
+      expect(['tip_login_to_send', 'tip_sending', 'tip_send']).toContain(key);
+    }
+  });
+});

--- a/apps/self-hosted/src/features/tipping/utils/tip-submit-label.ts
+++ b/apps/self-hosted/src/features/tipping/utils/tip-submit-label.ts
@@ -1,0 +1,22 @@
+/**
+ * Translation key for the tip dialog's submit button.
+ *
+ * Returns exactly one key for every state. The button used to render two
+ * expressions side by side, and `user?.username && loading ? a : b` binds as
+ * `(user?.username && loading) ? a : b`, so a logged-out visitor was shown the
+ * sign-in prompt and the send label at once ("Login to send a tipTip").
+ */
+export type TipSubmitLabelKey =
+  | 'tip_login_to_send'
+  | 'tip_sending'
+  | 'tip_send';
+
+export function getTipSubmitLabelKey(
+  username: string | undefined | null,
+  loading: boolean,
+): TipSubmitLabelKey {
+  if (!username) {
+    return 'tip_login_to_send';
+  }
+  return loading ? 'tip_sending' : 'tip_send';
+}

--- a/apps/self-hosted/src/globals.css
+++ b/apps/self-hosted/src/globals.css
@@ -88,10 +88,24 @@ button {
 
 /* Mobile responsiveness improvements */
 
-/* Prevent horizontal scroll */
+/*
+ * Prevent horizontal scroll.
+ *
+ * `clip`, not `hidden`. `overflow-x: hidden` makes the element a scroll
+ * container on BOTH axes (the other axis computes to auto), so body became the
+ * nearest scrollport for everything inside it. body's height is content-driven
+ * and never scrolls, so the sidebar's `lg:sticky` had a scrollport that could
+ * not scroll and it simply never stuck. `clip` still clips the overflow, but
+ * does not create a scroll container, so sticky resolves against the viewport
+ * again. It is the only overflow value that pairs with `visible` on the other
+ * axis instead of forcing it to auto.
+ *
+ * The clipping itself is still doing work: post bodies carry author-authored
+ * media and markup that can be wider than the column.
+ */
 html,
 body {
-  overflow-x: hidden;
+  overflow-x: clip;
   max-width: 100vw;
 }
 

--- a/apps/self-hosted/src/index.tsx
+++ b/apps/self-hosted/src/index.tsx
@@ -7,7 +7,13 @@ import { InstanceConfigManager } from './core';
 import { getRssFeedUrl } from './utils/rss-feed-url';
 import { routeTree } from './routeTree.gen';
 
-const router = createRouter({ routeTree });
+const router = createRouter({
+  routeTree,
+  // Path params are percent-encoded by default, which would turn the canonical
+  // /@author/permlink into /%40author/permlink. Every Hive frontend uses the
+  // '@' form and posts link to each other with it, so it stays literal.
+  pathParamsAllowedCharacters: ['@'],
+});
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/apps/self-hosted/src/routes/-canonical-post-links.test.ts
+++ b/apps/self-hosted/src/routes/-canonical-post-links.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Feed links go through the router, so the router's encoding decides the URL
+ * every reader, crawler and shared link carries.
+ *
+ * The router percent-encodes path params, so passing the canonical '@author'
+ * yields /%40author/permlink. Dropping the '@' avoids that but makes every feed
+ * link non-canonical, and '@author/permlink' is the form the rest of the Hive
+ * ecosystem links with. Allowing '@' through unencoded is what keeps both.
+ *
+ * The two halves only work together: allowing the character without passing it
+ * changes nothing, and passing it without allowing it produces %40. This checks
+ * the pair, since neither is expressible in the type system.
+ *
+ * Lives under src/routes with a '-' prefix, TanStack Router's convention for a
+ * non-route file in the routes directory.
+ */
+
+const APP = join(__dirname, '..', '..');
+
+function read(relative: string): string {
+  return readFileSync(join(APP, relative), 'utf8');
+}
+
+describe('canonical post links', () => {
+  it("configures the router to leave '@' unencoded", () => {
+    expect(read('src/index.tsx')).toMatch(
+      /pathParamsAllowedCharacters:\s*\['@'\]/,
+    );
+  });
+
+  it("builds feed post links with the '@' prefix", () => {
+    const source = read('src/features/blog/components/blog-post-item.tsx');
+
+    expect(source).toMatch(/author:\s*`@\$\{[^}]+\}`/);
+  });
+});

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -126,14 +126,6 @@ const SEGMENT_SAFE: Record<string, { occurrences: number; reason: string }> = {
     occurrences: 1,
     reason: 'Hive permlink, cannot contain a slash',
   },
-  'src/features/blog/components/blog-post-item.tsx:entryData.author': {
-    occurrences: 3,
-    reason: 'Hive username, cannot contain a slash',
-  },
-  'src/features/blog/components/blog-post-item.tsx:entryData.permlink': {
-    occurrences: 3,
-    reason: 'Hive permlink, cannot contain a slash',
-  },
 };
 
 interface FoundLink {

--- a/apps/self-hosted/src/routes/__root.tsx
+++ b/apps/self-hosted/src/routes/__root.tsx
@@ -38,7 +38,7 @@ ConfigManager.setQueryClient(queryClient);
 // any post query can resolve. Not awaited: the lists are fetched from a remote
 // origin and nothing about rendering the blog may depend on that origin being
 // reachable.
-loadDmcaLists();
+loadDmcaLists(queryClient);
 
 export const Route = createRootRoute({
   component: RootComponent,

--- a/apps/self-hosted/src/routes/__root.tsx
+++ b/apps/self-hosted/src/routes/__root.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/features/auth/storage";
 import { authenticationStore } from "@/store";
 import { t, InstanceConfigManager } from "@/core";
+import { loadDmcaLists } from "@/core/dmca";
 
 // Check if we're in development mode
 const isDev = process.env.NODE_ENV === "development";
@@ -31,6 +32,13 @@ const ReactQueryDevtools = isDev
 // Sync SDK's internal QueryClient with the app's client so SDK-side
 // cache invalidations and optimistic updates target the same cache.
 ConfigManager.setQueryClient(queryClient);
+
+// Load the DMCA lists the SDK's post queries filter against. Started here, at
+// module load, so the request is in flight before React mounts and well before
+// any post query can resolve. Not awaited: the lists are fetched from a remote
+// origin and nothing about rendering the blog may depend on that origin being
+// reachable.
+loadDmcaLists();
 
 export const Route = createRootRoute({
   component: RootComponent,

--- a/apps/self-hosted/src/routes/edit.$author.$permlink.tsx
+++ b/apps/self-hosted/src/routes/edit.$author.$permlink.tsx
@@ -1,40 +1,43 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { getPostQueryOptions } from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
-import { useIsBlogOwner, useIsAuthEnabled, useAuth } from "@/features/auth/hooks";
+import { useIsAuthEnabled, useAuth } from "@/features/auth/hooks";
 import { BlogSidebar } from "@/features/blog/layout/blog-sidebar";
 import { useEffect, useMemo } from "react";
 import { t } from "@/core";
 import { EditPostEditor } from "@/features/publish/components/edit-post-editor";
+import { canEditEntry } from "@/features/publish/utils/can-edit-entry";
 
 export const Route = createFileRoute("/edit/$author/$permlink")({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const isBlogOwner = useIsBlogOwner();
   const isAuthEnabled = useIsAuthEnabled();
   const { user } = useAuth();
   const navigate = useNavigate();
   const { author, permlink } = Route.useParams();
 
   const cleanAuthor = author.replace("@", "");
-  const isAuthorOwner = isBlogOwner && user?.username === cleanAuthor;
+  // Authorship, not instance ownership: on a community instance every member
+  // can publish, and requiring ownership here locked them out of their own
+  // posts. Broadcasting the edit still requires the author's own key.
+  const canEdit = canEditEntry(user?.username, cleanAuthor);
 
   useEffect(() => {
-    if (!isAuthEnabled || !isAuthorOwner) {
+    if (!isAuthEnabled || !canEdit) {
       navigate({ to: "/blog", search: { filter: "posts" } });
     }
-  }, [isAuthEnabled, isAuthorOwner, navigate]);
+  }, [isAuthEnabled, canEdit, navigate]);
 
   const queryOptions = getPostQueryOptions(cleanAuthor, permlink);
   const {
     data: entry,
     isLoading,
     error,
-  } = useQuery({ ...queryOptions, enabled: isAuthorOwner });
+  } = useQuery({ ...queryOptions, enabled: canEdit });
 
-  if (!isAuthEnabled || !isAuthorOwner) {
+  if (!isAuthEnabled || !canEdit) {
     return null;
   }
 

--- a/apps/self-hosted/src/styles/components.css
+++ b/apps/self-hosted/src/styles/components.css
@@ -76,6 +76,13 @@
   border-color: var(--theme-border-strong);
 }
 
+/* Selected-state border, the counterpart of .text-theme-accent. The tipping
+   currency cards already asked for this class; without it the selected card
+   fell back to Tailwind's default currentColor border. */
+.border-theme-accent {
+  border-color: var(--theme-accent);
+}
+
 /* Border Radius */
 .rounded-theme-sm {
   border-radius: var(--theme-radius-sm);
@@ -128,7 +135,14 @@
 
 /* Tag/Chip Styles */
 .tag-theme {
-  background-color: var(--theme-tag-bg, var(--theme-bg-tertiary));
+  /*
+   * `background`, not `background-color`: a template is free to set
+   * --theme-tag-bg to a gradient (modern-gradient, the default template, does).
+   * A gradient is not a <color>, so `background-color` dropped the declaration
+   * at computed-value time and the chips rendered with no background at all.
+   * The shorthand accepts a color and an image alike.
+   */
+  background: var(--theme-tag-bg, var(--theme-bg-tertiary));
   color: var(--theme-tag-text, var(--theme-text-secondary));
   border-radius: var(--theme-tag-radius, var(--theme-radius-full));
   font-family: var(--theme-font-ui);

--- a/apps/self-hosted/src/styles/themes/modern-gradient.css
+++ b/apps/self-hosted/src/styles/themes/modern-gradient.css
@@ -128,8 +128,10 @@
   border: 1px solid var(--theme-glass-border);
 }
 
-[data-style-template="modern-gradient"] .theme-tag {
-  background: var(--theme-tag-bg);
+/* `.tag-theme` is the class the chips actually carry; `.theme-tag` matched
+   nothing, so this rule never applied. The gradient background now comes from
+   the shared .tag-theme rule; only the border is specific to this template. */
+[data-style-template="modern-gradient"] .tag-theme {
   border: 1px solid var(--theme-border);
 }
 

--- a/apps/self-hosted/src/utils/use-document-meta.ts
+++ b/apps/self-hosted/src/utils/use-document-meta.ts
@@ -75,7 +75,7 @@ export function useDocumentMeta(meta: DocumentMeta) {
 
     // Set title
     if (meta.title) {
-      document.title = `${meta.title} — ${defaultTitle}`;
+      document.title = `${meta.title} | ${defaultTitle}`;
     }
 
     // OG tags


### PR DESCRIPTION
Reader-facing defects in the self-hosted blog app. One commit per defect.

**Tip button rendered two labels.** `{user?.username && loading ? sending : send}` binds as `(user?.username && loading) ? sending : send`, so a logged-out visitor got the sign-in prompt and the send label side by side. Both expressions are replaced by a single `getTipSubmitLabelKey()` call that returns exactly one key per state.

**Text-to-speech read markdown aloud.** The button gets the raw post body but only stripped HTML tags, so image URLs, link targets and the `#`/`*` markers were spoken. The correct strip already existed as a private helper in `blog-post-header`; it moved to `features/blog/utils/strip-markdown` and both call sites use it.

**Community authors could not edit their own posts.** `/publish` lets any authenticated user compose on a community instance, but `/edit` required `isBlogOwner` on top of a username match, so a member who published there could never reopen the post. The Edit control had the mirror problem: it rendered on `isBlogOwner` alone, so the instance owner saw it on every post and following it just redirected to `/blog`. Both now use `canEditEntry(user, author)`, which is the authority an edit actually needs, since the operation is broadcast under the author's own account.

**Sticky sidebar never stuck.** `html, body { overflow-x: hidden }` makes the element a scroll container on both axes, so body became the nearest scrollport for the sidebar's `lg:sticky`; body's height is content-driven and never scrolls, so it never stuck. `overflow-x: clip` clips the same content without creating a scroll container, so the horizontal-scroll guard stays and sticky resolves against the viewport.

**Tag chips had no background under modern-gradient.** That template, which is the default, sets `--theme-tag-bg` to a `linear-gradient`, but `.tag-theme` applied it through `background-color`. A gradient is not a color, so the declaration was dropped. The template's compensating rule targeted `.theme-tag`, a class no component renders. `.tag-theme` now uses the `background` shorthand and the template rule keeps only its border, against the real class. Also adds the `.border-theme-accent` utility the tipping currency cards already referenced but which was never defined.

**Undefined utility classes.** `bg-theme-bg` (sidebar tip button) and `text-theme-contrast` (tip send button) are not defined anywhere, so both were silent no-ops. Replaced with `bg-theme-primary` and `text-theme-primary`, matching the other tipping buttons.

**Feed cards reloaded the document.** The three post links on a card were raw anchors, so every feed-to-post click booted the SPA again, refetched the instance config and dropped the query cache the feed had just filled. They now use the router `Link` against the declared `/$author/$permlink` route. The author link stays a plain anchor because it leaves the instance. Note the href loses the `@` prefix (`/alice/post` rather than `/@alice/post`): the router percent-encodes path params, so keeping it would have produced `/%40alice/post`. Both forms resolve to the same route and the post page already strips a leading `@`, so existing links keep working. The dead-route guard's segment-safety entries for this file went with the templates they described.

**Document title separator.** Em dash replaced with the pipe the main app already uses.

**DMCA filtering was a no-op.** Every SDK post query runs results through `filterDmcaEntry`, but that reads lists which stay empty until `ConfigManager.setDmcaLists` is called, and nothing in this app called it. The lists are now fetched at bootstrap from the same three published files the main app bundles. The fetch starts at module load and is never awaited, and a failed or blocked request leaves that list empty, so an unreachable source cannot stop the blog rendering. Separately, the community feed called `bridge.get_ranked_posts` directly, skipping filtering and tag sanitization regardless of the lists; it now uses `getPostsRankedInfiniteQueryOptions`. That query also keeps pinned posts at the head of the first page, which the bespoke one did not, and sorts non-hot feeds by creation date.

Tests: new unit tests for the tip label, the markdown strip, the edit predicate and the DMCA loader, plus a guard that no module makes its own ranked-posts bridge call. Each was mutation-verified by breaking the fix and confirming the expected failure. The CSS fixes were checked by reading the compiled stylesheet after a build. Full suite 153 passing, typecheck and rsbuild build clean.
