### PR TITLE
feat(self-hosted): reader-facing Hive layer

### DIFF
--- a/apps/self-hosted/hosting/api/src/services/tenant-service-hive-seed.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service-hive-seed.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { TenantService } from './tenant-service';
+
+/**
+ * What a new tenant is created with, and what happens when an older one adopts
+ * the block.
+ *
+ * The seed literal is repeated here rather than imported from the app: this
+ * package builds with `rootDir: ./src` and its Docker context is this directory
+ * only, so an import reaching outside it fails the image build. The app owns
+ * the anti-drift check instead, reading this file's seed off its syntax tree
+ * (`src/core/hive-layer-seed.test.ts`).
+ *
+ * These exercise the pure config builders only, no DB and no RPC.
+ */
+const SEED = { readerLayer: 'standard', authorRewards: 'author' };
+
+describe('getDefaultConfig seeds the Hive layer', () => {
+  it('carries exactly the seeded block', async () => {
+    const config = await TenantService.getDefaultConfig('alice');
+    const { features } = config.configuration.instanceConfiguration;
+    expect(features.hive).toEqual(SEED);
+  });
+
+  it('seeds no beneficiary and no reward split, ever', async () => {
+    // Ecency taking a silent cut of a paying tenant's post rewards by default
+    // would be indefensible, so the seed is pinned to exactly two keys.
+    const config = await TenantService.getDefaultConfig('alice');
+    expect(
+      Object.keys(config.configuration.instanceConfiguration.features.hive),
+    ).toEqual(Object.keys(SEED));
+  });
+
+  it('offers only scalars, so no field can be frozen by the array guard', () => {
+    // isValidArrayReplacement rejects any array element that is an object, and
+    // mergeConfigGuarded takes an incoming value verbatim only when nothing is
+    // stored, so an array-of-objects field would save once and then be frozen
+    // behind a 200 OK forever.
+    for (const value of Object.values(SEED)) {
+      expect(typeof value).toBe('string');
+    }
+  });
+});
+
+describe('adopting the block on a config written before it existed', () => {
+  it('takes the whole object when nothing is stored at that key', () => {
+    // The `stored === undefined` lever: this is why an owner on a year-old
+    // config can save the block with no server change.
+    const stored = {
+      configuration: {
+        instanceConfiguration: { features: { likes: { enabled: true } } },
+      },
+    };
+    const merged = TenantService.mergeConfigGuarded(stored, {
+      configuration: {
+        instanceConfiguration: {
+          features: { hive: { readerLayer: 'standard' } },
+        },
+      },
+    });
+
+    const features = merged.configuration.instanceConfiguration.features;
+    expect(features.hive).toEqual({ readerLayer: 'standard' });
+    // and nothing else in the document moved
+    expect(features.likes).toEqual({ enabled: true });
+  });
+
+  it('accepts a partial write of one field', () => {
+    const stored = {
+      configuration: { instanceConfiguration: { features: {} } },
+    };
+    const merged = TenantService.mergeConfigGuarded(stored, {
+      configuration: {
+        instanceConfiguration: { features: { hive: { readerLayer: 'full' } } },
+      },
+    });
+    expect(merged.configuration.instanceConfiguration.features.hive).toEqual({
+      readerLayer: 'full',
+    });
+  });
+
+  it('stores a scalar at the block, and then refuses every object write', () => {
+    // Documented, not blessed. A hand-crafted PATCH can put a bare string here
+    // because nothing is stored yet; every later object write is dropped for a
+    // type mismatch while the API still answers 200, so the tenant is stuck
+    // until the row is repaired by hand. The client resolver's bail is what
+    // keeps the site rendering meanwhile, which is why it is load-bearing
+    // rather than paranoia and must not be refactored away.
+    const stored = {
+      configuration: { instanceConfiguration: { features: {} } },
+    };
+    const withScalar = TenantService.mergeConfigGuarded(stored, {
+      configuration: {
+        instanceConfiguration: { features: { hive: 'full' } },
+      },
+    });
+    expect(withScalar.configuration.instanceConfiguration.features.hive).toBe(
+      'full',
+    );
+
+    const repairAttempt = TenantService.mergeConfigGuarded(withScalar, {
+      configuration: {
+        instanceConfiguration: {
+          features: { hive: { readerLayer: 'standard' } },
+        },
+      },
+    });
+    expect(
+      repairAttempt.configuration.instanceConfiguration.features.hive,
+    ).toBe('full');
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -998,6 +998,17 @@ export const TenantService = {
             },
           },
           features: {
+            // How much of the Hive blockchain a reader sees. A new blog shows
+            // what each post earned, when its payout window closes, and a link
+            // to its record on chain; no feed payouts, no vote-weight picker,
+            // no downvotes. Every tenant created before this carries no `hive`
+            // block at all and resolves to `off`, so seeding it here changes
+            // nothing for them: getDefaultConfig is reached only through
+            // buildConfig, which is called only at tenant creation.
+            hive: {
+              readerLayer: 'standard',
+              authorRewards: 'author',
+            },
             postsFilters: ['posts', 'blog'],
             likes: { enabled: true },
             comments: { enabled: true },

--- a/apps/self-hosted/hosting/api/src/types.ts
+++ b/apps/self-hosted/hosting/api/src/types.ts
@@ -70,6 +70,17 @@ export interface BlogConfig {
         };
       };
       features: {
+        /**
+         * How much of the Hive blockchain the site shows readers. Decorative
+         * here, like the rest of this interface: nothing validates against it,
+         * and the client resolver treats every member as unknown-shaped.
+         */
+        hive?: {
+          readerLayer?: string;
+          authorRewards?: string;
+          payoutLabel?: string;
+          learnMoreUrl?: string;
+        };
         postsFilters?: string[];
         likes?: { enabled: boolean };
         comments?: { enabled: boolean };

--- a/apps/self-hosted/src/core/broadcast-payload-guard.test.ts
+++ b/apps/self-hosted/src/core/broadcast-payload-guard.test.ts
@@ -1,0 +1,228 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * A deploy may change what a visitor sees. It may never change what gets
+ * signed.
+ *
+ * This layer is a display layer. Nothing in it may cause a `comment_options`
+ * operation to be broadcast where one is not broadcast today, because a
+ * `comment_options` op is on chain forever and cannot be edited afterwards.
+ *
+ * The mechanism it relies on is in the SDK: `use-comment.ts` gates the whole
+ * second operation on `if (payload.options)`, so a payload without that key
+ * produces a byte-identical operation array. Both halves are pinned here, the
+ * gate and the absence of the key, because either one alone is an assumption.
+ *
+ * The anchor is deliberate: `options` is a field of the payload passed to
+ * `mutateAsync`, not an argument to `useComment`, whose second argument is
+ * `{ adapter }`.
+ */
+
+const SRC = join(__dirname, '..');
+const SDK_COMMENT = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'packages',
+  'sdk',
+  'src',
+  'modules',
+  'posts',
+  'mutations',
+  'use-comment.ts',
+);
+
+/** Exactly the keys every comment payload in this app carries today. */
+const EXPECTED_PAYLOAD_KEYS = [
+  'author',
+  'body',
+  'jsonMetadata',
+  'parentAuthor',
+  'parentPermlink',
+  'permlink',
+  'title',
+];
+
+/** `parentAuthor` appears on the SDK's CommentPayload and on nothing else here. */
+const COMMENT_PAYLOAD_MARKER = 'parentAuthor';
+
+/** Fields that exist only to configure a `comment_options` operation. */
+const OPTIONS_FIELDS = [
+  'comment_options',
+  'maxAcceptedPayout',
+  'percentHbd',
+  'allowVotes',
+  'allowCurationRewards',
+  'beneficiaries',
+];
+
+function sourceFiles(dir: string, into: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) {
+      sourceFiles(path, into);
+    } else if (/\.tsx?$/.test(name) && !/\.test\.tsx?$/.test(name)) {
+      into.push(path);
+    }
+  }
+  return into;
+}
+
+function parse(path: string): ts.SourceFile {
+  return ts.createSourceFile(
+    path,
+    readFileSync(path, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+}
+
+/**
+ * Local names that call a mutation.
+ *
+ * Covers `x.mutateAsync(...)` and the renamed form the publish bar uses,
+ * `const { mutateAsync: publishPost } = usePublishPost()`, which a check on the
+ * call text alone would miss entirely.
+ */
+function mutationAliases(sf: ts.SourceFile): Set<string> {
+  const aliases = new Set<string>();
+  const visit = (node: ts.Node) => {
+    if (ts.isBindingElement(node) && node.propertyName) {
+      const property = node.propertyName.getText(sf);
+      if (
+        (property === 'mutateAsync' || property === 'mutate') &&
+        ts.isIdentifier(node.name)
+      ) {
+        aliases.add(node.name.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return aliases;
+}
+
+/**
+ * Every name the file actually uses, comments excluded.
+ *
+ * Read off the syntax tree rather than by text search: a comment explaining why
+ * a `comment_options` operation is never emitted must not fail the guard that
+ * enforces it.
+ */
+function namesUsedIn(sf: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isIdentifier(node) ||
+      ts.isStringLiteral(node) ||
+      ts.isNoSubstitutionTemplateLiteral(node)
+    ) {
+      names.add(node.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return names;
+}
+
+interface Payload {
+  where: string;
+  keys: string[];
+}
+
+/** Every object literal handed to a mutation call in one file. */
+function payloadsIn(sf: ts.SourceFile, rel: string): Payload[] {
+  const aliases = mutationAliases(sf);
+  const found: Payload[] = [];
+
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression.getText(sf);
+      const isMutation =
+        /(^|\.)mutateAsync$/.test(callee) ||
+        /(^|\.)mutate$/.test(callee) ||
+        aliases.has(callee);
+
+      const [first] = node.arguments;
+      if (isMutation && first && ts.isObjectLiteralExpression(first)) {
+        const line =
+          sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
+        const keys = first.properties
+          .map((property) =>
+            property.name && !ts.isComputedPropertyName(property.name)
+              ? property.name.getText(sf)
+              : '<dynamic>',
+          )
+          .sort();
+        found.push({ where: `${rel}:${line}`, keys });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sf);
+  return found;
+}
+
+describe('no deploy of this layer changes a broadcast payload', () => {
+  const payloads = sourceFiles(SRC).flatMap((path) =>
+    payloadsIn(parse(path), path.replace(SRC, 'src')),
+  );
+
+  it('finds the mutation payloads it is meant to be checking', () => {
+    // Without this the whole suite passes vacuously the moment the walk stops
+    // matching, which is how a guard quietly stops guarding.
+    expect(payloads.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('passes no options object to any mutation', () => {
+    // `options` is what turns on the second operation. Absent, the operation
+    // array is byte-identical to today's.
+    const withOptions = payloads
+      .filter((payload) => payload.keys.includes('options'))
+      .map((payload) => payload.where);
+    expect(withOptions).toEqual([]);
+  });
+
+  it('never uses a comment_options field anywhere in the app', () => {
+    const offenders: string[] = [];
+    for (const path of sourceFiles(SRC)) {
+      const names = namesUsedIn(parse(path));
+      for (const field of OPTIONS_FIELDS) {
+        if (names.has(field))
+          offenders.push(`${path.replace(SRC, 'src')}:${field}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('pins the exact key set of every comment payload', () => {
+    // Any new key on a payload that becomes a `comment` operation has to be
+    // looked at, not only an `options` one.
+    const commentPayloads = payloads.filter((payload) =>
+      payload.keys.includes(COMMENT_PAYLOAD_MARKER),
+    );
+
+    // comment-form, use-publish-post, use-update-post.
+    expect(commentPayloads.map((payload) => payload.where)).toHaveLength(3);
+    for (const payload of commentPayloads) {
+      expect(payload.keys, payload.where).toEqual(EXPECTED_PAYLOAD_KEYS);
+    }
+  });
+
+  it('pins the SDK gate the absence of options relies on', () => {
+    // If this ever stops gating, "no options key" stops meaning "no operation".
+    const sdk = readFileSync(SDK_COMMENT, 'utf8');
+    expect(sdk).toContain('if (payload.options)');
+    const gate = sdk.indexOf('if (payload.options)');
+    const builder = sdk.indexOf('buildCommentOptionsOp(');
+    expect(gate).toBeGreaterThan(-1);
+    expect(builder).toBeGreaterThan(gate);
+  });
+});

--- a/apps/self-hosted/src/core/broadcast-payload-guard.test.ts
+++ b/apps/self-hosted/src/core/broadcast-payload-guard.test.ts
@@ -19,6 +19,19 @@ import { describe, expect, it } from 'vitest';
  * The anchor is deliberate: `options` is a field of the payload passed to
  * `mutateAsync`, not an argument to `useComment`, whose second argument is
  * `{ adapter }`.
+ *
+ * Two rules this file holds itself to, because a guard that passes without
+ * checking anything is worse than the defect it was written for:
+ *
+ *   - A payload it cannot read is a payload it cannot vouch for, so an
+ *     uninspectable mutation argument FAILS rather than being skipped.
+ *   - The SDK gate is asserted structurally, on the `if` statement that
+ *     actually contains the builder call, never on the order two strings
+ *     happen to appear in.
+ *
+ * The analysis functions are exercised against synthetic sources at the bottom,
+ * so each of those rules is demonstrated to catch its bypass rather than
+ * asserted to.
  */
 
 const SRC = join(__dirname, '..');
@@ -61,6 +74,10 @@ const OPTIONS_FIELDS = [
   'beneficiaries',
 ];
 
+/** The truthiness test the absence of an `options` key relies on. */
+const SDK_GATE = 'payload.options';
+const SDK_BUILDER = 'buildCommentOptionsOp';
+
 function sourceFiles(dir: string, into: string[] = []): string[] {
   for (const name of readdirSync(dir)) {
     const path = join(dir, name);
@@ -73,14 +90,18 @@ function sourceFiles(dir: string, into: string[] = []): string[] {
   return into;
 }
 
-function parse(path: string): ts.SourceFile {
+function parseSource(code: string, name = 'probe.tsx'): ts.SourceFile {
   return ts.createSourceFile(
-    path,
-    readFileSync(path, 'utf8'),
+    name,
+    code,
     ts.ScriptTarget.Latest,
     true,
     ts.ScriptKind.TSX,
   );
+}
+
+function parse(path: string): ts.SourceFile {
+  return parseSource(readFileSync(path, 'utf8'), path);
 }
 
 /**
@@ -133,10 +154,19 @@ function namesUsedIn(sf: ts.SourceFile): Set<string> {
 
 interface Payload {
   where: string;
-  keys: string[];
+  /**
+   * The payload's own property names, or null when the argument is not
+   * something this guard can read: an identifier, a call, a property access, a
+   * spread, a computed key. Null is a failure, never a skip. `mutateAsync(p)`
+   * hides an `options` key just as completely as writing one would add it, and
+   * the walk would still find enough literals elsewhere to look busy.
+   */
+  keys: string[] | null;
+  /** The argument as written, so a failure names the thing it could not read. */
+  argument: string;
 }
 
-/** Every object literal handed to a mutation call in one file. */
+/** Every payload handed to a mutation call in one file, readable or not. */
 function payloadsIn(sf: ts.SourceFile, rel: string): Payload[] {
   const aliases = mutationAliases(sf);
   const found: Payload[] = [];
@@ -150,17 +180,41 @@ function payloadsIn(sf: ts.SourceFile, rel: string): Payload[] {
         aliases.has(callee);
 
       const [first] = node.arguments;
-      if (isMutation && first && ts.isObjectLiteralExpression(first)) {
+      if (isMutation) {
         const line =
           sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
-        const keys = first.properties
-          .map((property) =>
-            property.name && !ts.isComputedPropertyName(property.name)
-              ? property.name.getText(sf)
-              : '<dynamic>',
-          )
-          .sort();
-        found.push({ where: `${rel}:${line}`, keys });
+        const where = `${rel}:${line}`;
+
+        if (!first) {
+          // No payload at all cannot carry an options key.
+          found.push({ where, keys: [], argument: '<no argument>' });
+        } else if (!ts.isObjectLiteralExpression(first)) {
+          found.push({
+            where,
+            keys: null,
+            argument: first.getText(sf).replace(/\s+/g, ' '),
+          });
+        } else {
+          const keys: string[] = [];
+          let readable = true;
+          for (const property of first.properties) {
+            // Anything without a name this guard can read: a spread, which
+            // carries whatever the spread object carries including `options`,
+            // or a computed key, which is a name only known at runtime. One
+            // check covers both because a SpreadAssignment has no `name` node
+            // at all.
+            if (!property.name || ts.isComputedPropertyName(property.name)) {
+              readable = false;
+              break;
+            }
+            keys.push(property.name.getText(sf));
+          }
+          found.push({
+            where,
+            keys: readable ? keys.sort() : null,
+            argument: first.getText(sf).replace(/\s+/g, ' '),
+          });
+        }
       }
     }
     ts.forEachChild(node, visit);
@@ -168,6 +222,61 @@ function payloadsIn(sf: ts.SourceFile, rel: string): Payload[] {
 
   visit(sf);
   return found;
+}
+
+interface GateReport {
+  /** Every call to the builder, by line. */
+  total: string[];
+  /** Those genuinely inside the then-branch of `if (<gate>)`. */
+  gated: string[];
+}
+
+/**
+ * Where the builder is called, and whether the gate really contains the call.
+ *
+ * Structural on purpose. The previous version compared `indexOf` positions, so
+ * an unconditional call after an unrelated `if (payload.options)` statement, or
+ * after a comment that merely mentioned one, satisfied it. This walks up from
+ * each call to see whether an `if` whose expression IS the gate has the call in
+ * its `thenStatement`, which is the only arrangement that actually prevents the
+ * operation from being emitted.
+ */
+function gateReport(
+  sf: ts.SourceFile,
+  gateText: string,
+  builderName: string,
+): GateReport {
+  const report: GateReport = { total: [], gated: [] };
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText(sf) === builderName
+    ) {
+      const at = `${sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1}`;
+      report.total.push(at);
+
+      let current: ts.Node = node;
+      let parent: ts.Node | undefined = node.parent;
+      while (parent) {
+        if (
+          ts.isIfStatement(parent) &&
+          parent.expression.getText(sf) === gateText &&
+          // the else branch does the opposite of gating
+          parent.thenStatement === current
+        ) {
+          report.gated.push(at);
+          break;
+        }
+        current = parent;
+        parent = parent.parent;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sf);
+  return report;
 }
 
 describe('no deploy of this layer changes a broadcast payload', () => {
@@ -181,11 +290,19 @@ describe('no deploy of this layer changes a broadcast payload', () => {
     expect(payloads.length).toBeGreaterThanOrEqual(4);
   });
 
+  it('can read every mutation payload in the app', () => {
+    // A payload this guard cannot inspect is a payload it cannot vouch for.
+    const opaque = payloads
+      .filter((payload) => payload.keys === null)
+      .map((payload) => `${payload.where} -> ${payload.argument}`);
+    expect(opaque).toEqual([]);
+  });
+
   it('passes no options object to any mutation', () => {
     // `options` is what turns on the second operation. Absent, the operation
     // array is byte-identical to today's.
     const withOptions = payloads
-      .filter((payload) => payload.keys.includes('options'))
+      .filter((payload) => payload.keys?.includes('options'))
       .map((payload) => payload.where);
     expect(withOptions).toEqual([]);
   });
@@ -206,7 +323,7 @@ describe('no deploy of this layer changes a broadcast payload', () => {
     // Any new key on a payload that becomes a `comment` operation has to be
     // looked at, not only an `options` one.
     const commentPayloads = payloads.filter((payload) =>
-      payload.keys.includes(COMMENT_PAYLOAD_MARKER),
+      payload.keys?.includes(COMMENT_PAYLOAD_MARKER),
     );
 
     // comment-form, use-publish-post, use-update-post.
@@ -218,11 +335,94 @@ describe('no deploy of this layer changes a broadcast payload', () => {
 
   it('pins the SDK gate the absence of options relies on', () => {
     // If this ever stops gating, "no options key" stops meaning "no operation".
-    const sdk = readFileSync(SDK_COMMENT, 'utf8');
-    expect(sdk).toContain('if (payload.options)');
-    const gate = sdk.indexOf('if (payload.options)');
-    const builder = sdk.indexOf('buildCommentOptionsOp(');
-    expect(gate).toBeGreaterThan(-1);
-    expect(builder).toBeGreaterThan(gate);
+    const report = gateReport(parse(SDK_COMMENT), SDK_GATE, SDK_BUILDER);
+    expect(report.total.length).toBeGreaterThan(0);
+    expect(report.gated).toEqual(report.total);
+  });
+});
+
+describe('the guard catches the ways around it', () => {
+  const payloadsOf = (code: string) => payloadsIn(parseSource(code), 'probe');
+  const gateOf = (code: string) =>
+    gateReport(parseSource(code, 'probe.ts'), SDK_GATE, SDK_BUILDER);
+
+  it('reads a plain object literal', () => {
+    const [payload] = payloadsOf('m.mutateAsync({ author: a, options: o });');
+    expect(payload.keys).toEqual(['author', 'options']);
+  });
+
+  it('refuses an identifier argument instead of ignoring it', () => {
+    // The hole: `mutateAsync(payload)` skipped every assertion below while the
+    // walk still found enough literals elsewhere for the suite to pass.
+    for (const code of [
+      'm.mutateAsync(payload);',
+      'm.mutateAsync(options.payload);',
+      'm.mutateAsync(buildPayload());',
+      'm.mutate(payload as CommentPayload);',
+    ]) {
+      const [payload] = payloadsOf(code);
+      expect(payload, code).toBeDefined();
+      expect(payload.keys, code).toBeNull();
+    }
+  });
+
+  it('refuses a literal whose keys it cannot enumerate', () => {
+    // A spread or a computed key hides `options` exactly as well as an
+    // identifier does.
+    for (const code of [
+      'm.mutateAsync({ ...base, title: t });',
+      'm.mutateAsync({ [key]: value, title: t });',
+    ]) {
+      const [payload] = payloadsOf(code);
+      expect(payload.keys, code).toBeNull();
+    }
+  });
+
+  it('refuses an aliased mutation with an unreadable argument', () => {
+    const [payload] = payloadsOf(
+      'const { mutateAsync: publish } = usePublishPost(); publish(payload);',
+    );
+    expect(payload.keys).toBeNull();
+  });
+
+  it('accepts a call with no payload at all', () => {
+    const [payload] = payloadsOf('m.mutate();');
+    expect(payload.keys).toEqual([]);
+  });
+
+  it('accepts the builder only inside the real gate', () => {
+    const gated = gateOf(
+      'function f(payload) { if (payload.options) { ops.push(buildCommentOptionsOp(a)); } }',
+    );
+    expect(gated.total).toHaveLength(1);
+    expect(gated.gated).toEqual(gated.total);
+  });
+
+  it.each([
+    [
+      'an unrelated gate statement earlier in the file',
+      'function f(payload) { if (payload.options) { log(1); } ops.push(buildCommentOptionsOp(a)); }',
+    ],
+    [
+      'a comment that merely mentions the gate',
+      'function f(payload) { /* if (payload.options) */ ops.push(buildCommentOptionsOp(a)); }',
+    ],
+    [
+      'the builder in the else branch',
+      'function f(payload) { if (payload.options) { log(1); } else { ops.push(buildCommentOptionsOp(a)); } }',
+    ],
+    [
+      'a weakened gate that lets null through',
+      'function f(payload) { if (payload.options !== undefined) { ops.push(buildCommentOptionsOp(a)); } }',
+    ],
+    [
+      'no gate at all',
+      'function f(payload) { ops.push(buildCommentOptionsOp(a)); }',
+    ],
+  ])('reports the builder as ungated with %s', (_label, code) => {
+    // Every one of these passed the previous subtext-ordering check.
+    const report = gateOf(code);
+    expect(report.total).toHaveLength(1);
+    expect(report.gated).toEqual([]);
   });
 });

--- a/apps/self-hosted/src/core/configuration-loader.ts
+++ b/apps/self-hosted/src/core/configuration-loader.ts
@@ -98,6 +98,21 @@ export interface InstanceConfig {
         };
       };
       features: {
+        /**
+         * How much of the Hive blockchain this site shows readers.
+         *
+         * Every member optional and nothing added to CONFIG_SKELETON: a value
+         * placed there would silently become the consumer's default. The
+         * absence values live in one place, `resolveHiveLayer`, which also
+         * treats this whole block as unknown-shaped because the hosting API's
+         * merge only checks `typeof`.
+         */
+        hive?: {
+          readerLayer?: string;
+          authorRewards?: string;
+          payoutLabel?: string;
+          learnMoreUrl?: string;
+        };
         postsFilters: string[];
         likes: { enabled: boolean };
         comments: { enabled: boolean };

--- a/apps/self-hosted/src/core/hive-layer-absence.test.ts
+++ b/apps/self-hosted/src/core/hive-layer-absence.test.ts
@@ -50,7 +50,6 @@ async function serveAndResolve(configuration: unknown) {
     features: instance.features,
     layer: resolveHiveLayer({
       features: instance.features,
-      isCommunityMode: instance.type === 'community' && !!instance.communityId,
       composerIsInternal: true,
     }),
   };
@@ -61,19 +60,13 @@ const OFF_POSTURE = {
   showPayoutInFeed: false,
   showChainNote: false,
   showChainPermalink: false,
-  showVoteWeightPicker: false,
-  allowDownvotes: false,
 };
 
+/** Read off the object, so a flag added without an OFF_POSTURE row fails here. */
 function posture(layer: ReturnType<typeof resolveHiveLayer>) {
-  return {
-    showPayoutOnPost: layer.showPayoutOnPost,
-    showPayoutInFeed: layer.showPayoutInFeed,
-    showChainNote: layer.showChainNote,
-    showChainPermalink: layer.showChainPermalink,
-    showVoteWeightPicker: layer.showVoteWeightPicker,
-    allowDownvotes: layer.allowDownvotes,
-  };
+  return Object.fromEntries(
+    Object.entries(layer).filter(([, value]) => typeof value === 'boolean'),
+  );
 }
 
 describe('the Hive layer through the real config merge', () => {

--- a/apps/self-hosted/src/core/hive-layer-absence.test.ts
+++ b/apps/self-hosted/src/core/hive-layer-absence.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveHiveLayer } from './hive-layer';
+
+/**
+ * The Hive layer is inert on every config already on disk.
+ *
+ * Not the resolver in isolation: this runs a served document through the real
+ * `mergeConfig` over `CONFIG_SKELETON` and reads the result the way the app
+ * does, so the property survives a change to the merge or the skeleton as well
+ * as to the resolver.
+ *
+ * Lives in its own file rather than as a second case in
+ * `config-merge-wiring.test.ts`: `configStore.initialize()` is idempotent and
+ * neither it nor `InstanceConfigManager` has a reset, so a second `it()` in one
+ * module silently asserts against the first one's config.
+ */
+
+vi.mock('../../config.json', () => ({
+  default: {
+    version: 1,
+    configuration: {
+      general: { theme: 'light', styles: {} },
+      instanceConfiguration: {
+        type: 'blog',
+        username: 'ecency',
+        meta: {},
+        layout: { sidebar: {} },
+        features: {},
+      },
+    },
+  },
+}));
+
+async function serveAndResolve(configuration: unknown) {
+  // A fresh module graph per case, so the singleton config store is new and
+  // `initialize()` is genuinely reached rather than short-circuiting.
+  vi.resetModules();
+  vi.stubGlobal('window', {});
+  globalThis.fetch = (async () => ({
+    ok: true,
+    json: async () => ({ version: 2, configuration }),
+  })) as unknown as typeof fetch;
+
+  const { InstanceConfigManager } = await import('./configuration-loader');
+  await InstanceConfigManager.initialize();
+  const config = InstanceConfigManager.getConfig();
+  const instance = config.configuration.instanceConfiguration;
+
+  return {
+    features: instance.features,
+    layer: resolveHiveLayer({
+      features: instance.features,
+      isCommunityMode: instance.type === 'community' && !!instance.communityId,
+      composerIsInternal: true,
+    }),
+  };
+}
+
+const OFF_POSTURE = {
+  showPayoutOnPost: false,
+  showPayoutInFeed: false,
+  showChainNote: false,
+  showChainPermalink: false,
+  showVoteWeightPicker: false,
+  allowDownvotes: false,
+};
+
+function posture(layer: ReturnType<typeof resolveHiveLayer>) {
+  return {
+    showPayoutOnPost: layer.showPayoutOnPost,
+    showPayoutInFeed: layer.showPayoutInFeed,
+    showChainNote: layer.showChainNote,
+    showChainPermalink: layer.showChainPermalink,
+    showVoteWeightPicker: layer.showVoteWeightPicker,
+    allowDownvotes: layer.allowDownvotes,
+  };
+}
+
+describe('the Hive layer through the real config merge', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('is off, and adds no key, on a config that predates it', async () => {
+    // Every instance currently on disk is in this state.
+    const { features, layer } = await serveAndResolve({
+      general: { theme: 'dark' },
+      instanceConfiguration: {
+        type: 'blog',
+        username: 'someone',
+        features: { likes: { enabled: true }, comments: { enabled: true } },
+      },
+    });
+
+    expect(posture(layer)).toEqual(OFF_POSTURE);
+    expect(layer.authorRewards).toBe('off');
+    expect(layer.payoutLabel).toBeNull();
+    expect(layer.learnMoreUrl).toBeNull();
+    // Nothing is added to CONFIG_SKELETON: a value placed there would silently
+    // become the consumer's default instead of the resolver's.
+    expect(features.hive).toBeUndefined();
+  });
+
+  it('is off, and does not throw, when the stored block is a scalar', async () => {
+    // Storable today: the hosting API's merge takes an incoming value verbatim
+    // when nothing is stored at that key, so a hand-crafted PATCH can put a
+    // bare string here and it reaches the client unvalidated.
+    const { layer } = await serveAndResolve({
+      general: {},
+      instanceConfiguration: {
+        type: 'blog',
+        username: 'someone',
+        features: { hive: 'full' },
+      },
+    });
+    expect(posture(layer)).toEqual(OFF_POSTURE);
+  });
+
+  it('turns on when the served document says so', async () => {
+    // The other half of the property: absence is inert because it is absent,
+    // not because the wiring is dead.
+    const { layer } = await serveAndResolve({
+      general: {},
+      instanceConfiguration: {
+        type: 'blog',
+        username: 'someone',
+        features: { hive: { readerLayer: 'standard' } },
+      },
+    });
+    expect(layer.showPayoutOnPost).toBe(true);
+    expect(layer.showChainPermalink).toBe(true);
+    expect(layer.showPayoutInFeed).toBe(false);
+  });
+});

--- a/apps/self-hosted/src/core/hive-layer-consumers.test.ts
+++ b/apps/self-hosted/src/core/hive-layer-consumers.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { resolveHiveLayer } from './hive-layer';
+
+/**
+ * Every posture the resolver offers has to be a posture the app renders.
+ *
+ * The finding this exists for: three postures were advertised and two shipped.
+ * `showPayoutInFeed`, a vote-weight flag and a downvote flag were all resolved
+ * from `readerLayer: full`, and not one of them was read by a component, so
+ * `full` behaved exactly like `standard` on a live site. A resolver test cannot
+ * catch that on its own, because the resolver was doing precisely what it said.
+ *
+ * So the check is on the other end: for every boolean the resolver returns,
+ * name the file and the component that renders it, and assert that file really
+ * reads the flag and really renders that component. Nothing in
+ * `apps/self-hosted` is DOM-testable (`environment: 'node'`,
+ * `include: ['src/**\/*.test.ts']`), so a source scan is the strongest
+ * statement about rendering available here, and it is the same mechanism
+ * `src/routes/-internal-links.test.ts` already uses.
+ */
+
+const SRC = join(__dirname, '..');
+
+/**
+ * Where each render flag is consumed. Adding a flag means adding a row, which
+ * means having somewhere to point it at.
+ */
+const FLAG_CONSUMERS: Record<string, { file: string; component: string }> = {
+  showPayoutOnPost: {
+    file: 'features/blog/components/blog-post-footer.tsx',
+    component: 'PostPayout',
+  },
+  showPayoutInFeed: {
+    file: 'features/blog/components/blog-post-item.tsx',
+    component: 'PostPayout',
+  },
+  showChainNote: {
+    file: 'features/blog/components/blog-post-footer.tsx',
+    component: 'HivePostNote',
+  },
+  showChainPermalink: {
+    file: 'features/blog/components/blog-post-footer.tsx',
+    component: 'HivePostNote',
+  },
+};
+
+/**
+ * Non-boolean resolver output that has no consumer yet.
+ *
+ * Deliberate, like a DYNAMIC_LINKS entry: an entry here is an admission, so it
+ * carries the reason and the thing that removes it. An empty list is the goal.
+ */
+const AWAITING_CONSUMER: Record<string, string> = {
+  authorRewards:
+    'composer reward controls, the second half of this track. Kept resolved because the hosting seed already writes the field and its external-composer clamp reads createPostUrl, which every existing tenant carries',
+};
+
+/** Which postures differ, computed from the resolver rather than restated. */
+function flagsFor(readerLayer: string): Record<string, boolean> {
+  const resolved = resolveHiveLayer({
+    features: { hive: { readerLayer } },
+    composerIsInternal: true,
+  });
+  return Object.fromEntries(
+    Object.entries(resolved).filter(([, value]) => typeof value === 'boolean'),
+  ) as Record<string, boolean>;
+}
+
+function parse(relative: string): ts.SourceFile {
+  const path = join(SRC, relative);
+  return ts.createSourceFile(
+    path,
+    readFileSync(path, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+}
+
+/** Every `x.<name>` property read in the file. */
+function propertyReads(sf: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+  const visit = (node: ts.Node) => {
+    if (ts.isPropertyAccessExpression(node)) {
+      names.add(node.name.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return names;
+}
+
+/** Every JSX tag rendered in the file. */
+function renderedTags(sf: ts.SourceFile): Set<string> {
+  const tags = new Set<string>();
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node)) {
+      tags.add(node.tagName.getText(sf));
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return tags;
+}
+
+describe('no posture is advertised without something that renders it', () => {
+  const resolvedKeys = Object.keys(
+    resolveHiveLayer({ features: {}, composerIsInternal: true }),
+  );
+
+  it('has a named consumer for every render flag the resolver returns', () => {
+    const flags = Object.keys(flagsFor('full'));
+    expect(flags.sort()).toEqual(Object.keys(FLAG_CONSUMERS).sort());
+  });
+
+  it('leaves no non-boolean output unaccounted for', () => {
+    // readerLayer is the posture itself; payoutLabel and learnMoreUrl are read
+    // by the two components above. Anything else has to be listed with a reason.
+    const named = new Set([
+      'readerLayer',
+      'payoutLabel',
+      'learnMoreUrl',
+      ...Object.keys(FLAG_CONSUMERS),
+      ...Object.keys(AWAITING_CONSUMER),
+    ]);
+    expect(resolvedKeys.filter((key) => !named.has(key))).toEqual([]);
+  });
+
+  it('states a reason for anything still awaiting a consumer', () => {
+    for (const [key, reason] of Object.entries(AWAITING_CONSUMER)) {
+      expect(resolvedKeys, `${key} is no longer resolved at all`).toContain(
+        key,
+      );
+      expect(reason.length).toBeGreaterThan(30);
+    }
+  });
+
+  it.each(Object.entries(FLAG_CONSUMERS))(
+    '%s is read where it is declared to be',
+    (flag, { file, component }) => {
+      const sf = parse(file);
+      expect(propertyReads(sf), `${file} never reads ${flag}`).toContain(flag);
+      expect(renderedTags(sf), `${file} never renders ${component}`).toContain(
+        component,
+      );
+    },
+  );
+
+  it('renders the difference between standard and full on a real surface', () => {
+    const standard = flagsFor('standard');
+    const full = flagsFor('full');
+    const added = Object.keys(full).filter(
+      (flag) => full[flag] && !standard[flag],
+    );
+
+    // full must add something...
+    expect(added.length).toBeGreaterThan(0);
+
+    // ...on a file that standard does not already light up, or the two
+    // postures are the same page with a different config value.
+    const standardFiles = new Set(
+      Object.keys(standard)
+        .filter((flag) => standard[flag])
+        .map((flag) => FLAG_CONSUMERS[flag].file),
+    );
+    const addedFiles = added.map((flag) => FLAG_CONSUMERS[flag].file);
+
+    expect(addedFiles.some((file) => !standardFiles.has(file))).toBe(true);
+  });
+});

--- a/apps/self-hosted/src/core/hive-layer-seed.test.ts
+++ b/apps/self-hosted/src/core/hive-layer-seed.test.ts
@@ -95,16 +95,13 @@ describe('the hosting seed and the client resolver agree', () => {
   it('resolves the seeded document to the standard posture', () => {
     const layer = resolveHiveLayer({
       features: { hive: seeded },
-      isCommunityMode: false,
       composerIsInternal: true,
     });
     expect(layer.readerLayer).toBe('standard');
     expect(layer.authorRewards).toBe('author');
     expect(layer.showPayoutOnPost).toBe(true);
     expect(layer.showChainPermalink).toBe(true);
-    // Not the full posture: no feed payouts, no weight picker, no downvotes.
+    // Not the full posture: no payout on feed cards.
     expect(layer.showPayoutInFeed).toBe(false);
-    expect(layer.showVoteWeightPicker).toBe(false);
-    expect(layer.allowDownvotes).toBe(false);
   });
 });

--- a/apps/self-hosted/src/core/hive-layer-seed.test.ts
+++ b/apps/self-hosted/src/core/hive-layer-seed.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import {
+  HIVE_LAYER_CONFIG_DEFAULTS,
+  HIVE_LAYER_SEED,
+  resolveHiveLayer,
+} from './hive-layer';
+
+/**
+ * The seed a new tenant is created with cannot drift from the resolver that
+ * reads it back.
+ *
+ * The value is written in `hosting/api`, which builds with `rootDir: ./src` and
+ * a Docker context of its own directory, so it cannot import this module and
+ * this module cannot import it. The seed is therefore read off that file's
+ * syntax tree. Two independently maintained copies of the same two strings is
+ * how a seeded value ends up meaning something the read site does not
+ * recognise, at which point every new instance silently falls back to `off` and
+ * nobody finds out until an owner asks where their earnings went.
+ */
+
+const TENANT_SERVICE = join(
+  __dirname,
+  '..',
+  '..',
+  'hosting',
+  'api',
+  'src',
+  'services',
+  'tenant-service.ts',
+);
+
+/** The `hive: { ... }` object literal seeded inside `features`, as data. */
+function seededHiveBlock(): Record<string, unknown> | null {
+  const sf = ts.createSourceFile(
+    TENANT_SERVICE,
+    readFileSync(TENANT_SERVICE, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  let found: Record<string, unknown> | null = null;
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      !ts.isComputedPropertyName(node.name) &&
+      node.name.getText(sf) === 'hive' &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      const block: Record<string, unknown> = {};
+      for (const property of node.initializer.properties) {
+        if (
+          ts.isPropertyAssignment(property) &&
+          !ts.isComputedPropertyName(property.name) &&
+          ts.isStringLiteralLike(property.initializer)
+        ) {
+          block[property.name.getText(sf)] = property.initializer.text;
+        } else {
+          // A non-string leaf would be a `number` or an object, both of which
+          // this design bars. Reported by failing the shape, not skipped.
+          block[property.name?.getText(sf) ?? '<computed>'] =
+            property.getText(sf);
+        }
+      }
+      found = block;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+
+  return found;
+}
+
+describe('the hosting seed and the client resolver agree', () => {
+  const seeded = seededHiveBlock();
+
+  it('finds the seeded block in the hosting API', () => {
+    expect(seeded).not.toBeNull();
+  });
+
+  it('seeds exactly what the resolver declares as the seed', () => {
+    expect(seeded).toEqual({ ...HIVE_LAYER_SEED });
+  });
+
+  it('seeds only keys the resolver has an absence value for', () => {
+    for (const key of Object.keys(seeded ?? {})) {
+      expect(Object.keys(HIVE_LAYER_CONFIG_DEFAULTS)).toContain(key);
+    }
+  });
+
+  it('resolves the seeded document to the standard posture', () => {
+    const layer = resolveHiveLayer({
+      features: { hive: seeded },
+      isCommunityMode: false,
+      composerIsInternal: true,
+    });
+    expect(layer.readerLayer).toBe('standard');
+    expect(layer.authorRewards).toBe('author');
+    expect(layer.showPayoutOnPost).toBe(true);
+    expect(layer.showChainPermalink).toBe(true);
+    // Not the full posture: no feed payouts, no weight picker, no downvotes.
+    expect(layer.showPayoutInFeed).toBe(false);
+    expect(layer.showVoteWeightPicker).toBe(false);
+    expect(layer.allowDownvotes).toBe(false);
+  });
+});

--- a/apps/self-hosted/src/core/hive-layer.test.ts
+++ b/apps/self-hosted/src/core/hive-layer.test.ts
@@ -15,72 +15,72 @@ import {
 
 function resolve(
   hive: unknown,
-  overrides: { isCommunityMode?: boolean; composerIsInternal?: boolean } = {},
+  overrides: { composerIsInternal?: boolean } = {},
 ): ResolvedHiveLayer {
   return resolveHiveLayer({
     features: hive === undefined ? {} : { hive },
-    isCommunityMode: overrides.isCommunityMode ?? false,
     composerIsInternal: overrides.composerIsInternal ?? true,
   });
 }
 
-/** Every render decision the posture expands to, as one comparable record. */
-function posture(resolved: ResolvedHiveLayer) {
-  return {
-    payoutOnPost: resolved.showPayoutOnPost,
-    payoutInFeed: resolved.showPayoutInFeed,
-    chainNote: resolved.showChainNote,
-    chainPermalink: resolved.showChainPermalink,
-    voteWeightPicker: resolved.showVoteWeightPicker,
-    downvotes: resolved.allowDownvotes,
-  };
+/**
+ * Every render decision the posture expands to, as one comparable record.
+ *
+ * Built by reading the booleans off the resolved object rather than by naming
+ * them, so a flag added to `ResolvedHiveLayer` without a row in these tables
+ * fails here instead of shipping unasserted.
+ */
+function posture(resolved: ResolvedHiveLayer): Record<string, boolean> {
+  return Object.fromEntries(
+    Object.entries(resolved).filter(([, value]) => typeof value === 'boolean'),
+  ) as Record<string, boolean>;
 }
 
 const OFF = {
-  payoutOnPost: false,
-  payoutInFeed: false,
-  chainNote: false,
-  chainPermalink: false,
-  voteWeightPicker: false,
-  downvotes: false,
+  showPayoutOnPost: false,
+  showPayoutInFeed: false,
+  showChainNote: false,
+  showChainPermalink: false,
 };
 
 const STANDARD = {
-  payoutOnPost: true,
-  payoutInFeed: false,
-  chainNote: true,
-  chainPermalink: true,
-  voteWeightPicker: false,
-  downvotes: false,
+  showPayoutOnPost: true,
+  showPayoutInFeed: false,
+  showChainNote: true,
+  showChainPermalink: true,
 };
 
-const FULL_BLOG = {
-  payoutOnPost: true,
-  payoutInFeed: true,
-  chainNote: true,
-  chainPermalink: true,
-  voteWeightPicker: true,
-  downvotes: false,
+const FULL = {
+  showPayoutOnPost: true,
+  showPayoutInFeed: true,
+  showChainNote: true,
+  showChainPermalink: true,
 };
-
-const FULL_COMMUNITY = { ...FULL_BLOG, downvotes: true };
 
 describe('resolveHiveLayer: the posture table', () => {
-  it('expands each posture on a blog instance', () => {
+  it('expands each posture', () => {
     expect(posture(resolve({ readerLayer: 'off' }))).toEqual(OFF);
     expect(posture(resolve({ readerLayer: 'standard' }))).toEqual(STANDARD);
-    expect(posture(resolve({ readerLayer: 'full' }))).toEqual(FULL_BLOG);
+    expect(posture(resolve({ readerLayer: 'full' }))).toEqual(FULL);
   });
 
-  it('expands each posture on a community instance', () => {
-    const community = { isCommunityMode: true };
-    expect(posture(resolve({ readerLayer: 'off' }, community))).toEqual(OFF);
-    expect(posture(resolve({ readerLayer: 'standard' }, community))).toEqual(
-      STANDARD,
+  it('makes full differ from standard, on exactly one surface', () => {
+    // The finding this pins: three postures were offered and two shipped,
+    // because the flags that separated full from standard had no consumer.
+    // Whatever full adds must be something a component reads; the companion
+    // test in hive-layer-consumers.test.ts is what checks that end.
+    const standard = posture(resolve({ readerLayer: 'standard' }));
+    const full = posture(resolve({ readerLayer: 'full' }));
+
+    const added = Object.keys(full).filter(
+      (flag) => full[flag] && !standard[flag],
     );
-    expect(posture(resolve({ readerLayer: 'full' }, community))).toEqual(
-      FULL_COMMUNITY,
+    const removed = Object.keys(full).filter(
+      (flag) => standard[flag] && !full[flag],
     );
+
+    expect(added).toEqual(['showPayoutInFeed']);
+    expect(removed).toEqual([]);
   });
 
   it('reports the posture it resolved', () => {
@@ -130,7 +130,6 @@ describe('resolveHiveLayer: absence and malformed documents', () => {
       posture(
         resolveHiveLayer({
           features: arrayFeatures,
-          isCommunityMode: true,
           composerIsInternal: true,
         }),
       ),
@@ -143,19 +142,10 @@ describe('resolveHiveLayer: absence and malformed documents', () => {
         posture(
           resolveHiveLayer({
             features,
-            isCommunityMode: true,
             composerIsInternal: true,
           }),
         ),
       ).toEqual(OFF);
-    }
-  });
-
-  it('never enables downvotes outside community mode', () => {
-    for (const readerLayer of ['off', 'standard', 'full', 'FULL', 42]) {
-      expect(
-        resolve({ readerLayer }, { isCommunityMode: false }).allowDownvotes,
-      ).toBe(false);
     }
   });
 });
@@ -265,7 +255,6 @@ describe('the config surface stays writable', () => {
   it('seeds a new instance with values the resolver accepts', () => {
     const seeded = resolveHiveLayer({
       features: { hive: HIVE_LAYER_SEED },
-      isCommunityMode: false,
       composerIsInternal: true,
     });
     expect(seeded.readerLayer).toBe('standard');

--- a/apps/self-hosted/src/core/hive-layer.test.ts
+++ b/apps/self-hosted/src/core/hive-layer.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HIVE_LAYER_CONFIG_DEFAULTS,
+  HIVE_LAYER_SEED,
+  PAYOUT_LABEL_MAX_LENGTH,
+  type ResolvedHiveLayer,
+  resolveHiveLayer,
+} from './hive-layer';
+
+/**
+ * Imported by relative path, not through `@/core`. The barrel pulls in
+ * `configuration-loader`, which imports the build-time `config.json` that is
+ * generated at image build and does not exist in CI.
+ */
+
+function resolve(
+  hive: unknown,
+  overrides: { isCommunityMode?: boolean; composerIsInternal?: boolean } = {},
+): ResolvedHiveLayer {
+  return resolveHiveLayer({
+    features: hive === undefined ? {} : { hive },
+    isCommunityMode: overrides.isCommunityMode ?? false,
+    composerIsInternal: overrides.composerIsInternal ?? true,
+  });
+}
+
+/** Every render decision the posture expands to, as one comparable record. */
+function posture(resolved: ResolvedHiveLayer) {
+  return {
+    payoutOnPost: resolved.showPayoutOnPost,
+    payoutInFeed: resolved.showPayoutInFeed,
+    chainNote: resolved.showChainNote,
+    chainPermalink: resolved.showChainPermalink,
+    voteWeightPicker: resolved.showVoteWeightPicker,
+    downvotes: resolved.allowDownvotes,
+  };
+}
+
+const OFF = {
+  payoutOnPost: false,
+  payoutInFeed: false,
+  chainNote: false,
+  chainPermalink: false,
+  voteWeightPicker: false,
+  downvotes: false,
+};
+
+const STANDARD = {
+  payoutOnPost: true,
+  payoutInFeed: false,
+  chainNote: true,
+  chainPermalink: true,
+  voteWeightPicker: false,
+  downvotes: false,
+};
+
+const FULL_BLOG = {
+  payoutOnPost: true,
+  payoutInFeed: true,
+  chainNote: true,
+  chainPermalink: true,
+  voteWeightPicker: true,
+  downvotes: false,
+};
+
+const FULL_COMMUNITY = { ...FULL_BLOG, downvotes: true };
+
+describe('resolveHiveLayer: the posture table', () => {
+  it('expands each posture on a blog instance', () => {
+    expect(posture(resolve({ readerLayer: 'off' }))).toEqual(OFF);
+    expect(posture(resolve({ readerLayer: 'standard' }))).toEqual(STANDARD);
+    expect(posture(resolve({ readerLayer: 'full' }))).toEqual(FULL_BLOG);
+  });
+
+  it('expands each posture on a community instance', () => {
+    const community = { isCommunityMode: true };
+    expect(posture(resolve({ readerLayer: 'off' }, community))).toEqual(OFF);
+    expect(posture(resolve({ readerLayer: 'standard' }, community))).toEqual(
+      STANDARD,
+    );
+    expect(posture(resolve({ readerLayer: 'full' }, community))).toEqual(
+      FULL_COMMUNITY,
+    );
+  });
+
+  it('reports the posture it resolved', () => {
+    expect(resolve({ readerLayer: 'standard' }).readerLayer).toBe('standard');
+    expect(resolve({ readerLayer: 'nonsense' }).readerLayer).toBe('off');
+  });
+});
+
+describe('resolveHiveLayer: absence and malformed documents', () => {
+  /**
+   * The safety property for the instances already on disk: none of them carries
+   * this block, and none of them may change when this ships.
+   */
+  it.each([
+    ['features.hive absent', undefined],
+    ['a bare string', 'full'],
+    ['an array', []],
+    ['null', null],
+    ['a number', 42],
+    ['readerLayer as a number', { readerLayer: 42 }],
+    ['readerLayer in the wrong case', { readerLayer: 'FULL' }],
+    ['readerLayer as a boolean', { readerLayer: true }],
+    ['an empty block', {}],
+  ])('resolves the off posture for %s', (_label, hive) => {
+    expect(posture(resolve(hive))).toEqual(OFF);
+  });
+
+  it('never reads a block off an array, whatever the array carries', () => {
+    // A plain `[]` resolves to the off posture whether or not the array check
+    // is there, because it has no keys either way, so the rule "an array is not
+    // a block" is only actually exercised by an array that does carry them.
+    // Not producible from JSON; asserted so the check cannot be deleted as
+    // unreachable and then be missing the day some other path produces one.
+    const arrayBlock = Object.assign(['full'], {
+      readerLayer: 'full',
+      authorRewards: 'author',
+      payoutLabel: 'Rewards',
+      learnMoreUrl: 'https://example.com',
+    });
+    expect(posture(resolve(arrayBlock))).toEqual(OFF);
+    expect(resolve(arrayBlock).authorRewards).toBe('off');
+    expect(resolve(arrayBlock).payoutLabel).toBeNull();
+    expect(resolve(arrayBlock).learnMoreUrl).toBeNull();
+
+    const arrayFeatures = Object.assign([], { hive: { readerLayer: 'full' } });
+    expect(
+      posture(
+        resolveHiveLayer({
+          features: arrayFeatures,
+          isCommunityMode: true,
+          composerIsInternal: true,
+        }),
+      ),
+    ).toEqual(OFF);
+  });
+
+  it('resolves the off posture when features itself is not an object', () => {
+    for (const features of [undefined, null, 'features', [], 7]) {
+      expect(
+        posture(
+          resolveHiveLayer({
+            features,
+            isCommunityMode: true,
+            composerIsInternal: true,
+          }),
+        ),
+      ).toEqual(OFF);
+    }
+  });
+
+  it('never enables downvotes outside community mode', () => {
+    for (const readerLayer of ['off', 'standard', 'full', 'FULL', 42]) {
+      expect(
+        resolve({ readerLayer }, { isCommunityMode: false }).allowDownvotes,
+      ).toBe(false);
+    }
+  });
+});
+
+describe('resolveHiveLayer: authorRewards', () => {
+  it('resolves the two literals', () => {
+    expect(resolve({ authorRewards: 'author' }).authorRewards).toBe('author');
+    expect(resolve({ authorRewards: 'off' }).authorRewards).toBe('off');
+  });
+
+  it.each([[true], [1], ['AUTHOR'], [null], [undefined], [{}]])(
+    'resolves off for %p',
+    (authorRewards) => {
+      expect(resolve({ authorRewards }).authorRewards).toBe('off');
+    },
+  );
+
+  it('is forced off when the composer is external', () => {
+    expect(
+      resolve({ authorRewards: 'author' }, { composerIsInternal: false })
+        .authorRewards,
+    ).toBe('off');
+  });
+
+  it('is independent of the reader posture', () => {
+    expect(resolve({ readerLayer: 'full' }).authorRewards).toBe('off');
+    expect(
+      resolve({ readerLayer: 'off', authorRewards: 'author' }).authorRewards,
+    ).toBe('author');
+  });
+});
+
+describe('resolveHiveLayer: payoutLabel', () => {
+  it('uses the owner value when it is a non-blank string', () => {
+    expect(resolve({ payoutLabel: 'Tips from readers' }).payoutLabel).toBe(
+      'Tips from readers',
+    );
+    expect(resolve({ payoutLabel: '  Rewards  ' }).payoutLabel).toBe('Rewards');
+  });
+
+  it.each([[5], [''], ['   '], [true], [null], [[]], [{}], [undefined]])(
+    'falls back to the built-in label for %p',
+    (payoutLabel) => {
+      expect(resolve({ payoutLabel }).payoutLabel).toBeNull();
+    },
+  );
+
+  it('cuts an over-long label at render rather than storing a correction', () => {
+    const long = 'r'.repeat(200);
+    expect(resolve({ payoutLabel: long }).payoutLabel).toHaveLength(
+      PAYOUT_LABEL_MAX_LENGTH,
+    );
+  });
+});
+
+describe('resolveHiveLayer: learnMoreUrl', () => {
+  it('accepts an absolute http(s) destination and re-serialises it', () => {
+    expect(
+      resolve({ learnMoreUrl: 'https://example.com/a' }).learnMoreUrl,
+    ).toBe('https://example.com/a');
+    expect(resolve({ learnMoreUrl: 'http://example.com' }).learnMoreUrl).toBe(
+      'http://example.com/',
+    );
+  });
+
+  it.each([
+    ['javascript:alert(1)'],
+    ['data:text/html,x'],
+    ['/about'],
+    ['about'],
+    [''],
+    ['   '],
+    [42],
+    [true],
+    [null],
+    [undefined],
+    [['https://example.com']],
+  ])('renders as plain text with no anchor for %p', (learnMoreUrl) => {
+    expect(resolve({ learnMoreUrl }).learnMoreUrl).toBeNull();
+  });
+});
+
+describe('the config surface stays writable', () => {
+  /**
+   * Every leaf offered under `features.hive` must be a scalar.
+   *
+   * `isValidArrayReplacement` in the hosting API rejects any array element where
+   * `typeof item === 'object'`, and `mergeConfigGuarded` takes an incoming value
+   * verbatim only when the stored value is absent. So an array-of-objects field
+   * would save exactly once and then be silently frozen behind a 200 OK, with
+   * the editor reporting "Saved!" over a discard. A `number` field is barred for
+   * the sibling reason: the editor's number input sends `null` when cleared.
+   *
+   * Scoped to the CONFIG defaults table, not to the resolved object: the
+   * resolved object deliberately carries `string | null` for the two optional
+   * strings, and nothing there is ever written back to a config document.
+   */
+  it('offers only scalars, and no number, under features.hive', () => {
+    for (const [key, value] of Object.entries(HIVE_LAYER_CONFIG_DEFAULTS)) {
+      expect(
+        ['string', 'boolean'],
+        `features.hive.${key} must be a select or a string`,
+      ).toContain(typeof value);
+    }
+  });
+
+  it('seeds a new instance with values the resolver accepts', () => {
+    const seeded = resolveHiveLayer({
+      features: { hive: HIVE_LAYER_SEED },
+      isCommunityMode: false,
+      composerIsInternal: true,
+    });
+    expect(seeded.readerLayer).toBe('standard');
+    expect(seeded.authorRewards).toBe('author');
+    expect(posture(seeded)).toEqual(STANDARD);
+  });
+
+  it('seeds only keys the defaults table declares', () => {
+    for (const key of Object.keys(HIVE_LAYER_SEED)) {
+      expect(Object.keys(HIVE_LAYER_CONFIG_DEFAULTS)).toContain(key);
+    }
+  });
+});

--- a/apps/self-hosted/src/core/hive-layer.ts
+++ b/apps/self-hosted/src/core/hive-layer.ts
@@ -1,0 +1,199 @@
+/**
+ * How much of the Hive blockchain this instance shows a reader.
+ *
+ * One posture select, `features.hive.readerLayer`, expands here into every
+ * downstream render decision. Kept pure and handed the raw `features` object
+ * rather than reading config itself, following `resolveHivesignerClientId`: the
+ * rule lives in one place and is testable without the config module.
+ *
+ * The governing rule for the whole Hive-native layer: a deploy may change what a
+ * visitor sees, it may never change what gets signed. Nothing in this module
+ * contributes to a broadcast payload. The composer-side counterpart
+ * (`authorRewards`) is resolved here so the posture lives in one place, but it
+ * only decides whether the composer offers the author a control; the reward
+ * controls themselves, and the `comment_options` operation they would produce,
+ * are not part of this layer yet.
+ *
+ * Every read is defensive. `mergeConfigGuarded` on the hosting API only checks
+ * `typeof`, so a hand-crafted PATCH can store any type-compatible value at any
+ * of these paths, and the served document reaches the client unvalidated. An
+ * unknown value therefore always resolves toward LESS, never more.
+ */
+
+export type ReaderLayer = 'off' | 'standard' | 'full';
+export type AuthorRewards = 'off' | 'author';
+
+export interface ResolvedHiveLayer {
+  readerLayer: ReaderLayer;
+  /** Payout figure in the post page meta row. */
+  showPayoutOnPost: boolean;
+  /** Payout figure in the feed card meta row. */
+  showPayoutInFeed: boolean;
+  /** "Published on Hive" note, optionally linked to `learnMoreUrl`. */
+  showChainNote: boolean;
+  /** "View this post on Hive" permalink to the chain record. */
+  showChainPermalink: boolean;
+  /** Reader picks how strongly their vote lands. */
+  showVoteWeightPicker: boolean;
+  /** Reader may downvote. Community instances only, always. */
+  allowDownvotes: boolean;
+  authorRewards: AuthorRewards;
+  /** Owner's own word for earnings, or null to use the built-in i18n label. */
+  payoutLabel: string | null;
+  /** Absolute http(s) URL, or null to render the Hive note as plain text. */
+  learnMoreUrl: string | null;
+}
+
+export interface HiveLayerInput {
+  /** Raw `instanceConfiguration.features`, of entirely unknown shape. */
+  features: unknown;
+  /**
+   * Same expression every other consumer uses (`use-instance-config.ts`):
+   * `type === 'community' && !!communityId`. Taking the resolved boolean rather
+   * than the raw type keeps one definition of "is a community" in the app; a
+   * second one would disagree on `type: 'community'` with an empty communityId,
+   * where the sidebar already renders the personal branch.
+   */
+  isCommunityMode: boolean;
+  /** `resolveCreatePostTarget(...).kind === 'internal'`. */
+  composerIsInternal: boolean;
+}
+
+/**
+ * What every leaf under `features.hive` resolves to when it is absent, and what
+ * the editor must offer as that field's default so the panel cannot display a
+ * state the site disagrees with.
+ *
+ * Deliberately flat and scalar. `isValidArrayReplacement` in the hosting API
+ * (`tenant-service.ts`) returns false for any array element where
+ * `typeof item === 'object'`, while the merge takes an incoming value verbatim
+ * only when the stored value is absent. An array-of-objects field here would
+ * therefore save exactly once and then be frozen behind a 200 OK forever. A
+ * `number` field is barred for the same class of reason: the editor's number
+ * input sends `null` when cleared. Selects and strings only, checked by test.
+ */
+export const HIVE_LAYER_CONFIG_DEFAULTS = {
+  readerLayer: 'off',
+  authorRewards: 'off',
+  payoutLabel: '',
+  learnMoreUrl: '',
+} as const;
+
+/**
+ * What a NEW instance is created with. Existing instances are untouched:
+ * absence resolves to the `off` posture, so this deploy is inert on every
+ * config already on disk.
+ */
+export const HIVE_LAYER_SEED = {
+  readerLayer: 'standard',
+  authorRewards: 'author',
+} as const;
+
+/** An owner-typed label longer than this is cut at render, never stored-corrected. */
+export const PAYOUT_LABEL_MAX_LENGTH = 40;
+
+const READER_LAYERS: readonly ReaderLayer[] = ['off', 'standard', 'full'];
+const AUTHOR_REWARDS: readonly AuthorRewards[] = ['off', 'author'];
+
+/** A value that can carry keys: not a primitive, not null, not an array. */
+function plainObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Exactly one of the allowed literals, or the fallback.
+ *
+ * No case folding and no trimming: `"FULL"` is not `full`. An owner who cannot
+ * produce the literal through the editor produced it by hand, and guessing at
+ * their intent is how an unknown value ends up granting more than it names.
+ */
+function oneOf<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  return typeof value === 'string' &&
+    (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : fallback;
+}
+
+/** The owner's own earnings label, or null to fall back to the built-in one. */
+function resolvePayoutLabel(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  return trimmed.slice(0, PAYOUT_LABEL_MAX_LENGTH);
+}
+
+/**
+ * An absolute http(s) destination, re-serialised, or null.
+ *
+ * This value becomes an `href`. Parsing and re-serialising means a
+ * `javascript:` or `data:` value cannot reach the DOM and a relative one cannot
+ * produce a link that goes nowhere, matching `create-post-target.ts`. Refusing
+ * renders the Hive note as plain text, which still reads correctly.
+ */
+function resolveLearnMoreUrl(value: unknown): string | null {
+  if (typeof value !== 'string' || value.trim() === '') return null;
+  let url: URL;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  return url.href;
+}
+
+/**
+ * Expand the posture into the render decisions, then apply the clamps.
+ *
+ * The clamps live here rather than in a component because storage cannot
+ * enforce them: everything below is downstream of the merge, at the read site.
+ */
+export function resolveHiveLayer(input: HiveLayerInput): ResolvedHiveLayer {
+  const features = plainObject(input.features);
+  // A bare string, an array or a number at `features.hive` means the whole
+  // block is absent. It is storable today, so this bail is load-bearing rather
+  // than paranoia: without it the site crashes on a value the API accepted.
+  const hive = features ? plainObject(features.hive) : null;
+
+  const readerLayer = oneOf(
+    hive?.readerLayer,
+    READER_LAYERS,
+    HIVE_LAYER_CONFIG_DEFAULTS.readerLayer,
+  );
+
+  const atLeastStandard = readerLayer === 'standard' || readerLayer === 'full';
+  const isFull = readerLayer === 'full';
+
+  return {
+    readerLayer,
+    showPayoutOnPost: atLeastStandard,
+    showPayoutInFeed: isFull,
+    // Not separately toggleable. A payout printed without the note that it is
+    // not final, or a weight picker whose effect is invisible, are each worse
+    // than showing neither.
+    showChainNote: atLeastStandard,
+    showChainPermalink: atLeastStandard,
+    showVoteWeightPicker: isFull,
+    // A personal blog owner cannot put a downvote arrow on their own posts, by
+    // hand-edited JSON or otherwise.
+    allowDownvotes: isFull && input.isCommunityMode,
+    // An owner who deliberately points "Create post" at an external composer
+    // must not get a panel that configures a composer nobody uses.
+    authorRewards: input.composerIsInternal
+      ? oneOf(
+          hive?.authorRewards,
+          AUTHOR_REWARDS,
+          HIVE_LAYER_CONFIG_DEFAULTS.authorRewards,
+        )
+      : 'off',
+    payoutLabel: resolvePayoutLabel(hive?.payoutLabel),
+    learnMoreUrl: resolveLearnMoreUrl(hive?.learnMoreUrl),
+  };
+}

--- a/apps/self-hosted/src/core/hive-layer.ts
+++ b/apps/self-hosted/src/core/hive-layer.ts
@@ -18,6 +18,17 @@
  * `typeof`, so a hand-crafted PATCH can store any type-compatible value at any
  * of these paths, and the served document reaches the client unvalidated. An
  * unknown value therefore always resolves toward LESS, never more.
+ *
+ * Nothing is resolved here that nothing can render. The reader vote-weight
+ * picker and the community downvote arrow are part of the `full` posture in the
+ * spec and are deliberately absent from this module: `VoteButton` comes from
+ * `@ecency/ui` through a committed `dist`, so a prop added in its source does
+ * not reach this app at all until that dist is rebuilt, which house policy keeps
+ * out of a feature PR. Resolving flags in that state advertises a posture the
+ * app cannot honour, so both return together with the `@ecency/ui` change that
+ * gives them a consumer, along with the `isCommunityMode` input the downvote
+ * clamp needs. See step 10 of the Hive-native layer spec. A test asserts that
+ * every render flag this module resolves is read by a component.
  */
 
 export type ReaderLayer = 'off' | 'standard' | 'full';
@@ -33,10 +44,6 @@ export interface ResolvedHiveLayer {
   showChainNote: boolean;
   /** "View this post on Hive" permalink to the chain record. */
   showChainPermalink: boolean;
-  /** Reader picks how strongly their vote lands. */
-  showVoteWeightPicker: boolean;
-  /** Reader may downvote. Community instances only, always. */
-  allowDownvotes: boolean;
   authorRewards: AuthorRewards;
   /** Owner's own word for earnings, or null to use the built-in i18n label. */
   payoutLabel: string | null;
@@ -47,14 +54,6 @@ export interface ResolvedHiveLayer {
 export interface HiveLayerInput {
   /** Raw `instanceConfiguration.features`, of entirely unknown shape. */
   features: unknown;
-  /**
-   * Same expression every other consumer uses (`use-instance-config.ts`):
-   * `type === 'community' && !!communityId`. Taking the resolved boolean rather
-   * than the raw type keeps one definition of "is a community" in the app; a
-   * second one would disagree on `type: 'community'` with an empty communityId,
-   * where the sidebar already renders the personal branch.
-   */
-  isCommunityMode: boolean;
   /** `resolveCreatePostTarget(...).kind === 'internal'`. */
   composerIsInternal: boolean;
 }
@@ -174,16 +173,13 @@ export function resolveHiveLayer(input: HiveLayerInput): ResolvedHiveLayer {
   return {
     readerLayer,
     showPayoutOnPost: atLeastStandard,
+    // The one thing `full` does that `standard` does not, so the two postures
+    // differ on a surface a reader can see rather than only in this object.
     showPayoutInFeed: isFull,
     // Not separately toggleable. A payout printed without the note that it is
-    // not final, or a weight picker whose effect is invisible, are each worse
-    // than showing neither.
+    // not final is worse than showing neither.
     showChainNote: atLeastStandard,
     showChainPermalink: atLeastStandard,
-    showVoteWeightPicker: isFull,
-    // A personal blog owner cannot put a downvote arrow on their own posts, by
-    // hand-edited JSON or otherwise.
-    allowDownvotes: isFull && input.isCommunityMode,
     // An owner who deliberately points "Create post" at an external composer
     // must not get a panel that configures a composer nobody uses.
     authorRewards: input.composerIsInternal

--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -91,7 +91,25 @@ type TranslationKey =
   | 'tip_transaction_failed'
   | 'tip_qr_no_address'
   | 'tip_qr_failed'
-  | 'cancel';
+  | 'cancel'
+  | 'rewards_pending'
+  | 'rewards_earned'
+  | 'rewards_declined'
+  | 'payout_window'
+  | 'payout_hint'
+  | 'published_on_hive'
+  | 'view_on_hive'
+  | 'hive_disclosure_vote'
+  | 'hive_disclosure_comment'
+  | 'hive_disclosure_publish'
+  | 'join_community'
+  | 'leave_community'
+  | 'joining'
+  | 'leaving'
+  | 'community_membership_failed'
+  | 'reputation_band_new'
+  | 'reputation_band_established'
+  | 'reputation_band_longstanding';
 
 type Translations = Record<TranslationKey, string>;
 
@@ -188,6 +206,28 @@ const translations: Record<string, Translations> = {
     tip_qr_no_address: 'No address',
     tip_qr_failed: 'Failed to generate QR',
     cancel: 'Cancel',
+    rewards_pending: 'Pending rewards',
+    rewards_earned: 'Earned',
+    rewards_declined: 'Rewards declined',
+    payout_window: 'Pays out',
+    payout_hint: 'Estimated value in HIVE Power and HBD',
+    published_on_hive: 'Published on Hive',
+    view_on_hive: 'View this post on Hive',
+    hive_disclosure_vote:
+      'Liking casts a vote on Hive and spends part of your voting power.',
+    hive_disclosure_comment:
+      'Comments are published to Hive. They are public and cannot be deleted.',
+    hive_disclosure_publish:
+      'Publishing writes this post publicly and permanently to Hive. Rewards close 7 days after publishing.',
+    join_community: 'Join',
+    leave_community: 'Leave',
+    joining: 'Joining...',
+    leaving: 'Leaving...',
+    community_membership_failed:
+      'Could not update your membership. Please try again.',
+    reputation_band_new: 'New',
+    reputation_band_established: 'Established',
+    reputation_band_longstanding: 'Long standing',
   },
   es: {
     loading: 'Cargando...',
@@ -280,6 +320,28 @@ const translations: Record<string, Translations> = {
     tip_qr_no_address: 'Sin dirección',
     tip_qr_failed: 'Error al generar el QR',
     cancel: 'Cancelar',
+    rewards_pending: 'Recompensas pendientes',
+    rewards_earned: 'Ganado',
+    rewards_declined: 'Recompensas rechazadas',
+    payout_window: 'Se paga',
+    payout_hint: 'Valor estimado en HIVE Power y HBD',
+    published_on_hive: 'Publicado en Hive',
+    view_on_hive: 'Ver esta publicación en Hive',
+    hive_disclosure_vote:
+      'Dar me gusta emite un voto en Hive y consume parte de tu poder de voto.',
+    hive_disclosure_comment:
+      'Los comentarios se publican en Hive. Son públicos y no se pueden borrar.',
+    hive_disclosure_publish:
+      'Al publicar, esta entrada se escribe en Hive de forma pública y permanente. Las recompensas se cierran 7 días después de publicar.',
+    join_community: 'Unirse',
+    leave_community: 'Salir',
+    joining: 'Uniéndose...',
+    leaving: 'Saliendo...',
+    community_membership_failed:
+      'No se pudo actualizar tu membresía. Inténtalo de nuevo.',
+    reputation_band_new: 'Nueva',
+    reputation_band_established: 'Establecida',
+    reputation_band_longstanding: 'Veterana',
   },
   de: {
     loading: 'Lädt...',
@@ -372,6 +434,28 @@ const translations: Record<string, Translations> = {
     tip_qr_no_address: 'Keine Adresse',
     tip_qr_failed: 'QR-Generierung fehlgeschlagen',
     cancel: 'Abbrechen',
+    rewards_pending: 'Ausstehende Belohnungen',
+    rewards_earned: 'Verdient',
+    rewards_declined: 'Belohnungen abgelehnt',
+    payout_window: 'Auszahlung',
+    payout_hint: 'Geschätzter Wert in HIVE Power und HBD',
+    published_on_hive: 'Auf Hive veröffentlicht',
+    view_on_hive: 'Diesen Beitrag auf Hive ansehen',
+    hive_disclosure_vote:
+      'Ein Like ist eine Stimme auf Hive und verbraucht einen Teil deiner Stimmkraft.',
+    hive_disclosure_comment:
+      'Kommentare werden auf Hive veröffentlicht. Sie sind öffentlich und können nicht gelöscht werden.',
+    hive_disclosure_publish:
+      'Das Veröffentlichen schreibt diesen Beitrag öffentlich und dauerhaft auf Hive. Belohnungen enden 7 Tage nach der Veröffentlichung.',
+    join_community: 'Beitreten',
+    leave_community: 'Verlassen',
+    joining: 'Beitritt...',
+    leaving: 'Austritt...',
+    community_membership_failed:
+      'Mitgliedschaft konnte nicht aktualisiert werden. Bitte erneut versuchen.',
+    reputation_band_new: 'Neu',
+    reputation_band_established: 'Etabliert',
+    reputation_band_longstanding: 'Langjährig',
   },
   fr: {
     loading: "Chargement...",
@@ -465,6 +549,28 @@ const translations: Record<string, Translations> = {
     tip_qr_no_address: 'Aucune adresse',
     tip_qr_failed: 'Échec de la génération du QR',
     cancel: 'Annuler',
+    rewards_pending: 'Récompenses en attente',
+    rewards_earned: 'Gagné',
+    rewards_declined: 'Récompenses refusées',
+    payout_window: 'Paiement',
+    payout_hint: 'Valeur estimée en HIVE Power et HBD',
+    published_on_hive: 'Publié sur Hive',
+    view_on_hive: 'Voir ce billet sur Hive',
+    hive_disclosure_vote:
+      'Aimer envoie un vote sur Hive et consomme une partie de votre pouvoir de vote.',
+    hive_disclosure_comment:
+      'Les commentaires sont publiés sur Hive. Ils sont publics et ne peuvent pas être supprimés.',
+    hive_disclosure_publish:
+      'La publication écrit ce billet sur Hive de façon publique et permanente. Les récompenses se ferment 7 jours après la publication.',
+    join_community: 'Rejoindre',
+    leave_community: 'Quitter',
+    joining: 'Adhésion...',
+    leaving: 'Départ...',
+    community_membership_failed:
+      'Impossible de mettre à jour votre adhésion. Veuillez réessayer.',
+    reputation_band_new: 'Nouveau',
+    reputation_band_established: 'Établi',
+    reputation_band_longstanding: 'De longue date',
   },
   ko: {
     loading: '로딩 중...',
@@ -557,6 +663,27 @@ const translations: Record<string, Translations> = {
     tip_qr_no_address: '주소 없음',
     tip_qr_failed: 'QR 생성 실패',
     cancel: '취소',
+    rewards_pending: '대기 중인 보상',
+    rewards_earned: '획득',
+    rewards_declined: '보상 거부됨',
+    payout_window: '지급',
+    payout_hint: 'HIVE Power와 HBD로 환산한 예상 금액',
+    published_on_hive: 'Hive에 게시됨',
+    view_on_hive: 'Hive에서 이 글 보기',
+    hive_disclosure_vote:
+      '좋아요는 Hive에 투표를 기록하며 회원님의 투표력을 소모합니다.',
+    hive_disclosure_comment:
+      '댓글은 Hive에 게시됩니다. 공개되며 삭제할 수 없습니다.',
+    hive_disclosure_publish:
+      '게시하면 이 글이 Hive에 공개적으로 영구히 기록됩니다. 보상은 게시 후 7일에 마감됩니다.',
+    join_community: '가입',
+    leave_community: '탈퇴',
+    joining: '가입 중...',
+    leaving: '탈퇴 중...',
+    community_membership_failed: '멤버십을 변경하지 못했습니다. 다시 시도해 주세요.',
+    reputation_band_new: '신규',
+    reputation_band_established: '활동 중',
+    reputation_band_longstanding: '오래된 계정',
   },
   ru: {
     loading: 'Загрузка...',
@@ -649,6 +776,28 @@ const translations: Record<string, Translations> = {
     tip_qr_no_address: 'Нет адреса',
     tip_qr_failed: 'Не удалось создать QR-код',
     cancel: 'Отмена',
+    rewards_pending: 'Ожидаемые награды',
+    rewards_earned: 'Заработано',
+    rewards_declined: 'Награды отклонены',
+    payout_window: 'Выплата',
+    payout_hint: 'Оценочная стоимость в HIVE Power и HBD',
+    published_on_hive: 'Опубликовано в Hive',
+    view_on_hive: 'Посмотреть этот пост в Hive',
+    hive_disclosure_vote:
+      'Лайк отправляет голос в Hive и расходует часть вашей силы голоса.',
+    hive_disclosure_comment:
+      'Комментарии публикуются в Hive. Они общедоступны, и их нельзя удалить.',
+    hive_disclosure_publish:
+      'Публикация записывает этот пост в Hive публично и навсегда. Награды закрываются через 7 дней после публикации.',
+    join_community: 'Вступить',
+    leave_community: 'Выйти',
+    joining: 'Вступление...',
+    leaving: 'Выход...',
+    community_membership_failed:
+      'Не удалось изменить членство. Попробуйте ещё раз.',
+    reputation_band_new: 'Новый',
+    reputation_band_established: 'Постоянный',
+    reputation_band_longstanding: 'Давний',
   },
 };
 

--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -109,7 +109,10 @@ type TranslationKey =
   | 'community_membership_failed'
   | 'reputation_band_new'
   | 'reputation_band_established'
-  | 'reputation_band_longstanding';
+  | 'reputation_band_longstanding'
+  | 'confirming'
+  | 'membership_unconfirmed'
+  | 'check_again';
 
 type Translations = Record<TranslationKey, string>;
 
@@ -228,6 +231,10 @@ const translations: Record<string, Translations> = {
     reputation_band_new: 'New',
     reputation_band_established: 'Established',
     reputation_band_longstanding: 'Long standing',
+    confirming: 'Confirming...',
+    membership_unconfirmed:
+      'Sent to Hive. The community has not confirmed this yet. Reload in a moment to check.',
+    check_again: 'Check again',
   },
   es: {
     loading: 'Cargando...',
@@ -342,6 +349,10 @@ const translations: Record<string, Translations> = {
     reputation_band_new: 'Nueva',
     reputation_band_established: 'Establecida',
     reputation_band_longstanding: 'Veterana',
+    confirming: 'Confirmando...',
+    membership_unconfirmed:
+      'Enviado a Hive. La comunidad todavía no lo ha confirmado. Vuelve a cargar en un momento para comprobarlo.',
+    check_again: 'Comprobar de nuevo',
   },
   de: {
     loading: 'Lädt...',
@@ -456,6 +467,10 @@ const translations: Record<string, Translations> = {
     reputation_band_new: 'Neu',
     reputation_band_established: 'Etabliert',
     reputation_band_longstanding: 'Langjährig',
+    confirming: 'Wird bestätigt...',
+    membership_unconfirmed:
+      'An Hive gesendet. Die Community hat es noch nicht bestätigt. Lade die Seite gleich neu, um nachzusehen.',
+    check_again: 'Erneut prüfen',
   },
   fr: {
     loading: "Chargement...",
@@ -571,6 +586,10 @@ const translations: Record<string, Translations> = {
     reputation_band_new: 'Nouveau',
     reputation_band_established: 'Établi',
     reputation_band_longstanding: 'De longue date',
+    confirming: 'Confirmation...',
+    membership_unconfirmed:
+      "Envoyé à Hive. La communauté ne l'a pas encore confirmé. Rechargez dans un instant pour vérifier.",
+    check_again: 'Vérifier à nouveau',
   },
   ko: {
     loading: '로딩 중...',
@@ -684,6 +703,10 @@ const translations: Record<string, Translations> = {
     reputation_band_new: '신규',
     reputation_band_established: '활동 중',
     reputation_band_longstanding: '오래된 계정',
+    confirming: '확인 중...',
+    membership_unconfirmed:
+      'Hive로 전송했습니다. 커뮤니티가 아직 확인하지 않았습니다. 잠시 후 새로 고쳐 확인해 주세요.',
+    check_again: '다시 확인',
   },
   ru: {
     loading: 'Загрузка...',
@@ -798,6 +821,10 @@ const translations: Record<string, Translations> = {
     reputation_band_new: 'Новый',
     reputation_band_established: 'Постоянный',
     reputation_band_longstanding: 'Давний',
+    confirming: 'Подтверждение...',
+    membership_unconfirmed:
+      'Отправлено в Hive. Сообщество это ещё не подтвердило. Обновите страницу через минуту, чтобы проверить.',
+    check_again: 'Проверить снова',
   },
 };
 

--- a/apps/self-hosted/src/core/index.ts
+++ b/apps/self-hosted/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from './apply-config-dom';
 export * from './configuration-loader';
 export * from './date-formatter';
+export * from './hive-layer';
 export * from './i18n';
 export * from './instance-type-filters';

--- a/apps/self-hosted/src/features/auth/components/comment-form.tsx
+++ b/apps/self-hosted/src/features/auth/components/comment-form.tsx
@@ -6,6 +6,7 @@ import { Link } from "@tanstack/react-router";
 import { useComment } from "@ecency/sdk";
 import { useAuth, useIsAuthenticated, useIsAuthEnabled } from "../hooks";
 import { t } from "@/core";
+import { CommentDisclosure } from "@/features/shared/hive-disclosure";
 import { createBroadcastAdapter } from "@/providers/sdk";
 
 interface CommentFormProps {
@@ -121,6 +122,13 @@ export function CommentForm({
       {error && (
         <div className="text-sm text-red-500 dark:text-red-400">{error}</div>
       )}
+
+      {/*
+        Not configurable, by design, and rendered only here: the unauthenticated
+        branch above is a login prompt, not a form, so nothing can be written
+        from it.
+      */}
+      <CommentDisclosure />
 
       <div className="flex justify-end">
         <button

--- a/apps/self-hosted/src/features/blog/components/blog-post-footer.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-footer.tsx
@@ -4,8 +4,12 @@ import type { Entry } from '@ecency/sdk';
 import { UilComment } from '@tooni/iconscout-unicons-react';
 import { useMemo } from 'react';
 import { InstanceConfigManager, t } from '@/core';
-import { VoteButton, ReblogButton } from '@/features/auth';
+import { useIsAuthEnabled, VoteButton, ReblogButton } from '@/features/auth';
+import { VoteDisclosure } from '@/features/shared/hive-disclosure';
 import { TipButton } from '@/features/tipping';
+import { useHiveLayer } from '../hooks/use-hive-layer';
+import { HivePostNote } from './hive-post-note';
+import { PostPayout } from './post-payout';
 
 interface Props {
   entry: Entry;
@@ -13,6 +17,8 @@ interface Props {
 
 export function BlogPostFooter({ entry }: Props) {
   const entryData = entry.original_entry || entry;
+  const hiveLayer = useHiveLayer();
+  const isAuthEnabled = useIsAuthEnabled();
 
   const showLikes = InstanceConfigManager.getConfigValue(
     ({ configuration }) =>
@@ -80,7 +86,28 @@ export function BlogPostFooter({ entry }: Props) {
             className="flex items-center gap-1"
           />
         )}
+        {hiveLayer.showPayoutOnPost && (
+          <PostPayout entry={entryData} label={hiveLayer.payoutLabel} />
+        )}
       </div>
+
+      {/*
+        Not configurable, by design. The gate is only whether a reader can vote
+        at all, which features.likes and features.auth already decide.
+      */}
+      {showLikes && isAuthEnabled && (
+        <div className="mt-2">
+          <VoteDisclosure />
+        </div>
+      )}
+
+      <HivePostNote
+        author={entryData.author}
+        permlink={entryData.permlink}
+        showNote={hiveLayer.showChainNote}
+        showPermalink={hiveLayer.showChainPermalink}
+        learnMoreUrl={hiveLayer.learnMoreUrl}
+      />
     </footer>
   );
 }

--- a/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
@@ -14,6 +14,8 @@ import clsx from 'clsx';
 import { useMemo } from 'react';
 import { formatDate, InstanceConfigManager } from '@/core';
 import { UserAvatar } from '@/features/shared/user-avatar';
+import { useHiveLayer } from '../hooks/use-hive-layer';
+import { PostPayout } from './post-payout';
 
 interface Props {
   entry: Entry;
@@ -21,6 +23,7 @@ interface Props {
 }
 
 export function BlogPostItem({ entry }: Props) {
+  const hiveLayer = useHiveLayer();
   const listType = InstanceConfigManager.getConfigValue(
     ({ configuration }) => configuration.instanceConfiguration.layout.listType,
   );
@@ -200,6 +203,20 @@ export function BlogPostItem({ entry }: Props) {
               <span>{commentsCount}</span>
             </div>
           </>
+        )}
+        {/*
+          The `full` posture, and the only thing it adds over `standard`. Same
+          meta row, same muted treatment as the post page, so one earnings
+          figure per surface still holds. PostPayout renders nothing when the
+          entry carries no readable payout, which is what keeps the search feed
+          safe: it hand-builds an Entry with no payout fields at all.
+        */}
+        {hiveLayer.showPayoutInFeed && (
+          <PostPayout
+            entry={entryData}
+            label={hiveLayer.payoutLabel}
+            separator={<span>•</span>}
+          />
         )}
       </div>
     </>

--- a/apps/self-hosted/src/features/blog/components/community-join-button.tsx
+++ b/apps/self-hosted/src/features/blog/components/community-join-button.tsx
@@ -11,6 +11,7 @@ import clsx from 'clsx';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { t } from '@/core';
 import { useAuth, useIsAuthEnabled, useIsAuthenticated } from '@/features/auth';
+import { LiveRegion } from '@/features/shared/live-region';
 import { createBroadcastAdapter } from '@/providers/sdk';
 import {
   MEMBERSHIP_CONFIRMATION,
@@ -98,14 +99,21 @@ export function CommunityJoinButton({ communityId }: Props) {
         await sleep(delayMs);
         if (cancelled.current) return;
 
-        const { data } = await refetch();
+        // A read that fails is not a reading. Letting the rejection escape here
+        // left the button in `confirming` forever, disabled, with no way out;
+        // an absent observation is already handled, and advances the run toward
+        // the honest `unconfirmed` ending instead.
+        let observed: boolean | undefined;
+        try {
+          const result = await refetch();
+          observed = result.isError ? undefined : result.data?.subscribed;
+        } catch (err) {
+          console.error('Community context read failed:', err);
+          observed = undefined;
+        }
         if (cancelled.current) return;
 
-        const step = nextConfirmationStep(
-          data?.subscribed,
-          target,
-          attemptsMade,
-        );
+        const step = nextConfirmationStep(observed, target, attemptsMade);
         if (step.kind === 'confirmed') {
           setPhase('idle');
           setDesired(null);
@@ -145,8 +153,14 @@ export function CommunityJoinButton({ communityId }: Props) {
         setPhase('failed');
         setError(t('community_membership_failed'));
         // The throw may have been a timeout on a broadcast that still landed,
-        // so the community stays the authority on what actually happened.
-        await refetch();
+        // so the community stays the authority on what actually happened. Its
+        // own failure must not replace the broadcast error the reader needs,
+        // nor escape as an unhandled rejection.
+        try {
+          await refetch();
+        } catch (readErr) {
+          console.error('Community context read failed:', readErr);
+        }
         return;
       }
 
@@ -207,24 +221,33 @@ export function CommunityJoinButton({ communityId }: Props) {
         {label}
       </button>
 
+      {/*
+        Both outcomes are announced, and both regions are mounted from the
+        first render rather than appearing with their message. A live region
+        created at the same moment as its content is usually not read out, so
+        conditionally rendering these would leave a screen reader user with a
+        button that silently goes disabled and nothing else.
+      */}
+      <LiveRegion
+        className="text-xs text-theme-muted"
+        message={phase === 'unconfirmed' ? t('membership_unconfirmed') : null}
+      />
+
       {phase === 'unconfirmed' && (
-        <div className="flex flex-col items-start gap-1">
-          <span className="text-xs text-theme-muted">
-            {t('membership_unconfirmed')}
-          </span>
-          <button
-            type="button"
-            onClick={handleCheckAgain}
-            className="text-xs underline text-theme-muted"
-          >
-            {t('check_again')}
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={handleCheckAgain}
+          className="text-xs underline text-theme-muted"
+        >
+          {t('check_again')}
+        </button>
       )}
 
-      {error && (
-        <span className="text-xs text-red-500 dark:text-red-400">{error}</span>
-      )}
+      <LiveRegion
+        urgency="assertive"
+        className="text-xs text-red-500 dark:text-red-400"
+        message={error}
+      />
     </div>
   );
 }

--- a/apps/self-hosted/src/features/blog/components/community-join-button.tsx
+++ b/apps/self-hosted/src/features/blog/components/community-join-button.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import {
+  getCommunityContextQueryOptions,
+  useSubscribeCommunity,
+  useUnsubscribeCommunity,
+} from '@ecency/sdk';
+import { useQuery } from '@tanstack/react-query';
+import { Link, useRouterState } from '@tanstack/react-router';
+import clsx from 'clsx';
+import { useCallback, useState } from 'react';
+import { t } from '@/core';
+import { useAuth, useIsAuthEnabled, useIsAuthenticated } from '@/features/auth';
+import { createBroadcastAdapter } from '@/providers/sdk';
+
+interface Props {
+  communityId: string;
+}
+
+const BUTTON =
+  'px-3 py-1 rounded-md border border-theme text-xs text-theme-primary hover:bg-theme-tertiary disabled:opacity-50 disabled:cursor-not-allowed';
+
+/**
+ * Join or leave the community whose subscriber count sits next to this.
+ *
+ * The sidebar has printed a membership number with no way to become one of
+ * them. Gated only on whether the instance has auth at all, exactly as
+ * ReblogButton is: nobody would choose to advertise a membership and forbid it.
+ *
+ * There is no auto-retry and no optimistic success. A `custom_json` broadcast
+ * being accepted by a node does not mean the community honoured it, so the
+ * button reads the community context back rather than assuming, and a failure
+ * says so instead of leaving a button that looks like it worked.
+ */
+export function CommunityJoinButton({ communityId }: Props) {
+  const { user } = useAuth();
+  const isAuthEnabled = useIsAuthEnabled();
+  const isAuthenticated = useIsAuthenticated();
+  const currentPath = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: context, refetch } = useQuery(
+    getCommunityContextQueryOptions(user?.username, communityId),
+  );
+
+  const adapter = createBroadcastAdapter();
+  const subscribe = useSubscribeCommunity(user?.username, { adapter });
+  const unsubscribe = useUnsubscribeCommunity(user?.username, { adapter });
+
+  const subscribed = context?.subscribed === true;
+  const isPending = subscribe.isPending || unsubscribe.isPending;
+
+  const handleClick = useCallback(async () => {
+    if (!user || isPending) return;
+    setError(null);
+    try {
+      if (subscribed) {
+        await unsubscribe.mutateAsync({ community: communityId });
+      } else {
+        await subscribe.mutateAsync({ community: communityId });
+      }
+    } catch (err) {
+      console.error('Community membership change failed:', err);
+      setError(t('community_membership_failed'));
+    } finally {
+      // Whether it succeeded or not, the community is the authority on who is
+      // subscribed. Read it back rather than trusting the broadcast.
+      await refetch();
+    }
+  }, [
+    user,
+    isPending,
+    subscribed,
+    communityId,
+    subscribe,
+    unsubscribe,
+    refetch,
+  ]);
+
+  if (!isAuthEnabled || !communityId) return null;
+
+  if (!isAuthenticated) {
+    return (
+      <Link
+        to="/login"
+        search={{ redirect: currentPath }}
+        className={clsx(BUTTON, 'inline-block')}
+      >
+        {t('join_community')}
+      </Link>
+    );
+  }
+
+  const label = isPending
+    ? subscribed
+      ? t('leaving')
+      : t('joining')
+    : subscribed
+      ? t('leave_community')
+      : t('join_community');
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isPending}
+        className={BUTTON}
+      >
+        {label}
+      </button>
+      {error && (
+        <span className="text-xs text-red-500 dark:text-red-400">{error}</span>
+      )}
+    </div>
+  );
+}

--- a/apps/self-hosted/src/features/blog/components/community-join-button.tsx
+++ b/apps/self-hosted/src/features/blog/components/community-join-button.tsx
@@ -8,10 +8,14 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { Link, useRouterState } from '@tanstack/react-router';
 import clsx from 'clsx';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { t } from '@/core';
 import { useAuth, useIsAuthEnabled, useIsAuthenticated } from '@/features/auth';
 import { createBroadcastAdapter } from '@/providers/sdk';
+import {
+  MEMBERSHIP_CONFIRMATION,
+  nextConfirmationStep,
+} from '../utils/membership-confirmation';
 
 interface Props {
   communityId: string;
@@ -21,16 +25,33 @@ const BUTTON =
   'px-3 py-1 rounded-md border border-theme text-xs text-theme-primary hover:bg-theme-tertiary disabled:opacity-50 disabled:cursor-not-allowed';
 
 /**
+ * idle       nothing in flight; the label reflects the community's own answer
+ * sending    the broadcast is out, no node has accepted it yet
+ * confirming accepted, and we are reading the community back until it agrees
+ * unconfirmed the read budget ran out; the change may or may not have landed
+ * failed     the broadcast itself threw
+ */
+type Phase = 'idle' | 'sending' | 'confirming' | 'unconfirmed' | 'failed';
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
  * Join or leave the community whose subscriber count sits next to this.
  *
  * The sidebar has printed a membership number with no way to become one of
  * them. Gated only on whether the instance has auth at all, exactly as
  * ReblogButton is: nobody would choose to advertise a membership and forbid it.
  *
- * There is no auto-retry and no optimistic success. A `custom_json` broadcast
- * being accepted by a node does not mean the community honoured it, so the
- * button reads the community context back rather than assuming, and a failure
- * says so instead of leaving a button that looks like it worked.
+ * Nothing here treats a successful broadcast as a completed membership change.
+ * Subscriptions go out in async mode, which resolves on mempool acceptance, so
+ * the community has usually not indexed anything by the time the promise
+ * settles. The button therefore reads the community back on a bounded schedule
+ * and stays disabled throughout, so it cannot be pressed a second time into a
+ * duplicate broadcast, and when the budget runs out it says the change is
+ * unconfirmed rather than claiming it worked. There is no optimistic cache
+ * write anywhere in this file, on purpose: the state we would be writing is
+ * exactly the state we do not know.
  */
 export function CommunityJoinButton({ communityId }: Props) {
   const { user } = useAuth();
@@ -39,7 +60,22 @@ export function CommunityJoinButton({ communityId }: Props) {
   const currentPath = useRouterState({
     select: (state) => state.location.pathname,
   });
+
+  const [phase, setPhase] = useState<Phase>('idle');
   const [error, setError] = useState<string | null>(null);
+  /** What the in-flight change is trying to make `subscribed` become. */
+  const [desired, setDesired] = useState<boolean | null>(null);
+
+  // Guards the broadcast against a second click landing in the same tick, ahead
+  // of the state update that disables the button.
+  const inFlight = useRef(false);
+  const cancelled = useRef(false);
+  useEffect(() => {
+    cancelled.current = false;
+    return () => {
+      cancelled.current = true;
+    };
+  }, []);
 
   const { data: context, refetch } = useQuery(
     getCommunityContextQueryOptions(user?.username, communityId),
@@ -50,34 +86,88 @@ export function CommunityJoinButton({ communityId }: Props) {
   const unsubscribe = useUnsubscribeCommunity(user?.username, { adapter });
 
   const subscribed = context?.subscribed === true;
-  const isPending = subscribe.isPending || unsubscribe.isPending;
+  const busy = phase === 'sending' || phase === 'confirming';
+
+  /** Read the community back until it agrees, or until the budget runs out. */
+  const confirm = useCallback(
+    async (target: boolean) => {
+      setPhase('confirming');
+      let delayMs = MEMBERSHIP_CONFIRMATION.intervalMs;
+
+      for (let attemptsMade = 1; ; attemptsMade++) {
+        await sleep(delayMs);
+        if (cancelled.current) return;
+
+        const { data } = await refetch();
+        if (cancelled.current) return;
+
+        const step = nextConfirmationStep(
+          data?.subscribed,
+          target,
+          attemptsMade,
+        );
+        if (step.kind === 'confirmed') {
+          setPhase('idle');
+          setDesired(null);
+          return;
+        }
+        if (step.kind === 'unconfirmed') {
+          setPhase('unconfirmed');
+          return;
+        }
+        delayMs = step.delayMs;
+      }
+    },
+    [refetch],
+  );
 
   const handleClick = useCallback(async () => {
-    if (!user || isPending) return;
+    if (!user || inFlight.current) return;
+    inFlight.current = true;
+
+    const target = !subscribed;
+    setDesired(target);
+    setError(null);
+    setPhase('sending');
+
+    // Held for the confirmation too, not just the broadcast: the operation is
+    // not over until the community has answered.
+    try {
+      try {
+        if (subscribed) {
+          await unsubscribe.mutateAsync({ community: communityId });
+        } else {
+          await subscribe.mutateAsync({ community: communityId });
+        }
+      } catch (err) {
+        console.error('Community membership change failed:', err);
+        if (cancelled.current) return;
+        setPhase('failed');
+        setError(t('community_membership_failed'));
+        // The throw may have been a timeout on a broadcast that still landed,
+        // so the community stays the authority on what actually happened.
+        await refetch();
+        return;
+      }
+
+      if (cancelled.current) return;
+      await confirm(target);
+    } finally {
+      inFlight.current = false;
+    }
+  }, [user, subscribed, communityId, subscribe, unsubscribe, refetch, confirm]);
+
+  /** Re-read the community. Never re-broadcasts, so it cannot duplicate. */
+  const handleCheckAgain = useCallback(async () => {
+    if (desired === null || inFlight.current) return;
+    inFlight.current = true;
     setError(null);
     try {
-      if (subscribed) {
-        await unsubscribe.mutateAsync({ community: communityId });
-      } else {
-        await subscribe.mutateAsync({ community: communityId });
-      }
-    } catch (err) {
-      console.error('Community membership change failed:', err);
-      setError(t('community_membership_failed'));
+      await confirm(desired);
     } finally {
-      // Whether it succeeded or not, the community is the authority on who is
-      // subscribed. Read it back rather than trusting the broadcast.
-      await refetch();
+      inFlight.current = false;
     }
-  }, [
-    user,
-    isPending,
-    subscribed,
-    communityId,
-    subscribe,
-    unsubscribe,
-    refetch,
-  ]);
+  }, [confirm, desired]);
 
   if (!isAuthEnabled || !communityId) return null;
 
@@ -93,24 +183,45 @@ export function CommunityJoinButton({ communityId }: Props) {
     );
   }
 
-  const label = isPending
-    ? subscribed
-      ? t('leaving')
-      : t('joining')
-    : subscribed
-      ? t('leave_community')
-      : t('join_community');
+  let label: string;
+  if (phase === 'sending') {
+    label = desired ? t('joining') : t('leaving');
+  } else if (phase === 'confirming') {
+    label = t('confirming');
+  } else {
+    label = subscribed ? t('leave_community') : t('join_community');
+  }
 
   return (
     <div className="flex flex-col items-start gap-1">
       <button
         type="button"
         onClick={handleClick}
-        disabled={isPending}
+        // Disabled through the unconfirmed state as well. Re-enabling it there
+        // would offer the reader the one action that produces a duplicate,
+        // precisely when we cannot tell them whether the first one landed.
+        disabled={busy || phase === 'unconfirmed'}
+        aria-busy={busy}
         className={BUTTON}
       >
         {label}
       </button>
+
+      {phase === 'unconfirmed' && (
+        <div className="flex flex-col items-start gap-1">
+          <span className="text-xs text-theme-muted">
+            {t('membership_unconfirmed')}
+          </span>
+          <button
+            type="button"
+            onClick={handleCheckAgain}
+            className="text-xs underline text-theme-muted"
+          >
+            {t('check_again')}
+          </button>
+        </div>
+      )}
+
       {error && (
         <span className="text-xs text-red-500 dark:text-red-400">{error}</span>
       )}

--- a/apps/self-hosted/src/features/blog/components/hive-post-note.tsx
+++ b/apps/self-hosted/src/features/blog/components/hive-post-note.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { UilExternalLinkAlt } from '@tooni/iconscout-unicons-react';
+import { t } from '@/core';
+
+interface Props {
+  author: string;
+  permlink: string;
+  showNote: boolean;
+  showPermalink: boolean;
+  /** Absolute http(s) URL, already validated, or null for plain text. */
+  learnMoreUrl: string | null;
+}
+
+/**
+ * Where this post lives outside the site: the note that it is on Hive, and the
+ * link to its record there.
+ *
+ * The note is the promotional layer and an owner can suppress it by choosing
+ * the `off` posture. It is not one of the three disclosures, which have no
+ * setting at all.
+ */
+export function HivePostNote({
+  author,
+  permlink,
+  showNote,
+  showPermalink,
+  learnMoreUrl,
+}: Props) {
+  if (!showNote && !showPermalink) return null;
+
+  // An absolute https literal the type checker cannot fold, so the dead-route
+  // guard files it as unresolved and it carries a DYNAMIC_LINKS entry.
+  const hiveUrl = `https://hivehub.dev/@${author}/${permlink}`;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-3 text-xs text-theme-muted">
+      {showNote &&
+        (learnMoreUrl ? (
+          <a
+            href={learnMoreUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            {t('published_on_hive')}
+          </a>
+        ) : (
+          <span>{t('published_on_hive')}</span>
+        ))}
+      {showPermalink && (
+        <a
+          href={hiveUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 underline"
+        >
+          {t('view_on_hive')}
+          <UilExternalLinkAlt className="size-3.5" aria-hidden="true" />
+        </a>
+      )}
+    </div>
+  );
+}

--- a/apps/self-hosted/src/features/blog/components/post-payout.tsx
+++ b/apps/self-hosted/src/features/blog/components/post-payout.tsx
@@ -2,6 +2,7 @@
 
 import type { Entry } from '@ecency/sdk';
 import { UilUsdCircle } from '@tooni/iconscout-unicons-react';
+import type { ReactNode } from 'react';
 import { formatRelativeTime, t } from '@/core';
 import {
   formatPayoutAmount,
@@ -13,6 +14,15 @@ interface Props {
   entry: Entry;
   /** Owner's own word for earnings, or null for the built-in label. */
   label: string | null;
+  /**
+   * Rendered immediately before the figure, and only when there is one.
+   *
+   * The feed row separates its items with a bullet. Putting that bullet at the
+   * call site would leave it stranded on every entry this renders nothing for,
+   * which on a search result is every entry, so the component that knows
+   * whether it renders owns the separator too.
+   */
+  separator?: ReactNode;
 }
 
 /**
@@ -23,7 +33,7 @@ interface Props {
  * all when the figure would be zero or the entry carries no readable payout
  * fields, which is what keeps the search feed safe.
  */
-export function PostPayout({ entry, label }: Props) {
+export function PostPayout({ entry, label, separator }: Props) {
   const payout = resolvePostPayout(entry);
   if (!payout) return null;
 
@@ -37,14 +47,17 @@ export function PostPayout({ entry, label }: Props) {
     label ?? (payout.paidOut ? t('rewards_earned') : t('rewards_pending'));
 
   return (
-    <div className="flex items-center gap-1" title={t('payout_hint')}>
-      <UilUsdCircle className="size-4" aria-hidden="true" />
-      <span>{payout.declined ? figure : `${heading} ${figure}`}</span>
-      {isPayoutWindowOpen(entry) && (
-        <span className="opacity-80">
-          {`· ${t('payout_window')} ${formatRelativeTime(entry.payout_at)}`}
-        </span>
-      )}
-    </div>
+    <>
+      {separator}
+      <div className="flex items-center gap-1" title={t('payout_hint')}>
+        <UilUsdCircle className="size-4" aria-hidden="true" />
+        <span>{payout.declined ? figure : `${heading} ${figure}`}</span>
+        {isPayoutWindowOpen(entry) && (
+          <span className="opacity-80">
+            {`· ${t('payout_window')} ${formatRelativeTime(entry.payout_at)}`}
+          </span>
+        )}
+      </div>
+    </>
   );
 }

--- a/apps/self-hosted/src/features/blog/components/post-payout.tsx
+++ b/apps/self-hosted/src/features/blog/components/post-payout.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import type { Entry } from '@ecency/sdk';
+import { UilUsdCircle } from '@tooni/iconscout-unicons-react';
+import { formatRelativeTime, t } from '@/core';
+import {
+  formatPayoutAmount,
+  isPayoutWindowOpen,
+  resolvePostPayout,
+} from '../utils/payout';
+
+interface Props {
+  entry: Entry;
+  /** Owner's own word for earnings, or null for the built-in label. */
+  label: string | null;
+}
+
+/**
+ * What the post earned, in the muted meta row beside likes and comments.
+ *
+ * Never a badge next to the headline: one earnings figure per surface, at the
+ * same size and colour as the other facts about the post. Renders nothing at
+ * all when the figure would be zero or the entry carries no readable payout
+ * fields, which is what keeps the search feed safe.
+ */
+export function PostPayout({ entry, label }: Props) {
+  const payout = resolvePostPayout(entry);
+  if (!payout) return null;
+
+  const figure = payout.declined
+    ? t('rewards_declined')
+    : formatPayoutAmount(payout.amount);
+
+  // A custom label is one string used in both states, so its copy has to be
+  // state-independent. The built-in one is not, and says which state it is in.
+  const heading =
+    label ?? (payout.paidOut ? t('rewards_earned') : t('rewards_pending'));
+
+  return (
+    <div className="flex items-center gap-1" title={t('payout_hint')}>
+      <UilUsdCircle className="size-4" aria-hidden="true" />
+      <span>{payout.declined ? figure : `${heading} ${figure}`}</span>
+      {isPayoutWindowOpen(entry) && (
+        <span className="opacity-80">
+          {`· ${t('payout_window')} ${formatRelativeTime(entry.payout_at)}`}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/self-hosted/src/features/blog/hooks/use-hive-layer.ts
+++ b/apps/self-hosted/src/features/blog/hooks/use-hive-layer.ts
@@ -20,7 +20,8 @@ export function useHiveLayer(): ResolvedHiveLayer {
 
     // Same expression as use-instance-config, deliberately: a second definition
     // of "is a community" would disagree with the sidebar on an instance typed
-    // community with no communityId.
+    // community with no communityId. The resolver does not take it today; the
+    // downvote clamp that needs it returns with the vote controls.
     const isCommunityMode =
       instance?.type === 'community' && !!instance?.communityId;
 
@@ -31,7 +32,6 @@ export function useHiveLayer(): ResolvedHiveLayer {
 
     return resolveHiveLayer({
       features: instance?.features,
-      isCommunityMode,
       composerIsInternal: composer.kind === 'internal',
     });
   }, []);

--- a/apps/self-hosted/src/features/blog/hooks/use-hive-layer.ts
+++ b/apps/self-hosted/src/features/blog/hooks/use-hive-layer.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import type { ResolvedHiveLayer } from '@/core';
+import { InstanceConfigManager, resolveHiveLayer } from '@/core';
+import { resolveCreatePostTarget } from '@/features/auth/utils/create-post-target';
+
+/**
+ * The resolved Hive layer for this instance.
+ *
+ * A non-reactive `getConfig()` read behind a `useMemo`, in exactly the shape
+ * `use-tipping-config.ts` already uses. Config is loaded once before the app
+ * renders and the editor's preview channel is DOM attributes, which cannot
+ * express a React render decision anyway. Introducing a second, reactive read
+ * idiom for one corner of the app is how the panel and the site end up
+ * disagreeing; saving and reloading is how every other field behaves today.
+ */
+export function useHiveLayer(): ResolvedHiveLayer {
+  return useMemo(() => {
+    const { configuration } = InstanceConfigManager.getConfig();
+    const instance = configuration.instanceConfiguration;
+
+    // Same expression as use-instance-config, deliberately: a second definition
+    // of "is a community" would disagree with the sidebar on an instance typed
+    // community with no communityId.
+    const isCommunityMode =
+      instance?.type === 'community' && !!instance?.communityId;
+
+    const composer = resolveCreatePostTarget({
+      createPostUrl: configuration.general?.createPostUrl,
+      isCommunityMode,
+    });
+
+    return resolveHiveLayer({
+      features: instance?.features,
+      isCommunityMode,
+      composerIsInternal: composer.kind === 'internal',
+    });
+  }, []);
+}

--- a/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
@@ -1,13 +1,26 @@
 import { formatMonthYear, InstanceConfigManager, t } from "@/core";
+import { useAuth } from "@/features/auth";
 import { UserAvatar } from "@/features/shared/user-avatar";
 import { TipButton } from "@/features/tipping";
-import { getAccountFullQueryOptions } from "@ecency/sdk";
+import {
+  getAccountFullQueryOptions,
+  getCommunityContextQueryOptions,
+} from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { CommunityJoinButton } from "../components/community-join-button";
 import {
   useCommunityData,
   useInstanceConfig,
 } from "../hooks/use-instance-config";
+import { isModeratorRole } from "../utils/community-role";
+import { resolveReputation } from "../utils/reputation-band";
+
+const REPUTATION_BAND_LABELS = {
+  new: "reputation_band_new",
+  established: "reputation_band_established",
+  longstanding: "reputation_band_longstanding",
+} as const;
 
 export function BlogSidebar() {
   const { username, isCommunityMode } = useInstanceConfig();
@@ -34,6 +47,13 @@ function BlogSidebarContent({ username }: { username: string }) {
     if (!data?.created) return null;
     return formatMonthYear(data.created);
   }, [data?.created]);
+
+  // The bare integer means nothing to a reader who has not learned the scale,
+  // and a zero is a failed bridge call rather than a new account.
+  const reputation = useMemo(
+    () => resolveReputation(data?.reputation),
+    [data?.reputation],
+  );
 
   const websiteUrl = useMemo(() => {
     const raw = data?.profile?.website;
@@ -78,10 +98,10 @@ function BlogSidebarContent({ username }: { username: string }) {
           <div className="text-xs font-medium mb-2 text-theme-muted">
             {t("hiveInfo")}
           </div>
-          {data.reputation !== undefined && (
+          {reputation && (
             <div className="text-xs mb-1 text-theme-muted">
               <span className="font-medium">{t("reputation")}:</span>{" "}
-              {Math.floor(data.reputation)}
+              {t(REPUTATION_BAND_LABELS[reputation.band])} ({reputation.score})
             </div>
           )}
           {joinDate && (
@@ -131,6 +151,16 @@ function BlogSidebarContent({ username }: { username: string }) {
 
 function CommunitySidebar() {
   const { data: community, isLoading } = useCommunityData();
+  const { communityId } = useInstanceConfig();
+  const { user } = useAuth();
+
+  // num_pending is a moderation queue, not a statistic about the community.
+  // The context query is disabled without a username, so a logged-out visitor
+  // resolves to no role and sees nothing.
+  const { data: context } = useQuery(
+    getCommunityContextQueryOptions(user?.username, communityId),
+  );
+  const isModerator = isModeratorRole(context?.role);
 
   // Get the community avatar URL from the image proxy
   const communityAvatarUrl = useMemo(() => {
@@ -216,6 +246,10 @@ function CommunitySidebar() {
         </div>
       </div>
 
+      <div className="mb-4">
+        <CommunityJoinButton communityId={communityId} />
+      </div>
+
       <div className="border-t border-theme pt-4 mt-4">
         <div className="text-xs font-medium mb-2 text-theme-muted">
           {t("community_info")}
@@ -232,7 +266,7 @@ function CommunitySidebar() {
             {community.lang.toUpperCase()}
           </div>
         )}
-        {community.num_pending > 0 && (
+        {isModerator && community.num_pending > 0 && (
           <div className="text-xs text-theme-muted">
             <span className="font-medium">{t("pending_posts")}:</span>{" "}
             {community.num_pending}

--- a/apps/self-hosted/src/features/blog/utils/community-role.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/community-role.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { isModeratorRole } from './community-role';
+
+describe('isModeratorRole', () => {
+  it('accepts the roles that can act on the pending queue', () => {
+    expect(isModeratorRole('owner')).toBe(true);
+    expect(isModeratorRole('admin')).toBe(true);
+    expect(isModeratorRole('mod')).toBe(true);
+  });
+
+  it('rejects every other role', () => {
+    for (const role of ['member', 'guest', 'muted', '']) {
+      expect(isModeratorRole(role)).toBe(false);
+    }
+  });
+
+  it('rejects the absent role a logged-out visitor has', () => {
+    // The community-context query is disabled without a username, so this is
+    // the value the sidebar actually sees for a reader who is not signed in.
+    for (const role of [undefined, null, true, 1, {}, ['mod']]) {
+      expect(isModeratorRole(role)).toBe(false);
+    }
+  });
+});

--- a/apps/self-hosted/src/features/blog/utils/community-role.ts
+++ b/apps/self-hosted/src/features/blog/utils/community-role.ts
@@ -1,0 +1,20 @@
+/**
+ * Which community roles may see moderator-only figures.
+ *
+ * `num_pending` is the length of a moderation queue. It has always been printed
+ * to every visitor, where it reads as a statistic about the community rather
+ * than as work waiting for someone with a button they do not have.
+ */
+const MODERATOR_ROLES = new Set(['owner', 'admin', 'mod']);
+
+/**
+ * True only for a role the app has actually been told about.
+ *
+ * `getCommunityContextQueryOptions` is disabled without both a username and a
+ * community name, so a logged-out visitor gets `undefined` here rather than a
+ * role. That is the right answer, but it is the answer by way of a disabled
+ * query, so the default is stated explicitly instead of inherited from it.
+ */
+export function isModeratorRole(role: unknown): boolean {
+  return typeof role === 'string' && MODERATOR_ROLES.has(role);
+}

--- a/apps/self-hosted/src/features/blog/utils/membership-confirmation-wiring.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/membership-confirmation-wiring.test.ts
@@ -8,9 +8,17 @@ import { describe, expect, it } from 'vitest';
  *
  * The policy itself is pure and tested next door. What cannot be tested that
  * way is the component that drives it, because nothing in `apps/self-hosted` is
- * DOM-testable, so the three properties that matter are asserted against the
- * source: it goes through the policy, it never writes the answer into the cache
- * itself, and the control stays disabled for as long as the answer is unknown.
+ * DOM-testable, so the properties that matter are asserted against the source:
+ * it goes through the policy, it never writes the answer into the cache itself,
+ * the control stays disabled for as long as the answer is unknown, the way out
+ * of the unconfirmed state cannot broadcast, and both outcomes are announced.
+ *
+ * Everything here is read off the syntax tree. An earlier version located the
+ * re-check by slicing between two `indexOf` results, which returns an empty
+ * string the moment either literal moves or is renamed, and an empty string
+ * matches no forbidden pattern, so the guard passed by evaporating. The
+ * analysis functions are exercised against synthetic sources at the bottom so
+ * that failure mode is demonstrated to be closed rather than asserted to be.
  */
 
 const JOIN_BUTTON = join(
@@ -20,31 +28,37 @@ const JOIN_BUTTON = join(
   'community-join-button.tsx',
 );
 
-const source = readFileSync(JOIN_BUTTON, 'utf8');
-const sf = ts.createSourceFile(
-  JOIN_BUTTON,
-  source,
-  ts.ScriptTarget.Latest,
-  true,
-  ts.ScriptKind.TSX,
-);
+function parseSource(code: string, name = 'probe.tsx'): ts.SourceFile {
+  return ts.createSourceFile(
+    name,
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+}
 
-function importedBindings(): Set<string> {
+const sf = parseSource(readFileSync(JOIN_BUTTON, 'utf8'), JOIN_BUTTON);
+
+function importedBindings(source: ts.SourceFile): Set<string> {
   const bindings = new Set<string>();
   const visit = (node: ts.Node) => {
     if (ts.isImportDeclaration(node) && node.importClause?.namedBindings) {
       const named = node.importClause.namedBindings;
       if (ts.isNamedImports(named)) {
-        for (const element of named.elements) bindings.add(element.name.text);
+        for (const element of named.elements) {
+          if (element.propertyName) bindings.add(element.propertyName.text);
+          bindings.add(element.name.text);
+        }
       }
     }
     ts.forEachChild(node, visit);
   };
-  visit(sf);
+  visit(source);
   return bindings;
 }
 
-function calledNames(): Set<string> {
+function calledNames(source: ts.SourceFile): Set<string> {
   const names = new Set<string>();
   const visit = (node: ts.Node) => {
     if (ts.isCallExpression(node)) {
@@ -52,44 +66,142 @@ function calledNames(): Set<string> {
       names.add(
         ts.isPropertyAccessExpression(callee)
           ? callee.name.text
-          : callee.getText(sf),
+          : callee.getText(source),
       );
     }
     ts.forEachChild(node, visit);
   };
-  visit(sf);
+  visit(source);
   return names;
 }
 
 /** The `disabled` expression of every `<button>` in the file. */
-function buttonDisabledExpressions(): string[] {
+function buttonDisabledExpressions(source: ts.SourceFile): string[] {
   const found: string[] = [];
   const visit = (node: ts.Node) => {
     if (
       (ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node)) &&
-      node.tagName.getText(sf) === 'button'
+      node.tagName.getText(source) === 'button'
     ) {
       for (const attribute of node.attributes.properties) {
         if (
           ts.isJsxAttribute(attribute) &&
-          attribute.name.getText(sf) === 'disabled' &&
+          attribute.name.getText(source) === 'disabled' &&
           attribute.initializer &&
           ts.isJsxExpression(attribute.initializer) &&
           attribute.initializer.expression
         ) {
-          found.push(attribute.initializer.expression.getText(sf));
+          found.push(attribute.initializer.expression.getText(source));
         }
       }
     }
     ts.forEachChild(node, visit);
   };
-  visit(sf);
+  visit(source);
+  return found;
+}
+
+/**
+ * The declaration of a top-level `const <name> = ...`, or null.
+ *
+ * Returning null rather than an empty region is the whole point: a handler this
+ * cannot find is a handler it cannot clear, and the caller asserts on the null
+ * before asserting on the contents.
+ */
+function declarationNamed(
+  source: ts.SourceFile,
+  name: string,
+): ts.VariableDeclaration | null {
+  let found: ts.VariableDeclaration | null = null;
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name
+    ) {
+      found = node;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return found;
+}
+
+/** Every call inside one declaration's own subtree. */
+function callsWithin(source: ts.SourceFile, node: ts.Node): string[] {
+  const calls: string[] = [];
+  const visit = (current: ts.Node) => {
+    if (ts.isCallExpression(current)) {
+      const callee = current.expression;
+      calls.push(
+        ts.isPropertyAccessExpression(callee)
+          ? callee.name.text
+          : callee.getText(source),
+      );
+    }
+    ts.forEachChild(current, visit);
+  };
+  visit(node);
+  return calls;
+}
+
+interface LiveRegionUse {
+  /** The `message` expression, so an always-null region is visible. */
+  message: string | undefined;
+  /** Conditions this element renders under; a live region must have none. */
+  conditions: string[];
+}
+
+function liveRegions(source: ts.SourceFile): LiveRegionUse[] {
+  const found: LiveRegionUse[] = [];
+
+  const conditionsAbove = (node: ts.Node): string[] => {
+    const conditions: string[] = [];
+    let current: ts.Node | undefined = node.parent;
+    while (current && !ts.isSourceFile(current)) {
+      if (ts.isConditionalExpression(current)) {
+        conditions.push(current.condition.getText(source));
+      } else if (
+        ts.isBinaryExpression(current) &&
+        (current.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+          current.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+      ) {
+        conditions.push(current.left.getText(source));
+      }
+      current = current.parent;
+    }
+    return conditions;
+  };
+
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node)) &&
+      node.tagName.getText(source) === 'LiveRegion'
+    ) {
+      let message: string | undefined;
+      for (const attribute of node.attributes.properties) {
+        if (
+          ts.isJsxAttribute(attribute) &&
+          attribute.name.getText(source) === 'message' &&
+          attribute.initializer &&
+          ts.isJsxExpression(attribute.initializer) &&
+          attribute.initializer.expression
+        ) {
+          message = attribute.initializer.expression.getText(source);
+        }
+      }
+      found.push({ message, conditions: conditionsAbove(node) });
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
   return found;
 }
 
 describe('the join button confirms rather than assumes', () => {
   it('goes through the bounded confirmation policy', () => {
-    const bindings = importedBindings();
+    const bindings = importedBindings(sf);
     expect(bindings).toContain('nextConfirmationStep');
     expect(bindings).toContain('MEMBERSHIP_CONFIRMATION');
   });
@@ -97,14 +209,14 @@ describe('the join button confirms rather than assumes', () => {
   it('reads the community back rather than trusting the broadcast', () => {
     // A subscribe resolves on mempool acceptance, so nothing is known until the
     // community itself answers.
-    expect(calledNames()).toContain('refetch');
+    expect(calledNames(sf)).toContain('refetch');
   });
 
   it('never writes the outcome into the cache itself', () => {
     // An optimistic write is the same claim as an optimistic label, made
     // somewhere harder to see: it would show "Leave" for a join that never
     // landed, and every other reader of this query key would believe it.
-    const calls = calledNames();
+    const calls = calledNames(sf);
     for (const forbidden of [
       'setQueryData',
       'setQueriesData',
@@ -120,7 +232,7 @@ describe('the join button confirms rather than assumes', () => {
     // Both states: while the community is being polled, and after the budget
     // ran out. Re-enabling in either offers the reader the one action that
     // produces a duplicate broadcast.
-    const [primary] = buttonDisabledExpressions();
+    const [primary] = buttonDisabledExpressions(sf);
     expect(primary).toBeDefined();
     expect(primary).toMatch(/busy/);
     expect(primary).toMatch(/unconfirmed/);
@@ -129,11 +241,119 @@ describe('the join button confirms rather than assumes', () => {
   it('offers a re-check that cannot broadcast', () => {
     // The way out of the unconfirmed state is another read, never another
     // custom_json.
-    expect(source).toContain('handleCheckAgain');
-    const checkAgain = source.slice(
-      source.indexOf('const handleCheckAgain'),
-      source.indexOf('if (!isAuthEnabled'),
+    const handler = declarationNamed(sf, 'handleCheckAgain');
+    expect(handler, 'handleCheckAgain is gone or renamed').not.toBeNull();
+
+    const calls = callsWithin(sf, handler as unknown as ts.Node);
+    expect(calls).toContain('confirm');
+    expect(calls).not.toContain('mutateAsync');
+    expect(calls).not.toContain('mutate');
+  });
+
+  it('cannot leave the run stuck when a read fails', () => {
+    // A rejected refetch used to escape the loop, leaving the button in
+    // `confirming` forever, disabled, with nothing to press.
+    const confirmFn = declarationNamed(sf, 'confirm');
+    expect(confirmFn, 'confirm is gone or renamed').not.toBeNull();
+
+    let hasCatch = false;
+    const visit = (node: ts.Node) => {
+      if (ts.isTryStatement(node) && node.catchClause) {
+        const guarded = callsWithin(sf, node.tryBlock);
+        if (guarded.includes('refetch')) hasCatch = true;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(confirmFn as unknown as ts.Node);
+
+    expect(hasCatch, 'the read inside the confirmation loop is unguarded').toBe(
+      true,
     );
-    expect(checkAgain).not.toMatch(/mutateAsync|mutate\(/);
+  });
+
+  it('announces both outcomes, from regions that are always mounted', () => {
+    const regions = liveRegions(sf);
+    // One for the unconfirmed ending, one for the broadcast error.
+    expect(regions).toHaveLength(2);
+    for (const region of regions) {
+      // A live region created at the same moment as its first message is
+      // usually not announced at all, so it must not be conditionally rendered.
+      expect(region.conditions, region.message).toEqual([]);
+      expect(region.message).toBeDefined();
+    }
+  });
+});
+
+describe('the guard catches the ways around it', () => {
+  it('returns null for a handler it cannot find', () => {
+    // The hole: the re-check was located by slicing between two indexOf
+    // results. Either literal moving returned -1, slice returned '', and an
+    // empty string matches no forbidden pattern, so the assertion passed
+    // without reading any code at all.
+    const renamed = parseSource('const somethingElse = () => {};');
+    expect(declarationNamed(renamed, 'handleCheckAgain')).toBeNull();
+  });
+
+  it('reads a broadcast back out of the re-check handler', () => {
+    const bad = parseSource(
+      'const handleCheckAgain = async () => { await subscribe.mutateAsync({ community: c }); };',
+    );
+    const handler = declarationNamed(bad, 'handleCheckAgain');
+    expect(handler).not.toBeNull();
+    expect(callsWithin(bad, handler as unknown as ts.Node)).toContain(
+      'mutateAsync',
+    );
+  });
+
+  it('does not see a broadcast in a handler that only reads', () => {
+    const good = parseSource(
+      'const handleCheckAgain = async () => { await confirm(desired); };',
+    );
+    const handler = declarationNamed(good, 'handleCheckAgain');
+    expect(callsWithin(good, handler as unknown as ts.Node)).toEqual([
+      'confirm',
+    ]);
+  });
+
+  it('catches an aliased import of the policy', () => {
+    const aliased = parseSource(
+      "import { nextConfirmationStep as step } from '../utils/membership-confirmation';",
+    );
+    expect(importedBindings(aliased)).toContain('nextConfirmationStep');
+  });
+
+  it('sees a conditionally rendered live region', () => {
+    const late = parseSource(
+      'export const A = () => <div>{failed && <LiveRegion message={msg} />}</div>;',
+    );
+    const [region] = liveRegions(late);
+    expect(region.conditions).toContain('failed');
+  });
+
+  it('sees an always-mounted live region as unconditional', () => {
+    const good = parseSource(
+      'export const A = () => <div><LiveRegion message={failed ? msg : null} /></div>;',
+    );
+    const [region] = liveRegions(good);
+    expect(region.conditions).toEqual([]);
+    expect(region.message).toBe('failed ? msg : null');
+  });
+
+  it('sees an unguarded read inside a loop', () => {
+    const unguarded = parseSource(
+      'const confirm = async () => { for (;;) { const r = await refetch(); } };',
+    );
+    const fn = declarationNamed(unguarded, 'confirm');
+    let hasCatch = false;
+    const visit = (node: ts.Node) => {
+      if (ts.isTryStatement(node) && node.catchClause) {
+        if (callsWithin(unguarded, node.tryBlock).includes('refetch')) {
+          hasCatch = true;
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(fn as unknown as ts.Node);
+    expect(hasCatch).toBe(false);
   });
 });

--- a/apps/self-hosted/src/features/blog/utils/membership-confirmation-wiring.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/membership-confirmation-wiring.test.ts
@@ -1,0 +1,139 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The join button must use the confirmation policy, and must not fake it.
+ *
+ * The policy itself is pure and tested next door. What cannot be tested that
+ * way is the component that drives it, because nothing in `apps/self-hosted` is
+ * DOM-testable, so the three properties that matter are asserted against the
+ * source: it goes through the policy, it never writes the answer into the cache
+ * itself, and the control stays disabled for as long as the answer is unknown.
+ */
+
+const JOIN_BUTTON = join(
+  __dirname,
+  '..',
+  'components',
+  'community-join-button.tsx',
+);
+
+const source = readFileSync(JOIN_BUTTON, 'utf8');
+const sf = ts.createSourceFile(
+  JOIN_BUTTON,
+  source,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TSX,
+);
+
+function importedBindings(): Set<string> {
+  const bindings = new Set<string>();
+  const visit = (node: ts.Node) => {
+    if (ts.isImportDeclaration(node) && node.importClause?.namedBindings) {
+      const named = node.importClause.namedBindings;
+      if (ts.isNamedImports(named)) {
+        for (const element of named.elements) bindings.add(element.name.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return bindings;
+}
+
+function calledNames(): Set<string> {
+  const names = new Set<string>();
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      names.add(
+        ts.isPropertyAccessExpression(callee)
+          ? callee.name.text
+          : callee.getText(sf),
+      );
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return names;
+}
+
+/** The `disabled` expression of every `<button>` in the file. */
+function buttonDisabledExpressions(): string[] {
+  const found: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node)) &&
+      node.tagName.getText(sf) === 'button'
+    ) {
+      for (const attribute of node.attributes.properties) {
+        if (
+          ts.isJsxAttribute(attribute) &&
+          attribute.name.getText(sf) === 'disabled' &&
+          attribute.initializer &&
+          ts.isJsxExpression(attribute.initializer) &&
+          attribute.initializer.expression
+        ) {
+          found.push(attribute.initializer.expression.getText(sf));
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+}
+
+describe('the join button confirms rather than assumes', () => {
+  it('goes through the bounded confirmation policy', () => {
+    const bindings = importedBindings();
+    expect(bindings).toContain('nextConfirmationStep');
+    expect(bindings).toContain('MEMBERSHIP_CONFIRMATION');
+  });
+
+  it('reads the community back rather than trusting the broadcast', () => {
+    // A subscribe resolves on mempool acceptance, so nothing is known until the
+    // community itself answers.
+    expect(calledNames()).toContain('refetch');
+  });
+
+  it('never writes the outcome into the cache itself', () => {
+    // An optimistic write is the same claim as an optimistic label, made
+    // somewhere harder to see: it would show "Leave" for a join that never
+    // landed, and every other reader of this query key would believe it.
+    const calls = calledNames();
+    for (const forbidden of [
+      'setQueryData',
+      'setQueriesData',
+      'setQueryDefaults',
+    ]) {
+      expect(calls, `${forbidden} would fabricate a membership`).not.toContain(
+        forbidden,
+      );
+    }
+  });
+
+  it('keeps the action disabled while the outcome is unknown', () => {
+    // Both states: while the community is being polled, and after the budget
+    // ran out. Re-enabling in either offers the reader the one action that
+    // produces a duplicate broadcast.
+    const [primary] = buttonDisabledExpressions();
+    expect(primary).toBeDefined();
+    expect(primary).toMatch(/busy/);
+    expect(primary).toMatch(/unconfirmed/);
+  });
+
+  it('offers a re-check that cannot broadcast', () => {
+    // The way out of the unconfirmed state is another read, never another
+    // custom_json.
+    expect(source).toContain('handleCheckAgain');
+    const checkAgain = source.slice(
+      source.indexOf('const handleCheckAgain'),
+      source.indexOf('if (!isAuthEnabled'),
+    );
+    expect(checkAgain).not.toMatch(/mutateAsync|mutate\(/);
+  });
+});

--- a/apps/self-hosted/src/features/blog/utils/membership-confirmation.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/membership-confirmation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ConfirmationPolicy,
+  confirmationBudgetMs,
+  MEMBERSHIP_CONFIRMATION,
+  nextConfirmationStep,
+} from './membership-confirmation';
+
+/** Two reads, one second apart, so the bound is easy to walk to the end of. */
+const SHORT: ConfirmationPolicy = { attempts: 2, intervalMs: 1000 };
+
+describe('nextConfirmationStep', () => {
+  it('confirms only when the community reports what was asked for', () => {
+    expect(nextConfirmationStep(true, true, 1, SHORT)).toEqual({
+      kind: 'confirmed',
+    });
+    expect(nextConfirmationStep(false, false, 1, SHORT)).toEqual({
+      kind: 'confirmed',
+    });
+  });
+
+  it('retries while there is budget left', () => {
+    // The case this exists for: the broadcast resolved on mempool acceptance,
+    // so the very first read back normally still says "not subscribed".
+    expect(nextConfirmationStep(false, true, 1, SHORT)).toEqual({
+      kind: 'retry',
+      delayMs: 1000,
+    });
+  });
+
+  it('gives up at the bound rather than waiting forever', () => {
+    expect(nextConfirmationStep(false, true, 2, SHORT)).toEqual({
+      kind: 'unconfirmed',
+    });
+    expect(nextConfirmationStep(false, true, 99, SHORT)).toEqual({
+      kind: 'unconfirmed',
+    });
+  });
+
+  it('never reports success from an absent reading', () => {
+    // A failed read is not agreement. Treating undefined as "matches" is how a
+    // network blip would confirm a membership that never happened.
+    expect(nextConfirmationStep(undefined, true, 1, SHORT)).toEqual({
+      kind: 'retry',
+      delayMs: 1000,
+    });
+    expect(nextConfirmationStep(undefined, true, 2, SHORT)).toEqual({
+      kind: 'unconfirmed',
+    });
+    expect(nextConfirmationStep(undefined, false, 2, SHORT)).toEqual({
+      kind: 'unconfirmed',
+    });
+  });
+
+  it('walks a whole unsuccessful run to the bound and no further', () => {
+    const steps: string[] = [];
+    for (let attemptsMade = 1; attemptsMade <= SHORT.attempts; attemptsMade++) {
+      steps.push(nextConfirmationStep(false, true, attemptsMade, SHORT).kind);
+    }
+    expect(steps).toEqual(['retry', 'unconfirmed']);
+  });
+});
+
+describe('the shipped policy', () => {
+  it('spans several Hive blocks without stranding the reader', () => {
+    // A block is 3s. Long enough for indexing lag, short enough that the
+    // unconfirmed state is reached rather than being theoretical.
+    expect(MEMBERSHIP_CONFIRMATION.intervalMs).toBeGreaterThanOrEqual(3000);
+    expect(MEMBERSHIP_CONFIRMATION.attempts).toBeGreaterThanOrEqual(3);
+    expect(confirmationBudgetMs()).toBeGreaterThanOrEqual(15000);
+    expect(confirmationBudgetMs()).toBeLessThanOrEqual(60000);
+  });
+
+  it('is bounded, so a run always terminates', () => {
+    expect(Number.isFinite(MEMBERSHIP_CONFIRMATION.attempts)).toBe(true);
+    expect(
+      nextConfirmationStep(false, true, MEMBERSHIP_CONFIRMATION.attempts).kind,
+    ).toBe('unconfirmed');
+  });
+});

--- a/apps/self-hosted/src/features/blog/utils/membership-confirmation.ts
+++ b/apps/self-hosted/src/features/blog/utils/membership-confirmation.ts
@@ -1,0 +1,70 @@
+/**
+ * When a community membership change may be called done.
+ *
+ * A subscribe or unsubscribe is a `custom_json` broadcast sent in async mode,
+ * which returns as soon as a node accepts it into its mempool. That is not
+ * block inclusion, and block inclusion is not Hivemind having indexed it, and
+ * `bridge.get_community_context` reads Hivemind. So a read taken immediately
+ * after the broadcast resolves almost always still says "not subscribed": the
+ * button falls back to "Join", and the reader, reasonably, presses it again and
+ * broadcasts a duplicate.
+ *
+ * The fix is to keep reading the community back on a bounded schedule and to
+ * treat only the community's own answer as confirmation. Nothing here writes to
+ * the cache: the whole point is that we do not yet know the operation landed,
+ * and an optimistic write would be the same lie in a different place.
+ */
+
+export interface ConfirmationPolicy {
+  /** How many times the community context is read back before giving up. */
+  attempts: number;
+  /** How long to wait before each read. */
+  intervalMs: number;
+}
+
+/**
+ * Six reads, three seconds apart, so about eighteen seconds.
+ *
+ * A Hive block is three seconds, so this spans several blocks plus Hivemind's
+ * own indexing lag, which covers the normal case comfortably. It is deliberately
+ * not longer: past this the honest thing is to say we cannot confirm it rather
+ * than to keep a reader watching a spinner.
+ */
+export const MEMBERSHIP_CONFIRMATION: ConfirmationPolicy = {
+  attempts: 6,
+  intervalMs: 3000,
+};
+
+export type ConfirmationStep =
+  /** The community reports the change. Done. */
+  | { kind: 'confirmed' }
+  /** Not yet, and there is budget left. Wait this long, then read again. */
+  | { kind: 'retry'; delayMs: number }
+  /** Budget spent without the community agreeing. Say so; do not claim success. */
+  | { kind: 'unconfirmed' };
+
+/**
+ * What to do after reading the community context back.
+ *
+ * @param observed  `subscribed` as the community currently reports it, or
+ *                  undefined when the read produced nothing.
+ * @param desired   what the broadcast was meant to make it.
+ * @param attemptsMade how many reads have completed, counting this one from 1.
+ */
+export function nextConfirmationStep(
+  observed: boolean | undefined,
+  desired: boolean,
+  attemptsMade: number,
+  policy: ConfirmationPolicy = MEMBERSHIP_CONFIRMATION,
+): ConfirmationStep {
+  if (observed === desired) return { kind: 'confirmed' };
+  if (attemptsMade >= policy.attempts) return { kind: 'unconfirmed' };
+  return { kind: 'retry', delayMs: policy.intervalMs };
+}
+
+/** The longest a reader can be left waiting, in milliseconds. */
+export function confirmationBudgetMs(
+  policy: ConfirmationPolicy = MEMBERSHIP_CONFIRMATION,
+): number {
+  return policy.attempts * policy.intervalMs;
+}

--- a/apps/self-hosted/src/features/blog/utils/payout.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/payout.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatPayoutAmount,
+  isPayoutWindowOpen,
+  type PayoutSource,
+  resolvePostPayout,
+} from './payout';
+
+/** A pending post as the bridge API actually returns one. */
+function pending(overrides: PayoutSource = {}): PayoutSource {
+  return {
+    pending_payout_value: '4.200 HBD',
+    author_payout_value: '0.000 HBD',
+    curator_payout_value: '0.000 HBD',
+    max_accepted_payout: '1000000.000 HBD',
+    is_paidout: false,
+    payout_at: '2026-08-10T00:00:00',
+    ...overrides,
+  };
+}
+
+/**
+ * The shape `search-results.tsx` builds by hand and casts `as unknown as Entry`.
+ * It carries no payout fields at all, which is the input that crashes an
+ * unguarded `parseAsset`.
+ */
+const SEARCH_SHAPED: PayoutSource = {};
+
+describe('resolvePostPayout', () => {
+  it('reads a pending payout', () => {
+    expect(resolvePostPayout(pending())).toEqual({
+      amount: 4.2,
+      declined: false,
+      paidOut: false,
+    });
+  });
+
+  it('sums author and curator payouts on a paid-out post', () => {
+    // The whole point: reading pending_payout_value alone prints $0.00 here,
+    // and on a real blog most posts are in this state.
+    const paid = pending({
+      is_paidout: true,
+      pending_payout_value: '0.000 HBD',
+      author_payout_value: '3.000 HBD',
+      curator_payout_value: '1.500 HBD',
+    });
+    expect(resolvePostPayout(paid)).toEqual({
+      amount: 4.5,
+      declined: false,
+      paidOut: true,
+    });
+  });
+
+  it('reports declined rewards rather than a zero amount', () => {
+    const declined = resolvePostPayout(
+      pending({ max_accepted_payout: '0.000 HBD' }),
+    );
+    expect(declined).toEqual({ amount: 0, declined: true, paidOut: false });
+  });
+
+  it('caps the figure at max_accepted_payout', () => {
+    const capped = pending({
+      pending_payout_value: '90.000 HBD',
+      max_accepted_payout: '10.000 HBD',
+    });
+    expect(resolvePostPayout(capped)?.amount).toBe(10);
+  });
+
+  it('returns null for an entry with no payout fields', () => {
+    expect(resolvePostPayout(SEARCH_SHAPED)).toBeNull();
+  });
+
+  it('does not throw on absent or non-string payout fields', () => {
+    // parseAsset's non-string branch reads `sval.amount.toString()`, so an
+    // absent field is a TypeError rather than NaN. Unguarded, that takes the
+    // whole page down through the root error boundary.
+    const hostile: PayoutSource[] = [
+      {},
+      { pending_payout_value: undefined },
+      { pending_payout_value: null },
+      { pending_payout_value: 42 },
+      { pending_payout_value: [] },
+      { pending_payout_value: 'not an asset' },
+      { pending_payout_value: '4.200 HBD', max_accepted_payout: null },
+      { pending_payout_value: '4.200 HBD', max_accepted_payout: 'rubbish' },
+    ];
+    for (const entry of hostile) {
+      expect(() => resolvePostPayout(entry)).not.toThrow();
+    }
+    expect(resolvePostPayout({ pending_payout_value: 42 })).toBeNull();
+    expect(
+      resolvePostPayout({ pending_payout_value: 'not an asset' }),
+    ).toBeNull();
+  });
+
+  it('says nothing when the cap is the only readable field', () => {
+    // Declined is a statement about a payout record. With no payout fields at
+    // all there is no record to make it about, so a lone zero cap must not
+    // print "Rewards declined" over an entry the payout math never saw.
+    expect(resolvePostPayout({ max_accepted_payout: '0.000 HBD' })).toBeNull();
+    expect(resolvePostPayout({ max_accepted_payout: '10.000 HBD' })).toBeNull();
+  });
+
+  it('still shows a payout when only the cap is unreadable', () => {
+    const entry = pending({ max_accepted_payout: 'rubbish' });
+    expect(resolvePostPayout(entry)?.amount).toBe(4.2);
+  });
+
+  it('suppresses a figure that would render as $0.00', () => {
+    expect(
+      resolvePostPayout(pending({ pending_payout_value: '0.000 HBD' })),
+    ).toBeNull();
+    expect(
+      resolvePostPayout(pending({ pending_payout_value: '0.004 HBD' })),
+    ).toBeNull();
+    expect(
+      resolvePostPayout(pending({ pending_payout_value: '0.005 HBD' }))?.amount,
+    ).toBe(0.01);
+  });
+});
+
+describe('formatPayoutAmount', () => {
+  it('always prints two decimals', () => {
+    expect(formatPayoutAmount(4.2)).toBe('$4.20');
+    expect(formatPayoutAmount(10)).toBe('$10.00');
+    expect(formatPayoutAmount(0.01)).toBe('$0.01');
+  });
+});
+
+describe('isPayoutWindowOpen', () => {
+  const now = new Date('2026-08-03T00:00:00Z');
+
+  it('is open while payout_at is in the future', () => {
+    expect(isPayoutWindowOpen(pending(), now)).toBe(true);
+  });
+
+  it('is closed once the post has paid out', () => {
+    // The regression this guards: formatRelativeTime adds a suffix
+    // unconditionally, so an archived post reads "pays out 2 years ago".
+    expect(isPayoutWindowOpen(pending({ is_paidout: true }), now)).toBe(false);
+  });
+
+  it('is closed when payout_at is already in the past', () => {
+    expect(
+      isPayoutWindowOpen(pending({ payout_at: '2024-01-01T00:00:00' }), now),
+    ).toBe(false);
+  });
+
+  it('is closed when payout_at is missing or unparseable', () => {
+    expect(isPayoutWindowOpen({}, now)).toBe(false);
+    expect(isPayoutWindowOpen(pending({ payout_at: 'soon' }), now)).toBe(false);
+    expect(isPayoutWindowOpen(pending({ payout_at: 12345 }), now)).toBe(false);
+  });
+
+  it('closes exactly at payout_at', () => {
+    // A zoneless Hive timestamp is UTC; the Z is appended before parsing so the
+    // window does not flip open or shut with the reader's own timezone. Under a
+    // UTC test runner this asserts the boundary comparison rather than the zone.
+    expect(
+      isPayoutWindowOpen(pending(), new Date('2026-08-09T23:59:59Z')),
+    ).toBe(true);
+    expect(
+      isPayoutWindowOpen(pending(), new Date('2026-08-10T00:00:00Z')),
+    ).toBe(false);
+  });
+});

--- a/apps/self-hosted/src/features/blog/utils/payout.ts
+++ b/apps/self-hosted/src/features/blog/utils/payout.ts
@@ -1,0 +1,121 @@
+import { parseAsset } from '@ecency/sdk';
+
+/**
+ * What a post has earned, read off the entry the feed already loaded.
+ *
+ * Kept pure and structurally typed rather than taking `Entry`, because the
+ * entries this runs against are not all real ones: `search-results.tsx` builds
+ * an object by hand with no payout fields at all and casts it
+ * `as unknown as Entry`. Every field below is therefore `unknown` and every
+ * read of it is defensive.
+ */
+export interface PayoutSource {
+  pending_payout_value?: unknown;
+  author_payout_value?: unknown;
+  curator_payout_value?: unknown;
+  max_accepted_payout?: unknown;
+  is_paidout?: unknown;
+  payout_at?: unknown;
+}
+
+export interface PostPayout {
+  /** Dollar figure to print, already capped at max_accepted_payout. */
+  amount: number;
+  /** The author set max_accepted_payout to zero: no rewards, not zero rewards. */
+  declined: boolean;
+  /** The seven-day window has closed and the figure is final. */
+  paidOut: boolean;
+}
+
+/**
+ * One asset string as a number, or null.
+ *
+ * `parseAsset` THROWS on an absent or non-string value: its else branch reads
+ * `sval.amount.toString()`, so `parseAsset(undefined)` is a TypeError, not NaN.
+ * A search-shaped entry has none of these fields, so an unguarded call here
+ * puts the whole page in the root error boundary. Catching is the point of this
+ * wrapper; the NaN check catches the other half, a string that is not an asset.
+ */
+function amountOf(value: unknown): number | null {
+  try {
+    const { amount } = parseAsset(value as string);
+    return Number.isFinite(amount) ? amount : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The payout to show, or null when there is nothing honest to show.
+ *
+ * Null covers three cases the caller must render as nothing rather than as a
+ * figure: no parseable payout fields at all (a search result), a total that
+ * rounds to $0.00, and any asset string the chain did not produce.
+ *
+ * Suppressing $0.00 is deliberate. It makes a three-week-old zero-earning post
+ * indistinguishable from a ten-minute-old one, which removes the case a
+ * personal blogger would actually mind and is part of what makes showing
+ * earnings by default defensible.
+ */
+export function resolvePostPayout(entry: PayoutSource): PostPayout | null {
+  const paidOut = entry.is_paidout === true;
+
+  // Naively reading pending_payout_value alone prints $0.00 on every archived
+  // post: after payout the pending value is zero and the money has moved into
+  // the author and curator fields.
+  const parts = paidOut
+    ? [
+        amountOf(entry.author_payout_value),
+        amountOf(entry.curator_payout_value),
+      ]
+    : [
+        amountOf(entry.pending_payout_value),
+        amountOf(entry.author_payout_value),
+        amountOf(entry.curator_payout_value),
+      ];
+
+  if (parts.every((part) => part === null)) return null;
+
+  const total = parts.reduce<number>((sum, part) => sum + (part ?? 0), 0);
+  const max = amountOf(entry.max_accepted_payout);
+
+  // A zero cap is the author declining rewards, which is a statement, not an
+  // amount. Printing $0.00 for it says something different and wrong.
+  if (max === 0) {
+    return { amount: 0, declined: true, paidOut };
+  }
+
+  const capped = max !== null && max > 0 && total >= max ? max : total;
+  const amount = Math.round(capped * 100) / 100;
+
+  if (amount === 0) return null;
+
+  return { amount, declined: false, paidOut };
+}
+
+/** `$4.20`. The dollar follows every Hive frontend and the HBD soft peg. */
+export function formatPayoutAmount(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}
+
+/**
+ * True when the payout window is still open and its closing time is knowable.
+ *
+ * Guarded on both `is_paidout` and the timestamp actually being in the future.
+ * `formatRelativeTime` adds a suffix unconditionally, so a `payout_at` in the
+ * past renders "pays out 2 years ago" on an archived post, which is most posts
+ * on a blog imported from an existing Hive account.
+ */
+export function isPayoutWindowOpen(
+  entry: PayoutSource,
+  now: Date = new Date(),
+): boolean {
+  if (entry.is_paidout === true) return false;
+  if (typeof entry.payout_at !== 'string') return false;
+  // Hive timestamps carry no zone designator and are UTC.
+  const at = new Date(
+    entry.payout_at.endsWith('Z') ? entry.payout_at : `${entry.payout_at}Z`,
+  );
+  const time = at.getTime();
+  return Number.isFinite(time) && time > now.getTime();
+}

--- a/apps/self-hosted/src/features/blog/utils/reputation-band.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/reputation-band.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { resolveReputation } from './reputation-band';
+
+describe('resolveReputation', () => {
+  it('bands the converted reputation scale', () => {
+    expect(resolveReputation(1)).toEqual({ band: 'new', score: 1 });
+    expect(resolveReputation(39.9)).toEqual({ band: 'new', score: 39 });
+    expect(resolveReputation(40)).toEqual({ band: 'established', score: 40 });
+    expect(resolveReputation(69.9)).toEqual({
+      band: 'established',
+      score: 69,
+    });
+    expect(resolveReputation(70)).toEqual({ band: 'longstanding', score: 70 });
+    expect(resolveReputation(83)).toEqual({ band: 'longstanding', score: 83 });
+  });
+
+  it('says nothing at zero', () => {
+    // getAccountFullQueryOptions degrades to reputation 0 when the bridge
+    // profile call fails, so a band label here would assert an account age the
+    // app has not established.
+    expect(resolveReputation(0)).toBeNull();
+    expect(resolveReputation(-5)).toBeNull();
+  });
+
+  it('says nothing for a value that is not a finite number', () => {
+    for (const value of [undefined, null, '55', Number.NaN, Infinity, {}, []]) {
+      expect(resolveReputation(value)).toBeNull();
+    }
+  });
+});

--- a/apps/self-hosted/src/features/blog/utils/reputation-band.ts
+++ b/apps/self-hosted/src/features/blog/utils/reputation-band.ts
@@ -1,0 +1,39 @@
+/**
+ * Hive reputation as something a reader can act on.
+ *
+ * The sidebar has always printed the bare integer, which means nothing to
+ * anyone who has not learned the scale. The number stays, because it is the
+ * thing other Hive tools show, but it is now labelled.
+ *
+ * Bands are on the converted 0-to-100ish scale the bridge API returns, not raw
+ * rshares reputation.
+ */
+export type ReputationBand = 'new' | 'established' | 'longstanding';
+
+export interface ResolvedReputation {
+  band: ReputationBand;
+  score: number;
+}
+
+/**
+ * The band and rounded score, or null when there is nothing to say.
+ *
+ * Null for anything at or below zero. `getAccountFullQueryOptions` degrades to
+ * `reputation: 0` when the bridge profile call fails, so zero is
+ * indistinguishable from a transport fault. Labelling that "New" would assert
+ * something the app has not established; printing "0" is what it does today and
+ * is just as wrong. Saying nothing is the only honest option.
+ */
+export function resolveReputation(
+  reputation: unknown,
+): ResolvedReputation | null {
+  if (typeof reputation !== 'number' || !Number.isFinite(reputation)) {
+    return null;
+  }
+  if (reputation <= 0) return null;
+
+  const score = Math.floor(reputation);
+  if (score < 40) return { band: 'new', score };
+  if (score < 70) return { band: 'established', score };
+  return { band: 'longstanding', score };
+}

--- a/apps/self-hosted/src/features/publish/components/publish-action-bar.tsx
+++ b/apps/self-hosted/src/features/publish/components/publish-action-bar.tsx
@@ -2,6 +2,7 @@ import { usePublishState } from "../hooks/use-publish-state";
 import { usePublishPost } from "../hooks/use-publish-post";
 import { Link } from "@tanstack/react-router";
 import { UilArrowLeft } from "@tooni/iconscout-unicons-react";
+import { PublishDisclosure } from "@/features/shared/hive-disclosure";
 
 interface Props {
   onSuccess?: () => void;
@@ -52,6 +53,14 @@ export function PublishActionBar({ onSuccess }: Props) {
       </Link>
       <div className="px-2 md:px-4 py-4 flex justify-end">
         <div className="flex flex-col items-end gap-2">
+          {/*
+            Not configurable, by design. Publishing is the one action here that
+            cannot be undone, so the statement of that goes above the button
+            regardless of how the instance is configured.
+          */}
+          <div className="max-w-sm text-right">
+            <PublishDisclosure />
+          </div>
           {error && (
             <div className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 px-4 py-2 rounded">
               {error.message}

--- a/apps/self-hosted/src/features/shared/hive-disclosure-guard.test.ts
+++ b/apps/self-hosted/src/features/shared/hive-disclosure-guard.test.ts
@@ -57,19 +57,31 @@ const CALL_SITES: Record<string, string> = {
   'features/blog/components/blog-post-footer.tsx': 'VoteDisclosure',
 };
 
-function parse(relative: string): ts.SourceFile {
-  const path = join(SRC, relative);
+function parseSource(code: string, name = 'probe.tsx'): ts.SourceFile {
   return ts.createSourceFile(
-    path,
-    readFileSync(path, 'utf8'),
+    name,
+    code,
     ts.ScriptTarget.Latest,
     true,
     ts.ScriptKind.TSX,
   );
 }
 
+function parse(relative: string): ts.SourceFile {
+  const path = join(SRC, relative);
+  return parseSource(readFileSync(path, 'utf8'), path);
+}
+
 interface Imported {
   specifier: string;
+  /**
+   * Both names an import introduces: what was exported, and what it is called
+   * here. `import { resolveHiveLayer as layer }` is the resolver under a name
+   * no list of forbidden bindings would think to contain, so recording only
+   * the local name let exactly that through. Recording only the exported name
+   * would miss the mirror image, a local name that happens to collide with a
+   * forbidden one, so both are kept and both are checked.
+   */
   bindings: string[];
 }
 
@@ -86,6 +98,9 @@ function importsOf(sf: ts.SourceFile): Imported[] {
       if (clause?.namedBindings) {
         if (ts.isNamedImports(clause.namedBindings)) {
           for (const element of clause.namedBindings.elements) {
+            // propertyName is set only on an aliased import, and is the name
+            // the module actually exported.
+            if (element.propertyName) bindings.push(element.propertyName.text);
             bindings.push(element.name.text);
           }
         } else {
@@ -145,15 +160,19 @@ function enclosingConditions(node: ts.Node, sf: ts.SourceFile): string[] {
   return conditions;
 }
 
+/** Everything a file pulls in that would let it read the Hive layer. */
+function forbiddenBindingsIn(sf: ts.SourceFile): string[] {
+  return importsOf(sf).flatMap((entry) =>
+    entry.bindings.filter((binding) => FORBIDDEN_BINDINGS.has(binding)),
+  );
+}
+
 describe('the disclosure floor has no way to be switched off', () => {
   const module = parse(DISCLOSURE_MODULE);
   const moduleImports = importsOf(module);
 
   it('imports nothing from the Hive layer resolver', () => {
-    const reachable = moduleImports.flatMap((entry) =>
-      entry.bindings.filter((binding) => FORBIDDEN_BINDINGS.has(binding)),
-    );
-    expect(reachable).toEqual([]);
+    expect(forbiddenBindingsIn(module)).toEqual([]);
   });
 
   it('imports nothing from a hive-layer module by path either', () => {
@@ -197,4 +216,87 @@ describe('the disclosure floor has no way to be switched off', () => {
       expect(gated).toEqual([]);
     },
   );
+});
+
+describe('the guard catches the ways around it', () => {
+  const from = (code: string) => parseSource(code);
+
+  it('passes a module that only imports what it should', () => {
+    expect(forbiddenBindingsIn(from("import { t } from '@/core';"))).toEqual(
+      [],
+    );
+  });
+
+  it('catches the resolver imported under another name', () => {
+    // The hole: only the LOCAL name was recorded, so an alias was a name no
+    // list of forbidden bindings would ever contain, and the resolver was
+    // fully reachable through it.
+    expect(
+      forbiddenBindingsIn(
+        from("import { resolveHiveLayer as layer } from '@/core';"),
+      ),
+    ).toContain('resolveHiveLayer');
+  });
+
+  it.each([
+    ["import { useHiveLayer as h } from '@/core';", 'useHiveLayer'],
+    [
+      "import { t, HIVE_LAYER_CONFIG_DEFAULTS as d } from '@/core';",
+      'HIVE_LAYER_CONFIG_DEFAULTS',
+    ],
+    [
+      "import type { ResolvedHiveLayer as L } from '@/core';",
+      'ResolvedHiveLayer',
+    ],
+    [
+      "import { InstanceConfigManager as cfg } from '@/core';",
+      'InstanceConfigManager',
+    ],
+  ])('catches %s', (code, expected) => {
+    expect(forbiddenBindingsIn(from(code))).toContain(expected);
+  });
+
+  it('still catches an unaliased import', () => {
+    expect(
+      forbiddenBindingsIn(from("import { resolveHiveLayer } from '@/core';")),
+    ).toContain('resolveHiveLayer');
+  });
+
+  it('catches a local name that collides with a forbidden one', () => {
+    // The mirror image: recording only the exported name would let a local
+    // `resolveHiveLayer` bound to some other export through.
+    expect(
+      forbiddenBindingsIn(
+        from("import { somethingElse as resolveHiveLayer } from './x';"),
+      ),
+    ).toContain('resolveHiveLayer');
+  });
+
+  it('catches a namespace import, which hides every name', () => {
+    const wildcards = importsOf(from("import * as core from '@/core';"));
+    expect(wildcards[0].bindings).toContain('*');
+  });
+
+  it('reads a Hive-layer condition wrapped around a disclosure', () => {
+    const sf = from(
+      'export const A = () => <div>{hiveLayer.showChainNote && <CommentDisclosure />}</div>;',
+    );
+    const [element] = jsxElements(sf, 'CommentDisclosure');
+    expect(enclosingConditions(element, sf)).toContain(
+      'hiveLayer.showChainNote',
+    );
+  });
+
+  it('does not read the auth and likes gates as Hive-layer conditions', () => {
+    // features.likes and features.auth already decide whether the action
+    // exists at all, so gating on them is allowed and must not be reported.
+    const sf = from(
+      'export const A = () => <div>{showLikes && isAuthEnabled && <VoteDisclosure />}</div>;',
+    );
+    const [element] = jsxElements(sf, 'VoteDisclosure');
+    const gated = enclosingConditions(element, sf).filter((condition) =>
+      /hiveLayer|resolveHiveLayer|useHiveLayer|readerLayer/.test(condition),
+    );
+    expect(gated).toEqual([]);
+  });
 });

--- a/apps/self-hosted/src/features/shared/hive-disclosure-guard.test.ts
+++ b/apps/self-hosted/src/features/shared/hive-disclosure-guard.test.ts
@@ -1,0 +1,200 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * "Not configurable" as a CI fact rather than a code-review promise.
+ *
+ * The three disclosures have no config key, and the only way to keep that true
+ * through later refactors is to forbid the wiring that would undo it. Nothing
+ * in `apps/self-hosted` is DOM-testable (`environment: 'node'`,
+ * `include: ['src/**\/*.test.ts']`), so a source scan is the only guarantee
+ * available here at all.
+ *
+ * Modelled on `src/routes/-internal-links.test.ts`, which already reads files
+ * off disk and drives the TypeScript compiler API; `typescript` is a
+ * devDependency.
+ */
+
+const SRC = join(__dirname, '..', '..');
+
+const DISCLOSURE_MODULE = 'features/shared/hive-disclosure.tsx';
+
+/**
+ * Bindings that would let the disclosure module read the Hive layer.
+ *
+ * Asserted on the imported BINDINGS, not on the module path. The resolver is
+ * re-exported from the `@/core` barrel and every component imports `t` from
+ * there, so a path-substring check would pass on exactly the wiring it exists
+ * to forbid: `import { t, resolveHiveLayer } from '@/core'` contains no
+ * 'hive-layer' anywhere.
+ */
+const FORBIDDEN_BINDINGS = new Set([
+  'resolveHiveLayer',
+  'useHiveLayer',
+  'ResolvedHiveLayer',
+  'HiveLayerInput',
+  'HIVE_LAYER_CONFIG_DEFAULTS',
+  'HIVE_LAYER_SEED',
+  'ReaderLayer',
+  'AuthorRewards',
+  'resolveCommentOptions',
+  // Reading config directly would be the same capability by another route.
+  'InstanceConfigManager',
+]);
+
+/** Where each disclosure has to be rendered, and under what name. */
+const CALL_SITES: Record<string, string> = {
+  'features/auth/components/comment-form.tsx': 'CommentDisclosure',
+  'features/publish/components/publish-action-bar.tsx': 'PublishDisclosure',
+  // The spec places the vote disclosure on the vote button itself. It renders
+  // in the post footer instead: `@ecency/ui`'s VoteButton is consumed from a
+  // committed dist, so a new prop added in its source would not reach the app,
+  // and the picker the spec puts the visible label on is not built yet. The
+  // requirement the floor actually states is visible inline text next to the
+  // action, which this is.
+  'features/blog/components/blog-post-footer.tsx': 'VoteDisclosure',
+};
+
+function parse(relative: string): ts.SourceFile {
+  const path = join(SRC, relative);
+  return ts.createSourceFile(
+    path,
+    readFileSync(path, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+}
+
+interface Imported {
+  specifier: string;
+  bindings: string[];
+}
+
+function importsOf(sf: ts.SourceFile): Imported[] {
+  const found: Imported[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      const bindings: string[] = [];
+      const clause = node.importClause;
+      if (clause?.name) bindings.push(clause.name.text);
+      if (clause?.namedBindings) {
+        if (ts.isNamedImports(clause.namedBindings)) {
+          for (const element of clause.namedBindings.elements) {
+            bindings.push(element.name.text);
+          }
+        } else {
+          // `import * as x` re-exposes everything, so the binding name is not
+          // enough to tell what is reachable. Recorded as a wildcard.
+          bindings.push('*');
+        }
+      }
+      found.push({ specifier: node.moduleSpecifier.text, bindings });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+}
+
+/** Every JSX element in the file with the given tag name. */
+function jsxElements(sf: ts.SourceFile, tag: string): ts.Node[] {
+  const found: ts.Node[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node)) &&
+      node.tagName.getText(sf) === tag
+    ) {
+      found.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+}
+
+/**
+ * The text of every condition this node renders under.
+ *
+ * A disclosure wrapped in `{hiveLayer.showChainNote && <CommentDisclosure />}`
+ * would be configurable in practice while still being imported, which is
+ * exactly the failure an import-only check would miss.
+ */
+function enclosingConditions(node: ts.Node, sf: ts.SourceFile): string[] {
+  const conditions: string[] = [];
+  let current: ts.Node | undefined = node.parent;
+  while (current && !ts.isSourceFile(current)) {
+    if (ts.isConditionalExpression(current)) {
+      conditions.push(current.condition.getText(sf));
+    } else if (
+      ts.isBinaryExpression(current) &&
+      (current.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+        current.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+    ) {
+      conditions.push(current.left.getText(sf));
+    } else if (ts.isIfStatement(current)) {
+      conditions.push(current.expression.getText(sf));
+    }
+    current = current.parent;
+  }
+  return conditions;
+}
+
+describe('the disclosure floor has no way to be switched off', () => {
+  const module = parse(DISCLOSURE_MODULE);
+  const moduleImports = importsOf(module);
+
+  it('imports nothing from the Hive layer resolver', () => {
+    const reachable = moduleImports.flatMap((entry) =>
+      entry.bindings.filter((binding) => FORBIDDEN_BINDINGS.has(binding)),
+    );
+    expect(reachable).toEqual([]);
+  });
+
+  it('imports nothing from a hive-layer module by path either', () => {
+    const paths = moduleImports
+      .map((entry) => entry.specifier)
+      .filter((specifier) => specifier.includes('hive-layer'));
+    expect(paths).toEqual([]);
+  });
+
+  it('does not pull the whole barrel in as a namespace', () => {
+    // `import * as core` would make every forbidden binding reachable under a
+    // name this test cannot see.
+    const wildcards = moduleImports.filter((entry) =>
+      entry.bindings.includes('*'),
+    );
+    expect(wildcards).toEqual([]);
+  });
+
+  it.each(Object.entries(CALL_SITES))(
+    '%s imports and renders %s',
+    (relative, component) => {
+      const sf = parse(relative);
+      const fromDisclosure = importsOf(sf).filter(
+        (entry) =>
+          entry.specifier.includes('hive-disclosure') &&
+          entry.bindings.includes(component),
+      );
+      expect(fromDisclosure).toHaveLength(1);
+      expect(jsxElements(sf, component)).toHaveLength(1);
+    },
+  );
+
+  it.each(Object.entries(CALL_SITES))(
+    '%s renders %s without a Hive-layer condition',
+    (relative, component) => {
+      const sf = parse(relative);
+      const [element] = jsxElements(sf, component);
+      const gated = enclosingConditions(element, sf).filter((condition) =>
+        /hiveLayer|resolveHiveLayer|useHiveLayer|readerLayer/.test(condition),
+      );
+      expect(gated).toEqual([]);
+    },
+  );
+});

--- a/apps/self-hosted/src/features/shared/hive-disclosure.tsx
+++ b/apps/self-hosted/src/features/shared/hive-disclosure.tsx
@@ -1,0 +1,43 @@
+import { t } from '@/core';
+
+/**
+ * The disclosure floor: three statements about what a click costs the visitor.
+ *
+ * These have NO config key. No default, no editor control, nothing a malformed
+ * document can switch off, and this module deliberately imports nothing from
+ * the Hive layer resolver so there is no path by which one could be added
+ * quietly. A source-scanning guard pins both halves of that.
+ *
+ * The person protected is not the site owner. It is a commenter on someone
+ * else's domain who may not know the word Hive and is one click from a
+ * permanent public write with their own key. The owner has no standing to waive
+ * a stranger's warning, and the owner is the one exposed when that commenter
+ * later says nobody told them.
+ *
+ * Explaining is optional, warning is not: the "Published on Hive" note and the
+ * learn-more link are promotional and an owner can suppress them. These cannot
+ * be suppressed.
+ *
+ * Accepted cost, stated rather than buried: on a white-label site the word Hive
+ * appears under the comment box and above the publish button regardless of how
+ * the owner has configured the rest.
+ *
+ * Each is one muted line. On a phone, one more line above a button matters.
+ */
+
+const LINE = 'text-xs text-theme-muted';
+
+/** Liking is an on-chain vote that spends the reader's own voting power. */
+export function VoteDisclosure() {
+  return <p className={LINE}>{t('hive_disclosure_vote')}</p>;
+}
+
+/** A comment is a permanent public write that cannot be deleted. */
+export function CommentDisclosure() {
+  return <p className={LINE}>{t('hive_disclosure_comment')}</p>;
+}
+
+/** Publishing is permanent, and rewards close seven days after it. */
+export function PublishDisclosure() {
+  return <p className={LINE}>{t('hive_disclosure_publish')}</p>;
+}

--- a/apps/self-hosted/src/features/shared/index.ts
+++ b/apps/self-hosted/src/features/shared/index.ts
@@ -1,6 +1,7 @@
 // Re-export shared components
 export { UserAvatar, type UserAvatarProps } from './user-avatar';
 export { ErrorMessage } from './error-message';
+export { LiveRegion } from './live-region';
 
 // Re-export components from @ecency/ui
 export {

--- a/apps/self-hosted/src/features/shared/live-region.tsx
+++ b/apps/self-hosted/src/features/shared/live-region.tsx
@@ -1,0 +1,41 @@
+import clsx from 'clsx';
+
+/**
+ * A status message a screen reader is told about when it changes.
+ *
+ * The first live region in this app. It exists because the join button conveys
+ * its two failure outcomes, "we could not confirm this" and "the broadcast
+ * failed", purely by text appearing while a button goes disabled, which a
+ * screen reader user is never told about at all.
+ *
+ * Deliberately small, and there is one rule in it worth stating because getting
+ * it wrong is silent: the region has to already be in the accessibility tree
+ * before the message arrives. A region that is mounted at the same moment as
+ * its first message is usually not announced. So callers render this
+ * unconditionally and pass `message={null}` when there is nothing to say, and
+ * the empty element renders no box of its own.
+ *
+ * `polite` waits for a pause in whatever the reader is saying. `assertive`
+ * interrupts, and is for things that went wrong.
+ */
+interface Props {
+  /** Null or empty renders nothing and announces nothing. */
+  message: string | null;
+  urgency?: 'polite' | 'assertive';
+  /** Applied only when there is a message, so the region takes no space empty. */
+  className?: string;
+}
+
+export function LiveRegion({ message, urgency = 'polite', className }: Props) {
+  return (
+    <span
+      // role and aria-live agree on purpose: some readers key off one, some off
+      // the other, and disagreeing is a way to be announced twice.
+      role={urgency === 'assertive' ? 'alert' : 'status'}
+      aria-live={urgency}
+      className={clsx(message ? className : undefined)}
+    >
+      {message}
+    </span>
+  );
+}

--- a/apps/self-hosted/src/routes/-internal-links.test.ts
+++ b/apps/self-hosted/src/routes/-internal-links.test.ts
@@ -94,6 +94,16 @@ const DYNAMIC_LINKS: Record<string, { occurrences: number; reason: string }> = {
       reason:
         'runtime config general.profileBaseUrl, defaults to https://ecency.com/@',
     },
+  'src/features/blog/components/hive-post-note.tsx:hiveUrl': {
+    occurrences: 1,
+    reason:
+      'absolute https template to the chain record; the checker widens it to string',
+  },
+  'src/features/blog/components/hive-post-note.tsx:learnMoreUrl': {
+    occurrences: 1,
+    reason:
+      'runtime config features.hive.learnMoreUrl, refused by resolveHiveLayer unless it parses as absolute http(s)',
+  },
 };
 
 const LINK_ATTRS = ['href', 'to'] as const;


### PR DESCRIPTION
Reader-facing half of the Hive-native layer for `apps/self-hosted`, per the approved spec. The composer reward controls are deliberately not here; they touch broadcast payloads and land separately.

## The governing rule

A deploy may change what a visitor sees. It may never change what gets signed.

`use-comment.ts` gates the whole `comment_options` operation on `if (payload.options)`, so a payload without that key produces an operation array byte-identical to today's. Nothing here adds one. `src/core/broadcast-payload-guard.test.ts` pins all three halves of that: no mutation payload anywhere in the app carries an `options` key, the exact key set of every comment payload is fixed, and the SDK gate those depend on is asserted rather than assumed.

## What is in it

**The resolver** (`src/core/hive-layer.ts`). Pure, no React, shaped like `resolveHivesignerClientId`. Turns `features.hive.readerLayer` (`off` / `standard` / `full`) into every downstream render decision, plus `payoutLabel` and `learnMoreUrl`. It is handed the raw `features` object rather than reading config itself.

Absence is the whole safety property. No `features.hive` block, a block that is a bare string or an array, an unknown enum value, a value of the wrong type: all resolve to the `off` posture, which renders exactly what every existing config renders today. Nothing is added to `CONFIG_SKELETON`, so no value there can silently become a consumer's default. Clamps live in the resolver because storage cannot enforce them: the hosting merge only checks `typeof`, so a hand-crafted PATCH can store anything type-compatible. Downvotes are off outside community mode for every posture, and community mode is computed with the same expression the rest of the app uses rather than a second definition.

`src/core/hive-layer-absence.test.ts` runs a served document through the real merge to prove the off posture end to end, and does it in its own file because `initialize()` is idempotent with no reset, so a second case in an existing file would assert against the first one's config.

**Payout display.** `payout.ts` ports the math from the web app's entry payout. A paid-out post sums author plus curator, so an archived post does not print $0.00. A zero `max_accepted_payout` reads as declined rather than as zero earnings. `parseAsset` throws rather than returning NaN when a field is absent, which is exactly the shape `search-results.tsx` builds by hand, so the wrapper catches and returns null and the badge renders nothing. A figure that would round to $0.00 is suppressed. The payout window renders only while it is genuinely open, otherwise every archived post would read "pays out 2 years ago".

The figure goes into the existing muted meta row at the same size and colour as likes and comments, never a badge by the headline. Alongside it, gated on the same posture: a one-line note that the post is published on Hive, optionally linked to the owner's `learnMoreUrl`, and a permalink to the chain record. Both are anchors the dead-route AST guard cannot resolve, so both carry a `DYNAMIC_LINKS` entry with a counted occurrence.

**The disclosure floor: three statements, no config key.** Liking casts a vote on Hive and spends part of the reader's own voting power. Comments are published to Hive, are public, and cannot be deleted. Publishing is public and permanent, and rewards close seven days after it.

These are deliberately not configurable and there is no field to switch them off. The person protected is not the site owner; it is a commenter on someone else's domain who may not know the word Hive and is one click from a permanent public write with their own key. The owner has no standing to waive a stranger's warning, and the owner is the one exposed when that commenter later says nobody told them. No key also means no absence semantics, no editor control, no migration, and nothing a malformed document can switch off.

The accepted cost, stated rather than buried: on a white-label site the word Hive now appears under the comment box and above the publish button regardless of configuration. All three strings ship in all six locales in this PR, so this is not English-only.

`hive-disclosure-guard.test.ts` makes that a CI fact rather than a review promise. It asserts the disclosure module imports no resolver binding, checked by binding name rather than by module path because the resolver is re-exported from the `@/core` barrel that every component already imports `t` from. It also asserts each call site renders its disclosure with no Hive-layer condition wrapping it, so the statements cannot be quietly gated later.

**Three fixes with no config field.** A community subscriber count with no way to subscribe now has a join button, gated only on whether the instance has auth at all, with an explicit failure state and a context refetch rather than an optimistic success, because a `custom_json` broadcast being accepted does not mean the community honoured it. The moderator-only pending queue is gated on the viewer's community role instead of being printed to every reader. The bare reputation integer is now a plain-language band plus the number, still inside the section the existing sidebar toggle governs. Reputation zero says nothing at all: the account query degrades to zero when the bridge profile call fails, so labelling it would assert something the app has not established.

**Seeding.** A new instance gets `readerLayer: standard`, `authorRewards: author` in `getDefaultConfig`, which is reached only at tenant creation, so this is inert for every existing instance. It is seeded in one place only. The seed is read back off its own syntax tree by a test in the app suite, so it cannot drift from the resolver that reads it: the two packages cannot import each other, and two hand-maintained copies of the same strings is how a seeded value ends up meaning something the read site does not recognise.

## Config surface

`config-fields.ts` is being changed elsewhere and is untouched here, so the four fields are not yet in the editor. Everything in this PR works from config present in the served document. The follow-up needs the `Hive layer` section with two selects and two strings, the `default` support the resolver's absence values pair with, and the section icon key.

## Verification

App suite, hosting API suite, typecheck, production build and the emitted-chunk Node globals check all pass. Every new test was mutation-verified: the fix was broken, the failure confirmed to be for the stated reason, and the code restored. Two mutants survived first time and the tests were strengthened rather than left as coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Hive configuration for reader visibility, author rewards, payout labels, and educational links.
  - Displayed post payouts, Hive publication notes, and localized disclosures for voting, commenting, and publishing.
  - Added community join/leave controls with confirmation and retry handling.
  - Added reputation bands and moderator-only visibility for pending posts.
- **Improvements**
  - Added defensive validation and safe defaults for Hive settings, payouts, URLs, and reputation values.
  - Added translations across six languages.
- **Tests**
  - Expanded coverage for Hive behavior, payouts, memberships, disclosures, configuration, and community permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->