### PR TITLE
self-hosted: cascade layers and theme token registration

### DIFF
--- a/apps/self-hosted/src/features/auth/components/comment-form.tsx
+++ b/apps/self-hosted/src/features/auth/components/comment-form.tsx
@@ -85,7 +85,7 @@ export function CommentForm({
     return (
       <div
         className={clsx(
-          "p-4 border border-theme rounded-lg bg-theme-hover",
+          "p-4 border border-theme rounded-lg bg-theme-secondary",
           className
         )}
       >
@@ -104,7 +104,7 @@ export function CommentForm({
   return (
     <div className={clsx("space-y-3", className)}>
       <div className="flex items-start gap-3">
-        <div className="flex-shrink-0 size-8 rounded-full bg-theme-hover flex items-center justify-center text-sm font-medium text-theme-primary">
+        <div className="flex-shrink-0 size-8 rounded-full bg-theme-secondary flex items-center justify-center text-sm font-medium text-theme-primary">
           {user?.username?.charAt(0).toUpperCase()}
         </div>
         <div className="flex-1">
@@ -112,7 +112,7 @@ export function CommentForm({
             value={body}
             onChange={(e) => setBody(e.target.value)}
             placeholder={t("write_comment")}
-            className="w-full px-3 py-2 rounded-md border border-theme bg-theme text-theme-primary placeholder:text-theme-muted focus:outline-none focus:ring-2 focus:ring-theme-strong resize-none"
+            className="w-full px-3 py-2 rounded-md border border-theme bg-theme text-theme-primary placeholder:text-theme-muted focus:outline-none focus:ring-2 focus:ring-theme-accent resize-none"
             rows={3}
             disabled={commentMutation.isPending}
           />

--- a/apps/self-hosted/src/features/auth/components/create-post-button.tsx
+++ b/apps/self-hosted/src/features/auth/components/create-post-button.tsx
@@ -7,8 +7,11 @@ import { Link } from "@tanstack/react-router";
 import { useIsAuthEnabled, useIsAuthenticated, useIsBlogOwner } from "../hooks";
 import { resolveCreatePostTarget } from "../utils/create-post-target";
 
+// `no-underline` and `font-serif` carried a `!` because the unlayered `a` and
+// `*` rules in globals.css beat every utility. Those rules are in @layer base
+// now, so an ordinary utility wins and the `!important` is not needed.
 const BUTTON_CLASS =
-  "fixed bottom-6 right-30 z-50 px-4 py-2 flex items-center text-sm !no-underline rounded-full border border-gray-400 dark:border-gray-600 !font-serif";
+  "fixed bottom-6 right-30 z-50 px-4 py-2 flex items-center text-sm no-underline rounded-full border border-gray-400 dark:border-gray-600 font-serif";
 
 export function CreatePostButton() {
   const isBlogOwner = useIsBlogOwner();

--- a/apps/self-hosted/src/features/blog/components/blog-post-discussion.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-discussion.tsx
@@ -149,7 +149,7 @@ export function BlogPostDiscussion({ entry, isRawContent }: Props) {
         <select
           value={order}
           onChange={(e) => setOrder(e.target.value as SortOrder)}
-          className="px-3 py-2 border border-theme rounded-theme-sm text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-theme-strong focus:border-transparent transition-theme hover:opacity-70 w-full sm:w-auto bg-theme-primary text-theme-primary font-theme-ui"
+          className="px-3 py-2 border border-theme rounded-theme-sm text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-theme-accent focus:border-transparent transition-theme hover:opacity-70 w-full sm:w-auto bg-theme-primary text-theme-primary font-theme-ui"
         >
           <option value="trending">Trending</option>
           <option value="author_reputation">Reputation</option>

--- a/apps/self-hosted/src/features/tipping/components/tipping-wallet-qr.tsx
+++ b/apps/self-hosted/src/features/tipping/components/tipping-wallet-qr.tsx
@@ -52,7 +52,7 @@ export function TippingWalletQr({
       alt="Wallet address QR code"
       width={size}
       height={size}
-      className={`rounded border border-theme ${className ?? ""}`}
+      className={`rounded border border-theme h-auto ${className ?? ""}`}
     />
   );
 }

--- a/apps/self-hosted/src/globals.css
+++ b/apps/self-hosted/src/globals.css
@@ -5,6 +5,16 @@
 /* biome-ignore lint/suspicious/noUnknownAtRules: @source is a Tailwind v4 feature */
 @source "../../../packages/ui/src/**/*.tsx";
 /*
+ * Tests are scanned like any other source, so a class-shaped word in a test's
+ * prose ships as a real rule to every instance: writing `bg-red-500` in a
+ * comment was enough to put `.bg-red-500` in the stylesheet. Nothing under a
+ * test file renders.
+ */
+/* biome-ignore lint/suspicious/noUnknownAtRules: @source is a Tailwind v4 feature */
+@source not "./**/*.test.ts";
+/* biome-ignore lint/suspicious/noUnknownAtRules: @source is a Tailwind v4 feature */
+@source not "../../../packages/ui/src/**/*.test.tsx";
+/*
  * The instance theme is applied as data-theme on <html> from the tenant config,
  * and every --theme-* token keys off it. Tailwind v4 otherwise compiles `dark:`
  * to @media (prefers-color-scheme: dark), which made every surface built from
@@ -15,6 +25,8 @@
 /* biome-ignore lint/suspicious/noUnknownAtRules: @custom-variant is a Tailwind v4 feature */
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
+/* biome-ignore lint/correctness/noInvalidPositionAtImportRule: Tailwind v4 requires @source before these imports */
+@import "./styles/theme-tokens.css";
 /* biome-ignore lint/correctness/noInvalidPositionAtImportRule: Tailwind v4 requires @source before these imports */
 @import "./styles/themes/index.css";
 /* biome-ignore lint/correctness/noInvalidPositionAtImportRule: Tailwind v4 requires @source before these imports */

--- a/apps/self-hosted/src/globals.css
+++ b/apps/self-hosted/src/globals.css
@@ -22,6 +22,32 @@
 /* biome-ignore lint/correctness/noInvalidPositionAtImportRule: Tailwind v4 requires @source before these imports */
 @import "./styles/blog-markdown.css";
 
+/*
+ * UNLAYERED BY DESIGN: every rule below whose subject is <html> or <body>.
+ *
+ * `@import "tailwindcss"` emits `@layer theme, base, components, utilities`,
+ * and an unlayered normal declaration beats a layered one whatever its
+ * specificity. Two things depend on that, and src/styles/cascade-layers.test.ts
+ * fails if either is quietly "tidied up" into the layer below:
+ *
+ * 1. `general.styles.background` is a free-form class string an owner types
+ *    into the configuration panel, and applyConfigDom puts it on <body>
+ *    (core/apply-config-dom.ts, applyBodyClasses). It has never painted,
+ *    because `background-color` here wins over any `bg-*` utility the owner
+ *    names. Layering this rule would hand the win to the 22 distinct compiled
+ *    `bg-*` literals, `bg-black` and `bg-white` among them, while
+ *    `color: var(--theme-text-primary)` stayed put: black text on a black page,
+ *    saved with a 200 OK, on a live instance. The field stays inert on purpose.
+ * 2. The responsive `font-size` overrides are `body` rules too. Layering them
+ *    while this one stayed unlayered would let `var(--theme-text-base)` beat
+ *    both media queries, dropping desktop body copy from 21px to the template's
+ *    base size on every instance.
+ *
+ * The collision surface is only what these rules declare, and nothing in the
+ * app puts a `text-*`, `font-*`, `leading-*`, `tracking-*`, `overflow-*` or
+ * padding utility on <html> or <body>: the only classes that reach <body> are
+ * the ones applyBodyClasses adds.
+ */
 html,
 body {
   min-height: 100%;
@@ -51,43 +77,6 @@ body {
   }
 }
 
-* {
-  font-family: inherit;
-}
-
-/* Theme-aware typography */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family: var(--theme-font-heading);
-  font-weight: 700;
-  letter-spacing: var(--theme-tracking-tight);
-  color: var(--theme-text-primary);
-}
-
-/* Theme-aware links */
-a {
-  color: inherit;
-  text-decoration: var(--theme-link-decoration, none);
-  text-decoration-color: var(--theme-link-decoration-color, transparent);
-  transition: all var(--theme-transition);
-}
-
-a:hover {
-  opacity: 0.7;
-  text-decoration-color: var(--theme-link-decoration-hover, inherit);
-}
-
-/* Theme-aware buttons */
-button {
-  font-family: var(--theme-font-ui);
-}
-
-/* Mobile responsiveness improvements */
-
 /*
  * Prevent horizontal scroll.
  *
@@ -109,53 +98,108 @@ body {
   max-width: 100vw;
 }
 
-/* Ensure images don't overflow */
-img {
-  max-width: 100%;
-  height: auto;
-}
-
-/* Prevent long words from breaking layout */
-.markdown-body,
-article {
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-}
-
-/* Code blocks should scroll horizontally on mobile */
-.markdown-body pre {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-/* Tables should scroll on mobile */
-.markdown-body table {
-  display: block;
-  width: max-content;
-  max-width: 100%;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-/* Improve touch targets on mobile */
-@media (max-width: 640px) {
-  button,
-  a {
-    min-height: 44px;
-    min-width: 44px;
-  }
-
-  /* Increase tap area for small interactive elements */
-  .flex.items-center.gap-1 {
-    padding: 4px 0;
-  }
-}
-
 /* Safe area insets for notched devices */
 @supports (padding: env(safe-area-inset-bottom)) {
   body {
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
     padding-bottom: env(safe-area-inset-bottom);
+  }
+}
+
+/*
+ * Everything else is a base rule and belongs in @layer base.
+ *
+ * Unlayered, these element rules beat every Tailwind utility however specific:
+ * `a { color: inherit }` beat `text-theme-accent`, `img { height: auto }` beat
+ * `h-48`, `h1 { font-weight: 700 }` beat `font-semibold`, and
+ * `* { font-family: inherit }` beat `font-mono`. That is why `no-underline` at
+ * blog-navigation.tsx did nothing while the comment above it said it did, and
+ * why two call sites had reached for `!` to get an ordinary utility to apply.
+ * In the layer they behave the way every other Tailwind project's base rules
+ * behave: they set the default and a utility on the element overrides it.
+ */
+@layer base {
+  * {
+    font-family: inherit;
+  }
+
+  /* Theme-aware typography */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--theme-font-heading);
+    font-weight: 700;
+    letter-spacing: var(--theme-tracking-tight);
+    color: var(--theme-text-primary);
+  }
+
+  /* Theme-aware links */
+  a {
+    color: inherit;
+    text-decoration: var(--theme-link-decoration, none);
+    text-decoration-color: var(--theme-link-decoration-color, transparent);
+    transition: all var(--theme-transition);
+  }
+
+  /*
+   * No `opacity` here. It used to be 0.7, which multiplied with the
+   * `hover:opacity-70` already on the wrapping heading in the feed to an
+   * effective 0.49, taking headline contrast on hover from 17.06 to 3.28.
+   * `text-decoration-color` stays: it is the only thing that makes
+   * --theme-link-decoration-hover visible outside .markdown-body.
+   */
+  a:hover {
+    text-decoration-color: var(--theme-link-decoration-hover, inherit);
+  }
+
+  /* Theme-aware buttons */
+  button {
+    font-family: var(--theme-font-ui);
+  }
+
+  /* Ensure images don't overflow */
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* Prevent long words from breaking layout */
+  .markdown-body,
+  article {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
+
+  /* Code blocks should scroll horizontally on mobile */
+  .markdown-body pre {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Tables should scroll on mobile */
+  .markdown-body table {
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Improve touch targets on mobile */
+  @media (max-width: 640px) {
+    button,
+    a {
+      min-height: 44px;
+      min-width: 44px;
+    }
+
+    /* Increase tap area for small interactive elements */
+    .flex.items-center.gap-1 {
+      padding: 4px 0;
+    }
   }
 }

--- a/apps/self-hosted/src/styles/cascade-layers.test.ts
+++ b/apps/self-hosted/src/styles/cascade-layers.test.ts
@@ -1,0 +1,142 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * globals.css must keep its element rules in @layer base and its <html> and
+ * <body> rules out of it.
+ *
+ * Unlayered normal declarations beat every layered one whatever the
+ * specificity, so the element rules here used to beat every Tailwind utility:
+ * `a { color: inherit }` beat `text-theme-accent`, `img { height: auto }` beat
+ * `h-48`, `* { font-family: inherit }` beat `font-mono`. In @layer base they
+ * behave like base rules everywhere else.
+ *
+ * The exemption is the load-bearing half. `general.styles.background` is a
+ * free-form class string an owner types into the configuration panel, and it
+ * lands on <body>. It has never painted, because `body`'s own
+ * `background-color` outranks any `bg-*` utility the owner names. Layering the
+ * body rule would hand the win to `bg-black` and `bg-white`, which are compiled
+ * from elsewhere in the app, while `color: var(--theme-text-primary)` stayed
+ * put: an unreadable page from a valid value, saved with a 200 OK, on a live
+ * instance. `@source inline(...)` on those class names would do the same
+ * through `background-image`, which is why it is refused here too.
+ *
+ * The `body` font-size overrides are body rules for a second reason: layering
+ * them while the main body rule stayed unlayered would let
+ * `var(--theme-text-base)` beat both media queries and shrink desktop body copy
+ * on every instance.
+ *
+ * jsdom does not implement cascade layers, so a computed-style assertion would
+ * pass for the wrong reason. This reads the stylesheet instead, and says so.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GLOBALS = join(resolve(HERE, '..'), 'globals.css');
+
+const LAYER = '@layer base';
+
+/**
+ * Selectors that must stay out of the layer, and why. This list is the guard:
+ * "unlayered" is a deliberate, explained property of exactly these rules.
+ */
+const UNLAYERED_BY_DESIGN: Record<string, string> = {
+  body: 'an owner-supplied bg-* class on <body> must never win',
+  'html, body': 'page-level box rules, same exposure through body classes',
+};
+
+interface Rule {
+  selector: string;
+  declarations: string;
+  layered: boolean;
+}
+
+/** Style rules of a stylesheet, at any at-rule nesting depth. */
+function rules(css: string): Rule[] {
+  const source = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const out: Rule[] = [];
+
+  const parse = (body: string, layered: boolean) => {
+    let prelude = '';
+    let depth = 0;
+    let start = 0;
+    for (let i = 0; i < body.length; i += 1) {
+      const char = body[i];
+      if (depth === 0) {
+        if (char === '{') {
+          depth = 1;
+          start = i + 1;
+        } else if (char === ';') {
+          prelude = '';
+        } else {
+          prelude += char;
+        }
+        continue;
+      }
+      if (char === '{') depth += 1;
+      else if (char === '}') {
+        depth -= 1;
+        if (depth > 0) continue;
+        const selector = prelude.trim().replace(/\s+/g, ' ');
+        const inner = body.slice(start, i);
+        if (selector.startsWith('@')) {
+          parse(inner, layered || selector.startsWith('@layer'));
+        } else {
+          out.push({ selector, declarations: inner, layered });
+        }
+        prelude = '';
+      }
+    }
+  };
+
+  parse(source, false);
+  return out;
+}
+
+describe('globals.css cascade layers', () => {
+  const css = readFileSync(GLOBALS, 'utf8');
+  const parsed = rules(css);
+
+  it('parses the stylesheet it is asserting on', () => {
+    expect(parsed.length).toBeGreaterThan(8);
+    expect(parsed.map((rule) => rule.selector)).toContain('body');
+    expect(css).toContain(`${LAYER} {`);
+  });
+
+  it('every rule that is not exempt is inside @layer base', () => {
+    const unlayered = parsed
+      .filter((rule) => !rule.layered)
+      .map((rule) => rule.selector)
+      .filter((selector) => !(selector in UNLAYERED_BY_DESIGN));
+
+    expect(unlayered).toEqual([]);
+  });
+
+  it('every exempt rule is a <html>/<body> rule and is unlayered', () => {
+    for (const selector of Object.keys(UNLAYERED_BY_DESIGN)) {
+      const parts = selector.split(',').map((part) => part.trim());
+      expect(parts.every((part) => part === 'html' || part === 'body')).toBe(
+        true,
+      );
+      const matching = parsed.filter((rule) => rule.selector === selector);
+      expect(matching.length).toBeGreaterThan(0);
+      expect(matching.every((rule) => !rule.layered)).toBe(true);
+    }
+  });
+
+  it('the body rule still declares the background the exemption protects', () => {
+    const body = parsed.filter(
+      (rule) => rule.selector === 'body' && !rule.layered,
+    );
+    expect(
+      body.some((rule) =>
+        /background-color:\s*var\(--theme-bg-primary\)/.test(rule.declarations),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not force the owner background classes into the build', () => {
+    expect(css).not.toMatch(/@source\s+inline\(/);
+  });
+});

--- a/apps/self-hosted/src/styles/components.css
+++ b/apps/self-hosted/src/styles/components.css
@@ -1,117 +1,21 @@
-/* Component Utility Classes - Using Theme Variables */
-
-/* Text Colors */
-.text-theme-primary {
-  color: var(--theme-text-primary);
-}
-
-.text-theme-secondary {
-  color: var(--theme-text-secondary);
-}
-
-.text-theme-muted {
-  color: var(--theme-text-muted);
-}
-
-.text-theme-disabled {
-  color: var(--theme-text-disabled);
-}
-
-.text-theme-accent {
-  color: var(--theme-accent);
-}
-
-/* Background Colors */
-.bg-theme {
-  background-color: var(--theme-bg-primary);
-}
-
-.bg-theme-primary {
-  background-color: var(--theme-bg-primary);
-}
-
-.bg-theme-secondary {
-  background-color: var(--theme-bg-secondary);
-}
-
-.bg-theme-tertiary {
-  background-color: var(--theme-bg-tertiary);
-}
-
-.bg-theme-card {
-  background-color: var(--theme-bg-card);
-}
-
-.bg-theme-hover {
-  background-color: var(--theme-bg-secondary);
-}
-
-.hover\:bg-theme-hover:hover {
-  background-color: var(--theme-bg-tertiary);
-}
-
-/* Font Families */
-.font-theme-body {
-  font-family: var(--theme-font-body);
-}
-
-.font-theme-heading {
-  font-family: var(--theme-font-heading);
-}
-
-.font-theme-ui {
-  font-family: var(--theme-font-ui);
-}
-
-.font-theme-mono {
-  font-family: var(--theme-font-mono);
-}
-
-/* Borders */
-.border-theme {
-  border-color: var(--theme-border);
-}
-
-.border-theme-strong {
-  border-color: var(--theme-border-strong);
-}
-
-/* Selected-state border, the counterpart of .text-theme-accent. The tipping
-   currency cards already asked for this class; without it the selected card
-   fell back to Tailwind's default currentColor border. */
-.border-theme-accent {
-  border-color: var(--theme-accent);
-}
-
-/* Border Radius */
-.rounded-theme-sm {
-  border-radius: var(--theme-radius-sm);
-}
-
-.rounded-theme {
-  border-radius: var(--theme-radius);
-}
-
-.rounded-theme-lg {
-  border-radius: var(--theme-radius-lg);
-}
-
-.rounded-theme-full {
-  border-radius: var(--theme-radius-full);
-}
-
-/* Shadows */
-.shadow-theme-sm {
-  box-shadow: var(--theme-shadow-sm);
-}
-
-.shadow-theme {
-  box-shadow: var(--theme-shadow);
-}
-
-.shadow-theme-lg {
-  box-shadow: var(--theme-shadow-lg);
-}
+/*
+ * Composite theme classes.
+ *
+ * Invariant: no rule here may name a class that a namespace in
+ * theme-tokens.css generates. These rules are unlayered, so a survivor would
+ * beat the generated utility and, worse, keep every `hover:`, `focus:` and
+ * `placeholder:` variant of it dead. src/styles/theme-classes.test.ts fails on
+ * a class that is both generated and hand-written.
+ *
+ * What lives here: composites that set several properties at once, the few
+ * single-property classes Tailwind has no namespace for (`content-width-theme`,
+ * `layout-gap-theme`, `transition-theme`), and the ancestor-scoped [data-*]
+ * blocks that drive layout from the tenant config.
+ *
+ * These stay unlayered on purpose. A composite applied to an element that still
+ * carries the utilities it replaces produces the composite's look, not the old
+ * one, so a missed cleanup is visible rather than a silent no-op.
+ */
 
 /* Typography Combinations */
 .heading-theme {
@@ -192,19 +96,6 @@
 
 .transition-theme-slow {
   transition: all var(--theme-transition-slow);
-}
-
-/* Icon Colors (for use with SVG icons) */
-.icon-theme-primary {
-  color: var(--theme-text-primary);
-}
-
-.icon-theme-muted {
-  color: var(--theme-text-muted);
-}
-
-.icon-theme-accent {
-  color: var(--theme-accent);
 }
 
 /* Meta text style (for dates, stats, etc.) */

--- a/apps/self-hosted/src/styles/theme-classes.test.ts
+++ b/apps/self-hosted/src/styles/theme-classes.test.ts
@@ -48,15 +48,7 @@ const UI_SRC = resolve(APP, '..', '..', 'packages', 'ui', 'src');
  * it starts working, and a newly dead class fails the emission check instead of
  * being added.
  */
-const KNOWN_UNREGISTERED: Record<string, string> = {
-  'focus:ring-theme-strong': 'no ring-theme-strong rule and no namespace',
-  'hover:bg-theme-secondary': 'variant of a hand-written class',
-  'hover:bg-theme-tertiary': 'variant of a hand-written class',
-  'hover:border-theme': 'variant of a hand-written class',
-  'hover:border-theme-strong': 'variant of a hand-written class',
-  'hover:text-theme-primary': 'variant of a hand-written class',
-  'placeholder:text-theme-muted': 'variant of a hand-written class',
-};
+const KNOWN_UNREGISTERED: Record<string, string> = {};
 
 /** Controls. Ordinary Tailwind classes, to prove the harness can see emission. */
 const CONTROLS = ['bg-red-500', 'hover:bg-red-500'];

--- a/apps/self-hosted/src/styles/theme-classes.test.ts
+++ b/apps/self-hosted/src/styles/theme-classes.test.ts
@@ -1,0 +1,349 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { compile } from 'tailwindcss';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Every `*-theme*` class the app writes must actually produce CSS.
+ *
+ * Tailwind cannot generate a variant for a class it did not create. The theme
+ * classes were hand-written rules in components.css, so `bg-theme-tertiary`
+ * rendered while `hover:bg-theme-tertiary` rendered nothing at all, silently,
+ * on every instance. Nobody noticed for as long as the classes have existed:
+ * 28 hover and focus states were written, reviewed and shipped dead.
+ *
+ * The check compiles the real src/globals.css with the project's own Tailwind
+ * and asks, for each class literal the components actually write, whether the
+ * stylesheet ends up containing a rule for it. Two ways that can be true:
+ *
+ *   generated  the class adds bytes when fed to the compiler as a candidate,
+ *              which is what a registered @theme namespace does
+ *   authored   a rule for the class is already in the baseline, which is what
+ *              the multi-property composites in components.css are
+ *
+ * Neither is enough on its own, and both at once is its own defect: an authored
+ * rule in components.css is unlayered, so it beats the generated utility and
+ * every variant of it, which is the exact failure this file exists to catch.
+ * `theme-classes emit exactly one rule` fails on that.
+ *
+ * Candidates are read through the TypeScript checker from `className` /
+ * `class` attributes and `clsx()` arguments rather than lexically, because a
+ * lexical sweep picks up `data-theme` (an attribute name, not a class) and
+ * config paths such as `configuration.general.theme`.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP = resolve(HERE, '..', '..');
+const SRC = join(APP, 'src');
+const UI_SRC = resolve(APP, '..', '..', 'packages', 'ui', 'src');
+
+/**
+ * Classes with no rule and no namespace, allowed only because they are already
+ * broken on `develop` and are removed by a named step rather than by this file.
+ *
+ * The list may shrink and must never grow: a stale entry fails
+ * `every allowlisted class is genuinely dead`, so nothing can hide here after
+ * it starts working, and a newly dead class fails the emission check instead of
+ * being added.
+ */
+const KNOWN_UNREGISTERED: Record<string, string> = {
+  'focus:ring-theme-strong': 'no ring-theme-strong rule and no namespace',
+  'hover:bg-theme-secondary': 'variant of a hand-written class',
+  'hover:bg-theme-tertiary': 'variant of a hand-written class',
+  'hover:border-theme': 'variant of a hand-written class',
+  'hover:border-theme-strong': 'variant of a hand-written class',
+  'hover:text-theme-primary': 'variant of a hand-written class',
+  'placeholder:text-theme-muted': 'variant of a hand-written class',
+};
+
+/** Controls. Ordinary Tailwind classes, to prove the harness can see emission. */
+const CONTROLS = ['bg-red-500', 'hover:bg-red-500'];
+
+const CLASS_ATTRIBUTES = new Set(['className', 'class']);
+const CLASS_HELPERS = new Set(['clsx', 'classNames', 'cn']);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      walk(path, out);
+    } else if (/\.tsx?$/.test(path) && !/\.test\.tsx?$/.test(path)) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/**
+ * String literal values of a type, or null when the type is not made only of
+ * string literals. A union of literals (a ternary) yields every branch; a plain
+ * `string` yields null so the caller falls back to walking the expression.
+ */
+function literalStrings(type: ts.Type): string[] | null {
+  const parts = type.isUnion() ? type.types : [type];
+  const out: string[] = [];
+  for (const part of parts) {
+    if (part.isStringLiteral()) {
+      out.push(part.value);
+    } else {
+      return null;
+    }
+  }
+  return out.length > 0 ? out : null;
+}
+
+function collectTokens(
+  node: ts.Node | undefined,
+  checker: ts.TypeChecker,
+  into: Set<string>,
+): void {
+  if (!node) return;
+
+  if (ts.isJsxExpression(node)) {
+    collectTokens(node.expression, checker, into);
+    return;
+  }
+
+  // A literal in a `className` position is contextually typed by the prop, so
+  // the checker widens it to `string`. Read those syntactically; the checker is
+  // for the values it can reach and the syntax cannot, such as an identifier
+  // bound to a module-level class string, possibly in another file.
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    for (const token of node.text.split(/\s+/)) if (token) into.add(token);
+    return;
+  }
+
+  const literals = ts.isExpression(node)
+    ? literalStrings(checker.getTypeAtLocation(node))
+    : null;
+  if (literals) {
+    for (const value of literals) {
+      for (const token of value.split(/\s+/)) if (token) into.add(token);
+    }
+    return;
+  }
+
+  if (ts.isTemplateExpression(node)) {
+    for (const token of node.head.text.split(/\s+/)) if (token) into.add(token);
+    for (const span of node.templateSpans) {
+      collectTokens(span.expression, checker, into);
+      for (const token of span.literal.text.split(/\s+/))
+        if (token) into.add(token);
+    }
+    return;
+  }
+  if (ts.isConditionalExpression(node)) {
+    collectTokens(node.whenTrue, checker, into);
+    collectTokens(node.whenFalse, checker, into);
+    return;
+  }
+  if (ts.isBinaryExpression(node)) {
+    collectTokens(node.left, checker, into);
+    collectTokens(node.right, checker, into);
+    return;
+  }
+  if (ts.isParenthesizedExpression(node)) {
+    collectTokens(node.expression, checker, into);
+    return;
+  }
+  if (ts.isArrayLiteralExpression(node)) {
+    for (const element of node.elements) collectTokens(element, checker, into);
+    return;
+  }
+  if (ts.isObjectLiteralExpression(node)) {
+    // clsx({ 'bg-theme': cond }) keys the class off the property name.
+    for (const property of node.properties) {
+      if (!ts.isPropertyAssignment(property)) continue;
+      const name = property.name;
+      if (ts.isStringLiteral(name) || ts.isIdentifier(name)) {
+        for (const token of name.text.split(/\s+/)) if (token) into.add(token);
+      }
+    }
+    return;
+  }
+  if (
+    ts.isCallExpression(node) &&
+    CLASS_HELPERS.has(node.expression.getText())
+  ) {
+    for (const argument of node.arguments)
+      collectTokens(argument, checker, into);
+  }
+}
+
+/** Every class literal written into a `className` / `class` prop or clsx(). */
+function classLiterals(): Map<string, string[]> {
+  const configPath = join(APP, 'tsconfig.json');
+  const { config } = ts.readConfigFile(configPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(config ?? {}, ts.sys, APP);
+  const program = ts.createProgram(
+    [...parsed.fileNames, ...walk(UI_SRC)],
+    parsed.options,
+  );
+  const checker = program.getTypeChecker();
+
+  const sites = new Map<string, string[]>();
+  for (const source of program.getSourceFiles()) {
+    if (source.isDeclarationFile) continue;
+    const file = source.fileName;
+    if (!file.startsWith(SRC) && !file.startsWith(UI_SRC)) continue;
+    if (/\.test\.tsx?$/.test(file)) continue;
+
+    const tokens = new Set<string>();
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isJsxAttribute(node) &&
+        CLASS_ATTRIBUTES.has(node.name.getText())
+      ) {
+        collectTokens(node.initializer, checker, tokens);
+      } else if (
+        ts.isCallExpression(node) &&
+        CLASS_HELPERS.has(node.expression.getText())
+      ) {
+        for (const argument of node.arguments)
+          collectTokens(argument, checker, tokens);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+
+    for (const token of tokens) {
+      const at = sites.get(token) ?? [];
+      at.push(relative(APP, file));
+      sites.set(token, at);
+    }
+  }
+  return sites;
+}
+
+/**
+ * A config path such as `configuration.general.theme` is a string in a
+ * `clsx()`-adjacent position often enough to matter. Tailwind's own dotted
+ * tokens are numeric (`p-1.5`) or bracketed (`leading-[1.04]`).
+ */
+function isConfigPathLike(token: string): boolean {
+  if (!token.includes('.')) return false;
+  if (token.includes('[')) return false;
+  return !/\d\.\d/.test(token);
+}
+
+function themeCandidates(sites: Map<string, string[]>): string[] {
+  return [...sites.keys()]
+    .filter((token) => token.includes('theme'))
+    .filter((token) => !isConfigPathLike(token))
+    .filter((token) => /^[a-z0-9][a-z0-9:/[\]().,%_!-]*$/i.test(token))
+    .sort();
+}
+
+async function loadStylesheet(id: string, base: string) {
+  const path = id.startsWith('tailwindcss')
+    ? join(
+        APP,
+        'node_modules',
+        id === 'tailwindcss' ? 'tailwindcss/index.css' : id,
+      )
+    : resolve(base, id);
+  return {
+    path,
+    base: dirname(path),
+    content: readFileSync(path, 'utf8'),
+  };
+}
+
+/**
+ * `compile()` is incremental: a compiler keeps every candidate it has been
+ * given, so a second build() reports the first build's bytes too. Each
+ * measurement therefore gets its own compiler.
+ */
+async function compileWith(candidates: string[]): Promise<string> {
+  const compiler = await compile(
+    readFileSync(join(SRC, 'globals.css'), 'utf8'),
+    { base: SRC, loadStylesheet },
+  );
+  return compiler.build(candidates);
+}
+
+/** `hover:bg-theme` -> `.hover\:bg-theme`, the selector Tailwind writes. */
+function escapeClass(name: string): string {
+  return `.${name.replace(/[.:/[\]()!%,]/g, (char) => `\\${char}`)}`;
+}
+
+/** How many rules in `css` target exactly this class. */
+function ruleCount(css: string, name: string): number {
+  const selector = escapeClass(name);
+  let count = 0;
+  let at = css.indexOf(selector);
+  while (at !== -1) {
+    const next = css[at + selector.length] ?? '';
+    // `.bg-theme` must not match inside `.bg-theme-primary`.
+    if (!/[a-zA-Z0-9_-]/.test(next)) count += 1;
+    at = css.indexOf(selector, at + 1);
+  }
+  return count;
+}
+
+describe('theme classes', () => {
+  const sites = classLiterals();
+  const candidates = themeCandidates(sites);
+
+  it('the harness sees ordinary Tailwind classes emit', async () => {
+    const baseline = (await compileWith([])).length;
+    for (const control of CONTROLS) {
+      expect((await compileWith([control])).length).toBeGreaterThan(baseline);
+    }
+    expect(candidates.length).toBeGreaterThan(20);
+  });
+
+  it('every theme class the components write produces CSS', async () => {
+    const baseline = await compileWith([]);
+    const dead: string[] = [];
+
+    for (const candidate of candidates) {
+      const generated =
+        (await compileWith([candidate])).length > baseline.length;
+      const authored = ruleCount(baseline, candidate) > 0;
+      if (!generated && !authored) dead.push(candidate);
+    }
+
+    const unexpected = dead.filter((name) => !(name in KNOWN_UNREGISTERED));
+    expect(
+      unexpected.map((name) => `${name} (${sites.get(name)?.join(', ')})`),
+    ).toEqual([]);
+  });
+
+  it('every allowlisted class is genuinely dead', async () => {
+    const baseline = await compileWith([]);
+    const alive: string[] = [];
+
+    for (const name of Object.keys(KNOWN_UNREGISTERED)) {
+      const generated = (await compileWith([name])).length > baseline.length;
+      const authored = ruleCount(baseline, name) > 0;
+      if (generated || authored) alive.push(name);
+    }
+
+    expect(alive).toEqual([]);
+  });
+
+  it('no theme class is both generated and hand-written', async () => {
+    const baseline = await compileWith([]);
+    const duplicated: string[] = [];
+
+    for (const candidate of candidates) {
+      const authored = ruleCount(baseline, candidate);
+      if (authored === 0) continue;
+      const withCandidate = await compileWith([candidate]);
+      if (withCandidate.length > baseline.length) {
+        duplicated.push(candidate);
+        continue;
+      }
+      // A rule that survives a namespace registration would win over the
+      // generated utility, because components.css is unlayered.
+      if (ruleCount(withCandidate, candidate) > authored) {
+        duplicated.push(candidate);
+      }
+    }
+
+    expect(duplicated).toEqual([]);
+  });
+});

--- a/apps/self-hosted/src/styles/theme-tokens.css
+++ b/apps/self-hosted/src/styles/theme-tokens.css
@@ -1,0 +1,81 @@
+/*
+ * Theme tokens registered as Tailwind namespaces.
+ *
+ * Everything here exists so that `hover:bg-theme-tertiary` produces CSS.
+ * Tailwind cannot generate a variant for a class it did not create, and the
+ * theme classes used to be hand-written rules in components.css, so the base
+ * class rendered and every variant of it rendered nothing: 28 hover and focus
+ * states were written, reviewed and shipped dead.
+ *
+ * `inline` is deliberate. It emits nothing onto `:root`, and the generated
+ * utility carries `var(--theme-bg-primary)` itself rather than a copy of its
+ * value, so every utility re-resolves against whatever element carries
+ * `[data-style-template]` or `[data-theme]` instead of resolving once against
+ * <html>.
+ *
+ * Per-utility namespaces, not `--color-*`, because the theme's names collide
+ * inside one colour namespace: `--color-theme-secondary` would have to generate
+ * both `bg-theme-secondary` (which must read --theme-bg-secondary) and
+ * `text-theme-secondary` (which must read --theme-text-secondary) from a single
+ * value, and `--color-theme` would have to serve both `bg-theme`
+ * (--theme-bg-primary) and `border-theme` (--theme-border, 40 call sites).
+ * Splitting by utility keeps every existing class name and value intact across
+ * roughly 300 call sites, with no renames.
+ *
+ * The accent is the one family with no collision, so it takes the whole colour
+ * namespace and `bg-`, `border-` and `ring-` all get the raw fill.
+ * `--text-color-theme-accent` then overrides `text-theme-accent` alone, which is
+ * what will let the accent *text* be contrast-corrected while the accent *fill*
+ * stays exactly the colour that was asked for.
+ *
+ * What does NOT belong here: anything setting more than one property. Those
+ * stay hand-written and unlayered in components.css, so that a composite
+ * applied over the utilities it replaces produces the composite's look rather
+ * than silently keeping the old one. See the invariant at the top of that file.
+ */
+/* biome-ignore lint/suspicious/noUnknownAtRules: @theme is a Tailwind v4 feature */
+@theme inline {
+  /* surfaces: bg-* only */
+  --background-color-theme: var(--theme-bg-primary);
+  --background-color-theme-primary: var(--theme-bg-primary);
+  --background-color-theme-secondary: var(--theme-bg-secondary);
+  --background-color-theme-tertiary: var(--theme-bg-tertiary);
+  --background-color-theme-card: var(--theme-bg-card);
+  /*
+   * `bg-theme-hover` was two different colours: the bare class was
+   * --theme-bg-secondary and the hand-written `hover:` variant was
+   * --theme-bg-tertiary. One namespace entry cannot be both, so it is the
+   * tertiary the six live `hover:bg-theme-hover` sites actually show, and the
+   * two bare uses were rewritten to `bg-theme-secondary`, which is what they
+   * already meant.
+   */
+  --background-color-theme-hover: var(--theme-bg-tertiary);
+
+  /* text: text-* only */
+  --text-color-theme-primary: var(--theme-text-primary);
+  --text-color-theme-secondary: var(--theme-text-secondary);
+  --text-color-theme-muted: var(--theme-text-muted);
+  --text-color-theme-accent: var(--theme-accent-text, var(--theme-accent));
+
+  /* borders: border-* only */
+  --border-color-theme: var(--theme-border);
+  --border-color-theme-strong: var(--theme-border-strong);
+
+  /* accent: the one collision-free family, gets the whole colour namespace */
+  --color-theme-accent: var(--theme-accent);
+  --color-theme-accent-contrast: var(--theme-accent-contrast, #ffffff);
+
+  --radius-theme-sm: var(--theme-radius-sm);
+  --radius-theme: var(--theme-radius);
+  --radius-theme-lg: var(--theme-radius-lg);
+  --radius-theme-full: var(--theme-radius-full);
+
+  --font-theme-body: var(--theme-font-body);
+  --font-theme-heading: var(--theme-font-heading);
+  --font-theme-ui: var(--theme-font-ui);
+  --font-theme-mono: var(--theme-font-mono);
+
+  --shadow-theme-sm: var(--theme-shadow-sm);
+  --shadow-theme: var(--theme-shadow);
+  --shadow-theme-lg: var(--theme-shadow-lg);
+}


### PR DESCRIPTION
Foundation for the self-hosted appearance work: the cascade fix, and the theme
tokens registered as real Tailwind namespaces. No new config knob and no new
editor code, both of which depend on this landing first.

## Why

Tailwind cannot generate a variant for a class it did not create. The theme
classes were hand-written rules in `components.css`, so `bg-theme-tertiary`
rendered and `hover:bg-theme-tertiary` rendered nothing at all. 28 hover and
focus states across the app were written, reviewed and shipped dead, which is
most of the reason the reader surface does not react to the cursor.

Separately, every element rule in `globals.css` was unlayered, and an unlayered
normal declaration beats a layered one whatever the specificity. So `a { color:
inherit }` beat `text-theme-accent`, `img { height: auto }` beat `h-48`,
`h1 { font-weight: 700 }` beat `font-semibold`, and `* { font-family: inherit }`
beat `font-mono`. That is why `no-underline` in the feed navigation did nothing
while the comment above it said it did, and why two call sites had reached for
`!` to make an ordinary utility apply.

## What changed

**1. Element rules move into `@layer base`.** The `<html>` and `<body>` rules
deliberately stay out of it, and there is a guard that fails if anyone moves
them in:

- `general.styles.background` is a free-form class string an owner types into
  the configuration panel, and it lands on `<body>`. It has never painted,
  because body's own `background-color` outranks any `bg-*` utility the owner
  names. Layering it would hand the win to `bg-black` and `bg-white`, which are
  compiled from elsewhere in the app, while `color: var(--theme-text-primary)`
  stayed put: an unreadable page from a valid value, saved with a 200 OK.
- The responsive `font-size` overrides are body rules for a second reason.
  Layering them while the main body rule stayed unlayered would let
  `var(--theme-text-base)` beat both media queries and shrink desktop body copy
  from 21px to the template base size everywhere.

`a:hover` also loses its `opacity: 0.7`, which multiplied with the
`hover:opacity-70` on the wrapping feed heading to an effective 0.49 and took
headline contrast on hover from 17.06 to 3.28. Its `text-decoration-color`
stays.

**2. `theme-tokens.css` registers the tokens as per-utility namespaces.**
Per-utility rather than `--color-*` because the names collide inside one colour
namespace: `--color-theme-secondary` would have to serve both
`bg-theme-secondary` (`--theme-bg-secondary`) and `text-theme-secondary`
(`--theme-text-secondary`), and `--color-theme` both `bg-theme` and
`border-theme` (`--theme-border`, 40 call sites). Every class name and value is
preserved, so no renames across roughly 300 call sites. `inline` keeps the
indirection, so a generated utility carries `var(--theme-bg-primary)` itself and
re-resolves on any element carrying `[data-style-template]` or `[data-theme]`.

The single-property rules the namespaces regenerate are deleted from
`components.css`; they are unlayered and would beat the generated utility and
keep every variant of it dead. The composites stay hand-written and unlayered on
purpose, so a composite applied over the utilities it replaces produces the
composite's look rather than a silent no-op.

**3. Four call sites**, all consequences of the two changes above:

- `bg-theme-hover` was two different colours: bare it was `--theme-bg-secondary`,
  the hand-written `hover:` variant was `--theme-bg-tertiary`. One namespace
  entry cannot be both, so it is the tertiary that six live sites already show,
  and the two bare uses in the comment form become `bg-theme-secondary`, which
  is the colour they already had.
- `focus:ring-theme-strong` was dead twice over, no rule and no namespace. Both
  sites move to `focus:ring-theme-accent`, which now exists and which both
  already pair with `focus:ring-2`.
- The QR image is the one `<img>` with no height utility, so it says `h-auto`
  now that the base rule can be overridden.
- The create-post button drops the `!` from `no-underline` and `font-serif`,
  which existed only to beat the unlayered rules.

**4. Tests are excluded from the Tailwind scan.** A class-shaped word in a
test's prose ships as a real rule: the fixture strings in
`apply-config-dom.test.ts` were putting five palette utilities into every
instance's stylesheet. That also narrows the surface of the body-class field the
cascade exemption exists to keep inert.

## Measurements

Compiling the real `src/globals.css` through the project's own
`tailwindcss@4.1.18`, one fresh compiler per candidate because `build()` is
incremental:

| | before | after |
|---|---|---|
| baseline, no candidates | 70086 B | 68398 B |
| theme classes that emit nothing | 33 of 33 | 0 of 32 |
| control `bg-red-500` / `hover:bg-red-500` | 115 B / 184 B | unchanged |
| built stylesheet | 111000 B | 109413 B |

Now live, having previously emitted zero: `hover:text-theme-primary` (6 files),
`hover:bg-theme-tertiary` (7), `hover:bg-theme-secondary` (5),
`hover:border-theme-strong` (3), `hover:border-theme` (1),
`placeholder:text-theme-muted` (2), and `focus:ring-theme-accent` replacing the
dead `focus:ring-theme-strong` (2).

Nothing is left dead. The guard's allowlist is empty.

## No appearance change without an owner action

Every generated utility carries the same value as the hand-written rule it
replaces, and the composites are byte-identical and still unlayered, verified by
reading the compiled stylesheet rule by rule. `text-theme-accent` becomes
`var(--theme-accent-text, var(--theme-accent))`; no template declares
`--theme-accent-text`, so it resolves through the fallback to exactly today's
colour, and the fallback is the hook the accent work will use later.

Three deliberate differences:

- Utilities now win over the base rules, which is the point of the change: 32
  `font-*` sites, 11 headings of which 4 drop 700 to the 600 their author wrote,
  the feed card images, and the mobile tap-area padding on `flex items-center
  gap-1` elements, which regain their own horizontal padding.
- `hover:` utilities are wrapped in `@media (hover: hover)`, so hover styles no
  longer stick after a tap on touch devices. That includes the six
  `hover:bg-theme-hover` sites that worked before.
- Inside article bodies, the `pre` and `table` scroll rules from `globals.css`
  now yield to the equivalent unlayered rules in `blog-markdown.css`:
  `overflow-x: auto` becomes `overflow: auto` on a `display: block; width:
  max-content` element, so both still scroll horizontally, and
  `-webkit-overflow-scrolling: touch` is dropped, which is a no-op on iOS 13 and
  later.

## Guards

`src/styles/cascade-layers.test.ts` parses `globals.css` and asserts every rule
other than an `<html>`/`<body>` rule is inside `@layer base`, that every
exempted selector really is an `<html>`/`<body>` rule and is unlayered, that the
body rule still declares the background the exemption protects, and that
`@source inline(` never appears. jsdom does not implement cascade layers, so a
computed-style test here would pass for the wrong reason.

`src/styles/theme-classes.test.ts` reads every class literal from `className`
attributes and `clsx()` arguments through the TypeScript checker, compiles the
real stylesheet, and asserts each theme class ends up with a rule, either
generated by a namespace or authored in `components.css`. It also fails when a
class is both, since an authored rule is unlayered and would beat the utility
and every variant of it.

Mutations verified, each caught by the named test: body rule moved into the
layer; body `background-color` declaration deleted; `@source inline(...)` added;
`img` rule moved back out of the layer; an allowlist entry removed; an allowlist
entry added for a class that is alive; a hand-written `.text-theme-muted`
restored alongside the namespace; `focus:ring-theme-strong` put back into a
component; a namespace entry deleted from `theme-tokens.css`.

## Verification

`vitest run` 427 passing across 44 files, `tsc --noEmit` clean, `rsbuild build`
plus `check-node-globals` clean. Biome reports zero diagnostics on the CSS and
test files added here, and the same count as `develop` on the three component
files, whose pre-existing formatting was left alone.

No rendered pixel is asserted anywhere here. CI proves the CSS exists; only a
look at a live instance proves it looks right.

CI is red for an unrelated reason: `pnpm install --frozen-lockfile` fails on
`nanoid@3.3.17` being inside the `minimumReleaseAge` window, which clears
itself.
