### PR TITLE
fix(hosting-api): tie custom domain capabilities to subscription standing, release unverified claims

### DIFF
--- a/apps/self-hosted/hosting/.env.example
+++ b/apps/self-hosted/hosting/.env.example
@@ -42,6 +42,19 @@ MONTHLY_PRICE_HBD=2.000
 PRO_UPGRADE_PRICE_HBD=5.000
 
 # =============================================================================
+# Subscription and domain lifecycle
+# =============================================================================
+# Days after expiry that a lapsed subscription keeps its custom-domain capabilities
+# (attach, verify, first-party CORS origin). The binding itself is never removed, so a
+# renewal restores everything. Any value that is not a positive integer falls back to 14.
+PRO_GRACE_DAYS=14
+
+# Days an unverified custom-domain claim is held before the hourly sweep releases it, so a
+# domain someone claimed and never pointed at us stops blocking its rightful owner. Verified
+# domains are never touched. Any value that is not a positive integer falls back to 14.
+UNVERIFIED_DOMAIN_CLAIM_DAYS=14
+
+# =============================================================================
 # x402 (Ecency's Hive micropayment rail) — showcases the protocol at checkout.
 # Point at the live facilitator; leave empty to hide the x402 option.
 # =============================================================================

--- a/apps/self-hosted/hosting/api/src/payment-listener-domain-sweep.test.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener-domain-sweep.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The hourly maintenance pass is where the unverified-domain release has to run. A sweep that
+// exists but is never called is exactly the state DomainService.cleanupExpiredVerifications is
+// in: written, tested by nobody, wired to nothing.
+
+const mocks = vi.hoisted(() => ({
+  callRPC: vi.fn(),
+  expireSubscriptions: vi.fn(),
+  reclaimAbandonedTenants: vi.fn(),
+  releaseUnverifiedDomains: vi.fn(),
+}));
+
+vi.mock('@ecency/sdk/hive', () => ({
+  callRPC: mocks.callRPC,
+  config: { nodes: [] },
+  setNodes: vi.fn(),
+}));
+
+vi.mock('./db/client', () => ({
+  db: { query: vi.fn(), queryOne: vi.fn(), queryAll: vi.fn(), transaction: vi.fn() },
+}));
+
+vi.mock('./services/tenant-service', () => ({
+  COMMUNITY_NAME: /^hive-\d+$/,
+  TenantService: {
+    expireSubscriptions: mocks.expireSubscriptions,
+    reclaimAbandonedTenants: mocks.reclaimAbandonedTenants,
+    releaseUnverifiedDomains: mocks.releaseUnverifiedDomains,
+  },
+}));
+
+vi.mock('./services/config-service', () => ({ ConfigService: { publishConfigFile: vi.fn() } }));
+vi.mock('./services/audit-service', () => ({ AuditService: { log: vi.fn() } }));
+
+const { PaymentListener, DEFAULT_UNVERIFIED_DOMAIN_CLAIM_DAYS } = await import('./payment-listener');
+
+function maintenancePass() {
+  const listener = new PaymentListener();
+  return (listener as any).checkExpirations();
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset();
+  mocks.expireSubscriptions.mockResolvedValue(0);
+  mocks.reclaimAbandonedTenants.mockResolvedValue([]);
+  mocks.releaseUnverifiedDomains.mockResolvedValue([]);
+  // Head block far ahead of the listener, so the caught-up gate is closed.
+  mocks.callRPC.mockResolvedValue({ head_block_number: 999_999 });
+});
+
+describe('the maintenance pass releases unverified domain claims', () => {
+  it('runs the release with the configured claim window', async () => {
+    await maintenancePass();
+
+    expect(mocks.releaseUnverifiedDomains).toHaveBeenCalledWith(
+      DEFAULT_UNVERIFIED_DOMAIN_CLAIM_DAYS
+    );
+  });
+
+  it('releases even while block replay is behind head', async () => {
+    // Unlike the abandoned-tenant reclaim, nothing on chain grants a domain, so there is no
+    // pending payment a backlog could be hiding.
+    await maintenancePass();
+
+    expect(mocks.reclaimAbandonedTenants).not.toHaveBeenCalled();
+    expect(mocks.releaseUnverifiedDomains).toHaveBeenCalled();
+  });
+
+  it('expires subscriptions first, so a failure to release cannot skip that', async () => {
+    mocks.releaseUnverifiedDomains.mockRejectedValue(new Error('database unavailable'));
+
+    await expect(maintenancePass()).resolves.toBeUndefined();
+
+    expect(mocks.expireSubscriptions).toHaveBeenCalled();
+  });
+});

--- a/apps/self-hosted/hosting/api/src/payment-listener-domain-sweep.test.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener-domain-sweep.test.ts
@@ -67,6 +67,29 @@ describe('the maintenance pass releases unverified domain claims', () => {
     expect(mocks.releaseUnverifiedDomains).toHaveBeenCalled();
   });
 
+  it('names the domain it freed in the maintenance log', async () => {
+    // The only reason this line exists is being able to tell WHICH domain was freed. Reporting
+    // the post-update row (what UPDATE ... RETURNING hands back) prints null for every release,
+    // which is indistinguishable from a sweep that released nothing.
+    mocks.releaseUnverifiedDomains.mockResolvedValue([
+      { username: 'alice', domain: 'mine.example.test' },
+    ]);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await maintenancePass();
+
+      const lines = log.mock.calls
+        .map((args) => args.join(' '))
+        .filter((line) => line.includes('Released unverified domain claim'));
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('mine.example.test');
+      expect(lines[0]).toContain('alice');
+    } finally {
+      log.mockRestore();
+    }
+  });
+
   it('expires subscriptions first, so a failure to release cannot skip that', async () => {
     mocks.releaseUnverifiedDomains.mockRejectedValue(new Error('database unavailable'));
 

--- a/apps/self-hosted/hosting/api/src/payment-listener.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener.ts
@@ -8,6 +8,7 @@
 import { callRPC, setNodes } from '@ecency/sdk/hive';
 import { db } from './db/client';
 import { COMMUNITY_NAME, TenantService } from './services/tenant-service';
+import { parseGraceDays } from './services/subscription';
 import { ConfigService } from './services/config-service';
 import { parseMemo, mapTenantFromDb, type ParsedMemo } from './types';
 import { AuditService } from './services/audit-service';
@@ -18,10 +19,13 @@ import * as Pricing from './pricing';
 // partial matches like '13.9' or '7foo', silently bypassing the safe fallback with a truncated
 // value. Empty, non-numeric, zero, and negative all fall back to 7. Exported for unit testing.
 export function parseAbandonedGraceDays(raw: string | undefined): number {
-  const trimmed = (raw ?? '').trim();
-  const n = /^\d+$/.test(trimmed) ? parseInt(trimmed, 10) : NaN;
-  return Number.isInteger(n) && n > 0 ? n : 7;
+  return parseGraceDays(raw, 7);
 }
+
+// Days an unverified custom-domain claim is held before the sweep releases it, freeing the
+// domain for its rightful owner. Same fail-safe parse: a zero/negative/NaN value would release
+// every pending claim on the next sweep, including one made minutes ago.
+export const DEFAULT_UNVERIFIED_DOMAIN_CLAIM_DAYS = 14;
 
 // Configuration. Payment amounts come from the shared pricing module so the listener validates
 // against exactly what every quoting route tells the user to pay.
@@ -37,6 +41,10 @@ const CONFIG = {
   // cutoff `NOW() - (n * INTERVAL '1 day')` land at or after now and sweep EVERY inactive tenant,
   // so a misconfigured env falls back to 7 rather than mass-reclaiming.
   ABANDONED_GRACE_DAYS: parseAbandonedGraceDays(process.env.ABANDONED_TENANT_GRACE_DAYS),
+  UNVERIFIED_DOMAIN_CLAIM_DAYS: parseGraceDays(
+    process.env.UNVERIFIED_DOMAIN_CLAIM_DAYS,
+    DEFAULT_UNVERIFIED_DOMAIN_CLAIM_DAYS
+  ),
 };
 
 // Configure hive-tx nodes. setNodes() trims/validates entries and no-ops on an
@@ -640,6 +648,21 @@ export class PaymentListener {
         if (reclaimed.length > 0) {
           console.log('[PaymentListener] Reclaimed', reclaimed.length, 'abandoned inactive tenants');
         }
+      }
+
+      // Release custom-domain claims that were never verified, so a domain someone claimed and
+      // never pointed at us stops blocking its rightful owner. Only unverified claims are
+      // touched, so no serving site is affected, and the operation is idempotent: a released
+      // row no longer matches. It needs no caught-up gate for the same reason the reclaim does
+      // (nothing on chain grants a domain), and it is deliberately AFTER the reclaim so a
+      // failure here cannot skip the expiry sweep.
+      const released = await TenantService.releaseUnverifiedDomains(
+        CONFIG.UNVERIFIED_DOMAIN_CLAIM_DAYS
+      );
+      for (const claim of released) {
+        console.log(
+          `[PaymentListener] Released unverified domain claim ${claim.domain} held by ${claim.username}`
+        );
       }
     } catch (error) {
       // Never let a transient DB error escape an interval/void call as an unhandled rejection.

--- a/apps/self-hosted/hosting/api/src/routes/domain-capability.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/domain-capability.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getByUsername: vi.fn(),
+  isDomainClaimed: vi.fn(),
+  setCustomDomain: vi.fn(),
+  verifyCustomDomain: vi.fn(),
+  removeCustomDomain: vi.fn(),
+  getByDomain: vi.fn(),
+  createVerification: vi.fn(),
+  verifyDomain: vi.fn(),
+  markVerified: vi.fn(),
+}));
+
+class DomainInUseError extends Error {}
+
+vi.mock('../services/tenant-service', () => ({
+  TenantService: {
+    getByUsername: mocks.getByUsername,
+    isDomainClaimed: mocks.isDomainClaimed,
+    setCustomDomain: mocks.setCustomDomain,
+    verifyCustomDomain: mocks.verifyCustomDomain,
+    removeCustomDomain: mocks.removeCustomDomain,
+    getByDomain: mocks.getByDomain,
+  },
+  DomainInUseError,
+}));
+
+vi.mock('../services/domain-service', () => ({
+  DomainService: {
+    createVerification: mocks.createVerification,
+    verifyDomain: mocks.verifyDomain,
+    markVerified: mocks.markVerified,
+  },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('user', { username: 'alice' });
+    await next();
+  },
+}));
+
+vi.mock('../services/audit-service', () => ({
+  AuditService: { log: vi.fn() },
+  parseClientIp: () => null,
+}));
+
+vi.mock('../utils/cors-domains', () => ({ addVerifiedDomainOrigin: vi.fn() }));
+
+const { domainRoutes } = await import('./domains');
+const { PRO_GRACE_DAYS } = await import('../services/subscription');
+
+function daysAgo(days: number): Date {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+function tenant(over: Record<string, unknown> = {}) {
+  return {
+    id: 'tenant-1',
+    username: 'alice',
+    owner: 'alice',
+    subscriptionPlan: 'pro',
+    subscriptionStatus: 'active',
+    subscriptionExpiresAt: new Date(Date.now() + 86_400_000),
+    customDomain: null,
+    customDomainVerified: false,
+    ...over,
+  };
+}
+
+function addDomain() {
+  return domainRoutes.request('http://localhost/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ domain: 'mine.example.test' }),
+  });
+}
+
+function verifyDomain() {
+  return domainRoutes.request('http://localhost/verify', { method: 'POST' });
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset();
+  mocks.isDomainClaimed.mockResolvedValue(false);
+  mocks.createVerification.mockResolvedValue({
+    verificationMethod: 'cname',
+    expiresAt: new Date().toISOString(),
+  });
+  mocks.setCustomDomain.mockImplementation(async () =>
+    tenant({ customDomain: 'mine.example.test', customDomainVerified: false })
+  );
+  mocks.verifyDomain.mockResolvedValue(true);
+  mocks.verifyCustomDomain.mockImplementation(async () =>
+    tenant({ customDomain: 'mine.example.test', customDomainVerified: true })
+  );
+  mocks.markVerified.mockResolvedValue(undefined);
+  mocks.removeCustomDomain.mockResolvedValue(undefined);
+});
+
+/**
+ * Expiry flips the status and leaves subscription_plan on 'pro' forever, so gates that read the
+ * plan alone kept a lapsed customer's custom-domain capabilities: they could attach a new domain
+ * (occupying it against the global UNIQUE constraint) and verify it (making it a first-party CORS
+ * origin). Attach and verify now read standing; delete never does.
+ */
+describe('custom domain capabilities follow subscription standing', () => {
+  it('lets an active Pro tenant attach and verify', async () => {
+    mocks.getByUsername.mockResolvedValue(tenant());
+    expect((await addDomain()).status).toBe(201);
+
+    mocks.getByUsername.mockResolvedValue(tenant({ customDomain: 'mine.example.test' }));
+    expect((await verifyDomain()).status).toBe(200);
+  });
+
+  it('still lets a tenant inside the grace window attach and verify', async () => {
+    // A renewal in progress must not be blocked; this is why the cutoff is a window and not
+    // the expiry instant.
+    mocks.getByUsername.mockResolvedValue(
+      tenant({
+        subscriptionStatus: 'expired',
+        subscriptionExpiresAt: daysAgo(PRO_GRACE_DAYS - 1),
+        customDomain: 'mine.example.test',
+      })
+    );
+
+    expect((await addDomain()).status).toBe(201);
+    expect((await verifyDomain()).status).toBe(200);
+  });
+
+  it('refuses an attach once the grace window has passed', async () => {
+    mocks.getByUsername.mockResolvedValue(
+      tenant({
+        subscriptionStatus: 'expired',
+        subscriptionExpiresAt: daysAgo(PRO_GRACE_DAYS + 1),
+      })
+    );
+
+    const response = await addDomain();
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toMatchObject({ customDomainCapability: 'lapsed' });
+    expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+  });
+
+  it('refuses a verification once the grace window has passed', async () => {
+    // Verification is what puts a domain into the served set and the CORS allowlist, so it is
+    // gated as tightly as the attach.
+    mocks.getByUsername.mockResolvedValue(
+      tenant({
+        subscriptionStatus: 'expired',
+        subscriptionExpiresAt: daysAgo(PRO_GRACE_DAYS + 1),
+        customDomain: 'mine.example.test',
+      })
+    );
+
+    const response = await verifyDomain();
+
+    expect(response.status).toBe(402);
+    expect(mocks.verifyCustomDomain).not.toHaveBeenCalled();
+  });
+
+  it('refuses a suspended tenant outright', async () => {
+    mocks.getByUsername.mockResolvedValue(
+      tenant({ subscriptionStatus: 'suspended', subscriptionExpiresAt: daysAgo(1) })
+    );
+
+    expect((await addDomain()).status).toBe(402);
+    expect((await verifyDomain()).status).toBe(402);
+  });
+
+  it('still refuses a standard-plan tenant with the plan message', async () => {
+    mocks.getByUsername.mockResolvedValue(tenant({ subscriptionPlan: 'standard' }));
+
+    const response = await addDomain();
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toMatchObject({ error: 'Custom domains require Pro plan' });
+  });
+
+  it('lets a lapsed tenant remove its domain', async () => {
+    // Releasing a domain must never be gated: it is how an owner frees a name, and refusing it
+    // would strand the domain exactly when the tenant is least entitled to hold it.
+    mocks.getByUsername.mockResolvedValue(
+      tenant({
+        subscriptionStatus: 'expired',
+        subscriptionExpiresAt: daysAgo(PRO_GRACE_DAYS + 30),
+        customDomain: 'mine.example.test',
+      })
+    );
+
+    const response = await domainRoutes.request('http://localhost/', { method: 'DELETE' });
+
+    expect(response.status).toBe(200);
+    expect(mocks.removeCustomDomain).toHaveBeenCalledWith('alice');
+  });
+});

--- a/apps/self-hosted/hosting/api/src/routes/domain-ownership.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/domain-ownership.test.ts
@@ -55,6 +55,9 @@ const COMMUNITY = {
   username: 'hive-125125',
   owner: 'alice',
   subscriptionPlan: 'pro',
+  // Attach and verify now require a subscription that is paid for, not just the Pro plan.
+  subscriptionStatus: 'active',
+  subscriptionExpiresAt: null as Date | null,
   customDomain: null as string | null,
 };
 

--- a/apps/self-hosted/hosting/api/src/routes/domains.ts
+++ b/apps/self-hosted/hosting/api/src/routes/domains.ts
@@ -9,6 +9,7 @@ import { zValidator } from '@hono/zod-validator';
 import { DomainInUseError, TenantService } from '../services/tenant-service';
 import type { Tenant } from '../types';
 import { DomainService } from '../services/domain-service';
+import { customDomainCapability } from '../services/subscription';
 import { authMiddleware } from '../middleware/auth';
 import { AuditService, parseClientIp } from '../services/audit-service';
 import { addVerifiedDomainOrigin } from '../utils/cors-domains';
@@ -52,6 +53,30 @@ async function resolveOwnedTenant(c: Context): Promise<OwnedTenant> {
   return { tenant, actor: authUser.username, response: null };
 }
 
+/**
+ * Refuse a custom-domain capability the tenant is no longer paying for.
+ *
+ * The plan alone is not enough: expiry never clears subscription_plan, so a lapsed tenant kept
+ * 'pro' and with it the ability to attach and verify domains. A tenant inside the grace window
+ * is still allowed, so a renewal in progress is never blocked. Returns null when allowed.
+ */
+function refuseIfNotEntitled(c: Context, tenant: Tenant): Response | null {
+  const capability = customDomainCapability(tenant);
+  if (capability.allowed) return null;
+
+  if (capability.state === 'none') {
+    return c.json({ error: 'Custom domains require Pro plan' }, 402);
+  }
+  return c.json(
+    {
+      error: 'Custom domains require an active subscription',
+      subscriptionStatus: tenant.subscriptionStatus,
+      customDomainCapability: capability.state,
+    },
+    402
+  );
+}
+
 // Validation schemas
 const addDomainSchema = z.object({
   domain: z.string()
@@ -67,10 +92,9 @@ domainRoutes.post('/', authMiddleware, zValidator('json', addDomainSchema), asyn
   if (!tenant) return response;
   const username = tenant.username;
 
-  // Check if Pro plan
-  if (tenant.subscriptionPlan !== 'pro') {
-    return c.json({ error: 'Custom domains require Pro plan' }, 402);
-  }
+  // Pro plan AND a subscription that is paid for (or inside the grace window after expiry).
+  const refusal = refuseIfNotEntitled(c, tenant);
+  if (refusal) return refusal;
 
   // Occupancy covers unverified reservations too: the column is UNIQUE either
   // way, so an unverified row still blocks everyone else.
@@ -130,6 +154,12 @@ domainRoutes.post('/verify', authMiddleware, async (c) => {
   const { tenant, actor, response } = await resolveOwnedTenant(c);
   if (!tenant) return response;
   const username = tenant.username;
+
+  // Verification had no plan or status gate at all, so a lapsed tenant could still turn an
+  // unverified claim into a verified one, which is what puts the domain into the served set and
+  // the first-party CORS allowlist.
+  const refusal = refuseIfNotEntitled(c, tenant);
+  if (refusal) return refusal;
 
   if (!tenant.customDomain) {
     return c.json({ error: 'No custom domain configured' }, 400);

--- a/apps/self-hosted/hosting/api/src/routes/internal.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.test.ts
@@ -425,6 +425,7 @@ describe('internal endpoint audit trail', () => {
       id: 'tenant-1',
       username: 'alice',
       subscriptionPlan: 'pro',
+      subscriptionStatus: 'active',
     });
 
     const response = await post('/domain', { username: 'alice', domain: 'blog.example.com' });
@@ -443,6 +444,7 @@ describe('internal endpoint audit trail', () => {
       id: 'tenant-1',
       username: 'alice',
       subscriptionPlan: 'pro',
+      subscriptionStatus: 'active',
     });
     mocks.createVerification.mockRejectedValueOnce(new Error('verification insert failed'));
 
@@ -458,6 +460,8 @@ describe('internal endpoint audit trail', () => {
     mocks.getByUsername.mockResolvedValue({
       id: 'tenant-1',
       username: 'alice',
+      subscriptionPlan: 'pro',
+      subscriptionStatus: 'active',
       customDomain: 'blog.example.com',
       customDomainVerified: false,
     });
@@ -487,6 +491,8 @@ describe('internal endpoint audit trail', () => {
     mocks.getByUsername.mockResolvedValueOnce({
       id: 'tenant-1',
       username: 'alice',
+      subscriptionPlan: 'pro',
+      subscriptionStatus: 'active',
       customDomain: 'blog.example.com',
       customDomainVerified: false,
     });

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -15,6 +15,7 @@ import {
   CAUGHT_UP_SQL,
 } from '../services/tenant-service';
 import { DomainService } from '../services/domain-service';
+import { customDomainCapability, type CapabilityState } from '../services/subscription';
 import { ConfigService } from '../services/config-service';
 import { AuditService, parseClientIp } from '../services/audit-service';
 import { mapTenantFromDb, type Tenant } from '../types';
@@ -305,6 +306,18 @@ internalRoutes.post('/activate', async (c) => {
   }
 });
 
+/**
+ * 402 body shared by both internal domain endpoints. 'none' means the plan never included
+ * custom domains; anything else means the subscription is not currently paying for them, which
+ * the caller can turn into a renewal prompt rather than an upgrade one.
+ */
+function capabilityRefusal(state: CapabilityState) {
+  return {
+    error: state === 'none' ? 'custom_domain_requires_pro' : 'subscription_not_active',
+    customDomainCapability: state,
+  };
+}
+
 // POST /v1/internal/domain - attach a custom domain to a tenant (service-to-service).
 // The web proxy has already verified the caller owns `username` (HiveSigner token); the shared
 // secret protects the endpoint. Mirrors the public /v1/domains shape but keyed by body username
@@ -332,9 +345,13 @@ internalRoutes.post('/domain', async (c) => {
   if (!tenant) {
     return c.json({ error: 'tenant_not_found' }, 404);
   }
-  // Custom domains require the Pro plan (internal value stays 'pro'; user-facing = Custom domain).
-  if (tenant.subscriptionPlan !== 'pro') {
-    return c.json({ error: 'custom_domain_requires_pro' }, 402);
+  // Custom domains require the Pro plan (internal value stays 'pro'; user-facing = Custom domain)
+  // AND a subscription that is paid for. Expiry never clears the plan, so the plan check alone
+  // let a lapsed tenant keep attaching domains on this rail too. A tenant inside the grace window
+  // after expiry is still allowed.
+  const capability = customDomainCapability(tenant);
+  if (!capability.allowed) {
+    return c.json(capabilityRefusal(capability.state), 402);
   }
 
   // Refuse a domain another tenant already holds, verified or not: the column is
@@ -405,9 +422,15 @@ internalRoutes.post('/domain/verify', async (c) => {
   if (!tenant.customDomain) {
     return c.json({ verified: false }, 200);
   }
-  // Already verified earlier -> idempotent success.
+  // Already verified earlier -> idempotent success. Answered before the capability check so a
+  // tenant that lapses after verifying still gets a truthful answer about its own domain; the
+  // check below only gates turning an unverified claim INTO a verified one.
   if (tenant.customDomainVerified) {
     return c.json({ verified: true }, 200);
+  }
+  const capability = customDomainCapability(tenant);
+  if (!capability.allowed) {
+    return c.json({ ...capabilityRefusal(capability.state), verified: false }, 402);
   }
 
   // Captured before the DNS round trip so the result is applied to the domain

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -15,6 +15,7 @@ import {
 import { mapTenantFromDb } from '../types';
 import { PAYMENT_ACCOUNT, MONTHLY_PRICE_HBD, PRO_UPGRADE_PRICE_HBD, hbd } from '../pricing';
 import { ConfigService, isPublishableTenant } from '../services/config-service';
+import { customDomainCapability } from '../services/subscription';
 import { authMiddleware } from '../middleware/auth';
 import { subscriptionPaywall, proUpgradePaywall } from '../middleware/x402-paywall';
 import { withPaymentTargetLock } from '../middleware/payment-target-lock';
@@ -621,6 +622,10 @@ tenantRoutes.get('/:username/status', async (c) => {
   const expiresAt = tenant.subscriptionExpiresAt ? new Date(tenant.subscriptionExpiresAt) : null;
   const daysRemaining = expiresAt ? Math.ceil((expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)) : null;
 
+  // Whether custom domains still work, and until when if the subscription has lapsed. Without
+  // this the owner's only signal is an attach or verify call failing.
+  const capability = customDomainCapability(tenant, now);
+
   return c.json({
     exists: true,
     subscriptionStatus: tenant.subscriptionStatus,
@@ -628,6 +633,8 @@ tenantRoutes.get('/:username/status', async (c) => {
     daysRemaining,
     customDomain: tenant.customDomain,
     customDomainVerified: tenant.customDomainVerified,
+    customDomainCapability: capability.state,
+    customDomainGraceEndsAt: capability.graceEndsAt,
     blogUrl: TenantService.getBlogUrl(tenant),
   });
 });

--- a/apps/self-hosted/hosting/api/src/services/release-unverified-domains.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/release-unverified-domains.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ transaction: vi.fn(), queryOne: vi.fn() }));
+
+vi.mock('../db/client', () => ({
+  db: { transaction: mocks.transaction, queryOne: mocks.queryOne, query: vi.fn() },
+}));
+vi.mock('@ecency/sdk/hive', () => ({ callRPC: vi.fn(), config: { set: vi.fn() } }));
+
+const { TenantService } = await import('./tenant-service');
+
+/** Records every statement the sweep runs on its transaction client. */
+function fakeTransaction(releasedRows: any[]) {
+  const calls: { sql: string; params: any[] }[] = [];
+  mocks.transaction.mockImplementation(async (fn: (client: any) => Promise<any>) =>
+    fn({
+      query: async (sql: string, params: any[] = []) => {
+        calls.push({ sql: sql.replace(/\s+/g, ' ').trim(), params });
+        if (/UPDATE tenants/.test(sql)) {
+          return { rows: releasedRows, rowCount: releasedRows.length };
+        }
+        return { rows: [], rowCount: 0 };
+      },
+    })
+  );
+  return calls;
+}
+
+beforeEach(() => {
+  mocks.transaction.mockReset();
+  mocks.queryOne.mockReset();
+});
+
+/**
+ * A tenant could claim a custom domain, never verify it, and hold it forever: custom_domain is
+ * UNIQUE whether or not it is verified, so the rightful owner was blocked with no way out.
+ * Nothing expired the claim, and the 7-day verification record nothing acted on would not have
+ * freed the column anyway.
+ */
+describe('TenantService.releaseUnverifiedDomains', () => {
+  it('only ever targets unverified claims with no recent verification record', async () => {
+    const calls = fakeTransaction([]);
+
+    await TenantService.releaseUnverifiedDomains(14);
+
+    const update = calls[0];
+    expect(update.sql).toContain('UPDATE tenants');
+    expect(update.sql).toContain('custom_domain_verified = false');
+    expect(update.sql).toContain('custom_domain IS NOT NULL');
+    // The claim date comes from the verification record the attach path always writes, so no
+    // schema change is needed and a claim made minutes ago is never swept.
+    expect(update.sql).toContain('NOT EXISTS');
+    expect(update.sql).toContain("dv.created_at > NOW() - ($1 * INTERVAL '1 day')");
+    expect(update.params).toEqual([14]);
+  });
+
+  it('clears the whole claim so the domain is free for its rightful owner', async () => {
+    const calls = fakeTransaction([]);
+
+    await TenantService.releaseUnverifiedDomains(14);
+
+    expect(calls[0].sql).toContain('custom_domain = NULL');
+    expect(calls[0].sql).toContain('custom_domain_verified_at = NULL');
+  });
+
+  it('deletes the stale verification records of the claims it released', async () => {
+    const calls = fakeTransaction([
+      { id: 'tenant-1', username: 'alice', custom_domain: 'mine.example.test' },
+    ]);
+
+    const released = await TenantService.releaseUnverifiedDomains(14);
+
+    expect(released).toEqual([{ username: 'alice', domain: 'mine.example.test' }]);
+    const cleanup = calls[1];
+    expect(cleanup.sql).toContain('DELETE FROM domain_verifications');
+    expect(cleanup.sql).toContain('verified = false');
+    expect(cleanup.params).toEqual([['tenant-1']]);
+  });
+
+  it('runs no cleanup when nothing was released', async () => {
+    const calls = fakeTransaction([]);
+
+    const released = await TenantService.releaseUnverifiedDomains(14);
+
+    expect(released).toEqual([]);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+/**
+ * A verification can be in flight when a claim is released. Nothing coordinates the two, and
+ * nothing needs to: the write is keyed on the domain that was checked, so a released claim
+ * matches no row and the caller is told to verify again rather than being handed a verified
+ * flag for a domain the tenant no longer holds.
+ */
+describe('an in-flight verification cannot resurrect a released claim', () => {
+  it('keys the verification write on both the tenant and the checked domain', async () => {
+    mocks.queryOne.mockResolvedValue(null);
+
+    const result = await TenantService.verifyCustomDomain('alice', 'mine.example.test');
+
+    const [sql, params] = mocks.queryOne.mock.calls[0];
+    expect(sql.replace(/\s+/g, ' ')).toContain('WHERE username = $1 AND custom_domain = $2');
+    expect(params).toEqual(['alice', 'mine.example.test']);
+    // No row matched (the claim was released mid-check), so the caller gets null.
+    expect(result).toBeNull();
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/release-unverified-domains.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/release-unverified-domains.test.ts
@@ -9,15 +9,29 @@ vi.mock('@ecency/sdk/hive', () => ({ callRPC: vi.fn(), config: { set: vi.fn() } 
 
 const { TenantService } = await import('./tenant-service');
 
-/** Records every statement the sweep runs on its transaction client. */
-function fakeTransaction(releasedRows: any[]) {
+/**
+ * Records every statement the sweep runs, and models the one database behaviour that matters
+ * here: once the claim is cleared, the domain is gone from the row. A read taken after the
+ * UPDATE (or a RETURNING clause, which reports the new row) yields a null domain, so a sweep
+ * that reports what it released has to capture it beforehand.
+ */
+function fakeTransaction(candidates: any[]) {
   const calls: { sql: string; params: any[] }[] = [];
+  let cleared = false;
   mocks.transaction.mockImplementation(async (fn: (client: any) => Promise<any>) =>
     fn({
       query: async (sql: string, params: any[] = []) => {
         calls.push({ sql: sql.replace(/\s+/g, ' ').trim(), params });
         if (/UPDATE tenants/.test(sql)) {
-          return { rows: releasedRows, rowCount: releasedRows.length };
+          cleared = true;
+          const rows = candidates.map((row) => ({ ...row, custom_domain: null }));
+          return { rows: /RETURNING/.test(sql) ? rows : [], rowCount: candidates.length };
+        }
+        if (/^SELECT/.test(sql.trim())) {
+          const rows = cleared
+            ? candidates.map((row) => ({ ...row, custom_domain: null }))
+            : candidates;
+          return { rows, rowCount: rows.length };
         }
         return { rows: [], rowCount: 0 };
       },
@@ -25,6 +39,8 @@ function fakeTransaction(releasedRows: any[]) {
   );
   return calls;
 }
+
+const CLAIM = { id: 'tenant-1', username: 'alice', custom_domain: 'mine.example.test' };
 
 beforeEach(() => {
   mocks.transaction.mockReset();
@@ -38,46 +54,64 @@ beforeEach(() => {
  * freed the column anyway.
  */
 describe('TenantService.releaseUnverifiedDomains', () => {
-  it('only ever targets unverified claims with no recent verification record', async () => {
+  it('only ever selects unverified claims with no recent verification record', async () => {
     const calls = fakeTransaction([]);
 
     await TenantService.releaseUnverifiedDomains(14);
 
-    const update = calls[0];
-    expect(update.sql).toContain('UPDATE tenants');
-    expect(update.sql).toContain('custom_domain_verified = false');
-    expect(update.sql).toContain('custom_domain IS NOT NULL');
+    const select = calls[0];
+    expect(select.sql).toContain('custom_domain_verified = false');
+    expect(select.sql).toContain('custom_domain IS NOT NULL');
     // The claim date comes from the verification record the attach path always writes, so no
     // schema change is needed and a claim made minutes ago is never swept.
-    expect(update.sql).toContain('NOT EXISTS');
-    expect(update.sql).toContain("dv.created_at > NOW() - ($1 * INTERVAL '1 day')");
-    expect(update.params).toEqual([14]);
+    expect(select.sql).toContain('NOT EXISTS');
+    expect(select.sql).toContain("dv.created_at > NOW() - ($1 * INTERVAL '1 day')");
+    expect(select.params).toEqual([14]);
+  });
+
+  it('locks the candidates it is about to clear', async () => {
+    // Without the lock a verification committing between the read and the write would have its
+    // result thrown away, unbinding a domain that had just been proven.
+    const calls = fakeTransaction([]);
+
+    await TenantService.releaseUnverifiedDomains(14);
+
+    expect(calls[0].sql).toContain('FOR UPDATE');
   });
 
   it('clears the whole claim so the domain is free for its rightful owner', async () => {
-    const calls = fakeTransaction([]);
+    const calls = fakeTransaction([CLAIM]);
 
     await TenantService.releaseUnverifiedDomains(14);
 
-    expect(calls[0].sql).toContain('custom_domain = NULL');
-    expect(calls[0].sql).toContain('custom_domain_verified_at = NULL');
+    const update = calls[1];
+    expect(update.sql).toContain('UPDATE tenants');
+    expect(update.sql).toContain('custom_domain = NULL');
+    expect(update.sql).toContain('custom_domain_verified_at = NULL');
+    expect(update.params).toEqual([['tenant-1']]);
   });
 
-  it('deletes the stale verification records of the claims it released', async () => {
-    const calls = fakeTransaction([
-      { id: 'tenant-1', username: 'alice', custom_domain: 'mine.example.test' },
-    ]);
+  it('reports the domain it released, read before the row was cleared', async () => {
+    // RETURNING would report the NEW row, whose custom_domain is NULL by construction.
+    fakeTransaction([CLAIM]);
 
     const released = await TenantService.releaseUnverifiedDomains(14);
 
     expect(released).toEqual([{ username: 'alice', domain: 'mine.example.test' }]);
-    const cleanup = calls[1];
+  });
+
+  it('deletes the stale verification records of the claims it released', async () => {
+    const calls = fakeTransaction([CLAIM]);
+
+    await TenantService.releaseUnverifiedDomains(14);
+
+    const cleanup = calls[2];
     expect(cleanup.sql).toContain('DELETE FROM domain_verifications');
     expect(cleanup.sql).toContain('verified = false');
     expect(cleanup.params).toEqual([['tenant-1']]);
   });
 
-  it('runs no cleanup when nothing was released', async () => {
+  it('writes nothing when there is nothing to release', async () => {
     const calls = fakeTransaction([]);
 
     const released = await TenantService.releaseUnverifiedDomains(14);
@@ -88,10 +122,10 @@ describe('TenantService.releaseUnverifiedDomains', () => {
 });
 
 /**
- * A verification can be in flight when a claim is released. Nothing coordinates the two, and
- * nothing needs to: the write is keyed on the domain that was checked, so a released claim
- * matches no row and the caller is told to verify again rather than being handed a verified
- * flag for a domain the tenant no longer holds.
+ * A verification can be in flight when a claim is released. Nothing coordinates the two beyond
+ * the row lock, and nothing needs to: the write is keyed on the domain that was checked, so a
+ * released claim matches no row and the caller is told to verify again rather than being handed
+ * a verified flag for a domain the tenant no longer holds.
  */
 describe('an in-flight verification cannot resurrect a released claim', () => {
   it('keys the verification write on both the tenant and the checked domain', async () => {

--- a/apps/self-hosted/hosting/api/src/services/release-unverified-domains.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/release-unverified-domains.test.ts
@@ -7,17 +7,33 @@ vi.mock('../db/client', () => ({
 }));
 vi.mock('@ecency/sdk/hive', () => ({ callRPC: vi.fn(), config: { set: vi.fn() } }));
 
-const { TenantService } = await import('./tenant-service');
+const { TenantService, DOMAIN_CLAIM_SETTLE_MINUTES } = await import('./tenant-service');
 
 /**
- * Records every statement the sweep runs, and models the one database behaviour that matters
- * here: once the claim is cleared, the domain is gone from the row. A read taken after the
- * UPDATE (or a RETURNING clause, which reports the new row) yields a null domain, so a sweep
- * that reports what it released has to capture it beforehand.
+ * Records every statement the sweep runs, and models the two database behaviours that matter here.
+ *
+ * Once the claim is cleared, the domain is gone from the row: a read taken after the UPDATE (or a
+ * RETURNING clause, which reports the new row) yields a null domain, so a sweep that reports what
+ * it released has to capture it beforehand.
+ *
+ * The settle window is evaluated rather than merely recorded. A candidate whose updated_at falls
+ * inside the window the SELECT asks for is withheld, the way Postgres would withhold it, so a
+ * sweep that drops that predicate is handed the row and releases it.
  */
 function fakeTransaction(candidates: any[]) {
   const calls: { sql: string; params: any[] }[] = [];
   let cleared = false;
+
+  const isSettling = (sql: string, params: any[], row: any) => {
+    if (!row.updated_at) return false;
+    const window = /updated_at < NOW\(\) - \(\$(\d+) \* INTERVAL '1 minute'\)/.exec(
+      sql.replace(/\s+/g, ' ')
+    );
+    if (!window) return false;
+    const minutes = params[Number(window[1]) - 1];
+    return row.updated_at.getTime() > Date.now() - minutes * 60_000;
+  };
+
   mocks.transaction.mockImplementation(async (fn: (client: any) => Promise<any>) =>
     fn({
       query: async (sql: string, params: any[] = []) => {
@@ -28,9 +44,10 @@ function fakeTransaction(candidates: any[]) {
           return { rows: /RETURNING/.test(sql) ? rows : [], rowCount: candidates.length };
         }
         if (/^SELECT/.test(sql.trim())) {
+          const matched = candidates.filter((row) => !isSettling(sql, params, row));
           const rows = cleared
-            ? candidates.map((row) => ({ ...row, custom_domain: null }))
-            : candidates;
+            ? matched.map((row) => ({ ...row, custom_domain: null }))
+            : matched;
           return { rows, rowCount: rows.length };
         }
         return { rows: [], rowCount: 0 };
@@ -41,6 +58,9 @@ function fakeTransaction(candidates: any[]) {
 }
 
 const CLAIM = { id: 'tenant-1', username: 'alice', custom_domain: 'mine.example.test' };
+// A claim in the middle of being attached: setCustomDomain has committed (which is what stamps
+// updated_at), the verification record that would date it is not in yet.
+const ATTACHING = { ...CLAIM, updated_at: new Date() };
 
 beforeEach(() => {
   mocks.transaction.mockReset();
@@ -66,7 +86,7 @@ describe('TenantService.releaseUnverifiedDomains', () => {
     // schema change is needed and a claim made minutes ago is never swept.
     expect(select.sql).toContain('NOT EXISTS');
     expect(select.sql).toContain("dv.created_at > NOW() - ($1 * INTERVAL '1 day')");
-    expect(select.params).toEqual([14]);
+    expect(select.params).toEqual([14, DOMAIN_CLAIM_SETTLE_MINUTES]);
   });
 
   it('locks the candidates it is about to clear', async () => {
@@ -109,6 +129,39 @@ describe('TenantService.releaseUnverifiedDomains', () => {
     expect(cleanup.sql).toContain('DELETE FROM domain_verifications');
     expect(cleanup.sql).toContain('verified = false');
     expect(cleanup.params).toEqual([['tenant-1']]);
+  });
+
+  /**
+   * The attach path commits the claim and writes the verification record that dates it as two
+   * separate statements, and a re-attach deletes the old record before inserting the new one. A
+   * sweep landing in either gap finds no record for the claim, so without the settle window it
+   * would clear a claim made seconds ago whatever claimDays says: the request would then write
+   * its verification record and answer 201 for a domain the tenant no longer held.
+   */
+  it('leaves a claim alone while its tenant row is still settling', async () => {
+    const calls = fakeTransaction([ATTACHING]);
+
+    const released = await TenantService.releaseUnverifiedDomains(14);
+
+    expect(released).toEqual([]);
+    // Nothing beyond the candidate read: no claim was cleared.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sql).toContain("updated_at < NOW() - ($2 * INTERVAL '1 minute')");
+  });
+
+  it('still releases a claim once its row has settled', async () => {
+    // Same row, last touched well outside the window: the settle guard delays a release, it does
+    // not cancel it.
+    const settled = {
+      ...ATTACHING,
+      updated_at: new Date(Date.now() - (DOMAIN_CLAIM_SETTLE_MINUTES + 1) * 60_000),
+    };
+    const calls = fakeTransaction([settled]);
+
+    const released = await TenantService.releaseUnverifiedDomains(14);
+
+    expect(released).toEqual([{ username: 'alice', domain: 'mine.example.test' }]);
+    expect(calls[1].sql).toContain('UPDATE tenants');
   });
 
   it('writes nothing when there is nothing to release', async () => {

--- a/apps/self-hosted/hosting/api/src/services/subscription.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/subscription.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  customDomainCapability,
+  parseGraceDays,
+  DEFAULT_PRO_GRACE_DAYS,
+} from './subscription';
+
+const NOW = new Date('2026-08-01T00:00:00Z');
+const GRACE = 14;
+
+function tenant(over: Partial<Parameters<typeof customDomainCapability>[0]> = {}) {
+  return {
+    subscriptionPlan: 'pro' as const,
+    subscriptionStatus: 'active' as const,
+    subscriptionExpiresAt: new Date('2026-09-01T00:00:00Z'),
+    ...over,
+  };
+}
+
+function daysBefore(days: number): Date {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+/**
+ * expireSubscriptions flips the status and never touches the plan, so a lapsed tenant kept
+ * plan = 'pro' forever and every capability gate that read the plan alone kept saying yes.
+ * Status is the source of truth; the plan is deliberately left alone because the origin's
+ * certificate sync selects on plan = 'pro' and downgrading would pull a late customer's cert.
+ */
+describe('customDomainCapability', () => {
+  it('allows an active Pro tenant', () => {
+    const capability = customDomainCapability(tenant(), NOW, GRACE);
+    expect(capability).toMatchObject({ state: 'active', allowed: true });
+  });
+
+  it('refuses a tenant that is not on the Pro plan', () => {
+    const capability = customDomainCapability(
+      tenant({ subscriptionPlan: 'standard' }),
+      NOW,
+      GRACE
+    );
+    expect(capability).toMatchObject({ state: 'none', allowed: false });
+  });
+
+  it('keeps capabilities through the grace window after expiry', () => {
+    // A customer who is a few days late is still renewing; refusing here would block the
+    // re-verification that a renewal can need.
+    const capability = customDomainCapability(
+      tenant({ subscriptionStatus: 'expired', subscriptionExpiresAt: daysBefore(GRACE - 1) }),
+      NOW,
+      GRACE
+    );
+    expect(capability).toMatchObject({ state: 'grace', allowed: true });
+    expect(capability.graceEndsAt).toBeInstanceOf(Date);
+  });
+
+  it('refuses once the grace window has passed', () => {
+    const capability = customDomainCapability(
+      tenant({ subscriptionStatus: 'expired', subscriptionExpiresAt: daysBefore(GRACE + 1) }),
+      NOW,
+      GRACE
+    );
+    expect(capability).toMatchObject({ state: 'lapsed', allowed: false });
+  });
+
+  it('gives no grace to a suspended tenant', () => {
+    // Suspension is an operator decision, not a late payment.
+    const capability = customDomainCapability(
+      tenant({ subscriptionStatus: 'suspended', subscriptionExpiresAt: daysBefore(1) }),
+      NOW,
+      GRACE
+    );
+    expect(capability).toMatchObject({ state: 'lapsed', allowed: false });
+  });
+
+  it('gives no capability to a tenant that was never activated', () => {
+    for (const status of ['inactive', 'abandoned'] as const) {
+      expect(
+        customDomainCapability(tenant({ subscriptionStatus: status }), NOW, GRACE)
+      ).toMatchObject({ state: 'lapsed', allowed: false });
+    }
+  });
+
+  it('fails closed when an expired tenant has no expiry date to measure from', () => {
+    const capability = customDomainCapability(
+      tenant({ subscriptionStatus: 'expired', subscriptionExpiresAt: null }),
+      NOW,
+      GRACE
+    );
+    expect(capability).toMatchObject({ state: 'lapsed', allowed: false });
+  });
+});
+
+describe('parseGraceDays', () => {
+  it('accepts a positive integer', () => {
+    expect(parseGraceDays('21', DEFAULT_PRO_GRACE_DAYS)).toBe(21);
+    expect(parseGraceDays('  7  ', DEFAULT_PRO_GRACE_DAYS)).toBe(7);
+  });
+
+  it('falls back for anything that is not a positive integer', () => {
+    // A zero or negative window would refuse (or release) the moment a subscription lapsed.
+    for (const raw of ['0', '-1', 'abc', '', '13.9', '7foo', '1e3', undefined]) {
+      expect(parseGraceDays(raw, DEFAULT_PRO_GRACE_DAYS)).toBe(DEFAULT_PRO_GRACE_DAYS);
+    }
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/subscription.ts
+++ b/apps/self-hosted/hosting/api/src/services/subscription.ts
@@ -1,0 +1,104 @@
+/**
+ * Subscription standing, and what a tenant is still entitled to once it lapses.
+ *
+ * `expireSubscriptions` flips subscription_status to 'expired' and deliberately does NOT touch
+ * subscription_plan, so a tenant that stopped paying kept plan = 'pro' forever. Every custom
+ * domain gate read the plan alone, which meant a lapsed customer could still attach a new domain
+ * and still verify it, occupying that domain against the global UNIQUE constraint and adding it
+ * to the first-party CORS allowlist.
+ *
+ * Status is the single source of truth for capability; the plan says what was bought, not
+ * whether it is currently paid for. The plan is deliberately left alone on expiry:
+ * hosting/origin/sync-custom-domains.py selects on `subscription_plan = 'pro'` to decide which
+ * hosts get a vhost and a certificate, so downgrading the plan would pull the certificate of a
+ * customer who is a few days late and take their site offline. That is worse than the bug.
+ *
+ * Between expiry and the end of the grace window the tenant keeps everything, so a renewal (or a
+ * re-verification during one) is never blocked by being briefly late. After it, capabilities are
+ * refused but nothing is unbound: the binding survives, and paying brings it straight back.
+ */
+
+import type { Tenant } from '../types';
+
+/** Fail safe to the default for any value that is not a positive integer. */
+export function parseGraceDays(raw: string | undefined, fallback: number): number {
+  const trimmed = (raw ?? '').trim();
+  const n = /^\d+$/.test(trimmed) ? parseInt(trimmed, 10) : NaN;
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+}
+
+export const DEFAULT_PRO_GRACE_DAYS = 14;
+
+/**
+ * Days after subscription_expires_at during which a lapsed tenant keeps its Pro capabilities.
+ * Long enough to cover a renewal that is being sorted out, short enough that a domain is not
+ * held indefinitely by an account that stopped paying.
+ */
+export const PRO_GRACE_DAYS = parseGraceDays(process.env.PRO_GRACE_DAYS, DEFAULT_PRO_GRACE_DAYS);
+
+export type CapabilityState =
+  /** Paid and current. */
+  | 'active'
+  /** Lapsed, still inside the grace window: everything keeps working. */
+  | 'grace'
+  /** Lapsed past the grace window (or suspended, or never activated): capabilities refused. */
+  | 'lapsed'
+  /** The plan does not include custom domains at all. */
+  | 'none';
+
+export interface CustomDomainCapability {
+  state: CapabilityState;
+  /** Whether a custom domain may be attached or verified right now. */
+  allowed: boolean;
+  /** End of the grace window, when the tenant is inside one. */
+  graceEndsAt: Date | null;
+}
+
+type StandingFields = Pick<
+  Tenant,
+  'subscriptionPlan' | 'subscriptionStatus' | 'subscriptionExpiresAt'
+>;
+
+/**
+ * Whether a tenant may attach or verify a custom domain, and why not when it may not.
+ *
+ * Fails closed: a status this does not recognise, or an 'expired' row with no expiry date to
+ * measure a grace window from, is treated as lapsed rather than allowed.
+ */
+export function customDomainCapability(
+  tenant: StandingFields,
+  now: Date = new Date(),
+  graceDays: number = PRO_GRACE_DAYS
+): CustomDomainCapability {
+  if (tenant.subscriptionPlan !== 'pro') {
+    return { state: 'none', allowed: false, graceEndsAt: null };
+  }
+  if (tenant.subscriptionStatus === 'active') {
+    return { state: 'active', allowed: true, graceEndsAt: null };
+  }
+  // Only an expiry lapse gets grace. 'suspended' is an operator decision, and
+  // 'inactive'/'abandoned' were never paid for, so none of them earn one.
+  if (tenant.subscriptionStatus === 'expired' && tenant.subscriptionExpiresAt) {
+    const graceEndsAt = new Date(
+      new Date(tenant.subscriptionExpiresAt).getTime() + graceDays * 24 * 60 * 60 * 1000
+    );
+    if (now <= graceEndsAt) {
+      return { state: 'grace', allowed: true, graceEndsAt };
+    }
+    return { state: 'lapsed', allowed: false, graceEndsAt };
+  }
+  return { state: 'lapsed', allowed: false, graceEndsAt: null };
+}
+
+/**
+ * SQL predicate for the same rule, for queries that select tenants in good standing. $1 is the
+ * grace window in days. Kept next to the function above so the two cannot drift apart.
+ */
+export const IN_GOOD_STANDING_SQL = `(
+  subscription_status = 'active'
+  OR (
+    subscription_status = 'expired'
+    AND subscription_expires_at IS NOT NULL
+    AND subscription_expires_at > NOW() - ($1 * INTERVAL '1 day')
+  )
+)`;

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -513,6 +513,64 @@ export const TenantService = {
   },
   
   /**
+   * Release custom-domain claims that were never verified.
+   *
+   * custom_domain is UNIQUE whether or not it is verified, so a tenant could claim a domain,
+   * never point DNS at it, and hold it against its rightful owner forever: nothing expired the
+   * claim. The verification RECORD had a 7-day expiry, but nothing acted on it and clearing it
+   * would not have freed the column anyway.
+   *
+   * A claim is released when no verification record for that exact domain has been created
+   * within `claimDays`. The record is what the attach path always writes, so it dates the claim
+   * without needing a new column (this service must keep running against the old schema while a
+   * deploy rolls out). Re-submitting the same domain writes a fresh record and restarts the
+   * clock, which is deliberate: an owner who is still working on DNS keeps their claim.
+   *
+   * Only unverified claims are touched, so a verified domain is never unbound and no serving
+   * site is affected. Idempotent: a released row has custom_domain NULL and cannot match again.
+   *
+   * A verification running at the moment of release is safe without any coordination:
+   * verifyCustomDomain keys its UPDATE on username AND domain, so once this clears the column it
+   * matches no row, returns null, and both rails already answer "verify again" for that.
+   */
+  async releaseUnverifiedDomains(claimDays: number): Promise<{ username: string; domain: string }[]> {
+    return db.transaction(async (client) => {
+      const released = await client.query<{ id: string; username: string; custom_domain: string }>(
+        `UPDATE tenants
+            SET custom_domain = NULL,
+                custom_domain_verified = false,
+                custom_domain_verified_at = NULL,
+                updated_at = NOW()
+          WHERE custom_domain IS NOT NULL
+            AND custom_domain_verified = false
+            AND NOT EXISTS (
+                  SELECT 1 FROM domain_verifications dv
+                   WHERE dv.tenant_id = tenants.id
+                     AND dv.domain = tenants.custom_domain
+                     AND dv.created_at > NOW() - ($1 * INTERVAL '1 day')
+                )
+          RETURNING id, username, custom_domain`,
+        [claimDays]
+      );
+
+      if (released.rowCount) {
+        // Drop the stale records with the claim they belonged to, in the same transaction, so
+        // the two can never disagree about whether a claim exists.
+        await client.query(
+          `DELETE FROM domain_verifications
+            WHERE tenant_id = ANY($1::uuid[]) AND verified = false`,
+          [released.rows.map((row) => row.id)]
+        );
+      }
+
+      return released.rows.map((row) => ({
+        username: row.username,
+        domain: row.custom_domain,
+      }));
+    });
+  },
+
+  /**
    * Delete tenant
    */
   async delete(username: string): Promise<void> {

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -46,6 +46,11 @@ const CONTROLLING_COMMUNITY_ROLES = new Set(['owner', 'admin']);
 // The time-based quarantine then only has to cover the residual seconds of healthy live tailing.
 export const ABANDONED_REREGISTER_QUARANTINE_HOURS = 1;
 
+// Settle window the unverified-domain sweep leaves around a freshly touched tenant row. The attach
+// path writes the claim and the verification record that dates it as two separate statements, so
+// for a moment a live claim has no record backing it; see releaseUnverifiedDomains.
+export const DOMAIN_CLAIM_SETTLE_MINUTES = 60;
+
 // Whether an existing row is an abandoned reservation that has cleared the re-registration
 // quarantine (so a fresh signup may reclaim its username). A live row, or one reclaimed within
 // the quarantine, is NOT reusable. The SQL upsert applies the same guard atomically; this is the
@@ -536,6 +541,18 @@ export const TenantService = {
    * verification's own UPDATE is keyed on username AND domain, matches no row, returns null, and
    * both rails already answer "verify again" for that.
    *
+   * A claim whose tenant row was touched within DOMAIN_CLAIM_SETTLE_MINUTES is also left alone.
+   * Dating the claim by its verification record only works once that record exists, and the attach
+   * path writes the two separately: setCustomDomain commits the claim, then createVerification
+   * deletes any previous record and inserts the new one. In both gaps no record matches the claim,
+   * so a sweep landing there would clear a claim made seconds ago no matter how large claimDays is,
+   * and the request would carry on to write its record and report success for a domain the tenant
+   * no longer held. Every write to a tenant row bumps updated_at (a trigger does it, so this does
+   * not depend on any statement remembering to), which puts a claim in mid-attach inside the
+   * window. An unrelated tenant write postpones a release by up to that window, which is the
+   * harmless direction: a squatted domain is freed an hour later rather than a domain being taken
+   * from someone who has just asked for it.
+   *
    * The claim is read before it is cleared rather than from RETURNING, which reports the NEW row
    * and would hand back a null domain for every release.
    */
@@ -546,6 +563,7 @@ export const TenantService = {
            FROM tenants
           WHERE custom_domain IS NOT NULL
             AND custom_domain_verified = false
+            AND updated_at < NOW() - ($2 * INTERVAL '1 minute')
             AND NOT EXISTS (
                   SELECT 1 FROM domain_verifications dv
                    WHERE dv.tenant_id = tenants.id
@@ -553,7 +571,7 @@ export const TenantService = {
                      AND dv.created_at > NOW() - ($1 * INTERVAL '1 day')
                 )
           FOR UPDATE`,
-        [claimDays]
+        [claimDays, DOMAIN_CLAIM_SETTLE_MINUTES]
       );
 
       if (candidates.rows.length === 0) return [];

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -529,18 +529,21 @@ export const TenantService = {
    * Only unverified claims are touched, so a verified domain is never unbound and no serving
    * site is affected. Idempotent: a released row has custom_domain NULL and cannot match again.
    *
-   * A verification running at the moment of release is safe without any coordination:
-   * verifyCustomDomain keys its UPDATE on username AND domain, so once this clears the column it
-   * matches no row, returns null, and both rails already answer "verify again" for that.
+   * Candidates are selected FOR UPDATE and cleared in the same transaction, which is what makes
+   * a verification racing the sweep safe in both directions. If the verification commits first,
+   * the locked re-read sees custom_domain_verified = true and the row is no longer a candidate,
+   * so a domain that was just proven is never unbound. If the sweep commits first, the
+   * verification's own UPDATE is keyed on username AND domain, matches no row, returns null, and
+   * both rails already answer "verify again" for that.
+   *
+   * The claim is read before it is cleared rather than from RETURNING, which reports the NEW row
+   * and would hand back a null domain for every release.
    */
   async releaseUnverifiedDomains(claimDays: number): Promise<{ username: string; domain: string }[]> {
     return db.transaction(async (client) => {
-      const released = await client.query<{ id: string; username: string; custom_domain: string }>(
-        `UPDATE tenants
-            SET custom_domain = NULL,
-                custom_domain_verified = false,
-                custom_domain_verified_at = NULL,
-                updated_at = NOW()
+      const candidates = await client.query<{ id: string; username: string; custom_domain: string }>(
+        `SELECT id, username, custom_domain
+           FROM tenants
           WHERE custom_domain IS NOT NULL
             AND custom_domain_verified = false
             AND NOT EXISTS (
@@ -549,21 +552,32 @@ export const TenantService = {
                      AND dv.domain = tenants.custom_domain
                      AND dv.created_at > NOW() - ($1 * INTERVAL '1 day')
                 )
-          RETURNING id, username, custom_domain`,
+          FOR UPDATE`,
         [claimDays]
       );
 
-      if (released.rowCount) {
-        // Drop the stale records with the claim they belonged to, in the same transaction, so
-        // the two can never disagree about whether a claim exists.
-        await client.query(
-          `DELETE FROM domain_verifications
-            WHERE tenant_id = ANY($1::uuid[]) AND verified = false`,
-          [released.rows.map((row) => row.id)]
-        );
-      }
+      if (candidates.rows.length === 0) return [];
+      const ids = candidates.rows.map((row) => row.id);
 
-      return released.rows.map((row) => ({
+      await client.query(
+        `UPDATE tenants
+            SET custom_domain = NULL,
+                custom_domain_verified = false,
+                custom_domain_verified_at = NULL,
+                updated_at = NOW()
+          WHERE id = ANY($1::uuid[])`,
+        [ids]
+      );
+
+      // Drop the stale records with the claim they belonged to, in the same transaction, so the
+      // two can never disagree about whether a claim exists. Verified records are left alone.
+      await client.query(
+        `DELETE FROM domain_verifications
+          WHERE tenant_id = ANY($1::uuid[]) AND verified = false`,
+        [ids]
+      );
+
+      return candidates.rows.map((row) => ({
         username: row.username,
         domain: row.custom_domain,
       }));

--- a/apps/self-hosted/hosting/api/src/utils/cors-domains.test.ts
+++ b/apps/self-hosted/hosting/api/src/utils/cors-domains.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ queryAll: vi.fn() }));
+
+vi.mock('../db/client', () => ({ db: { queryAll: mocks.queryAll } }));
+
+const { refreshVerifiedDomainOrigins, isVerifiedDomainOrigin, addVerifiedDomainOrigin } =
+  await import('./cors-domains');
+const { PRO_GRACE_DAYS } = await import('../services/subscription');
+
+beforeEach(() => {
+  mocks.queryAll.mockReset().mockResolvedValue([]);
+});
+
+/**
+ * A verified custom domain is a first-party origin: the SPA on it saves configuration and
+ * exchanges auth against this API. The query had no standing filter, so a tenant that stopped
+ * paying kept that privilege indefinitely.
+ */
+describe('verified custom-domain CORS origins', () => {
+  it('selects only Pro tenants in good standing, including the grace window', async () => {
+    await refreshVerifiedDomainOrigins();
+
+    const [sql, params] = mocks.queryAll.mock.calls[0];
+    const normalised = sql.replace(/\s+/g, ' ');
+    expect(normalised).toContain('custom_domain_verified = true');
+    expect(normalised).toContain("subscription_plan = 'pro'");
+    expect(normalised).toContain("subscription_status = 'active'");
+    expect(normalised).toContain("subscription_status = 'expired'");
+    expect(normalised).toContain("subscription_expires_at > NOW() - ($1 * INTERVAL '1 day')");
+    expect(params).toEqual([PRO_GRACE_DAYS]);
+  });
+
+  it('loads the origins the query returns', async () => {
+    mocks.queryAll.mockResolvedValue([{ custom_domain: 'Mine.Example.Test' }]);
+
+    await refreshVerifiedDomainOrigins();
+
+    expect(isVerifiedDomainOrigin('https://mine.example.test')).toBe(true);
+  });
+
+  it('keeps the previous set when the database is unavailable', async () => {
+    // A transient failure must not deny origins that are perfectly valid.
+    addVerifiedDomainOrigin('kept.example.test');
+    mocks.queryAll.mockRejectedValue(new Error('connection refused'));
+
+    await refreshVerifiedDomainOrigins();
+
+    expect(isVerifiedDomainOrigin('https://kept.example.test')).toBe(true);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/utils/cors-domains.ts
+++ b/apps/self-hosted/hosting/api/src/utils/cors-domains.ts
@@ -8,6 +8,7 @@
  */
 
 import { db } from '../db/client';
+import { IN_GOOD_STANDING_SQL, PRO_GRACE_DAYS } from '../services/subscription';
 
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -16,9 +17,15 @@ let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
 export async function refreshVerifiedDomainOrigins(): Promise<void> {
   try {
+    // Standing is part of the question: a first-party origin can save configuration and exchange
+    // auth, so a tenant that stopped paying should not keep one. The grace window is included,
+    // so a briefly-late customer's site keeps working through a renewal.
     const rows = await db.queryAll<{ custom_domain: string }>(
       `SELECT custom_domain FROM tenants
-       WHERE custom_domain IS NOT NULL AND custom_domain_verified = true`
+       WHERE custom_domain IS NOT NULL AND custom_domain_verified = true
+         AND subscription_plan = 'pro'
+         AND ${IN_GOOD_STANDING_SQL}`,
+      [PRO_GRACE_DAYS]
     );
     verifiedOrigins = new Set(
       rows

--- a/apps/self-hosted/hosting/docker-compose.yml
+++ b/apps/self-hosted/hosting/docker-compose.yml
@@ -52,6 +52,9 @@ services:
       - HOSTING_INTERNAL_SECRET=${HOSTING_INTERNAL_SECRET:-}
       - HOSTING_CARD_ENABLED=${HOSTING_CARD_ENABLED:-true}
       - HOSTING_CARD_USD_CENTS=${HOSTING_CARD_USD_CENTS:-200}
+      # Days a lapsed subscription keeps its custom-domain capabilities after expiry.
+      # Must match the listener below: both decide the same thing.
+      - PRO_GRACE_DAYS=${PRO_GRACE_DAYS:-14}
     volumes:
       - "tenant-configs:/app/configs"
     networks:
@@ -79,6 +82,9 @@ services:
       - PAYMENT_ACCOUNT=${PAYMENT_ACCOUNT:-ecency.hosting}
       - MONTHLY_PRICE_HBD=${MONTHLY_PRICE_HBD:-2.000}
       - PRO_UPGRADE_PRICE_HBD=${PRO_UPGRADE_PRICE_HBD:-5.000}
+      # Maintenance sweeps run here (expiry, abandoned reservations, unverified domain claims).
+      - PRO_GRACE_DAYS=${PRO_GRACE_DAYS:-14}
+      - UNVERIFIED_DOMAIN_CLAIM_DAYS=${UNVERIFIED_DOMAIN_CLAIM_DAYS:-14}
     volumes:
       # Activating a subscription writes the tenant's served config. Without
       # this mount that write lands in the container's own layer and never


### PR DESCRIPTION
Subscription and domain lifecycle on the managed blog hosting API. Closes #1312, closes #1311.

Independent of #1321 (request validation and error surface); the two touch different code paths.

## 1. A lapsed subscription kept its Pro custom-domain capabilities (#1312)

Confirmed in the code before changing anything:

- `expireSubscriptions` sets `subscription_status = 'expired'` and never touches `subscription_plan`, so a tenant that stopped paying keeps `plan = 'pro'` indefinitely.
- `POST /v1/domains` gated only on `subscriptionPlan !== 'pro'`.
- `POST /v1/domains/verify` had no plan or status gate at all.
- `POST /v1/internal/domain` matched the public route; `/v1/internal/domain/verify` had no gate.
- `refreshVerifiedDomainOrigins` selected every verified domain regardless of standing.

So a lapsed customer could attach a new domain, which occupies it against the global UNIQUE constraint and blocks its rightful owner, verify it, and keep it as a first-party CORS origin.

### What changed

Capability is now derived from standing, not from the plan (`services/subscription.ts`):

| plan | status | capability |
| --- | --- | --- |
| not pro | any | refused, "requires Pro plan" |
| pro | active | allowed |
| pro | expired, within `PRO_GRACE_DAYS` (default 14) | allowed |
| pro | expired, past the window | refused |
| pro | suspended / inactive / abandoned | refused |

Applied to attach and verify on both rails. `DELETE /v1/domains` is deliberately left ungated: releasing a domain must never be blocked. The verified-domain CORS query gained the same predicate, sharing one SQL fragment with the function so the two cannot drift.

### Why a grace window, and why the plan is not downgraded

The issue offers downgrading `subscription_plan` on expiry as one option. It would be the wrong one here: `hosting/origin/sync-custom-domains.py` selects on `subscription_plan = 'pro'` to decide which hosts get an nginx vhost and a Let's Encrypt certificate, so downgrading would remove the vhost and run `certbot delete` for a customer who is a few days late. Taking a paying-but-briefly-lapsed customer's site offline is worse than the bug.

So: status is the single source of truth for capability, the plan records what was bought, and the grace window covers a renewal in progress including any re-verification it needs. Past the window the tenant loses the capability but keeps the binding, so paying restores everything with no re-verification. `GET /v1/tenants/:username/status` now returns `customDomainCapability` and `customDomainGraceEndsAt` so the owner can see the state rather than discovering it through a failed request.

## 2. Nothing released an unverified custom-domain claim (#1311)

`custom_domain` is UNIQUE whether or not it is verified, so an unverified claim blocks everyone else. Nothing expired it. `DomainService.cleanupExpiredVerifications` exists but is called from nowhere, and it only deletes the verification record, which would not have freed the column.

The hourly maintenance pass in the payment listener now releases a claim when no verification record for that exact domain has been created within `UNVERIFIED_DOMAIN_CLAIM_DAYS` (default 14), and deletes the stale records in the same transaction.

- Only `custom_domain_verified = false` rows are touched, so no verified domain is unbound and no serving site is affected.
- Idempotent: a released row has `custom_domain` NULL and cannot match again.
- In-flight verification needs no coordination. `verifyCustomDomain` keys its UPDATE on username AND domain, so once the column is cleared it matches no row, returns null, and both rails already answer "the custom domain changed during verification, please verify again".
- No schema change. The claim is dated from the verification record the attach path always writes, so this runs unchanged against the current database and needs no migration applied ahead of the deploy.

A claim whose tenant row was touched in the last hour is also left alone. The attach path commits the claim and writes the record that dates it as two separate statements, and a re-attach deletes the old record before inserting the new one, so a sweep landing in either gap would see a claim with no record and clear one made seconds earlier. `updated_at`, which a trigger stamps on every tenant write, closes both gaps and fails toward keeping a claim.

Known limit: re-submitting the same domain writes a fresh verification record and restarts the clock. That is deliberate for an owner still working on DNS, but it does mean a determined holder with an active Pro subscription can keep re-claiming.

## Behaviour changes for existing tenants

- A tenant more than `PRO_GRACE_DAYS` past expiry can no longer attach or verify a custom domain on either rail (402), and its verified domain is dropped from the first-party CORS origin set, so config saves and auth exchange from that domain stop working. The site itself keeps serving.
- An unverified domain claim older than `UNVERIFIED_DOMAIN_CLAIM_DAYS` is released on the next hourly sweep. Any such claim on the box today is by definition at least that old, so the first sweep after deploy will act on the existing backlog.
- Both windows are env-configurable (`PRO_GRACE_DAYS`, `UNVERIFIED_DOMAIN_CLAIM_DAYS`), added to `docker-compose.yml` and `.env.example`, and any value that is not a positive integer falls back to the default rather than to zero.

Deliberately not changed: the origin certificate sync still serves expired tenants' custom domains, and the config sync still leaves expired tenants' files in place. Whether an expired site should eventually stop being served is a policy question, not part of this fix.

## Verification

`npm test` and `npm run build` in `apps/self-hosted/hosting/api` (222 tests, typecheck clean). Existing domain fixtures gained an explicit `subscriptionStatus`, since attach and verify now read it.

New tests were mutation-checked: reverting the attach gate to plan-only, removing the verify gate, removing the grace window, extending grace to suspended tenants, dropping the recent-claim guard from the release sweep, skipping its record cleanup, dropping its row lock, reporting the released domain from RETURNING or from a read taken after the clear, removing the standing filter from the CORS query, unwiring the sweep from the maintenance pass, and gating the sweep on the caught-up watermark each make the relevant test fail for its stated reason.

The second commit fixes a defect found in review of the first: the sweep reported the released domain from RETURNING, which reports the NEW row and is therefore always null. The claim is now read (FOR UPDATE) before it is cleared, which also removes the window where a verification committing mid-sweep would have been discarded.