### PR TITLE
feat(self-hosted): expose the Hive layer in the configuration editor

### DIFF
--- a/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
+++ b/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
@@ -2,40 +2,17 @@ import { memo, useEffect, useMemo, useState } from 'react';
 import { validateArrayDraft, validateArrayEntries } from '../array-field';
 import type { ConfigField } from '../config-fields';
 import { FLOATING_MENU_THEME } from '../constants';
+import {
+  displayedBooleanValue,
+  displayedSelectValue,
+  displayedStringValue,
+  getSectionIcon,
+} from '../field-display';
 import type {
   ConfigEditorProps,
   ConfigFieldEditorProps,
   ConfigValue,
 } from '../types';
-
-const sectionIcons: Record<string, string> = {
-  configuration: '⚙️',
-  general: '🌐',
-  styles: '🎨',
-  instanceConfiguration: '🔧',
-  meta: '📝',
-  layout: '📐',
-  search: '🔍',
-  sidebar: '📋',
-  followers: '👥',
-  following: '👤',
-  hiveInformation: '🐝',
-  features: '✨',
-  communities: '🏘️',
-  likes: '❤️',
-  wallet: '💳',
-  comments: '💬',
-  post: '📄',
-  text2Speech: '🔊',
-  hivesigner: '🔑',
-} as const;
-
-function getSectionIcon(label: string): string {
-  const key = Object.keys(sectionIcons).find(
-    (k) => k.toLowerCase() === label.toLowerCase().replace(/\s+/g, ''),
-  );
-  return key ? sectionIcons[key]! : '📦';
-}
 
 // Separate component for array fields to handle draft state
 interface ArrayFieldEditorProps {
@@ -163,7 +140,7 @@ const ConfigFieldEditor = memo<ConfigFieldEditorProps>(
 
     switch (field.type) {
       case 'boolean': {
-        const isChecked = value === true;
+        const isChecked = displayedBooleanValue(field, value);
         return (
           <div className="mb-4">
             <label className="block text-sm font-medium text-gray-200 mb-2 font-sans">
@@ -247,7 +224,7 @@ const ConfigFieldEditor = memo<ConfigFieldEditorProps>(
       }
 
       case 'select': {
-        const selectValue = typeof value === 'string' ? value : '';
+        const selectValue = displayedSelectValue(field, value);
         const options = field.options || [];
         return (
           <div className="mb-4">
@@ -289,7 +266,7 @@ const ConfigFieldEditor = memo<ConfigFieldEditorProps>(
       }
 
       default: {
-        const stringValue = typeof value === 'string' ? value : '';
+        const stringValue = displayedStringValue(field, value);
         return (
           <div className="mb-4">
             <label
@@ -307,6 +284,7 @@ const ConfigFieldEditor = memo<ConfigFieldEditorProps>(
               id={fullPath}
               type="text"
               value={stringValue}
+              maxLength={field.maxLength}
               onChange={(e) => handleChange(e.target.value)}
               className={inputClassName}
               style={inputStyle}

--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import {
+  HIVE_LAYER_CONFIG_DEFAULTS,
+  PAYOUT_LABEL_MAX_LENGTH,
+  resolveHiveLayer,
+} from '@/core/hive-layer';
 import { AUTH_METHODS } from '@/features/auth/utils/auth-methods';
 import type { ConfigField } from './config-fields';
 import { configFieldsMap } from './config-fields';
@@ -61,6 +66,136 @@ describe('hivesigner client id', () => {
 
   it('is pointed at from the login methods field', () => {
     expect(fieldAt(METHODS_PATH)?.description).toContain('Hivesigner');
+  });
+});
+
+const FEATURES_PATH = [
+  'configuration',
+  'instanceConfiguration',
+  'features',
+] as const;
+const HIVE_PATH = [...FEATURES_PATH, 'hive'] as const;
+
+/**
+ * The Hive layer resolves entirely from `features.hive`, and until these
+ * controls existed the only way to set it was a hand-written PATCH.
+ *
+ * Everything here is checked against the resolver rather than against a copy of
+ * its values, because a panel offering a value the app does not resolve, or
+ * defaulting to a different one, is worse than no panel: it reports a state the
+ * site disagrees with.
+ */
+describe('hive layer', () => {
+  it('is offered as a section under features', () => {
+    expect(fieldAt(HIVE_PATH)?.type).toBe('section');
+  });
+
+  /** `getSectionIcon` matches on the label, so this is what picks the glyph. */
+  it('is labelled Hive layer', () => {
+    expect(fieldAt(HIVE_PATH)?.label).toBe('Hive layer');
+  });
+
+  it('is the first section an owner meets under features', () => {
+    const sections = Object.entries(fieldAt(FEATURES_PATH)?.fields ?? {})
+      .filter(([, field]) => field.type === 'section')
+      .map(([key]) => key);
+    expect(sections[0]).toBe('hive');
+  });
+
+  it('offers a control for every key the resolver reads, and no others', () => {
+    expect(Object.keys(fieldAt(HIVE_PATH)?.fields ?? {}).sort()).toEqual(
+      Object.keys(HIVE_LAYER_CONFIG_DEFAULTS).sort(),
+    );
+  });
+
+  /**
+   * No `number`, because the number input writes null when cleared, and no
+   * `array`, because `isValidArrayReplacement` in the hosting API drops an
+   * array holding objects while the save still answers 200.
+   */
+  it('uses only selects and text inputs', () => {
+    for (const key of Object.keys(HIVE_LAYER_CONFIG_DEFAULTS)) {
+      expect(['select', 'string'], key).toContain(
+        fieldAt([...HIVE_PATH, key])?.type,
+      );
+    }
+  });
+
+  it('defaults every control to what the resolver reads for an absent key', () => {
+    for (const [key, expected] of Object.entries(HIVE_LAYER_CONFIG_DEFAULTS)) {
+      expect(fieldAt([...HIVE_PATH, key])?.default, key).toBe(expected);
+    }
+  });
+
+  it('lists the default first on every select', () => {
+    for (const key of Object.keys(HIVE_LAYER_CONFIG_DEFAULTS)) {
+      const field = fieldAt([...HIVE_PATH, key]);
+      if (field?.type !== 'select') continue;
+      expect(field.options?.[0]?.value, key).toBe(field.default);
+    }
+  });
+
+  it('offers only values the resolver accepts as given', () => {
+    const readerLayers = fieldAt([...HIVE_PATH, 'readerLayer'])?.options ?? [];
+    expect(readerLayers.map((option) => option.value)).toEqual([
+      'off',
+      'standard',
+      'full',
+    ]);
+    for (const { value } of readerLayers) {
+      const resolved = resolveHiveLayer({
+        features: { hive: { readerLayer: value } },
+        composerIsInternal: true,
+      });
+      // An option the resolver downgrades would be a posture the owner picked
+      // and did not get.
+      expect(resolved.readerLayer, value).toBe(value);
+    }
+
+    const rewards = fieldAt([...HIVE_PATH, 'authorRewards'])?.options ?? [];
+    expect(rewards.map((option) => option.value)).toEqual(['off', 'author']);
+    for (const { value } of rewards) {
+      const resolved = resolveHiveLayer({
+        features: { hive: { authorRewards: value } },
+        composerIsInternal: true,
+      });
+      expect(resolved.authorRewards, value).toBe(value);
+    }
+  });
+
+  /**
+   * The resolver cuts this label at render and never corrects what is stored,
+   * so the input has to stop at the same place or an owner stores text that is
+   * never shown, in a document capped at 64KB as a whole.
+   */
+  it('caps the earnings label where the resolver cuts it', () => {
+    expect(fieldAt([...HIVE_PATH, 'payoutLabel'])?.maxLength).toBe(
+      PAYOUT_LABEL_MAX_LENGTH,
+    );
+  });
+
+  it('says what an empty earnings label and an empty link mean', () => {
+    expect(fieldAt([...HIVE_PATH, 'payoutLabel'])?.description).toContain(
+      'Leave empty',
+    );
+    expect(fieldAt([...HIVE_PATH, 'learnMoreUrl'])?.description).toContain(
+      'Leave empty',
+    );
+  });
+
+  /** House rule, and these strings are read by owners, not developers. */
+  it('uses no em or en dashes in its copy', () => {
+    const section = fieldAt(HIVE_PATH);
+    const copy = [
+      section?.label,
+      section?.description,
+      ...Object.values(section?.fields ?? {}).flatMap((field) => [
+        field.label,
+        field.description,
+        ...(field.options ?? []).map((option) => option.label),
+      ]),
+    ].join(' ');
+    expect(copy).not.toMatch(/[—–]/);
   });
 });
 

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -1,3 +1,11 @@
+// Imported from the module rather than the `@/core` barrel on purpose: the
+// barrel pulls `configuration-loader`, which imports the build-time
+// `config.json`. That file is gitignored and absent in CI, so the barrel would
+// make this module, and every test that reads it, unloadable there.
+import {
+  HIVE_LAYER_CONFIG_DEFAULTS,
+  PAYOUT_LABEL_MAX_LENGTH,
+} from '@/core/hive-layer';
 import { AUTH_METHODS } from '@/features/auth/utils/auth-methods';
 
 export type ConfigFieldType =
@@ -21,6 +29,21 @@ export interface ConfigField {
    * holding objects and reports the save as successful anyway.
    */
   allowedValues?: readonly string[];
+  /**
+   * What the panel shows when the config carries no value at this path, which
+   * is every config written before the field existed.
+   *
+   * It must be the value the app resolves for an absent key, or the panel
+   * displays a state the site disagrees with. Displaying it writes nothing: a
+   * value reaches the document only through the field's `onChange`.
+   */
+  default?: string | boolean;
+  /**
+   * For `string` fields: the cap on the input, matching wherever the value is
+   * cut at render. The wire limit is the whole document, so this is about a
+   * sane control rather than storage.
+   */
+  maxLength?: number;
 }
 
 export const configFieldsMap: Record<string, ConfigField> = {
@@ -165,6 +188,72 @@ export const configFieldsMap: Record<string, ConfigField> = {
             label: 'Features',
             type: 'section',
             fields: {
+              /**
+               * Declared first so the posture question comes before the
+               * individual feature toggles. Only the order among sections is
+               * decided here: the editor renders every non-section field above
+               * every section regardless of declaration order.
+               *
+               * Four scalars, two selects and two strings. No `number` field,
+               * because the number input writes null when cleared, and no
+               * array, because the hosting API drops an array holding objects
+               * and still answers 200.
+               *
+               * Labels are hardcoded English, like every other label in this
+               * panel. This module is a module-level constant evaluated before
+               * the runtime config is loaded, so `t()` here would freeze
+               * whichever language the bundle started with.
+               */
+              hive: {
+                label: 'Hive layer',
+                type: 'section',
+                description:
+                  'How much of the Hive blockchain this site shows readers. Notices that voting, commenting and publishing are permanent are always shown and are not affected by these settings. Save and reload to see changes.',
+                fields: {
+                  readerLayer: {
+                    label: 'Show Hive activity to readers',
+                    type: 'select',
+                    // The value an absent key resolves to, so a config written
+                    // before this block existed reads correctly here instead of
+                    // showing an empty box.
+                    default: HIVE_LAYER_CONFIG_DEFAULTS.readerLayer,
+                    description:
+                      'Off shows no earnings and no links to Hive. Standard shows what a post earned, when its payout closes, and a link to it on Hive. Full also shows earnings on post cards in the list.',
+                    options: [
+                      { value: 'off', label: 'Off' },
+                      { value: 'standard', label: 'Standard' },
+                      { value: 'full', label: 'Full' },
+                    ],
+                  },
+                  authorRewards: {
+                    label: 'Reward controls when writing',
+                    type: 'select',
+                    default: HIVE_LAYER_CONFIG_DEFAULTS.authorRewards,
+                    description:
+                      'Off publishes with the usual Hive reward setting. Author chooses offers the writer all Hive Power or declining rewards, picked once at publish and not editable afterwards. Applies only to posts written here, so it does nothing when Create Post URL points at another site. The reward control itself is still being built, so this has no visible effect yet.',
+                    options: [
+                      { value: 'off', label: 'Off' },
+                      { value: 'author', label: 'Author chooses' },
+                    ],
+                  },
+                  payoutLabel: {
+                    label: 'Earnings label',
+                    type: 'string',
+                    default: HIVE_LAYER_CONFIG_DEFAULTS.payoutLabel,
+                    // Same cap the resolver cuts at, so nothing typed here can
+                    // be stored longer than it is shown.
+                    maxLength: PAYOUT_LABEL_MAX_LENGTH,
+                    description: `Your own word for what a post earned, for example Rewards or Tips from readers. Leave empty for the built-in wording. Longer than ${PAYOUT_LABEL_MAX_LENGTH} characters is cut where it is shown.`,
+                  },
+                  learnMoreUrl: {
+                    label: 'Learn more link',
+                    type: 'string',
+                    default: HIVE_LAYER_CONFIG_DEFAULTS.learnMoreUrl,
+                    description:
+                      'Leave empty to show the Hive note as plain text. Add a full https address and the note becomes a link to it.',
+                  },
+                },
+              },
               postsFilters: {
                 label: 'Post Filters',
                 type: 'array',

--- a/apps/self-hosted/src/features/floating-menu/field-display.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/field-display.test.ts
@@ -1,0 +1,329 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { HIVE_LAYER_CONFIG_DEFAULTS } from '@/core/hive-layer';
+import type { ConfigField } from './config-fields';
+import { configFieldsMap } from './config-fields';
+import {
+  displayedBooleanValue,
+  displayedSelectValue,
+  displayedStringValue,
+  FALLBACK_SECTION_ICON,
+  getSectionIcon,
+} from './field-display';
+import type { ConfigValue } from './types';
+
+/**
+ * What the panel shows an owner whose config predates a field.
+ *
+ * Every config on disk is in that state for anything added after it was
+ * written, and there is no staging tier: a merge deploys straight to live
+ * blogs. So the property under test is that an absent key displays the value
+ * the app resolves for an absent key, never an empty control that reads as
+ * "not configured" while the site behaves otherwise.
+ */
+
+const READER_LAYER: ConfigField = {
+  label: 'Show Hive activity to readers',
+  type: 'select',
+  default: 'off',
+  options: [
+    { value: 'off', label: 'Off' },
+    { value: 'standard', label: 'Standard' },
+    { value: 'full', label: 'Full' },
+  ],
+};
+
+/** A select as they all were before `default` existed. */
+const NO_DEFAULT: ConfigField = {
+  label: 'Instance Type',
+  type: 'select',
+  options: [
+    { value: 'blog', label: 'Blog (Personal)' },
+    { value: 'community', label: 'Community' },
+  ],
+};
+
+describe('select', () => {
+  it('shows the declared default when the config has no value', () => {
+    expect(displayedSelectValue(READER_LAYER, undefined)).toBe('off');
+  });
+
+  it('shows a stored value that is one of the options', () => {
+    expect(displayedSelectValue(READER_LAYER, 'standard')).toBe('standard');
+    expect(displayedSelectValue(READER_LAYER, 'full')).toBe('full');
+  });
+
+  const STORABLE_JUNK: Array<[string, ConfigValue]> = [
+    ['a number', 42],
+    ['null', null],
+    ['a boolean', true],
+    ['an object', { readerLayer: 'full' }],
+    ['an array', ['full']],
+  ];
+
+  it.each(STORABLE_JUNK)(
+    'shows the default for %s, which the API can store',
+    (_label, stored) => {
+      expect(displayedSelectValue(READER_LAYER, stored)).toBe('off');
+    },
+  );
+
+  /**
+   * The resolver does no case folding and resolves an unknown literal down to
+   * `off`, so a hand-crafted PATCH of 'FULL' is an off site. A select handed a
+   * value matching no option renders blank, which would claim the opposite.
+   */
+  it('shows the default for a string that matches no option', () => {
+    expect(displayedSelectValue(READER_LAYER, 'FULL')).toBe('off');
+  });
+
+  it('is unchanged for a select that declares no default', () => {
+    expect(displayedSelectValue(NO_DEFAULT, undefined)).toBe('');
+    expect(displayedSelectValue(NO_DEFAULT, 42)).toBe('');
+    expect(displayedSelectValue(NO_DEFAULT, 'community')).toBe('community');
+  });
+});
+
+describe('boolean', () => {
+  const off: ConfigField = { label: 'Enabled', type: 'boolean' };
+  const onByDefault: ConfigField = {
+    label: 'Enabled',
+    type: 'boolean',
+    default: true,
+  };
+
+  it('is unchanged for a toggle that declares no default', () => {
+    expect(displayedBooleanValue(off, undefined)).toBe(false);
+    expect(displayedBooleanValue(off, true)).toBe(true);
+    expect(displayedBooleanValue(off, false)).toBe(false);
+    expect(displayedBooleanValue(off, 'yes')).toBe(false);
+  });
+
+  it('falls through to a default of true only when nothing is stored', () => {
+    expect(displayedBooleanValue(onByDefault, undefined)).toBe(true);
+    expect(displayedBooleanValue(onByDefault, null)).toBe(true);
+    // An owner who switched it off stays switched off.
+    expect(displayedBooleanValue(onByDefault, false)).toBe(false);
+  });
+});
+
+describe('string', () => {
+  const label: ConfigField = {
+    label: 'Earnings label',
+    type: 'string',
+    default: '',
+    maxLength: 40,
+  };
+
+  it('shows the stored text', () => {
+    expect(displayedStringValue(label, 'Rewards')).toBe('Rewards');
+  });
+
+  it('shows the default when the config has no value', () => {
+    expect(displayedStringValue(label, undefined)).toBe('');
+    expect(displayedStringValue(label, 5)).toBe('');
+  });
+});
+
+describe('section icons', () => {
+  /**
+   * `getSectionIcon` is handed `field.label`, so a map keyed by the config key
+   * silently yields the fallback box. Pinned on the label the editor declares.
+   */
+  it('finds the Hive layer glyph from its label', () => {
+    expect(getSectionIcon('Hive layer')).toBe('🐝');
+  });
+
+  it('still finds the sections that already had one', () => {
+    expect(getSectionIcon('Hive Information')).toBe('🐝');
+    expect(getSectionIcon('Instance Configuration')).toBe('🔧');
+    expect(getSectionIcon('Features')).toBe('✨');
+  });
+
+  it('falls back for a section with no entry', () => {
+    expect(getSectionIcon('Layout Settings')).toBe(FALLBACK_SECTION_ICON);
+  });
+});
+
+/**
+ * A tenant document written before any of this existed. No `features.hive`,
+ * and none of the newer keys either. Names are invented.
+ */
+const LEGACY_CONFIG = {
+  version: 1,
+  configuration: {
+    general: {
+      theme: 'light',
+      styleTemplate: 'medium',
+      language: 'en',
+      styles: { background: 'bg-white' },
+    },
+    instanceConfiguration: {
+      type: 'blog',
+      username: 'blogowner',
+      meta: { title: 'A Blog', description: 'Words' },
+      layout: {
+        listType: 'list',
+        sidebar: { placement: 'right', followers: { enabled: true } },
+      },
+      features: {
+        postsFilters: ['blog', 'posts'],
+        likes: { enabled: true },
+        comments: { enabled: true },
+      },
+    },
+  },
+};
+
+type Node = Record<string, unknown>;
+
+/** Every non-section field in the map, with the value the legacy config holds. */
+function walk(
+  fields: Record<string, ConfigField>,
+  config: Node | undefined,
+  path: string[],
+): Array<{ path: string; field: ConfigField; value: unknown }> {
+  return Object.entries(fields).flatMap(([key, field]) => {
+    const value = config?.[key];
+    if (field.type === 'section' && field.fields) {
+      const child =
+        typeof value === 'object' && value !== null && !Array.isArray(value)
+          ? (value as Node)
+          : undefined;
+      return walk(field.fields, child, [...path, key]);
+    }
+    return [{ path: [...path, key].join('.'), field, value }];
+  });
+}
+
+describe('a config written before the Hive layer existed', () => {
+  const leaves = walk(configFieldsMap, LEGACY_CONFIG as unknown as Node, []);
+
+  it('reaches every Hive layer control with nothing stored', () => {
+    const hive = leaves.filter((leaf) =>
+      leaf.path.startsWith(
+        'configuration.instanceConfiguration.features.hive.',
+      ),
+    );
+    expect(hive).toHaveLength(Object.keys(HIVE_LAYER_CONFIG_DEFAULTS).length);
+    for (const leaf of hive) {
+      expect(leaf.value).toBeUndefined();
+    }
+  });
+
+  it('displays the resolver default for every Hive layer control', () => {
+    for (const [key, expected] of Object.entries(HIVE_LAYER_CONFIG_DEFAULTS)) {
+      const leaf = leaves.find(
+        (candidate) =>
+          candidate.path ===
+          `configuration.instanceConfiguration.features.hive.${key}`,
+      );
+      if (!leaf) throw new Error(`no editor control for features.hive.${key}`);
+      const value = leaf.value as ConfigValue;
+      const shown =
+        leaf.field.type === 'select'
+          ? displayedSelectValue(leaf.field, value)
+          : displayedStringValue(leaf.field, value);
+      expect(shown, `features.hive.${key}`).toBe(expected);
+    }
+  });
+
+  it('leaves no select blank when it declares a default', () => {
+    for (const leaf of leaves) {
+      if (leaf.field.type !== 'select' || leaf.field.default === undefined) {
+        continue;
+      }
+      const shown = displayedSelectValue(leaf.field, leaf.value as ConfigValue);
+      expect(shown, leaf.path).not.toBe('');
+      expect(
+        leaf.field.options?.map((option) => option.value),
+        leaf.path,
+      ).toContain(shown);
+    }
+  });
+
+  it('displays every other field exactly as it did before', () => {
+    for (const leaf of leaves) {
+      if (leaf.field.default !== undefined) continue;
+      const value = leaf.value as ConfigValue;
+      if (leaf.field.type === 'select') {
+        expect(displayedSelectValue(leaf.field, value), leaf.path).toBe(
+          typeof value === 'string' ? value : '',
+        );
+      } else if (leaf.field.type === 'boolean') {
+        expect(displayedBooleanValue(leaf.field, value), leaf.path).toBe(
+          value === true,
+        );
+      } else if (leaf.field.type === 'string') {
+        expect(displayedStringValue(leaf.field, value), leaf.path).toBe(
+          typeof value === 'string' ? value : '',
+        );
+      }
+    }
+  });
+});
+
+/**
+ * Everything above tests functions the panel is supposed to call. Nothing in a
+ * `.tsx` file is testable in this app, so what the panel actually calls is
+ * pinned by reading its source, the same mechanism
+ * `src/routes/-internal-links.test.ts` and `src/core/hive-layer-consumers.test.ts`
+ * already use. Without this, inlining the old expression back into the editor
+ * leaves every test above green while the select renders blank again.
+ */
+describe('the editor renders through these', () => {
+  const path = join(__dirname, 'components', 'config-editor.tsx');
+  const sf = ts.createSourceFile(
+    path,
+    readFileSync(path, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  /** Every function called by name in the file. */
+  function calledNames(): Set<string> {
+    const names = new Set<string>();
+    const visit = (node: ts.Node) => {
+      if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+        names.add(node.expression.text);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+    return names;
+  }
+
+  /** The expressions given to a JSX attribute of this name. */
+  function jsxAttributeValues(name: string): string[] {
+    const values: string[] = [];
+    const visit = (node: ts.Node) => {
+      if (ts.isJsxAttribute(node) && node.name.getText(sf) === name) {
+        values.push(node.initializer?.getText(sf) ?? '');
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+    return values;
+  }
+
+  it.each([
+    'displayedBooleanValue',
+    'displayedSelectValue',
+    'displayedStringValue',
+    'getSectionIcon',
+  ])('calls %s', (name) => {
+    expect(calledNames()).toContain(name);
+  });
+
+  /**
+   * The cap belongs on the input, not only in the field table: the resolver
+   * cuts the label at render and never corrects what was stored, and the
+   * document as a whole is capped on the wire.
+   */
+  it('caps a text input at the field maxLength', () => {
+    expect(jsxAttributeValues('maxLength')).toContain('{field.maxLength}');
+  });
+});

--- a/apps/self-hosted/src/features/floating-menu/field-display.ts
+++ b/apps/self-hosted/src/features/floating-menu/field-display.ts
@@ -1,0 +1,109 @@
+import type { ConfigField } from './config-fields';
+import type { ConfigValue } from './types';
+
+/**
+ * What the Configuration Editor puts on screen for a field and a section.
+ *
+ * Pure, and in a `.ts` module rather than inside `config-editor.tsx`, because
+ * this app's test runner is `environment: 'node'` with
+ * `include: ['src/**\/*.test.ts']`: nothing in a `.tsx` file is testable at all.
+ * The one thing worth testing about the panel is exactly this, what it shows
+ * for a config that has no value at a path, which is every config written
+ * before a field existed.
+ *
+ * Nothing here writes. A value reaches the document only through a field's
+ * `onChange`, so an owner who opens the panel, reads a default and saves
+ * without touching the control stores nothing new.
+ */
+
+/**
+ * Section glyphs, keyed by the section LABEL and not by its config key.
+ *
+ * `getSectionIcon` receives `field.label`, so a key that matches the config key
+ * instead of the label silently yields the fallback box. The lookup is
+ * case-insensitive and ignores spaces, which is why 'Hive Information' finds
+ * `hiveInformation`.
+ */
+const sectionIcons: Record<string, string> = {
+  configuration: '⚙️',
+  general: '🌐',
+  styles: '🎨',
+  instanceConfiguration: '🔧',
+  meta: '📝',
+  layout: '📐',
+  search: '🔍',
+  sidebar: '📋',
+  followers: '👥',
+  following: '👤',
+  hiveInformation: '🐝',
+  hiveLayer: '🐝',
+  features: '✨',
+  communities: '🏘️',
+  likes: '❤️',
+  wallet: '💳',
+  comments: '💬',
+  post: '📄',
+  text2Speech: '🔊',
+  hivesigner: '🔑',
+} as const;
+
+/** Shown for a section with no entry above. */
+export const FALLBACK_SECTION_ICON = '📦';
+
+export function getSectionIcon(label: string): string {
+  const normalized = label.toLowerCase().replace(/\s+/g, '');
+  const entry = Object.entries(sectionIcons).find(
+    ([key]) => key.toLowerCase() === normalized,
+  );
+  return entry?.[1] ?? FALLBACK_SECTION_ICON;
+}
+
+/**
+ * The toggle position for a boolean field.
+ *
+ * An absent key falls through to the declared default, so a flag that is on
+ * when unset cannot render as "Disabled" over a site that behaves as enabled.
+ * A stored `false` is still `false`: only absence takes the default.
+ */
+export function displayedBooleanValue(
+  field: ConfigField,
+  value: ConfigValue | undefined,
+): boolean {
+  return (value ?? field.default) === true;
+}
+
+/**
+ * The selected option for a select field.
+ *
+ * Two reasons the stored value is not simply handed to the select. A config
+ * that predates the field has nothing at that path, and a select whose value
+ * matches no option renders blank, which reads as "not configured" while the
+ * site is applying a value. Both resolve to the declared default, which is the
+ * same value the app resolves for an absent or unrecognised key, so the panel
+ * and the site agree.
+ *
+ * With no declared default this is what the editor did before, an empty
+ * string, so every field that predates `default` is unaffected.
+ */
+export function displayedSelectValue(
+  field: ConfigField,
+  value: ConfigValue | undefined,
+): string {
+  const fallback = typeof field.default === 'string' ? field.default : '';
+  if (typeof value !== 'string') return fallback;
+
+  const options = field.options;
+  if (options && options.length > 0) {
+    return options.some((option) => option.value === value) ? value : fallback;
+  }
+  return value;
+}
+
+/** The text in a string input, falling back to the declared default. */
+export function displayedStringValue(
+  field: ConfigField,
+  value: ConfigValue | undefined,
+): string {
+  if (typeof value === 'string') return value;
+  return typeof field.default === 'string' ? field.default : '';
+}


### PR DESCRIPTION
Follow-up to #1340, which shipped the resolver and its consumers but left the block unsettable through the panel. `config-fields.ts` was owned by #1339 at the time; that is merged, so this lands now.

## What an owner sees

One new section, **Hive layer**, declared first among the sections under Features, with four scalar controls:

| control | type | options / cap | default |
| --- | --- | --- | --- |
| Show Hive activity to readers | select | Off, Standard, Full | Off |
| Reward controls when writing | select | Off, Author chooses | Off |
| Earnings label | text | 40 characters | empty |
| Learn more link | text | | empty |

Option labels are single words because all four render in a one-third-width grid cell; the explanation is in each field description. The section description states that the notices about voting, commenting and publishing being permanent are always shown and are not affected by these settings, and that a save needs a reload.

No `number` field, because the number input writes `null` when cleared. No array, because the hosting API drops an array holding objects and still answers 200.

## Why the editor needed a `default`

Every config on disk lacks `features.hive`, so a select had nothing to show. `typeof value === 'string' ? value : ''` renders an empty box, which reads as "not configured" while the site resolves `off`.

`ConfigField` gains `default` and `maxLength`, and the three display expressions move out of `config-editor.tsx` into `field-display.ts`. Nothing in a `.tsx` file is reachable by this app's test runner (`environment: 'node'`, `include: ['src/**/*.test.ts']`), so this is the only way to test the behaviour rather than assert it in a review comment. A select falls back to the declared default both when nothing is stored and when the stored string matches no option, the second case being a hand-crafted value such as `"FULL"` that the resolver already downgrades to `off`.

Displaying a default writes nothing. A value reaches the document only through the field's `onChange`, so opening the panel and saving without touching the control stores nothing new.

**Inert for every existing field.** No field declared a `default` before this, so `typeof field.default === 'string' ? field.default : ''` reproduces the previous expression exactly, and the boolean branch reduces to `value === true`. `maxLength` is unset elsewhere and React omits the attribute. A test walks the whole field map against a config document with no `hive` block and asserts every field with no declared default displays exactly what it displayed before.

## Drift

The four defaults are read from `HIVE_LAYER_CONFIG_DEFAULTS` and the label cap from `PAYOUT_LABEL_MAX_LENGTH`, both exported by #1340, so they are the same values the resolver reads for an absent key rather than a second copy. Tests pin that there is a control for every key the resolver reads and no others, that every offered option survives the resolver unchanged, that the default is listed first, and that the editor really calls the display helpers.

The input cap and the render cap are the same constant. The resolver cuts the label at render and never corrects what is stored, and the document is capped as a whole on the wire, so an uncapped input would let an owner store text that is never shown.

## Not translated

The Configuration Editor makes zero `t()` calls; every label in it is hardcoded English. `config-fields.ts` is a module-level constant evaluated before the runtime config loads, so `t()` there would freeze whichever language the bundle started with. These strings follow that convention. Translating only the new section would be worse than either end state.

## Verified

`vitest run` 454 passing, `tsc --noEmit` clean, `rsbuild build` plus `check-node-globals` clean. Fifteen mutations checked, each failing on the test named for it and no survivor: the select fallback, the option-membership check, the boolean fallback, the icon key, the label, the `maxLength`, the option order, an option value the resolver rejects, an em dash in the copy, removal of the whole block, and each of the four call sites in the editor.

Biome on the touched files reports only diagnostics that are already on `develop` for the same lines; `config-editor.tsx` loses one, the non-null assertion in the icon lookup.

CI note: `pnpm install --frozen-lockfile` currently fails on `develop` too, on the `minimumReleaseAge` policy window for `nanoid@3.3.17`. It clears itself, and this branch does not touch the lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hive layer settings to the configuration editor, including reader visibility, author rewards, payout labels, and learn-more links.
  * Improved display of boolean, selection, and text settings with sensible defaults and validation.
  * Added a fallback icon for configuration sections.
  * Text fields now enforce their configured character limits.

* **Bug Fixes**
  * Invalid or missing setting values now fall back to appropriate defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->