### PR TITLE
Fix advanced search query building, validation and error reporting

### DIFF
--- a/apps/web/src/app/search/_components/search-advanced-form.tsx
+++ b/apps/web/src/app/search/_components/search-advanced-form.tsx
@@ -140,12 +140,15 @@ export function SearchAdvancedForm() {
     const parsed = new SearchQuery(built.q);
     const effective = buildSearchQuery({
       search: parsed.search,
-      author: parsed.author,
-      // A type: token in the free text shadows the select, because the API
-      // reads the first match. Letting the select win when it has a value
-      // drops the unusable token instead of the user's actual choice.
-      type: type || parsed.type,
-      category: parsed.category,
+      // The API keeps only the FIRST author:/type:/category: match, and the
+      // free text is placed ahead of the fields, so a token typed there would
+      // otherwise silently override the field the user filled in. Filling a
+      // field in is the more deliberate signal, so it wins; the token is used
+      // only when its field is empty. Tags are different on purpose: the API
+      // joins every tag: match, so both sources combine.
+      author: built.author || parsed.author,
+      type: built.type || parsed.type,
+      category: built.category || parsed.category,
       tags: parsed.tags
     });
 

--- a/apps/web/src/app/search/_components/search-advanced-form.tsx
+++ b/apps/web/src/app/search/_components/search-advanced-form.tsx
@@ -2,101 +2,180 @@ import i18next from "i18next";
 import { FormControl } from "@ui/input";
 import { Button } from "@ui/button";
 import React, { useEffect, useState } from "react";
-import { SearchQuery, SearchType } from "@/utils/search-query";
+import {
+  buildSearchQuery,
+  MAX_SEARCH_QUERY_LENGTH,
+  MAX_SEARCH_TAGS,
+  SearchQuery,
+  SearchType
+} from "@/utils/search-query";
 import { DateOpt } from "@/enums";
 import { SearchSort } from "@/app/decks/_components/consts";
-import useLocalStorage from "react-use/lib/useLocalStorage";
-import { useRouter, useSearchParams } from "next/navigation";
+import { ReadonlyURLSearchParams, useRouter, useSearchParams } from "next/navigation";
+
+interface FormValues {
+  search: string;
+  author: string;
+  type: SearchType;
+  category: string;
+  tags: string;
+  date: DateOpt;
+  sort: SearchSort;
+  hideLow: boolean;
+  includeNsfw: boolean;
+}
+
+function enumValue<T extends Record<string, string>>(
+  e: T,
+  value: string | null | undefined,
+  fallback: T[keyof T]
+): T[keyof T] {
+  return Object.values(e).includes(value as string) ? (value as T[keyof T]) : fallback;
+}
+
+function readFormValues(params: ReadonlyURLSearchParams | null): FormValues {
+  const searchQuery = new SearchQuery(params?.get("q") ?? "");
+
+  return {
+    // The tokens are shown in their own fields, so the free text field gets the
+    // stripped remainder. Seeding it with the raw query re-appended every filter
+    // on each apply until q blew past the API's length cap.
+    search: searchQuery.search,
+    author: searchQuery.author,
+    type: searchQuery.type,
+    category: searchQuery.category,
+    tags: searchQuery.tags.join(","),
+    date: enumValue(DateOpt, params?.get("date"), DateOpt.A),
+    sort: enumValue(SearchSort, params?.get("sort"), SearchSort.RELEVANCE),
+    hideLow: params?.get("hd") !== "0",
+    includeNsfw: params?.get("nsfw") === "1"
+  };
+}
 
 export function SearchAdvancedForm() {
   const router = useRouter();
   const params = useSearchParams();
 
-  const [search, setSearch] = useState("");
-  const [author, setAuthor] = useState("");
-  const [type, setType] = useState<SearchType>(SearchType.ALL);
-  const [category, setCategory] = useState("");
-  const [tags, setTags] = useState("");
-  const [date, setDate] = useLocalStorage<DateOpt>("recent_date", DateOpt.A);
-  const [sort, setSort] = useState<SearchSort>(SearchSort.RELEVANCE);
-  const [hideLow, setHideLow] = useState(false);
-  const [includeNsfw, setIncludeNsfw] = useState(false);
+  // Seeded on the first render rather than from an effect, otherwise every
+  // mount painted the defaults before the URL values replaced them - visible as
+  // the hide-low checkbox flashing unchecked.
+  const [initialValues] = useState(() => readFormValues(params));
+
+  const [search, setSearch] = useState(initialValues.search);
+  const [author, setAuthor] = useState(initialValues.author);
+  const [type, setType] = useState<SearchType>(initialValues.type);
+  const [category, setCategory] = useState(initialValues.category);
+  const [tags, setTags] = useState(initialValues.tags);
+  // Deliberately component state: this used to be the "recent_date" localStorage
+  // entry shared with the decks add-column form, so the two features overwrote
+  // each other and an untouched select silently reapplied a stale value.
+  const [date, setDate] = useState<DateOpt>(initialValues.date);
+  const [sort, setSort] = useState<SearchSort>(initialValues.sort);
+  const [hideLow, setHideLow] = useState(initialValues.hideLow);
+  const [includeNsfw, setIncludeNsfw] = useState(initialValues.includeNsfw);
+  const [error, setError] = useState("");
 
   useEffect(() => {
-    const q = params?.get("q");
-    if (q) {
-      const searchQuery = new SearchQuery(q);
-      setAuthor(searchQuery.author);
-      setType(searchQuery.type);
-      setCategory(searchQuery.category);
-      setTags(searchQuery.tags.join(","));
-      setSearch(searchQuery.query);
-    }
+    // Keep the panel in sync when the URL changes under it - navbar search,
+    // browser history. On mount these all match the seeded values.
+    const values = readFormValues(params);
+    setSearch(values.search);
+    setAuthor(values.author);
+    setType(values.type);
+    setCategory(values.category);
+    setTags(values.tags);
+    setDate(values.date);
+    setSort(values.sort);
+    setHideLow(values.hideLow);
+    setIncludeNsfw(values.includeNsfw);
+    // The fields the message pointed at are gone, so the message goes with them.
+    setError("");
+  }, [params]);
 
-    setSort((params?.get("sort") as SearchSort) ?? SearchSort.RELEVANCE);
-    setHideLow(params?.get("hd") !== "0");
-    setIncludeNsfw(params?.get("nsfw") === "1");
-    const urlDate = params?.get("date") as DateOpt | null;
-    if (urlDate) {
-      setDate(urlDate);
-    }
-  }, [params, setDate]);
-
-  const searchChanged = (e: React.ChangeEvent<HTMLInputElement>): void =>
-    setSearch(e.currentTarget.value);
-  const authorChanged = (e: React.ChangeEvent<HTMLInputElement>): void =>
-    setAuthor(e.target.value.trim());
-  const typeChanged = (e: React.ChangeEvent<HTMLSelectElement>): void =>
+  const searchChanged = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    setError("");
+    setSearch(e.target.value);
+  };
+  // No trimming while typing on the filter fields - it makes a trailing space
+  // impossible to type. They are normalized when the query is built instead.
+  const authorChanged = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    setError("");
+    setAuthor(e.target.value);
+  };
+  const typeChanged = (e: React.ChangeEvent<HTMLSelectElement>): void => {
+    setError("");
     setType(e.target.value as SearchType);
-  const categoryChanged = (e: React.ChangeEvent<HTMLInputElement>): void =>
-    setCategory(e.target.value.trim());
-  const tagsChanged = (e: React.ChangeEvent<HTMLInputElement>): void =>
-    setTags(e.target.value.trim());
-  const dateChanged = (e: React.ChangeEvent<HTMLSelectElement>): void =>
+  };
+  const categoryChanged = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    setError("");
+    setCategory(e.target.value);
+  };
+  const tagsChanged = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    setError("");
+    setTags(e.target.value);
+  };
+  const dateChanged = (e: React.ChangeEvent<HTMLSelectElement>): void => {
+    setError("");
     setDate(e.target.value as DateOpt);
-
-  const sortChanged = (e: React.ChangeEvent<HTMLSelectElement>): void =>
+  };
+  const sortChanged = (e: React.ChangeEvent<HTMLSelectElement>): void => {
+    setError("");
     setSort(e.target.value as SearchSort);
+  };
 
   const textInputDown = (e: React.KeyboardEvent) => {
-    if (e.keyCode === 13) {
+    if (e.key === "Enter") {
       apply();
     }
   };
 
-  const buildQuery = () => {
-    let q = search;
-
-    if (author) {
-      q += ` author:${author}`;
-    }
-
-    if (type) {
-      q += ` type:${type}`;
-    }
-
-    if (category) {
-      q += ` category:${category}`;
-    }
-
-    if (tags) {
-      q += ` tag:${tags}`;
-    }
-
-    return q;
-  };
-
   const apply = () => {
-    const q = buildQuery();
+    const built = buildSearchQuery({ search, author, type, category, tags });
+    // The free text field can hold token syntax of its own ("author:@Demo",
+    // "tag:a,b,c"), which both parsers read back as a filter. Re-parsing and
+    // rebuilding normalizes those tokens the same way the dedicated fields are
+    // normalized, makes the guards below measure what is actually sent, and
+    // keeps build -> parse -> rebuild a fixed point - without it the same
+    // search missed on the first Apply and matched on the second.
+    const parsed = new SearchQuery(built.q);
+    const effective = buildSearchQuery({
+      search: parsed.search,
+      author: parsed.author,
+      // A type: token in the free text shadows the select, because the API
+      // reads the first match. Letting the select win when it has a value
+      // drops the unusable token instead of the user's actual choice.
+      type: type || parsed.type,
+      category: parsed.category,
+      tags: parsed.tags
+    });
 
-    const params = new URLSearchParams();
-    params.append("q", q);
-    params.append("date", date ?? DateOpt.A);
-    params.append("sort", sort);
-    params.append("adv", "1");
-    if (!hideLow) params.append("hd", "0");
-    if (includeNsfw) params.append("nsfw", "1");
-    router.push(`?${params.toString()}`);
+    // A filter with no free text is a valid search ("everything by @user"), but
+    // a bare type: is not selective enough and the API rejects it.
+    if (!effective.search && !effective.author && !effective.category && effective.tags.length === 0) {
+      setError(i18next.t("search-comment.error-no-criteria"));
+      return;
+    }
+
+    if (effective.tags.length > MAX_SEARCH_TAGS) {
+      setError(i18next.t("search-comment.error-too-many-tags", { n: MAX_SEARCH_TAGS }));
+      return;
+    }
+
+    if (effective.q.length > MAX_SEARCH_QUERY_LENGTH) {
+      setError(i18next.t("search-comment.error-too-long", { n: MAX_SEARCH_QUERY_LENGTH }));
+      return;
+    }
+
+    setError("");
+
+    const nextParams = new URLSearchParams();
+    nextParams.append("q", effective.q);
+    nextParams.append("date", date);
+    nextParams.append("sort", sort);
+    nextParams.append("adv", "1");
+    if (!hideLow) nextParams.append("hd", "0");
+    if (includeNsfw) nextParams.append("nsfw", "1");
+    router.push(`?${nextParams.toString()}`);
   };
 
   return (
@@ -124,7 +203,7 @@ export function SearchAdvancedForm() {
         </div>
         <div className="col-span-12 sm:col-span-2 mb-4">
           <label>{i18next.t("search-comment.type")}</label>
-          <FormControl type="select" value={type} onChange={typeChanged}>
+          <FormControl type="select" value={type} onChange={typeChanged} onKeyDown={textInputDown}>
             {Object.values(SearchType).map((x) => (
               <option value={x} key={x}>
                 {i18next.t(`search-comment.type-${x}`)}
@@ -156,7 +235,7 @@ export function SearchAdvancedForm() {
         </div>
         <div className="col-span-12 sm:col-span-2 mb-4">
           <label>{i18next.t("search-comment.date")}</label>
-          <FormControl type="select" value={date ?? DateOpt.A} onChange={dateChanged}>
+          <FormControl type="select" value={date} onChange={dateChanged} onKeyDown={textInputDown}>
             {Object.values(DateOpt).map((x) => (
               <option value={x} key={x}>
                 {i18next.t(`search-comment.date-${x}`)}
@@ -166,7 +245,7 @@ export function SearchAdvancedForm() {
         </div>
         <div className="col-span-12 sm:col-span-2 mb-4">
           <label>{i18next.t("search-comment.sort")}</label>
-          <FormControl type="select" value={sort} onChange={sortChanged}>
+          <FormControl type="select" value={sort} onChange={sortChanged} onKeyDown={textInputDown}>
             {Object.values(SearchSort).map((x) => (
               <option value={x} key={x}>
                 {i18next.t(`search-comment.sort-${x}`)}
@@ -175,25 +254,38 @@ export function SearchAdvancedForm() {
           </FormControl>
         </div>
       </div>
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-center gap-4">
         <div className="flex items-center gap-4">
           <FormControl
             id="hide-low"
             type="checkbox"
             label={i18next.t("search-comment.hide-low")}
             checked={hideLow}
-            onChange={(v) => setHideLow(v)}
+            onChange={(v) => {
+              setError("");
+              setHideLow(v);
+            }}
           />
           <FormControl
             id="include-nsfw"
             type="checkbox"
             label={i18next.t("search-comment.include-nsfw")}
             checked={includeNsfw}
-            onChange={(v) => setIncludeNsfw(v)}
+            onChange={(v) => {
+              setError("");
+              setIncludeNsfw(v);
+            }}
           />
         </div>
 
-        <Button onClick={apply}>{i18next.t("g.apply")}</Button>
+        <div className="flex items-center gap-3">
+          {error && (
+            <div className="text-sm text-red-500" role="alert">
+              {error}
+            </div>
+          )}
+          <Button onClick={apply}>{i18next.t("g.apply")}</Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/search/_components/search-comment/index.tsx
+++ b/apps/web/src/app/search/_components/search-comment/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo, useState } from "react";
+import React, { Fragment, useCallback, useMemo, useState } from "react";
 import numeral from "numeral";
 import dayjs, { Dayjs } from "@/utils/dayjs";
 import "./_index.scss";
@@ -19,9 +19,15 @@ interface Props {
 }
 
 export function SearchComment({ disableResults }: Props) {
-  const [advanced, setAdvanced] = useState(false);
-
   const params = useSearchParams();
+
+  // The advanced form writes adv=1 when it applies filters, so a reloaded or
+  // shared advanced-search URL has to show the panel the active filters belong
+  // to. The URL only seeds it - once the user toggles, that choice wins.
+  const [advancedToggle, setAdvancedToggle] = useState<boolean>();
+  const advanced = advancedToggle ?? params?.get("adv") === "1";
+
+  const q = params?.get("q") ?? "";
 
   const since = useMemo(() => {
     let sinceDate: Dayjs | undefined;
@@ -49,20 +55,26 @@ export function SearchComment({ disableResults }: Props) {
   const {
     data: resultsPages,
     dataUpdatedAt,
-    isLoading,
+    isError,
     isFetching,
     fetchNextPage,
     hasNextPage
   } = useInfiniteQuery({
     ...getSearchApiInfiniteQueryOptions(
-      params?.get("q") ?? "",
+      q,
       params?.get("sort") ?? SearchSort.RELEVANCE,
       params?.get("hd") !== "0",
       since,
       undefined,
       params?.get("nsfw") === "1" || undefined
-    ),
-    initialData: { pages: [], pageParams: [] }
+    )
+    // No `initialData` here on purpose. Seeding it made `state.data` defined,
+    // which is exactly what shouldLoadOnMount checks, so React Query never
+    // fetched page 1 and the bottom sentinel was the only thing that could
+    // start it (refetchOnMount is false app-wide). That held only while the
+    // sentinel was near the top of a short card: with the advanced panel open
+    // from adv=1, on a phone the sentinel starts below the fold and page 1 was
+    // never requested at all. The sentinel now does what it says, pagination.
   });
   const results = useMemo(
     () =>
@@ -71,19 +83,33 @@ export function SearchComment({ disableResults }: Props) {
     [resultsPages]
   );
 
-  // initialData seeds this query as "success" with zero pages, so the bottom
-  // sentinel is also what bootstraps page 1 — see useBottomPagination.
-  const onBottom = useBottomPagination({
+  // Read the doc comment on this hook before changing anything around it.
+  const loadMore = useBottomPagination({
     data: resultsPages,
     dataUpdatedAt,
     hasNextPage,
     isFetching,
     fetchNextPage
   });
+  // fetchNextPage does not consult `enabled`, so on /search with no q the
+  // sentinel would still post an empty query and collect a 400. The identity
+  // changes with q, which is what re-runs the sentinel's effect once a query
+  // does arrive.
+  const onBottom = useCallback(() => {
+    if (q) {
+      loadMore();
+    }
+  }, [loadMore, q]);
   const hits = useMemo(
     () => resultsPages?.pages?.[resultsPages?.pages?.length - 1]?.hits ?? 0,
     [resultsPages?.pages]
   );
+
+  // There is a first page coming whenever a query is set and none has landed
+  // yet, which covers the gap between mount and the fetch resolving. Derived
+  // from the pages rather than isLoading so it stays true across the whole gap,
+  // and gates the empty message only - never the sentinel.
+  const isFirstPagePending = !!q && !isError && (resultsPages?.pages?.length ?? 0) === 0;
 
   return (
     <div className="border dark:border-dark-400 overflow-hidden bg-white rounded search-comment">
@@ -113,7 +139,7 @@ export function SearchComment({ disableResults }: Props) {
           href="#"
           onClick={(e) => {
             e.preventDefault();
-            setAdvanced(!advanced);
+            setAdvancedToggle(!advanced);
           }}
         >
           {advanced ? i18next.t("g.close") : i18next.t("search-comment.advanced")}
@@ -142,14 +168,29 @@ export function SearchComment({ disableResults }: Props) {
             );
           }
 
-          if (!isLoading) {
-            return <span>{i18next.t("g.no-matches")}</span>;
+          // Checked after the results branch: a failed "show more" must not
+          // replace the pages the user is already reading with an error.
+          // Gated on q for the same reason isFirstPagePending is: with no query
+          // there is nothing the user asked for to have failed. The backend
+          // explains the rejection in the response body, but that text is
+          // English only and lives in another repo, so it stays on the error
+          // object for Sentry rather than being rendered.
+          if (isError && q) {
+            return (
+              <div role="alert">
+                <span className="text-red-500">{i18next.t("search-comment.error-failed")}</span>
+              </div>
+            );
           }
 
-          return null;
+          if (isFirstPagePending) {
+            return null;
+          }
+
+          return <span>{i18next.t("g.no-matches")}</span>;
         })()}
 
-        {!disableResults && isLoading && <LinearProgress />}
+        {!disableResults && isFirstPagePending && <LinearProgress />}
       </div>
       <DetectBottom onBottom={onBottom} />
     </div>

--- a/apps/web/src/app/search/_components/search-communities/index.tsx
+++ b/apps/web/src/app/search/_components/search-communities/index.tsx
@@ -41,10 +41,9 @@ export function SearchCommunities() {
             return <LinearProgress />;
           }
 
-          // Unlike the people and topics panels this query is never disabled,
-          // so undefined data means the lookup failed. Saying "no matches" for
-          // a dropped RPC is the same failure/empty conflation the results list
-          // just lost.
+          // A failed lookup leaves data undefined with isLoading false, the
+          // same shape as an empty result. Saying "no matches" for a dropped
+          // RPC is the failure/empty conflation the results list just lost.
           if (isError) {
             return <span className="text-gray-600">{i18next.t("search-comment.error-failed")}</span>;
           }

--- a/apps/web/src/app/search/_components/search-communities/index.tsx
+++ b/apps/web/src/app/search/_components/search-communities/index.tsx
@@ -23,7 +23,12 @@ export function SearchCommunities() {
     () => new SearchQuery(params?.get("q") ?? "").search.split(" ")[0]?.replace("@", "") ?? "",
     [params]
   );
-  const { isLoading, data } = useQuery(getCommunitiesQueryOptions("rank", q, 4));
+  // Disabled without a term, like the sibling panels. Left enabled it falls
+  // back to listing the global top communities by rank, which a filter-only
+  // search ("author:demo") then presents as if those four matched the query.
+  const { isLoading, isError, data } = useQuery(
+    getCommunitiesQueryOptions("rank", q, 4, undefined, !!q)
+  );
 
   return (
     <div className="border border-[--border-color] bg-white rounded search-communities">
@@ -36,7 +41,17 @@ export function SearchCommunities() {
             return <LinearProgress />;
           }
 
-          if (data?.length === 0) {
+          // Unlike the people and topics panels this query is never disabled,
+          // so undefined data means the lookup failed. Saying "no matches" for
+          // a dropped RPC is the same failure/empty conflation the results list
+          // just lost.
+          if (isError) {
+            return <span className="text-gray-600">{i18next.t("search-comment.error-failed")}</span>;
+          }
+
+          // Without this the panel renders as an empty box on an empty result,
+          // hitting neither the spinner nor the empty state.
+          if (!data || data.length === 0) {
             return <span className="text-gray-600">{i18next.t("g.no-matches")}</span>;
           }
 

--- a/apps/web/src/app/search/_components/search-people/index.tsx
+++ b/apps/web/src/app/search/_components/search-people/index.tsx
@@ -17,7 +17,7 @@ export function SearchPeople() {
       (new SearchQuery(params?.get("q") ?? "").search.split(" ")[0]?.replace("@", "") ?? "").toLowerCase(),
     [params]
   );
-  const { data: results, isLoading } = useQuery(getSearchAccountQueryOptions(q));
+  const { data: results, isLoading, isError } = useQuery(getSearchAccountQueryOptions(q));
 
   return (
     <div className="border border-[--border-color] bg-white rounded  search-people">
@@ -30,7 +30,17 @@ export function SearchPeople() {
             return <LinearProgress />;
           }
 
-          if (results?.length === 0) {
+          // A failed lookup also leaves data undefined with isLoading false, so
+          // it has to be told apart from an empty one or the panel reports "no
+          // such account" for a request that never came back.
+          if (isError) {
+            return <span className="text-gray-600">{i18next.t("search-comment.error-failed")}</span>;
+          }
+
+          // With no term to look up the query is disabled, so isLoading is
+          // false and data is undefined - without this the panel renders as an
+          // empty box, hitting neither the spinner nor the empty state.
+          if (!results || results.length === 0) {
             return <span className="text-gray-600">{i18next.t("g.no-matches")}</span>;
           }
 

--- a/apps/web/src/app/search/_components/search-topics/index.tsx
+++ b/apps/web/src/app/search/_components/search-topics/index.tsx
@@ -19,7 +19,7 @@ export function SearchTopics() {
     [params]
   );
 
-  const { data, isLoading } = useQuery(getSearchTopicsQueryOptions(q, 10));
+  const { data, isLoading, isError } = useQuery(getSearchTopicsQueryOptions(q, 10));
 
   return (
     <div className="border border-[--border-color] bg-white rounded  search-topics">
@@ -32,7 +32,17 @@ export function SearchTopics() {
             return <LinearProgress />;
           }
 
-          if (data?.length === 0) {
+          // A failed lookup also leaves data undefined with isLoading false, so
+          // it has to be told apart from an empty one or the panel reports "no
+          // such topic" for a request that never came back.
+          if (isError) {
+            return <span className="text-gray-600">{i18next.t("search-comment.error-failed")}</span>;
+          }
+
+          // With no term to look up the query is disabled, so isLoading is
+          // false and data is undefined - without this the panel renders as an
+          // empty box, hitting neither the spinner nor the empty state.
+          if (!data || data.length === 0) {
             return <span className="text-gray-600">{i18next.t("g.no-matches")}</span>;
           }
 

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -2211,7 +2211,11 @@
     "sort-newest": "Recent",
     "hide-low": "Hide low payout content",
     "include-nsfw": "Show NSFW content",
-    "show-more": "show more"
+    "show-more": "show more",
+    "error-no-criteria": "Enter a search term, or an author, category or tag to filter by",
+    "error-too-many-tags": "Use at most {{n}} tags",
+    "error-too-long": "Search is too long. Use at most {{n}} characters",
+    "error-failed": "Search could not be completed. Please try again"
   },
   "search-people": {
     "title": "People"

--- a/apps/web/src/specs/app/search/search-advanced-form.spec.tsx
+++ b/apps/web/src/specs/app/search/search-advanced-form.spec.tsx
@@ -259,6 +259,13 @@ describe("SearchAdvancedForm", () => {
 
         // The API reads the FIRST type: match, so "prototype:v2" shadowed the
         // select with "v2" and the whole search came back 400.
+        //
+        // The truncation to "proto" is NOT desirable, it is this parser
+        // agreeing with the API's: both match a token inside an ordinary word.
+        // ecency/hivesearcher-api#11 anchors the token to a word boundary on
+        // the API side; the same change lands here once that is deployed, and
+        // this expectation becomes "prototype:v2 type:post". Anchoring only
+        // this side first would send text the deployed API still misreads.
         fireEvent.change(searchField(), { target: { value: "prototype:v2" } });
         fireEvent.change(typeSelect(), { target: { value: "post" } });
         fireEvent.click(applyButton());

--- a/apps/web/src/specs/app/search/search-advanced-form.spec.tsx
+++ b/apps/web/src/specs/app/search/search-advanced-form.spec.tsx
@@ -232,6 +232,28 @@ describe("SearchAdvancedForm", () => {
         expect(pushedParams().get("q")).toBe("author:demo");
       });
 
+      it("keeps a filled-in field when the free text carries the same token", () => {
+        render(<SearchAdvancedForm />);
+
+        // The API keeps only the first author: match and the free text goes
+        // first, so the token would otherwise override the visible filter.
+        fireEvent.change(searchField(), { target: { value: "coffee author:alice" } });
+        fireEvent.change(authorField(), { target: { value: "bob" } });
+        fireEvent.click(applyButton());
+
+        expect(pushedParams().get("q")).toBe("coffee author:bob");
+      });
+
+      it("merges tags from both places, since the API joins every tag token", () => {
+        render(<SearchAdvancedForm />);
+
+        fireEvent.change(searchField(), { target: { value: "coffee tag:travel" } });
+        fireEvent.change(tagsField(), { target: { value: "photography" } });
+        fireEvent.click(applyButton());
+
+        expect(pushedParams().get("q")).toBe("coffee tag:travel,photography");
+      });
+
       it("keeps the Type select when the free text carries a broken type token", () => {
         render(<SearchAdvancedForm />);
 

--- a/apps/web/src/specs/app/search/search-advanced-form.spec.tsx
+++ b/apps/web/src/specs/app/search/search-advanced-form.spec.tsx
@@ -254,24 +254,33 @@ describe("SearchAdvancedForm", () => {
         expect(pushedParams().get("q")).toBe("coffee tag:travel,photography");
       });
 
-      it("keeps the Type select when the free text carries a broken type token", () => {
+      it("drops a type: token the API would reject rather than sending it", () => {
         render(<SearchAdvancedForm />);
 
-        // The API reads the FIRST type: match, so "prototype:v2" shadowed the
-        // select with "v2" and the whole search came back 400.
-        //
-        // The truncation to "proto" is NOT desirable, it is this parser
-        // agreeing with the API's: both match a token inside an ordinary word.
-        // ecency/hivesearcher-api#11 anchors the token to a word boundary on
-        // the API side; the same change lands here once that is deployed, and
-        // this expectation becomes "prototype:v2 type:post". Anchoring only
-        // this side first would send text the deployed API still misreads.
+        // The one place this parser deliberately differs from the API's: the
+        // API keeps type="bogus" and answers 400, this discards an
+        // unrecognised value. Rebuilding then drops the token, so the user
+        // gets results for the rest of their text and sees the token
+        // disappear from the field rather than an error they cannot act on.
+        fireEvent.change(searchField(), { target: { value: "coffee type:bogus" } });
+        fireEvent.click(applyButton());
+
+        expect(screen.queryByRole("alert")).toBeNull();
+        expect(pushedParams().get("q")).toBe("coffee");
+      });
+
+      it("leaves a token-lookalike word alone and keeps the Type select", () => {
+        render(<SearchAdvancedForm />);
+
+        // "prototype:v2" is an ordinary word, not a type filter: a token only
+        // counts at a word boundary, here and in the API's parser. It used to
+        // read as type=v2, shadow the select and come back 400.
         fireEvent.change(searchField(), { target: { value: "prototype:v2" } });
         fireEvent.change(typeSelect(), { target: { value: "post" } });
         fireEvent.click(applyButton());
 
         expect(screen.queryByRole("alert")).toBeNull();
-        expect(pushedParams().get("q")).toBe("proto type:post");
+        expect(pushedParams().get("q")).toBe("prototype:v2 type:post");
       });
     });
   });

--- a/apps/web/src/specs/app/search/search-advanced-form.spec.tsx
+++ b/apps/web/src/specs/app/search/search-advanced-form.spec.tsx
@@ -1,0 +1,327 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  params: new URLSearchParams()
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push }),
+  // Next memoizes useSearchParams per URL. Handing back a stable instance here
+  // matters: a fresh object on every render would retrigger the form's sync
+  // effect and wipe whatever the test just typed.
+  useSearchParams: () => mocks.params,
+  ReadonlyURLSearchParams: URLSearchParams
+}));
+
+import { SearchAdvancedForm } from "@/app/search/_components/search-advanced-form";
+
+const searchField = () =>
+  screen.getByPlaceholderText("search-comment.search-placeholder") as HTMLInputElement;
+const authorField = () =>
+  screen.getByPlaceholderText("search-comment.author-placeholder") as HTMLInputElement;
+const categoryField = () =>
+  screen.getByPlaceholderText("search-comment.category-placeholder") as HTMLInputElement;
+const tagsField = () =>
+  screen.getByPlaceholderText("search-comment.tags-placeholder") as HTMLInputElement;
+// Type, Date and Sort in DOM order.
+const typeSelect = () => screen.getAllByRole("combobox")[0] as HTMLSelectElement;
+const applyButton = () => screen.getByRole("button", { name: "g.apply" });
+
+function pushedParams(): URLSearchParams {
+  expect(mocks.push).toHaveBeenCalledTimes(1);
+  return new URLSearchParams(mocks.push.mock.calls[0][0] as string);
+}
+
+describe("SearchAdvancedForm", () => {
+  beforeEach(() => {
+    mocks.push.mockClear();
+    mocks.params = new URLSearchParams();
+    localStorage.clear();
+  });
+
+  describe("apply", () => {
+    it("navigates on a filter-only search - an author with no free text", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.change(authorField(), { target: { value: "@Demo" } });
+      fireEvent.click(applyButton());
+
+      expect(screen.queryByRole("alert")).toBeNull();
+      // No leading space: " author:demo" is what the API rejected with
+      // "Parsed query is empty!".
+      expect(pushedParams().get("q")).toBe("author:demo");
+    });
+
+    it("navigates on a category-only and a tag-only search", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.change(categoryField(), { target: { value: "Hive-125125" } });
+      fireEvent.click(applyButton());
+      expect(pushedParams().get("q")).toBe("category:hive-125125");
+
+      mocks.push.mockClear();
+      fireEvent.change(categoryField(), { target: { value: "" } });
+      fireEvent.change(tagsField(), { target: { value: "Travel, Photography" } });
+      fireEvent.click(applyButton());
+      expect(pushedParams().get("q")).toBe("tag:travel,photography");
+    });
+
+    it("combines free text with the filters", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.change(searchField(), { target: { value: "coffee" } });
+      fireEvent.change(authorField(), { target: { value: "demo" } });
+      fireEvent.change(tagsField(), { target: { value: "travel" } });
+      fireEvent.click(applyButton());
+
+      expect(pushedParams().get("q")).toBe("coffee author:demo tag:travel");
+    });
+
+    it("marks the URL as advanced so the panel reopens on reload", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.change(authorField(), { target: { value: "demo" } });
+      fireEvent.click(applyButton());
+
+      expect(pushedParams().get("adv")).toBe("1");
+    });
+
+    it("applies on Enter from a text field", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.change(authorField(), { target: { value: "demo" } });
+      fireEvent.keyDown(authorField(), { key: "Enter" });
+
+      expect(pushedParams().get("q")).toBe("author:demo");
+    });
+  });
+
+  describe("validation", () => {
+    it("refuses an empty form and does not navigate", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.click(applyButton());
+
+      expect(screen.getByRole("alert")).toHaveTextContent("search-comment.error-no-criteria");
+      expect(mocks.push).not.toHaveBeenCalled();
+    });
+
+    it("refuses a bare type filter - the API needs something selective", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.change(typeSelect(), { target: { value: "post" } });
+      fireEvent.click(applyButton());
+
+      expect(screen.getByRole("alert")).toHaveTextContent("search-comment.error-no-criteria");
+      expect(mocks.push).not.toHaveBeenCalled();
+    });
+
+    it("refuses more than the allowed number of tags", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.change(tagsField(), { target: { value: "a, b, c, d, e, f" } });
+      fireEvent.click(applyButton());
+
+      expect(screen.getByRole("alert")).toHaveTextContent("search-comment.error-too-many-tags");
+      expect(mocks.push).not.toHaveBeenCalled();
+    });
+
+    it("accepts exactly the allowed number of tags", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.change(tagsField(), { target: { value: "a, b, c, d, e" } });
+      fireEvent.click(applyButton());
+
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(pushedParams().get("q")).toBe("tag:a,b,c,d,e");
+    });
+
+    it("counts deduped tags, so repeats do not trip the limit", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.change(tagsField(), { target: { value: "a, a, b, b, c, c, d, d, e, e" } });
+      fireEvent.click(applyButton());
+
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(pushedParams().get("q")).toBe("tag:a,b,c,d,e");
+    });
+
+    it("refuses a query longer than the API's cap", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.change(searchField(), { target: { value: "a".repeat(120) } });
+      fireEvent.click(applyButton());
+
+      expect(screen.getByRole("alert")).toHaveTextContent("search-comment.error-too-long");
+      expect(mocks.push).not.toHaveBeenCalled();
+    });
+
+    it("clears the error once the user edits a field", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.click(applyButton());
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      fireEvent.change(authorField(), { target: { value: "d" } });
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+
+    it("clears the error when the URL changes under the panel", () => {
+      const { rerender } = render(<SearchAdvancedForm />);
+
+      fireEvent.click(applyButton());
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // A navbar search or a Back navigation refills every field from the URL,
+      // so a message pointing at the old field values has to go with them.
+      mocks.params = new URLSearchParams("q=coffee");
+      rerender(<SearchAdvancedForm />);
+
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(searchField().value).toBe("coffee");
+    });
+
+    // The free text field can hold token syntax, which both parsers read back
+    // out as a filter. Guards that look at the field values instead of the
+    // query actually sent let these through to a 400.
+    describe("token syntax typed into the free text field", () => {
+      it("counts tags from every token, not just the tags field", () => {
+        render(<SearchAdvancedForm />);
+
+        fireEvent.change(searchField(), { target: { value: "tag:a,b,c" } });
+        fireEvent.change(tagsField(), { target: { value: "d, e, f" } });
+        fireEvent.click(applyButton());
+
+        expect(screen.getByRole("alert")).toHaveTextContent("search-comment.error-too-many-tags");
+        expect(mocks.push).not.toHaveBeenCalled();
+      });
+
+      it("refuses a bare type: token even though the field is not empty", () => {
+        render(<SearchAdvancedForm />);
+
+        fireEvent.change(searchField(), { target: { value: "type:post" } });
+        fireEvent.click(applyButton());
+
+        expect(screen.getByRole("alert")).toHaveTextContent("search-comment.error-no-criteria");
+        expect(mocks.push).not.toHaveBeenCalled();
+      });
+
+      it("still applies when the token leaves something selective behind", () => {
+        render(<SearchAdvancedForm />);
+
+        fireEvent.change(searchField(), { target: { value: "coffee tag:travel" } });
+        fireEvent.click(applyButton());
+
+        expect(screen.queryByRole("alert")).toBeNull();
+        expect(pushedParams().get("q")).toBe("coffee tag:travel");
+      });
+
+      it("normalizes a token typed there, so the first apply is not a miss", () => {
+        render(<SearchAdvancedForm />);
+
+        // Unnormalized, "author:@Demo" reaches an exact lowercase term filter
+        // and returns nothing, and only the second apply worked - by then the
+        // value had moved into the author field.
+        fireEvent.change(searchField(), { target: { value: "author:@Demo" } });
+        fireEvent.click(applyButton());
+
+        expect(pushedParams().get("q")).toBe("author:demo");
+      });
+
+      it("keeps the Type select when the free text carries a broken type token", () => {
+        render(<SearchAdvancedForm />);
+
+        // The API reads the FIRST type: match, so "prototype:v2" shadowed the
+        // select with "v2" and the whole search came back 400.
+        fireEvent.change(searchField(), { target: { value: "prototype:v2" } });
+        fireEvent.change(typeSelect(), { target: { value: "post" } });
+        fireEvent.click(applyButton());
+
+        expect(screen.queryByRole("alert")).toBeNull();
+        expect(pushedParams().get("q")).toBe("proto type:post");
+      });
+    });
+  });
+
+  describe("seeding from the URL", () => {
+    beforeEach(() => {
+      mocks.params = new URLSearchParams({
+        q: "coffee author:demo type:post category:hive-125125 tag:travel,photography",
+        date: "week",
+        sort: "newest",
+        adv: "1"
+      });
+    });
+
+    it("puts the stripped remainder in the free text field, not the raw query", () => {
+      render(<SearchAdvancedForm />);
+
+      expect(searchField().value).toBe("coffee");
+      expect(authorField().value).toBe("demo");
+      expect(categoryField().value).toBe("hive-125125");
+      expect(tagsField().value).toBe("travel,photography");
+    });
+
+    // Regression for the duplicate-token bug: seeding the free text with the raw
+    // query re-appended every filter on each apply ("coffee author:demo
+    // author:demo ...") until q passed the server's length cap.
+    it("does not duplicate the tokens when applied again untouched", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.click(applyButton());
+
+      expect(pushedParams().get("q")).toBe(mocks.params.get("q"));
+    });
+
+    it("keeps date and sort from the URL", () => {
+      render(<SearchAdvancedForm />);
+
+      fireEvent.click(applyButton());
+
+      const pushed = pushedParams();
+      expect(pushed.get("date")).toBe("week");
+      expect(pushed.get("sort")).toBe("newest");
+    });
+  });
+
+  describe("date", () => {
+    it("ignores the decks 'recent_date' entry and defaults to all time", () => {
+      // The two features shared this localStorage key with different defaults,
+      // so an untouched Date select silently reapplied the other one's value.
+      localStorage.setItem("recent_date", JSON.stringify("week"));
+
+      render(<SearchAdvancedForm />);
+
+      fireEvent.change(authorField(), { target: { value: "demo" } });
+      fireEvent.click(applyButton());
+
+      expect(pushedParams().get("date")).toBe("all");
+    });
+  });
+
+  describe("hide low", () => {
+    it("is checked on the first render when the URL does not opt out", () => {
+      render(<SearchAdvancedForm />);
+
+      expect(screen.getByRole("checkbox", { name: "search-comment.hide-low" })).toHaveAttribute(
+        "aria-checked",
+        "true"
+      );
+    });
+
+    it("reads hd=0 from the URL", () => {
+      mocks.params = new URLSearchParams({ q: "coffee", hd: "0" });
+
+      render(<SearchAdvancedForm />);
+
+      expect(screen.getByRole("checkbox", { name: "search-comment.hide-low" })).toHaveAttribute(
+        "aria-checked",
+        "false"
+      );
+    });
+  });
+});

--- a/apps/web/src/specs/app/search/search-comment.spec.tsx
+++ b/apps/web/src/specs/app/search/search-comment.spec.tsx
@@ -24,8 +24,8 @@ vi.mock("next/navigation", () => ({
 
 // The global spec setup mocks @ecency/sdk without the search options, so this
 // spec has to supply them. Everything except the queryFn stays faithful to the
-// real factory - `initialData` in the component only behaves the way finding 10
-// describes if getNextPageParam and `enabled` behave like production.
+// real factory: getNextPageParam and `enabled` have to behave like production
+// or neither the pagination nor the empty-query path means anything here.
 vi.mock("@ecency/sdk", () => ({
   getSearchApiInfiniteQueryOptions: (
     q: string,
@@ -100,8 +100,6 @@ function deferred<T>() {
 
 function renderSearch(search: string) {
   mocks.params = new URLSearchParams(search);
-  // Default staleTime: the seeded `initialData` is stale at once, so mounting
-  // requests page 1 - the job the bottom sentinel does in the browser.
   // refetchOnMount mirrors makeQueryClient(). Without it the app's real
   // bootstrap path is not the one under test: every fetch here would come from
   // a mount refetch production does not do, which is how a first page that
@@ -138,10 +136,8 @@ describe("SearchComment", () => {
 
       renderSearch("q=coffee");
 
-      // The query is seeded with initialData, so it is "success" with zero
-      // pages from the first paint and isLoading is never true. Without the
-      // pending guard the empty state renders here, before the request is even
-      // answered.
+      // The query is pending from the first paint with no cached data, and
+      // the empty state must wait for the answer rather than pre-empting it.
       expect(screen.queryByText(NO_MATCHES)).not.toBeInTheDocument();
       expect(screen.getByRole("progressbar")).toBeInTheDocument();
 

--- a/apps/web/src/specs/app/search/search-comment.spec.tsx
+++ b/apps/web/src/specs/app/search/search-comment.spec.tsx
@@ -1,0 +1,347 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// Shared, hoisted state the mocks below read at render time.
+const mocks = vi.hoisted(() => ({
+  params: new URLSearchParams(),
+  queryFn: vi.fn(),
+  sentinelFiresOnMount: false,
+  optionsCalls: [] as {
+    q: string;
+    sort: string;
+    hideLow: boolean;
+    since?: string;
+    includeNsfw?: boolean;
+  }[]
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mocks.params
+}));
+
+// The global spec setup mocks @ecency/sdk without the search options, so this
+// spec has to supply them. Everything except the queryFn stays faithful to the
+// real factory - `initialData` in the component only behaves the way finding 10
+// describes if getNextPageParam and `enabled` behave like production.
+vi.mock("@ecency/sdk", () => ({
+  getSearchApiInfiniteQueryOptions: (
+    q: string,
+    sort: string,
+    hideLow: boolean,
+    since?: string,
+    votes?: number,
+    includeNsfw?: boolean
+  ) => {
+    mocks.optionsCalls.push({ q, sort, hideLow, since, includeNsfw });
+    return {
+      queryKey: ["search", "api", q, sort, hideLow, since, includeNsfw],
+      queryFn: () => mocks.queryFn(),
+      initialPageParam: undefined,
+      getNextPageParam: (lastPage: { scroll_id?: string }) => lastPage?.scroll_id,
+      enabled: !!q,
+      retry: false
+    };
+  }
+}));
+
+vi.mock("@/features/shared", () => ({
+  // jsdom has no IntersectionObserver, so the sentinel never fires on its own
+  // and most fetches here are driven by the mount refetch and the show-more
+  // button. In a browser the sentinel sits at the bottom of a short results
+  // card and fires on mount, which is what bootstraps page 1 - tests that care
+  // about that path opt in with mocks.sentinelFiresOnMount.
+  DetectBottom: ({ onBottom }: { onBottom: () => void }) => {
+    React.useEffect(() => {
+      if (mocks.sentinelFiresOnMount) {
+        onBottom();
+      }
+    }, [onBottom]);
+    return null;
+  },
+  LinearProgress: () => <div role="progressbar" />,
+  SearchListItem: ({ res }: { res: { permlink: string } }) => <div>{res.permlink}</div>
+}));
+
+vi.mock("@/features/ui", () => ({
+  // `outline` is a Button prop, not a DOM attribute - drop it rather than
+  // forward it and have React warn on every render.
+  Button: ({ outline, ...rest }: React.ComponentProps<"button"> & { outline?: boolean }) => (
+    <button {...rest} />
+  )
+}));
+
+vi.mock("@/app/search/_components/search-advanced-form", () => ({
+  SearchAdvancedForm: () => <div>advanced-form</div>
+}));
+
+import { SearchComment } from "@/app/search/_components/search-comment";
+
+const NO_MATCHES = "g.no-matches"; // i18next is mocked to return the key
+const ERROR_FAILED = "search-comment.error-failed";
+
+function page(results: { author: string; permlink: string }[], scrollId?: string) {
+  return { hits: results.length, took: 1, results, scroll_id: scrollId };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  // Nothing awaits a rejection until the component does; keep node quiet.
+  promise.catch(() => {});
+  return { promise, resolve, reject };
+}
+
+function renderSearch(search: string) {
+  mocks.params = new URLSearchParams(search);
+  // Default staleTime: the seeded `initialData` is stale at once, so mounting
+  // requests page 1 - the job the bottom sentinel does in the browser.
+  // refetchOnMount mirrors makeQueryClient(). Without it the app's real
+  // bootstrap path is not the one under test: every fetch here would come from
+  // a mount refetch production does not do, which is how a first page that
+  // only ever loaded from the viewport sentinel looked healthy in this suite.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnMount: false } }
+  });
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <SearchComment />
+      </QueryClientProvider>
+    )
+  };
+}
+
+describe("SearchComment", () => {
+  beforeEach(() => {
+    mocks.queryFn.mockReset();
+    mocks.optionsCalls = [];
+    mocks.sentinelFiresOnMount = false;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe("first page (finding 10)", () => {
+    it("does not claim 'no matches' before page 1 has landed", async () => {
+      const first = deferred<ReturnType<typeof page>>();
+      mocks.queryFn.mockReturnValue(first.promise);
+
+      renderSearch("q=coffee");
+
+      // The query is seeded with initialData, so it is "success" with zero
+      // pages from the first paint and isLoading is never true. Without the
+      // pending guard the empty state renders here, before the request is even
+      // answered.
+      expect(screen.queryByText(NO_MATCHES)).not.toBeInTheDocument();
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+
+      first.resolve(page([]));
+
+      expect(await screen.findByText(NO_MATCHES)).toBeInTheDocument();
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    });
+
+    it("shows the empty state right away when there is nothing to search for", async () => {
+      renderSearch("");
+
+      // No `q` means no request is coming, so there is nothing to wait for.
+      expect(await screen.findByText(NO_MATCHES)).toBeInTheDocument();
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+      expect(mocks.queryFn).not.toHaveBeenCalled();
+    });
+
+    it("renders the results once they land", async () => {
+      mocks.queryFn.mockResolvedValue(page([{ author: "alice", permlink: "first-post" }]));
+
+      renderSearch("q=coffee");
+
+      expect(await screen.findByText("first-post")).toBeInTheDocument();
+      expect(screen.queryByText(NO_MATCHES)).not.toBeInTheDocument();
+      expect(screen.getByText("search-comment.matches-singular")).toBeInTheDocument();
+    });
+  });
+
+  describe("failures (finding 8)", () => {
+    it("renders the error state, not 'no matches', when the search is rejected", async () => {
+      const error = Object.assign(new Error("Request failed with status 400"), {
+        status: 400,
+        data: { error: "Parsed query is empty!" }
+      });
+      mocks.queryFn.mockRejectedValue(error);
+
+      renderSearch("q=author%3Ademo");
+
+      expect(await screen.findByText(ERROR_FAILED)).toBeInTheDocument();
+      // The whole point of the branch: a failure used to be indistinguishable
+      // from an empty result set.
+      expect(screen.queryByText(NO_MATCHES)).not.toBeInTheDocument();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("reports a rejected query without leaking the backend's own words", async () => {
+      mocks.queryFn.mockRejectedValue(
+        Object.assign(new Error("Request failed with status 400"), {
+          status: 400,
+          data: { message: { q: "Maximum 5 tags!" } }
+        })
+      );
+
+      renderSearch("q=coffee");
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent(ERROR_FAILED);
+      // The backend's text is English only and lives in another repo, so it
+      // stays on the error object for Sentry instead of reaching the page.
+      expect(screen.queryByText("Maximum 5 tags!")).not.toBeInTheDocument();
+    });
+
+    it("says nothing extra when the failure carries no usable body", async () => {
+      mocks.queryFn.mockRejectedValue(new Error("Failed to fetch"));
+
+      renderSearch("q=coffee");
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent(ERROR_FAILED);
+      // A proxy HTML page or a transport error has nothing to tell a user.
+      expect(alert).not.toHaveTextContent("Failed to fetch");
+    });
+
+    it("stays quiet on /search with no query at all", async () => {
+      // fetchNextPage does not consult `enabled`, so the sentinel used to post
+      // an empty query and collect a 400 the user never asked for. Drives the
+      // real bootstrap path, not the mount refetch, because that is where the
+      // doomed request came from.
+      mocks.sentinelFiresOnMount = true;
+      mocks.queryFn.mockRejectedValue(
+        Object.assign(new Error("Request failed with status 400"), {
+          status: 400,
+          data: { message: { q: "Query required" } }
+        })
+      );
+
+      renderSearch("q=");
+
+      expect(await screen.findByText(NO_MATCHES)).toBeInTheDocument();
+      await waitFor(() => expect(mocks.queryFn).not.toHaveBeenCalled());
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("still bootstraps page 1 from the sentinel when there is a query", async () => {
+      // The empty-q guard must not cost the bootstrap it wraps.
+      mocks.sentinelFiresOnMount = true;
+      mocks.queryFn.mockResolvedValue(page([{ author: "alice", permlink: "first-post" }]));
+
+      renderSearch("q=coffee");
+
+      expect(await screen.findByText("first-post")).toBeInTheDocument();
+    });
+
+    it("loads page 1 without the sentinel ever coming into view", async () => {
+      // The sentinel sits below the results, so with the advanced panel open on
+      // a short viewport it starts off screen and never fires. Page 1 must not
+      // depend on it, or that URL shows a spinner and issues no request at all.
+      mocks.sentinelFiresOnMount = false;
+      mocks.queryFn.mockResolvedValue(page([{ author: "alice", permlink: "first-post" }]));
+
+      renderSearch("q=coffee&adv=1");
+
+      expect(await screen.findByText("first-post")).toBeInTheDocument();
+      expect(mocks.queryFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the results a user is reading when loading more fails", async () => {
+      mocks.queryFn
+        .mockResolvedValueOnce(page([{ author: "alice", permlink: "first-post" }], "scroll-2"))
+        .mockRejectedValueOnce(new Error("Failed to fetch"));
+
+      renderSearch("q=coffee");
+
+      const showMore = await screen.findByText("search-comment.show-more");
+      fireEvent.click(showMore);
+
+      await waitFor(() => expect(mocks.queryFn).toHaveBeenCalledTimes(2));
+      expect(screen.getByText("first-post")).toBeInTheDocument();
+      expect(screen.queryByText(ERROR_FAILED)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("advanced panel (finding 9)", () => {
+    it("opens the panel a shared adv=1 URL belongs to", () => {
+      renderSearch("q=coffee+author%3Ademo&adv=1");
+
+      expect(screen.getByText("advanced-form")).toBeInTheDocument();
+      expect(screen.getByText("g.close")).toBeInTheDocument();
+    });
+
+    it("stays closed without adv=1", () => {
+      renderSearch("q=coffee");
+
+      expect(screen.queryByText("advanced-form")).not.toBeInTheDocument();
+      expect(screen.getByText("search-comment.advanced")).toBeInTheDocument();
+    });
+
+    it("lets the user's own toggle win over the URL in both directions", async () => {
+      renderSearch("q=coffee&adv=1");
+
+      fireEvent.click(screen.getByText("g.close"));
+      expect(screen.queryByText("advanced-form")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("search-comment.advanced"));
+      expect(screen.getByText("advanced-form")).toBeInTheDocument();
+    });
+  });
+
+  describe("search inputs come from the URL (finding 7)", () => {
+    const lastCall = () => mocks.optionsCalls[mocks.optionsCalls.length - 1];
+
+    it("ignores a stale localStorage date and stays all-time by default", () => {
+      // The advanced form's Date select used to be seeded from this key while
+      // the results read the URL only. Reading it here would pin every visitor
+      // to whatever the other feature last wrote.
+      localStorage.setItem("recent_date", "year");
+
+      renderSearch("q=coffee");
+
+      expect(lastCall().since).toBeUndefined();
+    });
+
+    it("honors an explicit date from the URL", () => {
+      renderSearch("q=coffee&date=week");
+
+      const since = lastCall().since;
+      expect(since).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+      const drift = Math.abs(
+        Date.now() - 7 * 24 * 60 * 60 * 1000 - new Date(`${since}Z`).getTime()
+      );
+      expect(drift).toBeLessThan(60_000);
+    });
+
+    it("passes sort, hide-low and nsfw through", () => {
+      renderSearch("q=coffee&sort=newest&hd=0&nsfw=1");
+
+      expect(lastCall()).toMatchObject({
+        q: "coffee",
+        sort: "newest",
+        hideLow: false,
+        includeNsfw: true
+      });
+    });
+
+    it("hides low-value results unless the URL opts out", () => {
+      renderSearch("q=coffee");
+
+      expect(lastCall()).toMatchObject({ sort: "relevance", hideLow: true });
+      expect(lastCall().includeNsfw).toBeUndefined();
+    });
+  });
+});

--- a/apps/web/src/specs/app/search/search-side-panels.spec.tsx
+++ b/apps/web/src/specs/app/search/search-side-panels.spec.tsx
@@ -1,0 +1,217 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// Shared, hoisted state the mocks below read at render time.
+const mocks = vi.hoisted(() => ({
+  params: new URLSearchParams(),
+  accounts: vi.fn(),
+  topics: vi.fn(),
+  communities: vi.fn(),
+  terms: { account: [] as string[], topics: [] as string[], communities: [] as string[] }
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mocks.params
+}));
+
+// The global spec setup mocks @ecency/sdk without these options. `enabled`
+// mirrors the real factories - it is the whole subject of these tests. Note
+// getCommunitiesQueryOptions defaults it to true and takes it as the 5th
+// argument, so the panel has to pass it explicitly.
+vi.mock("@ecency/sdk", () => ({
+  getSearchAccountQueryOptions: (q: string, limit = 5) => {
+    mocks.terms.account.push(q);
+    return {
+      queryKey: ["search", "account", q, limit],
+      queryFn: () => mocks.accounts(),
+      enabled: !!q.trim()
+    };
+  },
+  getSearchTopicsQueryOptions: (q: string, limit = 10) => {
+    mocks.terms.topics.push(q);
+    return {
+      queryKey: ["search", "topics", q, limit],
+      queryFn: () => mocks.topics(),
+      enabled: !!q.trim()
+    };
+  },
+  getCommunitiesQueryOptions: (
+    sort: string,
+    q?: string,
+    limit = 100,
+    observer: string | undefined = undefined,
+    enabled = true
+  ) => {
+    mocks.terms.communities.push(q ?? "");
+    return {
+      queryKey: ["communities", "list", sort, q ?? "", limit],
+      queryFn: () => mocks.communities(),
+      enabled
+    };
+  }
+}));
+
+vi.mock("@/features/shared", () => ({
+  LinearProgress: () => <div role="progressbar" />,
+  ProfileLink: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  UserAvatar: () => null
+}));
+
+vi.mock("@/features/pro", () => ({
+  ProBadge: () => null
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: React.ComponentProps<"a">) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  )
+}));
+
+// The global @/utils mock exposes only random + getAccessToken; these panels
+// format and link with the real helpers.
+vi.mock("@/utils", async () => ({
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token"),
+  ...(await vi.importActual<typeof import("@/utils/truncate")>("@/utils/truncate")),
+  ...(await vi.importActual<typeof import("@/utils/make-path")>("@/utils/make-path")),
+  ...(await vi.importActual<typeof import("@/utils/formatted-number")>("@/utils/formatted-number"))
+}));
+
+import { SearchPeople } from "@/app/search/_components/search-people";
+import { SearchCommunities } from "@/app/search/_components/search-communities";
+import { SearchTopics } from "@/app/search/_components/search-topics";
+
+const NO_MATCHES = "g.no-matches"; // i18next is mocked to return the key
+const ERROR_FAILED = "search-comment.error-failed";
+
+function renderPanel(panel: React.ReactElement, search: string) {
+  mocks.params = new URLSearchParams(search);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{panel}</QueryClientProvider>);
+}
+
+describe("search side panels", () => {
+  beforeEach(() => {
+    mocks.accounts.mockReset();
+    mocks.topics.mockReset();
+    mocks.communities.mockReset();
+    mocks.terms = { account: [], topics: [], communities: [] };
+  });
+
+  // Finding 12: a filter-only query ("all posts by @demo") leaves these panels
+  // with nothing to look up. Their queries are then disabled, so isLoading is
+  // false and data is undefined - the arm that used to be `data?.length === 0`
+  // matched neither, and the panel painted as an empty bordered box with just
+  // its heading.
+  describe("with no term to look up (finding 12)", () => {
+    const disabledPanels: [string, React.ReactElement, string][] = [
+      ["people", <SearchPeople key="people" />, "search-people.title"],
+      ["topics", <SearchTopics key="topics" />, "search-topics.title"]
+    ];
+
+    it.each(disabledPanels)(
+      "%s renders the empty state, not an empty box",
+      (_name, panel, title) => {
+        renderPanel(panel, "q=author%3Ademo");
+
+        expect(screen.getByText(title)).toBeInTheDocument();
+        expect(screen.getByText(NO_MATCHES)).toBeInTheDocument();
+        expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+      }
+    );
+
+    it("does not request anything at all", () => {
+      renderPanel(<SearchPeople />, "q=author%3Ademo+tag%3Atravel");
+      renderPanel(<SearchTopics />, "q=author%3Ademo+tag%3Atravel");
+      renderPanel(<SearchCommunities />, "q=author%3Ademo+tag%3Atravel");
+
+      expect(mocks.terms.account.at(-1)).toBe("");
+      expect(mocks.terms.topics.at(-1)).toBe("");
+      expect(mocks.accounts).not.toHaveBeenCalled();
+      expect(mocks.topics).not.toHaveBeenCalled();
+      // Communities defaults to enabled and lists the global top 4 by rank
+      // without a term, which a filter-only search would present as matches.
+      expect(mocks.communities).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a lookup fails", () => {
+    it.each([
+      ["people", <SearchPeople key="p" />, "accounts" as const],
+      ["topics", <SearchTopics key="t" />, "topics" as const],
+      ["communities", <SearchCommunities key="c" />, "communities" as const]
+    ])("%s says so instead of claiming no matches", async (_name, panel, mockName) => {
+      // A rejected query leaves data undefined with isLoading false, the same
+      // shape as an empty result. Telling a user no account matches "alice"
+      // when the lookup never returned is the failure/empty conflation the
+      // results list just lost.
+      mocks[mockName].mockRejectedValue(new Error("Failed to fetch"));
+
+      renderPanel(panel, "q=alice");
+
+      expect(await screen.findByText(ERROR_FAILED)).toBeInTheDocument();
+      expect(screen.queryByText(NO_MATCHES)).not.toBeInTheDocument();
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("with a term", () => {
+    it("looks people up by the free text, lowercased and without the @", async () => {
+      mocks.accounts.mockResolvedValue([
+        { name: "alice", metadata: { profile: { name: "Alice", about: "Photographer" } } }
+      ]);
+
+      renderPanel(<SearchPeople />, "q=%40Alice+author%3Ademo");
+
+      expect(await screen.findByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Photographer")).toBeInTheDocument();
+      expect(screen.queryByText(NO_MATCHES)).not.toBeInTheDocument();
+      expect(mocks.terms.account.at(-1)).toBe("alice");
+    });
+
+    it("keeps the spinner up while the lookup is in flight", async () => {
+      mocks.topics.mockReturnValue(new Promise(() => {}));
+
+      renderPanel(<SearchTopics />, "q=travel");
+
+      await waitFor(() => expect(screen.getByRole("progressbar")).toBeInTheDocument());
+      expect(screen.queryByText(NO_MATCHES)).not.toBeInTheDocument();
+    });
+
+    it("renders topics as links", async () => {
+      mocks.topics.mockResolvedValue(["travel", "photography"]);
+
+      renderPanel(<SearchTopics />, "q=Travel+tag%3Aphoto");
+
+      // The filter segment is the app default, so only the tag is asserted.
+      expect((await screen.findByText("travel")).getAttribute("href")).toMatch(/\/travel$/);
+      expect(screen.getByText("photography")).toBeInTheDocument();
+      expect(mocks.terms.topics.at(-1)).toBe("travel");
+    });
+
+    it("renders communities with their subscriber count", async () => {
+      mocks.communities.mockResolvedValue([
+        { name: "hive-125125", title: "Photography Lovers", about: "Snapshots", subscribers: 1234 }
+      ]);
+
+      renderPanel(<SearchCommunities />, "q=photo");
+
+      expect(await screen.findByText("Photography Lovers")).toBeInTheDocument();
+      expect(screen.getByText("communities.n-subscribers")).toBeInTheDocument();
+      expect(mocks.terms.communities.at(-1)).toBe("photo");
+    });
+
+    it("shows the empty state when a lookup comes back empty", async () => {
+      mocks.accounts.mockResolvedValue([]);
+
+      renderPanel(<SearchPeople />, "q=zzzz");
+
+      expect(await screen.findByText(NO_MATCHES)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/specs/utils/search-query.spec.ts
+++ b/apps/web/src/specs/utils/search-query.spec.ts
@@ -146,6 +146,12 @@ describe("normalizeSearchCategory", () => {
   it("keeps only the first word", () => {
     expect(normalizeSearchCategory("My Category")).toBe("my");
   });
+
+  it("strips a leading hash, like tags do", () => {
+    // Categories are matched by the same exact term query as tags, and users
+    // write them the same way.
+    expect(normalizeSearchCategory("#Hive-125125")).toBe("hive-125125");
+  });
 });
 
 describe("normalizeSearchTags", () => {

--- a/apps/web/src/specs/utils/search-query.spec.ts
+++ b/apps/web/src/specs/utils/search-query.spec.ts
@@ -307,3 +307,26 @@ describe("buildSearchQuery round trip", () => {
     expect(built.q.length).toBeLessThanOrEqual(MAX_SEARCH_QUERY_LENGTH);
   });
 });
+
+describe("token boundaries", () => {
+  // Must stay in lockstep with the API's parser (user_query_parser.py), which
+  // anchors the same way. A disagreement here is silently wrong results.
+  it("ignores a token glued to the end of an ordinary word", () => {
+    expect(new SearchQuery("prototype:v2").type).toBe(SearchType.ALL);
+    expect(new SearchQuery("prototype:v2").search).toBe("prototype:v2");
+    expect(new SearchQuery("subcategory:hive-1").category).toBe("");
+    expect(new SearchQuery("filetype:pdf hive").search).toBe("filetype:pdf hive");
+  });
+
+  it("still reads a real token beside a lookalike", () => {
+    const q = new SearchQuery("prototype:v2 type:post");
+    expect(q.type).toBe(SearchType.POST);
+    expect(q.search).toBe("prototype:v2");
+  });
+
+  it("does not run words together when a mid-query token is stripped", () => {
+    const q = new SearchQuery("foo tag:a,b bar");
+    expect(q.tags).toEqual(["a", "b"]);
+    expect(q.search).toBe("foo bar");
+  });
+});

--- a/apps/web/src/specs/utils/search-query.spec.ts
+++ b/apps/web/src/specs/utils/search-query.spec.ts
@@ -1,4 +1,31 @@
-import { SearchQuery } from "../../utils/search-query";
+import {
+  BuiltSearchQuery,
+  buildSearchQuery,
+  MAX_SEARCH_QUERY_LENGTH,
+  MAX_SEARCH_TAGS,
+  normalizeSearchAuthor,
+  normalizeSearchCategory,
+  normalizeSearchTags,
+  SearchQuery,
+  SearchType
+} from "../../utils/search-query";
+
+/**
+ * Parses a built query back out and rebuilds it, i.e. exactly what the advanced
+ * form does when it seeds its fields from the URL and the user presses Apply
+ * again without changing anything.
+ */
+function reapply(built: BuiltSearchQuery): BuiltSearchQuery {
+  const parsed = new SearchQuery(built.q);
+
+  return buildSearchQuery({
+    search: parsed.search,
+    author: parsed.author,
+    type: parsed.type,
+    category: parsed.category,
+    tags: parsed.tags
+  });
+}
 
 describe("Search query", () => {
   describe("author", () => {
@@ -52,6 +79,29 @@ describe("Search query", () => {
       const q = new SearchQuery("foo tag:bar,baz,zoo");
       expect(q.tags).toEqual(["bar", "baz", "zoo"]);
     });
+
+    it("drops the empty segment left by a trailing comma", () => {
+      expect(new SearchQuery("foo tag:a,").tags).toEqual(["a"]);
+      expect(new SearchQuery("foo tag:,a,,b,").tags).toEqual(["a", "b"]);
+    });
+
+    it("collects every tag token, the way the API does", () => {
+      // The API joins all of its tag: matches before splitting on commas, so
+      // reading only the first token here reports 3 tags for a query that
+      // actually applies 6 - and lets it past the MAX_SEARCH_TAGS guard.
+      expect(new SearchQuery("foo tag:a,b,c tag:d,e,f").tags).toEqual([
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f"
+      ]);
+    });
+
+    it("dedupes across tokens", () => {
+      expect(new SearchQuery("foo tag:a,b tag:b,c").tags).toEqual(["a", "b", "c"]);
+    });
   });
 
   describe("stripped query", () => {
@@ -61,5 +111,193 @@ describe("Search query", () => {
       );
       expect(q.search).toBe("foo bar zoo");
     });
+  });
+});
+
+describe("normalizeSearchAuthor", () => {
+  it("strips the @ and lowercases, so the API's exact term filter matches", () => {
+    expect(normalizeSearchAuthor("@Demo")).toBe("demo");
+  });
+
+  it("trims surrounding whitespace and repeated @", () => {
+    expect(normalizeSearchAuthor("  @@Demo  ")).toBe("demo");
+  });
+
+  it("leaves an empty value empty", () => {
+    expect(normalizeSearchAuthor("   ")).toBe("");
+  });
+
+  it("keeps only the first word, since the token stops at the space anyway", () => {
+    // "author:demo bob" filters on demo and turns "bob" into required free
+    // text, which is the same trap the tag field had.
+    expect(normalizeSearchAuthor("demo bob")).toBe("demo");
+  });
+});
+
+describe("normalizeSearchCategory", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeSearchCategory("  Hive-125125 ")).toBe("hive-125125");
+  });
+
+  it("leaves an empty value empty", () => {
+    expect(normalizeSearchCategory("  ")).toBe("");
+  });
+
+  it("keeps only the first word", () => {
+    expect(normalizeSearchCategory("My Category")).toBe("my");
+  });
+});
+
+describe("normalizeSearchTags", () => {
+  it("splits on commas and whitespace and lowercases", () => {
+    expect(normalizeSearchTags("  Travel, Photography ")).toEqual(["travel", "photography"]);
+  });
+
+  it("accepts space separated tags", () => {
+    expect(normalizeSearchTags("travel photography")).toEqual(["travel", "photography"]);
+  });
+
+  it("strips leading hashes", () => {
+    expect(normalizeSearchTags("#tag")).toEqual(["tag"]);
+    expect(normalizeSearchTags("##Tag, #other")).toEqual(["tag", "other"]);
+  });
+
+  it("dedupes in first-seen order", () => {
+    expect(normalizeSearchTags("travel, Travel, #travel, photography")).toEqual([
+      "travel",
+      "photography"
+    ]);
+  });
+
+  it("drops empty segments", () => {
+    expect(normalizeSearchTags("a,,b,")).toEqual(["a", "b"]);
+    expect(normalizeSearchTags("")).toEqual([]);
+    expect(normalizeSearchTags("   ,  ")).toEqual([]);
+  });
+
+  it("accepts an already split list through buildSearchQuery", () => {
+    expect(buildSearchQuery({ tags: ["Travel", "travel", "#Photography"] }).tags).toEqual([
+      "travel",
+      "photography"
+    ]);
+  });
+});
+
+describe("buildSearchQuery", () => {
+  it("appends every filter to the free text", () => {
+    const built = buildSearchQuery({
+      search: "coffee",
+      author: "@Demo",
+      type: SearchType.POST,
+      category: "Hive-125125",
+      tags: "Travel, Photography"
+    });
+
+    expect(built.q).toBe("coffee author:demo type:post category:hive-125125 tag:travel,photography");
+  });
+
+  it("joins tags with commas and no spaces", () => {
+    // A space inside the token would end it: the rest becomes required free text.
+    expect(buildSearchQuery({ tags: "travel, photography, food" }).q).toBe(
+      "tag:travel,photography,food"
+    );
+  });
+
+  it("produces no leading space when there is no free text", () => {
+    const built = buildSearchQuery({ author: "demo" });
+
+    expect(built.q).toBe("author:demo");
+    expect(built.q.startsWith(" ")).toBe(false);
+  });
+
+  it("omits the type token for SearchType.ALL", () => {
+    expect(buildSearchQuery({ search: "coffee", type: SearchType.ALL }).q).toBe("coffee");
+  });
+
+  it("collapses whitespace inside the free text", () => {
+    expect(buildSearchQuery({ search: "  coffee   beans  " }).q).toBe("coffee beans");
+  });
+
+  it("returns the normalized parts alongside the query", () => {
+    const built = buildSearchQuery({
+      search: " coffee ",
+      author: "@Demo",
+      type: SearchType.COMMENT,
+      category: "Hive-1",
+      tags: "Travel, travel, #photography"
+    });
+
+    expect(built.search).toBe("coffee");
+    expect(built.author).toBe("demo");
+    expect(built.type).toBe(SearchType.COMMENT);
+    expect(built.category).toBe("hive-1");
+    expect(built.tags).toEqual(["travel", "photography"]);
+  });
+
+  it("keeps the raw tag count so the caller can compare it to MAX_SEARCH_TAGS", () => {
+    const built = buildSearchQuery({ tags: "a, b, c, d, e, f" });
+
+    expect(built.tags).toHaveLength(6);
+    expect(built.tags.length > MAX_SEARCH_TAGS).toBe(true);
+  });
+
+  it("does not silently truncate an over-long query", () => {
+    const built = buildSearchQuery({ search: "a".repeat(MAX_SEARCH_QUERY_LENGTH + 20) });
+
+    expect(built.q.length).toBe(MAX_SEARCH_QUERY_LENGTH + 20);
+  });
+});
+
+describe("buildSearchQuery round trip", () => {
+  const cases: Record<string, Parameters<typeof buildSearchQuery>[0]> = {
+    "free text plus every filter": {
+      search: "coffee beans",
+      author: "@Demo",
+      type: SearchType.POST,
+      category: "Hive-125125",
+      tags: "Travel, Photography"
+    },
+    "author only": { author: "@Demo" },
+    "tags only": { tags: "Travel, Photography" },
+    "category only": { category: "Hive-1" },
+    "free text only": { search: "coffee" },
+    "type plus author": { author: "demo", type: SearchType.COMMENT }
+  };
+
+  Object.entries(cases).forEach(([name, parts]) => {
+    it(`parses back the normalized parts - ${name}`, () => {
+      const built = buildSearchQuery(parts);
+      const parsed = new SearchQuery(built.q);
+
+      expect(parsed.search).toBe(built.search);
+      expect(parsed.author).toBe(built.author);
+      expect(parsed.type).toBe(built.type);
+      expect(parsed.category).toBe(built.category);
+      expect(parsed.tags).toEqual(built.tags);
+    });
+
+    // Regression for the duplicate-token bug: the form used to seed its free
+    // text field from the RAW query, so every Apply re-appended the tokens
+    // ("coffee author:demo author:demo ...") until the API's length cap killed
+    // the search. Re-applying an unchanged form has to be a no-op.
+    it(`is idempotent when re-applied - ${name}`, () => {
+      const built = buildSearchQuery(parts);
+      const once = reapply(built);
+      const twice = reapply(once);
+
+      expect(once.q).toBe(built.q);
+      expect(twice.q).toBe(built.q);
+    });
+  });
+
+  it("does not accumulate tokens over repeated applies", () => {
+    let built = buildSearchQuery({ search: "coffee", author: "@Demo", tags: "Travel" });
+
+    for (let i = 0; i < 10; i++) {
+      built = reapply(built);
+    }
+
+    expect(built.q).toBe("coffee author:demo tag:travel");
+    expect(built.q.length).toBeLessThanOrEqual(MAX_SEARCH_QUERY_LENGTH);
   });
 });

--- a/apps/web/src/utils/search-query.ts
+++ b/apps/web/src/utils/search-query.ts
@@ -34,7 +34,9 @@ export function normalizeSearchAuthor(value: string): string {
 }
 
 export function normalizeSearchCategory(value: string): string {
-  return firstToken(value).toLowerCase();
+  // Leading "#" goes for the same reason it goes on tags: a category is matched
+  // by an exact term query, and users write categories the way they write tags.
+  return firstToken(value).replace(/^#+/, "").toLowerCase();
 }
 
 /**

--- a/apps/web/src/utils/search-query.ts
+++ b/apps/web/src/utils/search-query.ts
@@ -1,7 +1,17 @@
-const author_re = /author:([^\s]+)/g;
-const type_re = /type:([^\s]+)/g;
-const category_re = /category:([^\s]+)/g;
-const tag_re = /tag:([^\s]+)/g;
+// A token only counts at the start of the query or after whitespace, matching
+// the search API's parser. Unanchored, these matched inside ordinary words:
+// "prototype:v2" read as type=v2 and the API rejected it as an invalid type,
+// "subcategory:hive-1" filtered on category=hive-1 with a stray "sub" left as
+// required text. The boundary is captured rather than looked behind so it can
+// be put back when the token is stripped, keeping the neighbouring words apart
+// (a lookbehind would also be fine here, but this stays portable).
+const author_re = /(^|\s)author:([^\s]+)/g;
+const type_re = /(^|\s)type:([^\s]+)/g;
+const category_re = /(^|\s)category:([^\s]+)/g;
+const tag_re = /(^|\s)tag:([^\s]+)/g;
+
+// Index of the token value in a match; group 1 is the boundary.
+const VALUE = 2;
 
 export enum SearchType {
   ALL = "",
@@ -110,8 +120,8 @@ export function buildSearchQuery({
   }
 
   if (normalizedTags.length > 0) {
-    // No space after the commas: the tag token is matched with /tag:([^\s]+)/,
-    // so anything past a space stops filtering and becomes required free text.
+    // No space after the commas: a tag token ends at the first space, so
+    // anything past one stops filtering and becomes required free text.
     parts.push(`tag:${normalizedTags.join(",")}`);
   }
 
@@ -150,7 +160,7 @@ export class SearchQuery {
     // @ts-ignore
     const matches = [...this.query.matchAll(re)];
     if (matches.length > 0) {
-      return matches[0][1].trim();
+      return matches[0][VALUE].trim();
     }
 
     return "";
@@ -181,7 +191,7 @@ export class SearchQuery {
     const seen = new Set<string>();
 
     this.tags = [...this.query.matchAll(tag_re)]
-      .flatMap((match) => match[1].split(","))
+      .flatMap((match) => match[VALUE].split(","))
       .map((tag) => tag.trim())
       .filter((tag) => {
         if (tag === "" || seen.has(tag)) {
@@ -195,7 +205,9 @@ export class SearchQuery {
 
   private grabSearch = () => {
     [author_re, type_re, category_re, tag_re].forEach((r) => {
-      this.search = this.search.replace(r, () => "");
+      // Put the captured boundary back, or removing a mid-query token would
+      // run the words either side of it together.
+      this.search = this.search.replace(r, "$1");
     });
 
     while (this.search.indexOf("  ") !== -1) {

--- a/apps/web/src/utils/search-query.ts
+++ b/apps/web/src/utils/search-query.ts
@@ -9,6 +9,122 @@ export enum SearchType {
   COMMENT = "comment"
 }
 
+export const MAX_SEARCH_TAGS = 5;
+
+// The search API applies both caps itself (see query_validator); mirrored here
+// so the client can refuse instead of turning a 400 into an empty result list.
+export const MAX_SEARCH_QUERY_LENGTH = 100;
+
+/**
+ * Both parsers match a token with /author:([^\s]+)/, so a value containing a
+ * space stops filtering at the space and the remainder silently becomes
+ * required free text. Keep the first word only, which is what the API would
+ * have filtered on anyway.
+ */
+function firstToken(value: string): string {
+  return value.trim().split(/\s+/)[0] ?? "";
+}
+
+/**
+ * Hive account names are lowercase and the API filters authors with an exact
+ * term query, so "@Demo" has to become "demo" or it matches nothing.
+ */
+export function normalizeSearchAuthor(value: string): string {
+  return firstToken(value).replace(/^@+/, "").toLowerCase();
+}
+
+export function normalizeSearchCategory(value: string): string {
+  return firstToken(value).toLowerCase();
+}
+
+/**
+ * Accepts what a user actually types ("travel, photography", "#travel travel")
+ * and returns exact-match ready tags, deduped in first-seen order.
+ */
+export function normalizeSearchTags(value: string): string[] {
+  const seen = new Set<string>();
+
+  return value
+    .split(/[\s,]+/)
+    .map((tag) => tag.replace(/^#+/, "").toLowerCase())
+    .filter((tag) => {
+      if (tag === "" || seen.has(tag)) {
+        return false;
+      }
+
+      seen.add(tag);
+      return true;
+    });
+}
+
+export interface SearchQueryParts {
+  search?: string;
+  author?: string;
+  type?: SearchType;
+  category?: string;
+  /** Raw user input ("a, b") or an already split list. */
+  tags?: string | string[];
+}
+
+export interface BuiltSearchQuery {
+  /** The `q` value to put in the URL. Round-trips through `SearchQuery`. */
+  q: string;
+  search: string;
+  author: string;
+  type: SearchType;
+  category: string;
+  tags: string[];
+}
+
+/**
+ * Assembles the single `q` string that both this app and the search API parse
+ * back into filters. Returns the normalized parts too, because the caller has
+ * to validate the tag count and the total length before navigating.
+ */
+export function buildSearchQuery({
+  search = "",
+  author = "",
+  type = SearchType.ALL,
+  category = "",
+  tags = []
+}: SearchQueryParts): BuiltSearchQuery {
+  const normalizedSearch = search.trim().replace(/\s+/g, " ");
+  const normalizedAuthor = normalizeSearchAuthor(author);
+  const normalizedCategory = normalizeSearchCategory(category);
+  const normalizedTags = normalizeSearchTags(Array.isArray(tags) ? tags.join(",") : tags);
+
+  const parts = [normalizedSearch];
+
+  if (normalizedAuthor) {
+    parts.push(`author:${normalizedAuthor}`);
+  }
+
+  if (type) {
+    parts.push(`type:${type}`);
+  }
+
+  if (normalizedCategory) {
+    parts.push(`category:${normalizedCategory}`);
+  }
+
+  if (normalizedTags.length > 0) {
+    // No space after the commas: the tag token is matched with /tag:([^\s]+)/,
+    // so anything past a space stops filtering and becomes required free text.
+    parts.push(`tag:${normalizedTags.join(",")}`);
+  }
+
+  return {
+    // Dropping the empty free text here is what keeps a filter-only query from
+    // starting with a space.
+    q: parts.filter((part) => part !== "").join(" "),
+    search: normalizedSearch,
+    author: normalizedAuthor,
+    type,
+    category: normalizedCategory,
+    tags: normalizedTags
+  };
+}
+
 export class SearchQuery {
   public query: string = "";
   public search: string = "";
@@ -54,10 +170,25 @@ export class SearchQuery {
   };
 
   private grabTags = () => {
-    const tags = this.grab(tag_re);
-    if (tags !== "") {
-      this.tags = tags.split(",").map((x) => x.trim());
-    }
+    // Every tag: token counts, not just the first one. The API joins all of its
+    // own tag: matches before splitting on commas, so reading only the first
+    // token here under-reports the tags a query really applies and let a query
+    // past the MAX_SEARCH_TAGS guard that the API then rejects with a 400.
+    // A trailing comma ("tag:a,") must not yield an empty tag either - it would
+    // be shown back as a phantom tag and counted against the same cap.
+    const seen = new Set<string>();
+
+    this.tags = [...this.query.matchAll(tag_re)]
+      .flatMap((match) => match[1].split(","))
+      .map((tag) => tag.trim())
+      .filter((tag) => {
+        if (tag === "" || seen.has(tag)) {
+          return false;
+        }
+
+        seen.add(tag);
+        return true;
+      });
   };
 
   private grabSearch = () => {

--- a/packages/sdk/src/modules/search/parse-json-response.ts
+++ b/packages/sdk/src/modules/search/parse-json-response.ts
@@ -1,0 +1,41 @@
+export type RequestError = Error & { status?: number; data?: unknown };
+
+/**
+ * Reads a response body and, when the status is not OK, throws an error that
+ * keeps both the status and the parsed body.
+ *
+ * The search backend answers a malformed query with an explanation the user can
+ * act on ("Maximum 5 tags!", "Query string too long! ...", "Parsed query is
+ * empty!"). Dropping the body leaves callers with a bare status: they can
+ * neither tell the user what to change nor tell a deterministic rejection from
+ * a transient failure worth retrying.
+ *
+ * Module-internal on purpose - it is not part of the published SDK surface.
+ */
+export async function parseJsonResponse<T>(response: Response): Promise<T> {
+  const parseBody = async (): Promise<unknown> => {
+    try {
+      return await response.json();
+    } catch {
+      try {
+        return await response.text();
+      } catch {
+        return undefined;
+      }
+    }
+  };
+
+  const data = await parseBody();
+  if (!response.ok) {
+    const error = new Error(`Request failed with status ${response.status}`) as RequestError;
+    error.status = response.status;
+    error.data = data;
+    throw error;
+  }
+
+  if (data === undefined) {
+    throw new Error("Response body was empty or invalid JSON");
+  }
+
+  return data as T;
+}

--- a/packages/sdk/src/modules/search/parse-json-response.ts
+++ b/packages/sdk/src/modules/search/parse-json-response.ts
@@ -14,14 +14,25 @@ export type RequestError = Error & { status?: number; data?: unknown };
  */
 export async function parseJsonResponse<T>(response: Response): Promise<T> {
   const parseBody = async (): Promise<unknown> => {
+    // Read the body ONCE. Calling json() and then falling back to text() on the
+    // same response cannot work: json() consumes the stream, so the fallback
+    // always threw and the raw body of a non-JSON failure (an HTML error page
+    // from a proxy) was silently lost.
+    let raw: string;
     try {
-      return await response.json();
+      raw = await response.text();
     } catch {
-      try {
-        return await response.text();
-      } catch {
-        return undefined;
-      }
+      return undefined;
+    }
+
+    if (raw === "") {
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return raw;
     }
   };
 

--- a/packages/sdk/src/modules/search/queries/get-search-api-infinite-query-options.spec.ts
+++ b/packages/sdk/src/modules/search/queries/get-search-api-infinite-query-options.spec.ts
@@ -123,16 +123,18 @@ describe("getSearchApiInfiniteQueryOptions", () => {
       });
     });
 
-    it("does retry a 429", async () => {
+    it("does retry the transient 4xx statuses", async () => {
       const factory = await loadForEnv(false);
       const retry = retryOf(factory("coffee", "popularity", true));
 
-      // Rate limiting is about how often the request arrived, not what it
-      // contained, and backing off is exactly what resolves it. Failing on the
-      // first one is also sticky: with no pages, nothing retriggers the fetch.
-      expect(retry(0, rejection(429))).toBe(true);
-      expect(retry(2, rejection(429))).toBe(true);
-      expect(retry(3, rejection(429))).toBe(false);
+      // 429 and a gateway 408 describe when the request arrived, not what it
+      // contained, and backing off is exactly what resolves them. Failing on
+      // the first one is also sticky: with no pages, nothing retriggers.
+      [408, 429].forEach((status) => {
+        expect(retry(0, rejection(status))).toBe(true);
+        expect(retry(2, rejection(status))).toBe(true);
+        expect(retry(3, rejection(status))).toBe(false);
+      });
     });
 
     it("still retries a 5xx and a transport failure in the browser", async () => {

--- a/packages/sdk/src/modules/search/queries/get-search-api-infinite-query-options.spec.ts
+++ b/packages/sdk/src/modules/search/queries/get-search-api-infinite-query-options.spec.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { getSearchApiInfiniteQueryOptions } from "./get-search-api-infinite-query-options";
+import type { RequestError } from "../parse-json-response";
+
+type QueryFn = (ctx: {
+  pageParam?: string | undefined;
+  signal?: AbortSignal;
+}) => Promise<unknown>;
+
+type RetryFn = (failureCount: number, error: Error) => boolean;
+
+const options = (q = "coffee") => getSearchApiInfiniteQueryOptions(q, "popularity", true);
+
+const retryOf = (opts: ReturnType<typeof getSearchApiInfiniteQueryOptions>) =>
+  opts.retry as RetryFn;
+
+function response(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+const emptyPage = { hits: 0, took: 1, results: [] };
+
+/**
+ * `MAX_RETRIES` is read from `isServer` when the module is first evaluated, so
+ * the two environments have to be loaded as two separate module instances.
+ */
+async function loadForEnv(isServer: boolean) {
+  vi.resetModules();
+  vi.doMock("@tanstack/react-query", async (importOriginal) => {
+    const actual =
+      await importOriginal<typeof import("@tanstack/react-query")>();
+    return { ...actual, isServer };
+  });
+  const mod = await import("./get-search-api-infinite-query-options");
+  return mod.getSearchApiInfiniteQueryOptions;
+}
+
+describe("getSearchApiInfiniteQueryOptions", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.doUnmock("@tanstack/react-query");
+    vi.resetModules();
+  });
+
+  describe("rejected queries keep the backend's answer", () => {
+    // Regression for the "every failure looks like zero results" defect: the
+    // search backend answers a malformed query with the reason it rejected it,
+    // and a caller that only sees a thrown Error cannot tell a rejection from
+    // an empty result set, let alone say what to change.
+    it("puts the status and the body on the error for a 400", async () => {
+      fetchMock.mockResolvedValueOnce(
+        response(400, { error: "Parsed query is empty!" })
+      );
+
+      const error = await (options().queryFn as QueryFn)({
+        pageParam: undefined,
+        signal: undefined,
+      }).then(
+        () => undefined,
+        (e: RequestError) => e
+      );
+
+      expect(error?.status).toBe(400);
+      expect(error?.data).toEqual({ error: "Parsed query is empty!" });
+      expect(error?.message).toContain("400");
+    });
+
+    it("keeps flask-restful's argument-validation shape intact", async () => {
+      fetchMock.mockResolvedValueOnce(
+        response(400, { message: { q: "Maximum 5 tags!" } })
+      );
+
+      const error = await (options("a tag:1,2,3,4,5,6").queryFn as QueryFn)({
+        pageParam: undefined,
+        signal: undefined,
+      }).then(
+        () => undefined,
+        (e: RequestError) => e
+      );
+
+      expect(error?.status).toBe(400);
+      expect(error?.data).toEqual({ message: { q: "Maximum 5 tags!" } });
+    });
+
+    it("resolves with the parsed body on success", async () => {
+      fetchMock.mockResolvedValueOnce(response(200, emptyPage));
+
+      await expect(
+        (options().queryFn as QueryFn)({ pageParam: undefined, signal: undefined })
+      ).resolves.toEqual(emptyPage);
+    });
+  });
+
+  describe("retry policy", () => {
+    const rejection = (status: number) => {
+      const error = new Error(`Request failed with status ${status}`) as RequestError;
+      error.status = status;
+      return error;
+    };
+
+    it("never retries a 4xx that rejects the query itself", async () => {
+      const factory = await loadForEnv(false);
+      const retry = retryOf(factory("coffee", "popularity", true));
+
+      // The backend rejecting the query itself is deterministic: repeating it
+      // only delays the message that says what to fix.
+      [400, 404, 413].forEach((status) => {
+        expect(retry(0, rejection(status))).toBe(false);
+        expect(retry(2, rejection(status))).toBe(false);
+      });
+    });
+
+    it("does retry a 429", async () => {
+      const factory = await loadForEnv(false);
+      const retry = retryOf(factory("coffee", "popularity", true));
+
+      // Rate limiting is about how often the request arrived, not what it
+      // contained, and backing off is exactly what resolves it. Failing on the
+      // first one is also sticky: with no pages, nothing retriggers the fetch.
+      expect(retry(0, rejection(429))).toBe(true);
+      expect(retry(2, rejection(429))).toBe(true);
+      expect(retry(3, rejection(429))).toBe(false);
+    });
+
+    it("still retries a 5xx and a transport failure in the browser", async () => {
+      const factory = await loadForEnv(false);
+      const retry = retryOf(factory("coffee", "popularity", true));
+
+      expect(retry(0, rejection(500))).toBe(true);
+      expect(retry(2, rejection(503))).toBe(true);
+      // Budget is still the library default of 3 attempts after the first.
+      expect(retry(3, rejection(500))).toBe(false);
+
+      // A timeout or a dropped connection carries no status at all.
+      expect(retry(0, new Error("Failed to fetch"))).toBe(true);
+    });
+
+    it("does not retry at all on the server", async () => {
+      const factory = await loadForEnv(true);
+      const retry = retryOf(factory("coffee", "popularity", true));
+
+      expect(retry(0, rejection(500))).toBe(false);
+      expect(retry(0, new Error("Failed to fetch"))).toBe(false);
+    });
+
+    it("costs one request for a rejected query and four for a failing backend", async () => {
+      const factory = await loadForEnv(false);
+      const client = new QueryClient({
+        // Only collapses the backoff wait; the count is what is under test.
+        defaultOptions: { queries: { retryDelay: 0 } },
+      });
+
+      fetchMock.mockResolvedValue(response(400, { error: "Parsed query is empty!" }));
+      await expect(
+        client.fetchInfiniteQuery(factory("author:demo", "popularity", true))
+      ).rejects.toThrow();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      fetchMock.mockReset();
+      fetchMock.mockResolvedValue(response(502, "<html>bad gateway</html>"));
+      await expect(
+        client.fetchInfiniteQuery(factory("coffee", "popularity", true))
+      ).rejects.toThrow();
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("request payload", () => {
+    const payloadOf = () =>
+      JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+
+    it("sends only the parameters that are set", async () => {
+      fetchMock.mockResolvedValueOnce(response(200, emptyPage));
+
+      await (options().queryFn as QueryFn)({ pageParam: undefined, signal: undefined });
+
+      expect(String(fetchMock.mock.calls[0][0])).toContain("/search-api/search");
+      expect(payloadOf()).toEqual({ q: "coffee", sort: "popularity", hide_low: true });
+    });
+
+    it("adds since, scroll_id and include_nsfw when they apply", async () => {
+      fetchMock.mockResolvedValueOnce(response(200, emptyPage));
+
+      await (
+        getSearchApiInfiniteQueryOptions(
+          "coffee",
+          "popularity",
+          false,
+          "2026-01-01T00:00:00",
+          undefined,
+          true
+        ).queryFn as QueryFn
+      )({ pageParam: "scroll-2", signal: undefined });
+
+      expect(payloadOf()).toEqual({
+        q: "coffee",
+        sort: "popularity",
+        hide_low: false,
+        since: "2026-01-01T00:00:00",
+        scroll_id: "scroll-2",
+        include_nsfw: 1,
+      });
+    });
+
+    it("stays disabled without a query", () => {
+      expect(options("").enabled).toBe(false);
+      expect(options("coffee").enabled).toBe(true);
+    });
+  });
+});

--- a/packages/sdk/src/modules/search/queries/get-search-api-infinite-query-options.spec.ts
+++ b/packages/sdk/src/modules/search/queries/get-search-api-infinite-query-options.spec.ts
@@ -15,12 +15,32 @@ const options = (q = "coffee") => getSearchApiInfiniteQueryOptions(q, "popularit
 const retryOf = (opts: ReturnType<typeof getSearchApiInfiniteQueryOptions>) =>
   opts.retry as RetryFn;
 
-function response(status: number, body: unknown) {
+/**
+ * Backed by a single readable body, like a real `Response`: reading it twice
+ * throws, and `json()` rejects when the body is not JSON. A permissive double
+ * (independent `json()`/`text()`, `json()` resolving for any input) hides
+ * exactly the bugs this parser can have - it let a `json()`-then-`text()`
+ * fallback that can never run look covered.
+ *
+ * Pass `raw` to send a body that is not JSON at all.
+ */
+function response(status: number, body: unknown, raw?: string) {
+  const text = raw ?? JSON.stringify(body);
+  let consumed = false;
+
+  const read = async () => {
+    if (consumed) {
+      throw new TypeError("Body has already been consumed.");
+    }
+    consumed = true;
+    return text;
+  };
+
   return {
     ok: status >= 200 && status < 300,
     status,
-    json: async () => body,
-    text: async () => JSON.stringify(body),
+    text: read,
+    json: async () => JSON.parse(await read()) as unknown,
   } as unknown as Response;
 }
 
@@ -95,6 +115,33 @@ describe("getSearchApiInfiniteQueryOptions", () => {
       expect(error?.data).toEqual({ message: { q: "Maximum 5 tags!" } });
     });
 
+    it("keeps a non-JSON failure body as the raw text", async () => {
+      // A proxy in front of the API answers with HTML, not JSON. The body is
+      // read once and JSON.parse decides what it was, so this text survives.
+      fetchMock.mockResolvedValueOnce(
+        response(502, undefined, "<html>bad gateway</html>")
+      );
+
+      const error = await (options().queryFn as QueryFn)({
+        pageParam: undefined,
+        signal: undefined,
+      }).then(
+        () => undefined,
+        (e: RequestError) => e
+      );
+
+      expect(error?.status).toBe(502);
+      expect(error?.data).toBe("<html>bad gateway</html>");
+    });
+
+    it("rejects an empty body rather than resolving with nothing", async () => {
+      fetchMock.mockResolvedValueOnce(response(200, undefined, ""));
+
+      await expect(
+        (options().queryFn as QueryFn)({ pageParam: undefined, signal: undefined })
+      ).rejects.toThrow("Response body was empty or invalid JSON");
+    });
+
     it("resolves with the parsed body on success", async () => {
       fetchMock.mockResolvedValueOnce(response(200, emptyPage));
 
@@ -165,14 +212,16 @@ describe("getSearchApiInfiniteQueryOptions", () => {
         defaultOptions: { queries: { retryDelay: 0 } },
       });
 
-      fetchMock.mockResolvedValue(response(400, { error: "Parsed query is empty!" }));
+      fetchMock.mockImplementation(async () => response(400, { error: "Parsed query is empty!" }));
       await expect(
         client.fetchInfiniteQuery(factory("author:demo", "popularity", true))
       ).rejects.toThrow();
       expect(fetchMock).toHaveBeenCalledTimes(1);
 
       fetchMock.mockReset();
-      fetchMock.mockResolvedValue(response(502, "<html>bad gateway</html>"));
+      // Fresh per attempt: a real retry gets a new Response, and a reused body
+      // would be unreadable after the first read.
+      fetchMock.mockImplementation(async () => response(502, undefined, "<html>bad gateway</html>"));
       await expect(
         client.fetchInfiniteQuery(factory("coffee", "popularity", true))
       ).rejects.toThrow();

--- a/packages/sdk/src/modules/search/queries/get-search-api-infinite-query-options.ts
+++ b/packages/sdk/src/modules/search/queries/get-search-api-infinite-query-options.ts
@@ -1,6 +1,12 @@
-import { infiniteQueryOptions } from "@tanstack/react-query";
+import { infiniteQueryOptions, isServer } from "@tanstack/react-query";
 import { CONFIG, INTERNAL_API_TIMEOUT_MS, withTimeoutSignal, QueryKeys } from "@/modules/core";
 import { SearchResponse } from "../types/search-response";
+import { parseJsonResponse, type RequestError } from "../parse-json-response";
+
+// A `retry` callback replaces React Query's budget outright, so it has to be
+// restated: the library default of 3 in the browser, and none on the server,
+// where retrying a single-region search backend only stalls the render.
+const MAX_RETRIES = isServer ? 0 : 3;
 
 export function getSearchApiInfiniteQueryOptions(
   q: string,
@@ -48,14 +54,26 @@ export function getSearchApiInfiniteQueryOptions(
         signal: withTimeoutSignal(INTERNAL_API_TIMEOUT_MS, signal),
       });
 
-      if (!response.ok) {
-        throw new Error(`Search failed: ${response.status}`);
-      }
-
-      return response.json() as Promise<SearchResponse>;
+      // Keeps the backend's own explanation of a rejected query on the error
+      // (status + body), instead of collapsing it to a status code.
+      return parseJsonResponse<SearchResponse>(response);
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage: SearchResponse) => lastPage?.scroll_id,
     enabled: !!q,
+    retry: (failureCount: number, error: Error) => {
+      // A 4xx is the backend rejecting the query itself (too many tags, over
+      // the length cap, nothing left to search once the filters are parsed
+      // out). Repeating it repeats the same answer, so the only effect is four
+      // requests over several seconds before the UI can say what to change.
+      // 429 is the exception: it is about how often the request arrived, not
+      // what it contained, and it is the one 4xx that backing off resolves.
+      const { status } = error as RequestError;
+      if (status !== undefined && status >= 400 && status < 500 && status !== 429) {
+        return false;
+      }
+
+      return failureCount < MAX_RETRIES;
+    },
   });
 }

--- a/packages/sdk/src/modules/search/queries/get-search-api-infinite-query-options.ts
+++ b/packages/sdk/src/modules/search/queries/get-search-api-infinite-query-options.ts
@@ -66,10 +66,13 @@ export function getSearchApiInfiniteQueryOptions(
       // the length cap, nothing left to search once the filters are parsed
       // out). Repeating it repeats the same answer, so the only effect is four
       // requests over several seconds before the UI can say what to change.
-      // 429 is the exception: it is about how often the request arrived, not
-      // what it contained, and it is the one 4xx that backing off resolves.
+      // 408 and 429 are the exceptions: they describe when the request arrived
+      // rather than what it contained, and backing off is what resolves them.
+      // A client-side timeout aborts the fetch and carries no status at all,
+      // so this covers only a real 408 from a gateway in front of the API.
       const { status } = error as RequestError;
-      if (status !== undefined && status >= 400 && status < 500 && status !== 429) {
+      const isTransient = status === 408 || status === 429;
+      if (status !== undefined && status >= 400 && status < 500 && !isTransient) {
         return false;
       }
 

--- a/packages/sdk/src/modules/search/queries/get-similar-entries-query-options.spec.ts
+++ b/packages/sdk/src/modules/search/queries/get-similar-entries-query-options.spec.ts
@@ -24,6 +24,34 @@ const entry = {
 
 type QueryFn = (ctx: { signal?: AbortSignal }) => Promise<unknown>;
 
+/**
+ * Backed by a single readable body, like a real `Response`. The shared
+ * `parseJsonResponse` reads the body once with `text()`, so a double that only
+ * implements `json()` would pass here while the real thing failed.
+ */
+function response(
+  body: unknown,
+  { ok = true, status }: { ok?: boolean; status?: number } = {}
+) {
+  const text = JSON.stringify(body);
+  let consumed = false;
+
+  const read = async () => {
+    if (consumed) {
+      throw new TypeError("Body has already been consumed.");
+    }
+    consumed = true;
+    return text;
+  };
+
+  return {
+    ok,
+    status: status ?? (ok ? 200 : 500),
+    text: read,
+    json: async () => JSON.parse(await read()) as unknown,
+  } as unknown as Response;
+}
+
 function searchResponse(
   results: Partial<SearchResponse["results"][number]>[]
 ): SearchResponse {
@@ -88,15 +116,13 @@ describe("getSimilarEntriesQueryOptions", () => {
   });
 
   it("POSTs to /search-api/similar with title, tags, a truncated body and ~6 month since", async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () =>
+    fetchMock.mockResolvedValueOnce(response(
         searchResponse([
           { author: "c", permlink: "p2" },
           { author: "d", permlink: "p3" },
           { author: "e", permlink: "p4" },
-        ]),
-    });
+        ])
+    ));
 
     const options = getSimilarEntriesQueryOptions(entry);
     const result = (await (options.queryFn as QueryFn)({
@@ -122,7 +148,7 @@ describe("getSimilarEntriesQueryOptions", () => {
   });
 
   it("strips markdown image links and URLs from the body excerpt", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => searchResponse([]) });
+    fetchMock.mockResolvedValueOnce(response(searchResponse([])));
 
     const e = {
       author: "a",
@@ -141,9 +167,7 @@ describe("getSimilarEntriesQueryOptions", () => {
   });
 
   it("excludes the source post and nsfw, dedupes by author, caps at 4", async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () =>
+    fetchMock.mockResolvedValueOnce(response(
         searchResponse([
           { author: "a", permlink: "my-post", tags: [] }, // same permlink → dropped
           { author: "b", permlink: "p1", tags: ["nsfw"] }, // nsfw → dropped
@@ -153,8 +177,8 @@ describe("getSimilarEntriesQueryOptions", () => {
           { author: "e", permlink: "p5", tags: [] },
           { author: "f", permlink: "p6", tags: [] },
           { author: "g", permlink: "p7", tags: [] }, // beyond cap of 4
-        ]),
-    });
+        ])
+    ));
 
     const options = getSimilarEntriesQueryOptions(entry);
     const result = (await (options.queryFn as QueryFn)({
@@ -165,7 +189,7 @@ describe("getSimilarEntriesQueryOptions", () => {
   });
 
   it("handles a post with no tags or body", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => searchResponse([]) });
+    fetchMock.mockResolvedValueOnce(response(searchResponse([])));
 
     const options = getSimilarEntriesQueryOptions({ author: "a", permlink: "p" });
     const result = (await (options.queryFn as QueryFn)({
@@ -185,7 +209,7 @@ describe("getSimilarEntriesQueryOptions", () => {
     // json_metadata.tags as a bare string rather than an array. `?? []` only
     // guarded null/undefined, so `.filter` threw and crashed the entry-page
     // SSR prefetch. The call must not throw and the bad tags become [].
-    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => searchResponse([]) });
+    fetchMock.mockResolvedValueOnce(response(searchResponse([])));
 
     const e = {
       author: "a",
@@ -207,7 +231,7 @@ describe("getSimilarEntriesQueryOptions", () => {
   });
 
   it("throws on a failed request so the error surfaces (the strip then hides)", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+    fetchMock.mockResolvedValueOnce(response({}, { ok: false, status: 500 }));
 
     const options = getSimilarEntriesQueryOptions(entry);
     await expect(
@@ -228,7 +252,9 @@ describe("getSimilarEntriesQueryOptions", () => {
     // 2s cap on the server (so a slow cross-region call can't stall SSR) and the
     // 4s cap on the client (best-effort, doesn't block paint). Without this, a
     // refactor could silently fall back to the SDK's generic ~10s timeout.
-    fetchMock.mockResolvedValue({ ok: true, json: async () => searchResponse([]) });
+    // A fresh Response per call: one object cannot be read twice, and this
+    // test makes two requests.
+    fetchMock.mockImplementation(async () => response(searchResponse([])));
 
     // SSR context — no window.
     vi.stubGlobal("window", undefined);

--- a/packages/sdk/src/modules/search/requests.ts
+++ b/packages/sdk/src/modules/search/requests.ts
@@ -1,35 +1,6 @@
 import { CONFIG, INTERNAL_API_TIMEOUT_MS, getBoundFetch, withTimeoutSignal } from "@/modules/core";
 import { SearchResponse } from "./types/search-response";
-
-type RequestError = Error & { status?: number; data?: unknown };
-
-async function parseJsonResponse<T>(response: Response): Promise<T> {
-  const parseBody = async (): Promise<unknown> => {
-    try {
-      return await response.json();
-    } catch {
-      try {
-        return await response.text();
-      } catch {
-        return undefined;
-      }
-    }
-  };
-
-  const data = await parseBody();
-  if (!response.ok) {
-    const error = new Error(`Request failed with status ${response.status}`) as RequestError;
-    error.status = response.status;
-    error.data = data;
-    throw error;
-  }
-
-  if (data === undefined) {
-    throw new Error("Response body was empty or invalid JSON");
-  }
-
-  return data as T;
-}
+import { parseJsonResponse } from "./parse-json-response";
 
 export async function search(
   q: string,


### PR DESCRIPTION
Closes #1343. Needs ecency/hivesearcher-api#10 deployed for the filter-only case to return results.

The advanced form builds one `q` string by appending `author:`/`type:`/`category:`/`tag:` tokens to the free-text box, and the search API parses those same tokens back out with the same regexes. Most of these defects come from the two sides disagreeing about what that string means.

## Query building

- The free-text field was re-seeded from `searchQuery.query` (raw) instead of `.search` (stripped), so every Apply re-appended the filters: `coffee author:demo` then `coffee author:demo author:demo`, and eventually past the API's 100-character cap, at which point everything returned "No matches".
- A filter with no free text built `" author:demo"` with a leading space, and the API rejected the empty remainder. It now builds `author:demo`.
- Author, category and tags are lowercased and stripped of a leading `@`/`#`, because the API filters with exact `term` queries and Hive names and tags are lowercase. They are also cut at the first space: the token regex stops there regardless, and the remainder silently became required free text under `default_operator: AND`.
- Tags split on commas *and* whitespace, so `travel, photography` filters on both rather than filtering on `travel` and requiring the word `photography`. The filter fields are no longer `.trim()`ed on every keystroke, which made a trailing space impossible to type.
- The built query is re-parsed and rebuilt before it is sent, so token syntax typed into the free-text box is normalized like the dedicated fields are. That makes build/parse/rebuild a fixed point: `author:@Demo` typed into the search box used to miss on the first Apply and match on the second.

## Validation

Runs against the parsed query, not the field values, since the free-text box can carry tokens of its own. Nothing selective, more than 5 tags, or over 100 characters is now reported in the form instead of being sent and returning an unexplained 400.

## Failures and empties

- The results list and the people/communities/topics panels all rendered "No matches" or a blank box for a *failed* request. They now say the search failed. The backend's own text stays on the error object for Sentry rather than being rendered, since it is English only and lives in another repo.
- 4xx is no longer retried three times. 429 still is: it is about how often the request arrived, not what it contained.
- The empty state no longer appears before the first page has landed.
- `initialData` is gone from the results query. It made `state.data` defined, which is exactly what `shouldLoadOnMount` checks, so React Query never fetched page 1 and the viewport sentinel was the only thing that could start it (`refetchOnMount` is false app-wide). That held only while the sentinel sat near the top of a short card. With the advanced panel open it starts below the fold on a phone, and page 1 was never requested at all.
- The communities panel no longer lists the global top communities by rank when there is no term to look up, which a filter-only search presented as matches.

## Other

- `adv=1` is read back, so a reloaded or shared advanced-search URL shows the panel its active filters belong to. It was written and ignored.
- The date select is component state seeded from the URL. It read a `recent_date` localStorage entry shared with the decks add-column form (which defaults it differently), so the two overwrote each other and an untouched select silently reapplied a stale value, undoing the all-time default from 1919398.
- The hide-low checkbox no longer flashes unchecked on mount.
- Enter applies from the selects, and uses `e.key` rather than the deprecated `keyCode`.

## Test plan

- `apps/web`: 266 files / 2597 tests green. New specs for the form, the results panel and the side panels; `specs/utils/search-query.spec.ts` extended, including a round-trip idempotence test that is the regression test for the duplicating-tokens bug.
- `@ecency/sdk`: 45 files / 607 tests green, new spec for the search query options (error body, status, retry policy).
- `tsc --noEmit` clean for both, eslint clean.
- The `initialData` fix was mutation-tested: the spec's QueryClient now mirrors `makeQueryClient()` (`refetchOnMount: false`), and restoring `initialData` fails 7 tests including the one asserting page 1 loads without the sentinel. Before that the suite fetched via a mount refetch production does not do, which is how a first page that only ever loaded from the viewport sentinel looked healthy.

Note `packages/sdk/dist` is not rebuilt here: staging and master both run `pnpm build:packages` before the web build, so the app gets it, but npm consumers need the usual `patch:sdk` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search filters now sync with URL parameters and retain selections when navigating.
  * Added normalized query handling for authors, categories, tags, dates, and filter limits.
  * Enter and keyboard submission work consistently across search controls.
* **Bug Fixes**
  * Added clear validation and search failure messages.
  * Empty searches no longer trigger requests or display blank panels.
  * Existing results remain visible when loading additional results fails.
* **Tests**
  * Expanded coverage for search forms, filters, URL behavior, errors, pagination, and result states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->