### PR TITLE
Self-hosted hosting: make custom-domain attach atomic

### DIFF
--- a/apps/self-hosted/hosting/api/src/db/client.ts
+++ b/apps/self-hosted/hosting/api/src/db/client.ts
@@ -23,6 +23,18 @@ pool.on('error', (err) => {
   console.error('Database error:', err);
 });
 
+/**
+ * Anything statements can be run on: the pool helper below, or a transaction client.
+ *
+ * Service functions that must be able to share ONE transaction with a caller take this
+ * instead of reaching for `db` themselves. A function that reaches for the module-level
+ * `db` runs on its own connection, so it commits separately no matter what the caller
+ * wrapped around it, which is how the custom-domain attach ended up as two commits.
+ */
+export interface SqlExecutor {
+  query<T extends pg.QueryResultRow = any>(text: string, params?: any[]): Promise<pg.QueryResult<T>>;
+}
+
 // Helper for single queries
 export const db = {
   query: <T extends pg.QueryResultRow = any>(text: string, params?: any[]): Promise<pg.QueryResult<T>> => {

--- a/apps/self-hosted/hosting/api/src/payment-listener-domain-sweep.test.ts
+++ b/apps/self-hosted/hosting/api/src/payment-listener-domain-sweep.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // The hourly maintenance pass is where the unverified-domain release has to run. A sweep that
-// exists but is never called is exactly the state DomainService.cleanupExpiredVerifications is
-// in: written, tested by nobody, wired to nothing.
+// exists but is never called does nothing at all, which is the state the verification-cleanup
+// helpers in domain-service sat in until they were deleted: written, tested by nobody, wired to
+// nothing.
 
 const mocks = vi.hoisted(() => ({
   callRPC: vi.fn(),

--- a/apps/self-hosted/hosting/api/src/routes/domain-capability.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/domain-capability.test.ts
@@ -3,11 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   getByUsername: vi.fn(),
   isDomainClaimed: vi.fn(),
-  setCustomDomain: vi.fn(),
   verifyCustomDomain: vi.fn(),
   removeCustomDomain: vi.fn(),
   getByDomain: vi.fn(),
-  createVerification: vi.fn(),
+  attachDomain: vi.fn(),
   verifyDomain: vi.fn(),
   markVerified: vi.fn(),
 }));
@@ -18,7 +17,6 @@ vi.mock('../services/tenant-service', () => ({
   TenantService: {
     getByUsername: mocks.getByUsername,
     isDomainClaimed: mocks.isDomainClaimed,
-    setCustomDomain: mocks.setCustomDomain,
     verifyCustomDomain: mocks.verifyCustomDomain,
     removeCustomDomain: mocks.removeCustomDomain,
     getByDomain: mocks.getByDomain,
@@ -28,7 +26,7 @@ vi.mock('../services/tenant-service', () => ({
 
 vi.mock('../services/domain-service', () => ({
   DomainService: {
-    createVerification: mocks.createVerification,
+    attachDomain: mocks.attachDomain,
     verifyDomain: mocks.verifyDomain,
     markVerified: mocks.markVerified,
   },
@@ -84,13 +82,10 @@ function verifyDomain() {
 beforeEach(() => {
   for (const mock of Object.values(mocks)) mock.mockReset();
   mocks.isDomainClaimed.mockResolvedValue(false);
-  mocks.createVerification.mockResolvedValue({
-    verificationMethod: 'cname',
-    expiresAt: new Date().toISOString(),
-  });
-  mocks.setCustomDomain.mockImplementation(async () =>
-    tenant({ customDomain: 'mine.example.test', customDomainVerified: false })
-  );
+  mocks.attachDomain.mockImplementation(async () => ({
+    tenant: tenant({ customDomain: 'mine.example.test', customDomainVerified: false }),
+    verification: { verificationMethod: 'cname', expiresAt: new Date().toISOString() },
+  }));
   mocks.verifyDomain.mockResolvedValue(true);
   mocks.verifyCustomDomain.mockImplementation(async () =>
     tenant({ customDomain: 'mine.example.test', customDomainVerified: true })
@@ -141,7 +136,7 @@ describe('custom domain capabilities follow subscription standing', () => {
 
     expect(response.status).toBe(402);
     expect(await response.json()).toMatchObject({ customDomainCapability: 'lapsed' });
-    expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+    expect(mocks.attachDomain).not.toHaveBeenCalled();
   });
 
   it('refuses a verification once the grace window has passed', async () => {

--- a/apps/self-hosted/hosting/api/src/routes/domain-ownership.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/domain-ownership.test.ts
@@ -3,11 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   getByUsername: vi.fn(),
   isDomainClaimed: vi.fn(),
-  setCustomDomain: vi.fn(),
   verifyCustomDomain: vi.fn(),
   removeCustomDomain: vi.fn(),
   getByDomain: vi.fn(),
-  createVerification: vi.fn(),
+  attachDomain: vi.fn(),
   verifyDomain: vi.fn(),
   markVerified: vi.fn(),
 }));
@@ -18,7 +17,6 @@ vi.mock('../services/tenant-service', () => ({
   TenantService: {
     getByUsername: mocks.getByUsername,
     isDomainClaimed: mocks.isDomainClaimed,
-    setCustomDomain: mocks.setCustomDomain,
     verifyCustomDomain: mocks.verifyCustomDomain,
     removeCustomDomain: mocks.removeCustomDomain,
     getByDomain: mocks.getByDomain,
@@ -28,7 +26,7 @@ vi.mock('../services/tenant-service', () => ({
 
 vi.mock('../services/domain-service', () => ({
   DomainService: {
-    createVerification: mocks.createVerification,
+    attachDomain: mocks.attachDomain,
     verifyDomain: mocks.verifyDomain,
     markVerified: mocks.markVerified,
   },
@@ -67,12 +65,11 @@ function request(path: string, init?: RequestInit) {
 
 beforeEach(() => {
   for (const mock of Object.values(mocks)) mock.mockReset();
-  mocks.createVerification.mockResolvedValue({
-    verificationMethod: 'cname',
-    expiresAt: new Date().toISOString(),
-  });
   mocks.isDomainClaimed.mockResolvedValue(false);
-  mocks.setCustomDomain.mockResolvedValue({ ...COMMUNITY, customDomainVerified: false });
+  mocks.attachDomain.mockResolvedValue({
+    tenant: { ...COMMUNITY, customDomainVerified: false },
+    verification: { verificationMethod: 'cname', expiresAt: new Date().toISOString() },
+  });
 });
 
 describe('custom domains for a community instance', () => {
@@ -82,7 +79,6 @@ describe('custom domains for a community instance', () => {
     mocks.getByUsername.mockImplementation(async (name: string) =>
       name === 'hive-125125' ? { ...COMMUNITY } : null,
     );
-    mocks.setCustomDomain.mockResolvedValue({ ...COMMUNITY });
 
     const res = await request('/?tenant=hive-125125', {
       method: 'POST',
@@ -91,7 +87,7 @@ describe('custom domains for a community instance', () => {
     });
 
     expect(res.status).toBe(201);
-    expect(mocks.setCustomDomain).toHaveBeenCalledWith(
+    expect(mocks.attachDomain).toHaveBeenCalledWith(
       'hive-125125',
       'blog.example.com',
     );
@@ -107,7 +103,7 @@ describe('custom domains for a community instance', () => {
     });
 
     expect(res.status).toBe(403);
-    expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+    expect(mocks.attachDomain).not.toHaveBeenCalled();
   });
 });
 
@@ -125,12 +121,12 @@ describe('domain occupancy', () => {
     });
 
     expect(res.status).toBe(409);
-    expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+    expect(mocks.attachDomain).not.toHaveBeenCalled();
   });
 
   it('answers a lost race with a conflict rather than a server error', async () => {
     mocks.getByUsername.mockResolvedValue({ ...COMMUNITY, username: 'alice' });
-    mocks.setCustomDomain.mockRejectedValue(new DomainInUseError('x'));
+    mocks.attachDomain.mockRejectedValue(new DomainInUseError('x'));
 
     const res = await request('/', {
       method: 'POST',
@@ -246,12 +242,15 @@ describe('re-submitting a domain the tenant already holds', () => {
         customDomain: 'mine.example.com',
         customDomainVerified: true,
       });
-      // The statement preserves the flag only for an unchanged domain, so a
-      // still-verified result means nothing was reset.
-      mocks.setCustomDomain.mockResolvedValue({
-        ...COMMUNITY,
-        customDomain: 'mine.example.com',
-        customDomainVerified: true,
+      // The attach preserves the flag only for an unchanged domain, and answers with no
+      // verification when it found one, so a null verification means nothing was reset.
+      mocks.attachDomain.mockResolvedValue({
+        tenant: {
+          ...COMMUNITY,
+          customDomain: 'mine.example.com',
+          customDomainVerified: true,
+        },
+        verification: null,
       });
 
       const res = await request('/', {
@@ -261,7 +260,10 @@ describe('re-submitting a domain the tenant already holds', () => {
       });
 
       expect(res.status).toBe(200);
-      expect(mocks.createVerification).not.toHaveBeenCalled();
+      // Answered from the live domain rather than with fresh DNS instructions, which is what
+      // tells the caller nothing was reset. That the attach itself leaves the record alone is
+      // proved in domain-attach.test.ts.
+      expect(await res.json()).toMatchObject({ domain: 'mine.example.com', verified: true });
     })());
 
   it('still issues verification for a domain that is new to the tenant', async () => {
@@ -271,10 +273,13 @@ describe('re-submitting a domain the tenant already holds', () => {
       customDomain: 'old.example.com',
       customDomainVerified: true,
     });
-    mocks.setCustomDomain.mockResolvedValue({
-      ...COMMUNITY,
-      customDomain: 'new.example.com',
-      customDomainVerified: false,
+    mocks.attachDomain.mockResolvedValue({
+      tenant: {
+        ...COMMUNITY,
+        customDomain: 'new.example.com',
+        customDomainVerified: false,
+      },
+      verification: { verificationMethod: 'cname', expiresAt: new Date().toISOString() },
     });
 
     const res = await request('/', {
@@ -284,7 +289,7 @@ describe('re-submitting a domain the tenant already holds', () => {
     });
 
     expect(res.status).toBe(201);
-    expect(mocks.createVerification).toHaveBeenCalled();
+    expect(mocks.attachDomain).toHaveBeenCalledWith('alice', 'new.example.com');
   });
 });
 

--- a/apps/self-hosted/hosting/api/src/routes/domains.ts
+++ b/apps/self-hosted/hosting/api/src/routes/domains.ts
@@ -102,28 +102,26 @@ domainRoutes.post('/', authMiddleware, zValidator('json', addDomainSchema), asyn
     return c.json({ error: 'Domain already in use' }, 409);
   }
 
-  // Set domain and generate verification
-  let updated: Awaited<ReturnType<typeof TenantService.setCustomDomain>>;
+  // Claim and verification record in one transaction, the same call the internal rail makes.
+  let attached: Awaited<ReturnType<typeof DomainService.attachDomain>>;
   try {
-    updated = await TenantService.setCustomDomain(username, domain);
+    attached = await DomainService.attachDomain(username, domain);
   } catch (error) {
     if (error instanceof DomainInUseError) {
       return c.json({ error: 'Domain already in use' }, 409);
     }
     throw error;
   }
-  // The statement preserves the flag only when the domain was unchanged, so a
-  // still-verified row here means this was a repeat submit of a live domain.
-  // Re-issuing the verification would delete its record and the origin sync
-  // would drop the vhost and certificate.
-  if (updated.customDomainVerified) {
+  // A null verification means the attach found the domain already verified, so nothing was
+  // reset. Re-issuing would delete its record and the origin sync would drop the vhost and
+  // certificate.
+  const verification = attached.verification;
+  if (!verification) {
     return c.json({ domain, verified: true, message: 'Domain already verified' });
   }
 
-  // Recorded as soon as the tenant row changes, before the verification record
-  // it does not depend on, matching internal.ts: setCustomDomain also clears
-  // custom_domain_verified, so a throw from createVerification would otherwise
-  // leave the domain state changed with nothing in the trail to say what did it.
+  // After the transaction, not before it: an attach that throws now changes nothing, so an
+  // event describing a change would be describing one that never happened.
   void AuditService.log({
     tenantId: tenant.id,
     eventType: 'domain.added',
@@ -131,8 +129,6 @@ domainRoutes.post('/', authMiddleware, zValidator('json', addDomainSchema), asyn
     ipAddress: parseClientIp(c.req.header('x-forwarded-for')),
     userAgent: c.req.header('user-agent'),
   });
-
-  const verification = await DomainService.createVerification(username, domain);
 
   // The record NAME must be the domain itself: verification resolves the domain's CNAME
   // (and serving requires it too). The internal verification token is bookkeeping only.

--- a/apps/self-hosted/hosting/api/src/routes/internal.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.test.ts
@@ -8,9 +8,8 @@ const mocks = vi.hoisted(() => ({
   buildConfig: vi.fn(),
   getBlogUrl: vi.fn(),
   isDomainClaimed: vi.fn(),
-  setCustomDomain: vi.fn(),
   verifyCustomDomain: vi.fn(),
-  createVerification: vi.fn(),
+  attachDomain: vi.fn(),
   verifyDomain: vi.fn(),
   markVerified: vi.fn(),
   addVerifiedDomainOrigin: vi.fn(),
@@ -31,7 +30,6 @@ vi.mock('../services/tenant-service', () => ({
     buildConfig: mocks.buildConfig,
     getBlogUrl: mocks.getBlogUrl,
     isDomainClaimed: mocks.isDomainClaimed,
-    setCustomDomain: mocks.setCustomDomain,
     verifyCustomDomain: mocks.verifyCustomDomain,
   },
   ABANDONED_REREGISTER_QUARANTINE_HOURS: 24,
@@ -47,7 +45,7 @@ vi.mock('../services/config-service', () => ({
 
 vi.mock('../services/domain-service', () => ({
   DomainService: {
-    createVerification: mocks.createVerification,
+    attachDomain: mocks.attachDomain,
     verifyDomain: mocks.verifyDomain,
     markVerified: mocks.markVerified,
   },
@@ -185,12 +183,11 @@ describe('internal endpoint audit trail', () => {
     mocks.buildConfig.mockReset().mockResolvedValue({ version: 1 });
     mocks.getBlogUrl.mockReset().mockReturnValue('https://alice.blogs.ecency.com');
     mocks.isDomainClaimed.mockReset().mockResolvedValue(false);
-    mocks.setCustomDomain.mockReset().mockResolvedValue({
-      id: 'tenant-1',
-      customDomainVerified: false,
+    mocks.attachDomain.mockReset().mockResolvedValue({
+      tenant: { id: 'tenant-1', customDomainVerified: false },
+      verification: { verificationMethod: 'cname' },
     });
     mocks.verifyCustomDomain.mockReset().mockResolvedValue({ id: 'tenant-1' });
-    mocks.createVerification.mockReset().mockResolvedValue({ verificationMethod: 'cname' });
     mocks.verifyDomain.mockReset().mockResolvedValue(true);
     mocks.markVerified.mockReset().mockResolvedValue(undefined);
     mocks.addVerifiedDomainOrigin.mockReset();
@@ -237,12 +234,12 @@ describe('internal endpoint audit trail', () => {
       });
 
       expect(response.status).toBe(409);
-      expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+      expect(mocks.attachDomain).not.toHaveBeenCalled();
     });
 
     it('answers a lost unique race with a conflict, not a server error', async () => {
       mocks.getByUsername.mockResolvedValue({ ...proTenant });
-      mocks.setCustomDomain.mockRejectedValue(new DomainInUseError('raced'));
+      mocks.attachDomain.mockRejectedValue(new DomainInUseError('raced'));
 
       const response = await post('/domain', {
         username: 'alice',
@@ -258,11 +255,11 @@ describe('internal endpoint audit trail', () => {
         customDomain: 'mine.example.com',
         customDomainVerified: true,
       });
-      // The statement preserves the flag only when the stored domain already
-      // equals the requested one, so a still-verified result means no reset.
-      mocks.setCustomDomain.mockResolvedValue({
-        id: 'tenant-1',
-        customDomainVerified: true,
+      // The attach preserves the flag only when the stored domain already equals the requested
+      // one, and answers with no verification when it did, so nothing was reset.
+      mocks.attachDomain.mockResolvedValue({
+        tenant: { id: 'tenant-1', customDomainVerified: true },
+        verification: null,
       });
 
       const response = await post('/domain', {
@@ -273,7 +270,7 @@ describe('internal endpoint audit trail', () => {
       expect(response.status).toBe(200);
       // Re-issuing would delete the live verification record, and the origin
       // sync would drop the vhost and certificate with it.
-      expect(mocks.createVerification).not.toHaveBeenCalled();
+      expect(await response.json()).toEqual({ domain: 'mine.example.com', verified: true });
     });
 
     it('verifies against the domain that was checked', async () => {
@@ -437,8 +434,10 @@ describe('internal endpoint audit trail', () => {
       eventData: { domain: 'blog.example.com', username: 'alice', via: 'internal' },
     });
 
-    // setCustomDomain has committed (and cleared the verified flag) before the verification record
-    // is created, so a failure there must not cost the event describing that change.
+    // The attach is one transaction, so a failure inside it changes nothing at all. Recording
+    // domain.added anyway would put a domain change in the trail that the database never made.
+    // This is the other side of the old ordering, which logged first because the claim had
+    // already committed by the time the verification record could fail.
     mocks.auditLog.mockReset();
     mocks.getByUsername.mockResolvedValueOnce({
       id: 'tenant-1',
@@ -446,14 +445,13 @@ describe('internal endpoint audit trail', () => {
       subscriptionPlan: 'pro',
       subscriptionStatus: 'active',
     });
-    mocks.createVerification.mockRejectedValueOnce(new Error('verification insert failed'));
+    mocks.attachDomain.mockRejectedValueOnce(new Error('verification insert failed'));
 
     await Promise.resolve(
       post('/domain', { username: 'alice', domain: 'blog.example.com' })
     ).catch(() => undefined);
 
-    expect(mocks.auditLog).toHaveBeenCalledTimes(1);
-    expect(mocks.auditLog.mock.calls[0][0]).toMatchObject({ eventType: 'domain.added' });
+    expect(mocks.auditLog).not.toHaveBeenCalled();
   });
 
   it('records a domain verification before the bookkeeping that could strand it', async () => {

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -360,27 +360,26 @@ internalRoutes.post('/domain', async (c) => {
     return c.json({ error: 'domain_in_use' }, 409);
   }
 
-  let updated: Awaited<ReturnType<typeof TenantService.setCustomDomain>>;
+  // Claim and verification record in one transaction, the same call the public rail makes.
+  let attached: Awaited<ReturnType<typeof DomainService.attachDomain>>;
   try {
-    updated = await TenantService.setCustomDomain(username, domain);
+    attached = await DomainService.attachDomain(username, domain);
   } catch (error) {
     if (error instanceof DomainInUseError) {
       return c.json({ error: 'domain_in_use' }, 409);
     }
     throw error;
   }
-  // Recorded as soon as the tenant row changes, before the verification record it does not depend
-  // on: setCustomDomain also clears custom_domain_verified, so if createVerification then threw,
-  // the tenant's domain state would have changed with nothing in the trail to say what changed it.
-  // Still verified means the statement matched the domain already stored, so
-  // this was a repeat submit of a live domain and nothing was reset.
-  if (updated.customDomainVerified) {
+  // A null verification means the attach matched the domain already stored, so this was a repeat
+  // submit of a live domain and nothing was reset.
+  if (!attached.verification) {
     return c.json({ domain, verified: true }, 200);
   }
 
+  // After the transaction, not before it: an attach that throws now changes nothing, so an event
+  // describing a change would be describing one that never happened.
   auditInternal(c, tenant.id, 'domain.added', { domain, username, via: 'internal' });
 
-  await DomainService.createVerification(username, domain);
   const value = `${username}.${baseDomain}`;
 
   // The record NAME must be the domain itself: verification resolves the domain's CNAME

--- a/apps/self-hosted/hosting/api/src/services/domain-attach.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/domain-attach.test.ts
@@ -1,0 +1,309 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  transaction: vi.fn(),
+  // Anything the attach runs outside its transaction is a second commit, which is the bug this
+  // suite exists to prevent, so the pooled helpers refuse rather than answer.
+  query: vi.fn(() => {
+    throw new Error('statement ran outside the attach transaction');
+  }),
+  queryOne: vi.fn(() => {
+    throw new Error('statement ran outside the attach transaction');
+  }),
+}));
+
+vi.mock('../db/client', () => ({
+  db: { transaction: mocks.transaction, query: mocks.query, queryOne: mocks.queryOne },
+}));
+vi.mock('@ecency/sdk/hive', () => ({ callRPC: vi.fn(), config: { set: vi.fn() } }));
+
+const { DomainService } = await import('./domain-service');
+const { DomainInUseError } = await import('./tenant-service');
+
+const DAY = 24 * 60 * 60 * 1000;
+
+interface TenantRow {
+  id: string;
+  username: string;
+  custom_domain: string | null;
+  custom_domain_verified: boolean;
+  custom_domain_verified_at: string | null;
+  updated_at: string;
+}
+
+interface VerificationRow {
+  id: string;
+  tenant_id: string;
+  domain: string;
+  verification_token: string;
+  verification_method: 'cname';
+  verified: boolean;
+  verified_at: string | null;
+  expires_at: string;
+  created_at: string;
+}
+
+interface State {
+  tenants: TenantRow[];
+  verifications: VerificationRow[];
+}
+
+/**
+ * A database that commits the way Postgres does, so atomicity can be asserted rather than
+ * inferred from which mock was called.
+ *
+ * Statements run against a private copy of the state and are published only when the callback
+ * returns; a throw discards them, which is what db.transaction's ROLLBACK does. Every test here
+ * then reads the COMMITTED state, so a half-applied attach is visible as one.
+ *
+ * The interpreter honours the clauses that carry meaning for this file (which verification
+ * records a statement deletes, whether it looks for an existing one) so that dropping a clause
+ * changes a result. What the claim UPDATE preserves is modelled from the statement's intent; the
+ * statement text itself is pinned in set-custom-domain.test.ts.
+ */
+function fakeDatabase(initial: State, failOn?: RegExp) {
+  const committed: State = structuredClone(initial);
+  const log: { sql: string; params: any[] }[] = [];
+  let nextId = 1;
+
+  const client = (state: State) => ({
+    query: async (raw: string, params: any[] = []) => {
+      const sql = raw.replace(/\s+/g, ' ').trim();
+      log.push({ sql, params });
+      if (failOn?.test(sql)) throw new Error('statement failed');
+
+      if (/^UPDATE tenants/.test(sql)) {
+        const [username, domain] = params;
+        const holder = state.tenants.find(
+          (row) => row.custom_domain === domain && row.username !== username
+        );
+        // custom_domain is UNIQUE across tenants whatever its verified flag says.
+        if (holder) throw Object.assign(new Error('duplicate key'), { code: '23505' });
+
+        const tenant = state.tenants.find((row) => row.username === username);
+        if (!tenant) return { rows: [], rowCount: 0 };
+
+        const unchanged = tenant.custom_domain === domain;
+        tenant.custom_domain_verified = unchanged ? tenant.custom_domain_verified : false;
+        tenant.custom_domain_verified_at = unchanged ? tenant.custom_domain_verified_at : null;
+        tenant.custom_domain = domain;
+        tenant.updated_at = new Date().toISOString();
+        return { rows: [{ ...tenant }], rowCount: 1 };
+      }
+
+      if (/^DELETE FROM domain_verifications/.test(sql)) {
+        const [tenantId, domain] = params;
+        // Without the domain exclusion the statement drops every record the tenant has,
+        // including the one that dates the claim it is about to re-affirm.
+        const keepsCurrent = /domain <> \$2/.test(sql);
+        const before = state.verifications.length;
+        state.verifications = state.verifications.filter(
+          (row) => row.tenant_id !== tenantId || (keepsCurrent && row.domain === domain)
+        );
+        return { rows: [], rowCount: before - state.verifications.length };
+      }
+
+      if (/^SELECT \* FROM domain_verifications/.test(sql)) {
+        const [tenantId, domain] = params;
+        const rows = state.verifications
+          .filter((row) => row.tenant_id === tenantId && row.domain === domain)
+          .sort((a, b) => a.created_at.localeCompare(b.created_at));
+        return { rows: /LIMIT 1/.test(sql) ? rows.slice(0, 1) : rows, rowCount: rows.length };
+      }
+
+      if (/^INSERT INTO domain_verifications/.test(sql)) {
+        const [tenantId, domain, token, expiresAt] = params;
+        const row: VerificationRow = {
+          id: `verification-${nextId++}`,
+          tenant_id: tenantId,
+          domain,
+          verification_token: token,
+          verification_method: 'cname',
+          verified: false,
+          verified_at: null,
+          expires_at: new Date(expiresAt).toISOString(),
+          created_at: new Date().toISOString(),
+        };
+        state.verifications.push(row);
+        return { rows: [{ ...row }], rowCount: 1 };
+      }
+
+      throw new Error(`unexpected statement: ${sql}`);
+    },
+  });
+
+  mocks.transaction.mockImplementation(async (fn: (c: any) => Promise<any>) => {
+    const staged = structuredClone(committed);
+    const result = await fn(client(staged));
+    // Reached only when the callback returned: a throw leaves `staged` unpublished, exactly as
+    // a ROLLBACK leaves the transaction's writes unapplied.
+    committed.tenants = staged.tenants;
+    committed.verifications = staged.verifications;
+    return result;
+  });
+
+  return { state: committed, log };
+}
+
+function tenant(over: Partial<TenantRow> = {}): TenantRow {
+  return {
+    id: 'tenant-1',
+    username: 'alice',
+    custom_domain: null,
+    custom_domain_verified: false,
+    custom_domain_verified_at: null,
+    updated_at: new Date().toISOString(),
+    ...over,
+  };
+}
+
+function verification(over: Partial<VerificationRow> = {}): VerificationRow {
+  return {
+    id: 'verification-0',
+    tenant_id: 'tenant-1',
+    domain: 'mine.example.test',
+    verification_token: '_ecency-verify.original',
+    verification_method: 'cname',
+    verified: false,
+    verified_at: null,
+    expires_at: new Date(Date.now() + 7 * DAY).toISOString(),
+    created_at: new Date(Date.now() - 10 * DAY).toISOString(),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mocks.transaction.mockReset();
+  mocks.query.mockClear();
+  mocks.queryOne.mockClear();
+});
+
+/**
+ * Attaching a domain was two separately committed operations: the claim, then the verification
+ * record, whose own DELETE and INSERT were two more. Between any of them the tenant held a domain
+ * with no record backing it, and the release sweep dates a claim by that record, so a sweep
+ * landing in one of those windows freed a claim seconds old.
+ */
+describe('DomainService.attachDomain', () => {
+  it('claims the domain and issues its verification in a single transaction', async () => {
+    const db = fakeDatabase({ tenants: [tenant()], verifications: [] });
+
+    const attached = await DomainService.attachDomain('alice', 'mine.example.test');
+
+    expect(mocks.transaction).toHaveBeenCalledTimes(1);
+    expect(db.state.tenants[0].custom_domain).toBe('mine.example.test');
+    expect(db.state.verifications).toHaveLength(1);
+    expect(attached.verification?.domain).toBe('mine.example.test');
+    // A claim published on its own connection would be a separate commit and the gap would be back.
+    expect(mocks.query).not.toHaveBeenCalled();
+    expect(mocks.queryOne).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The failure the split path could not survive: the DELETE had already removed the record, the
+   * claim had already committed, and the INSERT then failed. The tenant was left holding a domain
+   * with nothing dating it, and its verified flag cleared, so the next sweep could take a live
+   * domain away from a paying customer.
+   */
+  it('leaves the previous domain and its record untouched when the record cannot be written', async () => {
+    const db = fakeDatabase(
+      {
+        tenants: [
+          tenant({
+            custom_domain: 'live.example.test',
+            custom_domain_verified: true,
+            custom_domain_verified_at: new Date().toISOString(),
+          }),
+        ],
+        verifications: [verification({ domain: 'live.example.test', verified: true })],
+      },
+      /^INSERT INTO domain_verifications/
+    );
+
+    await expect(DomainService.attachDomain('alice', 'new.example.test')).rejects.toThrow(
+      'statement failed'
+    );
+
+    expect(db.state.tenants[0].custom_domain).toBe('live.example.test');
+    expect(db.state.tenants[0].custom_domain_verified).toBe(true);
+    expect(db.state.verifications).toHaveLength(1);
+    expect(db.state.verifications[0].domain).toBe('live.example.test');
+  });
+
+  it('reports a domain another tenant holds as a conflict', async () => {
+    const db = fakeDatabase({
+      tenants: [tenant(), tenant({ id: 'tenant-2', username: 'bob', custom_domain: 'taken.example.test' })],
+      verifications: [],
+    });
+
+    await expect(DomainService.attachDomain('alice', 'taken.example.test')).rejects.toBeInstanceOf(
+      DomainInUseError
+    );
+    expect(db.state.tenants[0].custom_domain).toBeNull();
+  });
+
+  it('reports a missing tenant without writing anything', async () => {
+    const db = fakeDatabase({ tenants: [], verifications: [] });
+
+    await expect(DomainService.attachDomain('nobody', 'mine.example.test')).rejects.toThrow(
+      'Tenant not found'
+    );
+    expect(db.state.verifications).toEqual([]);
+  });
+});
+
+/**
+ * Re-submitting the same domain used to write a fresh verification record. That record is what
+ * the release sweep dates a claim by, so a holder could keep an unverifiable domain forever by
+ * re-posting it once a fortnight. The earliest record for a domain the tenant already holds now
+ * stays, and with it the claim's original date.
+ */
+describe('re-submitting a domain the tenant already holds', () => {
+  it('keeps the earliest verification record rather than restarting the claim clock', async () => {
+    const original = verification();
+    const db = fakeDatabase({
+      tenants: [tenant({ custom_domain: 'mine.example.test' })],
+      verifications: [original],
+    });
+
+    const attached = await DomainService.attachDomain('alice', 'mine.example.test');
+
+    expect(db.state.verifications).toHaveLength(1);
+    expect(db.state.verifications[0].created_at).toBe(original.created_at);
+    expect(db.state.verifications[0].verification_token).toBe(original.verification_token);
+    expect(attached.verification?.createdAt.toISOString()).toBe(original.created_at);
+  });
+
+  it('does not re-issue verification at all for a domain that is already verified', async () => {
+    // Re-issuing would delete the live record, and the origin sync would drop the vhost and the
+    // certificate with it.
+    const live = verification({ domain: 'live.example.test', verified: true });
+    const db = fakeDatabase({
+      tenants: [tenant({ custom_domain: 'live.example.test', custom_domain_verified: true })],
+      verifications: [live],
+    });
+
+    const attached = await DomainService.attachDomain('alice', 'live.example.test');
+
+    expect(attached.verification).toBeNull();
+    expect(db.state.verifications).toEqual([live]);
+    expect(db.log.every((call) => /^UPDATE tenants/.test(call.sql))).toBe(true);
+  });
+
+  it('issues a fresh record for a domain the tenant did not hold before', async () => {
+    const stale = verification({ domain: 'old.example.test' });
+    const db = fakeDatabase({
+      tenants: [tenant({ custom_domain: 'old.example.test' })],
+      verifications: [stale],
+    });
+
+    const attached = await DomainService.attachDomain('alice', 'new.example.test');
+
+    // The record for a domain the tenant no longer holds goes: it would otherwise date a claim
+    // nobody made, and the sweep matches records to the domain currently held.
+    expect(db.state.verifications).toHaveLength(1);
+    expect(db.state.verifications[0].domain).toBe('new.example.test');
+    expect(db.state.verifications[0].created_at).not.toBe(stale.created_at);
+    expect(attached.verification?.domain).toBe('new.example.test');
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/domain-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/domain-service.ts
@@ -5,50 +5,101 @@
  */
 
 import { promises as dns } from 'dns';
-import { db } from '../db/client';
+import { db, type SqlExecutor } from '../db/client';
 import { nanoid } from 'nanoid';
+import { TenantService } from './tenant-service';
 import {
   type DomainVerification,
   type DomainVerificationRow,
+  type Tenant,
   mapDomainVerificationFromDb,
 } from '../types';
 
 const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
 
+/** Days the instructions give for pointing DNS at us. Bookkeeping: nothing enforces it. */
+const VERIFICATION_WINDOW_DAYS = 7;
+
+/**
+ * Give the tenant a verification record for the domain it now holds.
+ *
+ * Records for domains it no longer holds are dropped, but a record for THIS domain is kept as
+ * it stands. Its created_at is what the release sweep dates the claim by, so replacing it on
+ * every submit let a holder restart the claim clock indefinitely by re-posting the same domain.
+ * Keeping the earliest record means the window runs from the first time the domain was asked
+ * for, which is the honest reading of "how long has this claim been unverified".
+ *
+ * Runs on the caller's executor so it commits with the claim, never separately.
+ */
+async function issueVerification(
+  exec: SqlExecutor,
+  tenantId: string,
+  domain: string
+): Promise<DomainVerification> {
+  const normalized = domain.toLowerCase();
+
+  await exec.query(
+    'DELETE FROM domain_verifications WHERE tenant_id = $1 AND domain <> $2',
+    [tenantId, normalized]
+  );
+
+  const existing = await exec.query<DomainVerificationRow>(
+    `SELECT * FROM domain_verifications
+      WHERE tenant_id = $1 AND domain = $2
+      ORDER BY created_at ASC
+      LIMIT 1`,
+    [tenantId, normalized]
+  );
+  if (existing.rows[0]) return mapDomainVerificationFromDb(existing.rows[0]);
+
+  const token = '_ecency-verify.' + nanoid(16);
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + VERIFICATION_WINDOW_DAYS);
+
+  const created = await exec.query<DomainVerificationRow>(
+    `INSERT INTO domain_verifications
+     (tenant_id, domain, verification_token, verification_method, expires_at)
+     VALUES ($1, $2, $3, 'cname', $4)
+     RETURNING *`,
+    [tenantId, normalized, token, expiresAt]
+  );
+
+  return mapDomainVerificationFromDb(created.rows[0]);
+}
+
+/** Outcome of an attach. A null verification means the domain was already verified. */
+export interface DomainAttachment {
+  tenant: Tenant;
+  verification: DomainVerification | null;
+}
+
 export const DomainService = {
   /**
-   * Create domain verification record
+   * Attach a custom domain to a tenant, claim and verification record together.
+   *
+   * ONE transaction, and the only way either rail attaches a domain. Split across two commits,
+   * as this was, there were windows in which a tenant held a domain with no record backing it:
+   * the release sweep dates a claim by that record, so a sweep landing in one of them cleared a
+   * claim seconds old, and a failed insert left the tenant holding a domain whose previous
+   * record had already been deleted. Neither state exists now: the claim and the record commit
+   * together or not at all.
+   *
+   * Re-submitting a domain the tenant already holds VERIFIED returns verification null and
+   * leaves everything alone. Re-issuing it would delete the live record, and the origin sync
+   * would drop the vhost and certificate with it. Whether the domain was unchanged is decided
+   * inside the UPDATE rather than from an earlier read, which a concurrent update could stale.
+   *
+   * Throws DomainInUseError if another tenant holds the domain, and 'Tenant not found' if the
+   * username matches no row.
    */
-  async createVerification(username: string, domain: string): Promise<DomainVerification> {
-    // Get tenant ID
-    const tenant = await db.queryOne<{ id: string }>(
-      'SELECT id FROM tenants WHERE username = $1',
-      [username]
-    );
+  async attachDomain(username: string, domain: string): Promise<DomainAttachment> {
+    return db.transaction(async (client) => {
+      const tenant = await TenantService.setCustomDomain(client, username, domain);
+      if (tenant.customDomainVerified) return { tenant, verification: null };
 
-    if (!tenant) throw new Error('Tenant not found');
-
-    // Generate verification token
-    const token = '_ecency-verify.' + nanoid(16);
-    const expiresAt = new Date();
-    expiresAt.setDate(expiresAt.getDate() + 7); // 7 days to verify
-
-    // Delete any existing verification for this domain
-    await db.query(
-      'DELETE FROM domain_verifications WHERE tenant_id = $1',
-      [tenant.id]
-    );
-
-    // Create new verification
-    const result = await db.queryOne<DomainVerificationRow>(
-      `INSERT INTO domain_verifications
-       (tenant_id, domain, verification_token, verification_method, expires_at)
-       VALUES ($1, $2, $3, 'cname', $4)
-       RETURNING *`,
-      [tenant.id, domain.toLowerCase(), token, expiresAt]
-    );
-
-    return mapDomainVerificationFromDb(result!);
+      const verification = await issueVerification(client, tenant.id, domain);
+      return { tenant, verification };
+    });
   },
 
   /**
@@ -104,28 +155,13 @@ export const DomainService = {
       [tenant.id, domain.toLowerCase()]
     );
   },
-
-  /**
-   * Get pending verifications (for cleanup job)
-   */
-  async getExpiredVerifications(): Promise<DomainVerification[]> {
-    const rows = await db.queryAll<DomainVerificationRow>(
-      `SELECT * FROM domain_verifications
-       WHERE verified = false AND expires_at < NOW()`
-    );
-    return rows.map(mapDomainVerificationFromDb);
-  },
-
-  /**
-   * Delete expired verifications
-   */
-  async cleanupExpiredVerifications(): Promise<number> {
-    const result = await db.query(
-      `DELETE FROM domain_verifications
-       WHERE verified = false AND expires_at < NOW()`
-    );
-    return result.rowCount || 0;
-  },
 };
+
+// getExpiredVerifications and cleanupExpiredVerifications were here, wired to nothing since they
+// were written. They are deleted rather than wired up: a record's expires_at is bookkeeping shown
+// in the DNS instructions, while the record itself now DATES the claim for the release sweep, so
+// deleting records on that expiry would hand the sweep a claim with no date and free a domain
+// early. Stale records are removed with the claim they belong to, by releaseUnverifiedDomains and
+// by removeCustomDomain.
 
 export default DomainService;

--- a/apps/self-hosted/hosting/api/src/services/release-unverified-domains.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/release-unverified-domains.test.ts
@@ -1,55 +1,97 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({ transaction: vi.fn(), queryOne: vi.fn() }));
+const mocks = vi.hoisted(() => ({ transaction: vi.fn(), queryOne: vi.fn(), query: vi.fn() }));
 
 vi.mock('../db/client', () => ({
-  db: { transaction: mocks.transaction, queryOne: mocks.queryOne, query: vi.fn() },
+  db: { transaction: mocks.transaction, queryOne: mocks.queryOne, query: mocks.query },
 }));
 vi.mock('@ecency/sdk/hive', () => ({ callRPC: vi.fn(), config: { set: vi.fn() } }));
 
-const { TenantService, DOMAIN_CLAIM_SETTLE_MINUTES } = await import('./tenant-service');
+const { TenantService } = await import('./tenant-service');
+
+const DAY = 24 * 60 * 60 * 1000;
+const CLAIM_DAYS = 14;
+
+interface FakeTenant {
+  id: string;
+  username: string;
+  custom_domain: string | null;
+  custom_domain_verified: boolean;
+  /** When the tenant row was last touched by anything at all, verification or not. */
+  updated_at?: Date;
+  /** created_at of the earliest verification record for the domain above; null when there is none. */
+  record_created_at: Date | null;
+}
 
 /**
- * Records every statement the sweep runs, and models the two database behaviours that matter here.
+ * Records every statement the sweep runs and EVALUATES the predicates it asks for, so a sweep
+ * that stops asking a question is handed the rows it should have withheld.
  *
- * Once the claim is cleared, the domain is gone from the row: a read taken after the UPDATE (or a
- * RETURNING clause, which reports the new row) yields a null domain, so a sweep that reports what
- * it released has to capture it beforehand.
+ * Three database behaviours matter here:
  *
- * The settle window is evaluated rather than merely recorded. A candidate whose updated_at falls
- * inside the window the SELECT asks for is withheld, the way Postgres would withhold it, so a
- * sweep that drops that predicate is handed the row and releases it.
+ * - Once the claim is cleared the domain is gone from the row, so a sweep that reports what it
+ *   released has to capture it beforehand (RETURNING reports the new row, whose domain is null).
+ * - The claim window is read off the SQL: a candidate whose verification record is newer than the
+ *   window the statement asks for is withheld. A statement that drops the NOT EXISTS entirely
+ *   protects nothing, which is what a released fresh claim would look like in production.
+ * - Anything the statement says about updated_at is honoured too, so re-introducing a settle
+ *   window on the tenant row shows up as a claim that stops being released.
+ *
+ * `onLock` runs between the candidate SELECT and the UPDATE, standing in for a transaction that
+ * commits while the sweep waits for its row lock.
  */
-function fakeTransaction(candidates: any[]) {
+function fakeSweep(candidates: FakeTenant[], onLock?: (rows: FakeTenant[]) => void) {
   const calls: { sql: string; params: any[] }[] = [];
-  let cleared = false;
 
-  const isSettling = (sql: string, params: any[], row: any) => {
-    if (!row.updated_at) return false;
-    const window = /updated_at < NOW\(\) - \(\$(\d+) \* INTERVAL '1 minute'\)/.exec(
-      sql.replace(/\s+/g, ' ')
-    );
+  const norm = (sql: string) => sql.replace(/\s+/g, ' ').trim();
+
+  const hasFreshRecord = (sql: string, params: any[], row: FakeTenant) => {
+    const window = /dv\.created_at > NOW\(\) - \(\$(\d+) \* INTERVAL '1 day'\)/.exec(norm(sql));
+    // No claim-window question in the statement means nothing is protected by one.
     if (!window) return false;
+    const days = params[Number(window[1]) - 1];
+    if (!row.record_created_at) return false;
+    return row.record_created_at.getTime() > Date.now() - days * DAY;
+  };
+
+  const isSettling = (sql: string, params: any[], row: FakeTenant) => {
+    const window = /updated_at < NOW\(\) - \(\$(\d+) \* INTERVAL '1 minute'\)/.exec(norm(sql));
+    if (!window || !row.updated_at) return false;
     const minutes = params[Number(window[1]) - 1];
     return row.updated_at.getTime() > Date.now() - minutes * 60_000;
   };
 
+  const releasable = (sql: string, params: any[], row: FakeTenant) =>
+    row.custom_domain !== null &&
+    row.custom_domain_verified === false &&
+    !hasFreshRecord(sql, params, row) &&
+    !isSettling(sql, params, row);
+
   mocks.transaction.mockImplementation(async (fn: (client: any) => Promise<any>) =>
     fn({
       query: async (sql: string, params: any[] = []) => {
-        calls.push({ sql: sql.replace(/\s+/g, ' ').trim(), params });
-        if (/UPDATE tenants/.test(sql)) {
-          cleared = true;
-          const rows = candidates.map((row) => ({ ...row, custom_domain: null }));
-          return { rows: /RETURNING/.test(sql) ? rows : [], rowCount: candidates.length };
-        }
+        calls.push({ sql: norm(sql), params });
+
         if (/^SELECT/.test(sql.trim())) {
-          const matched = candidates.filter((row) => !isSettling(sql, params, row));
-          const rows = cleared
-            ? matched.map((row) => ({ ...row, custom_domain: null }))
-            : matched;
+          const rows = candidates
+            .filter((row) => releasable(sql, params, row))
+            .map(({ id, username, custom_domain }) => ({ id, username, custom_domain }));
+          onLock?.(candidates);
           return { rows, rowCount: rows.length };
         }
+
+        if (/UPDATE tenants/.test(sql)) {
+          const ids: string[] = params[0] ?? [];
+          const matched = candidates.filter(
+            (row) => ids.includes(row.id) && releasable(sql, params, row)
+          );
+          for (const row of matched) row.custom_domain = null;
+          return {
+            rows: /RETURNING/.test(sql) ? matched.map((row) => ({ id: row.id })) : [],
+            rowCount: matched.length,
+          };
+        }
+
         return { rows: [], rowCount: 0 };
       },
     })
@@ -57,14 +99,21 @@ function fakeTransaction(candidates: any[]) {
   return calls;
 }
 
-const CLAIM = { id: 'tenant-1', username: 'alice', custom_domain: 'mine.example.test' };
-// A claim in the middle of being attached: setCustomDomain has committed (which is what stamps
-// updated_at), the verification record that would date it is not in yet.
-const ATTACHING = { ...CLAIM, updated_at: new Date() };
+function claim(over: Partial<FakeTenant> = {}): FakeTenant {
+  return {
+    id: 'tenant-1',
+    username: 'alice',
+    custom_domain: 'mine.example.test',
+    custom_domain_verified: false,
+    record_created_at: new Date(Date.now() - (CLAIM_DAYS + 1) * DAY),
+    ...over,
+  };
+}
 
 beforeEach(() => {
   mocks.transaction.mockReset();
   mocks.queryOne.mockReset();
+  mocks.query.mockReset();
 });
 
 /**
@@ -75,55 +124,55 @@ beforeEach(() => {
  */
 describe('TenantService.releaseUnverifiedDomains', () => {
   it('only ever selects unverified claims with no recent verification record', async () => {
-    const calls = fakeTransaction([]);
+    const calls = fakeSweep([]);
 
-    await TenantService.releaseUnverifiedDomains(14);
+    await TenantService.releaseUnverifiedDomains(CLAIM_DAYS);
 
     const select = calls[0];
     expect(select.sql).toContain('custom_domain_verified = false');
     expect(select.sql).toContain('custom_domain IS NOT NULL');
-    // The claim date comes from the verification record the attach path always writes, so no
-    // schema change is needed and a claim made minutes ago is never swept.
+    // The claim date comes from the verification record the attach path always writes in the
+    // same transaction as the claim, so no schema change is needed.
     expect(select.sql).toContain('NOT EXISTS');
     expect(select.sql).toContain("dv.created_at > NOW() - ($1 * INTERVAL '1 day')");
-    expect(select.params).toEqual([14, DOMAIN_CLAIM_SETTLE_MINUTES]);
+    expect(select.params).toEqual([CLAIM_DAYS]);
   });
 
   it('locks the candidates it is about to clear', async () => {
     // Without the lock a verification committing between the read and the write would have its
     // result thrown away, unbinding a domain that had just been proven.
-    const calls = fakeTransaction([]);
+    const calls = fakeSweep([]);
 
-    await TenantService.releaseUnverifiedDomains(14);
+    await TenantService.releaseUnverifiedDomains(CLAIM_DAYS);
 
     expect(calls[0].sql).toContain('FOR UPDATE');
   });
 
   it('clears the whole claim so the domain is free for its rightful owner', async () => {
-    const calls = fakeTransaction([CLAIM]);
+    const calls = fakeSweep([claim()]);
 
-    await TenantService.releaseUnverifiedDomains(14);
+    await TenantService.releaseUnverifiedDomains(CLAIM_DAYS);
 
     const update = calls[1];
     expect(update.sql).toContain('UPDATE tenants');
     expect(update.sql).toContain('custom_domain = NULL');
     expect(update.sql).toContain('custom_domain_verified_at = NULL');
-    expect(update.params).toEqual([['tenant-1']]);
+    expect(update.params[0]).toEqual(['tenant-1']);
   });
 
   it('reports the domain it released, read before the row was cleared', async () => {
     // RETURNING would report the NEW row, whose custom_domain is NULL by construction.
-    fakeTransaction([CLAIM]);
+    fakeSweep([claim()]);
 
-    const released = await TenantService.releaseUnverifiedDomains(14);
+    const released = await TenantService.releaseUnverifiedDomains(CLAIM_DAYS);
 
     expect(released).toEqual([{ username: 'alice', domain: 'mine.example.test' }]);
   });
 
   it('deletes the stale verification records of the claims it released', async () => {
-    const calls = fakeTransaction([CLAIM]);
+    const calls = fakeSweep([claim()]);
 
-    await TenantService.releaseUnverifiedDomains(14);
+    await TenantService.releaseUnverifiedDomains(CLAIM_DAYS);
 
     const cleanup = calls[2];
     expect(cleanup.sql).toContain('DELETE FROM domain_verifications');
@@ -131,46 +180,102 @@ describe('TenantService.releaseUnverifiedDomains', () => {
     expect(cleanup.params).toEqual([['tenant-1']]);
   });
 
-  /**
-   * The attach path commits the claim and writes the verification record that dates it as two
-   * separate statements, and a re-attach deletes the old record before inserting the new one. A
-   * sweep landing in either gap finds no record for the claim, so without the settle window it
-   * would clear a claim made seconds ago whatever claimDays says: the request would then write
-   * its verification record and answer 201 for a domain the tenant no longer held.
-   */
-  it('leaves a claim alone while its tenant row is still settling', async () => {
-    const calls = fakeTransaction([ATTACHING]);
+  it('leaves a claim alone while its verification record is inside the window', async () => {
+    const calls = fakeSweep([claim({ record_created_at: new Date(Date.now() - DAY) })]);
 
-    const released = await TenantService.releaseUnverifiedDomains(14);
+    const released = await TenantService.releaseUnverifiedDomains(CLAIM_DAYS);
 
     expect(released).toEqual([]);
     // Nothing beyond the candidate read: no claim was cleared.
     expect(calls).toHaveLength(1);
-    expect(calls[0].sql).toContain("updated_at < NOW() - ($2 * INTERVAL '1 minute')");
   });
 
-  it('still releases a claim once its row has settled', async () => {
-    // Same row, last touched well outside the window: the settle guard delays a release, it does
-    // not cancel it.
-    const settled = {
-      ...ATTACHING,
-      updated_at: new Date(Date.now() - (DOMAIN_CLAIM_SETTLE_MINUTES + 1) * 60_000),
-    };
-    const calls = fakeTransaction([settled]);
+  it('writes nothing when there is nothing to release', async () => {
+    const calls = fakeSweep([]);
 
-    const released = await TenantService.releaseUnverifiedDomains(14);
+    const released = await TenantService.releaseUnverifiedDomains(CLAIM_DAYS);
+
+    expect(released).toEqual([]);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+/**
+ * The sweep used to leave a claim alone for an hour after ANY write to its tenant row, because
+ * the attach committed the claim and the record that dates it separately and a sweep landing
+ * between them would have cleared a claim seconds old. The attach is one transaction now, and
+ * with the window gone the two ways a holder could postpone a release indefinitely are closed.
+ */
+describe('nothing but a fresh verification record can postpone a release', () => {
+  it('releases a claim whose tenant row was written a moment ago', async () => {
+    // A config save bumps updated_at through a trigger, so an account that saved more often than
+    // once an hour used to keep an unverifiable domain for as long as it kept saving.
+    const calls = fakeSweep([claim({ updated_at: new Date() })]);
+
+    const released = await TenantService.releaseUnverifiedDomains(CLAIM_DAYS);
+
+    expect(released).toEqual([{ username: 'alice', domain: 'mine.example.test' }]);
+    expect(calls[0].sql).not.toContain('updated_at <');
+  });
+
+  /**
+   * Re-submitting the same domain used to write a fresh verification record, which restarted the
+   * clock and let a holder keep a domain forever by re-posting it. The attach keeps the earliest
+   * record for a domain the tenant already holds (proved in domain-attach.test.ts), so the record
+   * still dates the claim from the first submit and the sweep still releases it.
+   */
+  it('releases a re-submitted claim whose earliest record is outside the window', async () => {
+    const calls = fakeSweep([
+      claim({
+        updated_at: new Date(),
+        record_created_at: new Date(Date.now() - (CLAIM_DAYS + 1) * DAY),
+      }),
+    ]);
+
+    const released = await TenantService.releaseUnverifiedDomains(CLAIM_DAYS);
 
     expect(released).toEqual([{ username: 'alice', domain: 'mine.example.test' }]);
     expect(calls[1].sql).toContain('UPDATE tenants');
   });
+});
 
-  it('writes nothing when there is nothing to release', async () => {
-    const calls = fakeTransaction([]);
+/**
+ * Under READ COMMITTED a row that was being updated when the SELECT reached it is re-checked
+ * against the updated version, but subqueries in that re-check still run on the statement's
+ * original snapshot. So an attach that commits while the sweep waits for the row lock is
+ * invisible to the candidate SELECT's NOT EXISTS, and the sweep would unbind a domain claimed a
+ * moment ago. The UPDATE repeats the predicate on a fresh snapshot of rows it already holds
+ * locked, which is what actually settles it.
+ */
+describe('a claim attached while the sweep waited for its lock survives', () => {
+  it('does not clear a row whose verification record landed after the candidate read', async () => {
+    const rows = [claim()];
+    const calls = fakeSweep(rows, (current) => {
+      // The attach committed: the tenant now holds the domain with a record written alongside it.
+      current[0].record_created_at = new Date();
+    });
 
-    const released = await TenantService.releaseUnverifiedDomains(14);
+    const released = await TenantService.releaseUnverifiedDomains(CLAIM_DAYS);
 
     expect(released).toEqual([]);
-    expect(calls).toHaveLength(1);
+    expect(rows[0].custom_domain).toBe('mine.example.test');
+    // The re-check is in the UPDATE itself, so it can never be skipped by an early return.
+    expect(calls[1].sql).toContain('UPDATE tenants');
+    expect(calls[1].sql).toContain('NOT EXISTS');
+    expect(calls[1].params).toEqual([['tenant-1'], CLAIM_DAYS]);
+    // Nothing was released, so no verification records are deleted either.
+    expect(calls.some((call) => /DELETE FROM domain_verifications/.test(call.sql))).toBe(false);
+  });
+
+  it('still releases the claims that did not change under it', async () => {
+    const rows = [claim(), claim({ id: 'tenant-2', username: 'bob', custom_domain: 'other.example.test' })];
+    fakeSweep(rows, (current) => {
+      current[0].record_created_at = new Date();
+    });
+
+    const released = await TenantService.releaseUnverifiedDomains(CLAIM_DAYS);
+
+    expect(released).toEqual([{ username: 'bob', domain: 'other.example.test' }]);
   });
 });
 

--- a/apps/self-hosted/hosting/api/src/services/set-custom-domain.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/set-custom-domain.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({ queryOne: vi.fn() }));
+const mocks = vi.hoisted(() => ({ query: vi.fn() }));
 
-vi.mock('../db/client', () => ({ db: { queryOne: mocks.queryOne } }));
+vi.mock('../db/client', () => ({ db: { query: mocks.query } }));
 vi.mock('@ecency/sdk/hive', () => ({ callRPC: vi.fn(), config: { set: vi.fn() } }));
 
 const { TenantService, DomainInUseError } = await import('./tenant-service');
+
+// The claim runs on whatever executor the attach hands it, so the test supplies one directly.
+const exec = { query: (sql: string, params?: any[]) => mocks.query(sql, params) };
 
 /**
  * Whether a re-submitted domain keeps its verification is decided inside the
@@ -17,13 +20,13 @@ const { TenantService, DomainInUseError } = await import('./tenant-service');
  */
 describe('setCustomDomain', () => {
   beforeEach(() => {
-    mocks.queryOne.mockReset().mockResolvedValue({ id: 't1', username: 'alice' });
+    mocks.query.mockReset().mockResolvedValue({ rows: [{ id: 't1', username: 'alice' }] });
   });
 
   it('preserves verification only when the stored domain is unchanged', async () => {
-    await TenantService.setCustomDomain('alice', 'mine.example.com');
+    await TenantService.setCustomDomain(exec, 'alice', 'mine.example.com');
 
-    const [sql, params] = mocks.queryOne.mock.calls[0];
+    const [sql, params] = mocks.query.mock.calls[0];
     const normalised = sql.replace(/\s+/g, ' ');
 
     expect(normalised).toContain(
@@ -36,32 +39,46 @@ describe('setCustomDomain', () => {
   });
 
   it('lowercases both the tenant and the domain', async () => {
-    await TenantService.setCustomDomain('Alice', 'Mine.Example.COM');
+    await TenantService.setCustomDomain(exec, 'Alice', 'Mine.Example.COM');
 
-    expect(mocks.queryOne.mock.calls[0][1]).toEqual(['alice', 'mine.example.com']);
+    expect(mocks.query.mock.calls[0][1]).toEqual(['alice', 'mine.example.com']);
   });
 
   it('reports a unique violation as a domain conflict', async () => {
-    mocks.queryOne.mockRejectedValue(Object.assign(new Error('dup'), { code: '23505' }));
+    mocks.query.mockRejectedValue(Object.assign(new Error('dup'), { code: '23505' }));
 
     await expect(
-      TenantService.setCustomDomain('alice', 'taken.example.com'),
+      TenantService.setCustomDomain(exec, 'alice', 'taken.example.com'),
     ).rejects.toBeInstanceOf(DomainInUseError);
   });
 
   it('does not swallow an unrelated database error', async () => {
-    mocks.queryOne.mockRejectedValue(Object.assign(new Error('boom'), { code: '08006' }));
+    mocks.query.mockRejectedValue(Object.assign(new Error('boom'), { code: '08006' }));
 
     await expect(
-      TenantService.setCustomDomain('alice', 'x.example.com'),
+      TenantService.setCustomDomain(exec, 'alice', 'x.example.com'),
     ).rejects.toThrow('boom');
   });
 
   it('reports a missing tenant', async () => {
-    mocks.queryOne.mockResolvedValue(null);
+    mocks.query.mockResolvedValue({ rows: [] });
 
     await expect(
-      TenantService.setCustomDomain('nobody', 'x.example.com'),
+      TenantService.setCustomDomain(exec, 'nobody', 'x.example.com'),
     ).rejects.toThrow('Tenant not found');
+  });
+
+  /**
+   * The claim must be able to share the attach transaction. If it reached for the module-level
+   * db instead of the executor it was handed, it would commit on its own connection and the
+   * claim would once again be able to exist without the verification record that dates it.
+   */
+  it('runs on the executor it was given, never on its own connection', async () => {
+    const shared = { query: vi.fn().mockResolvedValue({ rows: [{ id: 't1' }] }) };
+
+    await TenantService.setCustomDomain(shared, 'alice', 'mine.example.com');
+
+    expect(shared.query).toHaveBeenCalledTimes(1);
+    expect(mocks.query).not.toHaveBeenCalled();
   });
 });

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -2,7 +2,7 @@
  * Tenant Service
  */
 
-import { db } from '../db/client';
+import { db, type SqlExecutor } from '../db/client';
 import { callRPC, config as hiveTxConfig } from '@ecency/sdk/hive';
 import { Tenant, TenantRow, mapTenantFromDb } from '../types';
 import { ApiError } from '../errors';
@@ -80,11 +80,6 @@ export const POSTS_FILTERS_BY_TYPE: Record<'blog' | 'community', readonly string
 // The time-based quarantine then only has to cover the residual seconds of healthy live tailing.
 export const ABANDONED_REREGISTER_QUARANTINE_HOURS = 1;
 
-// Settle window the unverified-domain sweep leaves around a freshly touched tenant row. The attach
-// path writes the claim and the verification record that dates it as two separate statements, so
-// for a moment a live claim has no record backing it; see releaseUnverifiedDomains.
-export const DOMAIN_CLAIM_SETTLE_MINUTES = 60;
-
 // Whether an existing row is an abandoned reservation that has cleared the re-registration
 // quarantine (so a fresh signup may reclaim its username). A live row, or one reclaimed within
 // the quarantine, is NOT reusable. The SQL upsert applies the same guard atomically; this is the
@@ -110,6 +105,25 @@ export const CAUGHT_UP_SQL = `EXISTS (
   WHERE key = 'payment_listener.caught_up'
     AND updated_at > NOW() - INTERVAL '${LISTENER_CAUGHT_UP_MAX_AGE}'
 )`;
+
+/**
+ * What makes a custom-domain claim releasable, as SQL over `tenants`.
+ *
+ * Emitted from one place because releaseUnverifiedDomains applies it twice, in statements whose
+ * placeholder numbering differs: the two must not drift, or the re-check that protects a claim
+ * made mid-sweep would be asking a different question from the one that selected it.
+ * `claimDaysParam` is the 1-based placeholder holding the claim window in days.
+ */
+function unverifiedClaimPredicate(claimDaysParam: number): string {
+  return `custom_domain IS NOT NULL
+            AND custom_domain_verified = false
+            AND NOT EXISTS (
+                  SELECT 1 FROM domain_verifications dv
+                   WHERE dv.tenant_id = tenants.id
+                     AND dv.domain = tenants.custom_domain
+                     AND dv.created_at > NOW() - ($${claimDaysParam} * INTERVAL '1 day')
+                )`;
+}
 
 export const TenantService = {
   /**
@@ -516,10 +530,15 @@ export const TenantService = {
   },
   
   /**
-   * Set custom domain
+   * Claim half of a custom-domain attach: point the tenant row at the domain.
+   *
+   * Runs on a caller-supplied executor and is deliberately NOT a standalone entry point.
+   * A claim without the verification record that dates it is exactly the state the release
+   * sweep reads as expired, so the two belong in one transaction: go through
+   * DomainService.attachDomain, which is what both rails call.
    */
-  async setCustomDomain(username: string, domain: string): Promise<Tenant> {
-    let row: TenantRow | null;
+  async setCustomDomain(exec: SqlExecutor, username: string, domain: string): Promise<Tenant> {
+    let row: TenantRow | undefined;
 
     try {
       // Re-submitting the domain the tenant already holds keeps its verification.
@@ -527,7 +546,7 @@ export const TenantService = {
       // level guard would be check-then-act, and a concurrent update could make
       // the read stale between the two. Setting a DIFFERENT domain still clears
       // the flag, which is what re-verification exists for.
-      row = await db.queryOne<TenantRow>(
+      const result = await exec.query<TenantRow>(
         `UPDATE tenants
          SET custom_domain = $2,
              custom_domain_verified =
@@ -539,6 +558,7 @@ export const TenantService = {
          RETURNING *`,
         [username.toLowerCase(), domain.toLowerCase()]
       );
+      row = result.rows[0];
     } catch (error) {
       // custom_domain is UNIQUE. Losing the race to another tenant is a
       // conflict, not a server error: without this the raw Postgres message
@@ -644,10 +664,17 @@ export const TenantService = {
    * would not have freed the column anyway.
    *
    * A claim is released when no verification record for that exact domain has been created
-   * within `claimDays`. The record is what the attach path always writes, so it dates the claim
-   * without needing a new column (this service must keep running against the old schema while a
-   * deploy rolls out). Re-submitting the same domain writes a fresh record and restarts the
-   * clock, which is deliberate: an owner who is still working on DNS keeps their claim.
+   * within `claimDays`. The attach writes that record in the same transaction as the claim, so
+   * it dates every claim without needing a new column (migrations here are applied by hand, and
+   * a column the code required would 500 every request until someone ran the SQL). The attach
+   * keeps the EARLIEST record for a domain the tenant already
+   * holds, so re-submitting the same domain no longer restarts this clock: a squatter cannot
+   * hold a domain past claimDays by re-posting it, while an owner still working on DNS has the
+   * whole window from the moment they first asked for it.
+   *
+   * Nothing else can postpone a release either. The tenant row's updated_at is deliberately not
+   * consulted: it moves on every unrelated write (a config save bumps it through a trigger), so
+   * dating a claim by it let an account that saved often keep an unverifiable domain forever.
    *
    * Only unverified claims are touched, so a verified domain is never unbound and no serving
    * site is affected. Idempotent: a released row has custom_domain NULL and cannot match again.
@@ -659,17 +686,13 @@ export const TenantService = {
    * verification's own UPDATE is keyed on username AND domain, matches no row, returns null, and
    * both rails already answer "verify again" for that.
    *
-   * A claim whose tenant row was touched within DOMAIN_CLAIM_SETTLE_MINUTES is also left alone.
-   * Dating the claim by its verification record only works once that record exists, and the attach
-   * path writes the two separately: setCustomDomain commits the claim, then createVerification
-   * deletes any previous record and inserts the new one. In both gaps no record matches the claim,
-   * so a sweep landing there would clear a claim made seconds ago no matter how large claimDays is,
-   * and the request would carry on to write its record and report success for a domain the tenant
-   * no longer held. Every write to a tenant row bumps updated_at (a trigger does it, so this does
-   * not depend on any statement remembering to), which puts a claim in mid-attach inside the
-   * window. An unrelated tenant write postpones a release by up to that window, which is the
-   * harmless direction: a squatted domain is freed an hour later rather than a domain being taken
-   * from someone who has just asked for it.
+   * The UPDATE repeats the whole predicate rather than trusting the ids the SELECT returned.
+   * Under READ COMMITTED, a row that was being updated when the SELECT reached it is re-checked
+   * against the updated version, but subqueries in that re-check still run on the statement's
+   * ORIGINAL snapshot. So an attach that commits while the sweep waits for its lock is invisible
+   * to the NOT EXISTS, and a domain claimed a moment ago would be unbound. The UPDATE is a new
+   * statement on already-locked rows: it takes a fresh snapshot, sees the committed record, and
+   * simply matches nothing. RETURNING then reports which rows were actually cleared.
    *
    * The claim is read before it is cleared rather than from RETURNING, which reports the NEW row
    * and would hand back a null domain for every release.
@@ -679,44 +702,43 @@ export const TenantService = {
       const candidates = await client.query<{ id: string; username: string; custom_domain: string }>(
         `SELECT id, username, custom_domain
            FROM tenants
-          WHERE custom_domain IS NOT NULL
-            AND custom_domain_verified = false
-            AND updated_at < NOW() - ($2 * INTERVAL '1 minute')
-            AND NOT EXISTS (
-                  SELECT 1 FROM domain_verifications dv
-                   WHERE dv.tenant_id = tenants.id
-                     AND dv.domain = tenants.custom_domain
-                     AND dv.created_at > NOW() - ($1 * INTERVAL '1 day')
-                )
+          WHERE ${unverifiedClaimPredicate(1)}
           FOR UPDATE`,
-        [claimDays, DOMAIN_CLAIM_SETTLE_MINUTES]
+        [claimDays]
       );
 
       if (candidates.rows.length === 0) return [];
       const ids = candidates.rows.map((row) => row.id);
 
-      await client.query(
+      const cleared = await client.query<{ id: string }>(
         `UPDATE tenants
             SET custom_domain = NULL,
                 custom_domain_verified = false,
                 custom_domain_verified_at = NULL,
                 updated_at = NOW()
-          WHERE id = ANY($1::uuid[])`,
-        [ids]
+          WHERE id = ANY($1::uuid[])
+            AND ${unverifiedClaimPredicate(2)}
+          RETURNING id`,
+        [ids, claimDays]
       );
+
+      if (cleared.rows.length === 0) return [];
+      const releasedIds = new Set(cleared.rows.map((row) => row.id));
 
       // Drop the stale records with the claim they belonged to, in the same transaction, so the
       // two can never disagree about whether a claim exists. Verified records are left alone.
       await client.query(
         `DELETE FROM domain_verifications
           WHERE tenant_id = ANY($1::uuid[]) AND verified = false`,
-        [ids]
+        [[...releasedIds]]
       );
 
-      return candidates.rows.map((row) => ({
-        username: row.username,
-        domain: row.custom_domain,
-      }));
+      return candidates.rows
+        .filter((row) => releasedIds.has(row.id))
+        .map((row) => ({
+          username: row.username,
+          domain: row.custom_domain,
+        }));
     });
   },
 


### PR DESCRIPTION
Closes #1328. Follow-up to #1323, which closed the mid-attach race with a settle window and documented two holes it left. Both come from the same root, and this removes it.

## What changed

**Attach is one transaction.** `DomainService.attachDomain(username, domain)` runs the claim (`setCustomDomain`) and the verification record in a single `db.transaction`, and is the only way either rail attaches a domain: `routes/domains.ts` and `routes/internal.ts` both call it. `TenantService.setCustomDomain` now takes the executor it must run on, so it cannot commit separately by accident. The record's DELETE and INSERT are inside the same transaction.

**The settle window is gone.** `DOMAIN_CLAIM_SETTLE_MINUTES` and the `updated_at` predicate in `releaseUnverifiedDomains` are removed. The gap they covered no longer exists.

**A re-submit no longer restarts the claim clock.** The attach keeps the earliest verification record for a domain the tenant already holds, and drops records only for domains it no longer holds. That record's `created_at` is what dates the claim, so the window runs from the first time the domain was asked for.

**The sweep's UPDATE repeats the whole predicate** instead of trusting the ids its `SELECT ... FOR UPDATE` returned. Under READ COMMITTED a row re-checked after a concurrent update still evaluates subqueries on the statement's original snapshot, so an attach that commits while the sweep waits for the row lock would be invisible to the `NOT EXISTS` and the sweep would unbind a domain claimed a moment ago. The UPDATE is a new statement on rows it already holds locked: fresh snapshot, sees the committed record, matches nothing. `RETURNING id` then decides what is reported as released and whose records are deleted.

**Dead code:** `getExpiredVerifications` and `cleanupExpiredVerifications` are deleted rather than wired up. They were wired to nothing, and deleting records on `expires_at` would now hand the sweep a claim with no date and free a domain early. Stale records are removed with the claim they belong to, by `releaseUnverifiedDomains` and `removeCustomDomain`.

## Migration

**None.** No schema change: the claim is dated by the verification record that already exists, not by a new column. Nothing has to be run before or after the deploy.

A `custom_domain_claimed_at` column was the alternative. It was rejected because migrations here are applied by hand and there is no staging tier, so between the deploy and someone running the SQL every attach would 500, and code written to work against both schemas would have to keep the record-based path anyway.

## Behaviour change for existing tenants

- Claims currently protected only by the settle window become releasable again. A claim is released only if it is unverified, older than the claim window, and has no verification record inside that window, exactly as #1311 intended. Verified domains are untouched, so no serving site is affected.
- Re-submitting the same unverified domain no longer extends the claim. Existing records keep their current `created_at`, so nobody loses time retroactively.
- A failed attach now changes nothing at all. Previously the claim had already committed (with `custom_domain_verified` cleared) and only the record was lost. Because of that, the `domain.added` audit event now records after the transaction commits rather than before it: a failed attach records nothing, since nothing happened.
- A tenant re-pointing an already-verified domain to a new one keeps the old domain if the record write fails, rather than being left unverified.

## Tests

286 pass (275 before, 11 added). Every behaviour change is mutation-verified: reverting the attach to two commits, deleting every record for the tenant instead of keeping the current one, always inserting a fresh record, restoring the settle window, dropping the claim window from the SELECT, dropping the re-check from the UPDATE, reporting every candidate rather than the cleared ones, running the claim on its own connection, auditing before the attach, and re-issuing verification for an already-verified domain on either rail. Each mutant is killed by a named test, no survivors.

`domain-attach.test.ts` runs against a fake that commits the way Postgres does (statements apply to a private copy, published only when the callback returns), so a half-applied attach is asserted, not inferred. The sweep's fake evaluates the predicates the SQL asks for, so a statement that stops asking a question is handed the rows it should have withheld.