### PR TITLE
chore: align the workspace-root eslint with the packages' flat configs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,3 +34,12 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Lint
         run: pnpm -r lint
+      # `pnpm -r lint` runs each package's own eslint binary, so a workspace-root
+      # eslint on a major that cannot read the packages' flat configs stays
+      # invisible here while breaking every root-resolved invocation - `npx eslint`
+      # inside a package and editor ESLint servers both resolve to the workspace
+      # root, because the root package.json declares `workspaces`. That skew is
+      # what #1335 hit. Run one flat-config package through the root-resolved
+      # binary so the next skew fails here instead of at a desk.
+      - name: Root-resolved eslint reads the packages' flat configs
+        run: cd packages/sdk && "$GITHUB_WORKSPACE/node_modules/.bin/eslint" .

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.8",
     "@types/node": "^22",
-    "eslint": "^8",
+    "eslint": "^9.21.0",
     "sass-embedded": "^1.93.2",
     "tsup": "^8.5.0",
     "typescript": "^5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^22
         version: 22.18.8
       eslint:
-        specifier: ^8
-        version: 8.57.1
+        specifier: ^9.21.0
+        version: 9.37.0(jiti@2.6.1)
       postcss:
         specifier: ^8.5.10
         version: 8.5.18
@@ -3961,9 +3961,6 @@ packages:
 
   '@types/estree@0.0.39':
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -12007,8 +12004,6 @@ snapshots:
 
   '@types/estree@0.0.39': {}
 
-  '@types/estree@1.0.8': {}
-
   '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
@@ -12397,7 +12392,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@24.10.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -12459,7 +12454,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@24.10.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.16(@types/node@22.18.8)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.47.1)(tsx@4.21.0))
 
   '@vitest/utils@4.1.8':
     dependencies:
@@ -13700,7 +13695,7 @@ snapshots:
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
       ajv: 6.15.0
       chalk: 4.1.2


### PR DESCRIPTION
Refs #1335.

## What was actually wrong

The issue's error is real, but its diagnosis is not. `pnpm -r lint` (what the Lint workflow runs) does cover `packages/sdk`, and it passes: pnpm runs each package's own `node_modules/.bin/eslint`, which is 9.37.0 in all four flat-config packages.

The break is in root-resolved invocations. The root `package.json` declared `eslint: "^8"` (resolved 8.57.1) and also declares a `workspaces` field, so npm walks up to the repo root when computing its local prefix. `npx eslint .` from inside `packages/sdk` therefore picks 8.57.1, which cannot read the packages' flat configs:

```
ESLint: 8.57.1
TypeError: Error while loading rule '@typescript-eslint/no-unused-expressions':
Cannot read properties of undefined (reading 'allowShortCircuit')
    at Object.create (@typescript-eslint/utils/dist/eslint-utils/RuleCreator.js:31:20)
    at createRuleListeners (eslint@8.57.1/lib/linter/linter.js:895:21)
```

Editor ESLint servers rooted at the repo resolve the same way. So the linter is unrunnable by the two routes a developer actually reaches for, while CI stays green through a third.

## Per-project matrix (before this change)

| project | lint script | config | own eslint | typescript-eslint | own binary | root binary (8.57.1) |
|---|---|---|---|---|---|---|
| packages/sdk | `eslint .` | flat | 9.37.0 | 8.46.0 | runs, 555 files, 0 problems | throws |
| packages/ui | `eslint .` | flat | 9.37.0 | 8.46.0 | runs, 17 files, 0 problems | throws |
| packages/wallets | `eslint .` | flat | 9.37.0 | 8.46.0 | runs, 74 files, 0 problems | throws |
| packages/render-helper | `eslint .` | flat | 9.37.0 | 8.46.0 | runs, 60 files, 0 problems | runs |
| apps/web | `next lint` | `.eslintrc.json` | 8.57.1 | n/a | runs, 71 warnings | n/a |
| apps/self-hosted | none | biome | n/a | n/a | not covered | n/a |

So the skew was never confined to sdk: three of the four packages fail identically. render-helper survives only because its config does not spread `tseslint.configs.recommended`, so it never loads a rule whose schema is eslint 9 only.

## The fix

Root `eslint` goes from `^8` to `^9.21.0`, the spec the four packages already carry. Smallest coherent option:

- The repo already expects eslint 9 everywhere a flat config exists, so moving the odd one out is one line rather than downgrading four packages plus their typescript-eslint.
- `^9.21.0` dedupes onto the eslint 9.37.0 already in the lockfile. Nothing new is fetched, so `minimumReleaseAge` is not in play. The lockfile diff is 5 insertions / 10 deletions, all dedupe (`@types/estree` 1.0.8 drops out with eslint 8).
- Deleting the root dependency instead would leave `npx eslint` with nothing local to resolve and send it to the registry for an uncontrolled version.
- `apps/web` keeps its own `eslint: "^8"` for `eslint-config-next` and `next lint`, so it is untouched. Its lint output is byte-identical before and after.

## What the linter reports now that it runs everywhere

Nothing. All four packages are clean: 0 errors, 0 warnings across 706 files. There is no backlog to sequence.

That is less reassuring than it sounds. The sdk, ui and wallets configs switch off `no-explicit-any`, `no-unused-vars`, `ban-ts-comment`, `no-namespace`, `no-unnecessary-type-constraint`, `no-var` and `prefer-const`, which leaves 17 enabled rules. The linter is live (a scratch file using `Function` and `{}` is correctly rejected by `no-unsafe-function-type` and `no-empty-object-type`), but it is thin.

This has a direct bearing on step 3 of the issue: `@typescript-eslint/no-explicit-any` is **off** in `packages/sdk/eslint.config.mjs`. The `as any` casts in `get-posts-ranked-query-options.spec.ts` were never going to be flagged even with the linter running, so narrowing them is a typing decision rather than a lint fix. Untouched here, as sequenced.

## CI

`pnpm -r lint` already covers all four packages, so no package needs adding. What CI could not see was the root/leaf major skew, since it only ever runs the per-package binaries. The workflow gains one step that lints `packages/sdk` through the root-resolved binary, which fails on exactly the condition this PR fixes.

Left uncovered, deliberately: `apps/self-hosted` has no `lint` script, so `pnpm -r lint` skips it. It uses biome, and its only check script is `biome check --write`, which mutates and is not CI-safe. Running `biome check` read-only over it reports 251 errors and 181 warnings across 237 files, largely formatting. Wiring that into CI now would either fail the job or require a mass autofix across the app, so it belongs in its own change with its own review. Not doing it here.

## Known trade-off

The root binary is one binary, and the two config formats in this repo cannot both be served by it: `apps/web` is eslintrc, the four packages are flat config. Raising the root to 9 therefore breaks the one root-resolved path that used to work for `apps/web`. `cd apps/web && npx eslint <file>` exits 0 on develop and now exits 2 with "ESLint couldn't find an eslint.config.(js|mjs|cjs) file".

Taking that trade knowingly. Four projects gain a working root-resolved path and one loses it, and `apps/web` is the side that keeps alternatives: it ships its own eslint 8.57.1, so `pnpm exec eslint <file>` inside it and `pnpm --filter @ecency/web lint` both still exit 0, and `ESLINT_USE_FLAT_CONFIG=false` makes even the root binary work there. The packages had no working path at all. The failure is also legible now, ESLint naming the missing file and linking the migration guide, rather than an internal `RuleCreator` `TypeError` about `allowShortCircuit`.

The real resolution is migrating `apps/web` to flat config, which `next lint` already prompts for on every run since it is deprecated and gone in Next 16. That is its own change, not something to fold into a dependency alignment.

## Verification

- `pnpm install --frozen-lockfile` clean; lockfile is a fixed point of `pnpm install`
- `pnpm -r lint` passes; apps/web output identical to before
- `cd packages/sdk && npx eslint .` now exits 0 (was the TypeError above)
- root binary lints all four packages clean
- `pnpm --filter @ecency/sdk test`: 596 passed, 44 files
- `pnpm build:packages` then `pnpm --filter @ecency/self-hosted build`: pass, node-globals guard reports 3 chunks clean

Not closing #1335: the issue's step 3 is still open.