### PR TITLE
ci(self-hosted): run tests and the app build on pull requests

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -11,6 +11,13 @@ on:
       - 'packages/render-helper/**'
       - 'packages/wallets/**'
       - 'packages/ui/**'
+      # Root dependency inputs: the Dockerfile copies all of these before
+      # installing, so a lockfile bump, an override or a patch can change the
+      # emitted chunks without any file above being touched.
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - 'patches/**'
   # Tests and the app build also run on pull requests. Without this the first
   # time anything is compiled is the deploy, which serves live blogs: a bundle
   # that threw at load reached production that way and blanked every instance.
@@ -26,6 +33,13 @@ on:
       - 'packages/render-helper/**'
       - 'packages/wallets/**'
       - 'packages/ui/**'
+      # Root dependency inputs: the Dockerfile copies all of these before
+      # installing, so a lockfile bump, an override or a patch can change the
+      # emitted chunks without any file above being touched.
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - 'patches/**'
       # Deliberately only on this side. A change to this file should prove itself
       # on its own pull request, but merging one should not redeploy an app whose
       # code did not change, and develop deploys with no staging tier in between.
@@ -78,6 +92,23 @@ jobs:
       # load used to reach production uncompiled. This is also what runs
       # scripts/check-node-globals.mjs, which fails on a Node global that
       # Rsbuild does not provide.
+      #
+      # The shared packages are built first, in the same order as
+      # apps/self-hosted/Dockerfile. They resolve through their committed dist
+      # (and rsbuild.config.ts aliases @ecency/ui straight at it), so skipping
+      # this bundles whatever dist happens to be checked in and tests a
+      # different artifact than the image ships. A regression introduced in a
+      # package's source would then pass here and still reach production, which
+      # is how the last one arrived: it came from render-helper.
+      - name: Build shared packages
+        run: |
+          pnpm --filter @ecency/sdk build
+          pnpm --filter @ecency/render-helper build
+          pnpm --filter @ecency/ui build
+          pnpm --filter @ecency/wallets build
+        env:
+          CI: true
+
       - name: Build the self-hosted app
         run: |
           # Mirrors the Dockerfile: config.json is gitignored, so fall back to

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -26,6 +26,10 @@ on:
       - 'packages/render-helper/**'
       - 'packages/wallets/**'
       - 'packages/ui/**'
+      # Deliberately only on this side. A change to this file should prove itself
+      # on its own pull request, but merging one should not redeploy an app whose
+      # code did not change, and develop deploys with no staging tier in between.
+      - '.github/workflows/self-hosted.yml'
 
 # Default to read-only GITHUB_TOKEN. Build pushes to Docker Hub (external);
 # deploy jobs SCP/SSH to servers — neither path needs GitHub write access.

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -11,6 +11,21 @@ on:
       - 'packages/render-helper/**'
       - 'packages/wallets/**'
       - 'packages/ui/**'
+  # Tests and the app build also run on pull requests. Without this the first
+  # time anything is compiled is the deploy, which serves live blogs: a bundle
+  # that threw at load reached production that way and blanked every instance.
+  # The image build and the deploy stay push-only, so a pull request needs no
+  # secrets and can neither publish an image nor touch a server.
+  pull_request:
+    branches:
+      - develop
+      - main
+    paths:
+      - 'apps/self-hosted/**'
+      - 'packages/sdk/**'
+      - 'packages/render-helper/**'
+      - 'packages/wallets/**'
+      - 'packages/ui/**'
 
 # Default to read-only GITHUB_TOKEN. Build pushes to Docker Hub (external);
 # deploy jobs SCP/SSH to servers — neither path needs GitHub write access.
@@ -55,6 +70,20 @@ jobs:
       - name: Run hosting API tests
         run: cd apps/self-hosted/hosting/api && npm install && npm test
 
+      # The unit tests never compile the app, so a bundle that only fails at
+      # load used to reach production uncompiled. This is also what runs
+      # scripts/check-node-globals.mjs, which fails on a Node global that
+      # Rsbuild does not provide.
+      - name: Build the self-hosted app
+        run: |
+          # Mirrors the Dockerfile: config.json is gitignored, so fall back to
+          # the template exactly as the image build does.
+          [ -f apps/self-hosted/config.json ] \
+            || cp apps/self-hosted/config.template.json apps/self-hosted/config.json
+          pnpm --filter @ecency/self-hosted build
+        env:
+          CI: true
+
   build-blog:
     # Its own group: build-blog and build-api run in parallel and would otherwise cancel
     # each other.
@@ -62,6 +91,9 @@ jobs:
       group: ${{ github.workflow }}-build-blog-${{ github.ref }}
       cancel-in-progress: true
     needs: tests
+    # Publishes to Docker Hub, so it needs secrets a fork pull request cannot have
+    # and produces an artifact a pull request has no use for.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,6 +131,8 @@ jobs:
       group: ${{ github.workflow }}-build-api-${{ github.ref }}
       cancel-in-progress: true
     needs: tests
+    # Push-only, for the same reasons as build-blog.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The workflow ran only on push to `develop` and `main`, and `develop` deploys straight to the host serving live blogs. So the first time anything was compiled or tested was during the deploy itself.

That is exactly how #1331 happened. A dependency pulled Node`'`s `assert` polyfill into the bundle, the chunk threw `ReferenceError: process is not defined` at load, and every hosted blog went blank. The failure was in the build output, nothing built it before the deploy, and the unit tests never compile the app.

## What changes

Pull requests now run the `tests` job, and that job gains a build step.

The build is the part that matters. It is what runs `scripts/check-node-globals.mjs` against the emitted chunks, which is the check added in #1331 that fails on a Node global Rsbuild does not provide. Unit tests alone would not have caught that bug and still would not.

It mirrors the Dockerfile`'`s handling of `config.json`, which is gitignored, so it works on a fresh checkout:

```bash
[ -f apps/self-hosted/config.json ] \
  || cp apps/self-hosted/config.template.json apps/self-hosted/config.json
pnpm --filter @ecency/self-hosted build
```

Verified by deleting `config.json` and running exactly that from a clean worktree: the build succeeds and reports `[node-globals] 3 chunk(s) clean`.

## What deliberately does not change

`build-blog`, `build-api` and `deploy-staging` stay push-only.

The image builds publish to Docker Hub and need secrets a fork pull request cannot have, and produce an artifact a pull request has no use for, so both are gated on `github.event_name == 'push'`. The deploy was already gated on the branch ref, and is now additionally unreachable on a pull request because it depends on jobs that do not run. A pull request therefore needs no secrets, cannot publish an image and cannot reach a server.

## Note

The path filters are written out twice rather than shared through a YAML anchor. GitHub Actions does not support anchors, and an anchor here would break the whole workflow rather than fail loudly. The two lists must be kept in step.

The path filter now also covers this workflow file, but only on the `pull_request` side, so this PR tests its own change. It is asymmetric on purpose: a workflow edit should prove itself on its own pull request, while merging one should not redeploy an app whose code did not change, and `develop` deploys with no staging tier in between. That is the one intended difference between the two path lists.
