### PR TITLE
feat(self-hosted): use the built-in composer on personal blogs

### DIFF
--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -759,7 +759,10 @@ export const TenantService = {
           dateTimeFormat: 'YYYY-MM-DD HH:mm:ss',
           imageProxy: 'https://i.ecency.com',
           profileBaseUrl: 'https://ecency.com/@',
-          createPostUrl: 'https://ecency.com/publish',
+          // Empty means the built-in composer at /publish, so a new blog owner
+          // writes on their own domain. Only an owner who fills this in is sent
+          // to an external composer.
+          createPostUrl: '',
           styles: {
             background: 'bg-gradient-to-br from-[#f8fafc] to-[#e2e8f0]',
           },

--- a/apps/self-hosted/hosting/default-config.json
+++ b/apps/self-hosted/hosting/default-config.json
@@ -11,7 +11,7 @@
       "dateTimeFormat": "YYYY-MM-DD HH:mm:ss",
       "imageProxy": "https://i.ecency.com",
       "profileBaseUrl": "https://ecency.com/@",
-      "createPostUrl": "https://ecency.com/publish",
+      "createPostUrl": "",
       "styles": {
         "background": "bg-gradient-to-br from-[#f8fafc] to-[#e2e8f0]"
       }

--- a/apps/self-hosted/hosting/scripts/add-tenant.sh
+++ b/apps/self-hosted/hosting/scripts/add-tenant.sh
@@ -35,7 +35,7 @@ cat > "$CONFIG_FILE" << EOJSON
       "language": "en",
       "imageProxy": "https://i.ecency.com",
       "profileBaseUrl": "https://ecency.com/@",
-      "createPostUrl": "https://ecency.com/submit"
+      "createPostUrl": ""
     },
     "instanceConfiguration": {
       "type": "blog",

--- a/apps/self-hosted/src/features/auth/components/create-post-button.tsx
+++ b/apps/self-hosted/src/features/auth/components/create-post-button.tsx
@@ -5,6 +5,7 @@ import { useInstanceConfig } from "@/features/blog/hooks/use-instance-config";
 import { UilPen } from "@tooni/iconscout-unicons-react";
 import { Link } from "@tanstack/react-router";
 import { useIsAuthEnabled, useIsAuthenticated, useIsBlogOwner } from "../hooks";
+import { resolveCreatePostTarget } from "../utils/create-post-target";
 
 const BUTTON_CLASS =
   "fixed bottom-6 right-30 z-50 px-4 py-2 flex items-center text-sm !no-underline rounded-full border border-gray-400 dark:border-gray-600 !font-serif";
@@ -15,41 +16,50 @@ export function CreatePostButton() {
   const isAuthenticated = useIsAuthenticated();
   const { isCommunityMode } = useInstanceConfig();
 
-  const createPostUrl = InstanceConfigManager.getConfigValue(
-    ({ configuration }) =>
-      configuration.general.createPostUrl || "https://ecency.com/publish",
-  );
+  // Blog instances use the built-in editor by default too, so the owner writes
+  // on their own domain instead of being handed off elsewhere. An owner who has
+  // deliberately set general.createPostUrl still goes there. resolveCreatePostTarget
+  // owns the whole decision, including why community mode ignores the config.
+  const target = resolveCreatePostTarget({
+    createPostUrl: InstanceConfigManager.getConfigValue(
+      ({ configuration }) => configuration.general.createPostUrl,
+    ),
+    isCommunityMode,
+  });
 
   // Community instances: any authenticated user can post into the community
   // (standard Hive community moderation still applies). Blog instances: only
-  // the instance owner can post.
+  // the instance owner can post. The /publish route enforces the same rule, so
+  // hiding the button is presentation and not the gate.
   const canCreatePost = isCommunityMode ? isAuthenticated : isBlogOwner;
 
   if (!isAuthEnabled || !canCreatePost) {
     return null;
   }
 
-  // Community: use the built-in /publish editor, which publishes INTO the community
-  // (parentPermlink = communityId). Sending members to the external composer would
-  // lose the community target and post to their own blog instead.
-  if (isCommunityMode) {
+  const label = (
+    <>
+      <UilPen className="size-4" />
+      <span className="hidden sm:block">{t("create_post")}</span>
+    </>
+  );
+
+  if (target.kind === "internal") {
     return (
       <Link to="/publish" className={BUTTON_CLASS}>
-        <UilPen className="size-4" />
-        <span className="hidden sm:block">{t("create_post")}</span>
+        {label}
       </Link>
     );
   }
 
   return (
     <a
-      href={createPostUrl}
+      href={target.href}
       target="_blank"
       rel="noopener noreferrer"
       className={BUTTON_CLASS}
     >
-      <UilPen className="size-4" />
-      <span className="hidden sm:block">{t("create_post")}</span>
+      {label}
     </a>
   );
 }

--- a/apps/self-hosted/src/features/auth/utils/create-post-target.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/create-post-target.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCreatePostTarget } from './create-post-target';
+
+/** Blog instance unless a case says otherwise. */
+const blog = (createPostUrl: string | null | undefined) =>
+  resolveCreatePostTarget({ createPostUrl, isCommunityMode: false });
+
+describe('resolveCreatePostTarget', () => {
+  it('uses the built-in editor when nothing is configured', () => {
+    expect(blog(undefined)).toEqual({ kind: 'internal' });
+    expect(blog(null)).toEqual({ kind: 'internal' });
+    expect(blog('')).toEqual({ kind: 'internal' });
+    expect(blog('   ')).toEqual({ kind: 'internal' });
+  });
+
+  // Every live tenant carries this exact string because managed hosting wrote it
+  // at signup, so reading it as a configured composer would keep all of them on
+  // the old hand-off and the built-in editor would reach nobody.
+  it('treats the legacy hosting default as not configured', () => {
+    expect(blog('https://ecency.com/publish')).toEqual({ kind: 'internal' });
+  });
+
+  it('treats legacy default spellings as not configured', () => {
+    for (const value of [
+      'https://ecency.com/publish/',
+      'HTTPS://Ecency.com/Publish',
+      '  https://ecency.com/publish  ',
+      'http://ecency.com/publish',
+      'https://www.ecency.com/publish',
+    ]) {
+      expect(blog(value)).toEqual({ kind: 'internal' });
+    }
+  });
+
+  it('treats the built-in route itself as the built-in editor', () => {
+    // config.template.json ships "/publish"; that is this page, not a hand-off.
+    expect(blog('/publish')).toEqual({ kind: 'internal' });
+    expect(blog('/publish/')).toEqual({ kind: 'internal' });
+  });
+
+  it('keeps the escape hatch for a deliberately configured composer', () => {
+    expect(blog('https://example.com/write')).toEqual({
+      kind: 'external',
+      href: 'https://example.com/write',
+    });
+  });
+
+  it('does not mistake another ecency.com page for the legacy default', () => {
+    expect(blog('https://ecency.com/submit')).toEqual({
+      kind: 'external',
+      href: 'https://ecency.com/submit',
+    });
+  });
+
+  it('returns the configured url unchanged apart from trimming', () => {
+    expect(blog('  https://example.com/write?x=1&Y=2  ')).toEqual({
+      kind: 'external',
+      href: 'https://example.com/write?x=1&Y=2',
+    });
+  });
+
+  // An external composer cannot carry parentPermlink = communityId, so a member
+  // sent there would publish to their own blog instead of into the community.
+  it('ignores createPostUrl on a community instance', () => {
+    expect(
+      resolveCreatePostTarget({
+        createPostUrl: 'https://example.com/write',
+        isCommunityMode: true,
+      }),
+    ).toEqual({ kind: 'internal' });
+  });
+});

--- a/apps/self-hosted/src/features/auth/utils/create-post-target.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/create-post-target.test.ts
@@ -45,10 +45,12 @@ describe('resolveCreatePostTarget', () => {
     });
   });
 
-  it('does not mistake another ecency.com page for the legacy default', () => {
-    expect(blog('https://ecency.com/submit')).toEqual({
+  it('does not mistake another ecency.com page for a seeded default', () => {
+    // Only the two spellings provisioning actually wrote are non-decisions.
+    // An owner who deliberately points at some other ecency.com page keeps it.
+    expect(blog('https://ecency.com/@someone/drafts')).toEqual({
       kind: 'external',
-      href: 'https://ecency.com/submit',
+      href: 'https://ecency.com/@someone/drafts',
     });
   });
 
@@ -68,5 +70,46 @@ describe('resolveCreatePostTarget', () => {
         isCommunityMode: true,
       }),
     ).toEqual({ kind: 'internal' });
+  });
+
+  it('treats the add-tenant.sh seeded default as unset too', () => {
+    // hosting/scripts/add-tenant.sh wrote /submit rather than /publish. Same
+    // non-decision, so a scripted tenant must not be stranded on the hand-off.
+    for (const url of [
+      'https://ecency.com/submit',
+      'http://www.ecency.com/submit/',
+      '  HTTPS://Ecency.com/Submit  ',
+    ]) {
+      expect(
+        resolveCreatePostTarget({ createPostUrl: url, isCommunityMode: false }),
+      ).toEqual({ kind: 'internal' });
+    }
+  });
+
+  /**
+   * The configured value becomes an href. A scheme that executes must not reach
+   * the DOM, and a value that cannot resolve must not render a dead button.
+   */
+  it('refuses a configured value that is not an http(s) destination', () => {
+    for (const url of [
+      'javascript:alert(1)',
+      'JavaScript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      '/relative/path',
+      'not a url',
+    ]) {
+      expect(
+        resolveCreatePostTarget({ createPostUrl: url, isCommunityMode: false }),
+      ).toEqual({ kind: 'internal' });
+    }
+  });
+
+  it('still honours a real external composer', () => {
+    expect(
+      resolveCreatePostTarget({
+        createPostUrl: 'https://write.example.com/new',
+        isCommunityMode: false,
+      }),
+    ).toEqual({ kind: 'external', href: 'https://write.example.com/new' });
   });
 });

--- a/apps/self-hosted/src/features/auth/utils/create-post-target.ts
+++ b/apps/self-hosted/src/features/auth/utils/create-post-target.ts
@@ -1,0 +1,89 @@
+/**
+ * Where the "Create post" button sends the author.
+ *
+ * The built-in composer at /publish is the default for every instance type. A
+ * blog owner writes on their own domain instead of being handed off to another
+ * site. `general.createPostUrl` remains an escape hatch for an owner who has
+ * deliberately pointed the button at an external composer.
+ */
+
+/** The built-in composer route. */
+export const INTERNAL_PUBLISH_ROUTE = '/publish';
+
+/**
+ * Values that mean "nobody chose this", even though they are present in the
+ * stored config.
+ *
+ * Managed hosting wrote `https://ecency.com/publish` into every tenant's config
+ * at signup, back when personal blogs had no built-in composer. It is a default,
+ * not a decision: every live tenant carries it and none carries anything else.
+ * Reading it as a configured external composer would pin all of them to the old
+ * hand-off, so the new default would reach nobody. The http and www spellings
+ * are included because they say the same thing.
+ *
+ * Compared after `normalize`, so entries here are lowercase and carry no
+ * trailing slash.
+ */
+const LEGACY_EXTERNAL_DEFAULTS = new Set([
+  'https://ecency.com/publish',
+  'http://ecency.com/publish',
+  'https://www.ecency.com/publish',
+  'http://www.ecency.com/publish',
+]);
+
+export type CreatePostTarget =
+  /** Use the built-in editor on this instance. */
+  | { kind: 'internal' }
+  /** Hand off to the owner's configured composer. */
+  | { kind: 'external'; href: string };
+
+export interface CreatePostTargetInput {
+  /** Raw `general.createPostUrl` from the instance config. */
+  createPostUrl: string | null | undefined;
+  /** True when this instance is a community instance with a community id. */
+  isCommunityMode: boolean;
+}
+
+/** Fold away the differences that do not change which composer is meant. */
+function normalize(value: string): string {
+  return value.trim().toLowerCase().replace(/\/+$/, '');
+}
+
+/**
+ * Resolve the destination of the "Create post" button.
+ *
+ * Community instances always use the built-in editor: it is what carries the
+ * community target (parentPermlink = communityId), and an external composer
+ * would lose it and publish to the member's own blog instead. `createPostUrl`
+ * is therefore not honoured there.
+ *
+ * On a blog instance an absent, blank, legacy-default or self-referential value
+ * all mean the built-in editor. Anything else is the owner's own choice and is
+ * honoured as-is, only trimmed so surrounding whitespace cannot break the href.
+ */
+export function resolveCreatePostTarget({
+  createPostUrl,
+  isCommunityMode,
+}: CreatePostTargetInput): CreatePostTarget {
+  if (isCommunityMode) {
+    return { kind: 'internal' };
+  }
+
+  const configured = (createPostUrl ?? '').trim();
+
+  if (!configured) {
+    return { kind: 'internal' };
+  }
+
+  const normalized = normalize(configured);
+
+  if (normalized === INTERNAL_PUBLISH_ROUTE) {
+    return { kind: 'internal' };
+  }
+
+  if (LEGACY_EXTERNAL_DEFAULTS.has(normalized)) {
+    return { kind: 'internal' };
+  }
+
+  return { kind: 'external', href: configured };
+}

--- a/apps/self-hosted/src/features/auth/utils/create-post-target.ts
+++ b/apps/self-hosted/src/features/auth/utils/create-post-target.ts
@@ -29,6 +29,13 @@ const LEGACY_EXTERNAL_DEFAULTS = new Set([
   'http://ecency.com/publish',
   'https://www.ecency.com/publish',
   'http://www.ecency.com/publish',
+  // hosting/scripts/add-tenant.sh seeded this spelling instead. Same intent,
+  // same non-decision, so a tenant provisioned by the script is not stranded on
+  // the hand-off either.
+  'https://ecency.com/submit',
+  'http://ecency.com/submit',
+  'https://www.ecency.com/submit',
+  'http://www.ecency.com/submit',
 ]);
 
 export type CreatePostTarget =
@@ -42,6 +49,28 @@ export interface CreatePostTargetInput {
   createPostUrl: string | null | undefined;
   /** True when this instance is a community instance with a community id. */
   isCommunityMode: boolean;
+}
+
+/**
+ * Accept the value as an external destination, or refuse it.
+ *
+ * This string becomes an href. Parsing it and re-serializing means a
+ * `javascript:` or `data:` value cannot reach the DOM, and a relative or
+ * unparseable one cannot produce a link that goes nowhere. Refusing falls back
+ * to the built-in editor, which is the working destination, rather than
+ * rendering a button that does nothing.
+ */
+function toExternalTarget(value: string): CreatePostTarget | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return null;
+  }
+  return { kind: 'external', href: url.href };
 }
 
 /** Fold away the differences that do not change which composer is meant. */
@@ -58,8 +87,8 @@ function normalize(value: string): string {
  * is therefore not honoured there.
  *
  * On a blog instance an absent, blank, legacy-default or self-referential value
- * all mean the built-in editor. Anything else is the owner's own choice and is
- * honoured as-is, only trimmed so surrounding whitespace cannot break the href.
+ * all mean the built-in editor. Anything else is the owner's own choice, and is
+ * honoured only when it is a real http(s) destination.
  */
 export function resolveCreatePostTarget({
   createPostUrl,
@@ -85,5 +114,5 @@ export function resolveCreatePostTarget({
     return { kind: 'internal' };
   }
 
-  return { kind: 'external', href: configured };
+  return toExternalTarget(configured) ?? { kind: 'internal' };
 }

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -342,7 +342,8 @@ export const configFieldsMap: Record<string, ConfigField> = {
           createPostUrl: {
             label: 'Create Post URL',
             type: 'string',
-            description: 'URL for creating new posts (e.g., https://ecency.com/publish)',
+            description:
+              'Optional external composer for the Create post button. Leave empty to write here with the built-in editor. The old default https://ecency.com/publish also means the built-in editor.',
           },
           styles: {
             label: 'Styles',

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -65,9 +65,10 @@ const DYNAMIC_LINKS: Record<string, { occurrences: number; reason: string }> = {
     occurrences: 1,
     reason: 'getRssFeedUrl() returns an absolute ecency.com URL',
   },
-  'src/features/auth/components/create-post-button.tsx:createPostUrl': {
+  'src/features/auth/components/create-post-button.tsx:target.href': {
     occurrences: 1,
-    reason: 'runtime config general.createPostUrl, may be internal or absolute',
+    reason:
+      'runtime config general.createPostUrl, an owner-chosen external composer',
   },
   'src/features/blog/layout/blog-sidebar.tsx:websiteUrl': {
     occurrences: 1,


### PR DESCRIPTION
## What

Makes `/publish`, the built-in editor, the default destination of the Create post button on personal blog instances. Until now only community instances reached it; blog owners were sent to an external composer in a new tab, so every improvement to the built-in editor had reached the one instance type that is the primary product.

**This is a visible behaviour change for existing tenants.** A blog owner who clicks Create post now stays on their own domain instead of opening ecency.com in a new tab.

## Why the stored config had to be handled

`general.createPostUrl` remains the escape hatch, but managed hosting wrote `https://ecency.com/publish` into every tenant config at signup. Checked against the live hosting database: all 25 tenants carry that exact string and none carries anything else, so it is a default nobody chose rather than a setting anybody made. Reading it as a configured external composer would have pinned every existing tenant to the old hand-off and the change would have reached nobody.

`resolveCreatePostTarget` therefore treats as "not configured": empty or absent, the legacy default (plus its http and www spellings, case and trailing slash folded), and the self-referential `/publish` that `config.template.json` ships. Anything else is the owner's own choice and is honoured as-is. New tenants are created with an empty value so the legacy string stops spreading.

Community instances keep ignoring `createPostUrl` entirely. The built-in editor is what carries the community target (`parentPermlink = communityId`); an external composer would lose it and publish to the member's own blog.

## Verified, not changed

The rest of the publish path was already correct for blog mode:

- `resolvePublishTarget` already uses the post's first tag as the parent permlink in blog mode, so the post lands on the author's own blog. Tags are validated to Hive tag rules before they get there.
- The `/publish` route already gates on `isBlogOwner` for blog instances itself and redirects, so it does not rely on the button being hidden. Both the config and the restored session are ready before the route renders, so the gate does not race.
- `usePublishPost` already navigates to `/$author/$permlink` on this instance after a successful publish.

## Tests

New `create-post-target.test.ts` covers the default, the legacy value and its spellings, the escape hatch, and the community rule. The `-internal-links` exemption entry is retargeted at the new expression.

Mutation-verified: dropping the legacy-default check, dropping the `/publish` check, removing the community short-circuit, returning internal unconditionally, dropping the trim, weakening `normalize`, reverting the exemption key, and reverting the button to an unconditional external link each fail the expected assertions.

Also run: full app suite (134 passed), hosting API suite (190 passed), `tsc --noEmit` clean on both, rsbuild build, biome findings on touched files identical to develop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in post creation for self-hosted instances by default.
  * Supports optional external composer URLs when configured.
  * Community instances continue using the appropriate post creation destination.

* **Bug Fixes**
  * Improved handling of blank, legacy, self-referential, and whitespace-padded composer settings.
  * Invalid or unsafe composer URLs now safely fall back to the built-in editor.

* **Documentation**
  * Updated configuration guidance to explain built-in editor fallback and external composer options.

* **Tests**
  * Added coverage for internal, external, legacy, community, and invalid URL scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->