### PR TITLE
fix(hosting): restrict /v1/internal to the callers that use it

### DIFF
--- a/apps/self-hosted/hosting/.env.example
+++ b/apps/self-hosted/hosting/.env.example
@@ -73,6 +73,21 @@ X402_FACILITATOR_URL=https://x402.ecency.com
 # same value has to be set on the ePoints side, so rotate both together.
 # =============================================================================
 HOSTING_INTERNAL_SECRET=
+
+# Source-address allowlist for /v1/internal, as a second layer behind the edge nginx (which
+# enforces the same list, but is not on the path of anything that reaches the container
+# directly). Comma-separated; plain addresses and CIDR both work, IPv4 and IPv6:
+#
+#   HOSTING_INTERNAL_ALLOWED_IPS=203.0.113.10,198.51.100.0/24
+#
+# EMPTY OR UNSET ALLOWS EVERY SOURCE, which is the default on purpose: this deploys straight
+# to production with no staging tier, and a self-hoster has no list to supply. Turn it on
+# deliberately, after confirming from the access log which sources actually call. The address
+# is read from X-Real-IP, which the fronting proxy overwrites; X-Forwarded-For is not used
+# because the proxy appends to whatever the caller sent, so a caller can seed it. Entries
+# that do not parse are logged and skipped, and a value where nothing parses does not enforce.
+HOSTING_INTERNAL_ALLOWED_IPS=
+
 # Show/hide the card option in the signup UI + the price it displays (200 = $2.00).
 HOSTING_CARD_ENABLED=true
 HOSTING_CARD_USD_CENTS=200

--- a/apps/self-hosted/hosting/.env.example
+++ b/apps/self-hosted/hosting/.env.example
@@ -82,10 +82,18 @@ HOSTING_INTERNAL_SECRET=
 #
 # EMPTY OR UNSET ALLOWS EVERY SOURCE, which is the default on purpose: this deploys straight
 # to production with no staging tier, and a self-hoster has no list to supply. Turn it on
-# deliberately, after confirming from the access log which sources actually call. The address
-# is read from X-Real-IP, which the fronting proxy overwrites; X-Forwarded-For is not used
-# because the proxy appends to whatever the caller sent, so a caller can seed it. Entries
-# that do not parse are logged and skipped, and a value where nothing parses does not enforce.
+# deliberately, after confirming from the access log which sources actually call.
+#
+# What gets matched depends on how the request arrived. A request from a proxy the API trusts
+# (loopback, or the container's own gateway, which is where host-published traffic comes from)
+# is matched on X-Real-IP, the header that proxy overwrites. Anything else is matched on the
+# connection's own address and its headers are ignored, because a caller that did not come
+# through the proxy writes its own headers. So list the addresses your callers present TO the
+# proxy, not the proxy itself. X-Forwarded-For is never consulted: the proxy appends to
+# whatever the caller sent, so entries in it are caller-controlled.
+#
+# Entries that do not parse are logged and skipped, and a value where nothing parses does not
+# enforce. The boot log states which of those cases applies.
 HOSTING_INTERNAL_ALLOWED_IPS=
 
 # Show/hide the card option in the signup UI + the price it displays (200 = $2.00).

--- a/apps/self-hosted/hosting/api/src/index.ts
+++ b/apps/self-hosted/hosting/api/src/index.ts
@@ -14,6 +14,7 @@ import { paymentRoutes } from './routes/payments';
 import { authRoutes } from './routes/auth';
 import { internalRoutes, internalSecret, MIN_INTERNAL_SECRET_LENGTH } from './routes/internal';
 import { rateLimit } from './middleware/rate-limit';
+import { sourceAllowlist } from './middleware/source-allowlist';
 import { errorHandler } from './middleware/error-handler';
 import { db } from './db/client';
 import { TenantService } from './services/tenant-service';
@@ -69,6 +70,17 @@ app.use('/v1/domains/*', generalLimit);
 app.use('/v1/payments/*', generalLimit);
 app.use('/v1/auth/*', generalLimit);
 app.use('/v1/auth/*', authLimit);
+
+// Source-address allowlist for the service-to-service routes, ahead of the rate limit so a
+// refused source never spends a Redis round trip. Defence in depth behind the edge nginx,
+// which does the same check but is not on the path of anything that reaches the container
+// directly. Unset/empty allows everything: this deploys straight to production with no
+// staging tier, so it has to be switched on deliberately after the fact. Which state it is
+// in is logged at construction, next to the shared-secret startup line below.
+app.use(
+  '/v1/internal/*',
+  sourceAllowlist({ name: 'internal', value: process.env.HOSTING_INTERNAL_ALLOWED_IPS })
+);
 app.use('/v1/internal/*', internalLimit);
 
 // API Routes

--- a/apps/self-hosted/hosting/api/src/middleware/source-allowlist.test.ts
+++ b/apps/self-hosted/hosting/api/src/middleware/source-allowlist.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isAllowedAddress, parseAllowlist, sourceAllowlist } from './source-allowlist';
+
+/**
+ * Minimal Hono-shaped context. `headers` are the ones the container actually receives, i.e.
+ * after nginx has rewritten them, so a test that forges X-Forwarded-For is modelling a caller
+ * that put a value in its own request and nginx passed it along with the peer appended.
+ */
+function makeCtx(headers: Record<string, string> = {}, path = '/v1/internal/activate') {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return {
+    req: {
+      path,
+      header: (k: string) => lower[k.toLowerCase()],
+    },
+    json: (body: unknown, status?: number) => ({ body, status: status ?? 200 }),
+  } as any;
+}
+
+describe('parseAllowlist', () => {
+  it('treats unset, empty and whitespace-only values as not enforcing', () => {
+    for (const value of [undefined, '', '   ', ',', ' , ,']) {
+      expect(parseAllowlist(value).enforcing).toBe(false);
+    }
+  });
+
+  it('accepts plain addresses and CIDR, and reports unusable entries', () => {
+    const list = parseAllowlist('203.0.113.1, 198.51.100.0/24, ::1, 2001:db8::/32, nonsense, 203.0.113.1/33');
+    expect(list.rules).toHaveLength(4);
+    expect(list.invalid).toEqual(['nonsense', '203.0.113.1/33']);
+    expect(list.enforcing).toBe(true);
+  });
+
+  it('rejects malformed IPv4 rather than coercing it', () => {
+    // 010 is decimal here and octal elsewhere; 1.2.3 and 256 are simply not addresses.
+    expect(parseAllowlist('203.0.113.010').enforcing).toBe(false);
+    expect(parseAllowlist('1.2.3').enforcing).toBe(false);
+    expect(parseAllowlist('256.0.0.1').enforcing).toBe(false);
+  });
+});
+
+describe('isAllowedAddress', () => {
+  it('matches an exact IPv4 address and nothing else', () => {
+    const list = parseAllowlist('203.0.113.7');
+    expect(isAllowedAddress('203.0.113.7', list)).toBe(true);
+    expect(isAllowedAddress('203.0.113.8', list)).toBe(false);
+  });
+
+  it('matches inside an IPv4 CIDR and rejects just outside it', () => {
+    const list = parseAllowlist('198.51.100.0/24');
+    expect(isAllowedAddress('198.51.100.1', list)).toBe(true);
+    expect(isAllowedAddress('198.51.100.254', list)).toBe(true);
+    expect(isAllowedAddress('198.51.101.1', list)).toBe(false);
+    expect(isAllowedAddress('198.51.99.255', list)).toBe(false);
+  });
+
+  it('respects a non-byte-aligned prefix', () => {
+    const list = parseAllowlist('192.0.2.128/25');
+    expect(isAllowedAddress('192.0.2.128', list)).toBe(true);
+    expect(isAllowedAddress('192.0.2.255', list)).toBe(true);
+    expect(isAllowedAddress('192.0.2.127', list)).toBe(false);
+  });
+
+  it('matches IPv6 addresses and prefixes', () => {
+    const list = parseAllowlist('2001:db8:abcd::/48, ::1');
+    expect(isAllowedAddress('2001:db8:abcd:1::5', list)).toBe(true);
+    expect(isAllowedAddress('2001:db8:abce::1', list)).toBe(false);
+    expect(isAllowedAddress('::1', list)).toBe(true);
+    expect(isAllowedAddress('[::1]', list)).toBe(true);
+    expect(isAllowedAddress('fe80::1%eth0', list)).toBe(false);
+  });
+
+  it('treats an IPv4-mapped IPv6 peer as the IPv4 address it is', () => {
+    const list = parseAllowlist('203.0.113.7');
+    expect(isAllowedAddress('::ffff:203.0.113.7', list)).toBe(true);
+    expect(isAllowedAddress('::ffff:203.0.113.8', list)).toBe(false);
+    // ...and the same in reverse, when the rule is written in mapped form.
+    const mapped = parseAllowlist('::ffff:203.0.113.7');
+    expect(isAllowedAddress('203.0.113.7', mapped)).toBe(true);
+    expect(isAllowedAddress('203.0.113.8', mapped)).toBe(false);
+  });
+
+  it('never matches an unparseable or absent address while enforcing', () => {
+    const list = parseAllowlist('203.0.113.0/24');
+    expect(isAllowedAddress(null, list)).toBe(false);
+    expect(isAllowedAddress('', list)).toBe(false);
+    expect(isAllowedAddress('not-an-ip', list)).toBe(false);
+  });
+
+  it('does not mix address families', () => {
+    expect(isAllowedAddress('::ffff:0:0', parseAllowlist('0.0.0.0/0'))).toBe(true);
+    expect(isAllowedAddress('2001:db8::1', parseAllowlist('0.0.0.0/0'))).toBe(false);
+  });
+});
+
+describe('sourceAllowlist middleware', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  // The property that protects production: this ships to a host with no staging tier, so an
+  // unset variable must behave exactly as it did before this middleware existed.
+  it('allows every request when the variable is unset', async () => {
+    const mw = sourceAllowlist({ name: 'internal', value: undefined });
+    const next = vi.fn();
+    await mw(makeCtx({ 'x-real-ip': '203.0.113.9' }), next);
+    await mw(makeCtx(), next); // no client address at all
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows every request when the variable is empty', async () => {
+    const mw = sourceAllowlist({ name: 'internal', value: '   ' });
+    const next = vi.fn();
+    await mw(makeCtx(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows an address on the list', async () => {
+    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24, 203.0.113.9' });
+    const next = vi.fn();
+    await mw(makeCtx({ 'x-real-ip': '198.51.100.4' }), next);
+    await mw(makeCtx({ 'x-real-ip': '203.0.113.9' }), next);
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it('refuses an address off the list with a generic 403 that does not disclose the list', async () => {
+    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
+    const next = vi.fn();
+    const res = (await mw(makeCtx({ 'x-real-ip': '192.0.2.44' }), next)) as any;
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toBe(403);
+    // Byte-identical to the shared-secret refusal in routes/internal.ts.
+    expect(res.body).toEqual({ error: 'forbidden' });
+    expect(JSON.stringify(res.body)).not.toContain('198.51');
+  });
+
+  it('logs the refused address so a legitimate caller can be diagnosed', async () => {
+    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
+    await mw(makeCtx({ 'x-real-ip': '192.0.2.44' }), vi.fn());
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('192.0.2.44'));
+  });
+
+  // The whole point of reading X-Real-IP: nginx REPLACES it, while X-Forwarded-For is built
+  // with $proxy_add_x_forwarded_for and still carries whatever the caller put there.
+  it('cannot be bypassed by a forged X-Forwarded-For', async () => {
+    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
+    const next = vi.fn();
+    const res = (await mw(
+      makeCtx({
+        // What the container sees after nginx appended the real peer to the caller's header.
+        'x-forwarded-for': '198.51.100.4, 192.0.2.44',
+        'x-real-ip': '192.0.2.44',
+      }),
+      next
+    )) as any;
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toBe(403);
+  });
+
+  it('cannot be bypassed by forging X-Forwarded-For alone', async () => {
+    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
+    const next = vi.fn();
+    const res = (await mw(makeCtx({ 'x-forwarded-for': '198.51.100.4' }), next)) as any;
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toBe(403);
+  });
+
+  it('refuses a request that carries no trusted client address', async () => {
+    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
+    const next = vi.fn();
+    const res = (await mw(makeCtx(), next)) as any;
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toBe(403);
+  });
+
+  it('refuses a multi-valued X-Real-IP instead of guessing which element is real', async () => {
+    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
+    const next = vi.fn();
+    const res = (await mw(makeCtx({ 'x-real-ip': '198.51.100.4, 192.0.2.44' }), next)) as any;
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toBe(403);
+  });
+
+  it('does not enforce when the value is set but nothing in it parses', async () => {
+    const mw = sourceAllowlist({ name: 'internal', value: 'not-an-ip, also-not-an-ip' });
+    const next = vi.fn();
+    await mw(makeCtx({ 'x-real-ip': '192.0.2.44' }), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('NOT enforcing'));
+  });
+
+  it('still enforces the entries that did parse when one is malformed', async () => {
+    const mw = sourceAllowlist({ name: 'internal', value: 'garbage, 198.51.100.0/24' });
+    const next = vi.fn();
+    await mw(makeCtx({ 'x-real-ip': '198.51.100.4' }), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    const res = (await mw(makeCtx({ 'x-real-ip': '192.0.2.44' }), next)) as any;
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/middleware/source-allowlist.test.ts
+++ b/apps/self-hosted/hosting/api/src/middleware/source-allowlist.test.ts
@@ -1,16 +1,59 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { isAllowedAddress, parseAllowlist, sourceAllowlist } from './source-allowlist';
+import {
+  defaultGatewayAddress,
+  defaultTrustedProxies,
+  isAllowedAddress,
+  parseAllowlist,
+  parseDefaultGateway,
+  sourceAllowlist,
+} from './source-allowlist';
 
 /**
- * Minimal Hono-shaped context. `headers` are the ones the container actually receives, i.e.
- * after nginx has rewritten them, so a test that forges X-Forwarded-For is modelling a caller
- * that put a value in its own request and nginx passed it along with the peer appended.
+ * Addresses used below, all from the RFC 5737 documentation ranges.
+ *
+ * PROXY is deliberately INSIDE the allowlisted range. A trusted proxy that would pass the
+ * allowlist on its own is the only way to prove the peer is not being used as a fallback when
+ * the header it is trusted for is absent.
  */
-function makeCtx(headers: Record<string, string> = {}, path = '/v1/internal/activate') {
+const ALLOWED_RANGE = '198.51.100.0/24';
+const ALLOWED_IN_RANGE = '198.51.100.4';
+const ALLOWED_SINGLE = '203.0.113.9';
+const DENIED = '192.0.2.44';
+const PROXY = '198.51.100.7';
+
+/**
+ * Minimal Hono-shaped context.
+ *
+ * `env` mirrors the shape @hono/node-server's getConnInfo actually reads (c.env.incoming.socket),
+ * so these tests exercise the real accessor rather than a stub of it. Omitting `peer` models a
+ * request with no connection info at all, which is what a non-Node runtime would produce.
+ *
+ * `headers` are the ones the container receives. A test that sets X-Real-IP without a trusted
+ * peer is modelling a caller writing the header itself, which is exactly what a request that
+ * never traversed nginx can do.
+ */
+function makeCtx(
+  opts: { peer?: string | null; headers?: Record<string, string>; path?: string } = {}
+) {
+  const { peer, headers = {}, path = '/v1/internal/activate' } = opts;
   const lower: Record<string, string> = {};
   for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
   return {
+    env:
+      peer === undefined
+        ? undefined
+        : {
+            incoming: {
+              socket: {
+                // null models a socket that reports no address at all, e.g. one already
+                // torn down. The field is simply absent, exactly as Node leaves it.
+                remoteAddress: peer ?? undefined,
+                remotePort: 54321,
+                remoteFamily: peer?.includes(':') ? 'IPv6' : 'IPv4',
+              },
+            },
+          },
     req: {
       path,
       header: (k: string) => lower[k.toLowerCase()],
@@ -100,15 +143,24 @@ describe('sourceAllowlist middleware', () => {
     vi.restoreAllMocks();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
   });
+
+  /** Enforcing, with PROXY as the only peer whose X-Real-IP is believed. */
+  const enforcing = () =>
+    sourceAllowlist({
+      name: 'internal',
+      value: `${ALLOWED_RANGE}, ${ALLOWED_SINGLE}`,
+      trustedProxies: PROXY,
+    });
 
   // The property that protects production: this ships to a host with no staging tier, so an
   // unset variable must behave exactly as it did before this middleware existed.
   it('allows every request when the variable is unset', async () => {
     const mw = sourceAllowlist({ name: 'internal', value: undefined });
     const next = vi.fn();
-    await mw(makeCtx({ 'x-real-ip': '203.0.113.9' }), next);
-    await mw(makeCtx(), next); // no client address at all
+    await mw(makeCtx({ peer: DENIED, headers: { 'x-real-ip': DENIED } }), next);
+    await mw(makeCtx(), next); // no connection info and no headers at all
     expect(next).toHaveBeenCalledTimes(2);
   });
 
@@ -119,87 +171,255 @@ describe('sourceAllowlist middleware', () => {
     expect(next).toHaveBeenCalledTimes(1);
   });
 
-  it('allows an address on the list', async () => {
-    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24, 203.0.113.9' });
-    const next = vi.fn();
-    await mw(makeCtx({ 'x-real-ip': '198.51.100.4' }), next);
-    await mw(makeCtx({ 'x-real-ip': '203.0.113.9' }), next);
-    expect(next).toHaveBeenCalledTimes(2);
-  });
-
-  it('refuses an address off the list with a generic 403 that does not disclose the list', async () => {
-    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
-    const next = vi.fn();
-    const res = (await mw(makeCtx({ 'x-real-ip': '192.0.2.44' }), next)) as any;
-    expect(next).not.toHaveBeenCalled();
-    expect(res.status).toBe(403);
-    // Byte-identical to the shared-secret refusal in routes/internal.ts.
-    expect(res.body).toEqual({ error: 'forbidden' });
-    expect(JSON.stringify(res.body)).not.toContain('198.51');
-  });
-
-  it('logs the refused address so a legitimate caller can be diagnosed', async () => {
-    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
-    await mw(makeCtx({ 'x-real-ip': '192.0.2.44' }), vi.fn());
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('192.0.2.44'));
-  });
-
-  // The whole point of reading X-Real-IP: nginx REPLACES it, while X-Forwarded-For is built
-  // with $proxy_add_x_forwarded_for and still carries whatever the caller put there.
-  it('cannot be bypassed by a forged X-Forwarded-For', async () => {
-    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
-    const next = vi.fn();
-    const res = (await mw(
-      makeCtx({
-        // What the container sees after nginx appended the real peer to the caller's header.
-        'x-forwarded-for': '198.51.100.4, 192.0.2.44',
-        'x-real-ip': '192.0.2.44',
-      }),
-      next
-    )) as any;
-    expect(next).not.toHaveBeenCalled();
-    expect(res.status).toBe(403);
-  });
-
-  it('cannot be bypassed by forging X-Forwarded-For alone', async () => {
-    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
-    const next = vi.fn();
-    const res = (await mw(makeCtx({ 'x-forwarded-for': '198.51.100.4' }), next)) as any;
-    expect(next).not.toHaveBeenCalled();
-    expect(res.status).toBe(403);
-  });
-
-  it('refuses a request that carries no trusted client address', async () => {
-    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
-    const next = vi.fn();
-    const res = (await mw(makeCtx(), next)) as any;
-    expect(next).not.toHaveBeenCalled();
-    expect(res.status).toBe(403);
-  });
-
-  it('refuses a multi-valued X-Real-IP instead of guessing which element is real', async () => {
-    const mw = sourceAllowlist({ name: 'internal', value: '198.51.100.0/24' });
-    const next = vi.fn();
-    const res = (await mw(makeCtx({ 'x-real-ip': '198.51.100.4, 192.0.2.44' }), next)) as any;
-    expect(next).not.toHaveBeenCalled();
-    expect(res.status).toBe(403);
-  });
-
   it('does not enforce when the value is set but nothing in it parses', async () => {
     const mw = sourceAllowlist({ name: 'internal', value: 'not-an-ip, also-not-an-ip' });
     const next = vi.fn();
-    await mw(makeCtx({ 'x-real-ip': '192.0.2.44' }), next);
+    await mw(makeCtx({ peer: DENIED }), next);
     expect(next).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('NOT enforcing'));
   });
 
+  describe('behind a trusted proxy', () => {
+    it('allows a listed X-Real-IP', async () => {
+      const next = vi.fn();
+      await enforcing()(
+        makeCtx({ peer: PROXY, headers: { 'x-real-ip': ALLOWED_IN_RANGE } }),
+        next
+      );
+      await enforcing()(makeCtx({ peer: PROXY, headers: { 'x-real-ip': ALLOWED_SINGLE } }), next);
+      expect(next).toHaveBeenCalledTimes(2);
+    });
+
+    it('refuses an unlisted X-Real-IP even though the proxy peer itself is listed', async () => {
+      const next = vi.fn();
+      const res = (await enforcing()(
+        makeCtx({ peer: PROXY, headers: { 'x-real-ip': DENIED } }),
+        next
+      )) as any;
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toBe(403);
+    });
+
+    // No fallback to the peer. PROXY is inside the allowlisted range, so a fallback would let
+    // anything that can open a connection to the port through by simply omitting the header.
+    it('refuses when X-Real-IP is missing rather than falling back to the peer', async () => {
+      const next = vi.fn();
+      const res = (await enforcing()(makeCtx({ peer: PROXY }), next)) as any;
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toBe(403);
+    });
+
+    it('refuses an unparseable X-Real-IP rather than falling back to the peer', async () => {
+      const next = vi.fn();
+      for (const value of ['not-an-ip', '', `${ALLOWED_IN_RANGE}, ${DENIED}`]) {
+        const res = (await enforcing()(
+          makeCtx({ peer: PROXY, headers: { 'x-real-ip': value } }),
+          next
+        )) as any;
+        expect(res.status).toBe(403);
+      }
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('recognises the proxy through an IPv4-mapped peer address', async () => {
+      const next = vi.fn();
+      await enforcing()(
+        makeCtx({ peer: `::ffff:${PROXY}`, headers: { 'x-real-ip': ALLOWED_IN_RANGE } }),
+        next
+      );
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('trusts loopback by default, without being told to', async () => {
+      // No trustedProxies given, so the default set applies. Loopback is in it on every host,
+      // which covers a deployment where the proxy talks to the API directly rather than
+      // through a container port.
+      const mw = sourceAllowlist({ name: 'internal', value: ALLOWED_SINGLE });
+      const next = vi.fn();
+      await mw(makeCtx({ peer: '127.0.0.1', headers: { 'x-real-ip': ALLOWED_SINGLE } }), next);
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('not behind a trusted proxy', () => {
+    // The case this middleware exists for: a caller that reached the container without passing
+    // through the proxy writes its own headers, so the header must count for nothing.
+    it('refuses a forged X-Real-IP naming an allowlisted address', async () => {
+      const next = vi.fn();
+      const res = (await enforcing()(
+        makeCtx({ peer: DENIED, headers: { 'x-real-ip': ALLOWED_IN_RANGE } }),
+        next
+      )) as any;
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toBe(403);
+    });
+
+    it('judges the peer itself, ignoring any X-Real-IP it supplies', async () => {
+      const next = vi.fn();
+      // A listed peer is allowed even when it forges an UNLISTED header, which proves the
+      // header is not consulted at all rather than merely being overridden.
+      await enforcing()(
+        makeCtx({ peer: ALLOWED_SINGLE, headers: { 'x-real-ip': DENIED } }),
+        next
+      );
+      expect(next).toHaveBeenCalledTimes(1);
+
+      const res = (await enforcing()(makeCtx({ peer: DENIED }), next)) as any;
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).toBe(403);
+    });
+
+    it('refuses when the connection reports no address', async () => {
+      // Default trusted set, so loopback IS trusted here. Substituting any placeholder for a
+      // missing peer address would land inside that set and hand the caller its own header.
+      const mw = sourceAllowlist({ name: 'internal', value: ALLOWED_SINGLE });
+      const next = vi.fn();
+      const res = (await mw(
+        makeCtx({ peer: null, headers: { 'x-real-ip': ALLOWED_SINGLE } }),
+        next
+      )) as any;
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toBe(403);
+    });
+
+    it('refuses when there is no connection info to judge', async () => {
+      const next = vi.fn();
+      const res = (await enforcing()(
+        makeCtx({ headers: { 'x-real-ip': ALLOWED_IN_RANGE } }),
+        next
+      )) as any;
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toBe(403);
+    });
+
+    it('trusts no peer at all when the trusted-proxy set is empty', async () => {
+      // An empty set must mean "trust nobody", not "trust everybody": every request is then
+      // judged by its peer and X-Real-IP is never read.
+      const mw = sourceAllowlist({
+        name: 'internal',
+        value: `${ALLOWED_RANGE}, ${ALLOWED_SINGLE}`,
+        trustedProxies: '',
+      });
+      const next = vi.fn();
+      const res = (await mw(
+        makeCtx({ peer: DENIED, headers: { 'x-real-ip': ALLOWED_IN_RANGE } }),
+        next
+      )) as any;
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toBe(403);
+
+      await mw(makeCtx({ peer: ALLOWED_SINGLE }), next);
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('refusals', () => {
+    it('answer with a generic 403 that does not disclose the allowlist', async () => {
+      const next = vi.fn();
+      const res = (await enforcing()(makeCtx({ peer: DENIED }), next)) as any;
+      expect(res.status).toBe(403);
+      // Byte-identical to the shared-secret refusal in routes/internal.ts.
+      expect(res.body).toEqual({ error: 'forbidden' });
+      expect(JSON.stringify(res.body)).not.toContain('198.51');
+      expect(JSON.stringify(res.body)).not.toContain('203.0.113');
+    });
+
+    it('log the address judged, the peer, and which of the two it came from', async () => {
+      await enforcing()(makeCtx({ peer: DENIED }), vi.fn());
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(DENIED));
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('direct'));
+
+      await enforcing()(makeCtx({ peer: PROXY, headers: { 'x-real-ip': DENIED } }), vi.fn());
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('via trusted proxy'));
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(PROXY));
+    });
+  });
+
+  describe('X-Forwarded-For is never consulted', () => {
+    // It is built with $proxy_add_x_forwarded_for, which appends to whatever the caller sent,
+    // so entries in it are caller-controlled even for requests that did traverse the proxy.
+    it('does not accept a forged X-Forwarded-For from behind the proxy', async () => {
+      const next = vi.fn();
+      const res = (await enforcing()(
+        makeCtx({
+          peer: PROXY,
+          headers: { 'x-forwarded-for': `${ALLOWED_IN_RANGE}, ${DENIED}`, 'x-real-ip': DENIED },
+        }),
+        next
+      )) as any;
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toBe(403);
+    });
+
+    it('does not accept X-Forwarded-For in place of a missing X-Real-IP', async () => {
+      const next = vi.fn();
+      const res = (await enforcing()(
+        makeCtx({ peer: PROXY, headers: { 'x-forwarded-for': ALLOWED_IN_RANGE } }),
+        next
+      )) as any;
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toBe(403);
+    });
+  });
+
   it('still enforces the entries that did parse when one is malformed', async () => {
-    const mw = sourceAllowlist({ name: 'internal', value: 'garbage, 198.51.100.0/24' });
+    const mw = sourceAllowlist({
+      name: 'internal',
+      value: `garbage, ${ALLOWED_RANGE}`,
+      trustedProxies: PROXY,
+    });
     const next = vi.fn();
-    await mw(makeCtx({ 'x-real-ip': '198.51.100.4' }), next);
+    await mw(makeCtx({ peer: PROXY, headers: { 'x-real-ip': ALLOWED_IN_RANGE } }), next);
     expect(next).toHaveBeenCalledTimes(1);
-    const res = (await mw(makeCtx({ 'x-real-ip': '192.0.2.44' }), next)) as any;
+    const res = (await mw(makeCtx({ peer: PROXY, headers: { 'x-real-ip': DENIED } }), next)) as any;
     expect(next).toHaveBeenCalledTimes(1);
     expect(res.status).toBe(403);
+  });
+});
+
+describe('trusted-proxy defaults', () => {
+  // The literal /proc/net/route layout: a header line, then tab-separated fields where a
+  // Destination of 00000000 marks the default route and the Gateway is little-endian hex.
+  const table = [
+    'Iface\tDestination\tGateway \tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT',
+    // On-link subnet route (no next hop), then a route to another subnet VIA 192.0.2.2,
+    // then the default route via 192.0.2.1. The middle line is the one that catches a reader
+    // that forgets to check Destination: it has a perfectly valid, wrong gateway.
+    'eth0\t000200C0\t00000000\t0001\t0\t0\t0\t00FFFFFF\t0\t0\t0',
+    'eth0\t000300C0\t020200C0\t0003\t0\t0\t0\t00FFFFFF\t0\t0\t0',
+    'eth0\t00000000\t010200C0\t0003\t0\t0\t0\t00000000\t0\t0\t0',
+  ].join('\n');
+
+  it('reads the default route gateway, byte order and all', () => {
+    // 010200C0 little-endian is C0.00.02.01, and picking the wrong end gives 1.2.0.192.
+    // 192.0.2.2 would mean a non-default route was taken for the default one.
+    expect(parseDefaultGateway(table)).toBe('192.0.2.1');
+  });
+
+  it('returns null when there is no default route or the table is unusable', () => {
+    const noDefault = table.split('\n').filter((l) => !l.includes('\t00000000\t010200C0')).join('\n');
+    expect(parseDefaultGateway(noDefault)).toBeNull();
+    expect(parseDefaultGateway('')).toBeNull();
+    expect(parseDefaultGateway('Iface\tDestination\neth0\t00000000\tnothex')).toBeNull();
+    // A default route with a zero gateway is a direct link, not a next hop to trust.
+    expect(
+      parseDefaultGateway('Iface\tDestination\tGateway\neth0\t00000000\t00000000\t0003')
+    ).toBeNull();
+  });
+
+  it('trusts loopback plus the detected gateway, and nothing else', () => {
+    const trusted = defaultTrustedProxies().split(',');
+    expect(trusted).toContain('127.0.0.0/8');
+    expect(trusted).toContain('::1');
+    // The gateway matters because the API is published through a container port: the peer for
+    // a proxied request is the bridge address, never loopback. Dropping it would refuse every
+    // proxied call the moment the allowlist is switched on.
+    const gateway = defaultGatewayAddress();
+    if (gateway) {
+      expect(trusted).toContain(gateway);
+      expect(trusted).toHaveLength(3);
+    } else {
+      expect(trusted).toHaveLength(2);
+    }
   });
 });

--- a/apps/self-hosted/hosting/api/src/middleware/source-allowlist.ts
+++ b/apps/self-hosted/hosting/api/src/middleware/source-allowlist.ts
@@ -1,0 +1,249 @@
+/**
+ * Source-address allowlist for the service-to-service routes.
+ *
+ * The edge nginx already restricts /v1/internal to the callers that use it, but nginx is not
+ * the only way into the container: anything with access to the published port or the compose
+ * network reaches Hono directly and never passes that check. This is the same restriction
+ * expressed one layer in, so a bypass of the edge still has to come from an allowed address.
+ *
+ * OPT-IN BY DESIGN. An unset or empty allowlist allows every request. There is no staging
+ * tier for this service -- a merge deploys straight to the host serving live blogs -- so a
+ * default-deny would switch card activation off at merge time for every deployment,
+ * including self-hosters who have no allowlist to set. The operator turns it on afterwards
+ * by setting the variable on the host.
+ */
+
+import type { Context, Next } from 'hono';
+
+/** A parsed allowlist entry: a network address plus how many leading bits must match. */
+interface CidrRule {
+  bytes: Uint8Array;
+  prefix: number;
+}
+
+export interface SourceAllowlist {
+  /** Rules that parsed. Empty means "not enforcing". */
+  rules: CidrRule[];
+  /** Entries that did not parse, kept verbatim so a typo is visible in the startup log. */
+  invalid: string[];
+  /** True when the variable held at least one usable rule. */
+  enforcing: boolean;
+}
+
+function parseIpv4(value: string): Uint8Array | null {
+  const parts = value.split('.');
+  if (parts.length !== 4) return null;
+  const out = new Uint8Array(4);
+  for (let i = 0; i < 4; i++) {
+    const part = parts[i];
+    // Leading zeros are rejected rather than normalized: "010" is decimal 10 here and octal 8
+    // to some resolvers, and an allowlist that disagrees with the peer about what an entry
+    // means is worse than one that refuses it.
+    if (!/^(0|[1-9]\d{0,2})$/.test(part)) return null;
+    const n = Number(part);
+    if (n > 255) return null;
+    out[i] = n;
+  }
+  return out;
+}
+
+function parseIpv6(value: string): Uint8Array | null {
+  if (!value.includes(':')) return null;
+  const halves = value.split('::');
+  if (halves.length > 2) return null;
+
+  const readGroups = (part: string, out: number[]): boolean => {
+    if (part === '') return true;
+    const groups = part.split(':');
+    for (let i = 0; i < groups.length; i++) {
+      const group = groups[i];
+      if (group.includes('.')) {
+        // A dotted tail is only legal as the final 32 bits (e.g. ::ffff:203.0.113.1).
+        if (i !== groups.length - 1) return false;
+        const v4 = parseIpv4(group);
+        if (!v4) return false;
+        out.push((v4[0] << 8) | v4[1], (v4[2] << 8) | v4[3]);
+        continue;
+      }
+      if (!/^[0-9a-fA-F]{1,4}$/.test(group)) return false;
+      out.push(parseInt(group, 16));
+    }
+    return true;
+  };
+
+  const head: number[] = [];
+  const tail: number[] = [];
+  if (!readGroups(halves[0], head)) return null;
+  if (halves.length === 2 && !readGroups(halves[1], tail)) return null;
+
+  let groups: number[];
+  if (halves.length === 1) {
+    if (head.length !== 8) return null;
+    groups = head;
+  } else {
+    // "::" stands for at least one all-zero group, so the explicit ones can never fill 8.
+    if (head.length + tail.length > 7) return null;
+    groups = [...head, ...new Array(8 - head.length - tail.length).fill(0), ...tail];
+  }
+
+  const out = new Uint8Array(16);
+  for (let i = 0; i < 8; i++) {
+    out[i * 2] = (groups[i] >> 8) & 0xff;
+    out[i * 2 + 1] = groups[i] & 0xff;
+  }
+  return out;
+}
+
+/** Bytes for a bare address, or null when it is not an address at all. */
+function parseAddress(value: string): Uint8Array | null {
+  return value.includes(':') ? parseIpv6(value) : parseIpv4(value);
+}
+
+/**
+ * IPv4-mapped IPv6 (::ffff:a.b.c.d) is the same host as a.b.c.d, and which of the two forms
+ * shows up depends on the socket the request arrived on. Collapse it so an IPv4 rule matches
+ * a mapped peer and vice versa.
+ */
+function collapseMapped(rule: CidrRule): CidrRule {
+  const { bytes, prefix } = rule;
+  if (bytes.length !== 16 || prefix < 96) return rule;
+  for (let i = 0; i < 10; i++) {
+    if (bytes[i] !== 0) return rule;
+  }
+  if (bytes[10] !== 0xff || bytes[11] !== 0xff) return rule;
+  return { bytes: bytes.slice(12), prefix: prefix - 96 };
+}
+
+/** Parse one entry: a bare address or CIDR notation. Null when it is unusable. */
+function parseRule(entry: string): CidrRule | null {
+  // Bracketed IPv6 ("[::1]" / "[::1]/128") is what a URL-shaped value looks like; accept it.
+  const unbracketed = entry.replace(/^\[([^\]]+)\](.*)$/, '$1$2');
+  const slash = unbracketed.lastIndexOf('/');
+  const addressPart = slash === -1 ? unbracketed : unbracketed.slice(0, slash);
+  const prefixPart = slash === -1 ? null : unbracketed.slice(slash + 1);
+
+  const bytes = parseAddress(addressPart);
+  if (!bytes) return null;
+
+  const maxPrefix = bytes.length * 8;
+  let prefix = maxPrefix;
+  if (prefixPart !== null) {
+    if (!/^\d{1,3}$/.test(prefixPart)) return null;
+    prefix = Number(prefixPart);
+    if (prefix > maxPrefix) return null;
+  }
+  return collapseMapped({ bytes, prefix });
+}
+
+/** Split the configured value into rules, keeping unusable entries for the log. */
+export function parseAllowlist(raw: string | undefined | null): SourceAllowlist {
+  const rules: CidrRule[] = [];
+  const invalid: string[] = [];
+  for (const entry of (raw ?? '').split(',')) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    const rule = parseRule(trimmed);
+    if (rule) rules.push(rule);
+    else invalid.push(trimmed);
+  }
+  return { rules, invalid, enforcing: rules.length > 0 };
+}
+
+function matchesRule(address: Uint8Array, rule: CidrRule): boolean {
+  if (address.length !== rule.bytes.length) return false;
+  let remaining = rule.prefix;
+  for (let i = 0; i < address.length && remaining > 0; i++) {
+    const take = remaining >= 8 ? 8 : remaining;
+    const mask = take === 8 ? 0xff : (0xff << (8 - take)) & 0xff;
+    if ((address[i] & mask) !== (rule.bytes[i] & mask)) return false;
+    remaining -= take;
+  }
+  return true;
+}
+
+/** True when `ip` (a bare address string) falls inside any rule. */
+export function isAllowedAddress(ip: string | null | undefined, list: SourceAllowlist): boolean {
+  if (!list.enforcing) return true;
+  if (!ip) return false;
+  // Strip a zone id ("fe80::1%eth0") and any brackets before parsing.
+  const cleaned = ip.trim().replace(/^\[([^\]]+)\]$/, '$1').split('%')[0];
+  const parsed = parseAddress(cleaned);
+  if (!parsed) return false;
+  const address = collapseMapped({ bytes: parsed, prefix: parsed.length * 8 }).bytes;
+  return list.rules.some((rule) => matchesRule(address, rule));
+}
+
+/**
+ * The peer address as the fronting nginx saw it.
+ *
+ * X-Real-IP, NOT X-Forwarded-For. The vhost sets `X-Real-IP $remote_addr`, which REPLACES
+ * whatever the client sent, so its value is never client-supplied. X-Forwarded-For is built
+ * with `$proxy_add_x_forwarded_for`, which APPENDS the peer to the client's own header: a
+ * caller can put any address it likes in there, and only the last element is trustworthy --
+ * a position that silently shifts the moment another proxy is inserted in front. Keying an
+ * authorization decision on that is a bug waiting for a topology change; the rate limiter can
+ * live with it because the worst case there is a wrong bucket, not a granted request.
+ *
+ * The value is handed to the parser as-is. A comma-joined header (which nginx here never
+ * produces) is not an address and simply fails to parse, so it is refused rather than split
+ * on a guess about which element is the real one.
+ */
+function proxyClientIp(c: Context): string | null {
+  return c.req.header('x-real-ip')?.trim() || null;
+}
+
+export interface SourceAllowlistOptions {
+  /** Label used in logs, e.g. 'internal'. */
+  name: string;
+  /** Raw comma-separated value from the environment. Empty/unset means allow everything. */
+  value: string | undefined;
+}
+
+/**
+ * Middleware factory. The allowlist is parsed once, at construction, so a malformed entry is
+ * reported at boot rather than once per request.
+ */
+export function sourceAllowlist(options: SourceAllowlistOptions) {
+  const { name, value } = options;
+  const list = parseAllowlist(value);
+
+  // Say at boot which of the three states this is in. "Off" and "on" both look like a working
+  // service right up until the day a call is refused, and a typo has to be visible before it
+  // is the explanation for something else.
+  if (list.invalid.length > 0) {
+    console.error(
+      `[SourceAllowlist] ${name}: ignoring unparseable entries: ${list.invalid.join(', ')}`
+    );
+  }
+  if (list.enforcing) {
+    // Count only. The addresses are already in the environment; no reason to repeat them.
+    console.log(`[SourceAllowlist] ${name}: enforcing (${list.rules.length} rule(s))`);
+  } else if ((value ?? '').trim().length > 0) {
+    // Configured, but nothing in it survived parsing. Enforcing an empty list would deny every
+    // caller, so a typo would take card activation down; the edge allowlist is the primary gate
+    // and still holds. Loud, and not enforcing.
+    console.error(
+      `[SourceAllowlist] ${name}: no usable entries; NOT enforcing (fix the value to enable it)`
+    );
+  } else {
+    console.log(`[SourceAllowlist] ${name}: not configured; every source accepted`);
+  }
+
+  return async function sourceAllowlistMiddleware(c: Context, next: Next) {
+    if (!list.enforcing) return next();
+
+    const ip = proxyClientIp(c);
+    if (!isAllowedAddress(ip, list)) {
+      // Enough to diagnose (which gate, which address, whether the header was even present)
+      // without echoing the allowlist back into the response.
+      console.warn(
+        `[SourceAllowlist] ${name}: refused ${ip ?? '<no trusted client address>'} for ${c.req.path}`
+      );
+      // Deliberately identical to the shared-secret refusal, so a prober cannot tell which
+      // gate stopped it or learn anything about the allowlist from the body.
+      return c.json({ error: 'forbidden' }, 403);
+    }
+
+    await next();
+  };
+}

--- a/apps/self-hosted/hosting/api/src/middleware/source-allowlist.ts
+++ b/apps/self-hosted/hosting/api/src/middleware/source-allowlist.ts
@@ -11,9 +11,29 @@
  * default-deny would switch card activation off at merge time for every deployment,
  * including self-hosters who have no allowlist to set. The operator turns it on afterwards
  * by setting the variable on the host.
+ *
+ * WHERE THE CLIENT ADDRESS COMES FROM. The socket peer first, `X-Real-IP` only when that peer
+ * is a proxy we trust. Headers are only as good as whoever last wrote them: the vhost sets
+ * `X-Real-IP $remote_addr`, which replaces what the client sent, but that is a statement about
+ * requests that went through the vhost. The requests this middleware exists for are the ones
+ * that did not, and for those the caller writes every header itself, so believing X-Real-IP
+ * unconditionally would hand any direct caller an allowlisted identity for free. Reading the
+ * peer first and consulting the header only behind it keeps the header's guarantee tied to
+ * the thing that actually provides it.
+ *
+ * What this can and cannot reach, given how the API is published (loopback-only port, plus
+ * the compose network):
+ *  - another container on the compose network is a distinct peer address and is checked as
+ *    itself, which is the case this defends;
+ *  - a process on the host itself is indistinguishable from the proxy, because both arrive
+ *    through the same published port. Nothing at this layer can separate them; the shared
+ *    secret is what stands behind it there, and a process on that host can read the secret
+ *    out of the environment anyway.
  */
 
 import type { Context, Next } from 'hono';
+import { readFileSync } from 'node:fs';
+import { getConnInfo } from '@hono/node-server/conninfo';
 
 /** A parsed allowlist entry: a network address plus how many leading bits must match. */
 interface CidrRule {
@@ -161,35 +181,94 @@ function matchesRule(address: Uint8Array, rule: CidrRule): boolean {
   return true;
 }
 
-/** True when `ip` (a bare address string) falls inside any rule. */
-export function isAllowedAddress(ip: string | null | undefined, list: SourceAllowlist): boolean {
-  if (!list.enforcing) return true;
+/**
+ * Strict membership: does `ip` fall inside any of these rules. An EMPTY rule set matches
+ * nothing. Separate from isAllowedAddress below, which deliberately answers "yes" for a list
+ * that is not enforcing -- convenient for the allowlist, catastrophic for the trusted-proxy
+ * set, where "no rules" must mean "trust no peer" and not "trust every peer".
+ */
+function addressInRules(ip: string | null | undefined, rules: CidrRule[]): boolean {
   if (!ip) return false;
   // Strip a zone id ("fe80::1%eth0") and any brackets before parsing.
   const cleaned = ip.trim().replace(/^\[([^\]]+)\]$/, '$1').split('%')[0];
   const parsed = parseAddress(cleaned);
   if (!parsed) return false;
   const address = collapseMapped({ bytes: parsed, prefix: parsed.length * 8 }).bytes;
-  return list.rules.some((rule) => matchesRule(address, rule));
+  return rules.some((rule) => matchesRule(address, rule));
+}
+
+/** True when `ip` falls inside any rule, or when the list is not enforcing at all. */
+export function isAllowedAddress(ip: string | null | undefined, list: SourceAllowlist): boolean {
+  if (!list.enforcing) return true;
+  return addressInRules(ip, list.rules);
 }
 
 /**
- * The peer address as the fronting nginx saw it.
+ * The socket peer, via the Node adapter's ConnInfo helper. This API runs on Node
+ * (`node:24-alpine` running `tsx src/index.ts`, served by `@hono/node-server`), so this is the
+ * matching accessor; it reads `remoteAddress` off the underlying `IncomingMessage` socket.
  *
- * X-Real-IP, NOT X-Forwarded-For. The vhost sets `X-Real-IP $remote_addr`, which REPLACES
- * whatever the client sent, so its value is never client-supplied. X-Forwarded-For is built
- * with `$proxy_add_x_forwarded_for`, which APPENDS the peer to the client's own header: a
- * caller can put any address it likes in there, and only the last element is trustworthy --
- * a position that silently shifts the moment another proxy is inserted in front. Keying an
- * authorization decision on that is a bug waiting for a topology change; the rate limiter can
- * live with it because the worst case there is a wrong bucket, not a granted request.
- *
- * The value is handed to the parser as-is. A comma-joined header (which nginx here never
- * produces) is not an address and simply fails to parse, so it is refused rather than split
- * on a guess about which element is the real one.
+ * It throws rather than returning undefined when the request did not come from that adapter,
+ * so it is guarded: an unknown peer is treated as untrusted, which refuses while enforcing.
  */
-function proxyClientIp(c: Context): string | null {
-  return c.req.header('x-real-ip')?.trim() || null;
+function peerAddress(c: Context): string | null {
+  try {
+    return getConnInfo(c).remote.address?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The container's default gateway, read from the routing table.
+ *
+ * This is what makes "the request came in through the host" checkable. The API publishes to a
+ * loopback port on the host and Docker forwards that to the container, so the peer the
+ * container observes for a proxied request is NOT loopback: it is the bridge address, which is
+ * also the container's default gateway. Verified on the deployed host, where a request to the
+ * published port arrives from the bridge address while a sibling container on the same compose
+ * network arrives as its own distinct address.
+ *
+ * Detected rather than configured, because it differs per deployment (bridge subnets are
+ * assigned by Docker) and a wrong value would refuse every proxied call. A deployment where
+ * the API is not containerised has nginx talking to loopback directly, which is covered by the
+ * loopback rules alongside this.
+ *
+ * Split from the file read so the format handling is testable against a literal table.
+ */
+export function parseDefaultGateway(routeTable: string): string | null {
+  for (const line of routeTable.split('\n').slice(1)) {
+    const fields = line.trim().split(/\s+/);
+    // Destination 00000000 is the default route; field 2 is its gateway.
+    if (fields.length < 3 || fields[1] !== '00000000') continue;
+    const hex = fields[2];
+    if (!/^[0-9A-Fa-f]{8}$/.test(hex)) continue;
+    // Stored little-endian, so the four bytes read backwards.
+    const bytes = [0, 2, 4, 6].map((i) => parseInt(hex.slice(i, i + 2), 16)).reverse();
+    if (bytes.every((b) => b === 0)) continue;
+    return bytes.join('.');
+  }
+  return null;
+}
+
+/** The default gateway of the machine this process runs on, or null if it cannot be read. */
+export function defaultGatewayAddress(): string | null {
+  try {
+    return parseDefaultGateway(readFileSync('/proc/net/route', 'utf8'));
+  } catch {
+    // No /proc (non-Linux, or a locked-down filesystem). Loopback alone still applies.
+    return null;
+  }
+}
+
+/**
+ * Peers whose X-Real-IP is believed: loopback, plus the default gateway when there is one.
+ * Loopback covers an uncontainerised deployment; the gateway covers this one. Neither is an
+ * address a sibling container can present, since each of those has its own bridge address.
+ */
+export function defaultTrustedProxies(): string {
+  const gateway = defaultGatewayAddress();
+  return ['127.0.0.0/8', '::1', ...(gateway ? [gateway] : [])].join(',');
 }
 
 export interface SourceAllowlistOptions {
@@ -197,6 +276,13 @@ export interface SourceAllowlistOptions {
   name: string;
   /** Raw comma-separated value from the environment. Empty/unset means allow everything. */
   value: string | undefined;
+  /**
+   * Peers whose X-Real-IP is trusted, same syntax as `value`. Defaults to loopback plus the
+   * detected default gateway. A parameter rather than another environment variable: the
+   * default is derived from the machine it runs on, and an operator-supplied version of it is
+   * one more value to get wrong at 2am for no gain. Tests set it explicitly.
+   */
+  trustedProxies?: string;
 }
 
 /**
@@ -206,6 +292,10 @@ export interface SourceAllowlistOptions {
 export function sourceAllowlist(options: SourceAllowlistOptions) {
   const { name, value } = options;
   const list = parseAllowlist(value);
+  // Only needed while enforcing, and detecting it costs a file read, so skip it otherwise.
+  const trusted = list.enforcing
+    ? parseAllowlist(options.trustedProxies ?? defaultTrustedProxies())
+    : parseAllowlist('');
 
   // Say at boot which of the three states this is in. "Off" and "on" both look like a working
   // service right up until the day a call is refused, and a typo has to be visible before it
@@ -216,8 +306,13 @@ export function sourceAllowlist(options: SourceAllowlistOptions) {
     );
   }
   if (list.enforcing) {
-    // Count only. The addresses are already in the environment; no reason to repeat them.
-    console.log(`[SourceAllowlist] ${name}: enforcing (${list.rules.length} rule(s))`);
+    // Counts only. The addresses are already in the environment; no reason to repeat them.
+    // The trusted-proxy count is here because a zero would mean every request is judged by its
+    // peer and no X-Real-IP is ever read, which explains an otherwise baffling wall of 403s.
+    console.log(
+      `[SourceAllowlist] ${name}: enforcing (${list.rules.length} rule(s),` +
+        ` ${trusted.rules.length} trusted proxy rule(s))`
+    );
   } else if ((value ?? '').trim().length > 0) {
     // Configured, but nothing in it survived parsing. Enforcing an empty list would deny every
     // caller, so a typo would take card activation down; the edge allowlist is the primary gate
@@ -232,12 +327,22 @@ export function sourceAllowlist(options: SourceAllowlistOptions) {
   return async function sourceAllowlistMiddleware(c: Context, next: Next) {
     if (!list.enforcing) return next();
 
-    const ip = proxyClientIp(c);
-    if (!isAllowedAddress(ip, list)) {
-      // Enough to diagnose (which gate, which address, whether the header was even present)
-      // without echoing the allowlist back into the response.
+    const peer = peerAddress(c);
+    // Behind a proxy we trust, the caller's identity is the header that proxy wrote, and ONLY
+    // that: no falling back to the peer if it is missing or malformed, because the peer there
+    // is the proxy itself and falling back would admit anything that can open a connection to
+    // the port. Everywhere else the peer IS the caller and the header is just something the
+    // caller typed, so it is ignored outright.
+    const viaTrustedProxy = addressInRules(peer, trusted.rules);
+    const claimed = viaTrustedProxy ? c.req.header('x-real-ip')?.trim() || null : peer;
+
+    if (!isAllowedAddress(claimed, list)) {
+      // Enough to diagnose: which gate, the address judged, and whether it came from the peer
+      // or from a proxy's header, which is the difference between "add this to the allowlist"
+      // and "this did not come through the proxy at all". The allowlist is never echoed back.
       console.warn(
-        `[SourceAllowlist] ${name}: refused ${ip ?? '<no trusted client address>'} for ${c.req.path}`
+        `[SourceAllowlist] ${name}: refused ${claimed ?? '<none>'} for ${c.req.path}` +
+          ` (peer ${peer ?? '<unknown>'}, ${viaTrustedProxy ? 'via trusted proxy' : 'direct'})`
       );
       // Deliberately identical to the shared-secret refusal, so a prober cannot tell which
       // gate stopped it or learn anything about the allowlist from the body.

--- a/apps/self-hosted/hosting/docker-compose.yml
+++ b/apps/self-hosted/hosting/docker-compose.yml
@@ -50,9 +50,10 @@ services:
       # ePoints calls the internal activation endpoint with this shared secret; empty = card
       # activation disabled (endpoint fails closed).
       - HOSTING_INTERNAL_SECRET=${HOSTING_INTERNAL_SECRET:-}
-      # Comma-separated addresses/CIDRs allowed to reach /v1/internal, checked against the
-      # X-Real-IP the fronting proxy sets. Empty (the default) allows every source, so this
-      # is inert until an operator sets it; the edge nginx does the same check in front.
+      # Comma-separated addresses/CIDRs allowed to reach /v1/internal. Matched against
+      # X-Real-IP for requests arriving from a trusted proxy, and against the connection's own
+      # address otherwise. Empty (the default) allows every source, so this is inert until an
+      # operator sets it; the edge nginx does the same check in front.
       - HOSTING_INTERNAL_ALLOWED_IPS=${HOSTING_INTERNAL_ALLOWED_IPS:-}
       - HOSTING_CARD_ENABLED=${HOSTING_CARD_ENABLED:-true}
       - HOSTING_CARD_USD_CENTS=${HOSTING_CARD_USD_CENTS:-200}

--- a/apps/self-hosted/hosting/docker-compose.yml
+++ b/apps/self-hosted/hosting/docker-compose.yml
@@ -50,6 +50,10 @@ services:
       # ePoints calls the internal activation endpoint with this shared secret; empty = card
       # activation disabled (endpoint fails closed).
       - HOSTING_INTERNAL_SECRET=${HOSTING_INTERNAL_SECRET:-}
+      # Comma-separated addresses/CIDRs allowed to reach /v1/internal, checked against the
+      # X-Real-IP the fronting proxy sets. Empty (the default) allows every source, so this
+      # is inert until an operator sets it; the edge nginx does the same check in front.
+      - HOSTING_INTERNAL_ALLOWED_IPS=${HOSTING_INTERNAL_ALLOWED_IPS:-}
       - HOSTING_CARD_ENABLED=${HOSTING_CARD_ENABLED:-true}
       - HOSTING_CARD_USD_CENTS=${HOSTING_CARD_USD_CENTS:-200}
       # Days a lapsed subscription keeps its custom-domain capabilities after expiry.

--- a/apps/self-hosted/hosting/origin/README.md
+++ b/apps/self-hosted/hosting/origin/README.md
@@ -79,7 +79,7 @@ diagnostics.
 **Why the include path has a `*` in it.** nginx refuses to start on an `include` naming a
 file that does not exist:
 
-```
+```text
 nginx: [emerg] open() "/etc/nginx/hosting-internal-allow.conf" failed (2: No such file
 or directory) in /etc/nginx/sites-enabled/blogs.ecency.com.conf:67
 ```
@@ -101,8 +101,11 @@ Order matters: create the allowlist first, or the window between reloading nginx
 the file is a window where card activation and Pro blog claims return 403.
 
 ```bash
-# 1. Write the allowlist (root, 0644, world-readable so the nginx workers can read it)
-sudo install -m 0644 /dev/null /etc/nginx/hosting-internal-allow.conf
+# 1. Write the allowlist (root, 0644, world-readable so the nginx workers can read it).
+#    Created only when absent: installing over an existing file empties it, and the
+#    next reload would then refuse every internal caller. Safe to re-run.
+[ -e /etc/nginx/hosting-internal-allow.conf ] \
+  || sudo install -m 0644 /dev/null /etc/nginx/hosting-internal-allow.conf
 sudo nano /etc/nginx/hosting-internal-allow.conf      # allow ...;  one per line
 
 # 2. Back up the live vhost, then copy the new one in
@@ -133,12 +136,22 @@ Adding an address is a reload, not a rollback:
 sudo nano /etc/nginx/hosting-internal-allow.conf && sudo nginx -t && sudo systemctl reload nginx
 ```
 
-To drop the restriction entirely and go back to the previous behaviour:
+To drop the restriction entirely and go back to the previous behaviour, roll back **both**
+layers. Restoring the vhost alone leaves the container-side allowlist enforcing, so internal
+callers stay refused and the cause is no longer visible in the nginx config:
 
 ```bash
+# 1. The vhost
 sudo cp /etc/nginx/sites-available/blogs.ecency.com.conf.bak \
         /etc/nginx/sites-available/blogs.ecency.com.conf
 sudo nginx -t && sudo systemctl reload nginx
+
+# 2. The container-side allowlist, if it was ever set. Removing the line is not
+#    enough on its own: the running container keeps the environment it started
+#    with, so it has to be recreated.
+sudo sed -i '/^HOSTING_INTERNAL_ALLOWED_IPS=/d' ~/hosting/.env
+cd ~/hosting && docker compose up -d hosting-api
+docker logs ecency-hosting-api 2>&1 | grep SourceAllowlist   # expect "not configured"
 ```
 
 Do **not** roll back by deleting the allowlist file: the vhost still has `deny all`, so that
@@ -151,7 +164,18 @@ by a reload - it neutralises the check without editing the vhost.
 `HOSTING_INTERNAL_ALLOWED_IPS` in the hosting stack's `.env` is the same restriction enforced
 inside the API, for traffic that reaches the container without passing through here. It is
 unset by default and allows everything until it is set; it takes the same comma-separated
-addresses and CIDRs. Restart `hosting-api` after setting it.
+addresses and CIDRs.
+
+Apply it with `cd ~/hosting && docker compose up -d hosting-api`, which recreates the container
+because the resolved environment changed. `docker compose restart` is **not** enough: it restarts
+the existing container, which keeps the environment it was created with, so the new value is
+silently ignored and the allowlist appears not to work. Confirm with:
+
+```bash
+docker logs ecency-hosting-api 2>&1 | grep SourceAllowlist
+```
+
+which reports `enforcing (N rule(s), ...)` once it is live and `not configured` while it is not.
 
 Two differences from this file, both worth knowing before copying values across:
 

--- a/apps/self-hosted/hosting/origin/README.md
+++ b/apps/self-hosted/hosting/origin/README.md
@@ -16,6 +16,7 @@ in practice — **re-copy any change made there back into this directory.**
 | `blogs.ecency.com.conf` | `/etc/nginx/sites-available/` | TLS termination and proxying for the apex, the API, and tenant subdomains |
 | `sync-custom-domains.py` | cron, every 5 min | issues certificates and writes vhosts for custom domains and dotted tenant names |
 | `install.sh` | once, idempotent | nginx include dir, certbot deploy hook, cron entry |
+| `hosting-internal-allow.conf` | `/etc/nginx/` **only** (not in git) | who may reach `/v1/internal` |
 
 ## What the sync does
 
@@ -39,6 +40,120 @@ They are not committed because this repository is public and those addresses sit
 Cloudflare; publishing them would amount to handing out an origin-bypass list. The script
 exits with an explanatory error when the file is missing, rather than silently failing
 every DNS check and never issuing a certificate again.
+
+## hosting-internal-allow.conf (not in git)
+
+`/v1/internal` activates subscriptions, attaches custom domains and grants free Pro terms.
+It is service-to-service only, so the vhost restricts it to the services that call it:
+
+```nginx
+location /v1/internal/ {
+    include /etc/nginx/hosting-internal-allow*.conf;
+    deny all;
+    ...
+}
+```
+
+The list itself is not committed, for the same reason `origin-ips` is not: this repository is
+public and these are origin addresses.
+
+**What belongs in the file.** One `allow` directive per line, terminated with a semicolon,
+nothing else. Plain addresses and CIDR both work:
+
+```nginx
+# <who and why>
+allow 203.0.113.10;      # example only, not a real entry
+allow 198.51.100.0/24;   # example only, not a real entry
+```
+
+Everything not listed is refused by the `deny all` that follows the include. Who needs to be
+on it: every origin that runs the web app's `/api/hosting/*` server routes (one of them is
+co-located with this stack and arrives on the local docker bridge, so that is a range rather
+than a single address), and the ePoints host that posts card activations. Read them off the
+access log rather than guessing - `awk '$7 ~ /^\/v1\/internal/'` over `access.log*` gives the
+requests that have actually been made; take the peer column (the first field with the stock
+`combined` format, the third with the `realip` format this origin uses, since that one leads
+with `$http_cf_connecting_ip`). Adding 127.0.0.1 as well is convenient for on-box
+diagnostics.
+
+**Why the include path has a `*` in it.** nginx refuses to start on an `include` naming a
+file that does not exist:
+
+```
+nginx: [emerg] open() "/etc/nginx/hosting-internal-allow.conf" failed (2: No such file
+or directory) in /etc/nginx/sites-enabled/blogs.ecency.com.conf:67
+```
+
+That is a hard failure of the whole config, so a vhost with a plain include would take every
+tenant blog offline on any box where the file has not been created yet, including a rebuilt
+origin. A glob that matches nothing is skipped silently and the config still tests clean, so
+the worst case degrades to `deny all` on `/v1/internal` alone while everything else serves.
+Do not "tidy" the `*` away.
+
+**Both API prefixes are gated.** The vhost also exposes the API under `/hosting/`, which
+strips its prefix, so `/hosting/v1/internal/...` reaches the same handlers. There is a second
+location for that path with the same include. If you ever add another prefix that proxies to
+the hosting API, it needs the same treatment.
+
+### Applying it
+
+Order matters: create the allowlist first, or the window between reloading nginx and writing
+the file is a window where card activation and Pro blog claims return 403.
+
+```bash
+# 1. Write the allowlist (root, 0644, world-readable so the nginx workers can read it)
+sudo install -m 0644 /dev/null /etc/nginx/hosting-internal-allow.conf
+sudo nano /etc/nginx/hosting-internal-allow.conf      # allow ...;  one per line
+
+# 2. Back up the live vhost, then copy the new one in
+sudo cp /etc/nginx/sites-available/blogs.ecency.com.conf{,.bak}
+sudo cp blogs.ecency.com.conf /etc/nginx/sites-available/blogs.ecency.com.conf
+
+# 3. Test BEFORE reloading. A failed test here means nothing has changed yet.
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+Verify from a host that should be allowed and one that should not. A refused caller gets a
+bare nginx 403; an allowed one gets whatever the API says (405/404 for a GET on these
+POST-only routes is a pass - it means the request reached the container):
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' https://api.blogs.ecency.com/v1/internal/activate
+curl -s -o /dev/null -w '%{http_code}\n' https://api.blogs.ecency.com/hosting/v1/internal/activate
+```
+
+Refusals are logged as `access forbidden by rule` in `/var/log/nginx/error.log`, with the
+client address - that is where to look when a legitimate caller starts failing.
+
+### Rolling back
+
+Adding an address is a reload, not a rollback:
+
+```bash
+sudo nano /etc/nginx/hosting-internal-allow.conf && sudo nginx -t && sudo systemctl reload nginx
+```
+
+To drop the restriction entirely and go back to the previous behaviour:
+
+```bash
+sudo cp /etc/nginx/sites-available/blogs.ecency.com.conf.bak \
+        /etc/nginx/sites-available/blogs.ecency.com.conf
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+Do **not** roll back by deleting the allowlist file: the vhost still has `deny all`, so that
+refuses everyone rather than restoring service. If the backup is gone, the equivalent
+emergency fix is a temporary `allow all;` as the only line in the allowlist file, followed
+by a reload - it neutralises the check without editing the vhost.
+
+### The container-side allowlist is separate
+
+`HOSTING_INTERNAL_ALLOWED_IPS` in the hosting stack's `.env` is the same restriction enforced
+inside the API, for traffic that reaches the container without passing through here. It is
+unset by default and allows everything until it is set; it takes the same comma-separated
+addresses and CIDRs. Set it to the same list as this file and restart `hosting-api`. Because
+it reads `X-Real-IP`, which this vhost overwrites on every proxied request, it stays correct
+only as long as these locations keep setting that header.
 
 ## Two things in the vhost that are load-bearing
 

--- a/apps/self-hosted/hosting/origin/README.md
+++ b/apps/self-hosted/hosting/origin/README.md
@@ -151,9 +151,23 @@ by a reload - it neutralises the check without editing the vhost.
 `HOSTING_INTERNAL_ALLOWED_IPS` in the hosting stack's `.env` is the same restriction enforced
 inside the API, for traffic that reaches the container without passing through here. It is
 unset by default and allows everything until it is set; it takes the same comma-separated
-addresses and CIDRs. Set it to the same list as this file and restart `hosting-api`. Because
-it reads `X-Real-IP`, which this vhost overwrites on every proxied request, it stays correct
-only as long as these locations keep setting that header.
+addresses and CIDRs. Restart `hosting-api` after setting it.
+
+Two differences from this file, both worth knowing before copying values across:
+
+- **Give it the caller addresses, not `127.0.0.1`.** A request proxied from here arrives at the
+  container from the docker bridge, which the API recognises as a trusted proxy and therefore
+  judges on the `X-Real-IP` this vhost set, meaning the real caller. Loopback is never the
+  identity being matched, so an entry for it does nothing there. It stays useful *here*, where
+  it is what lets an on-box `curl --resolve api.blogs.ecency.com:443:127.0.0.1 ...` through.
+- **It cannot see a process on the origin itself.** Anything local can reach the API's
+  published port directly, and that is indistinguishable from this vhost doing the same. What
+  it does stop is a caller that is neither: another container on the compose network, which
+  arrives as its own address and is checked as itself. This vhost is the gate for everything
+  arriving over the network, and the shared secret is what stands behind both.
+
+Because the API believes `X-Real-IP` for proxied requests, it stays correct only as long as
+these locations keep setting that header.
 
 ## Two things in the vhost that are load-bearing
 

--- a/apps/self-hosted/hosting/origin/blogs.ecency.com.conf
+++ b/apps/self-hosted/hosting/origin/blogs.ecency.com.conf
@@ -49,6 +49,42 @@ server {
     ssl_certificate     /etc/letsencrypt/live/blogs.ecency.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/blogs.ecency.com/privkey.pem;
 
+    # Service-to-service routes: activate subscriptions, attach custom domains, grant free
+    # Pro terms. Not for the public, so only the services that call them may reach them.
+    #
+    # The allowlist itself lives in /etc/nginx/hosting-internal-allow.conf, NOT in git: this
+    # repository is public and those are origin addresses. The include path is a WILDCARD on
+    # purpose. nginx aborts with [emerg] "open() ... failed (2: No such file or directory)"
+    # on an include naming a file that does not exist, which would take every tenant blog
+    # down with it; a glob that matches nothing is simply skipped and the config still tests
+    # clean. With no allowlist file present, only `deny all` remains and this path 403s while
+    # everything else keeps serving. See origin/README.md for the file's contents.
+    #
+    # Both prefixes are gated. /hosting/ below strips its prefix, so /hosting/v1/internal/...
+    # reaches the same handlers; nginx picks the longest matching prefix location, so this
+    # block wins for those URIs and rewrites them back to /v1/internal/ for the container.
+    location /hosting/v1/internal/ {
+        include /etc/nginx/hosting-internal-allow*.conf;
+        deny all;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_pass http://127.0.0.1:3101/v1/internal/;
+    }
+
+    location /v1/internal/ {
+        include /etc/nginx/hosting-internal-allow*.conf;
+        deny all;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_pass http://127.0.0.1:3101;
+    }
+
     # Strip /hosting prefix for backward compat with apiBaseUrl default
     location /hosting/ {
         proxy_set_header Host $host;


### PR DESCRIPTION
Closes #1315.

`/v1/internal` activates subscriptions, attaches custom domains and grants free Pro terms. #1314 put a shared secret and a rate limit in front of it, but the route is still reachable from the public internet and the secret is the only hard gate. This adds a source restriction in two places.

## Edge nginx (`hosting/origin/blogs.ecency.com.conf`)

A `location /v1/internal/` block that includes an allowlist and denies everything else. The allowlist file lives on the host under `/etc/nginx/` and is **not** in this repository, because the entries are origin addresses and this repository is public.

The include path is a glob on purpose. nginx aborts with `[emerg] open() ... failed (2: No such file or directory)` on an include naming a file that does not exist, which would take every tenant blog offline on any box where the file has not been created yet, including a rebuilt origin. A glob that matches nothing is skipped silently, so the worst case degrades to `deny all` on `/v1/internal` alone. Verified both ways with `nginx -t` against this vhost.

The same gate is applied to `/hosting/v1/internal/`. The `/hosting/` location strips its own prefix and reaches the same handlers, so without a second block it was an open path to the routes this restricts; nginx picks the longest matching prefix, so the new block wins for those URIs and rewrites them back to `/v1/internal/` for the container.

`hosting/origin/` is not deployed by CI, so **this needs applying by hand** on the origin. `origin/README.md` documents what goes in the file, the order to apply it in (allowlist first, or there is a window of 403s), how to verify, and how to roll back.

## Application layer (`hosting/api/src/middleware/source-allowlist.ts`)

nginx is not on the path of anything that reaches the container directly, so the same check is enforced inside the API, configured by `HOSTING_INTERNAL_ALLOWED_IPS` (comma-separated, plain addresses and CIDR, IPv4 and IPv6).

**Unset or empty allows every source, so this is inert when it merges.** There is no staging tier here: a merge to `develop` deploys straight to the host serving live blogs, and a check that defaulted to deny would take card activation and Pro blog claims down at deploy time, for self-hosters too. It is switched on afterwards by setting the variable on the host and restarting `hosting-api`.

The client address comes from the **socket peer**, via the Node adapter's ConnInfo helper (`@hono/node-server/conninfo`; this API runs on `node:24-alpine` under `@hono/node-server`). `X-Real-IP` is consulted only when that peer is a trusted proxy.

Reading the header first was wrong, and the first revision of this PR did it. The vhost does overwrite `X-Real-IP`, but that is a guarantee about requests that went through the vhost, and the requests this layer exists for are the ones that did not: a caller reaching the published port or the compose network directly writes every header itself and could simply name an allowlisted address. So the peer is checked first, and:

- peer **is** a trusted proxy: the identity is that proxy's `X-Real-IP`, and only that. A missing or unparseable header refuses rather than falling back to the peer, since the peer there is the proxy and a fallback would admit anything able to open a connection to the port.
- peer is **not** a trusted proxy: the header is ignored entirely and the peer itself is matched.

`X-Forwarded-For` is never consulted either way: it is built with `$proxy_add_x_forwarded_for`, which appends the peer to whatever the caller sent, so entries in it are caller-controlled.

Trusted proxies are loopback plus the container's own default gateway, read from the routing table at startup. This is detected rather than configured because the API is published on a loopback port and forwarded into the container, so the peer for a proxied request is the bridge address and not loopback, and that address is assigned per deployment. Verified against the deployment: a request through the published port arrives from the bridge address, while a sibling container on the same compose network arrives as its own distinct address and is therefore judged as itself, which is the case this defends. A process on the host is indistinguishable from the proxy, always was, and the shared secret is what stands behind that case.

Refusals log the address judged, the peer, and which of the two it came from, and answer with the same generic `{"error":"forbidden"}` 403 the shared-secret check returns, so a prober cannot tell which gate stopped it. Entries that do not parse are logged and skipped; a value where nothing parses is reported loudly and does not enforce, rather than turning a typo into a full outage behind a gate nginx is already holding.

Wired through `docker-compose.yml` and `.env.example` with `${HOSTING_INTERNAL_ALLOWED_IPS:-}`, so an unset value arrives empty rather than as a literal string.

## Tests

32 tests in `source-allowlist.test.ts`, including the properties that matter most: an unset variable allows the request; a forged `X-Real-IP` from a non-proxy peer is refused; a genuine proxied request with a listed `X-Real-IP` is allowed; a proxied request with no `X-Real-IP` is refused rather than falling back to the peer (the proxy address used in that test is deliberately inside the allowlisted range, so a fallback would pass); and a forged `X-Forwarded-For` never helps. Suite is 275 passing (was 243). Every test was mutation-verified. On the peer logic: trusting every peer (the bug above), falling back to the peer when the header is absent, using the non-strict membership check so an empty trusted set trusts everyone, dropping the detected gateway and trusting loopback only, substituting loopback for a missing peer address, reading the gateway bytes in the wrong order, and ignoring the Destination column when reading the routing table. On the matching logic: dropping the unset-allows-everything guard, ignoring partial prefix bits in the mask, dropping the address-family check, disclosing the allowlist in the 403 body, dropping the address from the refusal log, not collapsing IPv4-mapped IPv6, accepting leading-zero octets, enforcing an allowlist where nothing parsed, and reversing the IPv6 `::` expansion. Each failed for its stated reason and was restored. Two mutants initially survived and the tests were strengthened until they did not, rather than being left as passing coverage.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional IP-based access controls for internal hosting API routes.
  * Supports IPv4, IPv6, CIDR ranges, trusted proxies, and forwarded client addresses.
  * Requests outside the configured allowlist are denied.
  * Added nginx-based allowlist protection for internal hosting endpoints.

* **Documentation**
  * Documented configuration, address formats, proxy behavior, verification, and rollback procedures.
  * Added the new allowlist setting to self-hosted deployment examples.
  * Unconfigured or empty allowlists continue permitting all sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->