### PR TITLE
fix(self-hosted): repair a config value stored with the wrong type

### DIFF
--- a/apps/self-hosted/hosting/api/src/routes/tenant-config-patch.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenant-config-patch.test.ts
@@ -19,6 +19,10 @@ vi.mock('../services/tenant-service', () => ({
   COMMUNITY_NAME: /^hive-\d+$/,
   isReregisterableAbandoned: () => false,
   ABANDONED_REREGISTER_QUARANTINE_HOURS: 1,
+  // Read at module scope by the PATCH body schema, so these are the real values: stubbing them
+  // loosely would let this suite accept reset paths the deployed route rejects.
+  CONFIG_RESET_PATH: /^configuration(\.[A-Za-z][A-Za-z0-9_-]*)+$/,
+  MAX_RESET_PATHS: 32,
 }));
 
 vi.mock('../services/config-service', () => ({
@@ -54,11 +58,11 @@ const TENANT = {
   subscriptionPlan: 'standard',
 };
 
-function patch(config: unknown) {
+function patch(config: unknown, reset?: unknown) {
   return tenantRoutes.request('http://localhost/alice', {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ config }),
+    body: JSON.stringify(reset === undefined ? { config } : { config, reset }),
   });
 }
 
@@ -68,6 +72,7 @@ beforeEach(() => {
   mocks.applyConfigDocument.mockImplementation(async () => ({
     tenant: { ...TENANT, config: { version: 1, configuration: {} } },
     discarded: [],
+    reset: [],
   }));
   mocks.updateConfig.mockImplementation(async () => ({
     ...TENANT,
@@ -116,7 +121,7 @@ describe('PATCH /v1/tenants/:username config validation', () => {
     const res = await patch(doc);
 
     expect(res.status).toBe(200);
-    expect(mocks.applyConfigDocument).toHaveBeenCalledWith('alice', doc);
+    expect(mocks.applyConfigDocument).toHaveBeenCalledWith('alice', doc, []);
     expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
 
@@ -146,6 +151,7 @@ describe('PATCH /v1/tenants/:username config validation', () => {
           reason: 'the instance type is set when the instance is created and cannot be changed here',
         },
       ],
+      reset: [],
     });
 
     const res = await patch({
@@ -166,5 +172,102 @@ describe('PATCH /v1/tenants/:username config validation', () => {
     const body = (await res.json()) as { discarded: unknown[]; message: string };
     expect(body.discarded).toEqual([]);
     expect(body.message).toBe('Configuration updated');
+  });
+});
+
+/**
+ * A value stored with the wrong primitive type cannot be replaced: the merge only accepts a
+ * value that agrees with what is stored. `reset` names stored values to drop so the document in
+ * the SAME request can write the replacement. It rides on this PATCH rather than an endpoint of
+ * its own, so it is authorized exactly as a save is: there is no second door to the config.
+ */
+describe('PATCH /v1/tenants/:username config reset', () => {
+  const doc = { version: 1, configuration: { general: { theme: 'dark' } } };
+
+  it('passes the requested paths to the service and reports what was cleared', async () => {
+    mocks.applyConfigDocument.mockResolvedValue({
+      tenant: { ...TENANT, config: { version: 1, configuration: {} } },
+      discarded: [],
+      reset: ['configuration.general.theme'],
+    });
+
+    const res = await patch(doc, ['configuration.general.theme']);
+
+    expect(res.status).toBe(200);
+    expect(mocks.applyConfigDocument).toHaveBeenCalledWith('alice', doc, [
+      'configuration.general.theme',
+    ]);
+    const body = (await res.json()) as { reset: string[] };
+    expect(body.reset).toEqual(['configuration.general.theme']);
+  });
+
+  it('refuses a caller who does not control the instance', async () => {
+    // The same 403 an ordinary save gets. A reset must never be reachable by anyone a save is
+    // not, and it is checked before the body is looked at.
+    mocks.getByUsername.mockResolvedValue({ ...TENANT, owner: 'bob' });
+
+    const res = await patch(doc, ['configuration.general.theme']);
+
+    expect(res.status).toBe(403);
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+    expect(mocks.generateConfigFile).not.toHaveBeenCalled();
+  });
+
+  it('refuses a reset sent without the document that replaces the value', async () => {
+    // A bare reset would be a delete. Requiring the document keeps it a repair, and means a
+    // caller cannot remove anything without stating what it expects to be stored.
+    const res = await patch({ theme: 'dark' }, ['configuration.general.theme']);
+
+    expect(res.status).toBe(400);
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+  });
+
+  it('refuses paths that are not values inside the configuration document', async () => {
+    for (const path of [
+      'configuration',
+      'version',
+      'general.theme',
+      'configuration.__proto__.polluted',
+      'configuration.general.0',
+      '../../etc/passwd',
+    ]) {
+      const res = await patch(doc, [path]);
+      expect(res.status, path).toBe(400);
+    }
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+  });
+
+  it('refuses a reset that is not a list of paths', async () => {
+    for (const reset of ['configuration.general.theme', 42, { path: 'x' }, [42]]) {
+      const res = await patch(doc, reset);
+      expect(res.status, JSON.stringify(reset)).toBe(400);
+    }
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+  });
+
+  it('refuses more paths than one repair can need', async () => {
+    const many = Array.from({ length: 33 }, (_, i) => `configuration.general.field${i}`);
+
+    const res = await patch(doc, many);
+
+    expect(res.status).toBe(400);
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+  });
+
+  it('answers an ordinary save with an empty reset list', async () => {
+    const res = await patch(doc);
+
+    const body = (await res.json()) as { reset: unknown[] };
+    expect(body.reset).toEqual([]);
+  });
+
+  it('answers a flat-key save with an empty reset list', async () => {
+    const res = await patch({ theme: 'dark' });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { reset: unknown[] };
+    expect(body.reset).toEqual([]);
   });
 });

--- a/apps/self-hosted/hosting/api/src/routes/tenant-validation.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenant-validation.test.ts
@@ -9,6 +9,9 @@ vi.mock('../services/tenant-service', () => ({
   // Shared with the payment listener so both recognise a community claim the
   // same way; the real pattern is used here rather than a stub of it.
   COMMUNITY_NAME: /^hive-\d+$/,
+  // Read at module scope by the PATCH body schema; the real values, for the same reason.
+  CONFIG_RESET_PATH: /^configuration(\.[A-Za-z][A-Za-z0-9_-]*)+$/,
+  MAX_RESET_PATHS: 32,
   TenantService: {
     verifyHiveAccount: async (name: string) => state.accounts.has(name),
     verifyCommunityControlledBy: async (community: string, account: string) =>

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -11,6 +11,8 @@ import {
   COMMUNITY_NAME,
   isReregisterableAbandoned,
   ABANDONED_REREGISTER_QUARANTINE_HOURS,
+  CONFIG_RESET_PATH,
+  MAX_RESET_PATHS,
 } from '../services/tenant-service';
 import { mapTenantFromDb } from '../types';
 import { PAYMENT_ACCOUNT, MONTHLY_PRICE_HBD, PRO_UPGRADE_PRICE_HBD, hbd } from '../pricing';
@@ -63,8 +65,17 @@ const flatConfigUpdateSchema = z.object({
 });
 // Only the container is validated here (an object, not an array or a scalar); the branch schema
 // above does the real work once the handler knows which document this is.
+//
+// `reset` names stored values to drop before the document is merged in, which is how a value
+// stored with the wrong type is repaired: the merge refuses any replacement that disagrees with
+// what is stored, so without this the field is frozen behind a 200 OK. It is a sibling of
+// `config`, never a value inside it, so nothing a document can carry (a null, an empty string)
+// can be read as a request to reset, and no reset can be mistaken for a value. Malformed paths
+// are a 400 here; well-formed ones the server will not act on come back in `discarded` with the
+// reason. TenantService.resetConfigPaths re-checks everything, this is only the early answer.
 const updateTenantSchema = z.object({
   config: z.record(z.any()).optional(),
+  reset: z.array(z.string().max(200).regex(CONFIG_RESET_PATH)).max(MAX_RESET_PATHS).optional(),
 });
 
 /** Whether a PATCH body carries a full config document rather than flat keys. */
@@ -587,6 +598,16 @@ tenantRoutes.patch('/:username', authMiddleware, zValidator('json', updateTenant
   // Validate against the schema for the document this actually is, and answer 400 with the
   // reason. A body that cannot be understood must never report a successful save.
   const isFullDoc = isFullConfigDocument(body.config);
+  const resetPaths = body.reset ?? [];
+  // A reset only clears a stored value so the SAME save can write the replacement, so it means
+  // nothing without the document that carries it. Refusing here also means a bare `{ reset: [...] }`
+  // body can never remove anything: the caller has to send the config it expects to be stored.
+  if (resetPaths.length > 0 && !isFullDoc) {
+    return c.json(
+      { error: 'Resetting a configuration value requires the full configuration document' },
+      400
+    );
+  }
   let configUpdate: any = body.config;
   if (body.config) {
     const parsed = isFullDoc
@@ -611,9 +632,13 @@ tenantRoutes.patch('/:username', authMiddleware, zValidator('json', updateTenant
   // fields pinned server-side; flat keys are normalized first, then merge the same way.
   // `discarded` lists what the server refused to store (pinned identity fields, filters the
   // instance type cannot serve, shape mismatches) so the editor can say so.
-  const { tenant: updatedTenant, discarded } = isFullDoc
-    ? await TenantService.applyConfigDocument(username, configUpdate)
-    : { tenant: await TenantService.updateConfig(username, configUpdate), discarded: [] };
+  const { tenant: updatedTenant, discarded, reset } = isFullDoc
+    ? await TenantService.applyConfigDocument(username, configUpdate, resetPaths)
+    : {
+        tenant: await TenantService.updateConfig(username, configUpdate),
+        discarded: [],
+        reset: [] as string[],
+      };
 
   // Publish only for a tenant that is entitled to be served. POST deliberately
   // does not write the file for the same reason: nginx serves any file that
@@ -628,7 +653,8 @@ tenantRoutes.patch('/:username', authMiddleware, zValidator('json', updateTenant
   void AuditService.log({
     tenantId: updatedTenant.id,
     eventType: 'tenant.config_updated',
-    eventData: { username },
+    // A reset is the one save that can drop a stored value, so record which ones it dropped.
+    eventData: reset.length > 0 ? { username, reset } : { username },
     ipAddress: parseClientIp(c.req.header('x-forwarded-for')),
     userAgent: c.req.header('user-agent'),
   });
@@ -640,7 +666,12 @@ tenantRoutes.patch('/:username', authMiddleware, zValidator('json', updateTenant
     // edit that the visitor cannot see yet is explainable.
     published,
     // Values the server did not store, with the reason for each. Empty on an ordinary save.
+    // A requested reset the server would not perform is reported here too.
     discarded,
+    // Paths whose stored value was cleared so this save could replace it. A requested path
+    // that is absent from both this and `discarded` needed no reset: the save applied it
+    // normally, so the client never has to guess which of the three happened.
+    reset,
     message: published
       ? discarded.length > 0
         ? 'Configuration updated. Some values were not applied.'

--- a/apps/self-hosted/hosting/api/src/services/config-reset.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-reset.test.ts
@@ -1,0 +1,500 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Repairing a value stored with the wrong type.
+ *
+ * mergeConfigGuarded only lets a stored value be replaced by one that agrees with its shape, so
+ * a key that already holds the wrong type is frozen: the save answers 200, the field comes back
+ * in `discarded`, and the bad value survives. The guard is doing real work (a string "false"
+ * must never stand in for a boolean), so the way out is an explicit reset that drops the stored
+ * value and lets the SAME save write the replacement into the now-absent slot.
+ *
+ * These run against applyConfigDocument with the database mocked, so they exercise the real
+ * order of sanitize, reset and merge rather than the pieces separately.
+ */
+
+const mocks = vi.hoisted(() => ({
+  queryOne: vi.fn(),
+}));
+
+vi.mock('../db/client', () => ({
+  db: { query: vi.fn(), queryOne: mocks.queryOne, transaction: vi.fn() },
+}));
+
+const { TenantService, CONFIG_RESET_PATH, MAX_RESET_PATHS, PINNED_INSTANCE_FIELDS } = await import(
+  './tenant-service'
+);
+
+/** The config as stored today, with `mutate` applied to break or extend it. */
+async function storedConfig(mutate: (config: any) => void = () => {}): Promise<any> {
+  const config = await TenantService.buildConfig('alice', undefined, 'alice');
+  mutate(config);
+  return config;
+}
+
+/** Stand in for the tenants row so applyConfigDocument can read and write it. */
+let saved: any = null;
+
+function seedTenant(config: any) {
+  saved = null;
+  mocks.queryOne.mockReset();
+  mocks.queryOne.mockImplementation(async (sql: string, params: any[]) => {
+    if (sql.trim().startsWith('SELECT')) {
+      return {
+        id: 'tenant-1',
+        username: 'alice',
+        owner: 'alice',
+        subscription_status: 'active',
+        subscription_plan: 'standard',
+        config,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+    }
+    // The UPDATE: params[1] is the JSON the server decided to store.
+    saved = JSON.parse(params[1]);
+    return {
+      id: 'tenant-1',
+      username: 'alice',
+      owner: 'alice',
+      subscription_status: 'active',
+      subscription_plan: 'standard',
+      config: saved,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+  });
+}
+
+/** A full config document carrying just the instance section given. */
+function instanceDoc(instanceConfiguration: any) {
+  return { version: 1, configuration: { instanceConfiguration } };
+}
+
+beforeEach(() => {
+  saved = null;
+  mocks.queryOne.mockReset();
+});
+
+describe('a malformed scalar can be repaired through the editor', () => {
+  it('was stuck before the reset existed', async () => {
+    // The behaviour the issue describes, kept as the baseline the fix is measured against:
+    // a correctly typed value is refused, reported, and the bad value survives.
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.general.theme = 7;
+      })
+    );
+
+    const { discarded } = await TenantService.applyConfigDocument('alice', {
+      version: 1,
+      configuration: { general: { theme: 'dark' } },
+    });
+
+    expect(saved.configuration.general.theme).toBe(7);
+    expect(discarded.map((d) => d.path)).toEqual(['configuration.general.theme']);
+  });
+
+  it('replaces the malformed scalar when the same save asks for a reset', async () => {
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.general.theme = 7;
+      })
+    );
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      { version: 1, configuration: { general: { theme: 'dark' } } },
+      ['configuration.general.theme']
+    );
+
+    expect(saved.configuration.general.theme).toBe('dark');
+    expect(reset).toEqual(['configuration.general.theme']);
+    expect(discarded).toEqual([]);
+    // and nothing else in the section moved
+    expect(saved.configuration.general.imageProxy).toBe('https://i.ecency.com');
+  });
+
+  it('repairs a scalar standing where a whole block belongs', async () => {
+    // features.hive is the case tenant-service-hive-seed.test.ts documents as unrepairable:
+    // a bare string stored where the block belongs refuses every later object write.
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.instanceConfiguration.features.hive = 'full';
+      })
+    );
+
+    const { reset } = await TenantService.applyConfigDocument(
+      'alice',
+      instanceDoc({ features: { hive: { readerLayer: 'standard', authorRewards: 'author' } } }),
+      ['configuration.instanceConfiguration.features.hive']
+    );
+
+    expect(saved.configuration.instanceConfiguration.features.hive).toEqual({
+      readerLayer: 'standard',
+      authorRewards: 'author',
+    });
+    expect(reset).toEqual(['configuration.instanceConfiguration.features.hive']);
+  });
+
+  it('repairs an array whose stored elements are of the wrong type', async () => {
+    // isValidArrayReplacement takes the element type from the stored array, so an array of
+    // numbers refuses every array of strings: the same trap one level down.
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.instanceConfiguration.features.auth.methods = [1, 2];
+      })
+    );
+
+    const { reset } = await TenantService.applyConfigDocument(
+      'alice',
+      instanceDoc({ features: { auth: { methods: ['keychain'] } } }),
+      ['configuration.instanceConfiguration.features.auth.methods']
+    );
+
+    expect(saved.configuration.instanceConfiguration.features.auth.methods).toEqual(['keychain']);
+    expect(reset).toEqual(['configuration.instanceConfiguration.features.auth.methods']);
+  });
+
+  it('repairs several fields in one save', async () => {
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.general.theme = 7;
+        c.configuration.instanceConfiguration.meta.title = 42;
+      })
+    );
+
+    const { reset } = await TenantService.applyConfigDocument(
+      'alice',
+      {
+        version: 1,
+        configuration: {
+          general: { theme: 'dark' },
+          instanceConfiguration: { meta: { title: 'My blog' } },
+        },
+      },
+      ['configuration.general.theme', 'configuration.instanceConfiguration.meta.title']
+    );
+
+    expect(saved.configuration.general.theme).toBe('dark');
+    expect(saved.configuration.instanceConfiguration.meta.title).toBe('My blog');
+    expect(reset).toHaveLength(2);
+  });
+});
+
+describe('the type guard is still enforced', () => {
+  it('refuses a mismatched value on a save that asks for no reset', async () => {
+    seedTenant(await storedConfig());
+
+    const { discarded, reset } = await TenantService.applyConfigDocument('alice', {
+      version: 1,
+      configuration: {
+        general: { theme: 42 },
+        instanceConfiguration: { features: { likes: { enabled: 'false' } } },
+      },
+    });
+
+    expect(saved.configuration.general.theme).toBe('system');
+    expect(saved.configuration.instanceConfiguration.features.likes.enabled).toBe(true);
+    expect(reset).toEqual([]);
+    expect(discarded.map((d) => d.path).sort()).toEqual([
+      'configuration.general.theme',
+      'configuration.instanceConfiguration.features.likes.enabled',
+    ]);
+  });
+
+  it('refuses a mismatched value at a path the caller did not name', async () => {
+    // A reset unlocks exactly one path. Everything else in the same document is judged by the
+    // usual rule, so a reset is never a blanket permission to write junk.
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.general.theme = 7;
+      })
+    );
+
+    await TenantService.applyConfigDocument(
+      'alice',
+      {
+        version: 1,
+        configuration: { general: { theme: 'dark', styleTemplate: 99 } },
+      },
+      ['configuration.general.theme']
+    );
+
+    expect(saved.configuration.general.theme).toBe('dark');
+    expect(saved.configuration.general.styleTemplate).toBe('medium');
+  });
+});
+
+describe('a reset cannot remove a pinned identity field', () => {
+  it.each(PINNED_INSTANCE_FIELDS)('refuses to reset %s', async (field) => {
+    seedTenant(await storedConfig());
+    const before = (await storedConfig()).configuration.instanceConfiguration[field];
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      instanceDoc({ [field]: 'attacker' }),
+      [`configuration.instanceConfiguration.${field}`]
+    );
+
+    expect(saved.configuration.instanceConfiguration[field]).toBe(before);
+    expect(reset).toEqual([]);
+    // Sanitize also reports its own pin for the value in the document, so the reset refusal
+    // has to be matched on its reason, not just on the path.
+    expect(discarded).toContainEqual({
+      path: `configuration.instanceConfiguration.${field}`,
+      reason: 'this field is set by the server and cannot be reset',
+    });
+  });
+
+  it('keeps the pin even when the reset names a path below it', async () => {
+    seedTenant(await storedConfig());
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      instanceDoc({ type: { nested: 'community' } }),
+      ['configuration.instanceConfiguration.type.nested']
+    );
+
+    expect(saved.configuration.instanceConfiguration.type).toBe('blog');
+    expect(reset).toEqual([]);
+    expect(discarded).toContainEqual({
+      path: 'configuration.instanceConfiguration.type.nested',
+      reason: 'this field is set by the server and cannot be reset',
+    });
+  });
+});
+
+describe('a reset cannot wipe configuration', () => {
+  it('refuses to clear a section that holds values', async () => {
+    seedTenant(await storedConfig());
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      { version: 1, configuration: { general: { theme: 'dark' } } },
+      ['configuration.general']
+    );
+
+    expect(saved.configuration.general.imageProxy).toBe('https://i.ecency.com');
+    expect(saved.configuration.general.theme).toBe('dark');
+    expect(reset).toEqual([]);
+    expect(discarded[0]).toMatchObject({
+      path: 'configuration.general',
+      reason: 'a section cannot be reset, only the individual values inside it',
+    });
+  });
+
+  it('refuses a path that is not inside the configuration document', async () => {
+    seedTenant(await storedConfig());
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      { version: 1, configuration: { general: { theme: 'dark' } } },
+      ['version', 'configuration', 'general.theme', '', 'configuration.']
+    );
+
+    expect(reset).toEqual([]);
+    expect(discarded).toHaveLength(5);
+    for (const entry of discarded) {
+      expect(entry.reason).toBe('not a value inside the configuration document');
+    }
+    expect(saved.version).toBe(1);
+  });
+
+  it('refuses prototype and index segments', async () => {
+    seedTenant(await storedConfig());
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      { version: 1, configuration: { general: { theme: 'dark' } } },
+      [
+        'configuration.__proto__',
+        'configuration.constructor.prototype',
+        'configuration.general.__proto__.polluted',
+        'configuration.instanceConfiguration.features.postsFilters.0',
+      ]
+    );
+
+    expect(reset).toEqual([]);
+    expect(discarded).toHaveLength(4);
+    // Refused on the shape of the path, before anything walks the config with it: not because
+    // the walk happens to find nothing there.
+    for (const entry of discarded) {
+      expect(entry.reason).toBe('not a value inside the configuration document');
+    }
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('refuses a reset the saved document carries no replacement for', async () => {
+    // Without this a reset would be a delete, and the served config would be left with a hole
+    // that nothing in the request fills.
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.general.theme = 7;
+      })
+    );
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      { version: 1, configuration: { general: { styleTemplate: 'minimal' } } },
+      ['configuration.general.theme']
+    );
+
+    expect(saved.configuration.general.theme).toBe(7);
+    expect(reset).toEqual([]);
+    expect(discarded[0]).toMatchObject({
+      path: 'configuration.general.theme',
+      reason: 'the saved document carries no replacement value for this field',
+    });
+  });
+
+  it('does not read a null in the document as a request to reset', async () => {
+    // Nulls are stripped before the merge (a null section must never erase stored settings), so
+    // a document whose field is null carries no replacement and the reset is refused. Only the
+    // `reset` list, never a value, can ask for a reset.
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.general.theme = 7;
+      })
+    );
+
+    const { reset } = await TenantService.applyConfigDocument(
+      'alice',
+      { version: 1, configuration: { general: { theme: null } } },
+      ['configuration.general.theme']
+    );
+
+    expect(saved.configuration.general.theme).toBe(7);
+    expect(reset).toEqual([]);
+  });
+
+  it('refuses the whole list once it is past the ceiling', async () => {
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.general.theme = 7;
+      })
+    );
+    const padding = Array.from({ length: MAX_RESET_PATHS }, (_, i) => `configuration.pad${i}`);
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      { version: 1, configuration: { general: { theme: 'dark' } } },
+      [...padding, 'configuration.general.theme']
+    );
+
+    // Not "the first 32 of them": a list this long is not a field-by-field repair, so none of
+    // it is applied and the caller is told why.
+    expect(reset).toEqual([]);
+    expect(saved.configuration.general.theme).toBe(7);
+    expect(discarded).toContainEqual({
+      path: 'reset',
+      reason: 'at most 32 values can be reset in one save',
+    });
+  });
+});
+
+describe('a reset changes nothing about a save that would have worked', () => {
+  it('is a no-op on a healthy field, and is not reported as a discard', async () => {
+    seedTenant(await storedConfig());
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      { version: 1, configuration: { general: { theme: 'dark' } } },
+      ['configuration.general.theme']
+    );
+
+    expect(saved.configuration.general.theme).toBe('dark');
+    // Nothing was cleared because nothing was blocking, and the save applied in full: saying
+    // "some values were not applied" here would be a lie the editor shows the owner.
+    expect(reset).toEqual([]);
+    expect(discarded).toEqual([]);
+  });
+
+  it('is a no-op when the key is not stored at all', async () => {
+    seedTenant(
+      await storedConfig((c) => {
+        delete c.configuration.general.theme;
+      })
+    );
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      { version: 1, configuration: { general: { theme: 'dark' } } },
+      ['configuration.general.theme']
+    );
+
+    expect(saved.configuration.general.theme).toBe('dark');
+    expect(reset).toEqual([]);
+    expect(discarded).toEqual([]);
+  });
+
+  it('leaves a save with no reset list byte-identical', async () => {
+    const doc = {
+      version: 1,
+      configuration: {
+        general: { theme: 'dark' },
+        instanceConfiguration: { meta: { title: 'T' } },
+      },
+    };
+
+    seedTenant(await storedConfig());
+    await TenantService.applyConfigDocument('alice', doc);
+    const withoutReset = JSON.stringify(saved);
+
+    seedTenant(await storedConfig());
+    await TenantService.applyConfigDocument('alice', doc, []);
+    expect(JSON.stringify(saved)).toBe(withoutReset);
+  });
+});
+
+describe('resetConfigPaths mechanics', () => {
+  it('does not mutate the config it was given', async () => {
+    const stored = await storedConfig((c) => {
+      c.configuration.general.theme = 7;
+    });
+    const before = JSON.stringify(stored);
+
+    const { config, reset } = TenantService.resetConfigPaths(
+      stored,
+      ['configuration.general.theme'],
+      { configuration: { general: { theme: 'dark' } } }
+    );
+
+    expect(reset).toEqual(['configuration.general.theme']);
+    expect(JSON.stringify(stored)).toBe(before);
+    expect('theme' in config.configuration.general).toBe(false);
+    // Untouched branches are shared, not copied.
+    expect(config.configuration.instanceConfiguration).toBe(
+      stored.configuration.instanceConfiguration
+    );
+  });
+
+  it('reads own properties only, so an inherited key is not mistaken for stored config', () => {
+    const stored = { configuration: { general: {} } };
+    // `toString` resolves through the prototype chain; readPath must not see it.
+    expect(TenantService.readPath(stored, ['configuration', 'general', 'toString'])).toBeUndefined();
+  });
+
+  it('takes no paths as no work', async () => {
+    const stored = await storedConfig();
+    const result = TenantService.resetConfigPaths(stored, undefined, {});
+    expect(result.config).toBe(stored);
+    expect(result.reset).toEqual([]);
+  });
+});
+
+/**
+ * The route validates reset paths at the edge with these two, and the route suite mocks this
+ * module and restates them literally. Pinned here so a change to the rule cannot pass while the
+ * route tests go on asserting the old one.
+ */
+describe('the reset request contract', () => {
+  it('pins the accepted path shape', () => {
+    expect(CONFIG_RESET_PATH.source).toBe('^configuration(\\.[A-Za-z][A-Za-z0-9_-]*)+$');
+    expect(MAX_RESET_PATHS).toBe(32);
+  });
+
+  it('pins the identity fields a reset may not touch', () => {
+    expect([...PINNED_INSTANCE_FIELDS]).toEqual(['username', 'owner', 'type', 'communityId']);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/config-reset.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-reset.test.ts
@@ -226,6 +226,132 @@ describe('the type guard is still enforced', () => {
   });
 });
 
+/**
+ * The reset has to know which side of the save is the broken one. Asking only whether the
+ * stored and incoming values disagree cannot tell: that question is symmetric, so it answers
+ * yes just as readily when the stored value is healthy and the replacement is junk, and the
+ * repair tool becomes the easiest way to corrupt a good field. The canonical shape for the
+ * path is what breaks the symmetry.
+ */
+describe('a reset cannot corrupt a healthy value', () => {
+  it('refuses to put a number over a healthy string', async () => {
+    seedTenant(await storedConfig());
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      { version: 1, configuration: { general: { theme: 42 } } },
+      ['configuration.general.theme']
+    );
+
+    expect(saved.configuration.general.theme).toBe('system');
+    expect(reset).toEqual([]);
+    expect(discarded).toContainEqual({
+      path: 'configuration.general.theme',
+      reason: 'the value being saved is not the type this setting must have',
+    });
+  });
+
+  it('refuses to put the string "false" over a healthy boolean', async () => {
+    seedTenant(await storedConfig());
+
+    const { reset } = await TenantService.applyConfigDocument(
+      'alice',
+      instanceDoc({ features: { likes: { enabled: 'false' } } }),
+      ['configuration.instanceConfiguration.features.likes.enabled']
+    );
+
+    expect(saved.configuration.instanceConfiguration.features.likes.enabled).toBe(true);
+    expect(reset).toEqual([]);
+  });
+
+  it('refuses array elements of the wrong type over a healthy array', async () => {
+    seedTenant(await storedConfig());
+
+    const { reset } = await TenantService.applyConfigDocument(
+      'alice',
+      instanceDoc({ features: { auth: { methods: [1, 2] } } }),
+      ['configuration.instanceConfiguration.features.auth.methods']
+    );
+
+    expect(saved.configuration.instanceConfiguration.features.auth.methods).toEqual([
+      'keychain',
+      'hivesigner',
+      'hiveauth',
+    ]);
+    expect(reset).toEqual([]);
+  });
+
+  it('refuses junk inside a replacement block, even repairing a broken one', async () => {
+    // The stored side really is broken here, so the only thing standing between the reset and
+    // a stored `readerLayer: 42` is checking the replacement against the canonical block.
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.instanceConfiguration.features.hive = 'full';
+      })
+    );
+
+    const { reset } = await TenantService.applyConfigDocument(
+      'alice',
+      instanceDoc({ features: { hive: { readerLayer: 42 } } }),
+      ['configuration.instanceConfiguration.features.hive']
+    );
+
+    expect(saved.configuration.instanceConfiguration.features.hive).toBe('full');
+    expect(reset).toEqual([]);
+  });
+
+  it('still accepts a block carrying a setting newer than the seed', async () => {
+    // The editor offers more of the Hive block than getDefaultConfig writes. A key the seed
+    // does not carry contradicts nothing, and a normal save may already write it into an
+    // absent slot, so refusing it would block the repair without protecting anything.
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.instanceConfiguration.features.hive = 'full';
+      })
+    );
+
+    const { reset } = await TenantService.applyConfigDocument(
+      'alice',
+      instanceDoc({
+        features: {
+          hive: { readerLayer: 'standard', authorRewards: 'author', payoutLabel: 'Earned' },
+        },
+      }),
+      ['configuration.instanceConfiguration.features.hive']
+    );
+
+    expect(saved.configuration.instanceConfiguration.features.hive).toEqual({
+      readerLayer: 'standard',
+      authorRewards: 'author',
+      payoutLabel: 'Earned',
+    });
+    expect(reset).toEqual(['configuration.instanceConfiguration.features.hive']);
+  });
+
+  it('refuses a setting the server has no default for', async () => {
+    // Nothing says what this field is supposed to be, so nothing can say which side is broken.
+    // Refusing leaves it stuck for an operator; guessing would let anything overwrite anything.
+    seedTenant(
+      await storedConfig((c) => {
+        c.configuration.instanceConfiguration.features.tipping = { buttonLabel: 42 };
+      })
+    );
+
+    const { discarded, reset } = await TenantService.applyConfigDocument(
+      'alice',
+      instanceDoc({ features: { tipping: { buttonLabel: 'Tip' } } }),
+      ['configuration.instanceConfiguration.features.tipping.buttonLabel']
+    );
+
+    expect(saved.configuration.instanceConfiguration.features.tipping.buttonLabel).toBe(42);
+    expect(reset).toEqual([]);
+    expect(discarded).toContainEqual({
+      path: 'configuration.instanceConfiguration.features.tipping.buttonLabel',
+      reason: 'the server has no default for this setting, so it cannot judge a replacement',
+    });
+  });
+});
+
 describe('a reset cannot remove a pinned identity field', () => {
   it.each(PINNED_INSTANCE_FIELDS)('refuses to reset %s', async (field) => {
     seedTenant(await storedConfig());
@@ -358,7 +484,7 @@ describe('a reset cannot wipe configuration', () => {
       })
     );
 
-    const { reset } = await TenantService.applyConfigDocument(
+    const { discarded, reset } = await TenantService.applyConfigDocument(
       'alice',
       { version: 1, configuration: { general: { theme: null } } },
       ['configuration.general.theme']
@@ -366,6 +492,11 @@ describe('a reset cannot wipe configuration', () => {
 
     expect(saved.configuration.general.theme).toBe(7);
     expect(reset).toEqual([]);
+    // Refused for carrying no replacement, which is what a stripped null leaves behind.
+    expect(discarded).toContainEqual({
+      path: 'configuration.general.theme',
+      reason: 'the saved document carries no replacement value for this field',
+    });
   });
 
   it('refuses the whole list once it is past the ceiling', async () => {
@@ -428,6 +559,28 @@ describe('a reset changes nothing about a save that would have worked', () => {
     expect(discarded).toEqual([]);
   });
 
+  it('stores the same config where the merge would have taken the value anyway', async () => {
+    // An empty array is a valid replacement for a stored array of any element type, so this
+    // save applies with or without the reset. The reset does fire, because the stored value is
+    // genuinely broken, and what it stores is identical either way.
+    const doc = instanceDoc({ features: { auth: { methods: [] } } });
+    const broken = (c: any) => {
+      c.configuration.instanceConfiguration.features.auth.methods = [1, 2];
+    };
+
+    seedTenant(await storedConfig(broken));
+    await TenantService.applyConfigDocument('alice', doc);
+    const withoutReset = JSON.stringify(saved);
+
+    seedTenant(await storedConfig(broken));
+    await TenantService.applyConfigDocument('alice', doc, [
+      'configuration.instanceConfiguration.features.auth.methods',
+    ]);
+
+    expect(saved.configuration.instanceConfiguration.features.auth.methods).toEqual([]);
+    expect(JSON.stringify(saved)).toBe(withoutReset);
+  });
+
   it('leaves a save with no reset list byte-identical', async () => {
     const doc = {
       version: 1,
@@ -457,7 +610,10 @@ describe('resetConfigPaths mechanics', () => {
     const { config, reset } = TenantService.resetConfigPaths(
       stored,
       ['configuration.general.theme'],
-      { configuration: { general: { theme: 'dark' } } }
+      {
+        document: { configuration: { general: { theme: 'dark' } } },
+        canonical: await TenantService.getDefaultConfig('alice', 'alice'),
+      }
     );
 
     expect(reset).toEqual(['configuration.general.theme']);
@@ -469,6 +625,18 @@ describe('resetConfigPaths mechanics', () => {
     );
   });
 
+  it('never walks a prototype key when checking a replacement against the canonical shape', () => {
+    // JSON.parse makes `__proto__` an own key, so a replacement object can carry one even
+    // though sanitize strips it before this runs. Refused rather than walked.
+    expect(
+      TenantService.matchesCanonicalShape(
+        { readerLayer: 'standard' },
+        JSON.parse('{"readerLayer":"standard","__proto__":{"polluted":true}}')
+      )
+    ).toBe(false);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
   it('reads own properties only, so an inherited key is not mistaken for stored config', () => {
     const stored = { configuration: { general: {} } };
     // `toString` resolves through the prototype chain; readPath must not see it.
@@ -477,7 +645,10 @@ describe('resetConfigPaths mechanics', () => {
 
   it('takes no paths as no work', async () => {
     const stored = await storedConfig();
-    const result = TenantService.resetConfigPaths(stored, undefined, {});
+    const result = TenantService.resetConfigPaths(stored, undefined, {
+      document: {},
+      canonical: {},
+    });
     expect(result.config).toBe(stored);
     expect(result.reset).toEqual([]);
   });

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -54,6 +54,34 @@ interface MergeReport {
 }
 
 /**
+ * Instance fields the server owns. A config save never stores what the client sent for these
+ * (sanitizeConfigDocument pins them from the tenant row), and a reset must not be able to
+ * remove one either: they are the same list so a field pinned in one place cannot be reached
+ * through the other.
+ */
+export const PINNED_INSTANCE_FIELDS = ['username', 'owner', 'type', 'communityId'] as const;
+
+/**
+ * Shape of a resettable path: a dot path into the configuration document, spelled exactly as
+ * the `discarded` channel reports it, so a client can send back the path it was told about.
+ * Requires at least one segment below `configuration`, and every segment to start with a
+ * letter, which keeps array indices and the prototype-pollution keys out.
+ */
+export const CONFIG_RESET_PATH = /^configuration(\.[A-Za-z][A-Za-z0-9_-]*)+$/;
+
+/** Keys that must never be walked, whatever the path regex allows. */
+const RESERVED_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** Ceiling on how many paths one save may reset. Repair is field-by-field, never a sweep. */
+export const MAX_RESET_PATHS = 32;
+
+/** What resetConfigPaths decided to do with one requested path. */
+type ResetVerdict =
+  | { action: 'clear' }
+  | { action: 'skip' }
+  | { action: 'refuse'; reason: string };
+
+/**
  * Post filters each instance type can actually serve.
  *
  * A blog instance queries bridge.get_account_posts, whose sort must be one of these; a
@@ -286,11 +314,18 @@ export const TenantService = {
    * sections it carries and can never erase the rest. Identity fields (username, owner, type,
    * communityId) are server-owned and pinned from the stored config so a config save can
    * never reassign control or re-type the tenant.
+   *
+   * `resetPaths` names values whose STORED copy is to be dropped before the merge, so the
+   * document's value lands in an absent slot. That is the only way to repair a value stored
+   * with the wrong type: the merge refuses any replacement that disagrees with what is stored,
+   * which is deliberate (a string "false" must never stand in for a boolean), but it also
+   * freezes a key that already holds the wrong type. See resetConfigPaths for the guarantees.
    */
   async applyConfigDocument(
     username: string,
-    doc: any
-  ): Promise<{ tenant: Tenant; discarded: DiscardedField[] }> {
+    doc: any,
+    resetPaths: readonly string[] = []
+  ): Promise<{ tenant: Tenant; discarded: DiscardedField[]; reset: string[] }> {
     const tenant = await this.getByUsername(username);
     if (!tenant) throw new Error('Tenant not found');
 
@@ -311,7 +346,16 @@ export const TenantService = {
       },
       discarded
     );
-    const newConfig = this.mergeConfigGuarded(tenant.config, clean, { path: '', discarded });
+    // Reset first, against the stored config and the already-sanitized document: identity
+    // fields are pinned into `clean` above, so a reset can never make one of them absent and
+    // let the client's value through.
+    const { config: base, reset } = this.resetConfigPaths(
+      tenant.config,
+      resetPaths,
+      clean,
+      discarded
+    );
+    const newConfig = this.mergeConfigGuarded(base, clean, { path: '', discarded });
 
     const row = await db.queryOne<TenantRow>(
       `UPDATE tenants
@@ -322,7 +366,142 @@ export const TenantService = {
       [username.toLowerCase(), JSON.stringify(newConfig)]
     );
 
-    return { tenant: mapTenantFromDb(row!), discarded };
+    return { tenant: mapTenantFromDb(row!), discarded, reset };
+  },
+
+  /**
+   * Drop the stored value at each requested path so the accompanying document can write a
+   * correctly typed one into the now-absent slot (the merge takes any value where nothing is
+   * stored). Returns the config to merge into, plus the paths actually cleared. Pure apart
+   * from the report; the input config is never mutated.
+   *
+   * A reset is the only way past the type guard, so it is deliberately the narrowest operation
+   * that repairs a stuck field. Five conditions must all hold, and the last one is what makes
+   * this safe to ship: a reset cannot change the outcome of a save that would have succeeded
+   * anyway.
+   *
+   *  1. The path is a well-formed path into `configuration`, so `version` and the document
+   *     root are out of reach.
+   *  2. It does not name a pinned identity field, which the server owns.
+   *  3. The document being saved carries a value at that same path. A reset never removes a
+   *     setting, it only replaces one, so it cannot be used to wipe config and cannot leave
+   *     the served file with a hole. A null in the document is stripped before this runs, so
+   *     "the value happens to be null" never reads as a reset.
+   *  4. The stored value is not a section (a non-empty object). Sections are repaired one
+   *     value at a time; no single request can drop a subtree.
+   *  5. The stored value actually blocks the document's value. Where the save would have
+   *     applied normally, the reset is a no-op.
+   *
+   * Not covered: a non-empty object stored where a scalar belongs stays stuck, because
+   * clearing it would be exactly the "replace a whole section with one value" move that
+   * condition 4 exists to prevent. Reaching that state takes a hand-written PATCH into a key
+   * the stored config did not have.
+   */
+  resetConfigPaths(
+    stored: any,
+    paths: readonly string[] | undefined,
+    document: any,
+    discarded?: DiscardedField[]
+  ): { config: any; reset: string[] } {
+    const reset: string[] = [];
+    if (!Array.isArray(paths) || paths.length === 0) return { config: stored, reset };
+    if (paths.length > MAX_RESET_PATHS) {
+      // All or nothing past the ceiling. A caller sending that many is not repairing fields one
+      // by one, and applying the first few of a list it did not mean is the worst answer.
+      console.warn('[TenantService] Refused config reset, too many paths:', paths.length);
+      discarded?.push({
+        path: 'reset',
+        reason: `at most ${MAX_RESET_PATHS} values can be reset in one save`,
+      });
+      return { config: stored, reset };
+    }
+
+    let config = stored;
+    for (const requested of paths) {
+      const path = typeof requested === 'string' ? requested : String(requested);
+      const verdict = this.resetVerdict(config, path, document);
+      if (verdict.action === 'refuse') {
+        console.warn('[TenantService] Refused config reset for path:', path);
+        discarded?.push({ path, reason: verdict.reason });
+        continue;
+      }
+      if (verdict.action === 'skip') continue;
+      config = this.deletePath(config, path.split('.'));
+      reset.push(path);
+    }
+
+    return { config, reset };
+  },
+
+  /** Decide what to do with one requested reset path. Pure. */
+  resetVerdict(config: any, path: string, document: any): ResetVerdict {
+    const segments = path.split('.');
+    if (!CONFIG_RESET_PATH.test(path) || segments.some((s) => RESERVED_PATH_SEGMENTS.has(s))) {
+      return { action: 'refuse', reason: 'not a value inside the configuration document' };
+    }
+    if (
+      segments.length >= 3 &&
+      segments[1] === 'instanceConfiguration' &&
+      (PINNED_INSTANCE_FIELDS as readonly string[]).includes(segments[2])
+    ) {
+      return { action: 'refuse', reason: 'this field is set by the server and cannot be reset' };
+    }
+
+    const incoming = this.readPath(document, segments);
+    if (incoming === undefined) {
+      return {
+        action: 'refuse',
+        reason: 'the saved document carries no replacement value for this field',
+      };
+    }
+
+    const current = this.readPath(config, segments);
+    // Nothing stored: the save already writes straight into the empty slot.
+    if (current === undefined) return { action: 'skip' };
+    const currentIsSection =
+      !!current &&
+      typeof current === 'object' &&
+      !Array.isArray(current) &&
+      Object.keys(current).length > 0;
+    if (currentIsSection) {
+      return {
+        action: 'refuse',
+        reason: 'a section cannot be reset, only the individual values inside it',
+      };
+    }
+    // The stored value already accepts what is being saved, so there is nothing to repair.
+    if (!this.mergeRefuses(current, incoming)) return { action: 'skip' };
+
+    return { action: 'clear' };
+  },
+
+  /**
+   * Read the value at a dot path, or undefined if any step is missing or not an object.
+   * Own properties only, so nothing inherited can be read as stored config. Pure.
+   */
+  readPath(node: any, segments: readonly string[]): any {
+    let current = node;
+    for (const segment of segments) {
+      if (!current || typeof current !== 'object' || Array.isArray(current)) return undefined;
+      if (!Object.prototype.hasOwnProperty.call(current, segment)) return undefined;
+      current = current[segment];
+    }
+    return current;
+  },
+
+  /**
+   * Copy `node` without the value at the dot path. Only the objects along the path are copied;
+   * everything else is shared with the input, which is left untouched. Pure.
+   */
+  deletePath(node: any, segments: readonly string[]): any {
+    const [head, ...rest] = segments;
+    const copy = Object.assign(Object.create(null), node);
+    if (rest.length === 0) {
+      delete copy[head];
+    } else {
+      copy[head] = this.deletePath(node[head], rest);
+    }
+    return copy;
   },
 
   /**
@@ -349,7 +528,6 @@ export const TenantService = {
       const stored = result[key];
       const incomingIsPlainObject =
         incoming && typeof incoming === 'object' && !Array.isArray(incoming);
-      const incomingIsArray = Array.isArray(incoming);
       const child = ctx
         ? { path: ctx.path ? `${ctx.path}.${key}` : key, discarded: ctx.discarded }
         : undefined;
@@ -359,30 +537,38 @@ export const TenantService = {
         result[key] = incomingIsPlainObject
           ? this.mergeConfigGuarded(Object.create(null), incoming, child)
           : incoming;
+      } else if (this.mergeRefuses(stored, incoming)) {
+        this.reportTypeMismatch(child, key);
       } else if (typeof stored === 'object' && !Array.isArray(stored)) {
-        if (!incomingIsPlainObject) {
-          this.reportTypeMismatch(child, key);
-          continue;
-        }
         result[key] = this.mergeConfigGuarded(stored, incoming, child);
-      } else if (Array.isArray(stored)) {
-        if (!incomingIsArray || !this.isValidArrayReplacement(stored, incoming)) {
-          this.reportTypeMismatch(child, key);
-          continue;
-        }
-        result[key] = incoming;
       } else {
-        // Stored scalar: only a scalar of the SAME primitive type may replace it, so a
-        // string "false" cannot stand in for a boolean, nor 42 for a string.
-        if (incomingIsPlainObject || incomingIsArray || typeof incoming !== typeof stored) {
-          this.reportTypeMismatch(child, key);
-          continue;
-        }
         result[key] = incoming;
       }
     }
 
     return result;
+  },
+
+  /**
+   * Whether the guarded merge would refuse `incoming` in place of `stored`: an object section
+   * only takes an object, an array only a valid array, and a scalar only a scalar of the same
+   * primitive type, so a string "false" cannot stand in for a boolean nor 42 for a string.
+   *
+   * The single statement of the rule. resetConfigPaths asks the same question to decide whether
+   * a stored value is actually blocking a save, and the two must not drift: a reset that fired
+   * where the merge would have accepted the value would be clearing a healthy field. Pure.
+   */
+  mergeRefuses(stored: any, incoming: any): boolean {
+    // An absent or null slot takes anything; this is what a reset creates.
+    if (stored === undefined || stored === null) return false;
+    const incomingIsPlainObject =
+      !!incoming && typeof incoming === 'object' && !Array.isArray(incoming);
+    const incomingIsArray = Array.isArray(incoming);
+    if (typeof stored === 'object' && !Array.isArray(stored)) return !incomingIsPlainObject;
+    if (Array.isArray(stored)) {
+      return !incomingIsArray || !this.isValidArrayReplacement(stored, incoming);
+    }
+    return incomingIsPlainObject || incomingIsArray || typeof incoming !== typeof stored;
   },
 
   /** Log a dropped value and, when the caller asked for a report, record it for the response. */
@@ -471,7 +657,7 @@ export const TenantService = {
       type: 'the instance type is set when the instance is created and cannot be changed here',
       communityId: 'the community id is set by the server',
     };
-    for (const key of ['username', 'owner', 'type', 'communityId'] as const) {
+    for (const key of PINNED_INSTANCE_FIELDS) {
       if (instance[key] !== undefined && instance[key] !== pins[key]) {
         discarded?.push({
           path: `configuration.instanceConfiguration.${key}`,
@@ -480,10 +666,9 @@ export const TenantService = {
       }
     }
 
-    instance.username = pins.username;
-    instance.owner = pins.owner;
-    instance.type = pins.type;
-    instance.communityId = pins.communityId;
+    for (const key of PINNED_INSTANCE_FIELDS) {
+      instance[key] = pins[key];
+    }
     // Served-only marker (injected at config-file generation); must never round-trip from a
     // client document into the stored config.
     delete instance.managed;

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -349,10 +349,19 @@ export const TenantService = {
     // Reset first, against the stored config and the already-sanitized document: identity
     // fields are pinned into `clean` above, so a reset can never make one of them absent and
     // let the client's value through.
+    //
+    // getDefaultConfig is the shape contract for a stored config: it is what seeds every
+    // tenant at creation, it lives in this service rather than in the SPA image, and the
+    // guarded merge already treats a stored config as authoritative on the grounds that it
+    // came from here. The SPA's config.template.json is a demo document (it carries settings
+    // the hosted product does not seed and misses ones it does) and is not in this image at
+    // all, so it cannot be the source of truth for what a hosted tenant's field must be.
+    // Only built when a reset was actually asked for.
+    const canonical = resetPaths.length > 0 ? await this.getDefaultConfig(tenant.username, tenant.owner) : null;
     const { config: base, reset } = this.resetConfigPaths(
       tenant.config,
       resetPaths,
-      clean,
+      { document: clean, canonical },
       discarded
     );
     const newConfig = this.mergeConfigGuarded(base, clean, { path: '', discarded });
@@ -376,9 +385,7 @@ export const TenantService = {
    * from the report; the input config is never mutated.
    *
    * A reset is the only way past the type guard, so it is deliberately the narrowest operation
-   * that repairs a stuck field. Five conditions must all hold, and the last one is what makes
-   * this safe to ship: a reset cannot change the outcome of a save that would have succeeded
-   * anyway.
+   * that repairs a stuck field. Every one of these must hold:
    *
    *  1. The path is a well-formed path into `configuration`, so `version` and the document
    *     root are out of reach.
@@ -387,20 +394,32 @@ export const TenantService = {
    *     setting, it only replaces one, so it cannot be used to wipe config and cannot leave
    *     the served file with a hole. A null in the document is stripped before this runs, so
    *     "the value happens to be null" never reads as a reset.
-   *  4. The stored value is not a section (a non-empty object). Sections are repaired one
+   *  4. `canonical` knows the path. Where the server cannot say what a setting is supposed to
+   *     be, it cannot say which side of the save is the broken one, so it refuses.
+   *  5. The value being saved matches the canonical shape for the path.
+   *  6. The stored value is not a section (a non-empty object). Sections are repaired one
    *     value at a time; no single request can drop a subtree.
-   *  5. The stored value actually blocks the document's value. Where the save would have
-   *     applied normally, the reset is a no-op.
+   *  7. The stored value does NOT match the canonical shape. This is what is being repaired.
+   *
+   * 5 and 7 are the pair that matters, and neither can stand in for the other. Asking only
+   * whether the two values disagree is symmetric: it fires just as readily when the STORED
+   * value is healthy and the incoming one is junk, which would turn a repair tool into the
+   * easiest way to put `theme: 42` over a good `theme: "system"`. Only a canonical shape can
+   * say which side is broken, so the replacement must be right AND the stored value wrong.
+   *
+   * A reset still cannot change what a save that would have succeeded stores. Where the merge
+   * would have accepted the incoming value, the merged result is that value, and clearing the
+   * slot first writes the same value into it.
    *
    * Not covered: a non-empty object stored where a scalar belongs stays stuck, because
    * clearing it would be exactly the "replace a whole section with one value" move that
-   * condition 4 exists to prevent. Reaching that state takes a hand-written PATCH into a key
-   * the stored config did not have.
+   * condition 6 exists to prevent, and so does any setting the canonical config has no entry
+   * for. Both stay repairable only by an operator editing the row.
    */
   resetConfigPaths(
     stored: any,
     paths: readonly string[] | undefined,
-    document: any,
+    context: { document: any; canonical: any },
     discarded?: DiscardedField[]
   ): { config: any; reset: string[] } {
     const reset: string[] = [];
@@ -419,7 +438,7 @@ export const TenantService = {
     let config = stored;
     for (const requested of paths) {
       const path = typeof requested === 'string' ? requested : String(requested);
-      const verdict = this.resetVerdict(config, path, document);
+      const verdict = this.resetVerdict(config, path, context);
       if (verdict.action === 'refuse') {
         console.warn('[TenantService] Refused config reset for path:', path);
         discarded?.push({ path, reason: verdict.reason });
@@ -434,7 +453,7 @@ export const TenantService = {
   },
 
   /** Decide what to do with one requested reset path. Pure. */
-  resetVerdict(config: any, path: string, document: any): ResetVerdict {
+  resetVerdict(config: any, path: string, context: { document: any; canonical: any }): ResetVerdict {
     const segments = path.split('.');
     if (!CONFIG_RESET_PATH.test(path) || segments.some((s) => RESERVED_PATH_SEGMENTS.has(s))) {
       return { action: 'refuse', reason: 'not a value inside the configuration document' };
@@ -447,7 +466,7 @@ export const TenantService = {
       return { action: 'refuse', reason: 'this field is set by the server and cannot be reset' };
     }
 
-    const incoming = this.readPath(document, segments);
+    const incoming = this.readPath(context.document, segments);
     if (incoming === undefined) {
       return {
         action: 'refuse',
@@ -455,9 +474,25 @@ export const TenantService = {
       };
     }
 
+    // What this setting is supposed to be. Without it the server cannot tell a broken stored
+    // value from a broken replacement, and guessing is how a healthy value gets overwritten.
+    const canonical = this.readPath(context.canonical, segments);
+    if (canonical === undefined) {
+      return {
+        action: 'refuse',
+        reason: 'the server has no default for this setting, so it cannot judge a replacement',
+      };
+    }
+    if (!this.matchesCanonicalShape(canonical, incoming)) {
+      return {
+        action: 'refuse',
+        reason: 'the value being saved is not the type this setting must have',
+      };
+    }
+
     const current = this.readPath(config, segments);
-    // Nothing stored: the save already writes straight into the empty slot.
-    if (current === undefined) return { action: 'skip' };
+    // Nothing usable stored: the save already writes straight into the slot.
+    if (current === undefined || current === null) return { action: 'skip' };
     const currentIsSection =
       !!current &&
       typeof current === 'object' &&
@@ -469,10 +504,31 @@ export const TenantService = {
         reason: 'a section cannot be reset, only the individual values inside it',
       };
     }
-    // The stored value already accepts what is being saved, so there is nothing to repair.
-    if (!this.mergeRefuses(current, incoming)) return { action: 'skip' };
+    // The stored value is the type it should be, so it is not what is broken.
+    if (this.matchesCanonicalShape(canonical, current)) return { action: 'skip' };
 
     return { action: 'clear' };
+  },
+
+  /**
+   * Whether `value` is shaped the way the canonical default says this setting must be: same
+   * primitive type as the default, an array whose elements match the default's element type, or
+   * an object whose known keys each match in turn.
+   *
+   * A key the default does not carry is left alone rather than refused. Those are settings
+   * added after the seed (the editor offers more of the Hive block than the seed writes), and a
+   * normal save is already allowed to write them into an absent slot, so refusing here would
+   * block the repair without protecting anything. Pure.
+   */
+  matchesCanonicalShape(canonical: any, value: any): boolean {
+    if (this.mergeRefuses(canonical, value)) return false;
+    if (!canonical || typeof canonical !== 'object' || Array.isArray(canonical)) return true;
+    for (const key of Object.keys(value)) {
+      if (RESERVED_PATH_SEGMENTS.has(key)) return false;
+      if (!Object.prototype.hasOwnProperty.call(canonical, key)) continue;
+      if (!this.matchesCanonicalShape(canonical[key], value[key])) return false;
+    }
+    return true;
   },
 
   /**


### PR DESCRIPTION
Closes #1344.

## The problem

`mergeConfigGuarded` only lets a stored value be replaced by one that agrees with its shape. Once a key holds a value of the wrong primitive type, no correctly typed value can replace it: the save returns 200, the key appears in `discarded`, and the bad value survives. The owner cannot repair it from the Configuration Editor.

Confirmed before building, against the real merge: a stored `general.theme: 7` refuses `'dark'` and reports it, while an absent or null slot takes any correctly typed value. Both facts are now pinned by tests, including the pre-fix behaviour as the baseline the repair is measured against.

## What this does

The type rule is unchanged. It is what stops a string `"false"` standing in for a boolean, and trading a stuck field for a quietly wrong one would be worse. Instead the PATCH takes an explicit reset.

```
PATCH /v1/tenants/:username
{
  "config": { "version": 1, "configuration": { "general": { "theme": "dark" } } },
  "reset": ["configuration.general.theme"]
}
```

`reset` names stored values to drop before the document is merged in, so the document's value lands in an absent slot, which the merge already accepts. Reset and replacement happen in one request, so there is no window where the served config has a hole, and no second save is needed.

### How a reset is expressed, and why it cannot fire by accident

Paths are a sibling of `config`, never a value inside it, so nothing a document can carry (a null, an empty string, a zero) can be read as a request to reset, and no reset can be mistaken for a value. Paths are spelled exactly as `discarded` reports them, so a client can send back the path it was just told about.

A path is cleared only when all of these hold:

1. it is a well-formed path into `configuration`, so `version` and the document root are out of reach;
2. it does not name a pinned identity field;
3. the document being saved carries a value at that same path, so a reset replaces a setting and never removes one (nulls are stripped before this runs, so a null field is not a replacement);
4. the canonical config knows the path;
5. the value being saved matches the canonical shape for that path;
6. the stored value is not a section, so no single request can drop a subtree;
7. the stored value does NOT match the canonical shape, which is what is being repaired.

5 and 7 are the pair that matters and neither can stand in for the other. Asking only whether the stored and incoming values disagree is symmetric: it cannot say which of the two is malformed, so it fires just as readily when the stored value is healthy and the replacement is junk. Only a canonical shape breaks the symmetry, so the replacement must be right and the stored value must be wrong.

Conditions 3 and 6 are what stop this becoming a way to wipe config: a section is repaired one value at a time, and every cleared value is replaced in the same request. A reset also still cannot change what a save that would have succeeded stores: where the merge would have accepted the incoming value, the merged result is that value, and clearing the slot first writes the same value into it.

A reset also unlocks exactly the path named. Every other value in the same document is judged by the usual rule.


### What the canonical shape is

`getDefaultConfig` in this service. It seeds every tenant at creation, it lives in the API rather than the SPA, and the guarded merge already treats a stored config as the shape contract on the grounds that it came from there. The alternatives were checked rather than assumed: `config.template.json` is described in the SPA's own code as a demo document, carries settings the hosted product does not seed and misses ones it does, and is not in this image at all (the API image build context is the api directory). `HIVE_LAYER_CONFIG_DEFAULTS` is a per-block example in the SPA, also outside this image, and covers one block.

Checking the replacement recurses into a block, so repairing `features.hive` cannot smuggle a wrong-typed `readerLayer` in with it. A key the canonical config does not carry is left alone rather than refused: the editor offers more of that block than the seed writes, and a normal save may already write such a key into an absent slot, so refusing would block the repair without protecting anything.

Where the canonical config has no entry for a path at all, the reset is refused. A server that cannot say what a setting is supposed to be cannot say which side of the save is broken, and guessing is how a healthy value gets overwritten. Those fields stay repairable only by an operator editing the row.

### Pinned identity fields

`username`, `owner`, `type` and `communityId` now come from one exported list that both the pin in `sanitizeConfigDocument` and the reset refusal read, so a field pinned in one place cannot be reached through the other. A reset naming one of them, or a path below one, is refused. The pin is applied to the sanitized document on every save regardless, so an identity field cannot be made absent even if the refusal were bypassed.

### Authorization

The reset rides on the existing PATCH, after the auth middleware and the existing `owner` check. There is no second door to the config, and a caller who cannot save cannot reset. Covered by a test that a non-owner gets 403 and the service is never called.

### Response

`reset` lists the paths actually cleared. A requested path the server would not act on comes back in `discarded` with the reason. A path in neither needed no reset and the save applied it normally, so the client never has to guess which of the three happened. A benign no-op deliberately does not go in `discarded`, since that channel drives the "some values were not applied" message. The audit entry records the cleared paths.

Edge validation answers 400 for a malformed path, a non-list, more than 32 paths, or a reset sent without the full configuration document. The service re-checks everything, so the guarantees do not depend on the route.

## Not covered

A non-empty object stored where a scalar belongs stays stuck, because clearing it would be the "replace a whole section with one value" move condition 6 exists to prevent. So does any setting the canonical config has no entry for. Both take a hand-written PATCH to reach and stay repairable by an operator editing the row.

## Migration

None. No schema change, no new column, no new endpoint. The audit entry uses the existing JSON column.

## Verification

All 292 existing tests pass; 42 added (334 total). Every new test was mutation-verified: 25 mutations applied one at a time, all killed. Both halves of the rule are covered independently: dropping the check on the incoming value is killed by the healthy-value cases, and dropping the check on the stored value is killed by the no-op case (a healthy field would be reported as repaired). Taking the canonical shape from the stored config instead of the seed is killed by 8 tests, since a broken value would become its own contract. The rest cover the unknown-path refusal, the recursion into a replacement block, the forward-compatible unknown key, the reserved-key guard, the pinned-field refusal, the section refusal, the replacement-required check, the absent-slot skip, the path regex, the reserved-segment check, the ceiling guard, `deletePath` mutating in place, `readPath` accepting inherited keys, `mergeRefuses` neutered two ways, and six route mutations including the owner check.

Two survivors were found and the tests strengthened rather than accepted: a reserved path segment was being refused by a later check, so the test now asserts it is refused on the shape of the path before anything walks the config; and a null field in the document was passing for the wrong reason, so that test now asserts the reason too.

Proven end to end against `applyConfigDocument` with the database mocked, so the order of sanitize, reset and merge is exercised rather than the pieces separately: a malformed scalar is repaired, a stuck array of the wrong element type is repaired, a scalar standing where a block belongs is repaired, a healthy value cannot be displaced by a number, by the string "false" or by array elements of the wrong type, a path with no canonical entry is refused, a reset cannot remove a pinned identity field, an unauthorized caller is refused, and the type guard still rejects a genuine mismatch.

## Client

Server side only. The editor keeps working unchanged and ignores the new response field. A follow-up can add a "reset this field" affordance next to the discarded-field report from #1320: the client work is to send `reset` with the paths the previous save reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resetting selected configuration paths to their canonical defaults when saving a complete configuration document.
  * Reset results now report which paths were applied or discarded.
  * Configuration audit records include successfully reset paths.

* **Bug Fixes**
  * Prevented resets from affecting protected fields, valid values, or unsafe paths.
  * Added safeguards for invalid, excessive, missing, and incorrectly typed reset requests.
  * Preserved existing validation and no-op save behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->