### PR TITLE
feat(hosting): reconcile Hivesigner redirect URIs against live tenants

### DIFF
--- a/apps/self-hosted/hosting/README.md
+++ b/apps/self-hosted/hosting/README.md
@@ -114,3 +114,35 @@ docker-compose up -d
 # Check tenant status
 ./scripts/tenant-status.sh alice
 ```
+
+## Hivesigner redirect URIs
+
+Hivesigner matches an OAuth callback with `redirect_uris.includes(callback)` against the app
+account's on-chain `posting_json_metadata`. Exact string match, no wildcards, so an instance whose
+`/auth` URI is not listed verbatim cannot complete a Hivesigner login. The self-hosted app hides the
+method when the instance has no usable client, which is why hosted blogs currently offer Keychain
+and HiveAuth only.
+
+`scripts/hivesigner-redirect-uris.py` reconciles that array against the live tenants:
+
+```
+DATABASE_URL=... ./scripts/hivesigner-redirect-uris.py
+```
+
+It prints a summary and writes the broadcast payload to a 0600 file. It does **not** broadcast:
+updating the account needs its posting key, and this service holds no signing key of any kind. Run
+the broadcast separately with the payload as `posting_json_metadata` (`account_update2`, posting
+authority).
+
+Notes:
+
+- Existing entries are never dropped, so a URI added by hand for something outside this script's
+  view survives. Entries that are registered but no longer live are reported for review rather than
+  removed.
+- Only `active` and `trialing` tenants are registered. An unverified custom domain is skipped, since
+  registering a domain someone merely claimed would let whoever controls that name receive callbacks
+  for the app.
+- The payload carries the account's whole existing profile, which on an app account includes its
+  secret. Do not paste it into a shared terminal, and delete the file afterwards.
+- Once the URIs are registered, set `general.hivesigner.clientId` in the tenant config template to
+  turn the method back on. No client code change is needed.

--- a/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
+++ b/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Reconcile the Hivesigner app account's redirect_uris against the live tenants.
+
+Hivesigner validates an OAuth callback with an exact string match against the
+app account's on-chain posting_json_metadata. From hivesigner-ui's login page:
+
+    if (!this.appProfile.redirect_uris.includes(this.callback) || ...)
+
+Array.includes. No wildcards, no prefix match, no origin-only match. So an
+instance whose /auth URI is not listed verbatim cannot complete a Hivesigner
+login, which is why the self-hosted app hides the method unless the instance
+names a client of its own.
+
+This produces the metadata that would register every live instance. It does not
+broadcast: updating posting_json_metadata needs the app account's posting key,
+and the hosting service deliberately holds no signing key of any kind. Someone
+who holds the key runs the broadcast, with this output as the payload.
+
+Existing entries are never dropped. The output is the current array plus
+whatever is missing, so a URI added by hand for something this script does not
+know about survives.
+
+The payload is written to a file rather than stdout. The account's existing
+profile is carried through unchanged, and on a Hivesigner app profile that
+includes an app secret, so echoing the payload would put it into terminal
+history, shell logs and any CI transcript that ran this. The summary on stdout
+is safe to paste; the file is not.
+
+Usage:
+    hivesigner-redirect-uris.py [--account ecency.app] [--base-domain blogs.ecency.com]
+                               [--database-url postgres://...] [--out PATH]
+
+Exit codes: 0 nothing to add, 10 additions needed, 1 error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+import tempfile
+import urllib.request
+
+DEFAULT_ACCOUNT = "ecency.app"
+DEFAULT_BASE_DOMAIN = "blogs.ecency.com"
+DEFAULT_RPC = "https://api.hive.blog"
+
+# Only these pay for a working login. A lapsed instance keeps serving, but
+# registering it spends metadata bytes on a site nobody is maintaining, and the
+# array is a shared resource.
+LIVE_STATUSES = ("active", "trialing")
+
+
+def fetch_account(rpc: str, account: str) -> dict:
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "condenser_api.get_accounts",
+            "params": [[account]],
+            "id": 1,
+        }
+    ).encode()
+    request = urllib.request.Request(
+        rpc, data=payload, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        result = json.load(response).get("result") or []
+    if not result:
+        raise SystemExit(f"account {account} does not exist")
+    return result[0]
+
+
+def current_metadata(account: dict) -> tuple[dict, list[str]]:
+    metadata = json.loads(account.get("posting_json_metadata") or "{}")
+    profile = metadata.get("profile") or {}
+    uris = profile.get("redirect_uris") or []
+    if not isinstance(uris, list):
+        raise SystemExit("redirect_uris on the account is not an array; refusing to guess")
+    return metadata, [u for u in uris if isinstance(u, str)]
+
+
+def wanted_uris(database_url: str, base_domain: str) -> list[str]:
+    try:
+        import psycopg
+    except ImportError:  # pragma: no cover - depends on the operator's box
+        raise SystemExit("psycopg is required: pip install 'psycopg[binary]'")
+
+    uris: list[str] = []
+    with psycopg.connect(database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT username, custom_domain, custom_domain_verified
+                  FROM tenants
+                 WHERE subscription_status = ANY(%s)
+                 ORDER BY username
+                """,
+                (list(LIVE_STATUSES),),
+            )
+            for username, custom_domain, verified in cursor.fetchall():
+                uris.append(f"https://{username}.{base_domain}/auth")
+                # An unverified claim is not the tenant's domain yet. Registering
+                # it would let whoever actually controls that name receive
+                # callbacks for the app.
+                if custom_domain and verified:
+                    uris.append(f"https://{custom_domain}/auth")
+    return uris
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--account", default=os.environ.get("HIVESIGNER_APP_ACCOUNT", DEFAULT_ACCOUNT))
+    parser.add_argument("--base-domain", default=os.environ.get("BASE_DOMAIN", DEFAULT_BASE_DOMAIN))
+    parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
+    parser.add_argument("--rpc", default=os.environ.get("HIVE_RPC", DEFAULT_RPC))
+    parser.add_argument(
+        "--out",
+        help="where to write the broadcast payload (default: a 0600 temp file)",
+    )
+    args = parser.parse_args()
+
+    if not args.database_url:
+        raise SystemExit("--database-url or DATABASE_URL is required")
+
+    account = fetch_account(args.rpc, args.account)
+    metadata, existing = current_metadata(account)
+    wanted = wanted_uris(args.database_url, args.base_domain)
+
+    missing = [u for u in wanted if u not in existing]
+    merged = existing + missing
+
+    metadata.setdefault("profile", {})["redirect_uris"] = merged
+    serialized = json.dumps(metadata, separators=(",", ":"))
+
+    print(f"account:    {args.account}")
+    print(f"registered: {len(existing)}")
+    print(f"to add:     {len(missing)}")
+    print(f"final:      {len(merged)}")
+    print(f"metadata:   {len(serialized)} bytes")
+
+    if missing:
+        print("\nwould add:")
+        for uri in missing:
+            print(f"  {uri}")
+
+        path = args.out
+        if path is None:
+            handle, path = tempfile.mkstemp(prefix="hivesigner-metadata-", suffix=".json")
+            os.close(handle)
+        with open(path, "w", encoding="utf-8") as payload:
+            payload.write(serialized)
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+
+        print(f"\npayload written to {path}")
+        print("broadcast it as posting_json_metadata (account_update2, posting authority).")
+        print("it carries the account's existing profile, including its app secret, so do")
+        print("not paste it into a shared terminal and delete it when you are done.")
+        # Stale entries are reported, never removed: one may be a hand-added URI
+        # for something outside this script's view, and dropping it silently
+        # breaks a login nobody will connect back to this run.
+        stale = [u for u in existing if u.endswith(f".{args.base_domain}/auth") and u not in wanted]
+        if stale:
+            print("\nregistered but no longer live, review by hand before removing:")
+            for uri in stale:
+                print(f"  {uri}")
+        return 10
+
+    print("\nnothing to add")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
+++ b/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
@@ -110,6 +110,27 @@ def wanted_uris(database_url: str, base_domain: str) -> list[str]:
     return uris
 
 
+def write_private(contents: str, path: str | None) -> str:
+    """
+    Write to a file only its owner can read, with no window where it is not.
+
+    Creating the file and then chmod-ing it leaves the payload readable by
+    anything on the box for the interval between the two, and world-readable
+    forever if the process dies in between. The mode has to be applied by the
+    call that creates the file.
+    """
+    if path is None:
+        handle, path = tempfile.mkstemp(prefix="hivesigner-metadata-", suffix=".json")
+    else:
+        # O_CREAT with mode 0600. An existing file keeps its own mode, so the
+        # caller owns that choice; a new one is never briefly readable.
+        handle = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
+
+    with os.fdopen(handle, "w", encoding="utf-8") as payload:
+        payload.write(contents)
+    return path
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--account", default=os.environ.get("HIVESIGNER_APP_ACCOUNT", DEFAULT_ACCOUNT))
@@ -146,26 +167,23 @@ def main() -> int:
         for uri in missing:
             print(f"  {uri}")
 
-        path = args.out
-        if path is None:
-            handle, path = tempfile.mkstemp(prefix="hivesigner-metadata-", suffix=".json")
-            os.close(handle)
-        with open(path, "w", encoding="utf-8") as payload:
-            payload.write(serialized)
-        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        path = write_private(serialized, args.out)
 
         print(f"\npayload written to {path}")
         print("broadcast it as posting_json_metadata (account_update2, posting authority).")
         print("it carries the account's existing profile, including its app secret, so do")
         print("not paste it into a shared terminal and delete it when you are done.")
-        # Stale entries are reported, never removed: one may be a hand-added URI
-        # for something outside this script's view, and dropping it silently
-        # breaks a login nobody will connect back to this run.
-        stale = [u for u in existing if u.endswith(f".{args.base_domain}/auth") and u not in wanted]
-        if stale:
-            print("\nregistered but no longer live, review by hand before removing:")
-            for uri in stale:
-                print(f"  {uri}")
+
+    # Reported whether or not anything is being added. Once every live instance
+    # is registered there is nothing to add, and that is exactly when a tenant
+    # going inactive would otherwise be reported by nobody.
+    stale = [u for u in existing if u.endswith(f".{args.base_domain}/auth") and u not in wanted]
+    if stale:
+        print("\nregistered but no longer live, review by hand before removing:")
+        for uri in stale:
+            print(f"  {uri}")
+
+    if missing:
         return 10
 
     print("\nnothing to add")


### PR DESCRIPTION
Part of #1318. This is the half that can ship without a decision.

## Why the built-in client cannot work today

Hivesigner validates a callback with an exact string match against the app account's on-chain metadata. From `ecency/hivesigner-ui/src/pages/login.vue`:

```js
if (!this.appProfile.redirect_uris.includes(this.callback) || !isValidUrl(this.callback)) {
```

`Array.includes`. No wildcards, no prefix or origin matching. An instance whose `/auth` URI is not listed verbatim cannot complete a login, which is why #1317 hides the method unless the instance names a client of its own.

## What this adds

`hosting/scripts/hivesigner-redirect-uris.py` reads the live tenants, reads the account, and produces the metadata that registers every live instance.

**It does not broadcast.** Updating `posting_json_metadata` needs the app account's posting key, and the hosting service holds no signing key of any kind today. Introducing one is a decision worth taking on its own rather than as a side effect of this, so the script stops at the payload and someone who holds the key runs the broadcast. That also means this is safe to merge now: nothing about it changes what the service does.

Design points that are deliberate:

- **Existing entries are never dropped.** Output is the current array plus what is missing. Entries registered but no longer live are reported for review, not removed, since one may be a URI added by hand for something the script cannot see.
- **Unverified custom domains are skipped.** Registering a domain someone merely claimed would let whoever actually controls that name receive callbacks for the app.
- **Only `active` and `trialing` tenants are registered.** A lapsed instance keeps serving, but the array is a shared resource.
- **The payload goes to a 0600 file rather than stdout.** It carries the account's whole existing profile, and an app profile includes its secret, so echoing it would put that into terminal history and any log or CI transcript of the run.

## Verified against the live data

Run against the hosting database: 4 URIs already registered, 9 to add, 13 final, 839 bytes of metadata. That is comfortably within what the field holds and it grows by one entry per instance, which is what makes per-instance registration viable at all. I had originally assumed the tenant set was unbounded and therefore unregistrable; the real numbers say otherwise.

## After the broadcast

No client change is needed. `resolveHivesignerClientId` prefers an explicitly configured value over the built-in default, so setting

```json
{ "general": { "hivesigner": { "clientId": "ecency.app" } } }
```

in the tenant config template turns the method on.