### PR TITLE
feat(self-hosted): composer reward controls

### DIFF
--- a/apps/self-hosted/src/core/broadcast-payload-guard.test.ts
+++ b/apps/self-hosted/src/core/broadcast-payload-guard.test.ts
@@ -7,20 +7,24 @@ import { describe, expect, it } from 'vitest';
  * A deploy may change what a visitor sees. It may never change what gets
  * signed.
  *
- * This layer is a display layer. Nothing in it may cause a `comment_options`
- * operation to be broadcast where one is not broadcast today, because a
- * `comment_options` op is on chain forever and cannot be edited afterwards.
+ * The Hive layer is a display layer. Nothing in it may cause a
+ * `comment_options` operation to be broadcast, because such an operation is on
+ * chain forever and cannot be edited afterwards. Exactly one thing in this app
+ * may produce one: an author's own per post choice in the composer, and only
+ * through `resolveCommentOptions`, which returns undefined for the selection
+ * nobody touched.
  *
  * The mechanism it relies on is in the SDK: `use-comment.ts` gates the whole
- * second operation on `if (payload.options)`, so a payload without that key
- * produces a byte-identical operation array. Both halves are pinned here, the
- * gate and the absence of the key, because either one alone is an assumption.
+ * second operation on `if (payload.options)`, so a payload whose `options` is
+ * absent or undefined produces a byte-identical operation array. Both halves
+ * are pinned here, the gate and what may appear at that key, because either one
+ * alone is an assumption.
  *
  * The anchor is deliberate: `options` is a field of the payload passed to
  * `mutateAsync`, not an argument to `useComment`, whose second argument is
  * `{ adapter }`.
  *
- * Two rules this file holds itself to, because a guard that passes without
+ * Three rules this file holds itself to, because a guard that passes without
  * checking anything is worse than the defect it was written for:
  *
  *   - A payload it cannot read is a payload it cannot vouch for, so an
@@ -28,10 +32,17 @@ import { describe, expect, it } from 'vitest';
  *   - The SDK gate is asserted structurally, on the `if` statement that
  *     actually contains the builder call, never on the order two strings
  *     happen to appear in.
+ *   - The one permitted `options` expression is checked by resolving its callee
+ *     to an imported binding, not by the name written at the call site, so a
+ *     local function borrowing the name does not inherit its permission.
  *
  * The analysis functions are exercised against synthetic sources at the bottom,
  * so each of those rules is demonstrated to catch its bypass rather than
  * asserted to.
+ *
+ * What the emitted operation actually contains is not asserted here, because
+ * source shape cannot show it. `use-publish-post.broadcast.test.ts` runs the
+ * hook and the SDK's own builder and compares operation arrays.
  */
 
 const SRC = join(__dirname, '..');
@@ -73,6 +84,25 @@ const OPTIONS_FIELDS = [
   'allowCurationRewards',
   'beneficiaries',
 ];
+
+/**
+ * The one module allowed to name those fields: the resolver that builds the
+ * object, where every value is a literal a test can read and no config value
+ * can reach. One door to the chain.
+ */
+const OPTIONS_BUILDER_FILE = 'src/core/hive-layer.ts';
+
+/** The only function whose result may be handed to a payload's `options`. */
+const OPTIONS_FACTORY = 'resolveCommentOptions';
+
+/**
+ * The only payload allowed to carry an `options` key at all.
+ *
+ * A comment reply must never acquire one: nothing in this app offers a reply
+ * author a reward choice, so an `options` key appearing there would be a
+ * decision taken on someone's behalf.
+ */
+const OPTIONS_CALL_SITES = ['src/features/publish/hooks/use-publish-post.ts'];
 
 /** The truthiness test the absence of an `options` key relies on. */
 const SDK_GATE = 'payload.options';
@@ -152,8 +182,36 @@ function namesUsedIn(sf: ts.SourceFile): Set<string> {
   return names;
 }
 
+/**
+ * Local name to the name it was imported under.
+ *
+ * The guard on the `options` expression resolves through this rather than
+ * trusting the text at the call site. `import { resolveCommentOptions } from
+ * '@/core/hive-layer'` and a local `function resolveCommentOptions()` read
+ * identically at the call site and are not remotely the same thing.
+ */
+function importedBindings(sf: ts.SourceFile): Map<string, string> {
+  const bindings = new Map<string, string>();
+  const visit = (node: ts.Node) => {
+    if (ts.isImportSpecifier(node)) {
+      const imported = (node.propertyName ?? node.name).getText(sf);
+      bindings.set(node.name.getText(sf), imported);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return bindings;
+}
+
+/** What a payload wrote at its `options` key. */
+type OptionsValue =
+  | { kind: 'call'; callee: string; imported: string | null; text: string }
+  | { kind: 'other'; text: string };
+
 interface Payload {
   where: string;
+  /** Path relative to `src`, for the call-site allowlist. */
+  file: string;
   /**
    * The payload's own property names, or null when the argument is not
    * something this guard can read: an identifier, a call, a property access, a
@@ -164,12 +222,35 @@ interface Payload {
   keys: string[] | null;
   /** The argument as written, so a failure names the thing it could not read. */
   argument: string;
+  /** The `options` expression, when the payload has one. */
+  options?: OptionsValue;
 }
 
 /** Every payload handed to a mutation call in one file, readable or not. */
 function payloadsIn(sf: ts.SourceFile, rel: string): Payload[] {
   const aliases = mutationAliases(sf);
+  const bindings = importedBindings(sf);
   const found: Payload[] = [];
+
+  const readOptions = (property: ts.ObjectLiteralElementLike): OptionsValue => {
+    // A shorthand `{ options }` has no initializer to read, and neither does a
+    // spread. Both land in `other`, which fails.
+    if (!ts.isPropertyAssignment(property)) {
+      return { kind: 'other', text: property.getText(sf).replace(/\s+/g, ' ') };
+    }
+    const value = property.initializer;
+    const text = value.getText(sf).replace(/\s+/g, ' ');
+    if (!ts.isCallExpression(value) || !ts.isIdentifier(value.expression)) {
+      return { kind: 'other', text };
+    }
+    const callee = value.expression.text;
+    return {
+      kind: 'call',
+      callee,
+      imported: bindings.get(callee) ?? null,
+      text,
+    };
+  };
 
   const visit = (node: ts.Node) => {
     if (ts.isCallExpression(node)) {
@@ -187,16 +268,18 @@ function payloadsIn(sf: ts.SourceFile, rel: string): Payload[] {
 
         if (!first) {
           // No payload at all cannot carry an options key.
-          found.push({ where, keys: [], argument: '<no argument>' });
+          found.push({ where, file: rel, keys: [], argument: '<no argument>' });
         } else if (!ts.isObjectLiteralExpression(first)) {
           found.push({
             where,
+            file: rel,
             keys: null,
             argument: first.getText(sf).replace(/\s+/g, ' '),
           });
         } else {
           const keys: string[] = [];
           let readable = true;
+          let options: OptionsValue | undefined;
           for (const property of first.properties) {
             // Anything without a name this guard can read: a spread, which
             // carries whatever the spread object carries including `options`,
@@ -207,12 +290,16 @@ function payloadsIn(sf: ts.SourceFile, rel: string): Payload[] {
               readable = false;
               break;
             }
-            keys.push(property.name.getText(sf));
+            const name = property.name.getText(sf);
+            keys.push(name);
+            if (name === 'options') options = readOptions(property);
           }
           found.push({
             where,
+            file: rel,
             keys: readable ? keys.sort() : null,
             argument: first.getText(sf).replace(/\s+/g, ' '),
+            options,
           });
         }
       }
@@ -298,25 +385,67 @@ describe('no deploy of this layer changes a broadcast payload', () => {
     expect(opaque).toEqual([]);
   });
 
-  it('passes no options object to any mutation', () => {
-    // `options` is what turns on the second operation. Absent, the operation
-    // array is byte-identical to today's.
+  it('passes an options object from exactly one place', () => {
+    // `options` is what turns on the second operation. Everywhere else its
+    // absence keeps the operation array byte-identical to today's.
     const withOptions = payloads
       .filter((payload) => payload.keys?.includes('options'))
-      .map((payload) => payload.where);
-    expect(withOptions).toEqual([]);
+      .map((payload) => payload.file);
+    expect([...new Set(withOptions)].sort()).toEqual([...OPTIONS_CALL_SITES]);
   });
 
-  it('never uses a comment_options field anywhere in the app', () => {
+  it('builds every options object through the one resolver', () => {
+    // Read off the expression, not off the name at the call site: the callee
+    // has to resolve to an imported binding whose original name is the
+    // resolver's. A locally declared function of the same name is a different
+    // function and does not inherit its permission.
+    const offenders = payloads
+      .filter((payload) => payload.options)
+      .filter(
+        (payload) =>
+          payload.options?.kind !== 'call' ||
+          payload.options.imported !== OPTIONS_FACTORY,
+      )
+      .map((payload) => `${payload.where} -> options: ${payload.options?.text}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('names a comment_options field in exactly one module', () => {
+    // Elsewhere in the app these names have no legitimate use, and in that one
+    // module every value is a literal this suite reads.
     const offenders: string[] = [];
     for (const path of sourceFiles(SRC)) {
+      const rel = path.replace(SRC, 'src');
+      if (rel === OPTIONS_BUILDER_FILE) continue;
       const names = namesUsedIn(parse(path));
       for (const field of OPTIONS_FIELDS) {
-        if (names.has(field))
-          offenders.push(`${path.replace(SRC, 'src')}:${field}`);
+        if (names.has(field)) offenders.push(`${rel}:${field}`);
       }
     }
     expect(offenders).toEqual([]);
+  });
+
+  it('never writes a beneficiary into the options it builds', () => {
+    // A beneficiary rewrites who gets paid. Seeding one on an author's behalf
+    // is not something this app may ever do, so the only value allowed at that
+    // key is an empty array literal, checked on the syntax tree rather than by
+    // trusting the resolver's unit test to keep looking at the same thing.
+    const sf = parse(join(SRC, ...OPTIONS_BUILDER_FILE.split('/').slice(1)));
+    const written: string[] = [];
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isPropertyAssignment(node) &&
+        node.name.getText(sf) === 'beneficiaries'
+      ) {
+        const value = node.initializer;
+        const empty =
+          ts.isArrayLiteralExpression(value) && value.elements.length === 0;
+        if (!empty) written.push(value.getText(sf).replace(/\s+/g, ' '));
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+    expect(written).toEqual([]);
   });
 
   it('pins the exact key set of every comment payload', () => {
@@ -329,6 +458,23 @@ describe('no deploy of this layer changes a broadcast payload', () => {
     // comment-form, use-publish-post, use-update-post.
     expect(commentPayloads.map((payload) => payload.where)).toHaveLength(3);
     for (const payload of commentPayloads) {
+      const allowed = OPTIONS_CALL_SITES.includes(payload.file)
+        ? [...EXPECTED_PAYLOAD_KEYS, 'options'].sort()
+        : EXPECTED_PAYLOAD_KEYS;
+      expect(payload.keys, payload.where).toEqual(allowed);
+    }
+  });
+
+  it('leaves the edit path with no options key at all', () => {
+    // Editing a post cannot change its reward settings: `comment_options` is
+    // written once and is not editable afterwards, so an `options` key here
+    // would be a control that silently does nothing, or worse, one that
+    // rebroadcasts a different split the author never chose.
+    const edit = payloads.filter((payload) =>
+      payload.file.includes('use-update-post'),
+    );
+    expect(edit).not.toHaveLength(0);
+    for (const payload of edit) {
       expect(payload.keys, payload.where).toEqual(EXPECTED_PAYLOAD_KEYS);
     }
   });
@@ -349,6 +495,55 @@ describe('the guard catches the ways around it', () => {
   it('reads a plain object literal', () => {
     const [payload] = payloadsOf('m.mutateAsync({ author: a, options: o });');
     expect(payload.keys).toEqual(['author', 'options']);
+  });
+
+  it('accepts the resolver call, imported, however it is spelled locally', () => {
+    for (const code of [
+      "import { resolveCommentOptions } from '@/core/hive-layer';\nm.mutateAsync({ author: a, options: resolveCommentOptions(s) });",
+      // Aliased on import: a different name at the call site, the same
+      // function. The binding is what is checked, so this passes.
+      "import { resolveCommentOptions as ro } from '@/core/hive-layer';\nm.mutateAsync({ author: a, options: ro(s) });",
+    ]) {
+      const [payload] = payloadsOf(code);
+      expect(payload.options?.kind, code).toBe('call');
+      expect(
+        payload.options?.kind === 'call' ? payload.options.imported : null,
+        code,
+      ).toBe('resolveCommentOptions');
+    }
+  });
+
+  it.each([
+    [
+      'a local function wearing the resolver name',
+      'function resolveCommentOptions(s) { return { percentHbd: 0 }; }\nm.mutateAsync({ options: resolveCommentOptions(s) });',
+    ],
+    [
+      'an object literal written inline',
+      "m.mutateAsync({ options: { maxAcceptedPayout: '0.000 HBD' } });",
+    ],
+    [
+      'a variable holding one',
+      'm.mutateAsync({ options: chosenOptions });',
+    ],
+    [
+      'a shorthand property',
+      'm.mutateAsync({ author, options });',
+    ],
+    [
+      'a conditional around the resolver',
+      "import { resolveCommentOptions } from '@/core/hive-layer';\nm.mutateAsync({ options: x ? resolveCommentOptions(s) : { percentHbd: 0 } });",
+    ],
+    [
+      'a method call that merely looks right',
+      "import { resolveCommentOptions } from '@/core/hive-layer';\nm.mutateAsync({ options: helpers.resolveCommentOptions(s) });",
+    ],
+  ])('refuses %s', (_label, code) => {
+    const [payload] = payloadsOf(code);
+    const accepted =
+      payload.options?.kind === 'call' &&
+      payload.options.imported === 'resolveCommentOptions';
+    expect(accepted).toBe(false);
   });
 
   it('refuses an identifier argument instead of ignoring it', () => {

--- a/apps/self-hosted/src/core/broadcast-payload-guard.test.ts
+++ b/apps/self-hosted/src/core/broadcast-payload-guard.test.ts
@@ -242,6 +242,67 @@ function constObjectLiterals(
   return found;
 }
 
+/**
+ * How a file decides whether a publish has to be confirmed.
+ *
+ * Read as a shape, not as a name that appears somewhere: the initializer has to
+ * BE a call to the resolver, wrapping a call to the shared clamp. Two mutations
+ * survived a guard that only checked the surrounding wiring, `= true` and
+ * `= authorRewards === 'author'`, and both put the confirm step back on
+ * publishes that emit nothing, which is the finding this whole change exists
+ * for. The second one is worse than it looks: it restates the rule from the
+ * posture flag, so it drifts from what is broadcast the moment the two differ.
+ */
+interface ConfirmationRule {
+  /** The imported name the declaration calls, or null if it calls nothing. */
+  outer: string | null;
+  /** The imported name that call's argument calls, or null. */
+  inner: string | null;
+  /** The inner call's arguments, as written. */
+  args: string[];
+}
+
+function confirmationRuleIn(
+  sf: ts.SourceFile,
+  name: string,
+): ConfirmationRule | null {
+  const bindings = importedBindings(sf);
+  let rule: ConfirmationRule | null = null;
+
+  /** The name a call resolves to through an import, or null. */
+  const importedCallee = (node: ts.Node): string | null => {
+    if (!ts.isCallExpression(node) || !ts.isIdentifier(node.expression)) {
+      return null;
+    }
+    return bindings.get(node.expression.text) ?? null;
+  };
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name &&
+      node.initializer
+    ) {
+      const outer = importedCallee(node.initializer);
+      const argument = ts.isCallExpression(node.initializer)
+        ? node.initializer.arguments[0]
+        : undefined;
+      rule = {
+        outer,
+        inner: argument ? importedCallee(argument) : null,
+        args:
+          argument && ts.isCallExpression(argument)
+            ? argument.arguments.map((each) => each.getText(sf))
+            : [],
+      };
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return rule;
+}
+
 /** What a payload wrote at its `options` key. */
 type OptionsValue =
   | { kind: 'call'; callee: string; imported: string | null; text: string }
@@ -527,12 +588,8 @@ describe('no deploy of this layer changes a broadcast payload', () => {
     }
   });
 
-  it('confirms the payload it publishes, not a second copy of it', () => {
-    // The confirmation is granted to a payload identity. If the object handed
-    // to `publishConfirmationKey` were built separately from the one handed to
-    // the mutation, the two could differ, and the author would be agreeing to
-    // something other than what goes out. Checked as an identity of syntax
-    // nodes: both arguments must be the same name, bound once, to one literal.
+  /** The publish bar, and the payload name it hands to the mutation. */
+  function publishBar() {
     const rel = 'features/publish/components/publish-action-bar.tsx';
     const sf = parse(join(SRC, ...rel.split('/')));
     const aliases = mutationAliases(sf);
@@ -556,7 +613,17 @@ describe('no deploy of this layer changes a broadcast payload', () => {
     const published = callsTo((callee) => aliases.has(callee));
     expect(published).toHaveLength(1);
     expect(published[0]).toHaveLength(1);
-    const payload = published[0][0];
+
+    return { sf, locals, callsTo, payload: published[0][0] };
+  }
+
+  it('confirms the payload it publishes, not a second copy of it', () => {
+    // The confirmation is granted to a payload identity. If the object handed
+    // to `publishConfirmationKey` were built separately from the one handed to
+    // the mutation, the two could differ, and the author would be agreeing to
+    // something other than what goes out. Checked as an identity of syntax
+    // nodes: both arguments must be the same name, bound once, to one literal.
+    const { locals, callsTo, payload } = publishBar();
 
     // Every function that decides whether a confirmation is held, or mints
     // one, has to be looking at that same object.
@@ -574,6 +641,22 @@ describe('no deploy of this layer changes a broadcast payload', () => {
     // And that name is one object literal, so "the same name" means the same
     // object rather than two things that happen to be spelled alike.
     expect(locals.get(payload)).toBeTruthy();
+  });
+
+  it('asks for a confirmation on the rule, not on a restatement of it', () => {
+    // The second press is asked for on the operation that would be emitted,
+    // for that same payload. `= true` asks always, which is the behaviour
+    // change owners who took the control off were made to live with;
+    // `= authorRewards === 'author'` asks whenever the panel is on, which
+    // drifts from what is broadcast as soon as an author leaves the selection
+    // alone. Neither is a call to the resolver, and that is what is checked.
+    const { sf, payload } = publishBar();
+    const rule = confirmationRuleIn(sf, 'needsConfirmation');
+
+    expect(rule, 'nothing decides whether to confirm').not.toBeNull();
+    expect(rule?.outer).toBe('emitsUneditableOperation');
+    expect(rule?.inner).toBe('resolveRewardSelection');
+    expect(rule?.args).toContain(`${payload}.rewardType`);
   });
 
   it('pins the SDK gate the absence of options relies on', () => {
@@ -698,6 +781,68 @@ describe('the guard catches the ways around it', () => {
   it('accepts a call with no payload at all', () => {
     const [payload] = payloadsOf('m.mutate();');
     expect(payload.keys).toEqual([]);
+  });
+
+  const ruleOf = (code: string) =>
+    confirmationRuleIn(parseSource(code), 'needsConfirmation');
+
+  const IMPORTS =
+    "import { emitsUneditableOperation, resolveRewardSelection } from '@/core/hive-layer';\n";
+
+  it('accepts the rule as written, and under an alias', () => {
+    for (const code of [
+      `${IMPORTS}const needsConfirmation = emitsUneditableOperation(resolveRewardSelection(authorRewards, variables.rewardType));`,
+      // Aliased imports: different names at the call site, same functions.
+      "import { emitsUneditableOperation as asks, resolveRewardSelection as honoured } from '@/core/hive-layer';\nconst needsConfirmation = asks(honoured(authorRewards, variables.rewardType));",
+    ]) {
+      const rule = ruleOf(code);
+      expect(rule?.outer, code).toBe('emitsUneditableOperation');
+      expect(rule?.inner, code).toBe('resolveRewardSelection');
+      expect(rule?.args, code).toContain('variables.rewardType');
+    }
+  });
+
+  it.each([
+    ['a hardcoded true, which asks always', 'const needsConfirmation = true;'],
+    [
+      'the posture flag restated',
+      'const needsConfirmation = authorRewards === "author";',
+    ],
+    [
+      'the panel condition reused',
+      'const needsConfirmation = authorRewards === "author" && rewardType !== "default";',
+    ],
+    [
+      'a local function wearing the resolver name',
+      'function emitsUneditableOperation(s) { return true; }\nconst needsConfirmation = emitsUneditableOperation(resolveRewardSelection(authorRewards, variables.rewardType));',
+    ],
+    [
+      'the clamp dropped',
+      `${IMPORTS}const needsConfirmation = emitsUneditableOperation(variables.rewardType);`,
+    ],
+    [
+      'the clamp replaced by a local one',
+      `${IMPORTS}function clamp(a, s) { return s; }\nconst needsConfirmation = emitsUneditableOperation(clamp(authorRewards, variables.rewardType));`,
+    ],
+  ])('refuses %s', (_label, code) => {
+    const rule = ruleOf(code);
+    const accepted =
+      rule?.outer === 'emitsUneditableOperation' &&
+      rule?.inner === 'resolveRewardSelection';
+    expect(accepted).toBe(false);
+  });
+
+  it('refuses a rule that reads a different object than the payload', () => {
+    // The ask has to be about the payload that goes out, not about a value
+    // that merely looks like part of one.
+    const rule = ruleOf(
+      `${IMPORTS}const needsConfirmation = emitsUneditableOperation(resolveRewardSelection(authorRewards, storedRewardType));`,
+    );
+    expect(rule?.args).not.toContain('variables.rewardType');
+  });
+
+  it('reports nothing when nothing decides at all', () => {
+    expect(ruleOf('const other = 1;')).toBeNull();
   });
 
   it('accepts the builder only inside the real gate', () => {

--- a/apps/self-hosted/src/core/broadcast-payload-guard.test.ts
+++ b/apps/self-hosted/src/core/broadcast-payload-guard.test.ts
@@ -203,6 +203,45 @@ function importedBindings(sf: ts.SourceFile): Map<string, string> {
   return bindings;
 }
 
+/**
+ * Object literals bound once to a `const` in this file, by name.
+ *
+ * A payload does not stop being readable because it was given a name. The
+ * publish bar builds its variables once and both confirms and publishes that
+ * one object, which is the only way the confirmation can be for the payload
+ * that goes out, so the walk follows the name to the literal.
+ *
+ * Deliberately narrow. `const` only, since a `let` can be reassigned to
+ * anything after the walk has looked at it, and a name declared more than once
+ * in the file is ambiguous and stays unreadable rather than being guessed at.
+ */
+function constObjectLiterals(
+  sf: ts.SourceFile,
+): Map<string, ts.ObjectLiteralExpression | null> {
+  const found = new Map<string, ts.ObjectLiteralExpression | null>();
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.parent &&
+      ts.isVariableDeclarationList(node.parent)
+    ) {
+      const isConst =
+        (node.parent.flags & ts.NodeFlags.Const) === ts.NodeFlags.Const;
+      const name = node.name.text;
+      const literal =
+        isConst && node.initializer && ts.isObjectLiteralExpression(node.initializer)
+          ? node.initializer
+          : null;
+      // Declared twice, or not a const object literal: unreadable either way.
+      found.set(name, found.has(name) ? null : literal);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+}
+
 /** What a payload wrote at its `options` key. */
 type OptionsValue =
   | { kind: 'call'; callee: string; imported: string | null; text: string }
@@ -230,6 +269,7 @@ interface Payload {
 function payloadsIn(sf: ts.SourceFile, rel: string): Payload[] {
   const aliases = mutationAliases(sf);
   const bindings = importedBindings(sf);
+  const locals = constObjectLiterals(sf);
   const found: Payload[] = [];
 
   const readOptions = (property: ts.ObjectLiteralElementLike): OptionsValue => {
@@ -260,21 +300,29 @@ function payloadsIn(sf: ts.SourceFile, rel: string): Payload[] {
         /(^|\.)mutate$/.test(callee) ||
         aliases.has(callee);
 
-      const [first] = node.arguments;
+      const [argument] = node.arguments;
+      // An identifier is followed to its `const` object literal, if it has
+      // one. An identifier that resolves to nothing is unreadable, exactly as
+      // it was before this could follow anything at all.
+      const first =
+        argument && ts.isIdentifier(argument)
+          ? (locals.get(argument.text) ?? null)
+          : argument;
+
       if (isMutation) {
         const line =
           sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
         const where = `${rel}:${line}`;
 
-        if (!first) {
+        if (!argument) {
           // No payload at all cannot carry an options key.
           found.push({ where, file: rel, keys: [], argument: '<no argument>' });
-        } else if (!ts.isObjectLiteralExpression(first)) {
+        } else if (!first || !ts.isObjectLiteralExpression(first)) {
           found.push({
             where,
             file: rel,
             keys: null,
-            argument: first.getText(sf).replace(/\s+/g, ' '),
+            argument: argument.getText(sf).replace(/\s+/g, ' '),
           });
         } else {
           const keys: string[] = [];
@@ -479,6 +527,55 @@ describe('no deploy of this layer changes a broadcast payload', () => {
     }
   });
 
+  it('confirms the payload it publishes, not a second copy of it', () => {
+    // The confirmation is granted to a payload identity. If the object handed
+    // to `publishConfirmationKey` were built separately from the one handed to
+    // the mutation, the two could differ, and the author would be agreeing to
+    // something other than what goes out. Checked as an identity of syntax
+    // nodes: both arguments must be the same name, bound once, to one literal.
+    const rel = 'features/publish/components/publish-action-bar.tsx';
+    const sf = parse(join(SRC, ...rel.split('/')));
+    const aliases = mutationAliases(sf);
+    const locals = constObjectLiterals(sf);
+
+    const callsTo = (predicate: (callee: string) => boolean): string[][] => {
+      const calls: string[][] = [];
+      const visit = (node: ts.Node) => {
+        if (
+          ts.isCallExpression(node) &&
+          predicate(node.expression.getText(sf))
+        ) {
+          calls.push(node.arguments.map((argument) => argument.getText(sf)));
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(sf);
+      return calls;
+    };
+
+    const published = callsTo((callee) => aliases.has(callee));
+    expect(published).toHaveLength(1);
+    expect(published[0]).toHaveLength(1);
+    const payload = published[0][0];
+
+    // Every function that decides whether a confirmation is held, or mints
+    // one, has to be looking at that same object.
+    const confirmations = callsTo(
+      (callee) =>
+        callee === 'publishConfirmationKey' || callee === 'isConfirmationHeld',
+    );
+    expect(confirmations.length).toBeGreaterThanOrEqual(2);
+    for (const call of confirmations) {
+      expect(call, `confirmation call does not read ${payload}`).toContain(
+        payload,
+      );
+    }
+
+    // And that name is one object literal, so "the same name" means the same
+    // object rather than two things that happen to be spelled alike.
+    expect(locals.get(payload)).toBeTruthy();
+  });
+
   it('pins the SDK gate the absence of options relies on', () => {
     // If this ever stops gating, "no options key" stops meaning "no operation".
     const report = gateReport(parse(SDK_COMMENT), SDK_GATE, SDK_BUILDER);
@@ -554,11 +651,29 @@ describe('the guard catches the ways around it', () => {
       'm.mutateAsync(options.payload);',
       'm.mutateAsync(buildPayload());',
       'm.mutate(payload as CommentPayload);',
+      // Named, but by something the walk cannot read through.
+      'const payload = buildPayload(); m.mutateAsync(payload);',
+      'let payload = { title: t }; payload = other; m.mutateAsync(payload);',
+      'const payload = { ...base }; m.mutateAsync(payload);',
+      // Two declarations of the name: which one reaches the call is not
+      // something this walk can decide, so it decides nothing.
+      'const payload = { title: t }; function f() { const payload = { options: o }; m.mutateAsync(payload); }',
     ]) {
       const [payload] = payloadsOf(code);
       expect(payload, code).toBeDefined();
       expect(payload.keys, code).toBeNull();
     }
+  });
+
+  it('follows a const object literal to its keys', () => {
+    // Naming the payload is allowed, and has to be: the publish bar confirms
+    // and publishes one object. It is read exactly as if it were written at
+    // the call site, options key and all.
+    const [payload] = payloadsOf(
+      'const variables = { title: t, options: o }; m.mutateAsync(variables);',
+    );
+    expect(payload.keys).toEqual(['options', 'title']);
+    expect(payload.options?.kind).toBe('other');
   });
 
   it('refuses a literal whose keys it cannot enumerate', () => {

--- a/apps/self-hosted/src/core/hive-layer-consumers.test.ts
+++ b/apps/self-hosted/src/core/hive-layer-consumers.test.ts
@@ -48,15 +48,29 @@ const FLAG_CONSUMERS: Record<string, { file: string; component: string }> = {
 };
 
 /**
- * Non-boolean resolver output that has no consumer yet.
+ * Non-boolean resolver output and where it is read.
+ *
+ * Same rule as the render flags, and checked the same way. `authorRewards` sat
+ * in the list below for a release with nothing reading it, which was acceptable
+ * only because it could not be wrong: nothing rendered a reward control and the
+ * broadcast guard pinned that no `options` key reached any payload. Now that
+ * the composer reads it, it is held to the same standard as everything else.
+ */
+const VALUE_CONSUMERS: Record<string, { file: string; component: string }> = {
+  authorRewards: {
+    file: 'features/publish/components/publish-action-bar.tsx',
+    component: 'PublishRewardSelector',
+  },
+};
+
+/**
+ * Resolver output that has no consumer yet.
  *
  * Deliberate, like a DYNAMIC_LINKS entry: an entry here is an admission, so it
- * carries the reason and the thing that removes it. An empty list is the goal.
+ * carries the reason and the thing that removes it. Empty is the goal, and it
+ * is empty.
  */
-const AWAITING_CONSUMER: Record<string, string> = {
-  authorRewards:
-    'composer reward controls, the second half of this track. Kept resolved because the hosting seed already writes the field and its external-composer clamp reads createPostUrl, which every existing tenant carries',
-};
+const AWAITING_CONSUMER: Record<string, string> = {};
 
 /** Which postures differ, computed from the resolver rather than restated. */
 function flagsFor(readerLayer: string): Record<string, boolean> {
@@ -80,12 +94,21 @@ function parse(relative: string): ts.SourceFile {
   );
 }
 
-/** Every `x.<name>` property read in the file. */
+/**
+ * Every property the file reads off an object, by either spelling.
+ *
+ * `x.showPayoutOnPost` and `const { authorRewards } = useHiveLayer()` are the
+ * same read, so both count. Anchoring on one of them would have made a
+ * consumer's choice of syntax decide whether the guard could see it.
+ */
 function propertyReads(sf: ts.SourceFile): Set<string> {
   const names = new Set<string>();
   const visit = (node: ts.Node) => {
     if (ts.isPropertyAccessExpression(node)) {
       names.add(node.name.text);
+    }
+    if (ts.isBindingElement(node)) {
+      names.add((node.propertyName ?? node.name).getText(sf));
     }
     ts.forEachChild(node, visit);
   };
@@ -118,12 +141,14 @@ describe('no posture is advertised without something that renders it', () => {
 
   it('leaves no non-boolean output unaccounted for', () => {
     // readerLayer is the posture itself; payoutLabel and learnMoreUrl are read
-    // by the two components above. Anything else has to be listed with a reason.
+    // by the two components above. Anything else needs a consumer named in
+    // VALUE_CONSUMERS, which is checked, or a reason in AWAITING_CONSUMER.
     const named = new Set([
       'readerLayer',
       'payoutLabel',
       'learnMoreUrl',
       ...Object.keys(FLAG_CONSUMERS),
+      ...Object.keys(VALUE_CONSUMERS),
       ...Object.keys(AWAITING_CONSUMER),
     ]);
     expect(resolvedKeys.filter((key) => !named.has(key))).toEqual([]);
@@ -138,7 +163,7 @@ describe('no posture is advertised without something that renders it', () => {
     }
   });
 
-  it.each(Object.entries(FLAG_CONSUMERS))(
+  it.each(Object.entries({ ...FLAG_CONSUMERS, ...VALUE_CONSUMERS }))(
     '%s is read where it is declared to be',
     (flag, { file, component }) => {
       const sf = parse(file);

--- a/apps/self-hosted/src/core/hive-layer.test.ts
+++ b/apps/self-hosted/src/core/hive-layer.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
+  DECLINED_MAX_ACCEPTED_PAYOUT,
+  DEFAULT_PERCENT_HBD,
   HIVE_LAYER_CONFIG_DEFAULTS,
   HIVE_LAYER_SEED,
   PAYOUT_LABEL_MAX_LENGTH,
   type ResolvedHiveLayer,
+  resolveCommentOptions,
   resolveHiveLayer,
+  resolveRewardType,
+  UNLIMITED_MAX_ACCEPTED_PAYOUT,
 } from './hive-layer';
 
 /**
@@ -265,6 +270,127 @@ describe('the config surface stays writable', () => {
   it('seeds only keys the defaults table declares', () => {
     for (const key of Object.keys(HIVE_LAYER_SEED)) {
       expect(Object.keys(HIVE_LAYER_CONFIG_DEFAULTS)).toContain(key);
+    }
+  });
+});
+
+describe("what the author's reward choice puts on chain", () => {
+  /**
+   * The governing rule, at the one place in this app that can break it: a
+   * deploy may change what a visitor sees, it may never change what gets
+   * signed. `undefined` here is not a null object, it is the absence of a
+   * second operation, and `use-comment.ts` gates on exactly that.
+   */
+  it('emits no operation at all for the untouched selection', () => {
+    expect(resolveCommentOptions('default')).toBeUndefined();
+  });
+
+  it('emits nothing for a selection it does not recognise', () => {
+    // The value is read back out of a draft in localStorage, which any visitor
+    // can edit and which outlives the release that wrote it. Unknown resolves
+    // toward the operation that is never broadcast, never toward one that is.
+    for (const selection of [
+      'sp ',
+      'SP',
+      'decline',
+      '',
+      undefined,
+      null,
+      42,
+      true,
+      { rewardType: 'dp' },
+      ['dp'],
+    ]) {
+      expect(
+        resolveCommentOptions(selection as never),
+        String(JSON.stringify(selection)),
+      ).toBeUndefined();
+      expect(resolveRewardType(selection)).toBe('default');
+    }
+  });
+
+  it('recognises exactly the three drafts-API selections', () => {
+    for (const selection of ['default', 'sp', 'dp'] as const) {
+      expect(resolveRewardType(selection)).toBe(selection);
+    }
+  });
+
+  it('writes every field explicitly for a full power up', () => {
+    // percentHbd 0 is the choice. Everything else is written out rather than
+    // left to the SDK's destructuring defaults, which would otherwise supply
+    // values across a package boundary that no one here reviewed and that no
+    // edit can reach once they are on chain.
+    expect(resolveCommentOptions('sp')).toEqual({
+      maxAcceptedPayout: '1000000.000 HBD',
+      percentHbd: 0,
+      allowVotes: true,
+      allowCurationRewards: true,
+      beneficiaries: [],
+    });
+  });
+
+  it('writes every field explicitly for declined rewards', () => {
+    expect(resolveCommentOptions('dp')).toEqual({
+      maxAcceptedPayout: '0.000 HBD',
+      percentHbd: 10000,
+      allowVotes: true,
+      allowCurationRewards: true,
+      beneficiaries: [],
+    });
+  });
+
+  it('never seeds a beneficiary', () => {
+    // Beneficiaries rewrite who gets paid. Nothing in this app may set one on
+    // an author's behalf, so "we ship none" is asserted on the emitted object
+    // rather than left as an absence somebody could later fill in.
+    for (const selection of ['default', 'sp', 'dp'] as const) {
+      expect(resolveCommentOptions(selection)?.beneficiaries ?? []).toEqual([]);
+    }
+  });
+
+  it('leaves votes and curation alone in every selection it emits', () => {
+    // Neither is offered as a choice anywhere in this app, so both must be the
+    // chain's own default in anything we broadcast. A false here would disable
+    // voting on a post permanently.
+    for (const selection of ['sp', 'dp'] as const) {
+      const options = resolveCommentOptions(selection);
+      expect(options?.allowVotes, selection).toBe(true);
+      expect(options?.allowCurationRewards, selection).toBe(true);
+    }
+  });
+
+  it('declines by capping the payout, and powers up without capping it', () => {
+    // The two selections must not bleed into each other: a power-up that also
+    // capped the payout would silently decline the rewards it was asked to
+    // convert.
+    expect(resolveCommentOptions('sp')?.maxAcceptedPayout).toBe(
+      UNLIMITED_MAX_ACCEPTED_PAYOUT,
+    );
+    expect(resolveCommentOptions('dp')?.maxAcceptedPayout).toBe(
+      DECLINED_MAX_ACCEPTED_PAYOUT,
+    );
+    expect(resolveCommentOptions('dp')?.percentHbd).toBe(DEFAULT_PERCENT_HBD);
+  });
+
+  it('reads no config value at all', () => {
+    // The composer control is per post and per author. If an instance could
+    // reach this function, a deploy could change what an author signs, which
+    // is the one thing this layer may never do.
+    const from = (features: unknown) =>
+      resolveHiveLayer({ features, composerIsInternal: true });
+    expect(from({ hive: { authorRewards: 'author' } }).authorRewards).toBe(
+      'author',
+    );
+    // Nothing in the resolved layer carries a reward split, a payout cap or a
+    // beneficiary for the composer to inherit.
+    const resolved = resolveHiveLayer({
+      features: { hive: HIVE_LAYER_SEED },
+      composerIsInternal: true,
+    });
+    for (const key of Object.keys(resolved)) {
+      expect(
+        ['maxAcceptedPayout', 'percentHbd', 'beneficiaries', 'rewardType'],
+      ).not.toContain(key);
     }
   });
 });

--- a/apps/self-hosted/src/core/hive-layer.test.ts
+++ b/apps/self-hosted/src/core/hive-layer.test.ts
@@ -6,8 +6,10 @@ import {
   HIVE_LAYER_SEED,
   PAYOUT_LABEL_MAX_LENGTH,
   type ResolvedHiveLayer,
+  emitsUneditableOperation,
   resolveCommentOptions,
   resolveHiveLayer,
+  resolveRewardSelection,
   resolveRewardType,
   UNLIMITED_MAX_ACCEPTED_PAYOUT,
 } from './hive-layer';
@@ -391,6 +393,58 @@ describe("what the author's reward choice puts on chain", () => {
       expect(
         ['maxAcceptedPayout', 'percentHbd', 'beneficiaries', 'rewardType'],
       ).not.toContain(key);
+    }
+  });
+});
+
+describe('what the instance honours, and what it has to ask about', () => {
+  /**
+   * One definition of the clamp, used by the composer and by the publish hook.
+   * Two expressions of it would let the composer ask for a confirmation the
+   * hook then ignores, or let the hook broadcast something nobody confirmed.
+   */
+  it('honours the author selection only where the control is offered', () => {
+    for (const selection of ['default', 'sp', 'dp'] as const) {
+      expect(resolveRewardSelection('author', selection)).toBe(selection);
+      expect(resolveRewardSelection('off', selection)).toBe('default');
+    }
+  });
+
+  it('collapses a selection it does not recognise, in either posture', () => {
+    for (const posture of ['author', 'off'] as const) {
+      expect(resolveRewardSelection(posture, 'SP' as never)).toBe('default');
+      expect(resolveRewardSelection(posture, undefined)).toBe('default');
+    }
+  });
+
+  /**
+   * The rule for asking twice. Read off the function that builds the
+   * operation, so "is there anything to confirm" and "here is what will be
+   * broadcast" are the same question asked once.
+   */
+  it('asks only where something uneditable would be emitted', () => {
+    expect(emitsUneditableOperation('default')).toBe(false);
+    expect(emitsUneditableOperation('sp')).toBe(true);
+    expect(emitsUneditableOperation('dp')).toBe(true);
+    expect(emitsUneditableOperation(undefined)).toBe(false);
+    expect(emitsUneditableOperation('decline' as never)).toBe(false);
+  });
+
+  it('never asks on an instance that does not offer the control', () => {
+    // The behaviour an owner who opted out keeps: one press, and an operation
+    // array identical to the one they had before this shipped.
+    for (const selection of ['default', 'sp', 'dp'] as const) {
+      const honoured = resolveRewardSelection('off', selection);
+      expect(emitsUneditableOperation(honoured), selection).toBe(false);
+      expect(resolveCommentOptions(honoured), selection).toBeUndefined();
+    }
+  });
+
+  it('agrees with itself: it asks exactly when an operation is built', () => {
+    for (const selection of ['default', 'sp', 'dp', 'nonsense'] as const) {
+      expect(emitsUneditableOperation(selection as never)).toBe(
+        resolveCommentOptions(selection as never) !== undefined,
+      );
     }
   });
 });

--- a/apps/self-hosted/src/core/hive-layer.ts
+++ b/apps/self-hosted/src/core/hive-layer.ts
@@ -282,3 +282,38 @@ export function resolveCommentOptions(
     beneficiaries: [],
   };
 }
+
+/**
+ * The selection an instance will actually honour.
+ *
+ * One definition, used by the composer and by the publish hook, because the
+ * two have to agree. The hook applies it again at the broadcast site, which is
+ * where it is load-bearing; the composer applies it to know what it is about to
+ * ask the author to confirm. If each had its own expression, an instance could
+ * ask for a confirmation it then does not act on, or act without asking.
+ */
+export function resolveRewardSelection(
+  authorRewards: AuthorRewards,
+  selection: RewardType | undefined,
+): RewardType {
+  return authorRewards === 'author' ? resolveRewardType(selection) : 'default';
+}
+
+/**
+ * Whether publishing this selection would put something on chain that no later
+ * edit can reach.
+ *
+ * This is the rule for asking the author to press twice, and it is derived from
+ * `resolveCommentOptions` rather than from the posture flag on purpose. The
+ * second press exists because a `comment_options` operation cannot be edited or
+ * removed afterwards. Where none is emitted, the publish is an ordinary post
+ * that its author can edit, and there is nothing a confirmation would protect,
+ * so asking would be a behaviour change bought for nothing. Reading the answer
+ * off the same function that builds the operation means the question and the
+ * broadcast cannot drift apart.
+ */
+export function emitsUneditableOperation(
+  selection: RewardType | undefined,
+): boolean {
+  return resolveCommentOptions(selection) !== undefined;
+}

--- a/apps/self-hosted/src/core/hive-layer.ts
+++ b/apps/self-hosted/src/core/hive-layer.ts
@@ -7,12 +7,12 @@
  * rule lives in one place and is testable without the config module.
  *
  * The governing rule for the whole Hive-native layer: a deploy may change what a
- * visitor sees, it may never change what gets signed. Nothing in this module
- * contributes to a broadcast payload. The composer-side counterpart
- * (`authorRewards`) is resolved here so the posture lives in one place, but it
- * only decides whether the composer offers the author a control; the reward
- * controls themselves, and the `comment_options` operation they would produce,
- * are not part of this layer yet.
+ * visitor sees, it may never change what gets signed. `authorRewards` decides
+ * only whether the composer offers the author a control. What that control can
+ * put on chain is `resolveCommentOptions` at the bottom of this file, and its
+ * answer for the untouched selection is `undefined`, which is what keeps the
+ * broadcast byte-identical to today for every author who does not choose
+ * otherwise. No config value reaches that function.
  *
  * Every read is defensive. `mergeConfigGuarded` on the hosting API only checks
  * `typeof`, so a hand-crafted PATCH can store any type-compatible value at any
@@ -30,6 +30,8 @@
  * clamp needs. See step 10 of the Hive-native layer spec. A test asserts that
  * every render flag this module resolves is read by a component.
  */
+
+import type { CommentPayload, DraftRewardType } from '@ecency/sdk';
 
 export type ReaderLayer = 'off' | 'standard' | 'full';
 export type AuthorRewards = 'off' | 'author';
@@ -191,5 +193,92 @@ export function resolveHiveLayer(input: HiveLayerInput): ResolvedHiveLayer {
       : 'off',
     payoutLabel: resolvePayoutLabel(hive?.payoutLabel),
     learnMoreUrl: resolveLearnMoreUrl(hive?.learnMoreUrl),
+  };
+}
+
+/**
+ * The author's reward choice for one post, in the drafts API's vocabulary.
+ *
+ * `DraftRewardType` is reused rather than redeclared so config, composer and
+ * the drafts API cannot drift into three spellings of the same three states.
+ */
+export type RewardType = DraftRewardType;
+
+/**
+ * Every field of a `comment_options` operation, with none of them optional.
+ *
+ * Derived from the SDK's own payload type rather than restated, and wrapped in
+ * `Required` on purpose: `use-comment.ts` destructures this object with
+ * defaults (`maxAcceptedPayout = "1000000.000 HBD"`, `percentHbd = 10000`,
+ * `allowVotes = true`, `allowCurationRewards = true`, `beneficiaries = []`),
+ * so any field we leave out is silently filled in across a package boundary by
+ * a value we never reviewed and can never edit once it is on chain. `Required`
+ * turns that from a rule someone has to remember into a compile error, and it
+ * fails loudly if the SDK ever adds a sixth field.
+ */
+export type ExplicitCommentOptions = Required<
+  NonNullable<CommentPayload['options']>
+>;
+
+/** Hive's own "no cap", the value a post carries when nothing is set. */
+export const UNLIMITED_MAX_ACCEPTED_PAYOUT = '1000000.000 HBD';
+/** A cap of zero is how Hive expresses declined rewards. */
+export const DECLINED_MAX_ACCEPTED_PAYOUT = '0.000 HBD';
+/** 10000 basis points, Hive's own default split. */
+export const DEFAULT_PERCENT_HBD = 10000;
+
+const REWARD_TYPES: readonly RewardType[] = ['default', 'sp', 'dp'];
+
+/**
+ * One of the three reward selections, or `default` for anything else.
+ *
+ * The stored value comes from the draft in localStorage, which any visitor can
+ * edit and which outlives the version of the app that wrote it. Unknown
+ * resolves to `default`, and `default` emits nothing, so a corrupted draft
+ * cannot broadcast an operation the author never chose.
+ */
+export function resolveRewardType(value: unknown): RewardType {
+  return oneOf(value, REWARD_TYPES, 'default');
+}
+
+/**
+ * What the author's selection puts on chain, or `undefined` for none.
+ *
+ * `undefined` is the whole safety property of this track: `use-comment.ts`
+ * gates the second operation on `if (payload.options)`, so an absent or
+ * undefined value produces an operation array byte-identical to the one this
+ * app broadcasts today. That is why the untouched selection returns nothing at
+ * all rather than an object spelling out Hive's defaults: an emitted
+ * `comment_options` operation is on chain forever and cannot be edited, and no
+ * author asked for one.
+ *
+ * When something IS emitted, every field is written explicitly. See
+ * `ExplicitCommentOptions`.
+ *
+ * No beneficiary is ever seeded. A beneficiary rewrites who gets paid, and
+ * doing that on an author's behalf is not a default anyone may set for them.
+ * The empty array is written rather than omitted so that "we ship none" is a
+ * value a test can read.
+ */
+export function resolveCommentOptions(
+  selection: RewardType | undefined,
+): ExplicitCommentOptions | undefined {
+  const rewardType = resolveRewardType(selection);
+
+  if (rewardType === 'default') {
+    return undefined;
+  }
+
+  return {
+    // Declining rewards is a payout cap of zero. Powering up is unchanged pay
+    // with none of it in Hive Dollars, so the cap stays at Hive's own no-cap.
+    maxAcceptedPayout:
+      rewardType === 'dp'
+        ? DECLINED_MAX_ACCEPTED_PAYOUT
+        : UNLIMITED_MAX_ACCEPTED_PAYOUT,
+    percentHbd: rewardType === 'sp' ? 0 : DEFAULT_PERCENT_HBD,
+    allowVotes: true,
+    allowCurationRewards: true,
+    beneficiaries: [],
   };
 }

--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -102,6 +102,13 @@ type TranslationKey =
   | 'hive_disclosure_vote'
   | 'hive_disclosure_comment'
   | 'hive_disclosure_publish'
+  | 'reward_split_label'
+  | 'reward_split_default'
+  | 'reward_split_sp'
+  | 'reward_split_dp'
+  | 'reward_split_broadcast'
+  | 'reward_split_permanent'
+  | 'publish_confirm'
   | 'join_community'
   | 'leave_community'
   | 'joining'
@@ -234,6 +241,14 @@ const translations: Record<string, Translations> = {
       'Comments are published to Hive. They are public and cannot be deleted.',
     hive_disclosure_publish:
       'Publishing writes this post publicly and permanently to Hive. Rewards close 7 days after publishing.',
+    reward_split_label: 'Post rewards',
+    reward_split_default: 'Half in Hive Power, half in Hive Dollars',
+    reward_split_sp: 'All in Hive Power',
+    reward_split_dp: 'Decline rewards',
+    reward_split_broadcast: 'This post will be published with:',
+    reward_split_permanent:
+      'Reward settings cannot be changed after publishing.',
+    publish_confirm: 'Press again to publish',
     join_community: 'Join',
     leave_community: 'Leave',
     joining: 'Joining...',
@@ -366,6 +381,14 @@ const translations: Record<string, Translations> = {
       'Los comentarios se publican en Hive. Son públicos y no se pueden borrar.',
     hive_disclosure_publish:
       'Al publicar, esta entrada se escribe en Hive de forma pública y permanente. Las recompensas se cierran 7 días después de publicar.',
+    reward_split_label: 'Recompensas de la publicación',
+    reward_split_default: 'Mitad en Hive Power, mitad en Hive Dollars',
+    reward_split_sp: 'Todo en Hive Power',
+    reward_split_dp: 'Rechazar las recompensas',
+    reward_split_broadcast: 'Esta publicación se publicará con:',
+    reward_split_permanent:
+      'La configuración de recompensas no se puede cambiar después de publicar.',
+    publish_confirm: 'Pulsa de nuevo para publicar',
     join_community: 'Unirse',
     leave_community: 'Salir',
     joining: 'Uniéndose...',
@@ -500,6 +523,14 @@ const translations: Record<string, Translations> = {
       'Kommentare werden auf Hive veröffentlicht. Sie sind öffentlich und können nicht gelöscht werden.',
     hive_disclosure_publish:
       'Das Veröffentlichen schreibt diesen Beitrag öffentlich und dauerhaft auf Hive. Belohnungen enden 7 Tage nach der Veröffentlichung.',
+    reward_split_label: 'Belohnungen für diesen Beitrag',
+    reward_split_default: 'Halb in Hive Power, halb in Hive Dollars',
+    reward_split_sp: 'Alles in Hive Power',
+    reward_split_dp: 'Belohnungen ablehnen',
+    reward_split_broadcast: 'Dieser Beitrag wird veröffentlicht mit:',
+    reward_split_permanent:
+      'Die Belohnungseinstellung kann nach dem Veröffentlichen nicht mehr geändert werden.',
+    publish_confirm: 'Zum Veröffentlichen erneut drücken',
     join_community: 'Beitreten',
     leave_community: 'Verlassen',
     joining: 'Beitritt...',
@@ -635,6 +666,14 @@ const translations: Record<string, Translations> = {
       'Les commentaires sont publiés sur Hive. Ils sont publics et ne peuvent pas être supprimés.',
     hive_disclosure_publish:
       'La publication écrit ce billet sur Hive de façon publique et permanente. Les récompenses se ferment 7 jours après la publication.',
+    reward_split_label: 'Récompenses du billet',
+    reward_split_default: 'Moitié en Hive Power, moitié en Hive Dollars',
+    reward_split_sp: 'Tout en Hive Power',
+    reward_split_dp: 'Refuser les récompenses',
+    reward_split_broadcast: 'Ce billet sera publié avec :',
+    reward_split_permanent:
+      'Le réglage des récompenses ne peut plus être modifié après la publication.',
+    publish_confirm: 'Appuyez à nouveau pour publier',
     join_community: 'Rejoindre',
     leave_community: 'Quitter',
     joining: 'Adhésion...',
@@ -770,6 +809,13 @@ const translations: Record<string, Translations> = {
       '댓글은 Hive에 게시됩니다. 공개되며 삭제할 수 없습니다.',
     hive_disclosure_publish:
       '게시하면 이 글이 Hive에 공개적으로 영구히 기록됩니다. 보상은 게시 후 7일에 마감됩니다.',
+    reward_split_label: '게시물 보상',
+    reward_split_default: '절반은 Hive Power, 절반은 Hive Dollars',
+    reward_split_sp: '전액 Hive Power',
+    reward_split_dp: '보상 거절',
+    reward_split_broadcast: '이 게시물은 다음 설정으로 게시됩니다:',
+    reward_split_permanent: '보상 설정은 게시한 뒤에는 바꿀 수 없습니다.',
+    publish_confirm: '게시하려면 한 번 더 누르세요',
     join_community: '가입',
     leave_community: '탈퇴',
     joining: '가입 중...',
@@ -901,6 +947,14 @@ const translations: Record<string, Translations> = {
       'Комментарии публикуются в Hive. Они общедоступны, и их нельзя удалить.',
     hive_disclosure_publish:
       'Публикация записывает этот пост в Hive публично и навсегда. Награды закрываются через 7 дней после публикации.',
+    reward_split_label: 'Награды за пост',
+    reward_split_default: 'Половина в Hive Power, половина в Hive Dollars',
+    reward_split_sp: 'Всё в Hive Power',
+    reward_split_dp: 'Отказаться от наград',
+    reward_split_broadcast: 'Этот пост будет опубликован с настройкой:',
+    reward_split_permanent:
+      'Настройку наград нельзя изменить после публикации.',
+    publish_confirm: 'Нажмите ещё раз, чтобы опубликовать',
     join_community: 'Вступить',
     leave_community: 'Выйти',
     joining: 'Вступление...',

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -230,7 +230,7 @@ export const configFieldsMap: Record<string, ConfigField> = {
                     type: 'select',
                     default: HIVE_LAYER_CONFIG_DEFAULTS.authorRewards,
                     description:
-                      'Off publishes with the usual Hive reward setting. Author chooses offers the writer all Hive Power or declining rewards, picked once at publish and not editable afterwards. Applies only to posts written here, so it does nothing when Create Post URL points at another site. The reward control itself is still being built, so this has no visible effect yet.',
+                      'Off publishes with the usual Hive reward setting. Author chooses offers the writer all Hive Power or declining rewards, picked once at publish and not editable afterwards. Applies only to posts written here, so it does nothing when Create Post URL points at another site.',
                     options: [
                       { value: 'off', label: 'Off' },
                       { value: 'author', label: 'Author chooses' },

--- a/apps/self-hosted/src/features/publish/components/publish-action-bar.tsx
+++ b/apps/self-hosted/src/features/publish/components/publish-action-bar.tsx
@@ -1,12 +1,21 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { usePublishState } from "../hooks/use-publish-state";
 import { usePublishPost } from "../hooks/use-publish-post";
 import { Link } from "@tanstack/react-router";
 import { UilArrowLeft } from "@tooni/iconscout-unicons-react";
 import { t } from "@/core";
+import {
+  emitsUneditableOperation,
+  resolveRewardSelection,
+} from "@/core/hive-layer";
 import { useHiveLayer } from "@/features/blog/hooks/use-hive-layer";
 import { PublishDisclosure } from "@/features/shared/hive-disclosure";
 import { nextPublishPress } from "../utils/publish-press";
+import type { PublishVariables } from "../utils/publish-variables";
+import {
+  isConfirmationHeld,
+  publishConfirmationKey,
+} from "../utils/publish-variables";
 import { PublishRewardSelector } from "./publish-reward-selector";
 
 interface Props {
@@ -26,8 +35,16 @@ export function PublishActionBar({ onSuccess }: Props) {
     error,
   } = usePublishPost({ beforeNavigate: clearAll });
 
-  /** A press has asked to publish and is waiting for a second one. */
-  const [armed, setArmed] = useState(false);
+  /**
+   * The publish variables a confirmation is currently held for, or null.
+   *
+   * Not a boolean. A confirmation belongs to one exact payload, so it is stored
+   * as that payload's identity and compared on every render. Editing the title,
+   * the body, the tags or the reward choice produces a different key and the
+   * button is no longer armed, with no render in between where it would still
+   * publish on the next press.
+   */
+  const [armedFor, setArmedFor] = useState<string | null>(null);
   /**
    * A broadcast has been started and has not settled.
    *
@@ -48,37 +65,46 @@ export function PublishActionBar({ onSuccess }: Props) {
     safeContent.trim().length > 0 &&
     safeTags.length > 0;
 
-  // Changing what would be broadcast withdraws the confirmation. Otherwise an
-  // author could arm the button on one reward split and publish another.
-  useEffect(() => {
-    setArmed(false);
-  }, [rewardType]);
+  // Built once and both confirmed and published, so the payload the author
+  // agreed to is the payload that goes out. A second object built for the
+  // confirmation could drift from this one the day a field is added.
+  const variables: PublishVariables = {
+    title: safeTitle,
+    body: safeContent,
+    tags: safeTags,
+    rewardType,
+  };
+  const armed = isConfirmationHeld(armedFor, variables);
+
+  // Ask a second time exactly when this publish would put something on chain
+  // that no later edit can reach. Where the instance offers no reward control,
+  // or the author left the selection alone, nothing irreversible is added and
+  // the button publishes on the first press as it always did.
+  const needsConfirmation = emitsUneditableOperation(
+    resolveRewardSelection(authorRewards, variables.rewardType),
+  );
 
   const handlePublish = async () => {
     const press = nextPublishPress({
       canPublish,
       isPublishing,
       inFlight: inFlight.current,
+      needsConfirmation,
       armed,
     });
 
     if (press === "ignore") return;
 
     if (press === "arm") {
-      setArmed(true);
+      setArmedFor(publishConfirmationKey(variables));
       return;
     }
 
     inFlight.current = true;
-    setArmed(false);
+    setArmedFor(null);
 
     try {
-      await publishPost({
-        title: safeTitle,
-        body: safeContent,
-        tags: safeTags,
-        rewardType,
-      });
+      await publishPost(variables);
       onSuccess?.();
     } catch (err) {
       // Error is handled by usePublishPost hook

--- a/apps/self-hosted/src/features/publish/components/publish-action-bar.tsx
+++ b/apps/self-hosted/src/features/publish/components/publish-action-bar.tsx
@@ -1,20 +1,43 @@
+import { useEffect, useRef, useState } from "react";
 import { usePublishState } from "../hooks/use-publish-state";
 import { usePublishPost } from "../hooks/use-publish-post";
 import { Link } from "@tanstack/react-router";
 import { UilArrowLeft } from "@tooni/iconscout-unicons-react";
+import { t } from "@/core";
+import { useHiveLayer } from "@/features/blog/hooks/use-hive-layer";
 import { PublishDisclosure } from "@/features/shared/hive-disclosure";
+import { nextPublishPress } from "../utils/publish-press";
+import { PublishRewardSelector } from "./publish-reward-selector";
 
 interface Props {
   onSuccess?: () => void;
 }
 
 export function PublishActionBar({ onSuccess }: Props) {
-  const { title, content, tags, clearAll } = usePublishState();
+  const { title, content, tags, rewardType, setRewardTypeState, clearAll } =
+    usePublishState();
+  // Clamped by the resolver to `off` when "Create post" points at another
+  // site: an owner who sends authors elsewhere must not get a panel that
+  // configures a composer nobody uses.
+  const { authorRewards } = useHiveLayer();
   const {
     mutateAsync: publishPost,
     isPending: isPublishing,
     error,
   } = usePublishPost({ beforeNavigate: clearAll });
+
+  /** A press has asked to publish and is waiting for a second one. */
+  const [armed, setArmed] = useState(false);
+  /**
+   * A broadcast has been started and has not settled.
+   *
+   * A ref rather than state, and set before the await rather than after a
+   * render: `isPublishing` only becomes true on the next render, so two presses
+   * in the same frame can both see it false. Broadcasts retry on their own, and
+   * a duplicated publish is a second post on chain that nobody can delete, so
+   * the thing that refuses the second press has to be synchronous.
+   */
+  const inFlight = useRef(false);
 
   const safeTitle = title ?? "";
   const safeContent = content ?? "";
@@ -25,19 +48,45 @@ export function PublishActionBar({ onSuccess }: Props) {
     safeContent.trim().length > 0 &&
     safeTags.length > 0;
 
+  // Changing what would be broadcast withdraws the confirmation. Otherwise an
+  // author could arm the button on one reward split and publish another.
+  useEffect(() => {
+    setArmed(false);
+  }, [rewardType]);
+
   const handlePublish = async () => {
-    if (!canPublish || isPublishing) return;
+    const press = nextPublishPress({
+      canPublish,
+      isPublishing,
+      inFlight: inFlight.current,
+      armed,
+    });
+
+    if (press === "ignore") return;
+
+    if (press === "arm") {
+      setArmed(true);
+      return;
+    }
+
+    inFlight.current = true;
+    setArmed(false);
 
     try {
       await publishPost({
         title: safeTitle,
         body: safeContent,
         tags: safeTags,
+        rewardType,
       });
       onSuccess?.();
     } catch (err) {
       // Error is handled by usePublishPost hook
       console.error("Failed to publish:", err);
+    } finally {
+      // A failed publish leaves the button unarmed, so recovering from an
+      // error costs the same two presses as the first attempt did.
+      inFlight.current = false;
     }
   };
 
@@ -53,6 +102,13 @@ export function PublishActionBar({ onSuccess }: Props) {
       </Link>
       <div className="px-2 md:px-4 py-4 flex justify-end">
         <div className="flex flex-col items-end gap-2">
+          {authorRewards === "author" && (
+            <PublishRewardSelector
+              value={rewardType}
+              onChange={setRewardTypeState}
+              disabled={isPublishing}
+            />
+          )}
           {/*
             Not configurable, by design. Publishing is the one action here that
             cannot be undone, so the statement of that goes above the button
@@ -82,7 +138,12 @@ export function PublishActionBar({ onSuccess }: Props) {
                 Publishing...
               </span>
             ) : (
-              "Publish"
+              // Same button, second press. No dialog: a dialog is one more
+              // thing to dismiss and it moves the decision away from the split
+              // printed directly above.
+              <span aria-live="polite">
+                {armed ? t("publish_confirm") : "Publish"}
+              </span>
             )}
           </button>
         </div>

--- a/apps/self-hosted/src/features/publish/components/publish-reward-selector.tsx
+++ b/apps/self-hosted/src/features/publish/components/publish-reward-selector.tsx
@@ -1,0 +1,76 @@
+import { t } from "@/core";
+import type { RewardType } from "@/core";
+
+/**
+ * The author's reward choice for this post, offered only where the instance
+ * asked for it (`features.hive.authorRewards`, resolved by `useHiveLayer`).
+ *
+ * Two things this panel does unconditionally, on every selection including the
+ * untouched one: it prints the split about to be broadcast, and it prints that
+ * the split cannot be changed afterwards. A reward choice is written into a
+ * `comment_options` operation that lives on chain forever and that no edit can
+ * reach, so an author has to be able to read what they are about to sign
+ * without opening the select.
+ *
+ * The instance has no say in the value. It only decides whether this component
+ * renders at all. There is no configurable split and no configurable
+ * beneficiary, because on a community instance the composer is used by other
+ * people and an instance-level value would rewrite a stranger's payout terms.
+ */
+
+type OptionLabelKey =
+  | "reward_split_default"
+  | "reward_split_sp"
+  | "reward_split_dp";
+
+const OPTION_LABELS: Record<RewardType, OptionLabelKey> = {
+  default: "reward_split_default",
+  sp: "reward_split_sp",
+  dp: "reward_split_dp",
+};
+
+const ORDER: RewardType[] = ["default", "sp", "dp"];
+
+interface Props {
+  value: RewardType;
+  onChange: (value: RewardType) => void;
+  disabled?: boolean;
+}
+
+export function PublishRewardSelector({ value, onChange, disabled }: Props) {
+  const summaryId = "publish-reward-summary";
+
+  return (
+    <div className="flex flex-col gap-1 text-right max-w-sm">
+      <label
+        className="text-xs text-theme-muted"
+        htmlFor="publish-reward-select"
+      >
+        {t("reward_split_label")}
+      </label>
+      <select
+        id="publish-reward-select"
+        className="text-sm px-2 py-1 rounded-lg border border-theme bg-transparent"
+        value={value}
+        disabled={disabled}
+        aria-describedby={summaryId}
+        onChange={(e) => onChange(e.target.value as RewardType)}
+      >
+        {ORDER.map((option) => (
+          <option key={option} value={option}>
+            {t(OPTION_LABELS[option])}
+          </option>
+        ))}
+      </select>
+      {/*
+        Printed for every selection, never only for the ones that emit an
+        operation: an author who never opens the select still gets told what
+        their post pays and that it is settled at publish.
+      */}
+      <p className="text-xs text-theme-muted" id={summaryId}>
+        {t("reward_split_broadcast")} {t(OPTION_LABELS[value])}
+      </p>
+      <p className="text-xs text-theme-muted">{t("reward_split_permanent")}</p>
+    </div>
+  );
+}

--- a/apps/self-hosted/src/features/publish/hooks/use-publish-post.broadcast.test.ts
+++ b/apps/self-hosted/src/features/publish/hooks/use-publish-post.broadcast.test.ts
@@ -1,0 +1,357 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildCommentOp, buildCommentOptionsOp } from '@ecency/sdk';
+import type { AuthorRewards, RewardType } from '@/core/hive-layer';
+
+/**
+ * What this app actually broadcasts when an author presses publish.
+ *
+ * Not a description of it. The real `usePublishPost` runs, with only the auth,
+ * router and config edges replaced, and the payload it hands to the SDK is
+ * captured. That payload is then fed through the SDK's own operations builder,
+ * lifted out of `use-comment.ts` by the TypeScript compiler and executed with
+ * the SDK's real operation builders, so the arrays compared below are the
+ * arrays that would be signed.
+ *
+ * The property that matters: for an author who does not touch the reward
+ * control, the operation array is byte-for-byte the one this app broadcast
+ * before the control existed. That is asserted by building the same post twice,
+ * once with the `options` key this PR added and once with it removed, and
+ * comparing the serialised results. A `comment_options` operation cannot be
+ * edited or removed once it is on chain, which is why this is a test rather
+ * than a code review promise.
+ *
+ * Lifting the builder out of the SDK rather than reimplementing it is
+ * deliberate. A local copy of the `if (payload.options)` gate would pass
+ * whatever the SDK did, including the day it stops gating.
+ */
+
+const SDK_COMMENT = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  'packages',
+  'sdk',
+  'src',
+  'modules',
+  'posts',
+  'mutations',
+  'use-comment.ts',
+);
+
+/** Captured payloads, in call order, filled by the mocked `useComment`. */
+const captured: Record<string, unknown>[] = [];
+/** Drives the resolver clamp without going near a config document. */
+let authorRewards: AuthorRewards = 'author';
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '@tanstack/react-query',
+  );
+  return {
+    ...actual,
+    // The hook body is the thing under test, so it is run directly rather than
+    // through a React render. `mutateAsync` is wired to the real `mutationFn`.
+    useMutation: (options: { mutationFn: (variables: unknown) => unknown }) => ({
+      ...options,
+      mutateAsync: (variables: unknown) => options.mutationFn(variables),
+    }),
+  };
+});
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => () => undefined,
+}));
+
+vi.mock('@ecency/sdk', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@ecency/sdk');
+  return {
+    ...actual,
+    // Only the broadcast edge is replaced. The payload is kept exactly as the
+    // hook built it, and the SDK's real builders stay available above.
+    useComment: () => ({
+      mutateAsync: async (payload: Record<string, unknown>) => {
+        captured.push(payload);
+        return { id: 'tx' };
+      },
+    }),
+  };
+});
+
+vi.mock('@/features/auth/hooks', () => ({
+  useAuth: () => ({ user: { username: 'alice' } }),
+}));
+
+vi.mock('@/features/blog/hooks/use-instance-config', () => ({
+  useInstanceConfig: () => ({ isCommunityMode: false, communityId: undefined }),
+}));
+
+vi.mock('@/features/blog/hooks/use-hive-layer', () => ({
+  useHiveLayer: () => ({ authorRewards }),
+}));
+
+vi.mock('@/providers/sdk', () => ({
+  createBroadcastAdapter: () => ({}),
+}));
+
+type Operation = [string, Record<string, unknown>];
+
+/**
+ * The SDK's own payload-to-operations function, extracted and made callable.
+ *
+ * `useBroadcastMutation(mutationKey, username, operations, ...)` receives it as
+ * its third argument and calls it as `const ops = operations(payload)`, so this
+ * function IS the operation array. Extracting it by position rather than by
+ * text means a rewrite of the SDK surfaces here as a failure to find it, not as
+ * a stale copy that keeps passing.
+ */
+function extractSdkOperationsBuilder(): (
+  payload: Record<string, unknown>,
+) => Operation[] {
+  const source = ts.createSourceFile(
+    SDK_COMMENT,
+    readFileSync(SDK_COMMENT, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  let builder: ts.Expression | undefined;
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText(source) === 'useBroadcastMutation'
+    ) {
+      builder = node.arguments[2];
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  if (!builder) {
+    throw new Error(
+      'could not find the operations builder passed to useBroadcastMutation',
+    );
+  }
+
+  const js = ts.transpileModule(`(${builder.getText(source)})`, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.None,
+    },
+  }).outputText;
+
+  // The two builders are the only free names in that function. Injecting the
+  // SDK's real ones means the arrays below carry real operation objects.
+  return new Function(
+    'buildCommentOp',
+    'buildCommentOptionsOp',
+    `return ${js}`,
+  )(buildCommentOp, buildCommentOptionsOp);
+}
+
+/** Every name `use-comment.ts` destructures out of `payload.options`. */
+function sdkOptionFields(): string[] {
+  const source = ts.createSourceFile(
+    SDK_COMMENT,
+    readFileSync(SDK_COMMENT, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  const fields: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.initializer?.getText(source) === 'payload.options' &&
+      ts.isObjectBindingPattern(node.name)
+    ) {
+      for (const element of node.name.elements) {
+        fields.push(element.name.getText(source));
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return fields;
+}
+
+const buildOperations = extractSdkOperationsBuilder();
+
+/** Run the real hook body for one reward selection and return its payload. */
+async function publish(rewardType: RewardType): Promise<
+  Record<string, unknown>
+> {
+  const { usePublishPost } = await import('./use-publish-post');
+  const mutation = usePublishPost() as unknown as {
+    mutationFn: (variables: unknown) => Promise<unknown>;
+  };
+
+  const before = captured.length;
+  await mutation.mutationFn({
+    title: 'A post',
+    body: 'Some body text',
+    tags: ['photography'],
+    rewardType,
+  });
+  expect(captured.length).toBe(before + 1);
+  return captured[captured.length - 1];
+}
+
+/** The payload as this app sent it before a reward control existed. */
+function withoutOptionsKey(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  const copy = { ...payload };
+  delete copy.options;
+  return copy;
+}
+
+beforeEach(() => {
+  captured.length = 0;
+  authorRewards = 'author';
+});
+
+describe('the operation array an author actually signs', () => {
+  it('extracts a builder that produces a real comment operation', () => {
+    // Without this, every comparison below could be comparing two empty
+    // arrays produced by an extraction that silently stopped working.
+    const ops = buildOperations({
+      author: 'alice',
+      permlink: 'a-post',
+      parentAuthor: '',
+      parentPermlink: 'photography',
+      title: 'A post',
+      body: 'Some body text',
+      jsonMetadata: { tags: ['photography'] },
+    });
+    expect(ops).toHaveLength(1);
+    expect(ops[0][0]).toBe('comment');
+    expect(ops[0][1].author).toBe('alice');
+  });
+
+  it('broadcasts one operation, byte for byte the old one, on the default selection', async () => {
+    const payload = await publish('default');
+
+    // The key exists, and its value is nothing. That is the whole mechanism:
+    // `use-comment.ts` gates the second operation on `if (payload.options)`.
+    expect('options' in payload).toBe(true);
+    expect(payload.options).toBeUndefined();
+
+    const withControl = buildOperations(payload);
+    const asBefore = buildOperations(withoutOptionsKey(payload));
+
+    expect(JSON.stringify(withControl)).toBe(JSON.stringify(asBefore));
+    expect(withControl).toHaveLength(1);
+    expect(withControl.map(([name]) => name)).toEqual(['comment']);
+  });
+
+  it('adds a fully written comment_options for a full power up', async () => {
+    const payload = await publish('sp');
+    const ops = buildOperations(payload);
+
+    expect(ops.map(([name]) => name)).toEqual(['comment', 'comment_options']);
+    expect(ops[1][1]).toEqual({
+      author: 'alice',
+      permlink: ops[0][1].permlink,
+      max_accepted_payout: '1000000.000 HBD',
+      percent_hbd: 0,
+      allow_votes: true,
+      allow_curation_rewards: true,
+      extensions: [],
+    });
+    // The comment operation itself is untouched by the choice.
+    expect(JSON.stringify(ops[0])).toBe(
+      JSON.stringify(buildOperations(withoutOptionsKey(payload))[0]),
+    );
+  });
+
+  it('adds a fully written comment_options for declined rewards', async () => {
+    const payload = await publish('dp');
+    const ops = buildOperations(payload);
+
+    expect(ops.map(([name]) => name)).toEqual(['comment', 'comment_options']);
+    expect(ops[1][1]).toEqual({
+      author: 'alice',
+      permlink: ops[0][1].permlink,
+      max_accepted_payout: '0.000 HBD',
+      percent_hbd: 10000,
+      allow_votes: true,
+      allow_curation_rewards: true,
+      extensions: [],
+    });
+  });
+
+  it('never carries a beneficiary extension', async () => {
+    // Beneficiaries are a separate surface and are not offered here. The
+    // extensions array is where one would appear, so it is asserted empty on
+    // every selection that emits an operation at all.
+    for (const selection of ['default', 'sp', 'dp'] as const) {
+      const ops = buildOperations(await publish(selection));
+      const options = ops.find(([name]) => name === 'comment_options');
+      expect(options?.[1].extensions ?? [], selection).toEqual([]);
+    }
+  });
+
+  it('emits nothing when the instance does not offer the control', async () => {
+    // A draft can hold a selection from before the owner switched the panel
+    // off. It must not reach the chain: the instance decides whether the
+    // author is asked, and an author who was never asked publishes as before.
+    authorRewards = 'off';
+
+    for (const selection of ['sp', 'dp'] as const) {
+      const payload = await publish(selection);
+      expect(payload.options, selection).toBeUndefined();
+      expect(buildOperations(payload), selection).toHaveLength(1);
+    }
+  });
+
+  it('writes every field the SDK would otherwise default for us', async () => {
+    // The reason the resolver spells all five out. These names are read off
+    // the SDK's own destructuring pattern, so adding a sixth defaulted field
+    // there fails here instead of shipping a value nobody chose.
+    const fields = sdkOptionFields();
+    expect(fields.length).toBeGreaterThanOrEqual(5);
+
+    const payload = await publish('sp');
+    expect(Object.keys(payload.options as object).sort()).toEqual(
+      [...fields].sort(),
+    );
+  });
+
+  it('demonstrates the default it is avoiding', async () => {
+    // Same builder, same post, with one field left out: the SDK fills in a
+    // payout cap of its own across the package boundary. Harmless here and
+    // permanent on chain, which is why nothing in this app hands it a partial
+    // options object.
+    const payload = await publish('sp');
+    const partial = { ...payload, options: { percentHbd: 0 } };
+    const ops = buildOperations(partial);
+
+    expect(ops[1][1].max_accepted_payout).toBe('1000000.000 HBD');
+    expect(ops[1][1].allow_votes).toBe(true);
+  });
+
+  it('keeps the rest of the payload exactly as it was', async () => {
+    // `options` is the only key this PR adds. Anything else appearing on the
+    // way to a `comment` operation is a change to what gets signed.
+    const payload = await publish('default');
+    expect(Object.keys(payload).sort()).toEqual([
+      'author',
+      'body',
+      'jsonMetadata',
+      'options',
+      'parentAuthor',
+      'parentPermlink',
+      'permlink',
+      'title',
+    ]);
+  });
+});

--- a/apps/self-hosted/src/features/publish/hooks/use-publish-post.broadcast.test.ts
+++ b/apps/self-hosted/src/features/publish/hooks/use-publish-post.broadcast.test.ts
@@ -4,6 +4,10 @@ import ts from 'typescript';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildCommentOp, buildCommentOptionsOp } from '@ecency/sdk';
 import type { AuthorRewards, RewardType } from '@/core/hive-layer';
+import {
+  emitsUneditableOperation,
+  resolveRewardSelection,
+} from '@/core/hive-layer';
 
 /**
  * What this app actually broadcasts when an author presses publish.
@@ -337,6 +341,24 @@ describe('the operation array an author actually signs', () => {
 
     expect(ops[1][1].max_accepted_payout).toBe('1000000.000 HBD');
     expect(ops[1][1].allow_votes).toBe(true);
+  });
+
+  it('asks for a confirmation exactly when the operation array grows', async () => {
+    // The publish button asks twice only where something uneditable is being
+    // added. Checked against the operation array this same file builds, so the
+    // rule cannot say one thing while the broadcast does another. The `off`
+    // rows are the behaviour an owner who took the control away keeps: one
+    // press, one operation.
+    for (const posture of ['author', 'off'] as const) {
+      for (const selection of ['default', 'sp', 'dp'] as const) {
+        authorRewards = posture;
+        const ops = buildOperations(await publish(selection));
+        const asks = emitsUneditableOperation(
+          resolveRewardSelection(posture, selection),
+        );
+        expect(asks, `${posture}/${selection}`).toBe(ops.length > 1);
+      }
+    }
   });
 
   it('keeps the rest of the payload exactly as it was', async () => {

--- a/apps/self-hosted/src/features/publish/hooks/use-publish-post.ts
+++ b/apps/self-hosted/src/features/publish/hooks/use-publish-post.ts
@@ -1,7 +1,13 @@
 import { useComment } from '@ecency/sdk';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
+// Imported from the module rather than the `@/core` barrel: the barrel pulls
+// in `configuration-loader`, which imports the build-time `config.json` that
+// only exists after an image build, so a test of this hook could not load it.
+import type { RewardType } from '@/core/hive-layer';
+import { resolveCommentOptions } from '@/core/hive-layer';
 import { useAuth } from '@/features/auth/hooks';
+import { useHiveLayer } from '@/features/blog/hooks/use-hive-layer';
 import { useInstanceConfig } from '@/features/blog/hooks/use-instance-config';
 import { createBroadcastAdapter } from '@/providers/sdk';
 import { createPermlink } from '../utils/permlink';
@@ -15,6 +21,7 @@ export function usePublishPost({
   const { user } = useAuth();
   const navigate = useNavigate();
   const { isCommunityMode, communityId } = useInstanceConfig();
+  const { authorRewards } = useHiveLayer();
 
   const adapter = createBroadcastAdapter();
   const commentMutation = useComment(user?.username, { adapter });
@@ -25,10 +32,12 @@ export function usePublishPost({
       title,
       body,
       tags,
+      rewardType,
     }: {
       title: string;
       body: string;
       tags: string[];
+      rewardType: RewardType;
     }) => {
       if (!user) {
         throw new Error('Authentication required to publish post');
@@ -57,6 +66,14 @@ export function usePublishPost({
         communityId,
       });
 
+      // The instance is not allowed to choose a reward split, only whether the
+      // author is asked at all. With the control switched off there is nothing
+      // to honour, and a selection left in a stale draft must not survive the
+      // owner turning the panel off, so it collapses back to the untouched
+      // selection here rather than at the render site.
+      const rewardSelection =
+        authorRewards === 'author' ? rewardType : 'default';
+
       await commentMutation.mutateAsync({
         author: user.username,
         permlink,
@@ -69,6 +86,11 @@ export function usePublishPost({
           app: 'ecency-selfhost/1.0',
           format: 'markdown',
         },
+        // The only door to a `comment_options` operation in this app, and it
+        // returns undefined for every author who did not choose otherwise,
+        // which the SDK's `if (payload.options)` gate turns into an operation
+        // array byte-identical to the one published before this existed.
+        options: resolveCommentOptions(rewardSelection),
       });
 
       // Return where the new post lives so onSuccess can land the author ON it.

--- a/apps/self-hosted/src/features/publish/hooks/use-publish-post.ts
+++ b/apps/self-hosted/src/features/publish/hooks/use-publish-post.ts
@@ -4,13 +4,16 @@ import { useNavigate } from '@tanstack/react-router';
 // Imported from the module rather than the `@/core` barrel: the barrel pulls
 // in `configuration-loader`, which imports the build-time `config.json` that
 // only exists after an image build, so a test of this hook could not load it.
-import type { RewardType } from '@/core/hive-layer';
-import { resolveCommentOptions } from '@/core/hive-layer';
+import {
+  resolveCommentOptions,
+  resolveRewardSelection,
+} from '@/core/hive-layer';
 import { useAuth } from '@/features/auth/hooks';
 import { useHiveLayer } from '@/features/blog/hooks/use-hive-layer';
 import { useInstanceConfig } from '@/features/blog/hooks/use-instance-config';
 import { createBroadcastAdapter } from '@/providers/sdk';
 import { createPermlink } from '../utils/permlink';
+import type { PublishVariables } from '../utils/publish-variables';
 import { resolvePublishTarget } from '../utils/publish-target';
 
 export function usePublishPost({
@@ -28,17 +31,7 @@ export function usePublishPost({
 
   return useMutation({
     mutationKey: ['publish-post'],
-    mutationFn: async ({
-      title,
-      body,
-      tags,
-      rewardType,
-    }: {
-      title: string;
-      body: string;
-      tags: string[];
-      rewardType: RewardType;
-    }) => {
+    mutationFn: async ({ title, body, tags, rewardType }: PublishVariables) => {
       if (!user) {
         throw new Error('Authentication required to publish post');
       }
@@ -69,10 +62,10 @@ export function usePublishPost({
       // The instance is not allowed to choose a reward split, only whether the
       // author is asked at all. With the control switched off there is nothing
       // to honour, and a selection left in a stale draft must not survive the
-      // owner turning the panel off, so it collapses back to the untouched
-      // selection here rather than at the render site.
-      const rewardSelection =
-        authorRewards === 'author' ? rewardType : 'default';
+      // owner turning the panel off. Applied here, at the broadcast site, and
+      // through the same function the composer uses to decide what it is
+      // asking the author to confirm.
+      const rewardSelection = resolveRewardSelection(authorRewards, rewardType);
 
       await commentMutation.mutateAsync({
         author: user.username,

--- a/apps/self-hosted/src/features/publish/hooks/use-publish-state.ts
+++ b/apps/self-hosted/src/features/publish/hooks/use-publish-state.ts
@@ -1,10 +1,15 @@
 import { useCallback } from "react";
+// From the module, not the `@/core` barrel: the barrel imports the build-time
+// `config.json`, which does not exist when tests run.
+import type { RewardType } from "@/core/hive-layer";
+import { resolveRewardType } from "@/core/hive-layer";
 import { useSynchronizedLocalStorage } from "@/utils/use-synchronized-local-storage";
 
 const STORAGE_KEY_PREFIX = "publish-draft";
 const KEY_TITLE = `${STORAGE_KEY_PREFIX}-title`;
 const KEY_BODY = `${STORAGE_KEY_PREFIX}-body`;
 const KEY_TAGS = `${STORAGE_KEY_PREFIX}-tags`;
+const KEY_REWARD_TYPE = `${STORAGE_KEY_PREFIX}-reward-type`;
 
 const MAX_TITLE_LENGTH = 255;
 const MAX_TAG_LENGTH = 24;
@@ -12,6 +17,12 @@ const MAX_TAG_LENGTH = 24;
 const defaultTitle = "";
 const defaultBody = "";
 const defaultTags: string[] = [];
+/**
+ * Nothing extra is broadcast unless the author says so, on every draft, every
+ * time. A draft that has never been touched publishes exactly as this app
+ * publishes today.
+ */
+const defaultRewardType: RewardType = "default";
 
 export function usePublishState() {
   const [title, setTitle] = useSynchronizedLocalStorage<string>(
@@ -25,6 +36,10 @@ export function usePublishState() {
   const [tags, setTags] = useSynchronizedLocalStorage<string[]>(
     KEY_TAGS,
     defaultTags,
+  );
+  const [storedRewardType, setRewardType] = useSynchronizedLocalStorage<string>(
+    KEY_REWARD_TYPE,
+    defaultRewardType,
   );
 
   const setTitleState = useCallback(
@@ -51,19 +66,34 @@ export function usePublishState() {
     [setTags]
   );
 
+  const setRewardTypeState = useCallback(
+    (value: RewardType) => {
+      setRewardType(resolveRewardType(value));
+    },
+    [setRewardType]
+  );
+
   const clearAll = useCallback(() => {
     setTitle(defaultTitle);
     setContent(defaultBody);
     setTags(defaultTags);
-  }, [setTitle, setContent, setTags]);
+    // A reward choice belongs to the post it was made for. Carrying it into
+    // the next post would decline rewards, or power them up, on something the
+    // author never chose it for.
+    setRewardType(defaultRewardType);
+  }, [setTitle, setContent, setTags, setRewardType]);
 
   return {
     title,
     content,
     tags,
+    // Normalised on the way out, not only on the way in: this value is read
+    // back from localStorage, which is editable and outlives any one release.
+    rewardType: resolveRewardType(storedRewardType),
     setTitleState,
     setContentState,
     setTagsState,
+    setRewardTypeState,
     clearAll,
   };
 }

--- a/apps/self-hosted/src/features/publish/index.ts
+++ b/apps/self-hosted/src/features/publish/index.ts
@@ -16,4 +16,9 @@ export { useUpdatePost } from "./hooks/use-update-post";
 // Utils
 export { createPermlink } from "./utils/permlink";
 export { nextPublishPress } from "./utils/publish-press";
+export {
+  isConfirmationHeld,
+  publishConfirmationKey,
+} from "./utils/publish-variables";
+export type { PublishVariables } from "./utils/publish-variables";
 export { htmlToMarkdown, markdownToHtml } from "./utils/markdown";

--- a/apps/self-hosted/src/features/publish/index.ts
+++ b/apps/self-hosted/src/features/publish/index.ts
@@ -3,6 +3,7 @@ export { PublishEditor } from "./components/publish-editor";
 export { PublishEditorToolbar } from "./components/publish-editor-toolbar";
 export { PublishEditorTableToolbar } from "./components/publish-editor-table-toolbar";
 export { PublishActionBar } from "./components/publish-action-bar";
+export { PublishRewardSelector } from "./components/publish-reward-selector";
 export { PublishTagsSelector } from "./components/publish-tags-selector";
 export { EditPostEditor } from "./components/edit-post-editor";
 
@@ -14,4 +15,5 @@ export { useUpdatePost } from "./hooks/use-update-post";
 
 // Utils
 export { createPermlink } from "./utils/permlink";
+export { nextPublishPress } from "./utils/publish-press";
 export { htmlToMarkdown, markdownToHtml } from "./utils/markdown";

--- a/apps/self-hosted/src/features/publish/utils/publish-press.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/publish-press.test.ts
@@ -28,6 +28,7 @@ class PublishButton {
   inFlight = false;
   isPublishing = false;
   canPublish = true;
+  needsConfirmation = true;
   /** How many times a broadcast was actually started. */
   broadcasts = 0;
   readonly log: PublishPress[] = [];
@@ -45,6 +46,7 @@ class PublishButton {
       canPublish: this.canPublish,
       isPublishing: this.isPublishing,
       inFlight: this.inFlight,
+      needsConfirmation: this.needsConfirmation,
       armed: this.armed,
     };
   }
@@ -142,23 +144,95 @@ describe('one publish button, two presses, one broadcast', () => {
     expect(button.armed).toBe(false);
   });
 
-  it('publishes on exactly one of the sixteen states', () => {
+  it('publishes on exactly three of the thirty-two states', () => {
     // The whole truth table, so a later change that widens the publishing
     // condition shows up as a diff here rather than as a duplicate post.
     const publishing: PublishPressState[] = [];
     for (const canPublish of [false, true]) {
       for (const isPublishing of [false, true]) {
         for (const inFlight of [false, true]) {
-          for (const armed of [false, true]) {
-            const state = { canPublish, isPublishing, inFlight, armed };
-            if (nextPublishPress(state) === 'publish') publishing.push(state);
+          for (const needsConfirmation of [false, true]) {
+            for (const armed of [false, true]) {
+              const state = {
+                canPublish,
+                isPublishing,
+                inFlight,
+                needsConfirmation,
+                armed,
+              };
+              if (nextPublishPress(state) === 'publish') publishing.push(state);
+            }
           }
         }
       }
     }
 
     expect(publishing).toEqual([
-      { canPublish: true, isPublishing: false, inFlight: false, armed: true },
+      {
+        canPublish: true,
+        isPublishing: false,
+        inFlight: false,
+        needsConfirmation: false,
+        armed: false,
+      },
+      {
+        canPublish: true,
+        isPublishing: false,
+        inFlight: false,
+        needsConfirmation: false,
+        armed: true,
+      },
+      {
+        canPublish: true,
+        isPublishing: false,
+        inFlight: false,
+        needsConfirmation: true,
+        armed: true,
+      },
     ]);
+  });
+});
+
+describe('nothing irreversible means nothing to confirm', () => {
+  /**
+   * The finding this exists for: an instance that took the reward control off,
+   * or one clamped off because "Create post" points elsewhere, was made to
+   * press twice for a publish that adds nothing to the operation array. The
+   * second press protected nothing and was a behaviour change imposed on
+   * owners who opted out.
+   */
+  it('publishes on the first press when nothing extra is emitted', () => {
+    const button = new PublishButton();
+    button.needsConfirmation = false;
+    expect(button.press()).toBe('publish');
+    expect(button.broadcasts).toBe(1);
+  });
+
+  it('still cannot double fire without the confirm step', () => {
+    // The confirm step is not what stops a double click, and this is the path
+    // where it is absent, so the synchronous latch has to carry it alone.
+    const button = new PublishButton();
+    button.needsConfirmation = false;
+    for (let i = 0; i < 20; i += 1) button.press();
+    expect(button.broadcasts).toBe(1);
+  });
+
+  it('does nothing on an incomplete draft either', () => {
+    const button = new PublishButton();
+    button.needsConfirmation = false;
+    button.canPublish = false;
+    expect(button.press()).toBe('ignore');
+    expect(button.broadcasts).toBe(0);
+  });
+
+  it('asks again as soon as something irreversible is added', () => {
+    // Turning the reward selection to one that emits an operation puts the
+    // confirm step back, on the same button, with no reload.
+    const button = new PublishButton();
+    button.needsConfirmation = false;
+    button.needsConfirmation = true;
+    expect(button.press()).toBe('arm');
+    expect(button.broadcasts).toBe(0);
+    expect(button.press()).toBe('publish');
   });
 });

--- a/apps/self-hosted/src/features/publish/utils/publish-press.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/publish-press.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import {
+  nextPublishPress,
+  type PublishPress,
+  type PublishPressState,
+} from './publish-press';
+
+/**
+ * The publish button asks twice, and must broadcast once.
+ *
+ * A confirm state on the same button is a second press, which is also the
+ * shape of an accidental double click. Broadcasts retry on their own and a
+ * duplicated publish is a second post on chain that nobody can delete, so
+ * "cannot double fire" is driven here as a sequence of presses rather than
+ * asserted about the component, which this app cannot render in a test.
+ */
+
+/**
+ * The button as the component wires it.
+ *
+ * `armed` is React state and `inFlight` is a ref the handler sets before it
+ * awaits. `isPublishing` is the mutation's own flag, which only turns true on
+ * the next render, so it is updated here only when `render()` is called. That
+ * lag is the reason `inFlight` exists at all.
+ */
+class PublishButton {
+  armed = false;
+  inFlight = false;
+  isPublishing = false;
+  canPublish = true;
+  /** How many times a broadcast was actually started. */
+  broadcasts = 0;
+  readonly log: PublishPress[] = [];
+
+  /**
+   * @param flushState whether React has committed `armed` before the next
+   *   press is handled. Two clicks inside one frame have not, which is the
+   *   friendlier case; a click, a paint and a second click have, which is the
+   *   case that could actually double fire.
+   */
+  constructor(private readonly flushState = true) {}
+
+  private state(): PublishPressState {
+    return {
+      canPublish: this.canPublish,
+      isPublishing: this.isPublishing,
+      inFlight: this.inFlight,
+      armed: this.armed,
+    };
+  }
+
+  press(): PublishPress {
+    const action = nextPublishPress(this.state());
+    this.log.push(action);
+
+    if (action === 'arm' && this.flushState) {
+      this.armed = true;
+    }
+
+    if (action === 'publish') {
+      // Exactly the order the handler uses: the synchronous latch first, then
+      // the state, then the await.
+      this.inFlight = true;
+      this.armed = false;
+      this.broadcasts += 1;
+    }
+
+    return action;
+  }
+
+  /** A render happens: the mutation's pending flag catches up. */
+  render(): void {
+    this.isPublishing = this.inFlight;
+  }
+
+  /** The broadcast settles, successfully or not. */
+  settle(): void {
+    this.inFlight = false;
+    this.isPublishing = false;
+  }
+}
+
+describe('one publish button, two presses, one broadcast', () => {
+  it('arms on the first press and broadcasts on the second', () => {
+    const button = new PublishButton();
+    expect(button.press()).toBe('arm');
+    expect(button.broadcasts).toBe(0);
+    expect(button.press()).toBe('publish');
+    expect(button.broadcasts).toBe(1);
+  });
+
+  it('broadcasts once however fast the button is pressed', () => {
+    const button = new PublishButton();
+    for (let i = 0; i < 20; i += 1) button.press();
+    expect(button.broadcasts).toBe(1);
+    expect(button.log.filter((action) => action === 'publish')).toHaveLength(1);
+  });
+
+  it('broadcasts nothing on a double click inside one frame', () => {
+    // Neither press sees the other's state, so both only ask.
+    const button = new PublishButton(false);
+    button.press();
+    button.press();
+    expect(button.broadcasts).toBe(0);
+  });
+
+  it('ignores every press while the broadcast is in the air', () => {
+    const button = new PublishButton();
+    button.press();
+    button.press();
+    expect(button.broadcasts).toBe(1);
+
+    // Before the mutation's own flag has caught up: this is the window the
+    // latch exists for, and the button is not even disabled yet.
+    expect(button.isPublishing).toBe(false);
+    for (let i = 0; i < 5; i += 1) expect(button.press()).toBe('ignore');
+
+    button.render();
+    for (let i = 0; i < 5; i += 1) expect(button.press()).toBe('ignore');
+    expect(button.broadcasts).toBe(1);
+  });
+
+  it('costs two presses again after a failed publish', () => {
+    const button = new PublishButton();
+    button.press();
+    button.press();
+    button.settle();
+
+    // No silent second attempt: the author has to ask, and confirm, again.
+    expect(button.press()).toBe('arm');
+    expect(button.broadcasts).toBe(1);
+    expect(button.press()).toBe('publish');
+    expect(button.broadcasts).toBe(2);
+  });
+
+  it('does nothing at all on an incomplete draft', () => {
+    const button = new PublishButton();
+    button.canPublish = false;
+    for (let i = 0; i < 5; i += 1) expect(button.press()).toBe('ignore');
+    // Not even armed, so completing the draft does not leave a button one
+    // press away from broadcasting.
+    expect(button.armed).toBe(false);
+  });
+
+  it('publishes on exactly one of the sixteen states', () => {
+    // The whole truth table, so a later change that widens the publishing
+    // condition shows up as a diff here rather than as a duplicate post.
+    const publishing: PublishPressState[] = [];
+    for (const canPublish of [false, true]) {
+      for (const isPublishing of [false, true]) {
+        for (const inFlight of [false, true]) {
+          for (const armed of [false, true]) {
+            const state = { canPublish, isPublishing, inFlight, armed };
+            if (nextPublishPress(state) === 'publish') publishing.push(state);
+          }
+        }
+      }
+    }
+
+    expect(publishing).toEqual([
+      { canPublish: true, isPublishing: false, inFlight: false, armed: true },
+    ]);
+  });
+});

--- a/apps/self-hosted/src/features/publish/utils/publish-press.ts
+++ b/apps/self-hosted/src/features/publish/utils/publish-press.ts
@@ -1,22 +1,34 @@
 /**
  * What one press of the publish button does.
  *
- * Publishing is the only irreversible action in this app, so the button asks
- * twice: the first press arms it, the second one broadcasts. That is a second
- * chance to read the reward split, which cannot be edited once it is on chain.
+ * The button asks twice when, and only when, the publish would put something on
+ * chain that no later edit can reach: a `comment_options` operation carrying
+ * the author's reward choice. A post itself can be edited afterwards, so where
+ * no such operation is emitted there is nothing a confirmation would protect
+ * and the button publishes on the first press, exactly as it did before any of
+ * this existed. `needsConfirmation` carries that decision in, computed from the
+ * function that builds the operation rather than from the config posture, so
+ * the question and the broadcast cannot drift apart.
  *
- * It is also the edit most able to do harm, because a second press is exactly
- * the shape of an accidental double click. Broadcasts already retry, and a
- * duplicated publish is a duplicate post on chain that nobody can take back,
- * so the decision to broadcast is made here, from a state a test can drive,
- * rather than inside a component nothing in this app can render.
+ * A second press is also the shape of an accidental double click. Broadcasts
+ * already retry, and a duplicated publish is a duplicate post on chain that
+ * nobody can take back, so the decision to broadcast is made here, from a state
+ * a test can drive, rather than inside a component nothing in this app can
+ * render.
  *
  * `inFlight` is the part that matters and the part a React state flag cannot
  * do: a `isPending` from the mutation only becomes true after a re-render, so
  * two presses in the same frame can both read it as false. The component holds
  * `inFlight` in a ref it sets before awaiting, which is synchronous, and this
- * function refuses on it. `canPublish` and `isPublishing` are passed through
- * unchanged from what the button already disabled itself on.
+ * function refuses on it. It is the only thing standing between a double click
+ * and two posts when `needsConfirmation` is false, which is most publishes.
+ * `canPublish` and `isPublishing` are passed through unchanged from what the
+ * button already disabled itself on.
+ *
+ * `armed` is not a flag the component toggles. It is granted to one exact set
+ * of publish variables and recomputed on every render, so editing the title,
+ * the body, the tags or the reward choice withdraws it with no window in which
+ * a confirmation granted for one payload could publish another.
  */
 
 /** One press: do nothing, ask for confirmation, or broadcast. */
@@ -29,7 +41,9 @@ export interface PublishPressState {
   isPublishing: boolean;
   /** A broadcast has been started and has not settled. Set synchronously. */
   inFlight: boolean;
-  /** A previous press armed the button and nothing has disarmed it since. */
+  /** This publish would emit an operation that cannot be edited afterwards. */
+  needsConfirmation: boolean;
+  /** The confirmation currently held is for exactly these variables. */
   armed: boolean;
 }
 
@@ -39,6 +53,13 @@ export function nextPublishPress(state: PublishPressState): PublishPress {
   // saying "press again" while a broadcast is in the air.
   if (!state.canPublish || state.isPublishing || state.inFlight) {
     return 'ignore';
+  }
+
+  // Nothing irreversible is being added, so nothing is asked. An owner who
+  // turned the reward control off, or who points "Create post" elsewhere, gets
+  // the single press they had before.
+  if (!state.needsConfirmation) {
+    return 'publish';
   }
 
   return state.armed ? 'publish' : 'arm';

--- a/apps/self-hosted/src/features/publish/utils/publish-press.ts
+++ b/apps/self-hosted/src/features/publish/utils/publish-press.ts
@@ -1,0 +1,45 @@
+/**
+ * What one press of the publish button does.
+ *
+ * Publishing is the only irreversible action in this app, so the button asks
+ * twice: the first press arms it, the second one broadcasts. That is a second
+ * chance to read the reward split, which cannot be edited once it is on chain.
+ *
+ * It is also the edit most able to do harm, because a second press is exactly
+ * the shape of an accidental double click. Broadcasts already retry, and a
+ * duplicated publish is a duplicate post on chain that nobody can take back,
+ * so the decision to broadcast is made here, from a state a test can drive,
+ * rather than inside a component nothing in this app can render.
+ *
+ * `inFlight` is the part that matters and the part a React state flag cannot
+ * do: a `isPending` from the mutation only becomes true after a re-render, so
+ * two presses in the same frame can both read it as false. The component holds
+ * `inFlight` in a ref it sets before awaiting, which is synchronous, and this
+ * function refuses on it. `canPublish` and `isPublishing` are passed through
+ * unchanged from what the button already disabled itself on.
+ */
+
+/** One press: do nothing, ask for confirmation, or broadcast. */
+export type PublishPress = 'ignore' | 'arm' | 'publish';
+
+export interface PublishPressState {
+  /** The draft has a title, a body and at least one tag. */
+  canPublish: boolean;
+  /** The mutation reports itself pending. Lags a press by one render. */
+  isPublishing: boolean;
+  /** A broadcast has been started and has not settled. Set synchronously. */
+  inFlight: boolean;
+  /** A previous press armed the button and nothing has disarmed it since. */
+  armed: boolean;
+}
+
+export function nextPublishPress(state: PublishPressState): PublishPress {
+  // Nothing to publish, or something is already going out. Both mean the press
+  // does nothing at all: not even re-arming, which would leave the button
+  // saying "press again" while a broadcast is in the air.
+  if (!state.canPublish || state.isPublishing || state.inFlight) {
+    return 'ignore';
+  }
+
+  return state.armed ? 'publish' : 'arm';
+}

--- a/apps/self-hosted/src/features/publish/utils/publish-variables.test.ts
+++ b/apps/self-hosted/src/features/publish/utils/publish-variables.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isConfirmationHeld,
+  publishConfirmationKey,
+  type PublishVariables,
+} from './publish-variables';
+
+/**
+ * A confirmation is granted to a payload, not to a button.
+ *
+ * The finding this exists for: the arm was withdrawn only when the reward
+ * selection changed, so an author could confirm, then edit the title, the body
+ * or the tags, and publish the revised post with one further press. What went
+ * out was not what was agreed to, which is the whole point of asking.
+ *
+ * The fix has to survive a field being added to the payload, so the key is
+ * derived from the object rather than from a list of field names, and the
+ * tests below prove that by changing a field this module has never heard of.
+ */
+
+const DRAFT: PublishVariables = {
+  title: 'A post',
+  body: 'Some body text',
+  tags: ['photography', 'hive'],
+  rewardType: 'dp',
+};
+
+/** Same draft, so the same key, regardless of how it was assembled. */
+describe('the identity of a publish payload', () => {
+  it('is the same for the same draft', () => {
+    expect(publishConfirmationKey({ ...DRAFT })).toBe(
+      publishConfirmationKey(DRAFT),
+    );
+  });
+
+  it('does not depend on the order the fields were written in', () => {
+    const reordered = {
+      rewardType: DRAFT.rewardType,
+      tags: DRAFT.tags,
+      body: DRAFT.body,
+      title: DRAFT.title,
+    } as PublishVariables;
+    expect(publishConfirmationKey(reordered)).toBe(
+      publishConfirmationKey(DRAFT),
+    );
+  });
+
+  it.each([
+    ['title', { title: 'A post ' }],
+    ['body', { body: 'Some body text.' }],
+    ['a tag', { tags: ['photography', 'hive', 'art'] }],
+    ['tag order', { tags: ['hive', 'photography'] }],
+    ['tag spelling', { tags: ['photograph', 'hive'] }],
+    ['the reward selection', { rewardType: 'default' as const }],
+  ])('changes when %s changes', (_label, change) => {
+    expect(publishConfirmationKey({ ...DRAFT, ...change })).not.toBe(
+      publishConfirmationKey(DRAFT),
+    );
+  });
+
+  it('covers a field this module has never heard of', () => {
+    // The property that matters for the next person: the key is derived from
+    // whatever the payload carries, so a thumbnail, a scheduled time or a poll
+    // added to PublishVariables is covered without editing this file.
+    const withNewField = { ...DRAFT, thumbnail: 'a.jpg' } as PublishVariables;
+    const changed = { ...DRAFT, thumbnail: 'b.jpg' } as PublishVariables;
+
+    expect(publishConfirmationKey(withNewField)).not.toBe(
+      publishConfirmationKey(DRAFT),
+    );
+    expect(publishConfirmationKey(changed)).not.toBe(
+      publishConfirmationKey(withNewField),
+    );
+  });
+
+  it('sees inside a nested field', () => {
+    // A future field is as likely to be an object as a string, and a key that
+    // stopped at the top level would call two different drafts the same.
+    const one = {
+      ...DRAFT,
+      metadata: { poll: { question: 'a' } },
+    } as PublishVariables;
+    const two = {
+      ...DRAFT,
+      metadata: { poll: { question: 'b' } },
+    } as PublishVariables;
+
+    expect(publishConfirmationKey(one)).not.toBe(publishConfirmationKey(two));
+  });
+
+  it('ignores the key order of a nested field', () => {
+    const one = { ...DRAFT, metadata: { a: 1, b: 2 } } as PublishVariables;
+    const two = { ...DRAFT, metadata: { b: 2, a: 1 } } as PublishVariables;
+    expect(publishConfirmationKey(one)).toBe(publishConfirmationKey(two));
+  });
+});
+
+describe('a confirmation is held for one payload only', () => {
+  it('is not held before anything was confirmed', () => {
+    expect(isConfirmationHeld(null, DRAFT)).toBe(false);
+  });
+
+  it('is held for the draft it was granted for', () => {
+    const armedFor = publishConfirmationKey(DRAFT);
+    expect(isConfirmationHeld(armedFor, DRAFT)).toBe(true);
+    // Including a copy of it: identity is the payload, not the object.
+    expect(isConfirmationHeld(armedFor, { ...DRAFT })).toBe(true);
+  });
+
+  it.each([
+    ['the title is edited', { title: 'A different post' }],
+    ['the body is edited', { body: 'Rewritten' }],
+    ['a tag is added', { tags: ['photography', 'hive', 'art'] }],
+    ['a tag is removed', { tags: ['photography'] }],
+    ['the tags are reordered', { tags: ['hive', 'photography'] }],
+    ['the reward choice changes', { rewardType: 'sp' as const }],
+  ])('is withdrawn when %s', (_label, change) => {
+    const armedFor = publishConfirmationKey(DRAFT);
+    expect(isConfirmationHeld(armedFor, { ...DRAFT, ...change })).toBe(false);
+  });
+
+  it('comes back if the draft is edited back', () => {
+    // Not a rule anyone needs, but it says what the check actually is: the
+    // payload, and nothing about the sequence of edits that produced it.
+    const armedFor = publishConfirmationKey(DRAFT);
+    const edited = { ...DRAFT, title: 'Changed' };
+    expect(isConfirmationHeld(armedFor, edited)).toBe(false);
+    expect(isConfirmationHeld(armedFor, { ...edited, title: DRAFT.title })).toBe(
+      true,
+    );
+  });
+
+  it('is withdrawn when a field this module cannot name changes', () => {
+    const armedFor = publishConfirmationKey({
+      ...DRAFT,
+      thumbnail: 'a.jpg',
+    } as PublishVariables);
+    expect(
+      isConfirmationHeld(armedFor, {
+        ...DRAFT,
+        thumbnail: 'b.jpg',
+      } as PublishVariables),
+    ).toBe(false);
+  });
+});

--- a/apps/self-hosted/src/features/publish/utils/publish-variables.ts
+++ b/apps/self-hosted/src/features/publish/utils/publish-variables.ts
@@ -1,0 +1,76 @@
+import type { RewardType } from '@/core/hive-layer';
+
+/**
+ * Everything that decides what a publish broadcasts.
+ *
+ * The permlink is derived from the title, the metadata from the tags and the
+ * instance's own type, and the reward operation from the selection, so this is
+ * the whole input to the payload rather than a summary of it. The publish hook
+ * takes exactly this type, so a field added to the payload is added here.
+ */
+export interface PublishVariables {
+  title: string;
+  body: string;
+  tags: string[];
+  rewardType: RewardType;
+}
+
+/**
+ * A stable identity for one set of publish variables.
+ *
+ * The publish button asks the author to confirm, and the thing they confirmed
+ * has to be the thing that goes out. So the confirmation is granted to this
+ * key rather than to the button, and any edit to the draft produces a
+ * different key and withdraws it.
+ *
+ * Derived rather than enumerated. It walks whatever keys the object actually
+ * has, at every depth, so a field added to `PublishVariables` is covered
+ * without anybody remembering to add it here. Nothing in this function names a
+ * field, which is the point: the previous version watched the reward selection
+ * only, so an author could confirm one post and publish a different one by
+ * editing the title in between.
+ *
+ * Sorted at every level because key order is not part of what gets broadcast,
+ * and two orderings of the same draft must not read as two different drafts.
+ *
+ * The one thing it cannot see is a value JSON does not represent, a File or a
+ * class instance for example. A field like that is a real gap, so the tests
+ * below pin the derivation on a nested object and an unknown field, and a new
+ * field of that kind needs its own identity here.
+ */
+export function publishConfirmationKey(variables: PublishVariables): string {
+  return JSON.stringify(stableShape(variables));
+}
+
+/**
+ * Whether a confirmation is currently held for exactly these variables.
+ *
+ * The rule the publish button arms on, kept here rather than in the component
+ * so it can be driven by a test: nothing in this app renders a `.tsx`. A
+ * confirmation is not a flag that stays true until something remembers to
+ * clear it. It is held for one payload and evaporates the moment the payload
+ * differs, which is the only version of "confirm" that cannot approve one post
+ * and publish another.
+ */
+export function isConfirmationHeld(
+  armedFor: string | null,
+  variables: PublishVariables,
+): boolean {
+  return armedFor !== null && armedFor === publishConfirmationKey(variables);
+}
+
+function stableShape(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    // Order matters in a tag list, so it is preserved.
+    return value.map(stableShape);
+  }
+  if (value !== null && typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(source)
+        .sort()
+        .map((key) => [key, stableShape(source[key])]),
+    );
+  }
+  return value;
+}

--- a/apps/self-hosted/src/features/shared/hive-disclosure-guard.test.ts
+++ b/apps/self-hosted/src/features/shared/hive-disclosure-guard.test.ts
@@ -300,3 +300,93 @@ describe('the guard catches the ways around it', () => {
     expect(gated).toEqual([]);
   });
 });
+
+/**
+ * The composer's reward panel makes the same kind of promise as the floor
+ * above, one step further in: it is shown only where the instance asked for
+ * it, but once shown it always states the split about to be broadcast and that
+ * the split cannot be changed afterwards. A `comment_options` operation is
+ * written once and no edit reaches it, so those two lines are not allowed to
+ * become conditional on the selection, on the posture, or on anything else.
+ *
+ * Checked here rather than in the panel's own test because there is no such
+ * thing: `include: ['src/**\/*.test.ts']` means no `.tsx` in this app is
+ * rendered by any test, so the syntax tree is the strongest statement
+ * available.
+ */
+const REWARD_PANEL = 'features/publish/components/publish-reward-selector.tsx';
+const REWARD_PANEL_HOST =
+  'features/publish/components/publish-action-bar.tsx';
+
+/** Every `t('key')` call in the file, with the key it was given. */
+function translationCalls(
+  sf: ts.SourceFile,
+): { key: string; node: ts.Node }[] {
+  const found: { key: string; node: ts.Node }[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText(sf) === 't' &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      found.push({ key: node.arguments[0].text, node });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+}
+
+describe('the composer states what it is about to broadcast', () => {
+  const panel = parse(REWARD_PANEL);
+
+  it.each(['reward_split_broadcast', 'reward_split_permanent'])(
+    'prints %s unconditionally',
+    (key) => {
+      const calls = translationCalls(panel).filter(
+        (call) => call.key === key,
+      );
+      expect(calls, `${key} is never printed`).toHaveLength(1);
+      // Any condition at all, not only a Hive-layer one: an author who leaves
+      // the selection alone still gets told what their post pays.
+      expect(enclosingConditions(calls[0].node, panel)).toEqual([]);
+    },
+  );
+
+  it('prints the split for the selection actually held', () => {
+    // A hardcoded split would read as a statement of fact while the select
+    // said something else. The printed label has to be looked up from the
+    // current value, and that lookup must not sit under a condition either.
+    const lookups: ts.Node[] = [];
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isElementAccessExpression(node) &&
+        node.expression.getText(panel) === 'OPTION_LABELS' &&
+        node.argumentExpression.getText(panel) === 'value'
+      ) {
+        lookups.push(node);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(panel);
+
+    expect(lookups.length).toBeGreaterThan(0);
+    for (const lookup of lookups) {
+      expect(enclosingConditions(lookup, panel)).toEqual([]);
+    }
+  });
+
+  it('is shown exactly where the instance asked for it', () => {
+    // The panel itself is conditional, and this is the one condition it may
+    // carry: the resolved posture, which the resolver has already clamped to
+    // off for an external composer.
+    const host = parse(REWARD_PANEL_HOST);
+    const [element] = jsxElements(host, 'PublishRewardSelector');
+    expect(element, 'the reward panel is not rendered at all').toBeDefined();
+
+    const conditions = enclosingConditions(element, host);
+    expect(conditions).toHaveLength(1);
+    expect(conditions[0]).toContain('authorRewards');
+  });
+});


### PR DESCRIPTION
Step 13 of the Hive-native layer: the composer reward control, and the only
part of the track that changes what gets broadcast.

## What an author sees

Where `features.hive.authorRewards` resolves to `author`, the publish bar gains
a small panel above the disclosure line: a select with three choices, and two
lines that are printed for every choice including the untouched one, saying
what the post will be published with and that reward settings cannot be changed
afterwards. The publish button then asks twice. The first press changes its
label to "Press again to publish", the second one broadcasts. No dialog, same
button, and `canPublish` / `isPublishing` are unchanged.

Where it resolves to `off`, which is every config that has not been written
since the seed landed, nothing new renders and nothing new is broadcast.

## When the button asks twice, and what withdraws the confirmation

Two review findings, both fixed after the first push.

**It asks only when there is something to confirm.** The second press exists
because a `comment_options` operation cannot be edited or removed once it is on
chain. A post itself can be edited, so where no such operation is emitted the
confirmation protects nothing, and an instance that took the reward control off,
or that points Create post elsewhere, kept its single press. The rule is read off
the function that builds the operation rather than off the config posture:

```ts
const needsConfirmation = emitsUneditableOperation(
  resolveRewardSelection(authorRewards, variables.rewardType),
);
```

`emitsUneditableOperation` is `resolveCommentOptions(selection) !== undefined`,
and `resolveRewardSelection` is the one clamp the publish hook applies at the
broadcast site, so the composer and the hook cannot disagree about which
selection an instance honours. The broadcast test asserts, for both postures and
all three selections, that the ask agrees with whether the operation array
actually grew.

**The confirmation is held for a payload, not for a button.** It was withdrawn
only when the reward selection changed, so an author could confirm, then edit the
title, the body or the tags, and publish the revised post with one further press.
It is now granted to a payload identity: `publishConfirmationKey` walks whatever
keys the publish variables carry, at every depth, with no field named anywhere in
it, so a thumbnail or a poll added later is covered without anyone remembering to
extend a list. `isConfirmationHeld` is recomputed on every render, so there is no
window where a confirmation granted for one payload could publish another, and
the bar builds its variables once and both confirms and publishes that same
object.

The synchronous in-flight ref is unchanged. It is what stops a double click, and
it is now carrying that alone on the first-press path, which the press tests
cover explicitly.

## What is emitted

`resolveCommentOptions` in `src/core/hive-layer.ts` is the only thing in the app
that can produce a `comment_options` operation.

| selection | emitted |
| --- | --- |
| default | nothing at all, no operation |
| sp | `percentHbd: 0`, every other field written explicitly |
| dp | `maxAcceptedPayout: "0.000 HBD"`, every other field written explicitly |

`use-comment.ts` gates the whole second operation on `if (payload.options)` and
fills in its own defaults for every field left out the moment that object
exists, so nothing partial is ever handed to it. The return type is
`Required<NonNullable<CommentPayload['options']>>`, derived from the SDK payload
rather than restated, which makes a missing field a compile error and fails
loudly if the SDK ever adds a sixth. No beneficiary is ever seeded, and the
empty array is written rather than omitted so that a test can read it.

The selection is stored with the rest of the draft, normalised on read because
localStorage outlives any release, cleared after a successful publish, and
collapsed back to `default` at the call site when the instance does not offer
the control, so a stale draft cannot broadcast a choice the author was never
asked to make. Per post beneficiaries are a separate surface and are not here.

## How the default path is proven unchanged

`use-publish-post.broadcast.test.ts` runs the real `usePublishPost` with only
the auth, router and config edges replaced, captures the payload it hands the
SDK, and feeds it through the SDK's own operations builder, lifted out of
`use-comment.ts` with the TypeScript compiler and executed with the SDK's real
operation builders. The same post is built twice, once with the `options` key
this PR adds and once with it removed, and the serialised operation arrays are
compared. The `sp` and `dp` cases assert the full `comment_options` operation
field by field, and one case feeds a deliberately partial options object to
show the SDK default this is avoiding.

Guards, all AST based rather than text based:

- an `options` key may appear at one call site only, and its value must be a
  call whose callee resolves to an imported `resolveCommentOptions`, so a local
  function of the same name does not inherit the permission
- the publish bar's confirm rule must be a call to an imported
  `emitsUneditableOperation` wrapping an imported `resolveRewardSelection` over
  the same object handed to the mutation, so it cannot be restated as a constant
  or as the posture flag
- every call that mints or tests a confirmation must read that same object, and
  the payload walk now follows a `const` object literal to its keys so naming a
  payload does not make it unreadable
- a `comment_options` field name may appear in one module only, and a
  `beneficiaries` value there must be an empty array literal
- the edit path keeps no `options` key, since `comment_options` is not editable
  after the fact
- the panel's two statements must be unconditional, and the panel itself may be
  gated on nothing but the resolved posture
- `authorRewards` comes out of `AWAITING_CONSUMER` and is now held to the same
  named consumer check as every render flag

`publish-press.test.ts` drives the button as a state machine. A press only
broadcasts from `armed`, and refuses while a broadcast is in flight, which the
component tracks in a ref set before the await rather than in `isPending`, which
lags a press by one render. Twenty presses in a row broadcast once, a double
click inside one frame broadcasts nothing, and a failed publish costs two
presses again. Broadcasts retry on their own, so a publish path that can double
fire is a real hazard rather than a theoretical one.

Twenty seven mutations were applied and each was confirmed to fail the guard
meant for it, plus one inert control that correctly fails nothing. They include
removing the clamp, writing the options object inline, declaring a local decoy
resolver, seeding a beneficiary, weakening the SDK gate to a key presence check,
removing the in flight latch, removing the confirm step, making either panel
statement conditional, dropping the new confirm branch, inverting it, hardcoding
it, restating it from the posture flag, reducing the confirmation key to the
reward selection, blinding it to the tag list, letting the arm survive any edit,
and building a second object for the confirmation.

## Rollout

Every tenant seeded during the current window carries
`authorRewards: author`, seeded ahead of the editor fields by an earlier PR in
this track. This is the consumer of that field, so those tenants get the
composer panel on merge with no owner action. That is the intended default and
it was recorded as a known activation date rather than a surprise. Any config
without the block resolves to `off` and is untouched.

The spec calls this the riskiest edit in the track and asks for a manual pass on
a dev instance before merge. Nothing here can be rendered by a test, so the
panel layout, the confirm label and the disclosure wording still want a human
look at a real composer.
