### PR TITLE
fix(self-hosted): stop reporting a failed request as an empty one

### DIFF
--- a/apps/self-hosted/src/core/dmca.test.ts
+++ b/apps/self-hosted/src/core/dmca.test.ts
@@ -164,11 +164,11 @@ describe('loadDmcaLists', () => {
   it('refetches post queries once the lists land', async () => {
     vi.stubGlobal('fetch', respond(FULL));
     const loadDmcaLists = await importLoader();
-    const invalidateQueries = vi.fn();
+    const resetQueries = vi.fn();
 
-    await loadDmcaLists({ invalidateQueries } as never);
+    await loadDmcaLists({ resetQueries } as never);
 
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['posts'] });
+    expect(resetQueries).toHaveBeenCalledWith({ queryKey: ['posts'] });
   });
 
   it('does not refetch when the lists came back empty', async () => {
@@ -181,12 +181,84 @@ describe('loadDmcaLists', () => {
       }),
     );
     const loadDmcaLists = await importLoader();
-    const invalidateQueries = vi.fn();
+    const resetQueries = vi.fn();
 
-    await loadDmcaLists({ invalidateQueries } as never);
+    await loadDmcaLists({ resetQueries } as never);
 
     // Nothing to filter, so the refetch would cost every visitor a round of
-    // requests for no change whenever the lists are unreachable.
-    expect(invalidateQueries).not.toHaveBeenCalled();
+    // requests for no change whenever the lists are unreachable. The empty
+    // lists are the lists in force and the cache already agrees with them.
+    expect(resetQueries).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The property the reading surfaces depend on.
+ *
+ * Those surfaces deliberately keep what they have loaded when a request fails,
+ * because throwing away sixty posts over one timed-out page is worse than
+ * saying the page failed. That is only safe while everything in the cache was
+ * filtered under the lists currently in force. A post cached before the lists
+ * installed was filtered against nothing, so if it merely got marked stale and
+ * its refetch then failed, takedown-listed content would stay on screen.
+ *
+ * Checked against a real QueryClient rather than a spy, because the difference
+ * between invalidating and resetting is not visible in the call, only in what
+ * is left in the cache afterwards.
+ */
+describe('cached posts do not survive the lists installing', () => {
+  const KEY = ['posts', 'entry', '@baduser/stolen-post'];
+  const UNFILTERED = { author: 'baduser', permlink: 'stolen-post', body: 'x' };
+
+  async function seededClient() {
+    const { QueryClient } = await import('@tanstack/react-query');
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    // Exactly the losing side of the startup race: the query resolved while
+    // the lists were still in flight, so filterDmcaEntry ran against nothing.
+    client.setQueryData(KEY, UNFILTERED);
+    return client;
+  }
+
+  it('clears post data that predates the lists', async () => {
+    vi.stubGlobal('fetch', respond(FULL));
+    const loadDmcaLists = await importLoader();
+    const client = await seededClient();
+
+    await loadDmcaLists(client);
+
+    // Not "is marked stale": gone. A refetch that fails must not be able to
+    // put this back on screen.
+    expect(client.getQueryData(KEY)).toBeUndefined();
+    client.clear();
+  });
+
+  it('leaves nothing behind for a failed refetch to fall back to', async () => {
+    vi.stubGlobal('fetch', respond(FULL));
+    const loadDmcaLists = await importLoader();
+    const client = await seededClient();
+
+    await loadDmcaLists(client);
+
+    // Stand in for the refetch exhausting its retries. Under invalidation the
+    // entry is still there at this point, which is the hole.
+    const state = client.getQueryState(KEY);
+    expect(state?.data).toBeUndefined();
+    client.clear();
+  });
+
+  it('touches only post data', async () => {
+    vi.stubGlobal('fetch', respond(FULL));
+    const loadDmcaLists = await importLoader();
+    const client = await seededClient();
+    client.setQueryData(['accounts', 'alice'], { name: 'alice' });
+
+    await loadDmcaLists(client);
+
+    expect(client.getQueryData(['accounts', 'alice'])).toEqual({
+      name: 'alice',
+    });
+    client.clear();
   });
 });

--- a/apps/self-hosted/src/core/dmca.ts
+++ b/apps/self-hosted/src/core/dmca.ts
@@ -63,14 +63,23 @@ let pending: Promise<void> | undefined;
  * Loads the lists into the SDK config. Memoised: repeated calls share the first
  * request. Always resolves, and always applies whatever it managed to fetch.
  *
- * Post queries are refetched once the lists land. Nothing about rendering may
- * wait on a remote origin, so the fetch is not awaited, which leaves a window
- * where a query resolves first: filterDmcaEntry runs against an empty
- * configuration, and the unfiltered result is cached and displayed for the rest
- * of the session. Refetching closes it. Every post key starts with "posts", so
- * one invalidation reaches them all.
+ * Cached post data is thrown away once the lists land. Nothing about rendering
+ * may wait on a remote origin, so the fetch is not awaited, which leaves a
+ * window where a post query resolves first: filterDmcaEntry runs against an
+ * empty configuration and the unfiltered result is cached. Every post key
+ * starts with "posts", so one call reaches them all.
  *
- * Skipped when nothing was loaded, since there is then nothing to filter and
+ * `resetQueries`, not `invalidateQueries`. Invalidation only marks the data
+ * stale and schedules a refetch, and query-core keeps the existing `data`
+ * through a failed refetch. Reading surfaces now deliberately keep what they
+ * have when a request fails, so an invalidation whose refetch then failed would
+ * leave the pre-list, unfiltered entry on screen for the rest of the session.
+ * Resetting clears the data first, so what is kept through a later failure is
+ * only ever content that was filtered under the lists currently in force, and
+ * a failed refetch shows the failure rather than takedown-listed content.
+ *
+ * Skipped when nothing was loaded, since there is then nothing to filter: the
+ * empty lists are the lists in force, the cache already agrees with them, and
  * the refetch would be pure cost for every visitor whenever the lists are
  * unreachable.
  */
@@ -81,7 +90,7 @@ export function loadDmcaLists(queryClient?: QueryClient): Promise<void> {
     const listed =
       lists.accounts.length + lists.tags.length + lists.posts.length;
     if (listed > 0 && queryClient) {
-      queryClient.invalidateQueries({ queryKey: ['posts'] });
+      queryClient.resetQueries({ queryKey: ['posts'] });
     }
   });
   return pending;

--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -112,7 +112,17 @@ type TranslationKey =
   | 'reputation_band_longstanding'
   | 'confirming'
   | 'membership_unconfirmed'
-  | 'check_again';
+  | 'check_again'
+  | 'posts_load_failed'
+  | 'post_refresh_failed'
+  | 'comments_loading'
+  | 'comments_empty'
+  | 'comments_load_failed'
+  | 'comments_incomplete'
+  | 'community_load_failed'
+  | 'app_error_title'
+  | 'app_error_description'
+  | 'reload_page';
 
 type Translations = Record<TranslationKey, string>;
 
@@ -235,6 +245,17 @@ const translations: Record<string, Translations> = {
     membership_unconfirmed:
       'Sent to Hive. The community has not confirmed this yet. Reload in a moment to check.',
     check_again: 'Check again',
+    posts_load_failed: 'Could not load more posts.',
+    post_refresh_failed: 'Could not refresh this post.',
+    comments_loading: 'Loading comments...',
+    comments_empty: 'No comments yet. Be the first to comment!',
+    comments_load_failed: 'Could not load comments.',
+    comments_incomplete: 'Some comments could not be loaded.',
+    community_load_failed: 'Could not load community details.',
+    app_error_title: 'Something went wrong',
+    app_error_description:
+      'This page could not be displayed. Reloading usually fixes it.',
+    reload_page: 'Reload',
   },
   es: {
     loading: 'Cargando...',
@@ -353,6 +374,18 @@ const translations: Record<string, Translations> = {
     membership_unconfirmed:
       'Enviado a Hive. La comunidad todavía no lo ha confirmado. Vuelve a cargar en un momento para comprobarlo.',
     check_again: 'Comprobar de nuevo',
+    posts_load_failed: 'No se pudieron cargar más publicaciones.',
+    post_refresh_failed: 'No se pudo actualizar esta publicación.',
+    comments_loading: 'Cargando comentarios...',
+    comments_empty: 'Aún no hay comentarios. ¡Sé el primero en comentar!',
+    comments_load_failed: 'No se pudieron cargar los comentarios.',
+    comments_incomplete: 'Algunos comentarios no se pudieron cargar.',
+    community_load_failed:
+      'No se pudieron cargar los datos de la comunidad.',
+    app_error_title: 'Algo salió mal',
+    app_error_description:
+      'No se pudo mostrar esta página. Recargar suele solucionarlo.',
+    reload_page: 'Recargar',
   },
   de: {
     loading: 'Lädt...',
@@ -471,6 +504,18 @@ const translations: Record<string, Translations> = {
     membership_unconfirmed:
       'An Hive gesendet. Die Community hat es noch nicht bestätigt. Lade die Seite gleich neu, um nachzusehen.',
     check_again: 'Erneut prüfen',
+    posts_load_failed: 'Weitere Beiträge konnten nicht geladen werden.',
+    post_refresh_failed: 'Dieser Beitrag konnte nicht aktualisiert werden.',
+    comments_loading: 'Kommentare werden geladen...',
+    comments_empty: 'Noch keine Kommentare. Schreibe den ersten!',
+    comments_load_failed: 'Kommentare konnten nicht geladen werden.',
+    comments_incomplete:
+      'Einige Kommentare konnten nicht geladen werden.',
+    community_load_failed: 'Community-Daten konnten nicht geladen werden.',
+    app_error_title: 'Etwas ist schief gelaufen',
+    app_error_description:
+      'Diese Seite konnte nicht angezeigt werden. Ein Neuladen hilft meistens.',
+    reload_page: 'Neu laden',
   },
   fr: {
     loading: "Chargement...",
@@ -590,6 +635,19 @@ const translations: Record<string, Translations> = {
     membership_unconfirmed:
       "Envoyé à Hive. La communauté ne l'a pas encore confirmé. Rechargez dans un instant pour vérifier.",
     check_again: 'Vérifier à nouveau',
+    posts_load_failed: "Impossible de charger plus d'articles.",
+    post_refresh_failed: "Impossible d'actualiser cet article.",
+    comments_loading: 'Chargement des commentaires...',
+    comments_empty: 'Aucun commentaire pour le moment. Soyez le premier!',
+    comments_load_failed: 'Impossible de charger les commentaires.',
+    comments_incomplete:
+      "Certains commentaires n'ont pas pu être chargés.",
+    community_load_failed:
+      'Impossible de charger les informations de la communauté.',
+    app_error_title: "Une erreur s'est produite",
+    app_error_description:
+      "Cette page n'a pas pu s'afficher. Recharger règle souvent le problème.",
+    reload_page: 'Recharger',
   },
   ko: {
     loading: '로딩 중...',
@@ -707,6 +765,17 @@ const translations: Record<string, Translations> = {
     membership_unconfirmed:
       'Hive로 전송했습니다. 커뮤니티가 아직 확인하지 않았습니다. 잠시 후 새로 고쳐 확인해 주세요.',
     check_again: '다시 확인',
+    posts_load_failed: '게시물을 더 불러오지 못했습니다.',
+    post_refresh_failed: '이 게시물을 새로 고치지 못했습니다.',
+    comments_loading: '댓글 불러오는 중...',
+    comments_empty: '아직 댓글이 없습니다. 첫 댓글을 남겨보세요!',
+    comments_load_failed: '댓글을 불러오지 못했습니다.',
+    comments_incomplete: '일부 댓글을 불러오지 못했습니다.',
+    community_load_failed: '커뮤니티 정보를 불러오지 못했습니다.',
+    app_error_title: '문제가 발생했습니다',
+    app_error_description:
+      '이 페이지를 표시할 수 없습니다. 새로 고치면 대개 해결됩니다.',
+    reload_page: '새로 고침',
   },
   ru: {
     loading: 'Загрузка...',
@@ -825,6 +894,17 @@ const translations: Record<string, Translations> = {
     membership_unconfirmed:
       'Отправлено в Hive. Сообщество это ещё не подтвердило. Обновите страницу через минуту, чтобы проверить.',
     check_again: 'Проверить снова',
+    posts_load_failed: 'Не удалось загрузить больше постов.',
+    post_refresh_failed: 'Не удалось обновить этот пост.',
+    comments_loading: 'Загрузка комментариев...',
+    comments_empty: 'Комментариев пока нет. Оставьте первый!',
+    comments_load_failed: 'Не удалось загрузить комментарии.',
+    comments_incomplete: 'Некоторые комментарии не удалось загрузить.',
+    community_load_failed: 'Не удалось загрузить данные сообщества.',
+    app_error_title: 'Что-то пошло не так',
+    app_error_description:
+      'Не удалось отобразить эту страницу. Обычно помогает перезагрузка.',
+    reload_page: 'Перезагрузить',
   },
 };
 

--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -122,7 +122,9 @@ type TranslationKey =
   | 'community_load_failed'
   | 'app_error_title'
   | 'app_error_description'
-  | 'reload_page';
+  | 'reload_page'
+  | 'community_refresh_failed'
+  | 'edit_read_failed';
 
 type Translations = Record<TranslationKey, string>;
 
@@ -256,6 +258,9 @@ const translations: Record<string, Translations> = {
     app_error_description:
       'This page could not be displayed. Reloading usually fixes it.',
     reload_page: 'Reload',
+    community_refresh_failed: 'Could not refresh community details.',
+    edit_read_failed:
+      'Could not load the current version of this post. Editing stays closed until it loads, so a save cannot overwrite newer changes.',
   },
   es: {
     loading: 'Cargando...',
@@ -386,6 +391,10 @@ const translations: Record<string, Translations> = {
     app_error_description:
       'No se pudo mostrar esta página. Recargar suele solucionarlo.',
     reload_page: 'Recargar',
+    community_refresh_failed:
+      'No se pudieron actualizar los datos de la comunidad.',
+    edit_read_failed:
+      'No se pudo cargar la versión actual de esta publicación. La edición permanece cerrada hasta que cargue, para que al guardar no se sobrescriban cambios más nuevos.',
   },
   de: {
     loading: 'Lädt...',
@@ -516,6 +525,10 @@ const translations: Record<string, Translations> = {
     app_error_description:
       'Diese Seite konnte nicht angezeigt werden. Ein Neuladen hilft meistens.',
     reload_page: 'Neu laden',
+    community_refresh_failed:
+      'Community-Daten konnten nicht aktualisiert werden.',
+    edit_read_failed:
+      'Die aktuelle Fassung dieses Beitrags konnte nicht geladen werden. Die Bearbeitung bleibt geschlossen, bis sie geladen ist, damit ein Speichern keine neueren Änderungen überschreibt.',
   },
   fr: {
     loading: "Chargement...",
@@ -648,6 +661,10 @@ const translations: Record<string, Translations> = {
     app_error_description:
       "Cette page n'a pas pu s'afficher. Recharger règle souvent le problème.",
     reload_page: 'Recharger',
+    community_refresh_failed:
+      'Impossible d\'actualiser les informations de la communauté.',
+    edit_read_failed:
+      "Impossible de charger la version actuelle de cet article. L'édition reste fermée tant qu'elle n'a pas chargé, pour qu'un enregistrement n'écrase pas des modifications plus récentes.",
   },
   ko: {
     loading: '로딩 중...',
@@ -776,6 +793,9 @@ const translations: Record<string, Translations> = {
     app_error_description:
       '이 페이지를 표시할 수 없습니다. 새로 고치면 대개 해결됩니다.',
     reload_page: '새로 고침',
+    community_refresh_failed: '커뮤니티 정보를 새로 고치지 못했습니다.',
+    edit_read_failed:
+      '이 게시물의 최신 버전을 불러오지 못했습니다. 저장할 때 더 새로운 변경 사항을 덮어쓰지 않도록, 불러올 때까지 편집을 열지 않습니다.',
   },
   ru: {
     loading: 'Загрузка...',
@@ -905,6 +925,10 @@ const translations: Record<string, Translations> = {
     app_error_description:
       'Не удалось отобразить эту страницу. Обычно помогает перезагрузка.',
     reload_page: 'Перезагрузить',
+    community_refresh_failed:
+      'Не удалось обновить данные сообщества.',
+    edit_read_failed:
+      'Не удалось загрузить текущую версию этого поста. Редактор не откроется, пока она не загрузится, чтобы сохранение не перезаписало более новые изменения.',
   },
 };
 

--- a/apps/self-hosted/src/features/blog/components/blog-post-discussion.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-discussion.tsx
@@ -4,7 +4,14 @@ import { callRPC, type Entry, QueryKeys } from '@ecency/sdk';
 import { useQuery } from '@tanstack/react-query';
 import { UilComment } from '@tooni/iconscout-unicons-react';
 import { useMemo, useState } from 'react';
+import { t } from '@/core';
 import { CommentForm } from '@/features/auth';
+import { InlineError } from '@/features/shared/inline-error';
+import {
+  nothingToShow,
+  resolveQueryOutcome,
+} from '@/features/shared/query-outcome';
+import { selectTopLevelComments } from '../utils/top-level-comments';
 import { BlogDiscussionList } from './blog-discussion-list';
 
 interface Props {
@@ -63,7 +70,13 @@ export function BlogPostDiscussion({ entry, isRawContent }: Props) {
   const [order, setOrder] = useState<SortOrder>('created');
   const entryData = entry.original_entry || entry;
 
-  const { data: allComments = [], isLoading } = useQuery({
+  const {
+    data: allComments = [],
+    isEnabled,
+    isError,
+    isSuccess,
+    refetch,
+  } = useQuery({
     // Use the SDK's canonical discussions key so useComment's post-broadcast invalidation
     // (which matches ["posts","discussions",author,permlink,...]) actually refetches this
     // list; a bespoke ["discussions",...] key never matched, so new comments only appeared
@@ -91,44 +104,24 @@ export function BlogPostDiscussion({ entry, isRawContent }: Props) {
   });
 
   const topLevelComments = useMemo(
-    () =>
-      allComments.filter(
-        (x) =>
-          x.parent_author === entryData.author &&
-          x.parent_permlink === entryData.permlink,
-      ),
+    () => selectTopLevelComments(entryData, allComments),
     [allComments, entryData],
   );
 
-  if (isLoading) {
-    return (
-      <div className="mb-8">
-        <CommentForm
-          parentAuthor={entryData.author}
-          parentPermlink={entryData.permlink}
-          className="mb-6"
-        />
-        <div className="text-center py-8 text-theme-muted">
-          Loading comments...
-        </div>
-      </div>
-    );
-  }
+  // Counted on the replies, not on the response: bridge.get_discussion carries
+  // the root post itself, so the response is never empty on a success and
+  // measuring it would make every outcome look like content.
+  const hasComments = topLevelComments.length > 0;
 
-  if (topLevelComments.length === 0) {
-    return (
-      <div className="mb-8">
-        <CommentForm
-          parentAuthor={entryData.author}
-          parentPermlink={entryData.permlink}
-          className="mb-6"
-        />
-        <div className="text-center py-8 text-theme-muted">
-          No comments yet. Be the first to comment!
-        </div>
-      </div>
-    );
-  }
+  // Was: destructuring only `{ data = [], isLoading }`, so once the retries
+  // were spent a failed fetch fell straight through to "No comments yet. Be
+  // the first to comment!" on a post that has a discussion.
+  const outcome = resolveQueryOutcome({
+    isEnabled,
+    isError,
+    isSuccess,
+    hasContent: hasComments,
+  });
 
   return (
     <div className="mb-6 sm:mb-8">
@@ -138,32 +131,60 @@ export function BlogPostDiscussion({ entry, isRawContent }: Props) {
         className="mb-6"
       />
 
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4 sm:mb-6 pb-4 sm:pb-6 border-b border-theme">
-        <div className="flex items-center gap-2">
-          <UilComment className="size-4 sm:size-5 text-theme-muted" />
-          <h2 className="text-lg sm:text-xl font-semibold heading-theme">
-            {topLevelComments.length}{' '}
-            {topLevelComments.length === 1 ? 'Comment' : 'Comments'}
-          </h2>
-        </div>
-        <select
-          value={order}
-          onChange={(e) => setOrder(e.target.value as SortOrder)}
-          className="px-3 py-2 border border-theme rounded-theme-sm text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-theme-accent focus:border-transparent transition-theme hover:opacity-70 w-full sm:w-auto bg-theme-primary text-theme-primary font-theme-ui"
-        >
-          <option value="trending">Trending</option>
-          <option value="author_reputation">Reputation</option>
-          <option value="votes">Votes</option>
-          <option value="created">Newest</option>
-        </select>
-      </div>
+      {hasComments && (
+        <>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4 sm:mb-6 pb-4 sm:pb-6 border-b border-theme">
+            <div className="flex items-center gap-2">
+              <UilComment className="size-4 sm:size-5 text-theme-muted" />
+              <h2 className="text-lg sm:text-xl font-semibold heading-theme">
+                {topLevelComments.length}{' '}
+                {topLevelComments.length === 1 ? 'Comment' : 'Comments'}
+              </h2>
+            </div>
+            <select
+              value={order}
+              onChange={(e) => setOrder(e.target.value as SortOrder)}
+              className="px-3 py-2 border border-theme rounded-theme-sm text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-theme-accent focus:border-transparent transition-theme hover:opacity-70 w-full sm:w-auto bg-theme-primary text-theme-primary font-theme-ui"
+            >
+              <option value="trending">Trending</option>
+              <option value="author_reputation">Reputation</option>
+              <option value="votes">Votes</option>
+              <option value="created">Newest</option>
+            </select>
+          </div>
 
-      <BlogDiscussionList
-        discussionList={allComments}
-        parent={entryData}
-        root={entryData}
-        isRawContent={isRawContent}
-      />
+          <BlogDiscussionList
+            discussionList={allComments}
+            parent={entryData}
+            root={entryData}
+            isRawContent={isRawContent}
+          />
+        </>
+      )}
+
+      {nothingToShow(outcome) && (
+        <div className="text-center py-8 text-theme-muted">
+          {t('comments_empty')}
+        </div>
+      )}
+
+      {outcome === 'pending' && (
+        <div className="text-center py-8 text-theme-muted">
+          {t('comments_loading')}
+        </div>
+      )}
+
+      {(outcome === 'failed' || outcome === 'stale') && (
+        <InlineError
+          className="mt-4"
+          message={
+            outcome === 'stale'
+              ? t('comments_incomplete')
+              : t('comments_load_failed')
+          }
+          onRetry={() => refetch()}
+        />
+      )}
     </div>
   );
 }

--- a/apps/self-hosted/src/features/blog/components/blog-post-page.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-page.tsx
@@ -13,6 +13,11 @@ import { BlogPostDiscussion } from './blog-post-discussion';
 import { BlogPostFooter } from './blog-post-footer';
 import { BlogPostHeader } from './blog-post-header';
 import { ErrorMessage } from '@/features/shared/error-message';
+import { InlineError } from '@/features/shared/inline-error';
+import {
+  nothingToShow,
+  resolveQueryOutcome,
+} from '@/features/shared/query-outcome';
 
 export function BlogPostPage() {
   const params = useParams({ strict: false });
@@ -30,10 +35,21 @@ export function BlogPostPage() {
 
   const {
     data: entry,
-    isLoading,
-    error,
+    isEnabled,
+    isError,
+    isSuccess,
     refetch,
   } = useQuery(getPostQueryOptions(author, permlink));
+
+  // `staleTime` is a minute and `refetchOnMount` is left at its default, so a
+  // reader who returns to an article triggers a background refetch of it. That
+  // refetch failing used to replace the article they were half way through.
+  const outcome = resolveQueryOutcome({
+    isEnabled,
+    isError,
+    isSuccess,
+    hasContent: !!entry,
+  });
 
   // Installed here rather than in BlogPostBody so one listener serves both the
   // post body and the comment bodies below it.
@@ -90,17 +106,31 @@ export function BlogPostPage() {
       : {},
   );
 
-  if (isLoading) {
+  // The article comes first, ahead of every failure branch. Once it has been
+  // read once it stays on screen, and a later failure is reported under it
+  // rather than in place of it.
+  if (entry) {
     return (
       <BlogLayout>
-        <div className="text-center py-12 text-theme-muted">
-          {t('loadingPost')}
-        </div>
+        <article className="space-y-4 sm:space-y-6">
+          <BlogPostHeader entry={entry} />
+          <BlogPostBody entry={entry} isRawContent={isRawContent} />
+          <BlogPostFooter entry={entry} />
+          {outcome === 'stale' && (
+            <InlineError
+              message={t('post_refresh_failed')}
+              onRetry={() => refetch()}
+            />
+          )}
+          {showComments && (
+            <BlogPostDiscussion entry={entry} isRawContent={isRawContent} />
+          )}
+        </article>
       </BlogLayout>
     );
   }
 
-  if (error) {
+  if (outcome === 'failed') {
     return (
       <BlogLayout>
         <ErrorMessage onRetry={() => refetch()} />
@@ -108,7 +138,7 @@ export function BlogPostPage() {
     );
   }
 
-  if (!entry) {
+  if (nothingToShow(outcome)) {
     return (
       <BlogLayout>
         <div className="text-center py-12 text-theme-muted">
@@ -118,16 +148,13 @@ export function BlogPostPage() {
     );
   }
 
+  // 'pending'. Every state above is named, so this is the only one left: the
+  // request is out, or paused because the browser is offline.
   return (
     <BlogLayout>
-      <article className="space-y-4 sm:space-y-6">
-        <BlogPostHeader entry={entry} />
-        <BlogPostBody entry={entry} isRawContent={isRawContent} />
-        <BlogPostFooter entry={entry} />
-        {showComments && (
-          <BlogPostDiscussion entry={entry} isRawContent={isRawContent} />
-        )}
-      </article>
+      <div className="text-center py-12 text-theme-muted">
+        {t('loadingPost')}
+      </div>
     </BlogLayout>
   );
 }

--- a/apps/self-hosted/src/features/blog/components/blog-posts-list.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-posts-list.tsx
@@ -11,6 +11,11 @@ import { BlogPostItem } from './blog-post-item';
 import { DetectBottom } from './detect-bottom';
 import { useInstanceConfig } from '../hooks/use-instance-config';
 import { ErrorMessage } from '@/features/shared/error-message';
+import { InlineError } from '@/features/shared/inline-error';
+import {
+  nothingToShow,
+  resolveQueryOutcome,
+} from '@/features/shared/query-outcome';
 
 interface Props {
   filter?: string;
@@ -65,9 +70,26 @@ export function BlogPostsList({ filter = 'posts', limit = 20 }: Props) {
     select: selectPosts,
   });
 
-  const { data = [], fetchNextPage, isFetching, hasNextPage, isError, refetch } = isCommunityMode
-    ? communityQuery
-    : blogQuery;
+  const {
+    data = [],
+    fetchNextPage,
+    isFetching,
+    hasNextPage,
+    isEnabled,
+    isError,
+    isSuccess,
+    refetch,
+  } = isCommunityMode ? communityQuery : blogQuery;
+
+  // Was: `if (isError) return <ErrorMessage />` above the map. query-core keeps
+  // `data` through an error, so that discarded every page already rendered and
+  // the reader's place in them because one later page failed.
+  const outcome = resolveQueryOutcome({
+    isEnabled,
+    isError,
+    isSuccess,
+    hasContent: data.length > 0,
+  });
 
   const previousLengthRef = useRef(0);
 
@@ -80,13 +102,15 @@ export function BlogPostsList({ filter = 'posts', limit = 20 }: Props) {
     }
   }, [data.length]);
 
-  if (isError) {
+  // Nothing loaded and the request failed: there is no content to protect, so
+  // the full panel is still right. It is the only branch that may take over.
+  if (outcome === 'failed') {
     return <ErrorMessage onRetry={() => refetch()} />;
   }
 
   return (
     <div className="blog-posts-list">
-      {data.length === 0 && !isFetching && (
+      {nothingToShow(outcome) && !isFetching && (
         <div className="text-center py-12 text-theme-muted">{t('noPosts')}</div>
       )}
 
@@ -102,12 +126,32 @@ export function BlogPostsList({ filter = 'posts', limit = 20 }: Props) {
         );
       })}
 
-      {hasNextPage && <DetectBottom onBottom={() => fetchNextPage()} />}
+      {/* Unmounted while the last page is failing. The reader is sitting at the
+          bottom of the feed, so leaving it mounted would refire the same fetch
+          the moment the retries stop, in a loop. The strip below carries the
+          retry instead, as a deliberate one. */}
+      {hasNextPage && outcome !== 'stale' && (
+        <DetectBottom onBottom={() => fetchNextPage()} />
+      )}
 
       {isFetching && (
         <div className="text-center py-8 text-theme-muted">
           {t('loadingMore')}
         </div>
+      )}
+
+      {/* Asked, no answer, not fetching: a fetch paused while offline looks
+          exactly like this. It is not evidence that the author has no posts. */}
+      {outcome === 'pending' && !isFetching && (
+        <div className="text-center py-12 text-theme-muted">{t('loading')}</div>
+      )}
+
+      {outcome === 'stale' && !isFetching && (
+        <InlineError
+          className="my-6"
+          message={t('posts_load_failed')}
+          onRetry={() => (hasNextPage ? fetchNextPage() : refetch())}
+        />
       )}
     </div>
   );

--- a/apps/self-hosted/src/features/blog/components/blog-posts-list.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-posts-list.tsx
@@ -10,6 +10,7 @@ import { t } from '@/core';
 import { BlogPostItem } from './blog-post-item';
 import { DetectBottom } from './detect-bottom';
 import { useInstanceConfig } from '../hooks/use-instance-config';
+import { chooseFeedRetry } from '../utils/feed-retry';
 import { ErrorMessage } from '@/features/shared/error-message';
 import { InlineError } from '@/features/shared/inline-error';
 import {
@@ -77,6 +78,8 @@ export function BlogPostsList({ filter = 'posts', limit = 20 }: Props) {
     hasNextPage,
     isEnabled,
     isError,
+    isFetchNextPageError,
+    isRefetchError,
     isSuccess,
     refetch,
   } = isCommunityMode ? communityQuery : blogQuery;
@@ -150,7 +153,12 @@ export function BlogPostsList({ filter = 'posts', limit = 20 }: Props) {
         <InlineError
           className="my-6"
           message={t('posts_load_failed')}
-          onRetry={() => (hasNextPage ? fetchNextPage() : refetch())}
+          onRetry={() =>
+            chooseFeedRetry({ isFetchNextPageError, isRefetchError }) ===
+            'next-page'
+              ? fetchNextPage()
+              : refetch()
+          }
         />
       )}
     </div>

--- a/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
@@ -238,6 +238,16 @@ function CommunitySidebar() {
 
   return (
     <div className="lg:sticky lg:top-0 border-b lg:border-b-0 lg:border-l border-theme p-4 sm:p-6 lg:h-screen lg:overflow-y-auto -ml-4">
+      {/* The panel below is a previous response, still true as far as it goes.
+          Saying so is the point: computing the stale outcome and then rendering
+          as if nothing had happened reads as handled when it is not. */}
+      {outcome === "stale" && (
+        <InlineError
+          className="mb-4"
+          message={t("community_refresh_failed")}
+          onRetry={() => refetch()}
+        />
+      )}
       <div className="flex items-center gap-3 mb-4">
         {communityAvatarUrl ? (
           <img

--- a/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
@@ -1,5 +1,10 @@
 import { formatMonthYear, InstanceConfigManager, t } from "@/core";
 import { useAuth } from "@/features/auth";
+import { InlineError } from "@/features/shared/inline-error";
+import {
+  nothingToShow,
+  resolveQueryOutcome,
+} from "@/features/shared/query-outcome";
 import { UserAvatar } from "@/features/shared/user-avatar";
 import { TipButton } from "@/features/tipping";
 import {
@@ -7,7 +12,7 @@ import {
   getCommunityContextQueryOptions,
 } from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 import { CommunityJoinButton } from "../components/community-join-button";
 import {
   useCommunityData,
@@ -149,8 +154,23 @@ function BlogSidebarContent({ username }: { username: string }) {
   );
 }
 
+/** The panel chrome, so every state below sits in the same box. */
+function CommunitySidebarShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="lg:sticky lg:top-0 border-b lg:border-b-0 lg:border-l border-theme p-4 sm:p-6 lg:h-screen lg:overflow-y-auto">
+      {children}
+    </div>
+  );
+}
+
 function CommunitySidebar() {
-  const { data: community, isLoading } = useCommunityData();
+  const {
+    data: community,
+    isEnabled,
+    isError,
+    isSuccess,
+    refetch,
+  } = useCommunityData();
   const { communityId } = useInstanceConfig();
   const { user } = useAuth();
 
@@ -173,25 +193,46 @@ function CommunitySidebar() {
     return `${proxyBase}/u/${community.name}/avatar/medium`;
   }, [community?.name]);
 
-  if (isLoading) {
+  // Was: `if (!community)` renders "Community not found.", which is what the
+  // owner of a running community was shown whenever one bridge call failed.
+  // Only a response that came back empty says anything about existence.
+  const outcome = resolveQueryOutcome({
+    isEnabled,
+    isError,
+    isSuccess,
+    hasContent: !!community,
+  });
+
+  if (!community) {
+    if (outcome === "failed") {
+      return (
+        <CommunitySidebarShell>
+          <InlineError
+            message={t("community_load_failed")}
+            onRetry={() => refetch()}
+          />
+        </CommunitySidebarShell>
+      );
+    }
+
+    if (nothingToShow(outcome)) {
+      return (
+        <CommunitySidebarShell>
+          <div className="text-sm text-theme-muted">
+            {t("community_not_found")}
+          </div>
+        </CommunitySidebarShell>
+      );
+    }
+
     return (
-      <div className="lg:sticky lg:top-0 border-b lg:border-b-0 lg:border-l border-theme p-4 sm:p-6 lg:h-screen lg:overflow-y-auto">
+      <CommunitySidebarShell>
         <div className="animate-pulse">
           <div className="size-16 rounded-full bg-theme-tertiary mb-4" />
           <div className="h-4 w-32 bg-theme-tertiary rounded mb-2" />
           <div className="h-3 w-48 bg-theme-tertiary rounded" />
         </div>
-      </div>
-    );
-  }
-
-  if (!community) {
-    return (
-      <div className="lg:sticky lg:top-0 border-b lg:border-b-0 lg:border-l border-theme p-4 sm:p-6 lg:h-screen lg:overflow-y-auto">
-        <div className="text-sm text-theme-muted">
-          {t("community_not_found")}
-        </div>
-      </div>
+      </CommunitySidebarShell>
     );
   }
 

--- a/apps/self-hosted/src/features/blog/utils/feed-retry.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/feed-retry.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { chooseFeedRetry, type FeedErrorFlags } from './feed-retry';
+
+const flags = (over: Partial<FeedErrorFlags> = {}): FeedErrorFlags => ({
+  isFetchNextPageError: false,
+  isRefetchError: false,
+  ...over,
+});
+
+describe('chooseFeedRetry', () => {
+  it('fetches the next page when the next page is what failed', () => {
+    expect(chooseFeedRetry(flags({ isFetchNextPageError: true }))).toBe(
+      'next-page',
+    );
+  });
+
+  it('refreshes when the refresh is what failed', () => {
+    // The case a hasNextPage check gets wrong. There are more pages to come, so
+    // that check would append one, clearing the error while the pages the
+    // reader is looking at stay exactly as stale as they were.
+    expect(chooseFeedRetry(flags({ isRefetchError: true }))).toBe('refresh');
+  });
+
+  it('refreshes when neither flag says which operation failed', () => {
+    expect(chooseFeedRetry(flags())).toBe('refresh');
+  });
+
+  it('prefers the next page when query-core reports both', () => {
+    // Both set means the newer failure is the one on screen at the bottom of
+    // the feed, which is where the reader is and where the retry button is.
+    expect(
+      chooseFeedRetry(
+        flags({ isFetchNextPageError: true, isRefetchError: true }),
+      ),
+    ).toBe('next-page');
+  });
+
+  it('never answers next-page off anything but a next-page failure', () => {
+    for (const isFetchNextPageError of [false, true]) {
+      for (const isRefetchError of [false, true]) {
+        const answer = chooseFeedRetry({
+          isFetchNextPageError,
+          isRefetchError,
+        });
+        if (answer === 'next-page') {
+          expect(isFetchNextPageError).toBe(true);
+        }
+      }
+    }
+  });
+});

--- a/apps/self-hosted/src/features/blog/utils/feed-retry.ts
+++ b/apps/self-hosted/src/features/blog/utils/feed-retry.ts
@@ -1,0 +1,39 @@
+/**
+ * Which operation a feed's retry button should run.
+ *
+ * An infinite query has two ways to fail and one error flag shared between
+ * them, so "the feed is in an error state" does not say what to retry. Picking
+ * off `hasNextPage` gets it wrong in the case that matters: a refresh of the
+ * pages already loaded can fail while there are still more pages to come, and
+ * calling `fetchNextPage` then appends a page and clears the error while
+ * leaving the pages the reader is actually looking at exactly as stale as they
+ * were. The failure disappears from the screen without having been fixed.
+ *
+ * `isFetchNextPageError` and `isRefetchError` are query-core's own answer to
+ * which of the two failed, so retry the one that did.
+ */
+export type FeedRetry = 'next-page' | 'refresh';
+
+export interface FeedErrorFlags {
+  /** The last `fetchNextPage` failed. */
+  isFetchNextPageError: boolean;
+  /** The last refetch of the loaded pages failed. */
+  isRefetchError: boolean;
+}
+
+export function chooseFeedRetry({
+  isFetchNextPageError,
+  isRefetchError,
+}: FeedErrorFlags): FeedRetry {
+  if (isFetchNextPageError) {
+    return 'next-page';
+  }
+  if (isRefetchError) {
+    return 'refresh';
+  }
+  // Neither flag set while the feed still shows an error: the failure came from
+  // somewhere other than those two operations. Refreshing re-validates
+  // everything already on screen, so it is the answer that cannot leave a stale
+  // page behind; appending is the one that can.
+  return 'refresh';
+}

--- a/apps/self-hosted/src/features/blog/utils/top-level-comments.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/top-level-comments.test.ts
@@ -1,0 +1,61 @@
+import type { Entry } from '@ecency/sdk';
+import { describe, expect, it } from 'vitest';
+import { selectTopLevelComments } from './top-level-comments';
+
+const root = { author: 'alice', permlink: 'a-post' };
+
+const entry = (over: Partial<Entry>): Entry => over as Entry;
+
+const rootPost = entry({
+  author: 'alice',
+  permlink: 'a-post',
+  parent_author: '',
+  parent_permlink: 'hive-125125',
+});
+
+const reply = entry({
+  author: 'bob',
+  permlink: 're-a-post',
+  parent_author: 'alice',
+  parent_permlink: 'a-post',
+});
+
+const nested = entry({
+  author: 'carol',
+  permlink: 're-re-a-post',
+  parent_author: 'bob',
+  parent_permlink: 're-a-post',
+});
+
+describe('selectTopLevelComments', () => {
+  it('does not count the post itself as a comment on itself', () => {
+    // The reason this file exists. A post with no comments comes back from
+    // bridge.get_discussion carrying one entry, the post, so a length check on
+    // the response says every post has a discussion.
+    expect(selectTopLevelComments(root, [rootPost])).toEqual([]);
+  });
+
+  it('takes the replies written on the post', () => {
+    expect(selectTopLevelComments(root, [rootPost, reply])).toEqual([reply]);
+  });
+
+  it('leaves replies to replies out of the top level', () => {
+    expect(selectTopLevelComments(root, [rootPost, reply, nested])).toEqual([
+      reply,
+    ]);
+  });
+
+  it('is empty for an empty response, without throwing', () => {
+    expect(selectTopLevelComments(root, [])).toEqual([]);
+  });
+
+  it('ignores an entry parented on a different post', () => {
+    const elsewhere = entry({
+      author: 'dave',
+      permlink: 're-other',
+      parent_author: 'alice',
+      parent_permlink: 'other-post',
+    });
+    expect(selectTopLevelComments(root, [rootPost, elsewhere])).toEqual([]);
+  });
+});

--- a/apps/self-hosted/src/features/blog/utils/top-level-comments.ts
+++ b/apps/self-hosted/src/features/blog/utils/top-level-comments.ts
@@ -1,0 +1,24 @@
+import type { Entry } from '@ecency/sdk';
+
+/**
+ * The replies written directly on a post, out of a `bridge.get_discussion`
+ * response.
+ *
+ * Worth having as its own function because the response is not a list of
+ * comments: it is the whole thread keyed by author/permlink, and the root post
+ * itself is one of the entries. So a post with no comments at all still comes
+ * back carrying one item, and any code that treats "the response has entries"
+ * as "the post has comments" reads every post as having a discussion. That
+ * matters now that the count decides whether the app is allowed to say "no
+ * comments yet": measured on the raw response it would never say it, and
+ * measured wrongly in the other direction it would say it on a failure.
+ */
+export function selectTopLevelComments(
+  entry: Pick<Entry, 'author' | 'permlink'>,
+  discussion: Entry[],
+): Entry[] {
+  return discussion.filter(
+    (x) =>
+      x.parent_author === entry.author && x.parent_permlink === entry.permlink,
+  );
+}

--- a/apps/self-hosted/src/features/publish/utils/read-confirmed.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/read-confirmed.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
-import type { QueryOutcome } from '@/features/shared/query-outcome';
-import { isReadConfirmed } from './read-confirmed';
+import { QueryClient, QueryObserver } from '@tanstack/react-query';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type QueryOutcome,
+  resolveQueryOutcome,
+} from '@/features/shared/query-outcome';
+import { isReadConfirmed, type ReadEvidence } from './read-confirmed';
 
 const ALL: QueryOutcome[] = [
   'content',
@@ -11,27 +15,207 @@ const ALL: QueryOutcome[] = [
   'pending',
 ];
 
+const evidence = (over: Partial<ReadEvidence> = {}): ReadEvidence => ({
+  outcome: 'content',
+  fetchedAfterMount: true,
+  ...over,
+});
+
 describe('isReadConfirmed', () => {
-  it('confirms on a successful read', () => {
-    expect(isReadConfirmed('content', false)).toBe(true);
+  it('confirms on a read that settled during this mount and succeeded', () => {
+    expect(isReadConfirmed(evidence(), false)).toBe(true);
   });
 
-  it('does not confirm on a cached entry whose re-read failed', () => {
-    // The whole point. 'stale' means there is an entry to render and the last
-    // attempt to re-read it failed, so its title and body may already be
-    // behind the chain. Editing from it overwrites the newer version.
-    expect(isReadConfirmed('stale', false)).toBe(false);
+  it('does not confirm on cached data that was never re-read', () => {
+    // The defect this gate exists for, and the one its first version missed.
+    // A cached entry reports a successful outcome with no request behind it.
+    expect(
+      isReadConfirmed(
+        evidence({ outcome: 'content', fetchedAfterMount: false }),
+        false,
+      ),
+    ).toBe(false);
   });
 
-  it('confirms off nothing else', () => {
-    const confirming = ALL.filter((o) => isReadConfirmed(o, false));
-    expect(confirming).toEqual(['content']);
+  it('does not confirm when the read belonging to this mount failed', () => {
+    // isFetchedAfterMount counts error updates too, so it is true here while
+    // the entry on screen is still the old cached one.
+    expect(
+      isReadConfirmed(
+        evidence({ outcome: 'stale', fetchedAfterMount: true }),
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it('confirms off no other outcome, whatever the fetch flag says', () => {
+    for (const fetchedAfterMount of [false, true]) {
+      const confirming = ALL.filter((outcome) =>
+        isReadConfirmed({ outcome, fetchedAfterMount }, false),
+      );
+      expect(confirming).toEqual(fetchedAfterMount ? ['content'] : []);
+    }
   });
 
   it('stays confirmed once a read has succeeded', () => {
     // A later failure must not close an editor holding unsaved work.
     for (const outcome of ALL) {
-      expect(isReadConfirmed(outcome, true)).toBe(true);
+      for (const fetchedAfterMount of [false, true]) {
+        expect(isReadConfirmed({ outcome, fetchedAfterMount }, true)).toBe(
+          true,
+        );
+      }
     }
+  });
+});
+
+/**
+ * The gate rests on two claims about query-core that are invisible in the
+ * component and one of which was wrong the first time: that a successful status
+ * means a read happened (it does not), and that a fetch is issued on mount (it
+ * is not, under the global one minute staleTime). So the claims are measured
+ * against the installed query-core rather than taken from the names.
+ *
+ * Driven through a real QueryObserver with the options the edit route uses.
+ * `.tsx` cannot be rendered in this suite, but none of this is a React concern:
+ * the observer is where these flags are computed.
+ */
+describe('the query-core contract the gate depends on', () => {
+  const KEY = ['posts', 'entry', '@alice/a-post'];
+  const CACHED = { author: 'alice', permlink: 'a-post', title: 'cached' };
+  const FRESH = { author: 'alice', permlink: 'a-post', title: 'fresh' };
+
+  interface Mounted {
+    /** Evidence at first render, before anything belonging to it has settled. */
+    onMount: ReadEvidence;
+    /** The same once the mount's fetch has settled. */
+    settled: ReadEvidence;
+    /** How many times the query function ran. */
+    calls: number;
+  }
+
+  async function mountEditorQuery({
+    warm,
+    fail,
+    override = true,
+  }: {
+    warm: boolean;
+    fail: boolean;
+    /** False leaves refetchOnMount absent, as every other query in the app has it. */
+    override?: boolean;
+  }): Promise<Mounted> {
+    const client = new QueryClient();
+    if (warm) client.setQueryData(KEY, CACHED);
+
+    const queryFn = vi.fn(async () => {
+      if (fail) throw new Error('bridge unreachable');
+      return FRESH;
+    });
+
+    const observer = new QueryObserver(client, {
+      queryKey: KEY,
+      queryFn,
+      // The app's global defaults, plus the editor's own override. The option
+      // is omitted rather than set to undefined when the override is off: a
+      // key present with an undefined value is not the same thing to the
+      // observer as a key that is not there.
+      staleTime: 60_000,
+      retry: false,
+      ...(override ? { refetchOnMount: 'always' as const } : {}),
+    });
+
+    const read = (): ReadEvidence => {
+      const r = observer.getCurrentResult();
+      return {
+        outcome: resolveQueryOutcome({
+          isEnabled: r.isEnabled,
+          isError: r.isError,
+          isSuccess: r.isSuccess,
+          hasContent: r.data !== undefined,
+        }),
+        fetchedAfterMount: r.isFetchedAfterMount,
+      };
+    };
+
+    const onMount = read();
+    const unsubscribe = observer.subscribe(() => {});
+    await vi.waitFor(() =>
+      expect(observer.getCurrentResult().isFetching).toBe(false),
+    );
+    const settled = read();
+    unsubscribe();
+    client.clear();
+
+    return { onMount, settled, calls: queryFn.mock.calls.length };
+  }
+
+  it('does not fetch on mount at all without the always override', async () => {
+    // The realistic path: a reader opens a post and clicks Edit inside the
+    // minute. Nothing is requested, so isFetchedAfterMount can never become
+    // true, and the override is what makes this gate operable rather than a
+    // permanent lock.
+    const m = await mountEditorQuery({
+      warm: true,
+      fail: false,
+      override: false,
+    });
+
+    expect(m.calls).toBe(0);
+    // and the outcome reads as a success the whole time, which is the trap
+    expect(m.onMount.outcome).toBe('content');
+    expect(m.settled.fetchedAfterMount).toBe(false);
+    expect(isReadConfirmed(m.settled, false)).toBe(false);
+  });
+
+  it("fetches on mount with 'always' despite the stale time", async () => {
+    const m = await mountEditorQuery({ warm: true, fail: false });
+    expect(m.calls).toBe(1);
+  });
+
+  it('does not open the editor before the mount read resolves', async () => {
+    const m = await mountEditorQuery({ warm: true, fail: false });
+
+    // The cache is warm, so an entry exists and the outcome already reads as a
+    // success. The fetch flag is the only thing separating this from a read.
+    expect(m.onMount.outcome).toBe('content');
+    expect(m.onMount.fetchedAfterMount).toBe(false);
+    expect(isReadConfirmed(m.onMount, false)).toBe(false);
+  });
+
+  it('opens the editor once that read succeeds', async () => {
+    const m = await mountEditorQuery({ warm: true, fail: false });
+
+    expect(m.settled.fetchedAfterMount).toBe(true);
+    expect(m.settled.outcome).toBe('content');
+    expect(isReadConfirmed(m.settled, false)).toBe(true);
+  });
+
+  it('keeps the editor shut when the mount read fails on a warm cache', async () => {
+    const m = await mountEditorQuery({ warm: true, fail: true });
+
+    // isFetchedAfterMount counts the error update, so on its own it would open
+    // the editor here, on the cached entry. That is the overwrite.
+    expect(m.settled.fetchedAfterMount).toBe(true);
+    expect(m.settled.outcome).toBe('stale');
+    expect(isReadConfirmed(m.settled, false)).toBe(false);
+  });
+
+  it('shows the notice rather than the editor with no cache and a failing read', async () => {
+    const m = await mountEditorQuery({ warm: false, fail: true });
+
+    expect(m.settled.outcome).toBe('failed');
+    expect(isReadConfirmed(m.settled, false)).toBe(false);
+  });
+
+  it('does not close an editor that is already open when a later read fails', async () => {
+    const opened = await mountEditorQuery({ warm: true, fail: false });
+    const confirmed = isReadConfirmed(opened.settled, false);
+    expect(confirmed).toBe(true);
+
+    // Whatever a later background fetch does, the author keeps the editor and
+    // everything they have typed into it.
+    const later = await mountEditorQuery({ warm: true, fail: true });
+    expect(later.settled.outcome).toBe('stale');
+    expect(isReadConfirmed(later.settled, confirmed)).toBe(true);
   });
 });

--- a/apps/self-hosted/src/features/publish/utils/read-confirmed.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/read-confirmed.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { QueryOutcome } from '@/features/shared/query-outcome';
+import { isReadConfirmed } from './read-confirmed';
+
+const ALL: QueryOutcome[] = [
+  'content',
+  'stale',
+  'failed',
+  'empty',
+  'unasked',
+  'pending',
+];
+
+describe('isReadConfirmed', () => {
+  it('confirms on a successful read', () => {
+    expect(isReadConfirmed('content', false)).toBe(true);
+  });
+
+  it('does not confirm on a cached entry whose re-read failed', () => {
+    // The whole point. 'stale' means there is an entry to render and the last
+    // attempt to re-read it failed, so its title and body may already be
+    // behind the chain. Editing from it overwrites the newer version.
+    expect(isReadConfirmed('stale', false)).toBe(false);
+  });
+
+  it('confirms off nothing else', () => {
+    const confirming = ALL.filter((o) => isReadConfirmed(o, false));
+    expect(confirming).toEqual(['content']);
+  });
+
+  it('stays confirmed once a read has succeeded', () => {
+    // A later failure must not close an editor holding unsaved work.
+    for (const outcome of ALL) {
+      expect(isReadConfirmed(outcome, true)).toBe(true);
+    }
+  });
+});

--- a/apps/self-hosted/src/features/publish/utils/read-confirmed.ts
+++ b/apps/self-hosted/src/features/publish/utils/read-confirmed.ts
@@ -1,0 +1,26 @@
+import type { QueryOutcome } from '@/features/shared/query-outcome';
+
+/**
+ * Whether the post being edited has been read successfully in this session.
+ *
+ * Keeping cached content through a failed request is right for a reader and
+ * wrong for an author. The editor seeds its title, body, tags and metadata from
+ * whatever entry it is handed, and an update broadcast carries no version
+ * check, so opening the editor on a cached entry whose re-read failed lets a
+ * save overwrite a newer version of the post with an older one. The author is
+ * given no sign that anything went wrong, and the post they overwrote is their
+ * own.
+ *
+ * So the editor waits for a success, rather than for the presence of data.
+ *
+ * It is a latch and not a live check on purpose. Once a read has succeeded the
+ * editor is holding unsaved work, and a later background failure must not close
+ * it: that would throw away everything typed since. The gate is on opening,
+ * which is the moment the stale content would be adopted.
+ */
+export function isReadConfirmed(
+  outcome: QueryOutcome,
+  alreadyConfirmed: boolean,
+): boolean {
+  return alreadyConfirmed || outcome === 'content';
+}

--- a/apps/self-hosted/src/features/publish/utils/read-confirmed.ts
+++ b/apps/self-hosted/src/features/publish/utils/read-confirmed.ts
@@ -1,26 +1,66 @@
 import type { QueryOutcome } from '@/features/shared/query-outcome';
 
 /**
- * Whether the post being edited has been read successfully in this session.
+ * Evidence that the post being edited was read successfully during this mount.
  *
- * Keeping cached content through a failed request is right for a reader and
- * wrong for an author. The editor seeds its title, body, tags and metadata from
- * whatever entry it is handed, and an update broadcast carries no version
- * check, so opening the editor on a cached entry whose re-read failed lets a
- * save overwrite a newer version of the post with an older one. The author is
- * given no sign that anything went wrong, and the post they overwrote is their
- * own.
+ * Both fields are needed, and why each is insufficient alone is why this gate
+ * has a second version.
  *
- * So the editor waits for a success, rather than for the presence of data.
+ * `outcome` alone is not enough. It is built from `isSuccess`, which query-core
+ * sets the moment the cache holds an entry, before any request. With
+ * `staleTime` at a minute and `refetchOnMount` at its default, an entry younger
+ * than that is not refetched at all, so a reader who opens a post and clicks
+ * Edit within the minute reaches an editor seeded entirely from cache with no
+ * read having happened. Measured against the installed query-core: warm cache,
+ * `staleTime: 60_000`, default `refetchOnMount`, and the query function is
+ * called zero times while `isSuccess` is true on the first render. Cached and
+ * never re-read is indistinguishable from freshly read at the point this gate
+ * asks, which is how the first version of it passed review with the defect
+ * still open.
+ *
+ * `fetchedAfterMount` alone is not enough either. Read from the installed
+ * query-core, it is `dataUpdateCount > initial || errorUpdateCount > initial`,
+ * so a fetch that failed sets it exactly as a fetch that succeeded does. On a
+ * warm cache with a failing read it is true while the entry on screen is still
+ * the old cached one.
+ *
+ * Together they say what is actually required: a request belonging to this
+ * mount settled, and it settled successfully.
+ */
+export interface ReadEvidence {
+  /** The outcome of the query backing the editor. */
+  outcome: QueryOutcome;
+  /**
+   * query-core's `isFetchedAfterMount`: a fetch belonging to this mount has
+   * settled. Only meaningful when the query also sets `refetchOnMount: 'always'`,
+   * since otherwise `staleTime` can suppress the fetch entirely and this stays
+   * false forever.
+   */
+  fetchedAfterMount: boolean;
+}
+
+/**
+ * Whether the editor may open.
+ *
+ * Keeping cached content through a failed or absent request is right for a
+ * reader and wrong for an author. The editor seeds its title, body, tags and
+ * metadata from whatever entry it is handed, and an update broadcast carries no
+ * version check, so opening on an entry that was not read during this mount
+ * lets a save overwrite a newer version of the post with an older one. The
+ * author is given no sign that anything went wrong, and the post they
+ * overwrote is their own.
+ *
+ * This applies to the editor and not to the reading surfaces. Those should keep
+ * showing what they have. The editor is different because it writes.
  *
  * It is a latch and not a live check on purpose. Once a read has succeeded the
  * editor is holding unsaved work, and a later background failure must not close
  * it: that would throw away everything typed since. The gate is on opening,
- * which is the moment the stale content would be adopted.
+ * which is the moment stale content would be adopted.
  */
 export function isReadConfirmed(
-  outcome: QueryOutcome,
+  { outcome, fetchedAfterMount }: ReadEvidence,
   alreadyConfirmed: boolean,
 ): boolean {
-  return alreadyConfirmed || outcome === 'content';
+  return alreadyConfirmed || (fetchedAfterMount && outcome === 'content');
 }

--- a/apps/self-hosted/src/features/shared/crash-screen.tsx
+++ b/apps/self-hosted/src/features/shared/crash-screen.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import type { ErrorInfo } from 'react';
+import { t } from '@/core';
+
+/**
+ * What a visitor sees when a render throws.
+ *
+ * Before this, the root boundary fell through to its own default: a 200px box
+ * containing the raw `error.message` of a JavaScript exception, an English
+ * "Retry" on an instance configured in any of six languages, and no way home.
+ * It replaced the masthead, the navigation and the owner's config panel with
+ * that box. The 404 next to it in `__root.tsx` was already a full themed page,
+ * for the same class of event.
+ *
+ * Retry is a reload, not a re-render. The boundary's own retry clears its state
+ * and renders the identical tree, so a deterministic error fails again in the
+ * same frame and the button reads as broken. A reload at least re-runs the app
+ * from nothing, and the link out of here is a real navigation for the common
+ * case where one route is what crashed.
+ */
+export function CrashScreen() {
+  return (
+    <div className="min-h-screen bg-theme-primary flex items-center justify-center">
+      <div className="text-center px-4">
+        <h1 className="text-2xl sm:text-3xl font-bold mb-4 heading-theme">
+          {t('app_error_title')}
+        </h1>
+        <p className="text-theme-muted mb-8">{t('app_error_description')}</p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="px-6 py-2 rounded-lg bg-black text-white hover:bg-black/80 transition-colors font-medium"
+          >
+            {t('reload_page')}
+          </button>
+          {/* A plain anchor, not a router Link: the router is part of what may
+              have just thrown, and a full document load is the point. */}
+          <a
+            href="/blog?filter=posts"
+            className="px-6 py-2 rounded-lg border border-theme text-theme-primary hover:bg-theme-tertiary transition-colors font-medium"
+          >
+            {t('back_to_blog')}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Leaves a record that the blog crashed.
+ *
+ * The boundary's `componentDidCatch` logs only when NODE_ENV is development,
+ * which on a built instance is never, so a crashing blog produced no trace
+ * anywhere. This app wires up no error reporting service, so the console is the
+ * only place to leave one, and an owner or a support request can find it there.
+ */
+export function reportRenderCrash(error: Error, errorInfo: ErrorInfo) {
+  console.error(
+    '[self-hosted] render crash',
+    error,
+    errorInfo?.componentStack ?? '',
+  );
+}

--- a/apps/self-hosted/src/features/shared/failure-states.test.ts
+++ b/apps/self-hosted/src/features/shared/failure-states.test.ts
@@ -370,8 +370,8 @@ describe('the editor waits for a read that succeeded', () => {
   it('does not open on the presence of a cached entry alone', () => {
     // Every reading surface treats "there is an entry" as enough. This one
     // cannot: the editor seeds title, body, tags and metadata from that entry
-    // and the update broadcast carries no version check, so a cached entry
-    // whose re-read failed lets a save overwrite the author's own newer post.
+    // and the update broadcast carries no version check, so an entry that was
+    // not read during this mount lets a save overwrite the author's newer post.
     const gates: boolean[] = [];
     each(sf, (n) => {
       if (!ts.isJsxSelfClosingElement(n) && !ts.isJsxOpeningElement(n)) return;
@@ -384,6 +384,66 @@ describe('the editor waits for a read that succeeded', () => {
     });
     expect(gates).toEqual([true]);
     expect(callsFunction(sf, 'isReadConfirmed')).toBe(true);
+  });
+
+  /**
+   * This defect survived a first fix because the gate looked right. It asked
+   * whether the query had succeeded, and query-core reports success the instant
+   * the cache holds an entry, with no request behind it. So the property worth
+   * pinning is not "the editor is gated" but what the gate is allowed to count
+   * as evidence: something that can only be true after a request belonging to
+   * this mount has come back.
+   */
+  it('requires evidence from after this mount, not the presence of data', () => {
+    // Read off the argument rather than the file: the destructured name stays
+    // present in the source even if what is handed to the gate is a constant,
+    // and a hardcoded `fetchedAfterMount: true` is the same defect again.
+    const evidence: string[] = [];
+    each(sf, (n) => {
+      if (
+        !ts.isCallExpression(n) ||
+        !ts.isIdentifier(n.expression) ||
+        n.expression.text !== 'isReadConfirmed'
+      ) {
+        return;
+      }
+      for (const arg of n.arguments) {
+        if (!ts.isObjectLiteralExpression(arg)) continue;
+        for (const prop of arg.properties) {
+          if (
+            !ts.isPropertyAssignment(prop) ||
+            !ts.isIdentifier(prop.name) ||
+            prop.name.text !== 'fetchedAfterMount'
+          ) {
+            continue;
+          }
+          evidence.push(prop.initializer.getText(sf));
+        }
+      }
+    });
+    expect(evidence).toEqual(['isFetchedAfterMount']);
+  });
+
+  it('issues that request even when the cache is fresh', () => {
+    // Without this the global one minute staleTime suppresses the fetch
+    // entirely, isFetchedAfterMount never becomes true, and the gate above
+    // turns from a safety check into a door that never opens.
+    const overrides: string[] = [];
+    each(sf, (n) => {
+      if (
+        !ts.isPropertyAssignment(n) ||
+        !ts.isIdentifier(n.name) ||
+        n.name.text !== 'refetchOnMount'
+      ) {
+        return;
+      }
+      overrides.push(
+        ts.isStringLiteralLike(n.initializer)
+          ? n.initializer.text
+          : '<dynamic>',
+      );
+    });
+    expect(overrides).toEqual(['always']);
   });
 });
 

--- a/apps/self-hosted/src/features/shared/failure-states.test.ts
+++ b/apps/self-hosted/src/features/shared/failure-states.test.ts
@@ -1,0 +1,423 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Source guards for the one rule this app kept breaking: never state something
+ * a request has not established.
+ *
+ * Three shapes of it shipped at once. A failed page fetch discarded the pages
+ * already on screen. A failed comments fetch rendered "No comments yet" on a
+ * post with a discussion, and a failed community fetch rendered "Community not
+ * found." to the owner of a running one. And an uncaught render error printed a
+ * raw JavaScript exception where the whole site had been.
+ *
+ * None of it is reachable from a unit test: vitest here runs `environment:
+ * 'node'` over `src/**\/*.test.ts`, so `.tsx` cannot be rendered at all. The
+ * decision itself lives in `query-outcome.ts` and is tested directly next door.
+ * What is left is whether the components actually route through it, which is a
+ * property of the source, so it is checked in the source. Same approach as
+ * `routes/-internal-links.test.ts`.
+ */
+
+const APP = join(__dirname, '..', '..', '..');
+const SRC = join(APP, 'src');
+
+/** The one sanctioned test that licenses saying "there is nothing here". */
+const GUARD = 'nothingToShow';
+
+/** Strings a reader reads as a statement that the content does not exist. */
+const EMPTINESS_CLAIMS = new Set([
+  'noPosts',
+  'postNotFound',
+  'community_not_found',
+  'comments_empty',
+  'no_results',
+]);
+
+/**
+ * Every emptiness claim, and how many times it may appear, guarded by GUARD.
+ *
+ * Pinned rather than counted, so deleting a guard fails here as loudly as
+ * adding an unguarded claim, and so a second claim in the same file has to be
+ * looked at rather than inheriting the first one's cover.
+ */
+const GUARDED_CLAIMS: Record<string, number> = {
+  'src/features/blog/components/blog-posts-list.tsx:noPosts': 1,
+  'src/features/blog/components/blog-post-page.tsx:postNotFound': 1,
+  'src/features/blog/components/blog-post-discussion.tsx:comments_empty': 1,
+  'src/features/blog/layout/blog-sidebar.tsx:community_not_found': 1,
+  'src/routes/edit.$author.$permlink.tsx:postNotFound': 1,
+};
+
+/**
+ * Claims that are not routed through GUARD. Adding an entry is a deliberate
+ * act: say why it is safe, and say what would close it.
+ */
+const UNGUARDED_CLAIMS: Record<
+  string,
+  { occurrences: number; reason: string }
+> = {
+  'src/features/blog/components/search-results.tsx:no_results': {
+    occurrences: 1,
+    reason:
+      'search already returns its error branch above this one, so a failed search is not reported as no results. What is left is a fetch paused because the browser is offline, which reports no data, no error and no loading. Closing that belongs with the rest of the search empty state, which also has to echo the query back and offer a retry.',
+  },
+};
+
+/**
+ * The surfaces that render fetched content. Each must decide through the shared
+ * outcome, and none may return a failure UI out of a raw query flag, which is
+ * the exact shape that threw away content already on screen.
+ */
+const READING_SURFACES = [
+  'src/features/blog/components/blog-posts-list.tsx',
+  'src/features/blog/components/blog-post-page.tsx',
+  'src/features/blog/components/blog-post-discussion.tsx',
+  'src/features/blog/layout/blog-sidebar.tsx',
+  'src/routes/edit.$author.$permlink.tsx',
+];
+
+/** Raw query flags. A return gated on one of these is the regression. */
+const RAW_FAILURE_FLAGS = new Set(['isError', 'error', 'isLoading']);
+
+function tsxFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...tsxFiles(full));
+    } else if (entry.name.endsWith('.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const rel = (file: string) => `src/${relative(SRC, file).split(sep).join('/')}`;
+
+function parse(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+}
+
+function each(node: ts.Node, visit: (n: ts.Node) => void): void {
+  visit(node);
+  ts.forEachChild(node, (child) => each(child, visit));
+}
+
+/** Does this expression call `name(...)` anywhere inside it? */
+function callsFunction(expr: ts.Node, name: string): boolean {
+  let found = false;
+  each(expr, (n) => {
+    if (
+      ts.isCallExpression(n) &&
+      ts.isIdentifier(n.expression) &&
+      n.expression.text === name
+    ) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+/** Does this expression read one of these bare identifiers? */
+function readsIdentifier(expr: ts.Node, names: Set<string>): boolean {
+  let found = false;
+  each(expr, (n) => {
+    if (!ts.isIdentifier(n) || !names.has(n.text)) return;
+    // `entry.error` is a property of something else, not the query flag.
+    if (ts.isPropertyAccessExpression(n.parent) && n.parent.name === n) return;
+    found = true;
+  });
+  return found;
+}
+
+/**
+ * The conditions every path reaching `node` has to have passed.
+ *
+ * Only the three shapes that actually appear as a branch on the way to a piece
+ * of JSX are read: the then-branch of an `if`, the true arm of a ternary, and
+ * the right side of `&&`. Anything else leaves the node ungoverned and it has
+ * to be classified, which is the safe direction to be wrong in.
+ */
+function dominators(node: ts.Node): ts.Node[] {
+  const tests: ts.Node[] = [];
+  let child: ts.Node = node;
+  let parent: ts.Node | undefined = node.parent;
+
+  while (parent) {
+    if (ts.isIfStatement(parent) && child === parent.thenStatement) {
+      tests.push(parent.expression);
+    } else if (
+      ts.isConditionalExpression(parent) &&
+      child === parent.whenTrue
+    ) {
+      tests.push(parent.condition);
+    } else if (
+      ts.isBinaryExpression(parent) &&
+      parent.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken &&
+      child === parent.right
+    ) {
+      tests.push(parent.left);
+    }
+    child = parent;
+    parent = parent.parent;
+  }
+  return tests;
+}
+
+function isGuarded(node: ts.Node, guard: string): boolean {
+  return dominators(node).some((test) => callsFunction(test, guard));
+}
+
+interface Claim {
+  key: string;
+  guarded: boolean;
+}
+
+function sweepClaims(): Claim[] {
+  const claims: Claim[] = [];
+  for (const file of tsxFiles(SRC)) {
+    const sf = parse(file);
+    each(sf, (n) => {
+      if (
+        !ts.isCallExpression(n) ||
+        !ts.isIdentifier(n.expression) ||
+        n.expression.text !== 't' ||
+        n.arguments.length !== 1
+      ) {
+        return;
+      }
+      const [arg] = n.arguments;
+      if (!ts.isStringLiteralLike(arg)) return;
+      if (!EMPTINESS_CLAIMS.has(arg.text)) return;
+      claims.push({
+        key: `${rel(file)}:${arg.text}`,
+        guarded: isGuarded(n, GUARD),
+      });
+    });
+  }
+  return claims;
+}
+
+function tally(keys: string[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const key of keys) out[key] = (out[key] ?? 0) + 1;
+  return out;
+}
+
+describe('emptiness is only ever claimed off something established', () => {
+  const claims = sweepClaims();
+
+  it('finds the claims it is meant to be checking', () => {
+    // A rename that made this sweep match nothing would otherwise pass silently.
+    expect(claims.length).toBeGreaterThanOrEqual(
+      Object.keys(GUARDED_CLAIMS).length,
+    );
+  });
+
+  it('routes every guarded claim through the shared outcome', () => {
+    const guarded = tally(claims.filter((c) => c.guarded).map((c) => c.key));
+    expect(guarded).toEqual(GUARDED_CLAIMS);
+  });
+
+  it('classifies every claim that is not', () => {
+    const unguarded = tally(claims.filter((c) => !c.guarded).map((c) => c.key));
+    const declared = Object.fromEntries(
+      Object.entries(UNGUARDED_CLAIMS).map(([k, v]) => [k, v.occurrences]),
+    );
+    expect(unguarded).toEqual(declared);
+  });
+
+  it('reads the guard as a call, not as any mention of the name', () => {
+    // The classifier itself, exercised on both answers.
+    const probe = (code: string) => {
+      const sf = ts.createSourceFile(
+        'probe.tsx',
+        code,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TSX,
+      );
+      let target: ts.Node | undefined;
+      each(sf, (n) => {
+        if (
+          ts.isCallExpression(n) &&
+          ts.isIdentifier(n.expression) &&
+          n.expression.text === 't'
+        ) {
+          target = n;
+        }
+      });
+      return target ? isGuarded(target, GUARD) : undefined;
+    };
+
+    expect(
+      probe('const A = () => (nothingToShow(o) ? t("noPosts") : null);'),
+    ).toBe(true);
+    expect(
+      probe('const A = () => nothingToShow(o) && <p>{t("noPosts")}</p>;'),
+    ).toBe(true);
+    expect(
+      probe('function A() { if (nothingToShow(o)) { return t("noPosts"); } }'),
+    ).toBe(true);
+    // the shapes that must not count
+    expect(probe('const A = () => t("noPosts");')).toBe(false);
+    expect(
+      probe('const A = () => (o === "empty" ? t("noPosts") : null);'),
+    ).toBe(false);
+    expect(
+      probe(
+        'function A() { if (nothingToShow(o)) { return null; } return t("noPosts"); }',
+      ),
+    ).toBe(false);
+    expect(probe('const A = () => nothingToShow(o) || t("noPosts");')).toBe(
+      false,
+    );
+  });
+});
+
+describe('a failure does not take content off the screen', () => {
+  for (const surface of READING_SURFACES) {
+    const sf = parse(join(APP, surface));
+
+    it(`${surface} decides through the shared outcome`, () => {
+      expect(callsFunction(sf, 'resolveQueryOutcome')).toBe(true);
+    });
+
+    it(`${surface} returns nothing off a raw query flag`, () => {
+      // `if (isError) return <ErrorMessage />` above the content is the whole
+      // defect: query-core keeps `data` through an error, so that return
+      // discarded pages the reader already had, and their place in them.
+      const offenders: string[] = [];
+      each(sf, (n) => {
+        if (!ts.isIfStatement(n)) return;
+        if (!readsIdentifier(n.expression, RAW_FAILURE_FLAGS)) return;
+        let returns = false;
+        each(n.thenStatement, (inner) => {
+          if (ts.isReturnStatement(inner)) returns = true;
+        });
+        if (returns) {
+          const line =
+            sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1;
+          offenders.push(`${surface}:${line}`);
+        }
+      });
+      expect(offenders).toEqual([]);
+    });
+  }
+});
+
+describe('a failed page does not turn into a retry storm', () => {
+  const file = 'src/features/blog/components/blog-posts-list.tsx';
+  const sf = parse(join(APP, file));
+
+  it('takes the bottom sentinel down while the feed is failing', () => {
+    // The reader is sitting at the bottom of the feed, which is where the
+    // fetch failed. Leaving the intersection sentinel mounted refires the same
+    // request the instant the retries stop, forever. Keeping the loaded posts
+    // on screen is only an improvement if that does not happen, so the retry
+    // has to be the reader's, through the strip.
+    const sentinels: boolean[] = [];
+    each(sf, (n) => {
+      if (!ts.isJsxSelfClosingElement(n) && !ts.isJsxOpeningElement(n)) return;
+      if (n.tagName.getText(sf) !== 'DetectBottom') return;
+      sentinels.push(
+        dominators(n).some((test) =>
+          readsIdentifier(test, new Set(['outcome'])),
+        ),
+      );
+    });
+    expect(sentinels).toEqual([true]);
+  });
+});
+
+describe('what counts as content is measured on the right thing', () => {
+  const file = 'src/features/blog/components/blog-post-discussion.tsx';
+  const sf = parse(join(APP, file));
+
+  it('measures the discussion by its replies, not by the response', () => {
+    // bridge.get_discussion returns the whole thread including the root post,
+    // so the response is never empty on a success. Measured on it, every post
+    // resolves to 'content' and the app can neither say "no comments yet" when
+    // that is true nor report a failure when it is not.
+    const offenders: string[] = [];
+    each(sf, (n) => {
+      if (
+        !ts.isCallExpression(n) ||
+        !ts.isIdentifier(n.expression) ||
+        n.expression.text !== 'resolveQueryOutcome'
+      ) {
+        return;
+      }
+      for (const arg of n.arguments) {
+        if (!ts.isObjectLiteralExpression(arg)) continue;
+        for (const prop of arg.properties) {
+          if (
+            !ts.isPropertyAssignment(prop) ||
+            !ts.isIdentifier(prop.name) ||
+            prop.name.text !== 'hasContent'
+          ) {
+            continue;
+          }
+          if (readsIdentifier(prop.initializer, new Set(['allComments']))) {
+            offenders.push(prop.getText(sf));
+          }
+        }
+      }
+    });
+    expect(offenders).toEqual([]);
+    expect(callsFunction(sf, 'selectTopLevelComments')).toBe(true);
+  });
+});
+
+describe('the root error boundary is dressed and reports', () => {
+  const root = parse(join(APP, 'src/routes/__root.tsx'));
+
+  it('passes a themed fallback and an error handler', () => {
+    const props: string[] = [];
+    each(root, (n) => {
+      if (!ts.isJsxOpeningLikeElement(n)) return;
+      if (n.tagName.getText(root) !== 'ErrorBoundary') return;
+      for (const attr of n.attributes.properties) {
+        if (ts.isJsxAttribute(attr) && ts.isIdentifier(attr.name)) {
+          props.push(attr.name.text);
+        }
+      }
+    });
+    // Without these the boundary falls back to printing `error.message` raw,
+    // with a hardcoded English retry that re-renders the tree that just threw.
+    expect(props).toContain('fallback');
+    expect(props).toContain('onError');
+  });
+
+  const crash = parse(join(APP, 'src/features/shared/crash-screen.tsx'));
+
+  it('offers a reload rather than re-rendering the tree that threw', () => {
+    let reloads = false;
+    each(crash, (n) => {
+      if (ts.isPropertyAccessExpression(n) && n.name.text === 'reload') {
+        reloads = true;
+      }
+    });
+    expect(reloads).toBe(true);
+  });
+
+  it('takes every word it shows from the locale system', () => {
+    const literals: string[] = [];
+    each(crash, (n) => {
+      if (ts.isJsxText(n) && n.text.trim().length > 0) {
+        literals.push(n.text.trim());
+      }
+    });
+    expect(literals).toEqual([]);
+    expect(callsFunction(crash, 't')).toBe(true);
+  });
+});

--- a/apps/self-hosted/src/features/shared/failure-states.test.ts
+++ b/apps/self-hosted/src/features/shared/failure-states.test.ts
@@ -127,6 +127,32 @@ function callsFunction(expr: ts.Node, name: string): boolean {
   return found;
 }
 
+/** Does this node call `receiver.name(...)` anywhere inside it? */
+function callsMethod(node: ts.Node, name: string): boolean {
+  let found = false;
+  each(node, (n) => {
+    if (
+      ts.isCallExpression(n) &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      n.expression.name.text === name
+    ) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+/** Does this expression compare against this string literal anywhere inside it? */
+function mentionsLiteral(node: ts.Node, value: string): boolean {
+  let found = false;
+  each(node, (n) => {
+    if (ts.isStringLiteralLike(n) && n.text === value) {
+      found = true;
+    }
+  });
+  return found;
+}
+
 /** Does this expression read one of these bare identifiers? */
 function readsIdentifier(expr: ts.Node, names: Set<string>): boolean {
   let found = false;
@@ -315,6 +341,74 @@ describe('a failure does not take content off the screen', () => {
   }
 });
 
+describe('a surface that keeps content says the refresh failed', () => {
+  // Computing a stale outcome and then rendering as though nothing happened is
+  // worse than not computing it: to anyone reading the file it looks handled,
+  // and to the reader the content silently stops being current.
+  for (const surface of READING_SURFACES) {
+    const sf = parse(join(APP, surface));
+
+    it(`${surface} renders a failure notice under the stale outcome`, () => {
+      const announced: boolean[] = [];
+      each(sf, (n) => {
+        if (!ts.isJsxSelfClosingElement(n) && !ts.isJsxOpeningElement(n))
+          return;
+        if (n.tagName.getText(sf) !== 'InlineError') return;
+        announced.push(
+          dominators(n).some((test) => mentionsLiteral(test, 'stale')),
+        );
+      });
+      expect(announced).toContain(true);
+    });
+  }
+});
+
+describe('the editor waits for a read that succeeded', () => {
+  const file = 'src/routes/edit.$author.$permlink.tsx';
+  const sf = parse(join(APP, file));
+
+  it('does not open on the presence of a cached entry alone', () => {
+    // Every reading surface treats "there is an entry" as enough. This one
+    // cannot: the editor seeds title, body, tags and metadata from that entry
+    // and the update broadcast carries no version check, so a cached entry
+    // whose re-read failed lets a save overwrite the author's own newer post.
+    const gates: boolean[] = [];
+    each(sf, (n) => {
+      if (!ts.isJsxSelfClosingElement(n) && !ts.isJsxOpeningElement(n)) return;
+      if (n.tagName.getText(sf) !== 'EditPageContent') return;
+      gates.push(
+        dominators(n).some((test) =>
+          readsIdentifier(test, new Set(['readConfirmed'])),
+        ),
+      );
+    });
+    expect(gates).toEqual([true]);
+    expect(callsFunction(sf, 'isReadConfirmed')).toBe(true);
+  });
+});
+
+describe('keeping content is paired with a cache that was filtered', () => {
+  const file = 'src/core/dmca.ts';
+  const sf = ts.createSourceFile(
+    file,
+    readFileSync(join(APP, file), 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  it('throws away post data that predates the lists', () => {
+    // The pairing this whole file exists to protect. The reading surfaces keep
+    // what they have when a request fails; that is only safe while everything
+    // cached was filtered under the lists currently in force. A post cached
+    // before the lists installed was filtered against nothing, so invalidating
+    // it, which only schedules a refetch, leaves takedown-listed content on
+    // screen for the rest of the session when that refetch fails.
+    expect(callsMethod(sf, 'resetQueries')).toBe(true);
+    expect(callsMethod(sf, 'invalidateQueries')).toBe(false);
+  });
+});
+
 describe('a failed page does not turn into a retry storm', () => {
   const file = 'src/features/blog/components/blog-posts-list.tsx';
   const sf = parse(join(APP, file));
@@ -336,6 +430,29 @@ describe('a failed page does not turn into a retry storm', () => {
       );
     });
     expect(sentinels).toEqual([true]);
+  });
+
+  it('retries the operation that failed, not the one that is available', () => {
+    // Choosing off hasNextPage gets the common case wrong: a failed refresh of
+    // the loaded pages while more pages exist would append a page, clearing
+    // the error while leaving every page the reader can see just as stale.
+    const retries: boolean[] = [];
+    each(sf, (n) => {
+      if (!ts.isJsxSelfClosingElement(n) && !ts.isJsxOpeningElement(n)) return;
+      if (n.tagName.getText(sf) !== 'InlineError') return;
+      for (const attr of n.attributes.properties) {
+        if (
+          !ts.isJsxAttribute(attr) ||
+          !ts.isIdentifier(attr.name) ||
+          attr.name.text !== 'onRetry' ||
+          !attr.initializer
+        ) {
+          continue;
+        }
+        retries.push(callsFunction(attr.initializer, 'chooseFeedRetry'));
+      }
+    });
+    expect(retries).toEqual([true]);
   });
 });
 

--- a/apps/self-hosted/src/features/shared/index.ts
+++ b/apps/self-hosted/src/features/shared/index.ts
@@ -1,7 +1,15 @@
 // Re-export shared components
 export { UserAvatar, type UserAvatarProps } from './user-avatar';
+export { CrashScreen, reportRenderCrash } from './crash-screen';
 export { ErrorMessage } from './error-message';
+export { InlineError } from './inline-error';
 export { LiveRegion } from './live-region';
+export {
+  nothingToShow,
+  type QueryFacts,
+  type QueryOutcome,
+  resolveQueryOutcome,
+} from './query-outcome';
 
 // Re-export components from @ecency/ui
 export {

--- a/apps/self-hosted/src/features/shared/inline-error.tsx
+++ b/apps/self-hosted/src/features/shared/inline-error.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { UilExclamationTriangle } from '@tooni/iconscout-unicons-react';
+import clsx from 'clsx';
+import { t } from '@/core';
+
+/**
+ * A failure reported next to the content it belongs to, without replacing it.
+ *
+ * There is no toast layer in this app and this is not the place to introduce
+ * one: a message about a feed that failed to extend belongs at the end of that
+ * feed, where the reader already is, not floating over a corner of the screen.
+ * So this is a strip, it sits inline in the flow it describes, and it carries
+ * the retry for exactly that request.
+ *
+ * `ErrorMessage` stays the right component when there is nothing else on
+ * screen. This one is for when there is, so it is quiet and it does not take a
+ * screenful.
+ */
+interface Props {
+  /** What failed, in the reader's language. Falls back to the generic line. */
+  message?: string;
+  /** Retries the one request that failed, not the whole page. */
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function InlineError({ message, onRetry, className }: Props) {
+  return (
+    <div
+      // Announced when it appears, because nothing else changes on screen to
+      // signal it: the content the reader already has stays exactly as it was.
+      role="alert"
+      className={clsx(
+        'flex flex-wrap items-center justify-center gap-x-3 gap-y-2 rounded-theme-sm border border-theme px-4 py-3 text-sm text-theme-muted',
+        className,
+      )}
+    >
+      <UilExclamationTriangle
+        aria-hidden="true"
+        className="size-4 shrink-0 text-red-500"
+      />
+      <span>{message ?? t('error_loading')}</span>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="underline text-theme-accent hover:opacity-70 transition-theme"
+        >
+          {t('retry')}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/self-hosted/src/features/shared/query-outcome.test.ts
+++ b/apps/self-hosted/src/features/shared/query-outcome.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  nothingToShow,
+  type QueryFacts,
+  type QueryOutcome,
+  resolveQueryOutcome,
+} from './query-outcome';
+
+const facts = (over: Partial<QueryFacts> = {}): QueryFacts => ({
+  isEnabled: true,
+  isError: false,
+  isSuccess: false,
+  hasContent: false,
+  ...over,
+});
+
+/** Every combination of the four inputs, so no case is decided by accident. */
+function everyCombination(): QueryFacts[] {
+  const out: QueryFacts[] = [];
+  for (const isEnabled of [false, true]) {
+    for (const isError of [false, true]) {
+      for (const isSuccess of [false, true]) {
+        for (const hasContent of [false, true]) {
+          out.push({ isEnabled, isError, isSuccess, hasContent });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+describe('resolveQueryOutcome', () => {
+  it('keeps content when a later attempt fails', () => {
+    // The page-three failure. Sixty posts are on screen; the answer has to be
+    // "still here, and the last request failed", never "gone".
+    expect(
+      resolveQueryOutcome(
+        facts({ isSuccess: true, hasContent: true, isError: true }),
+      ),
+    ).toBe('stale');
+  });
+
+  it('reports content with nothing outstanding as content', () => {
+    expect(
+      resolveQueryOutcome(facts({ isSuccess: true, hasContent: true })),
+    ).toBe('content');
+  });
+
+  it('separates a failure with nothing on screen from emptiness', () => {
+    expect(resolveQueryOutcome(facts({ isError: true }))).toBe('failed');
+  });
+
+  it('only calls it empty when a response came back carrying nothing', () => {
+    expect(resolveQueryOutcome(facts({ isSuccess: true }))).toBe('empty');
+  });
+
+  it('separates a query that was never switched on', () => {
+    // A post URL with no permlink, an instance with no username: nothing was
+    // asked, and nothing ever will be.
+    expect(resolveQueryOutcome(facts({ isEnabled: false }))).toBe('unasked');
+  });
+
+  it('reports an unanswered query as pending, not as empty', () => {
+    // This is also the offline shape. React Query pauses a fetch when the
+    // browser reports no connection: no data, no error, and isLoading false,
+    // because nothing is in flight. Read as data it says the author has
+    // published nothing.
+    expect(resolveQueryOutcome(facts())).toBe('pending');
+  });
+
+  it('never claims emptiness off anything but a success or an unasked query', () => {
+    for (const f of everyCombination()) {
+      const outcome = resolveQueryOutcome(f);
+      if (!nothingToShow(outcome)) continue;
+      // Reached the point where a component would print "No posts found."
+      expect(f.hasContent).toBe(false);
+      expect(f.isError).toBe(false);
+      expect(f.isSuccess || !f.isEnabled).toBe(true);
+    }
+  });
+
+  it('never discards content, whatever else is true', () => {
+    for (const f of everyCombination()) {
+      if (!f.hasContent) continue;
+      const outcome = resolveQueryOutcome(f);
+      expect(['content', 'stale']).toContain(outcome);
+    }
+  });
+
+  it('surfaces every failure either as failed or as stale', () => {
+    for (const f of everyCombination()) {
+      if (!f.isError) continue;
+      const outcome = resolveQueryOutcome(f);
+      expect(outcome).toBe(f.hasContent ? 'stale' : 'failed');
+    }
+  });
+
+  it('resolves every combination to exactly one outcome', () => {
+    const table = everyCombination().map((f) => [
+      `${f.isEnabled ? 'on' : 'off'}/${f.isError ? 'err' : '-'}/${
+        f.isSuccess ? 'ok' : '-'
+      }/${f.hasContent ? 'has' : '-'}`,
+      resolveQueryOutcome(f),
+    ]);
+
+    expect(Object.fromEntries(table)).toEqual({
+      'off/-/-/-': 'unasked',
+      'off/-/-/has': 'content',
+      'off/-/ok/-': 'empty',
+      'off/-/ok/has': 'content',
+      'off/err/-/-': 'failed',
+      'off/err/-/has': 'stale',
+      'off/err/ok/-': 'failed',
+      'off/err/ok/has': 'stale',
+      'on/-/-/-': 'pending',
+      'on/-/-/has': 'content',
+      'on/-/ok/-': 'empty',
+      'on/-/ok/has': 'content',
+      'on/err/-/-': 'failed',
+      'on/err/-/has': 'stale',
+      'on/err/ok/-': 'failed',
+      'on/err/ok/has': 'stale',
+    });
+  });
+});
+
+describe('nothingToShow', () => {
+  it('licenses only the two established outcomes', () => {
+    const all: QueryOutcome[] = [
+      'content',
+      'stale',
+      'failed',
+      'empty',
+      'unasked',
+      'pending',
+    ];
+    expect(all.filter(nothingToShow)).toEqual(['empty', 'unasked']);
+  });
+});

--- a/apps/self-hosted/src/features/shared/query-outcome.ts
+++ b/apps/self-hosted/src/features/shared/query-outcome.ts
@@ -1,0 +1,96 @@
+/**
+ * What a query has actually established, as a single value.
+ *
+ * The defect this exists for: failure and emptiness were indistinguishable at
+ * every reading surface, so a request that did not come back was rendered as a
+ * factual claim about the author's work. A post with a live discussion read
+ * "No comments yet. Be the first to comment!" once the retries gave up, and the
+ * owner of a running community was told "Community not found." on one RPC blip.
+ *
+ * React Query keeps `data` from the last success when a later fetch fails, so
+ * two facts have to be read together rather than either one alone. Reading only
+ * `data` turns a failure into emptiness. Reading only `isError` throws away
+ * content that is still on screen and still perfectly good.
+ *
+ * The order in `resolveQueryOutcome` is the whole of the fix:
+ *
+ *   1. Content already loaded outweighs a later failure. Sixty posts and the
+ *      reader's scroll position are not discarded because page three timed out.
+ *   2. Emptiness is only ever claimed off a success, or off a query that was
+ *      never asked because its inputs name nothing. Nothing else proves it.
+ *   3. Everything else is "we do not know yet", which includes a fetch paused
+ *      while offline: that reports no data, no error and no loading at all.
+ */
+
+export interface QueryFacts {
+  /**
+   * The query's `isEnabled`. False when its own preconditions are unmet, for
+   * example a post URL carrying no permlink or an instance with no username
+   * configured. Such a query has asked nothing and will never answer.
+   */
+  isEnabled: boolean;
+  /** The query's `isError`: the last attempt failed and its retries are spent. */
+  isError: boolean;
+  /** The query's `isSuccess`: it has resolved successfully at least once. */
+  isSuccess: boolean;
+  /**
+   * Whether anything the caller can actually render is on screen right now.
+   * Not simply `data !== undefined`: a discussion response carries the root
+   * post itself, so the caller passes the count of the thing it renders.
+   */
+  hasContent: boolean;
+}
+
+export type QueryOutcome =
+  /** Content on screen and nothing outstanding against it. */
+  | 'content'
+  /** Content on screen and the latest attempt failed. Keep it, and say so. */
+  | 'stale'
+  /** Nothing on screen, and the attempt failed. Say that, not "nothing here". */
+  | 'failed'
+  /** A successful response returned nothing. The only proof of emptiness. */
+  | 'empty'
+  /** Never asked, because the inputs name nothing to fetch. */
+  | 'unasked'
+  /** Asked, no answer yet. Also covers a fetch paused while offline. */
+  | 'pending';
+
+export function resolveQueryOutcome({
+  isEnabled,
+  isError,
+  isSuccess,
+  hasContent,
+}: QueryFacts): QueryOutcome {
+  // Content first, deliberately: this single line is what stops a failed
+  // page-three fetch from wiping the two pages the reader is looking at.
+  if (hasContent) {
+    return isError ? 'stale' : 'content';
+  }
+  if (isError) {
+    return 'failed';
+  }
+  if (isSuccess) {
+    return 'empty';
+  }
+  if (!isEnabled) {
+    return 'unasked';
+  }
+  return 'pending';
+}
+
+/**
+ * Whether a component may state that there is nothing to show.
+ *
+ * True for 'empty', where a response came back carrying nothing, and for
+ * 'unasked', where no request was ever made because the inputs name nothing to
+ * fetch. Both are established: one by an answer, one by the absence of a
+ * question.
+ *
+ * Never true for 'failed', 'stale' or 'pending'. In those the app does not
+ * know, and saying "no posts" or "post not found" there is the lie this module
+ * exists to remove. Every emptiness message in the app is gated on this call,
+ * and a source guard fails the build if a new one is not.
+ */
+export function nothingToShow(outcome: QueryOutcome): boolean {
+  return outcome === 'empty' || outcome === 'unasked';
+}

--- a/apps/self-hosted/src/routes/__root.tsx
+++ b/apps/self-hosted/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import { FloatingMenu } from "@/features/floating-menu";
 import { AuthProvider, useIsBlogOwner } from "@/features/auth";
 import { ClaimLanding } from "@/features/claim";
 import { ErrorBoundary, SkipToContent } from "@/features/shared";
+import { CrashScreen, reportRenderCrash } from "@/features/shared/crash-screen";
 import {
   clearHiveAuthSession,
   clearUser,
@@ -84,7 +85,11 @@ function RootComponent() {
         </Suspense>
       )}
       <SkipToContent />
-      <ErrorBoundary>
+      {/* Both props are load-bearing. Without `fallback` the boundary prints
+          the raw exception message in a small box with a hardcoded English
+          retry; without `onError` a crash on a live instance is recorded
+          nowhere at all. */}
+      <ErrorBoundary fallback={<CrashScreen />} onError={reportRenderCrash}>
         {isTemplate ? (
           <ClaimLanding />
         ) : (

--- a/apps/self-hosted/src/routes/edit.$author.$permlink.tsx
+++ b/apps/self-hosted/src/routes/edit.$author.$permlink.tsx
@@ -3,15 +3,17 @@ import { getPostQueryOptions } from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useIsAuthEnabled, useAuth } from "@/features/auth/hooks";
 import { BlogSidebar } from "@/features/blog/layout/blog-sidebar";
-import { type ReactNode, useEffect, useMemo } from "react";
+import { type ReactNode, useEffect, useMemo, useRef } from "react";
 import { t } from "@/core";
 import { ErrorMessage } from "@/features/shared/error-message";
+import { InlineError } from "@/features/shared/inline-error";
 import {
   nothingToShow,
   resolveQueryOutcome,
 } from "@/features/shared/query-outcome";
 import { EditPostEditor } from "@/features/publish/components/edit-post-editor";
 import { canEditEntry } from "@/features/publish/utils/can-edit-entry";
+import { isReadConfirmed } from "@/features/publish/utils/read-confirmed";
 
 export const Route = createFileRoute("/edit/$author/$permlink")({
   component: RouteComponent,
@@ -35,6 +37,9 @@ function RouteComponent() {
     }
   }, [isAuthEnabled, canEdit, navigate]);
 
+  /** Set once the post has been read successfully, and never cleared. */
+  const readConfirmed = useRef(false);
+
   const queryOptions = getPostQueryOptions(cleanAuthor, permlink);
   const {
     data: entry,
@@ -54,12 +59,33 @@ function RouteComponent() {
     hasContent: !!entry,
   });
 
+  // Latched during render rather than in an effect, so the editor appears on
+  // the same frame the read succeeds instead of flashing the notice first.
+  readConfirmed.current = isReadConfirmed(outcome, readConfirmed.current);
+
   if (!isAuthEnabled || !canEdit) {
     return null;
   }
 
-  if (entry) {
+  // Presence of an entry is not enough here, unlike every reading surface. A
+  // cached entry whose re-read failed can be older than the post on chain, and
+  // an update broadcast carries no version check, so saving it would overwrite
+  // the author's own newer work with no sign that anything had gone wrong.
+  if (entry && readConfirmed.current) {
     return <EditPageContent entry={entry} />;
+  }
+
+  if (outcome === "stale") {
+    return (
+      <EditShell>
+        <div className="py-12">
+          <InlineError
+            message={t("edit_read_failed")}
+            onRetry={() => refetch()}
+          />
+        </div>
+      </EditShell>
+    );
   }
 
   if (outcome === "failed") {

--- a/apps/self-hosted/src/routes/edit.$author.$permlink.tsx
+++ b/apps/self-hosted/src/routes/edit.$author.$permlink.tsx
@@ -3,8 +3,13 @@ import { getPostQueryOptions } from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useIsAuthEnabled, useAuth } from "@/features/auth/hooks";
 import { BlogSidebar } from "@/features/blog/layout/blog-sidebar";
-import { useEffect, useMemo } from "react";
+import { type ReactNode, useEffect, useMemo } from "react";
 import { t } from "@/core";
+import { ErrorMessage } from "@/features/shared/error-message";
+import {
+  nothingToShow,
+  resolveQueryOutcome,
+} from "@/features/shared/query-outcome";
 import { EditPostEditor } from "@/features/publish/components/edit-post-editor";
 import { canEditEntry } from "@/features/publish/utils/can-edit-entry";
 
@@ -33,39 +38,65 @@ function RouteComponent() {
   const queryOptions = getPostQueryOptions(cleanAuthor, permlink);
   const {
     data: entry,
-    isLoading,
-    error,
+    isEnabled,
+    isError,
+    isSuccess,
+    refetch,
   } = useQuery({ ...queryOptions, enabled: canEdit });
+
+  // Was: `if (error || !entry)` renders "Post not found." One failed bridge
+  // call told an author their own post did not exist, on the screen they had
+  // opened to edit it.
+  const outcome = resolveQueryOutcome({
+    isEnabled,
+    isError,
+    isSuccess,
+    hasContent: !!entry,
+  });
 
   if (!isAuthEnabled || !canEdit) {
     return null;
   }
 
-  if (isLoading) {
+  if (entry) {
+    return <EditPageContent entry={entry} />;
+  }
+
+  if (outcome === "failed") {
     return (
-      <div className="min-h-screen bg-theme-primary">
-        <div className="container mx-auto container-padding-theme">
-          <div className="text-center py-12 text-theme-muted">
-            {t("loadingPost")}
-          </div>
-        </div>
-      </div>
+      <EditShell>
+        <ErrorMessage onRetry={() => refetch()} />
+      </EditShell>
     );
   }
 
-  if (error || !entry) {
+  if (nothingToShow(outcome)) {
     return (
-      <div className="min-h-screen bg-theme-primary">
-        <div className="container mx-auto container-padding-theme">
-          <div className="text-center py-12 text-theme-muted">
-            {t("postNotFound")}
-          </div>
+      <EditShell>
+        <div className="text-center py-12 text-theme-muted">
+          {t("postNotFound")}
         </div>
-      </div>
+      </EditShell>
     );
   }
 
-  return <EditPageContent entry={entry} />;
+  return (
+    <EditShell>
+      <div className="text-center py-12 text-theme-muted">
+        {t("loadingPost")}
+      </div>
+    </EditShell>
+  );
+}
+
+function EditShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-theme-primary">
+      <div className="container mx-auto container-padding-theme">
+        {children}
+      </div>
+    </div>
+  );
 }
 
 /**

--- a/apps/self-hosted/src/routes/edit.$author.$permlink.tsx
+++ b/apps/self-hosted/src/routes/edit.$author.$permlink.tsx
@@ -45,9 +45,21 @@ function RouteComponent() {
     data: entry,
     isEnabled,
     isError,
+    isFetchedAfterMount,
     isSuccess,
     refetch,
-  } = useQuery({ ...queryOptions, enabled: canEdit });
+  } = useQuery({
+    ...queryOptions,
+    enabled: canEdit,
+    // The reading surfaces leave this at its default and serve from cache,
+    // which is what they should do. This one cannot. The global staleTime is a
+    // minute, so a reader who opens a post and clicks Edit inside that minute
+    // would otherwise reach the editor with no request having been made at all,
+    // and `isFetchedAfterMount` would stay false forever. Verified against the
+    // installed query-core: 'always' is checked before the staleness test, so
+    // it issues the fetch regardless of staleTime.
+    refetchOnMount: 'always',
+  });
 
   // Was: `if (error || !entry)` renders "Post not found." One failed bridge
   // call told an author their own post did not exist, on the screen they had
@@ -60,17 +72,21 @@ function RouteComponent() {
   });
 
   // Latched during render rather than in an effect, so the editor appears on
-  // the same frame the read succeeds instead of flashing the notice first.
-  readConfirmed.current = isReadConfirmed(outcome, readConfirmed.current);
+  // the same frame the read succeeds instead of flashing a notice first.
+  readConfirmed.current = isReadConfirmed(
+    { outcome, fetchedAfterMount: isFetchedAfterMount },
+    readConfirmed.current,
+  );
 
   if (!isAuthEnabled || !canEdit) {
     return null;
   }
 
-  // Presence of an entry is not enough here, unlike every reading surface. A
-  // cached entry whose re-read failed can be older than the post on chain, and
-  // an update broadcast carries no version check, so saving it would overwrite
-  // the author's own newer work with no sign that anything had gone wrong.
+  // Presence of an entry is not enough here, unlike every reading surface, and
+  // neither is a successful outcome: an entry served straight from cache reads
+  // as a success without a request having been made. An update broadcast
+  // carries no version check, so editing either of those could overwrite the
+  // author's own newer work with no sign that anything had gone wrong.
   if (entry && readConfirmed.current) {
     return <EditPageContent entry={entry} />;
   }


### PR DESCRIPTION
Failure and emptiness were indistinguishable at every reading surface of the self-hosted app, so a request that did not come back was rendered as a statement of fact about the author's work. Three of those, from section F6 of the review.

## What a reader saw, and sees now

**A failed page fetch discarded the pages already on screen.** `blog-posts-list.tsx` early-returned an error panel above the map, and query-core keeps `data` through an error, so one failed page threw away every post loaded before it and the reader's place in them. `blog-post-page.tsx` did the same for a single post, and with `staleTime` at a minute and `refetchOnMount` at its default, a failed background refetch could replace an article someone was half way through.

Now the content is rendered first, ahead of every failure branch, and the failure is reported by a strip underneath it with a retry for that one request. The bottom sentinel is unmounted while the feed is failing: the reader is sitting exactly where the fetch failed, so leaving it mounted would refire the same request the instant the retries stopped, in a loop.

**A failed fetch was reported as emptiness.** `blog-post-discussion.tsx` destructured only `{ data = [], isLoading }`, so once the retries were spent it fell through to "No comments yet. Be the first to comment!" on a post with a discussion. `blog-sidebar.tsx` had the same shape and told the owner of a running community "Community not found." on one RPC blip. `edit.$author.$permlink.tsx` returned "Post not found." on `error || !entry`, so a failed bridge call told an author their own post did not exist on the screen they had opened to edit it.

Now each of those says the request failed and offers a retry, and the emptiness message appears only when a response actually came back carrying nothing.

**The crash screen was a raw JavaScript exception.** The root `<ErrorBoundary>` took no props, so it fell through to its own default: `error.message` printed verbatim in a 200px box, a hardcoded English "Retry" on an instance configured in any of six languages, and no link home, replacing the masthead, the navigation and the config panel. Its retry re-rendered the identical tree, so a deterministic error failed again in the same frame. `componentDidCatch` logs only when `NODE_ENV` is development, so on a built instance a crash was recorded nowhere.

Now it is a themed full page in the shape of the 404 that already sits next to it, with a reload and a link back to the blog, both localised, and an `onError` that leaves a record in the console.

## How

One shared decision in `features/shared/query-outcome.ts`. It reads content and failure together rather than either alone, and the order is the fix: content already loaded outweighs a later failure, emptiness is only claimed off a success or off a query that was never switched on, and everything else is pending. Pending also covers a fetch paused because the browser is offline, which reports no data, no error and no loading, and used to read as "this author has published nothing".

Failures are surfaced by an inline strip placed next to the content it belongs to. No toast or notification layer: a message about a feed that failed to extend belongs at the end of that feed, where the reader already is.

All new strings go through the locale system, in all six languages. `packages/ui` is untouched, so no dist rebuild: `ErrorBoundary` already accepts `fallback` and `onError`, and passing them from the app side also sidesteps the retry that re-renders the tree that threw.

## Verification

App suite 498 passing, typecheck clean, `rsbuild build` plus `check-node-globals.mjs` clean.

- `query-outcome.test.ts` resolves every combination of the four inputs and pins the whole table, plus the three invariants stated as invariants: content is never discarded, every failure surfaces, emptiness is never claimed off anything else.
- `top-level-comments.test.ts` covers the subtle one. `bridge.get_discussion` returns the thread including the root post, so the response is never empty on a success, and measuring it would make every post look like it has comments.
- `failure-states.test.ts` is a source guard walking the TypeScript AST, in the manner of `routes/-internal-links.test.ts`, since vitest here is `environment: 'node'` over `src/**/*.test.ts` and cannot render a `.tsx` at all. It fails the build if an emptiness message is not dominated by the guard, if a reading surface returns out of a raw query flag, if the feed leaves its sentinel mounted through a failure, if the discussion measures content on the raw response, or if the root boundary loses either prop. Claims it cannot account for have to be classified with a reason, which is how the one remaining gap is recorded rather than left silent.

Every test was mutation verified: fourteen mutations, one per claim, each confirmed to fail for its own stated reason and then restored. No survivors.

## Not in this change

- Search still says "No results found." when its fetch is paused offline. It already orders its error branch above that one, so a failed search is not reported as emptiness; the offline hole is left with the rest of the search empty state, which also has to echo the query back. Recorded as a classified exemption in the guard rather than left implicit.
- The offline work proper, the config editor validity item and the tip confirmation item are each their own change.
- Global `retry: 3` and `staleTime` are unchanged. With the content kept, the retries are now honest waiting rather than a delay in front of a wipe.


## Review follow-up

Keeping cached content is right for a reader and wrong in two places, both fixed.

**DMCA lists.** The lists are fetched at boot and deliberately not awaited, so a post query can resolve first and cache a result that was filtered against an empty configuration. That was closed by invalidating the post queries once the lists landed, but invalidation only marks data stale and schedules a refetch, and query-core keeps the existing data through a failed one. With the reading surfaces now keeping what they have, an invalidation whose refetch then failed would have left the pre-list, unfiltered entry on screen for the rest of the session. The loader resets those queries instead, so the data is cleared before any refetch is attempted and what survives a failure is only ever content filtered under the lists currently in force. Checked against a real `QueryClient`, since the difference is not visible in the call, only in what is left in the cache, and paired with a source guard because it is not obvious from either file alone.

**The editor.** It opened on the presence of a cached entry, seeds title, body, tags and metadata from it, and the update broadcast carries no version check, so an entry whose re-read failed could be saved over the author's own newer post with no sign anything had gone wrong. Editing now waits for a read that succeeded, and a stale read shows the author why it is closed with a retry. It is a latch and not a live check: once open the editor holds unsaved work, and a later background failure must not close it.

**Feed retry** picked its operation off `hasNextPage`, so a failed refresh of the loaded pages appended another page instead, clearing the error while leaving every page the reader could see just as stale. It now retries whichever operation query-core reports as having failed.

**Community sidebar** computed a stale outcome and rendered as though nothing had happened. A computed and ignored signal reads as handled, so it is now shown.

Seven further mutations verified for these, plus the original fourteen re-run.

## The editor gate, second round

The first version of that gate was aimed slightly to the side of the defect and is worth writing down, because it looked right.

It waited for a successful outcome. But query-core reports success the moment the cache holds an entry, before any request, and the global `staleTime` is a minute with `refetchOnMount` at its default. So the realistic path stayed open: a reader views a post, clicks Edit inside the minute, and the editor opens on cached content with **no read having happened at all**. Cached and never re-read is indistinguishable from freshly read at the point the gate was asking.

The gate now asks for evidence that can only exist after a request belonging to this mount came back. Both halves are load-bearing, and both were measured against the installed query-core rather than taken from the names:

- `isFetchedAfterMount` is `dataUpdateCount || errorUpdateCount` exceeding the value captured when the observer bound to the query, so **a failed fetch sets it exactly as a successful one does**. On a warm cache with a failing read it is true while the entry on screen is still the old cached one. Alone it would open the editor on precisely the content that must not be edited.
- A successful outcome alone is the original defect.

Together: a request from this mount settled, and it settled successfully.

The editor's query sets `refetchOnMount: 'always'` so a request is issued at all. Confirmed from the same source that `'always'` is evaluated before the staleness test rather than being subordinate to it, so `staleTime` does not suppress it. Without the override the flag could never become true and the gate would be a door that never opens. Scoped to that one query: reading surfaces should keep serving from cache, which is the point of this PR.

The latch is unchanged and was right. Once a read has confirmed, the editor holds unsaved work and a later background failure must not close it.

What an author sees in the warm-cache case: a brief "Loading post..." while the mount's own read runs, then the editor. If that read fails, the notice with a retry rather than an editor. Previously, the editor immediately, seeded from cache.

The contract is measured in the suite through a real `QueryObserver` with the options the route uses, including the case that proves the old gate wrong: warm cache, default `refetchOnMount`, zero calls to the query function, successful status throughout. The source guard reads the argument handed to the gate rather than scanning the file, so a hardcoded flag fails it, and pins `refetchOnMount` to `'always'` rather than merely present.

28 mutations verified across the three rounds, no survivors.

