### PR TITLE
self-hosted: make Hivesigner setup reachable and explained

### DIFF
--- a/apps/self-hosted/DEPLOYMENT.md
+++ b/apps/self-hosted/DEPLOYMENT.md
@@ -130,6 +130,32 @@ Enable/disable features in your config:
 }
 ```
 
+`methods` accepts `keychain`, `hivesigner` and `hiveauth`. Any other name is ignored.
+
+### Hivesigner Login
+
+Listing `hivesigner` is not enough on its own. The button stays hidden until the
+instance names a Hivesigner app:
+
+```json
+{
+  "general": {
+    "hivesigner": { "clientId": "your-app-id" }
+  }
+}
+```
+
+Two ways to get an id:
+
+- Register your own Hivesigner app and put its id here.
+- Email hello@ecency.com to get this site's `/auth` address registered on the
+  shared `ecency.app` app, then put `ecency.app` here.
+
+Hivesigner refuses to return to an address its app has not registered, so a
+login button offered without this can only end on an error page. That is why it
+stays hidden instead. Site owners can also set the id in the Configuration
+Editor, under General Settings > Hivesigner.
+
 ### Layout Options
 
 ```json

--- a/apps/self-hosted/src/features/auth/auth-provider.tsx
+++ b/apps/self-hosted/src/features/auth/auth-provider.tsx
@@ -4,7 +4,8 @@ import { createContext, type ReactNode, useEffect, useMemo } from 'react';
 import { InstanceConfigManager } from '@/core';
 import { useAuthStore } from '@/store';
 import { clearHiveAuthSession, clearUser } from './storage';
-import type { AuthContextValue, AuthMethod, AuthUser } from './types';
+import type { AuthContextValue, AuthUser } from './types';
+import { availableAuthMethods } from './utils/auth-methods';
 import { resolveHivesignerClientId } from './utils/hivesigner';
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -33,8 +34,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // explanation: Hivesigner rejects a redirect_uri its app has not registered,
   // and a hosted blog's origin cannot be registered in advance, so it is offered
   // only when the instance names a client of its own.
-  const availableMethods = ((authConfig?.methods ?? []) as AuthMethod[]).filter(
-    (method) => (method === 'hivesigner' ? hivesignerClientId !== null : true),
+  const availableMethods = availableAuthMethods(
+    authConfig?.methods,
+    hivesignerClientId,
   );
 
   // Get the instance owner. Falls back to the showcased username for older

--- a/apps/self-hosted/src/features/auth/utils/auth-methods.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/auth-methods.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { AUTH_METHODS, availableAuthMethods } from './auth-methods';
+
+/**
+ * What a reader is offered. Hivesigner without a registered client can only end
+ * in an OAuth error, so it must not reach the login page at all: the owner is
+ * told about it in the configuration editor, which only the owner can open.
+ */
+describe('methods offered to a visitor', () => {
+  it('drops hivesigner when the instance has no client id', () => {
+    expect(
+      availableAuthMethods(['keychain', 'hivesigner', 'hiveauth'], null),
+    ).toEqual(['keychain', 'hiveauth']);
+  });
+
+  it('offers hivesigner once the instance has a client id', () => {
+    expect(
+      availableAuthMethods(['keychain', 'hivesigner'], 'myblog.app'),
+    ).toEqual(['keychain', 'hivesigner']);
+  });
+
+  it('leaves the other methods alone either way', () => {
+    expect(availableAuthMethods(['keychain', 'hiveauth'], null)).toEqual([
+      'keychain',
+      'hiveauth',
+    ]);
+  });
+
+  it('offers nothing when no methods are configured', () => {
+    expect(availableAuthMethods(undefined, 'myblog.app')).toEqual([]);
+  });
+
+  it('lists exactly the methods the login page can render', () => {
+    expect([...AUTH_METHODS]).toEqual(['keychain', 'hivesigner', 'hiveauth']);
+  });
+});

--- a/apps/self-hosted/src/features/auth/utils/auth-methods.ts
+++ b/apps/self-hosted/src/features/auth/utils/auth-methods.ts
@@ -1,0 +1,33 @@
+import type { AuthMethod } from '../types';
+
+/**
+ * Every login method this app can actually complete.
+ *
+ * The login page renders a known method or nothing, so a name outside this list
+ * is accepted by the config and then does nothing at all. The configuration
+ * editor checks entries against this list so a typo is rejected where it is
+ * typed instead of disappearing into a saved config.
+ */
+export const AUTH_METHODS: readonly AuthMethod[] = [
+  'keychain',
+  'hivesigner',
+  'hiveauth',
+];
+
+/**
+ * The methods a visitor may be offered, from the configured list.
+ *
+ * Hivesigner is dropped unless the instance has a client id. OAuth rejects a
+ * redirect_uri its app has not registered, so without one the button can only
+ * send the visitor to an error page with no explanation; hiding it is the
+ * intended behaviour, not a fallback. The owner is told about it in the
+ * configuration editor, which no reader can open.
+ */
+export function availableAuthMethods(
+  configured: readonly string[] | undefined,
+  hivesignerClientId: string | null,
+): AuthMethod[] {
+  return ((configured ?? []) as AuthMethod[]).filter((method) =>
+    method === 'hivesigner' ? hivesignerClientId !== null : true,
+  );
+}

--- a/apps/self-hosted/src/features/floating-menu/array-field.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/array-field.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import {
+  INVALID_ARRAY_MESSAGE,
+  NON_PRIMITIVE_ARRAY_MESSAGE,
+  validateArrayDraft,
+  validateArrayEntries,
+} from './array-field';
+
+const AUTH_METHODS = ['keychain', 'hivesigner', 'hiveauth'] as const;
+
+describe('list fields without a fixed set of values', () => {
+  it('takes any list of plain values', () => {
+    expect(validateArrayDraft('["blog", "posts"]')).toEqual({
+      value: ['blog', 'posts'],
+      error: null,
+    });
+    expect(validateArrayDraft('[1, 5, 10]')).toEqual({
+      value: [1, 5, 10],
+      error: null,
+    });
+  });
+
+  it('refuses text that is not a list, without applying anything', () => {
+    for (const draft of ['not json', '{"a": 1}', '"blog"', '']) {
+      expect(validateArrayDraft(draft)).toEqual({
+        value: null,
+        error: INVALID_ARRAY_MESSAGE,
+      });
+    }
+  });
+
+  /**
+   * The hosting API drops an array holding an object or a null and still
+   * answers 200, so a value taken here would look saved and never be.
+   */
+  it('refuses objects, arrays and nulls inside the list', () => {
+    expect(validateArrayDraft('[{"value": "blog"}]')).toEqual({
+      value: null,
+      error: NON_PRIMITIVE_ARRAY_MESSAGE,
+    });
+    expect(validateArrayDraft('[["blog"]]')).toEqual({
+      value: null,
+      error: NON_PRIMITIVE_ARRAY_MESSAGE,
+    });
+    expect(validateArrayDraft('["blog", null]')).toEqual({
+      value: null,
+      error: NON_PRIMITIVE_ARRAY_MESSAGE,
+    });
+  });
+});
+
+/**
+ * `features.auth.methods` is the case this exists for: the login page renders a
+ * method it knows or nothing at all, so a misspelled name is accepted by the
+ * config and then does nothing, with no way for the owner to tell.
+ */
+describe('login methods, checked against the set the app can serve', () => {
+  it('takes the methods the app can complete', () => {
+    expect(
+      validateArrayDraft('["keychain", "hivesigner"]', AUTH_METHODS),
+    ).toEqual({ value: ['keychain', 'hivesigner'], error: null });
+  });
+
+  it('names the misspelling and the valid options, and applies nothing', () => {
+    const result = validateArrayDraft('["keychain", "hivesign"]', AUTH_METHODS);
+
+    expect(result.value).toBe(null);
+    expect(result.error).toContain('"hivesign"');
+    expect(result.error).toContain('keychain, hivesigner, hiveauth');
+    // The valid neighbour must not be reported as the problem.
+    expect(result.error).not.toContain('"keychain"');
+  });
+
+  it('reports every unknown entry, not just the first', () => {
+    const result = validateArrayDraft('["hivesign", "keycahin"]', AUTH_METHODS);
+
+    expect(result.error).toContain('"hivesign"');
+    expect(result.error).toContain('"keycahin"');
+  });
+
+  it('rejects a non-string entry where names are expected', () => {
+    expect(validateArrayEntries([42], AUTH_METHODS)).not.toBe(null);
+    expect(validateArrayEntries([true], AUTH_METHODS)).not.toBe(null);
+  });
+
+  it('accepts an empty list, which offers no login at all', () => {
+    expect(validateArrayEntries([], AUTH_METHODS)).toBe(null);
+  });
+
+  /** An entry already in the saved config has to be reported on open. */
+  it('checks a stored value, not only typed text', () => {
+    expect(validateArrayEntries(['keychain'], AUTH_METHODS)).toBe(null);
+    expect(validateArrayEntries(['hivesign'], AUTH_METHODS)).toContain(
+      '"hivesign"',
+    );
+  });
+});

--- a/apps/self-hosted/src/features/floating-menu/array-field.ts
+++ b/apps/self-hosted/src/features/floating-menu/array-field.ts
@@ -1,0 +1,82 @@
+import type { ConfigPrimitive } from './types';
+
+/** Shown when the text in the box is not a JSON array at all. */
+export const INVALID_ARRAY_MESSAGE = 'Invalid JSON array';
+
+/**
+ * Shown when the list holds anything but a plain value.
+ *
+ * The hosting API rejects an array element that is null or an object, and a
+ * rejected value is dropped behind a 200 OK, so the owner has no way to tell
+ * the setting never changed.
+ */
+export const NON_PRIMITIVE_ARRAY_MESSAGE =
+  'A list can only contain text, numbers or true and false.';
+
+export interface ArrayDraftResult {
+  /** The array to apply, or null when the draft must not be applied. */
+  value: ConfigPrimitive[] | null;
+  /** What to tell the owner, or null when the draft is fine. */
+  error: string | null;
+}
+
+/** `Not a valid option: "hivesign". Choose from: keychain, hivesigner, hiveauth.` */
+function unknownEntriesMessage(
+  unknown: readonly unknown[],
+  allowedValues: readonly string[],
+): string {
+  const listed = unknown.map((entry) => JSON.stringify(entry)).join(', ');
+  return `Not a valid option: ${listed}. Choose from: ${allowedValues.join(', ')}.`;
+}
+
+/**
+ * Check the entries of a list field, returning a message or null when fine.
+ *
+ * `allowedValues` turns a free-text list into a checked set: an entry outside it
+ * is a name nothing in the app reads, so it is accepted by the config and then
+ * does nothing. Rejecting it here is the only point where the owner can still
+ * see what they typed.
+ */
+export function validateArrayEntries(
+  entries: readonly unknown[],
+  allowedValues?: readonly string[],
+): string | null {
+  if (entries.some((entry) => entry === null || typeof entry === 'object')) {
+    return NON_PRIMITIVE_ARRAY_MESSAGE;
+  }
+
+  if (!allowedValues) return null;
+
+  const unknown = entries.filter(
+    (entry) => typeof entry !== 'string' || !allowedValues.includes(entry),
+  );
+  return unknown.length > 0
+    ? unknownEntriesMessage(unknown, allowedValues)
+    : null;
+}
+
+/**
+ * Parse and check what the owner typed into a list field.
+ *
+ * `value` is non-null only when there is no error, so an invalid draft is never
+ * written into the config: it stays in the box, with the reason under it, until
+ * it is fixed.
+ */
+export function validateArrayDraft(
+  draft: string,
+  allowedValues?: readonly string[],
+): ArrayDraftResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(draft);
+  } catch {
+    return { value: null, error: INVALID_ARRAY_MESSAGE };
+  }
+
+  if (!Array.isArray(parsed)) {
+    return { value: null, error: INVALID_ARRAY_MESSAGE };
+  }
+
+  const error = validateArrayEntries(parsed, allowedValues);
+  return error ? { value: null, error } : { value: parsed, error: null };
+}

--- a/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
+++ b/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useMemo, useState } from 'react';
+import { validateArrayDraft, validateArrayEntries } from '../array-field';
 import type { ConfigField } from '../config-fields';
 import { FLOATING_MENU_THEME } from '../constants';
 import type {
@@ -26,6 +27,7 @@ const sectionIcons: Record<string, string> = {
   comments: '💬',
   post: '📄',
   text2Speech: '🔊',
+  hivesigner: '🔑',
 } as const;
 
 function getSectionIcon(label: string): string {
@@ -57,29 +59,30 @@ function ArrayFieldEditor({
   // Memoize the serialized value to avoid recalculating on every render
   const serializedValue = useMemo(() => JSON.stringify(arrayValue), [arrayValue]);
   const [draftJson, setDraftJson] = useState(() => JSON.stringify(arrayValue, null, 2));
-  const [isValid, setIsValid] = useState(true);
+  // Checked on mount too, so a value that is already in the saved config is
+  // reported rather than waiting for the owner to touch the field.
+  const [error, setError] = useState<string | null>(() =>
+    validateArrayEntries(arrayValue, field.allowedValues),
+  );
+  const isValid = error === null;
 
   // Sync draft when external value changes
   useEffect(() => {
     const newJson = JSON.stringify(arrayValue, null, 2);
     setDraftJson(newJson);
-    setIsValid(true);
-  }, [serializedValue]);
+    setError(validateArrayEntries(arrayValue, field.allowedValues));
+  }, [serializedValue, field.allowedValues]);
 
   const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;
     setDraftJson(newValue);
 
-    try {
-      const parsed = JSON.parse(newValue);
-      if (Array.isArray(parsed)) {
-        setIsValid(true);
-        handleChange(parsed);
-      } else {
-        setIsValid(false);
-      }
-    } catch {
-      setIsValid(false);
+    // A rejected draft is never written into the config: the owner keeps
+    // looking at what they typed and at the reason it was not taken.
+    const result = validateArrayDraft(newValue, field.allowedValues);
+    setError(result.error);
+    if (result.value) {
+      handleChange(result.value);
     }
   };
 
@@ -110,7 +113,7 @@ function ArrayFieldEditor({
         aria-invalid={!isValid}
       />
       <p className={`text-xs mt-1 font-sans ${isValid ? 'text-gray-400' : 'text-red-400'}`}>
-        {isValid ? 'Enter a valid JSON array' : 'Invalid JSON array'}
+        {error ?? 'Enter a valid JSON array'}
       </p>
     </div>
   );

--- a/apps/self-hosted/src/features/floating-menu/components/floating-menu-window.tsx
+++ b/apps/self-hosted/src/features/floating-menu/components/floating-menu-window.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/features/auth/utils/hosting-token';
 import { configFieldsMap } from '../config-fields';
 import { FLOATING_MENU_THEME } from '../constants';
+import { getHivesignerSetupNotice } from '../hivesigner-setup';
 import {
   readDiscarded,
   readSavedConfig,
@@ -99,6 +100,19 @@ export function FloatingMenuWindow({
   const originalStateRef = useRef<ConfigDomSnapshot | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
   const managed = useMemo(() => isManagedHosting(), []);
+
+  // Everything the owner is being told, in one place. This window is the whole
+  // audience: it is rendered for the instance owner only, so a setting that
+  // cannot work can be reported here without a reader ever seeing it. Read from
+  // the edited document, so it answers for what is on screen and clears as soon
+  // as the client id is typed.
+  const notices = useMemo(
+    () =>
+      [notice, getHivesignerSetupNotice(config)].filter(
+        (message): message is string => !!message,
+      ),
+    [notice, config],
+  );
 
   // Focus the dialog when it opens for keyboard accessibility
   useEffect(() => {
@@ -496,13 +510,15 @@ export function FloatingMenuWindow({
             </div>
           )}
 
-          {/* Field the server owns, rejected before it can be edited */}
-          {notice && (
+          {/* Owner-only: a field the server owns, or a setting that cannot work as configured */}
+          {notices.length > 0 && (
             <output
-              className="block px-4 py-2 text-sm font-sans text-gray-300 border-b shrink-0"
+              className="block px-4 py-2 text-sm font-sans text-gray-300 border-b shrink-0 space-y-1"
               style={{ borderColor: FLOATING_MENU_THEME.borderColor }}
             >
-              {notice}
+              {notices.map((message) => (
+                <p key={message}>{message}</p>
+              ))}
             </output>
           )}
 

--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { AUTH_METHODS } from '@/features/auth/utils/auth-methods';
+import type { ConfigField } from './config-fields';
+import { configFieldsMap } from './config-fields';
+
+/** The field at a config path, or undefined when the editor does not offer it. */
+function fieldAt(path: readonly string[]): ConfigField | undefined {
+  let fields: Record<string, ConfigField> | undefined = configFieldsMap;
+  let field: ConfigField | undefined;
+
+  for (const key of path) {
+    field = fields?.[key];
+    if (!field) return undefined;
+    fields = field.fields;
+  }
+
+  return field;
+}
+
+const CLIENT_ID_PATH = [
+  'configuration',
+  'general',
+  'hivesigner',
+  'clientId',
+] as const;
+const METHODS_PATH = [
+  'configuration',
+  'instanceConfiguration',
+  'features',
+  'auth',
+  'methods',
+] as const;
+
+/**
+ * Without this the setting exists only in the JSON document, which an owner on
+ * managed hosting has no way to reach, so Hivesigner login could be configured
+ * and never switched on.
+ */
+describe('hivesigner client id', () => {
+  it('is offered in the editor, at the path the app reads', () => {
+    expect(fieldAt(CLIENT_ID_PATH)).toBeDefined();
+  });
+
+  /**
+   * A text input. The number input writes null when cleared, and null erases
+   * the stored section on merge.
+   */
+  it('is a text field', () => {
+    expect(fieldAt(CLIENT_ID_PATH)?.type).toBe('string');
+  });
+
+  it('gives both routes to a working setup', () => {
+    const description = fieldAt(CLIENT_ID_PATH)?.description ?? '';
+
+    // Route one: the owner registers an app themselves.
+    expect(description).toContain('register your own');
+    // Route two: only Ecency can register this site on the shared app.
+    expect(description).toContain('hello@ecency.com');
+    expect(description).toContain('ecency.app');
+  });
+
+  it('is pointed at from the login methods field', () => {
+    expect(fieldAt(METHODS_PATH)?.description).toContain('Hivesigner');
+  });
+});
+
+describe('login methods', () => {
+  /** A list of names, never objects: the hosting API drops those and reports success. */
+  it('stays a list', () => {
+    expect(fieldAt(METHODS_PATH)?.type).toBe('array');
+  });
+
+  it('accepts only the methods the app can serve', () => {
+    expect(fieldAt(METHODS_PATH)?.allowedValues).toEqual(AUTH_METHODS);
+  });
+});

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -1,3 +1,5 @@
+import { AUTH_METHODS } from '@/features/auth/utils/auth-methods';
+
 export type ConfigFieldType =
   | 'string'
   | 'number'
@@ -12,6 +14,13 @@ export interface ConfigField {
   description?: string;
   fields?: Record<string, ConfigField>;
   options?: Array<{ value: string; label: string }>;
+  /**
+   * For `array` fields: the only entries this list accepts. Anything else is
+   * rejected in the editor instead of being saved into a config that no code
+   * reads. Entries stay primitives, since the hosting API drops an array
+   * holding objects and reports the save as successful anyway.
+   */
+  allowedValues?: readonly string[];
 }
 
 export const configFieldsMap: Record<string, ConfigField> = {
@@ -256,7 +265,9 @@ export const configFieldsMap: Record<string, ConfigField> = {
                   methods: {
                     label: 'Auth Methods',
                     type: 'array',
-                    description: 'Available login methods: keychain, hivesigner, hiveauth',
+                    allowedValues: AUTH_METHODS,
+                    description:
+                      'Available login methods: keychain, hivesigner, hiveauth. Hivesigner also needs a client id, set under General Settings > Hivesigner.',
                   },
                 },
               },
@@ -344,6 +355,20 @@ export const configFieldsMap: Record<string, ConfigField> = {
             type: 'string',
             description:
               'Optional external composer for the Create post button. Leave empty to write here with the built-in editor. The old default https://ecency.com/publish also means the built-in editor.',
+          },
+          hivesigner: {
+            label: 'Hivesigner',
+            type: 'section',
+            fields: {
+              clientId: {
+                label: 'Hivesigner Client ID',
+                // A text input, never a number one: the number input writes null
+                // when cleared, and null erases the stored section on merge.
+                type: 'string',
+                description:
+                  "Hivesigner login stays hidden until this is set. Either register your own Hivesigner app and put its id here, or email hello@ecency.com to get this site's /auth address registered on the shared ecency.app app, then put ecency.app here.",
+              },
+            },
           },
           styles: {
             label: 'Styles',

--- a/apps/self-hosted/src/features/floating-menu/hivesigner-setup.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/hivesigner-setup.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getHivesignerSetupNotice,
+  HIVESIGNER_SETUP_NOTICE,
+} from './hivesigner-setup';
+
+function configWith(options: {
+  methods?: unknown;
+  enabled?: unknown;
+  clientId?: unknown;
+}) {
+  return {
+    configuration: {
+      general:
+        options.clientId === undefined
+          ? {}
+          : { hivesigner: { clientId: options.clientId } },
+      instanceConfiguration: {
+        features: {
+          auth: {
+            enabled: options.enabled ?? true,
+            methods: options.methods ?? ['keychain'],
+          },
+        },
+      },
+    },
+  };
+}
+
+/**
+ * The gap this closes: the owner adds hivesigner, the save succeeds, and no
+ * button ever appears, with nothing to tell "needs a step" from "broken".
+ */
+describe('hivesigner setup notice', () => {
+  it('warns when hivesigner is offered but no client id is set', () => {
+    expect(
+      getHivesignerSetupNotice(configWith({ methods: ['hivesigner'] })),
+    ).toBe(HIVESIGNER_SETUP_NOTICE);
+  });
+
+  it('tells the owner both routes and where to do each', () => {
+    expect(HIVESIGNER_SETUP_NOTICE).toContain('General Settings > Hivesigner');
+    expect(HIVESIGNER_SETUP_NOTICE).toContain('hello@ecency.com');
+  });
+
+  it('says nothing once the owner names their own app', () => {
+    expect(
+      getHivesignerSetupNotice(
+        configWith({ methods: ['hivesigner'], clientId: 'myblog.app' }),
+      ),
+    ).toBe(null);
+  });
+
+  /**
+   * Naming ecency.app is the second route, taken once the /auth address has
+   * been registered on the shared app, and it is a deliberate choice rather
+   * than the built-in default.
+   */
+  it('says nothing once the owner names the shared app', () => {
+    expect(
+      getHivesignerSetupNotice(
+        configWith({ methods: ['hivesigner'], clientId: 'ecency.app' }),
+      ),
+    ).toBe(null);
+  });
+
+  it('still warns when the client id is blank or not text', () => {
+    expect(
+      getHivesignerSetupNotice(
+        configWith({ methods: ['hivesigner'], clientId: '   ' }),
+      ),
+    ).toBe(HIVESIGNER_SETUP_NOTICE);
+    expect(
+      getHivesignerSetupNotice(
+        configWith({ methods: ['hivesigner'], clientId: 42 }),
+      ),
+    ).toBe(HIVESIGNER_SETUP_NOTICE);
+  });
+
+  it('says nothing when hivesigner is not offered', () => {
+    expect(
+      getHivesignerSetupNotice(
+        configWith({ methods: ['keychain', 'hiveauth'] }),
+      ),
+    ).toBe(null);
+  });
+
+  /** Login is off, so there is no missing button to explain. */
+  it('says nothing when authentication is disabled', () => {
+    expect(
+      getHivesignerSetupNotice(
+        configWith({ methods: ['hivesigner'], enabled: false }),
+      ),
+    ).toBe(null);
+  });
+
+  it('survives a config missing the sections it reads', () => {
+    expect(getHivesignerSetupNotice({})).toBe(null);
+    expect(getHivesignerSetupNotice(null)).toBe(null);
+    expect(getHivesignerSetupNotice({ configuration: 'oops' })).toBe(null);
+    expect(
+      getHivesignerSetupNotice(configWith({ methods: 'hivesigner' })),
+    ).toBe(null);
+  });
+});

--- a/apps/self-hosted/src/features/floating-menu/hivesigner-setup.ts
+++ b/apps/self-hosted/src/features/floating-menu/hivesigner-setup.ts
@@ -1,0 +1,59 @@
+import { resolveHivesignerClientId } from '@/features/auth/utils/hivesigner';
+
+/**
+ * What the owner is told when Hivesigner is configured but cannot work.
+ *
+ * Both routes are named because they lead to different actions: registering an
+ * app is something the owner does alone, registering this site on the shared
+ * app is something only Ecency can do.
+ */
+export const HIVESIGNER_SETUP_NOTICE =
+  "Hivesigner is listed as a login method but this site has no Hivesigner client id, so the button stays hidden. Add your own app id under General Settings > Hivesigner, or email hello@ecency.com to get this site's /auth address registered on the shared ecency.app app.";
+
+const AUTH_PATH = [
+  'configuration',
+  'instanceConfiguration',
+  'features',
+  'auth',
+] as const;
+const CLIENT_ID_PATH = [
+  'configuration',
+  'general',
+  'hivesigner',
+  'clientId',
+] as const;
+
+function readKey(source: unknown, key: string): unknown {
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    return undefined;
+  }
+  return (source as Record<string, unknown>)[key];
+}
+
+function readPath(source: unknown, path: readonly string[]): unknown {
+  return path.reduce<unknown>((value, key) => readKey(value, key), source);
+}
+
+/**
+ * The notice for a config that asks for Hivesigner login it cannot serve, or
+ * null when there is nothing to say.
+ *
+ * The method is hidden from readers in that state and no broken button is ever
+ * rendered, which is correct and stays that way. What was missing is that the
+ * owner had no way to tell a silent method from a broken one. Takes the config
+ * document rather than reading the loaded one, so the editor can check what is
+ * on screen, unsaved edits included.
+ */
+export function getHivesignerSetupNotice(config: unknown): string | null {
+  const auth = readPath(config, AUTH_PATH);
+  // Same rule the app applies: absent means off, and with login off there is no
+  // button to miss.
+  if (readKey(auth, 'enabled') !== true) return null;
+
+  const methods = readKey(auth, 'methods');
+  if (!Array.isArray(methods) || !methods.includes('hivesigner')) return null;
+
+  return resolveHivesignerClientId(readPath(config, CLIENT_ID_PATH)) === null
+    ? HIVESIGNER_SETUP_NOTICE
+    : null;
+}


### PR DESCRIPTION
## Problem

An instance owner can add `hivesigner` to `features.auth.methods`, save successfully, and never see a login button. The method is filtered out unless the instance names a Hivesigner client id, and the client id had no field in the Configuration Editor at all, so on managed hosting there was no way to set it and nothing said why the button was missing.

The default stays as it is: Hivesigner is not offered unless the instance names a client. Hivesigner rejects a redirect address its app has not registered, so a button offered without one can only send the visitor to an error page. Hiding it is the intended behaviour; what is added here is the way to change it and the explanation when it applies.

## Changes

**Client id is editable.** `general.hivesigner.clientId` is now a field in the Configuration Editor, under General Settings > Hivesigner. It is a text field, not a number field: the number input writes `null` when cleared and `null` erases the stored section on merge. The help text gives both routes, register your own Hivesigner app and use its id, or email hello@ecency.com to get the instance `/auth` address registered on the shared `ecency.app` app and then use `ecency.app`.

**Login methods are a checked set.** `features.auth.methods` stays a JSON array of strings, and array fields now accept an optional list of allowed entries. An entry outside the set is rejected in the editor, naming what was typed and the valid options, and is not written into the config. The field also rejects objects and nulls inside the list, which the hosting API drops while still answering 200, so a value like that would look saved and never be.

**Owner-only notice.** When `hivesigner` is listed and no client id resolves, the editor shows what to do next. It reuses the existing notice region in the editor window. The editor renders only for the instance owner, so a reader never sees it, and the method stays hidden from readers exactly as before.

The filter that drops Hivesigner from the offered methods moved out of the provider component into a small tested module. Behaviour is unchanged.

`DEPLOYMENT.md` gains the same explanation for people deploying from the docs rather than the editor.

## Verification

- `vitest run`: 31 files, 276 tests pass. New tests cover the methods validation, the notice conditions, the offered-methods rule and the editor field shape.
- Every new test was mutation checked: breaking each rule fails the test that names it.
- `tsc --noEmit` clean, `rsbuild build` plus `check-node-globals` clean.
- Biome on the touched files reports nothing that is not already reported on `develop`.