### PR TITLE
feat(self-hosted): tell an owner their site is configurable

### DIFF
--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -263,7 +263,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       'Could not load the current version of this post. Editing stays closed until it loads, so a save cannot overwrite newer changes.',
     login_owner_hint:
-      'If this site is yours, sign in with the account that owns it. A settings button then appears, where you can change the title, logo, theme and layout.',
+      'If this site is yours, sign in with the account that owns it to change the title, logo, theme and layout. Those settings can only be saved from Hivesigner or a Hive browser extension; a HiveAuth session can vote and comment but cannot save them yet.',
   },
   es: {
     loading: 'Cargando...',
@@ -399,7 +399,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       'No se pudo cargar la versión actual de esta publicación. La edición permanece cerrada hasta que cargue, para que al guardar no se sobrescriban cambios más nuevos.',
     login_owner_hint:
-      'Si este sitio es tuyo, inicia sesión con la cuenta propietaria. Aparecerá entonces un botón de ajustes donde puedes cambiar el título, el logo, el tema y el diseño.',
+      'Si este sitio es tuyo, inicia sesión con la cuenta propietaria para cambiar el título, el logo, el tema y el diseño. Esos ajustes solo se pueden guardar desde Hivesigner o una extensión de navegador de Hive; una sesión de HiveAuth puede votar y comentar, pero todavía no puede guardarlos.',
   },
   de: {
     loading: 'Lädt...',
@@ -535,7 +535,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       'Die aktuelle Fassung dieses Beitrags konnte nicht geladen werden. Die Bearbeitung bleibt geschlossen, bis sie geladen ist, damit ein Speichern keine neueren Änderungen überschreibt.',
     login_owner_hint:
-      'Wenn diese Website Ihnen gehört, melden Sie sich mit dem Konto an, dem sie gehört. Danach erscheint eine Schaltfläche für Einstellungen, in der Sie Titel, Logo, Design und Layout ändern können.',
+      'Wenn diese Website Ihnen gehört, melden Sie sich mit dem Konto an, dem sie gehört, um Titel, Logo, Design und Layout zu ändern. Diese Einstellungen lassen sich nur über Hivesigner oder eine Hive-Browsererweiterung speichern; eine HiveAuth-Sitzung kann abstimmen und kommentieren, sie aber noch nicht speichern.',
   },
   fr: {
     loading: "Chargement...",
@@ -673,7 +673,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       "Impossible de charger la version actuelle de cet article. L'édition reste fermée tant qu'elle n'a pas chargé, pour qu'un enregistrement n'écrase pas des modifications plus récentes.",
     login_owner_hint:
-      "Si ce site est le vôtre, connectez-vous avec le compte qui en est propriétaire. Un bouton de réglages apparaît alors, pour modifier le titre, le logo, le thème et la mise en page.",
+      "Si ce site est le vôtre, connectez-vous avec le compte qui en est propriétaire pour modifier le titre, le logo, le thème et la mise en page. Ces réglages ne peuvent être enregistrés que depuis Hivesigner ou une extension de navigateur Hive ; une session HiveAuth peut voter et commenter, mais pas encore les enregistrer.",
   },
   ko: {
     loading: '로딩 중...',
@@ -806,7 +806,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       '이 게시물의 최신 버전을 불러오지 못했습니다. 저장할 때 더 새로운 변경 사항을 덮어쓰지 않도록, 불러올 때까지 편집을 열지 않습니다.',
     login_owner_hint:
-      '이 사이트가 회원님의 것이라면 소유 계정으로 로그인하세요. 로그인하면 제목, 로고, 테마, 레이아웃을 바꿀 수 있는 설정 버튼이 나타납니다.',
+      '이 사이트가 회원님의 것이라면 소유 계정으로 로그인해 제목, 로고, 테마, 레이아웃을 바꿀 수 있습니다. 이 설정은 Hivesigner 또는 Hive 브라우저 확장으로만 저장할 수 있습니다. HiveAuth 세션은 투표와 댓글은 되지만 아직 설정을 저장하지는 못합니다.',
   },
   ru: {
     loading: 'Загрузка...',
@@ -941,7 +941,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       'Не удалось загрузить текущую версию этого поста. Редактор не откроется, пока она не загрузится, чтобы сохранение не перезаписало более новые изменения.',
     login_owner_hint:
-      'Если это ваш сайт, войдите с аккаунта-владельца. После этого появится кнопка настроек, где можно изменить название, логотип, тему и макет.',
+      'Если это ваш сайт, войдите с аккаунта-владельца, чтобы изменить название, логотип, тему и макет. Эти настройки сохраняются только через Hivesigner или расширение браузера для Hive; сессия HiveAuth может голосовать и комментировать, но пока не может их сохранить.',
   },
 };
 

--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -124,7 +124,8 @@ type TranslationKey =
   | 'app_error_description'
   | 'reload_page'
   | 'community_refresh_failed'
-  | 'edit_read_failed';
+  | 'edit_read_failed'
+  | 'login_owner_hint';
 
 type Translations = Record<TranslationKey, string>;
 
@@ -261,6 +262,8 @@ const translations: Record<string, Translations> = {
     community_refresh_failed: 'Could not refresh community details.',
     edit_read_failed:
       'Could not load the current version of this post. Editing stays closed until it loads, so a save cannot overwrite newer changes.',
+    login_owner_hint:
+      'If this site is yours, sign in with the account that owns it. A settings button then appears, where you can change the title, logo, theme and layout.',
   },
   es: {
     loading: 'Cargando...',
@@ -395,6 +398,8 @@ const translations: Record<string, Translations> = {
       'No se pudieron actualizar los datos de la comunidad.',
     edit_read_failed:
       'No se pudo cargar la versión actual de esta publicación. La edición permanece cerrada hasta que cargue, para que al guardar no se sobrescriban cambios más nuevos.',
+    login_owner_hint:
+      'Si este sitio es tuyo, inicia sesión con la cuenta propietaria. Aparecerá entonces un botón de ajustes donde puedes cambiar el título, el logo, el tema y el diseño.',
   },
   de: {
     loading: 'Lädt...',
@@ -529,6 +534,8 @@ const translations: Record<string, Translations> = {
       'Community-Daten konnten nicht aktualisiert werden.',
     edit_read_failed:
       'Die aktuelle Fassung dieses Beitrags konnte nicht geladen werden. Die Bearbeitung bleibt geschlossen, bis sie geladen ist, damit ein Speichern keine neueren Änderungen überschreibt.',
+    login_owner_hint:
+      'Wenn diese Website Ihnen gehört, melden Sie sich mit dem Konto an, dem sie gehört. Danach erscheint eine Schaltfläche für Einstellungen, in der Sie Titel, Logo, Design und Layout ändern können.',
   },
   fr: {
     loading: "Chargement...",
@@ -665,6 +672,8 @@ const translations: Record<string, Translations> = {
       'Impossible d\'actualiser les informations de la communauté.',
     edit_read_failed:
       "Impossible de charger la version actuelle de cet article. L'édition reste fermée tant qu'elle n'a pas chargé, pour qu'un enregistrement n'écrase pas des modifications plus récentes.",
+    login_owner_hint:
+      "Si ce site est le vôtre, connectez-vous avec le compte qui en est propriétaire. Un bouton de réglages apparaît alors, pour modifier le titre, le logo, le thème et la mise en page.",
   },
   ko: {
     loading: '로딩 중...',
@@ -796,6 +805,8 @@ const translations: Record<string, Translations> = {
     community_refresh_failed: '커뮤니티 정보를 새로 고치지 못했습니다.',
     edit_read_failed:
       '이 게시물의 최신 버전을 불러오지 못했습니다. 저장할 때 더 새로운 변경 사항을 덮어쓰지 않도록, 불러올 때까지 편집을 열지 않습니다.',
+    login_owner_hint:
+      '이 사이트가 회원님의 것이라면 소유 계정으로 로그인하세요. 로그인하면 제목, 로고, 테마, 레이아웃을 바꿀 수 있는 설정 버튼이 나타납니다.',
   },
   ru: {
     loading: 'Загрузка...',
@@ -929,6 +940,8 @@ const translations: Record<string, Translations> = {
       'Не удалось обновить данные сообщества.',
     edit_read_failed:
       'Не удалось загрузить текущую версию этого поста. Редактор не откроется, пока она не загрузится, чтобы сохранение не перезаписало более новые изменения.',
+    login_owner_hint:
+      'Если это ваш сайт, войдите с аккаунта-владельца. После этого появится кнопка настроек, где можно изменить название, логотип, тему и макет.',
   },
 };
 

--- a/apps/self-hosted/src/features/auth/index.ts
+++ b/apps/self-hosted/src/features/auth/index.ts
@@ -38,6 +38,7 @@ export {
   hasKeychainLikeExtension,
 } from './utils/hive-extensions';
 export { isHivesignerCallback, parseHivesignerCallback } from './utils/hivesigner';
+export { AUTH_METHODS, availableAuthMethods, orderAuthMethods } from './utils/auth-methods';
 export { isHiveAuthSessionValid } from './utils/hive-auth';
 
 // Components

--- a/apps/self-hosted/src/features/auth/utils/auth-methods.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/auth-methods.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { AUTH_METHODS, availableAuthMethods } from './auth-methods';
+import type { AuthMethod } from '../types';
+import {
+  AUTH_METHODS,
+  availableAuthMethods,
+  orderAuthMethods,
+} from './auth-methods';
 
 /**
  * What a reader is offered. Hivesigner without a registered client can only end
@@ -32,5 +37,73 @@ describe('methods offered to a visitor', () => {
 
   it('lists exactly the methods the login page can render', () => {
     expect([...AUTH_METHODS]).toEqual(['keychain', 'hivesigner', 'hiveauth']);
+  });
+});
+
+/**
+ * The order they are offered in.
+ *
+ * `keychain` needs a desktop browser extension. On a phone its card is an
+ * install prompt for software the device cannot run, so offering it first made
+ * the first thing an owner read on their own site a dead end. Nothing else on
+ * this page can be device-aware without asking the browser, so the fix is the
+ * static order: whatever completes anywhere goes first.
+ */
+describe('the order methods are offered in', () => {
+  it('offers the extension last, after the methods a phone can finish', () => {
+    expect(orderAuthMethods(['keychain', 'hivesigner', 'hiveauth'])).toEqual([
+      'hiveauth',
+      'hivesigner',
+      'keychain',
+    ]);
+  });
+
+  it('puts hiveauth first on a default instance, which has no hivesigner client', () => {
+    // What availableAuthMethods actually hands this function on the stock
+    // config: hivesigner is already gone, so the phone-capable method has to
+    // come out in front of the extension or the page opens on the dead end.
+    const offered = availableAuthMethods(
+      ['keychain', 'hivesigner', 'hiveauth'],
+      null,
+    );
+    expect(orderAuthMethods(offered)).toEqual(['hiveauth', 'keychain']);
+  });
+
+  it('is a reordering, never a filter', () => {
+    const configured: AuthMethod[] = ['keychain', 'hiveauth'];
+    const ordered = orderAuthMethods(configured);
+    expect([...ordered].sort()).toEqual([...configured].sort());
+    expect(ordered).toHaveLength(configured.length);
+  });
+
+  it('keeps an unranked method rather than dropping it', () => {
+    // The config type is not enforced at runtime, and availableAuthMethods
+    // casts rather than filters, so an unknown name reaches this function. It
+    // must survive to the page, which decides what to do with it.
+    const ordered = orderAuthMethods([
+      'made-up',
+      'keychain',
+      'hiveauth',
+    ] as unknown as AuthMethod[]);
+    expect(ordered).toEqual(['hiveauth', 'keychain', 'made-up']);
+  });
+
+  it('keeps unranked methods in the order they were configured', () => {
+    const ordered = orderAuthMethods([
+      'zzz',
+      'aaa',
+      'hiveauth',
+    ] as unknown as AuthMethod[]);
+    expect(ordered).toEqual(['hiveauth', 'zzz', 'aaa']);
+  });
+
+  it('does not mutate the list it was given', () => {
+    const configured: AuthMethod[] = ['keychain', 'hiveauth'];
+    orderAuthMethods(configured);
+    expect(configured).toEqual(['keychain', 'hiveauth']);
+  });
+
+  it('offers nothing when nothing is available', () => {
+    expect(orderAuthMethods([])).toEqual([]);
   });
 });

--- a/apps/self-hosted/src/features/auth/utils/auth-methods.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/auth-methods.test.ts
@@ -3,6 +3,7 @@ import type { AuthMethod } from '../types';
 import {
   AUTH_METHODS,
   availableAuthMethods,
+  canSaveConfiguration,
   orderAuthMethods,
 } from './auth-methods';
 
@@ -43,30 +44,39 @@ describe('methods offered to a visitor', () => {
 /**
  * The order they are offered in.
  *
- * `keychain` needs a desktop browser extension. On a phone its card is an
- * install prompt for software the device cannot run, so offering it first made
- * the first thing an owner read on their own site a dead end. Nothing else on
- * this page can be device-aware without asking the browser, so the fix is the
- * static order: whatever completes anywhere goes first.
+ * Ranked by what completes the task the login page advertises, which is
+ * configuring the site. `hiveauth` cannot save a configuration change at all
+ * (`getHostingToken` has no case for it and throws), so leading with it sent an
+ * owner through sign-in, the panel and an edit before telling them to log in
+ * again with something else. `config-saving-capability.test.ts` holds the
+ * capability list to the switch that decides it.
  */
 describe('the order methods are offered in', () => {
-  it('offers the extension last, after the methods a phone can finish', () => {
+  it('offers both saving methods before the one that cannot save', () => {
     expect(orderAuthMethods(['keychain', 'hivesigner', 'hiveauth'])).toEqual([
-      'hiveauth',
       'hivesigner',
       'keychain',
+      'hiveauth',
     ]);
   });
 
-  it('puts hiveauth first on a default instance, which has no hivesigner client', () => {
+  it('leads with hivesigner, the only method that saves and works on a phone', () => {
+    expect(orderAuthMethods(['hiveauth', 'keychain', 'hivesigner'])[0]).toBe(
+      'hivesigner',
+    );
+  });
+
+  it('still puts the extension ahead of hiveauth on a default instance', () => {
     // What availableAuthMethods actually hands this function on the stock
-    // config: hivesigner is already gone, so the phone-capable method has to
-    // come out in front of the extension or the page opens on the dead end.
+    // config: hivesigner is dropped for want of a client id, so the only
+    // method left that can save is the extension, and it has to come first
+    // even though it cannot complete on a phone. Nothing offered on a stock
+    // instance both saves and works on a phone, which is why the hint says so.
     const offered = availableAuthMethods(
       ['keychain', 'hivesigner', 'hiveauth'],
       null,
     );
-    expect(orderAuthMethods(offered)).toEqual(['hiveauth', 'keychain']);
+    expect(orderAuthMethods(offered)).toEqual(['keychain', 'hiveauth']);
   });
 
   it('is a reordering, never a filter', () => {
@@ -85,7 +95,7 @@ describe('the order methods are offered in', () => {
       'keychain',
       'hiveauth',
     ] as unknown as AuthMethod[]);
-    expect(ordered).toEqual(['hiveauth', 'keychain', 'made-up']);
+    expect(ordered).toEqual(['keychain', 'hiveauth', 'made-up']);
   });
 
   it('keeps unranked methods in the order they were configured', () => {
@@ -105,5 +115,74 @@ describe('the order methods are offered in', () => {
 
   it('offers nothing when nothing is available', () => {
     expect(orderAuthMethods([])).toEqual([]);
+  });
+});
+
+/**
+ * Duplicates.
+ *
+ * The page renders one card per entry, keyed by the method name. The shape this
+ * replaced tested `includes()` per known method, so a config naming one twice
+ * still rendered it once; mapping the list renders it twice, under one React
+ * key. The config is not validated at runtime, so the list has to arrive
+ * already unique.
+ */
+describe('a method configured more than once', () => {
+  it('is offered exactly one card', () => {
+    expect(orderAuthMethods(['keychain', 'keychain', 'hiveauth'])).toEqual([
+      'keychain',
+      'hiveauth',
+    ]);
+  });
+
+  it('produces a list whose entries are unique, so React keys cannot collide', () => {
+    const ordered = orderAuthMethods([
+      'hiveauth',
+      'keychain',
+      'hiveauth',
+      'keychain',
+      'hivesigner',
+      'hivesigner',
+    ]);
+    expect(new Set(ordered).size).toBe(ordered.length);
+    expect(ordered).toEqual(['hivesigner', 'keychain', 'hiveauth']);
+  });
+
+  it('deduplicates an unknown method too, and still does not rank it', () => {
+    const ordered = orderAuthMethods([
+      'made-up',
+      'hiveauth',
+      'made-up',
+    ] as unknown as AuthMethod[]);
+    expect(ordered).toEqual(['hiveauth', 'made-up']);
+  });
+
+  it('keeps the first occurrence, so a duplicate cannot move an unranked method up', () => {
+    const ordered = orderAuthMethods([
+      'zzz',
+      'aaa',
+      'zzz',
+    ] as unknown as AuthMethod[]);
+    expect(ordered).toEqual(['zzz', 'aaa']);
+  });
+});
+
+/**
+ * The capability the ordering is derived from. The list itself is held to
+ * `hosting-token.ts` by `config-saving-capability.test.ts`; here it only has to
+ * answer the question the page asks it.
+ */
+describe('which methods can save a configuration change', () => {
+  it('says yes for the two the hosting API can mint a token from', () => {
+    expect(canSaveConfiguration('hivesigner')).toBe(true);
+    expect(canSaveConfiguration('keychain')).toBe(true);
+  });
+
+  it('says no for hiveauth, which cannot sign the login challenge', () => {
+    expect(canSaveConfiguration('hiveauth')).toBe(false);
+  });
+
+  it('says no for a method it has never heard of', () => {
+    expect(canSaveConfiguration('made-up' as AuthMethod)).toBe(false);
   });
 });

--- a/apps/self-hosted/src/features/auth/utils/auth-methods.ts
+++ b/apps/self-hosted/src/features/auth/utils/auth-methods.ts
@@ -31,3 +31,39 @@ export function availableAuthMethods(
     method === 'hivesigner' ? hivesignerClientId !== null : true,
   );
 }
+
+/**
+ * The order the login page offers the methods in.
+ *
+ * `keychain` is a desktop browser extension, so on a phone its card can only
+ * render an install prompt for software the device cannot run. Offered first,
+ * that install prompt was the first thing an owner opening their own site on a
+ * phone read, and it looks exactly like a dead end. Methods that need nothing
+ * installed lead instead; the extension keeps its card for the desktop visitor
+ * who has one, one place further down.
+ *
+ * This orders, it never filters: `availableAuthMethods` already decided what a
+ * visitor may be offered, and a method that is not ranked here keeps its
+ * configured position at the end rather than vanishing from the page.
+ */
+const DISPLAY_ORDER: readonly AuthMethod[] = [
+  'hiveauth',
+  'hivesigner',
+  'keychain',
+];
+
+export function orderAuthMethods(
+  methods: readonly AuthMethod[],
+): AuthMethod[] {
+  const rank = (method: AuthMethod) => {
+    const index = DISPLAY_ORDER.indexOf(method);
+    return index === -1 ? DISPLAY_ORDER.length : index;
+  };
+
+  // Sorted on an explicit original index rather than relying on the runtime's
+  // sort being stable, so unranked methods keep the order the owner configured.
+  return methods
+    .map((method, index) => ({ method, index }))
+    .sort((a, b) => rank(a.method) - rank(b.method) || a.index - b.index)
+    .map((entry) => entry.method);
+}

--- a/apps/self-hosted/src/features/auth/utils/auth-methods.ts
+++ b/apps/self-hosted/src/features/auth/utils/auth-methods.ts
@@ -33,23 +33,61 @@ export function availableAuthMethods(
 }
 
 /**
- * The order the login page offers the methods in.
+ * The methods a session can be exchanged for a hosting API token with, and
+ * therefore the only ones that can save a configuration change.
  *
- * `keychain` is a desktop browser extension, so on a phone its card can only
- * render an install prompt for software the device cannot run. Offered first,
- * that install prompt was the first thing an owner opening their own site on a
- * phone read, and it looks exactly like a dead end. Methods that need nothing
- * installed lead instead; the extension keeps its card for the desktop visitor
- * who has one, one place further down.
+ * Saving PATCHes the managed-hosting API, which accepts only its own token.
+ * `getHostingToken` mints one from a Hivesigner access token verified server
+ * side, or from a login challenge signed offline by a browser extension. A
+ * HiveAuth session can broadcast to the chain, so it votes, comments and
+ * publishes, but it cannot sign an arbitrary buffer: `hive-auth-wrapper`
+ * exposes no `broadcast: false` mode, so there is no way to answer the
+ * challenge at all. Every other session reaches `getHostingToken`'s `default`
+ * and throws.
  *
- * This orders, it never filters: `availableAuthMethods` already decided what a
- * visitor may be offered, and a method that is not ranked here keeps its
- * configured position at the end rather than vanishing from the page.
+ * Kept here rather than inside `hosting-token.ts` because the login page has to
+ * know it BEFORE an owner spends a session finding out, and the copy on that
+ * page names these methods. `config-saving-capability.test.ts` holds this list
+ * to the switch in `hosting-token.ts`, so a method gaining or losing the
+ * capability cannot drift away from what the page promises.
  */
-const DISPLAY_ORDER: readonly AuthMethod[] = [
-  'hiveauth',
+export const CONFIG_SAVING_METHODS: readonly AuthMethod[] = [
   'hivesigner',
   'keychain',
+];
+
+/** Whether a session of this kind can save a configuration change. */
+export function canSaveConfiguration(method: AuthMethod): boolean {
+  return CONFIG_SAVING_METHODS.includes(method);
+}
+
+/**
+ * The order the login page offers the methods in.
+ *
+ * Ranked by what completes the task the page advertises, which is configuring
+ * the site. Ranking by ease of signing in put HiveAuth first, and HiveAuth is
+ * the one method that cannot save anything: an owner following it signed in,
+ * opened the panel, edited, saved, and only then learned they had to log in
+ * again with something else. Promoting a method that cannot finish is worse
+ * than saying nothing.
+ *
+ * So both saving methods lead, and `hivesigner` leads them, because it is the
+ * only one that both saves and works on a phone. It is dropped by
+ * `availableAuthMethods` on an instance with no client id, which is every
+ * seeded instance today, so ranking it first costs a stock instance nothing and
+ * is already correct for an instance that sets one.
+ *
+ * `hiveauth` last is not a demotion of the reader path: a reader only needs to
+ * vote and comment, which it does, and it is still on the page.
+ *
+ * This orders and deduplicates, it never filters. `availableAuthMethods`
+ * already decided what a visitor may be offered, so a method that is not ranked
+ * here keeps its configured position at the end rather than vanishing.
+ */
+const DISPLAY_ORDER: readonly AuthMethod[] = [
+  'hivesigner',
+  'keychain',
+  'hiveauth',
 ];
 
 export function orderAuthMethods(
@@ -60,9 +98,21 @@ export function orderAuthMethods(
     return index === -1 ? DISPLAY_ORDER.length : index;
   };
 
+  // Deduplicated on the way in. The configured list is not validated at
+  // runtime, and the page renders one card per entry keyed by the method name,
+  // so a config naming a method twice produced two cards under one React key.
+  // First occurrence wins, so an unranked duplicate cannot jump its position.
+  const seen = new Set<AuthMethod>();
+  const unique: AuthMethod[] = [];
+  for (const method of methods) {
+    if (seen.has(method)) continue;
+    seen.add(method);
+    unique.push(method);
+  }
+
   // Sorted on an explicit original index rather than relying on the runtime's
   // sort being stable, so unranked methods keep the order the owner configured.
-  return methods
+  return unique
     .map((method, index) => ({ method, index }))
     .sort((a, b) => rank(a.method) - rank(b.method) || a.index - b.index)
     .map((entry) => entry.method);

--- a/apps/self-hosted/src/features/auth/utils/config-saving-capability.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/config-saving-capability.test.ts
@@ -1,0 +1,397 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import type { AuthMethod } from '../types';
+import {
+  AUTH_METHODS,
+  CONFIG_SAVING_METHODS,
+  canSaveConfiguration,
+  orderAuthMethods,
+} from './auth-methods';
+
+/**
+ * The login page advertises configuring the site, so it must not lead with a
+ * method that cannot save one.
+ *
+ * `getHostingToken` exchanges the current session for a managed-hosting token,
+ * and it can only do that for a Hivesigner access token or an extension-signed
+ * challenge. Every other session falls to `default` and throws, which surfaces
+ * at save time: after the owner has signed in, opened the panel and made an
+ * edit. Nothing in the type system connects that switch to the order the page
+ * offers methods in, or to the sentence on the page that names them, so both
+ * links are asserted here.
+ *
+ * Two properties, neither visible to the type checker:
+ *
+ *   1. `CONFIG_SAVING_METHODS` is exactly what `hosting-token.ts` handles. A
+ *      method gaining or losing the capability has to move this list, which is
+ *      what the ordering and the copy are derived from;
+ *   2. no method that cannot save is offered before one that can.
+ *
+ * Nothing in `apps/self-hosted` is DOM-testable (`environment: 'node'`,
+ * `include: ['src/**\/*.test.ts']`), so a source scan is the only guarantee
+ * available for the first. Modelled on
+ * `src/features/shared/hive-disclosure-guard.test.ts`.
+ */
+
+const SRC = join(__dirname, '..', '..', '..');
+
+const HOSTING_TOKEN_MODULE = 'features/auth/utils/hosting-token.ts';
+const I18N_MODULE = 'core/i18n.ts';
+
+const HINT_KEY = 'login_owner_hint';
+
+/**
+ * What the hint has to call each method.
+ *
+ * Every method is named, whichever side of the capability line it is on: the
+ * ones that save because the owner has to pick one, the ones that cannot
+ * because the owner has to be warned before spending a session on it. A copy
+ * rewrite that quietly drops one fails here.
+ */
+const HINT_NAMES: Record<AuthMethod, string> = {
+  hivesigner: 'hivesigner',
+  keychain: 'browser extension',
+  hiveauth: 'hiveauth',
+};
+
+function parseSource(code: string, name = 'probe.ts'): ts.SourceFile {
+  return ts.createSourceFile(
+    name,
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function parse(relative: string): ts.SourceFile {
+  const path = join(SRC, relative);
+  return parseSource(readFileSync(path, 'utf8'), path);
+}
+
+function walk(node: ts.Node, visit: (n: ts.Node) => void): void {
+  visit(node);
+  ts.forEachChild(node, (child) => walk(child, visit));
+}
+
+interface SwitchShape {
+  /** String-literal case labels, in source order. */
+  cases: string[];
+  /** Whether the switch has a default clause, and whether it throws. */
+  hasDefault: boolean;
+  defaultThrows: boolean;
+}
+
+/**
+ * The shape of the switch on `discriminant`, read from the syntax tree.
+ *
+ * Read as case labels rather than as occurrences of the method names. The
+ * module's own doc comment lists all three methods in prose, so any text search
+ * for "hiveauth" in this file finds it and concludes the opposite of the truth.
+ */
+function switchOn(
+  sf: ts.SourceFile,
+  discriminant: string,
+): SwitchShape | undefined {
+  let shape: SwitchShape | undefined;
+
+  walk(sf, (node) => {
+    if (!ts.isSwitchStatement(node)) return;
+    if (node.expression.getText(sf).replace(/\s+/g, '') !== discriminant) {
+      return;
+    }
+
+    const cases: string[] = [];
+    let hasDefault = false;
+    let defaultThrows = false;
+
+    for (const clause of node.caseBlock.clauses) {
+      if (ts.isCaseClause(clause)) {
+        if (
+          ts.isStringLiteral(clause.expression) ||
+          ts.isNoSubstitutionTemplateLiteral(clause.expression)
+        ) {
+          cases.push(clause.expression.text);
+        } else {
+          // A computed label is not readable here, and treating it as absent
+          // would understate what the switch handles.
+          cases.push(`<computed:${clause.expression.getText(sf)}>`);
+        }
+        continue;
+      }
+      hasDefault = true;
+      for (const statement of clause.statements) {
+        walk(statement, (inner) => {
+          if (ts.isThrowStatement(inner)) defaultThrows = true;
+        });
+      }
+    }
+
+    shape = { cases, hasDefault, defaultThrows };
+  });
+
+  return shape;
+}
+
+/** The value of `key` in the given locale block of `i18n.ts`. */
+function localeValue(
+  sf: ts.SourceFile,
+  locale: string,
+  key: string,
+): string | undefined {
+  let value: string | undefined;
+
+  walk(sf, (node) => {
+    if (
+      !ts.isVariableDeclaration(node) ||
+      !ts.isIdentifier(node.name) ||
+      node.name.text !== 'translations' ||
+      !node.initializer ||
+      !ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      return;
+    }
+    for (const block of node.initializer.properties) {
+      if (
+        !ts.isPropertyAssignment(block) ||
+        !ts.isIdentifier(block.name) ||
+        block.name.text !== locale ||
+        !ts.isObjectLiteralExpression(block.initializer)
+      ) {
+        continue;
+      }
+      for (const entry of block.initializer.properties) {
+        if (
+          ts.isPropertyAssignment(entry) &&
+          entry.name &&
+          ts.isIdentifier(entry.name) &&
+          entry.name.text === key &&
+          (ts.isStringLiteral(entry.initializer) ||
+            ts.isNoSubstitutionTemplateLiteral(entry.initializer))
+        ) {
+          value = entry.initializer.text;
+        }
+      }
+    }
+  });
+
+  return value;
+}
+
+describe('what can save a configuration change', () => {
+  const hostingToken = parse(HOSTING_TOKEN_MODULE);
+  const shape = switchOn(hostingToken, 'user.loginType');
+
+  it('reads the session switch that mints the hosting token', () => {
+    // Guards the reader: an undefined shape would make the next tests pass
+    // vacuously or fail for the wrong reason.
+    expect(shape).toBeDefined();
+  });
+
+  it('handles exactly the methods declared able to save', () => {
+    expect([...shape!.cases].sort()).toEqual([...CONFIG_SAVING_METHODS].sort());
+  });
+
+  it('refuses every other session rather than saving silently', () => {
+    expect(shape!.hasDefault).toBe(true);
+    expect(shape!.defaultThrows).toBe(true);
+  });
+
+  it('leaves at least one method unable to save, which the copy must warn about', () => {
+    // Not an aspiration: while this holds, the hint has a caveat to carry, and
+    // the test below requires it to. If HiveAuth ever gains offline signing
+    // this fails, which is the prompt to re-read the copy.
+    const unable = AUTH_METHODS.filter((method) => !canSaveConfiguration(method));
+    expect(unable).toEqual(['hiveauth']);
+  });
+});
+
+describe('the page never offers a method that cannot finish the task first', () => {
+  it('orders every saving method ahead of every non-saving one', () => {
+    const ordered = orderAuthMethods(AUTH_METHODS);
+    const violations: string[] = [];
+    for (let i = 0; i < ordered.length; i++) {
+      for (let j = i + 1; j < ordered.length; j++) {
+        if (!canSaveConfiguration(ordered[i]) && canSaveConfiguration(ordered[j])) {
+          violations.push(`${ordered[i]} offered before ${ordered[j]}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('holds for whatever subset an instance actually offers', () => {
+    // The stock instance offers two of the three, and a config may name any
+    // subset in any order. The invariant is about the output, not about the
+    // one list the previous test happens to pass in.
+    const subsets: AuthMethod[][] = [
+      ['hiveauth', 'keychain'],
+      ['keychain', 'hiveauth'],
+      ['hiveauth', 'hivesigner'],
+      ['hiveauth'],
+      ['hiveauth', 'keychain', 'hivesigner'],
+    ];
+    for (const subset of subsets) {
+      const ordered = orderAuthMethods(subset);
+      const firstNonSaver = ordered.findIndex((m) => !canSaveConfiguration(m));
+      if (firstNonSaver === -1) continue;
+      const after = ordered.slice(firstNonSaver);
+      expect(after.filter(canSaveConfiguration)).toEqual([]);
+    }
+  });
+
+  it('puts the one method that both saves and works on a phone first', () => {
+    expect(orderAuthMethods(AUTH_METHODS)[0]).toBe('hivesigner');
+  });
+});
+
+describe('the hint names every method on the right side of the line', () => {
+  const i18n = parse(I18N_MODULE);
+  const hint = localeValue(i18n, 'en', HINT_KEY);
+
+  it('finds the hint to check', () => {
+    expect(hint).toBeDefined();
+  });
+
+  it.each(CONFIG_SAVING_METHODS)('names %s as a way to save', (method) => {
+    expect(hint!.toLowerCase()).toContain(HINT_NAMES[method]);
+  });
+
+  it.each(AUTH_METHODS.filter((m) => !canSaveConfiguration(m)))(
+    'warns that %s cannot save',
+    (method) => {
+      expect(hint!.toLowerCase()).toContain(HINT_NAMES[method]);
+    },
+  );
+
+  it('does not claim the settings panel simply works once signed in', () => {
+    // The sentence this replaced promised a settings button and stopped there,
+    // which is what led an owner into a save they could not complete.
+    expect(hint!.toLowerCase()).toMatch(/cannot save|only be saved/);
+  });
+});
+
+describe('the guard catches the ways around it', () => {
+  it('sees a case added for a method that cannot really save', () => {
+    const sf = parseSource(
+      [
+        'function f(user: { loginType: string }) {',
+        '  switch (user.loginType) {',
+        "    case 'hivesigner': return 1;",
+        "    case 'keychain': return 2;",
+        "    case 'hiveauth': return 3;",
+        '    default: throw new Error("no");',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+    expect(switchOn(sf, 'user.loginType')!.cases).toEqual([
+      'hivesigner',
+      'keychain',
+      'hiveauth',
+    ]);
+  });
+
+  it('sees a case removed', () => {
+    const sf = parseSource(
+      [
+        'function f(user: { loginType: string }) {',
+        '  switch (user.loginType) {',
+        "    case 'hivesigner': return 1;",
+        '    default: throw new Error("no");',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+    expect(switchOn(sf, 'user.loginType')!.cases).toEqual(['hivesigner']);
+  });
+
+  it('sees a default that returns instead of throwing', () => {
+    const sf = parseSource(
+      [
+        'function f(user: { loginType: string }) {',
+        '  switch (user.loginType) {',
+        "    case 'keychain': return 2;",
+        "    default: return '';",
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+    const shape = switchOn(sf, 'user.loginType')!;
+    expect(shape.hasDefault).toBe(true);
+    expect(shape.defaultThrows).toBe(false);
+  });
+
+  it('sees a switch with no default at all', () => {
+    const sf = parseSource(
+      [
+        'function f(user: { loginType: string }) {',
+        '  switch (user.loginType) {',
+        "    case 'keychain': return 2;",
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+    expect(switchOn(sf, 'user.loginType')!.hasDefault).toBe(false);
+  });
+
+  it('does not read a switch on something else as the session switch', () => {
+    const sf = parseSource(
+      [
+        'function f(x: { kind: string }) {',
+        '  switch (x.kind) {',
+        "    case 'hiveauth': return 3;",
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+    expect(switchOn(sf, 'user.loginType')).toBeUndefined();
+  });
+
+  it('does not let a prose mention of a method count as handling it', () => {
+    // The real module's doc comment names all three. A text search would read
+    // the opposite of the truth off it.
+    const sf = parseSource(
+      [
+        '/** hivesigner, keychain and hiveauth are all mentioned here. */',
+        'function f(user: { loginType: string }) {',
+        '  switch (user.loginType) {',
+        "    case 'keychain': return 2;",
+        '    default: throw new Error("no");',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+    expect(switchOn(sf, 'user.loginType')!.cases).toEqual(['keychain']);
+  });
+
+  it('reports an unreadable case label rather than skipping it', () => {
+    const sf = parseSource(
+      [
+        'declare const K: string;',
+        'function f(user: { loginType: string }) {',
+        '  switch (user.loginType) {',
+        '    case K: return 2;',
+        '    default: throw new Error("no");',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+    expect(switchOn(sf, 'user.loginType')!.cases).toEqual(['<computed:K>']);
+  });
+
+  it('reads a hint that dropped a method name', () => {
+    const sf = parseSource(
+      [
+        'const translations = {',
+        "  en: { login_owner_hint: 'Sign in with Hivesigner to save.' },",
+        '};',
+      ].join('\n'),
+    );
+    const hint = localeValue(sf, 'en', HINT_KEY)!;
+    expect(hint.toLowerCase()).toContain('hivesigner');
+    expect(hint.toLowerCase()).not.toContain('hiveauth');
+  });
+});

--- a/apps/self-hosted/src/routes/-login-owner-hint.test.ts
+++ b/apps/self-hosted/src/routes/-login-owner-hint.test.ts
@@ -1,0 +1,449 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The login page is the only place a hosted site says it is configurable.
+ *
+ * The Configuration Editor renders through `AuthorizedFloatingMenu`, gated on
+ * `useIsBlogOwner()`, so it exists only for a viewer who has already
+ * authenticated as the instance owner. Nothing outside it says so, which leaves
+ * the instruction reachable only by someone who has already followed it. The
+ * owner has to be told on a page they can reach while logged out, or a site
+ * runs indefinitely on whatever it was provisioned with.
+ *
+ * That makes two properties load-bearing, and neither is visible to the type
+ * checker:
+ *
+ *   1. the hint is rendered under no condition at all. Gating it on ownership
+ *      would restore the exact circularity it exists to break, and gating it on
+ *      anything else would hide it from someone;
+ *   2. the login methods are rendered in the order `orderAuthMethods` returns.
+ *      Rendered in source order, a phone opens on an install prompt for a
+ *      desktop browser extension.
+ *
+ * Nothing in `apps/self-hosted` is DOM-testable (`environment: 'node'`,
+ * `include: ['src/**\/*.test.ts']`), so a source scan is the only guarantee
+ * available. Modelled on `src/routes/-internal-links.test.ts` and
+ * `src/features/shared/hive-disclosure-guard.test.ts`, which already drive the
+ * TypeScript compiler API; `typescript` is a devDependency.
+ *
+ * Lives under src/routes with a `-` prefix, TanStack Router's convention for a
+ * non-route file in the routes directory.
+ */
+
+const SRC = join(__dirname, '..');
+
+const LOGIN_PAGE = 'routes/login.tsx';
+const I18N_MODULE = 'core/i18n.ts';
+
+const HINT_KEY = 'login_owner_hint';
+
+/** Every login method card the page can render. */
+const METHOD_COMPONENTS = [
+  'ExtensionLogin',
+  'HivesignerLogin',
+  'HiveAuthLogin',
+] as const;
+
+function parseSource(code: string, name = 'probe.tsx'): ts.SourceFile {
+  return ts.createSourceFile(
+    name,
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+    name.endsWith('.ts') ? ts.ScriptKind.TS : ts.ScriptKind.TSX,
+  );
+}
+
+function parse(relative: string): ts.SourceFile {
+  const path = join(SRC, relative);
+  return parseSource(readFileSync(path, 'utf8'), path);
+}
+
+function walk(node: ts.Node, visit: (n: ts.Node) => void): void {
+  visit(node);
+  ts.forEachChild(node, (child) => walk(child, visit));
+}
+
+/**
+ * Every `t('some_key')` call in the file, as the key plus the call node.
+ *
+ * Read as a call to the translator, not as an occurrence of the string. A
+ * literal `"If this site is yours..."` typed straight into the JSX contains the
+ * same words and would satisfy any text search while bypassing the locale
+ * system entirely, which is the defect this codebase already carries in
+ * `src/features/floating-menu/**`.
+ */
+function translationCalls(sf: ts.SourceFile): { key: string; node: ts.Node }[] {
+  const found: { key: string; node: ts.Node }[] = [];
+  walk(sf, (node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 't' &&
+      node.arguments.length === 1
+    ) {
+      const [arg] = node.arguments;
+      if (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) {
+        found.push({ key: arg.text, node });
+      }
+    }
+  });
+  return found;
+}
+
+/**
+ * The text of every condition this node renders under.
+ *
+ * `{isBlogOwner && <p>{t('login_owner_hint')}</p>}` renders the hint only for
+ * someone who has already logged in, which is precisely the circularity the
+ * hint exists to break, and an import-or-presence check would pass on it.
+ */
+function enclosingConditions(node: ts.Node, sf: ts.SourceFile): string[] {
+  const conditions: string[] = [];
+  let current: ts.Node | undefined = node.parent;
+  while (current && !ts.isSourceFile(current)) {
+    if (ts.isConditionalExpression(current)) {
+      conditions.push(current.condition.getText(sf));
+    } else if (
+      ts.isBinaryExpression(current) &&
+      (current.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+        current.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+    ) {
+      conditions.push(current.left.getText(sf));
+    } else if (ts.isIfStatement(current)) {
+      conditions.push(current.expression.getText(sf));
+    }
+    current = current.parent;
+  }
+  return conditions;
+}
+
+/** Every JSX element in the subtree whose tag is one of `tags`. */
+function jsxElements(root: ts.Node, sf: ts.SourceFile, tags: readonly string[]) {
+  const found: { tag: string; node: ts.Node }[] = [];
+  walk(root, (node) => {
+    if (ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node)) {
+      const tag = node.tagName.getText(sf);
+      if (tags.includes(tag)) found.push({ tag, node });
+    }
+  });
+  return found;
+}
+
+/**
+ * The `.map(...)` call the ordered login methods are rendered through.
+ *
+ * Follows the value rather than a name: the call to `orderAuthMethods` is found
+ * first, then the variable it is declared into (through `useMemo`, or not), and
+ * only then the `.map` on that variable. Matching a name like `orderedMethods`
+ * would pass on a variable holding something else entirely.
+ */
+function orderedMethodsMap(sf: ts.SourceFile): ts.CallExpression | undefined {
+  let binding: string | undefined;
+
+  walk(sf, (node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'orderAuthMethods'
+    ) {
+      let current: ts.Node | undefined = node;
+      while (current && !ts.isSourceFile(current)) {
+        if (ts.isVariableDeclaration(current) && ts.isIdentifier(current.name)) {
+          binding = current.name.text;
+          return;
+        }
+        current = current.parent;
+      }
+    }
+  });
+
+  if (!binding) return undefined;
+
+  let mapCall: ts.CallExpression | undefined;
+  walk(sf, (node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'map' &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === binding
+    ) {
+      mapCall = node;
+    }
+  });
+  return mapCall;
+}
+
+/** Locales in `i18n.ts`, each mapped to its value for `key`, if it has one. */
+function localeValues(
+  sf: ts.SourceFile,
+  key: string,
+): Record<string, string | undefined> {
+  const locales: Record<string, string | undefined> = {};
+
+  walk(sf, (node) => {
+    if (
+      !ts.isVariableDeclaration(node) ||
+      !ts.isIdentifier(node.name) ||
+      node.name.text !== 'translations' ||
+      !node.initializer ||
+      !ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      return;
+    }
+
+    for (const locale of node.initializer.properties) {
+      if (
+        !ts.isPropertyAssignment(locale) ||
+        !ts.isIdentifier(locale.name) ||
+        !ts.isObjectLiteralExpression(locale.initializer)
+      ) {
+        continue;
+      }
+      let value: string | undefined;
+      for (const entry of locale.initializer.properties) {
+        if (!ts.isPropertyAssignment(entry) || !entry.name) continue;
+        const name = ts.isIdentifier(entry.name)
+          ? entry.name.text
+          : ts.isStringLiteral(entry.name)
+            ? entry.name.text
+            : undefined;
+        if (name !== key) continue;
+        if (
+          ts.isStringLiteral(entry.initializer) ||
+          ts.isNoSubstitutionTemplateLiteral(entry.initializer)
+        ) {
+          value = entry.initializer.text;
+        }
+      }
+      locales[locale.name.text] = value;
+    }
+  });
+
+  return locales;
+}
+
+/** The string members of a string-literal union type alias. */
+function unionMembers(sf: ts.SourceFile, alias: string): string[] {
+  const members: string[] = [];
+  walk(sf, (node) => {
+    if (!ts.isTypeAliasDeclaration(node) || node.name.text !== alias) return;
+    const type = node.type;
+    const parts = ts.isUnionTypeNode(type) ? type.types : [type];
+    for (const part of parts) {
+      if (ts.isLiteralTypeNode(part) && ts.isStringLiteral(part.literal)) {
+        members.push(part.literal.text);
+      }
+    }
+  });
+  return members;
+}
+
+describe('the login page tells an owner the site is configurable', () => {
+  const page = parse(LOGIN_PAGE);
+
+  it('renders the hint through the locale system exactly once', () => {
+    const calls = translationCalls(page).filter((c) => c.key === HINT_KEY);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('renders the hint under no condition at all', () => {
+    // The whole point: it has to be readable by someone who is not logged in,
+    // because the panel it describes only exists for someone who is.
+    const [call] = translationCalls(page).filter((c) => c.key === HINT_KEY);
+    expect(enclosingConditions(call.node, page)).toEqual([]);
+  });
+
+  it('places the hint inside the rendered output, not in a string constant', () => {
+    const [call] = translationCalls(page).filter((c) => c.key === HINT_KEY);
+    let inJsx = false;
+    let current: ts.Node | undefined = call.node.parent;
+    while (current && !ts.isSourceFile(current)) {
+      if (ts.isJsxExpression(current)) {
+        inJsx = true;
+        break;
+      }
+      current = current.parent;
+    }
+    expect(inJsx).toBe(true);
+  });
+
+  it('leaves no hardcoded English on the page for a locale to miss', () => {
+    // Every string the page displays is a t() call, so these two must not come
+    // back as literals the way they shipped.
+    const source = page.getFullText();
+    for (const literal of [
+      'Choose your preferred login method',
+      'Back to blog',
+    ]) {
+      expect(source).not.toContain(literal);
+    }
+  });
+});
+
+describe('the login methods are offered in the order the resolver returns', () => {
+  const page = parse(LOGIN_PAGE);
+
+  it('renders them by mapping the ordered list', () => {
+    expect(orderedMethodsMap(page)).toBeDefined();
+  });
+
+  it('renders no method card outside that map', () => {
+    // Source order is what put a desktop-extension install prompt first on a
+    // phone. A card rendered next to the map, on its own `includes` check,
+    // would restore that for whichever method it is.
+    const map = orderedMethodsMap(page);
+    const inside = new Set(
+      jsxElements(map!, page, METHOD_COMPONENTS).map((e) => e.node),
+    );
+    const outside = jsxElements(page, page, METHOD_COMPONENTS)
+      .filter((e) => !inside.has(e.node))
+      .map((e) => e.tag);
+    expect(outside).toEqual([]);
+  });
+
+  it('renders every method card the page imports', () => {
+    const map = orderedMethodsMap(page);
+    const rendered = jsxElements(map!, page, METHOD_COMPONENTS).map(
+      (e) => e.tag,
+    );
+    expect([...rendered].sort()).toEqual([...METHOD_COMPONENTS].sort());
+  });
+});
+
+describe('the hint is translated everywhere the app claims to be', () => {
+  const i18n = parse(I18N_MODULE);
+  const values = localeValues(i18n, HINT_KEY);
+
+  it('is a declared translation key', () => {
+    expect(unionMembers(i18n, 'TranslationKey')).toContain(HINT_KEY);
+  });
+
+  it('finds every locale the app ships', () => {
+    // Guards the reader itself: an empty result would make the next test pass
+    // vacuously.
+    expect(Object.keys(values).length).toBeGreaterThanOrEqual(6);
+  });
+
+  it.each(Object.keys(values))('%s defines it with real text', (locale) => {
+    const value = values[locale];
+    expect(value).toBeDefined();
+    expect(value!.trim().length).toBeGreaterThan(0);
+    expect(value).not.toBe(HINT_KEY);
+  });
+});
+
+describe('the guard catches the ways around it', () => {
+  const from = (code: string) => parseSource(code);
+
+  it('reads the condition an owner gate would put around the hint', () => {
+    const sf = from(
+      "export const A = () => <div>{isBlogOwner && <p>{t('login_owner_hint')}</p>}</div>;",
+    );
+    const [call] = translationCalls(sf).filter((c) => c.key === HINT_KEY);
+    expect(enclosingConditions(call.node, sf)).toContain('isBlogOwner');
+  });
+
+  it('reads the condition a ternary would put around the hint', () => {
+    const sf = from(
+      "export const A = () => <div>{user ? <p>{t('login_owner_hint')}</p> : null}</div>;",
+    );
+    const [call] = translationCalls(sf).filter((c) => c.key === HINT_KEY);
+    expect(enclosingConditions(call.node, sf)).toContain('user');
+  });
+
+  it('does not accept the hint written as a literal', () => {
+    const sf = from(
+      'export const A = () => <p>If this site is yours, sign in with the account that owns it.</p>;',
+    );
+    expect(translationCalls(sf).filter((c) => c.key === HINT_KEY)).toEqual([]);
+  });
+
+  it('does not accept the key mentioned outside a t() call', () => {
+    const sf = from("const KEY = 'login_owner_hint'; export const A = () => KEY;");
+    expect(translationCalls(sf).filter((c) => c.key === HINT_KEY)).toEqual([]);
+  });
+
+  it('finds the map through a useMemo, and through a plain const', () => {
+    for (const declaration of [
+      'const ordered = useMemo(() => orderAuthMethods(m), [m]);',
+      'const ordered = orderAuthMethods(m);',
+    ]) {
+      const sf = from(
+        [
+          'export const A = () => {',
+          declaration,
+          '  return <div>{ordered.map((x) => <ExtensionLogin key={x} />)}</div>;',
+          '};',
+        ].join('\n'),
+      );
+      expect(orderedMethodsMap(sf)).toBeDefined();
+    }
+  });
+
+  it('does not accept a map over some other list', () => {
+    // The hole a name match would leave: `orderedMethods` reading whatever it
+    // likes, with the resolver called and thrown away.
+    const sf = from(
+      [
+        'export const A = () => {',
+        '  const ordered = orderAuthMethods(m);',
+        '  const orderedMethods = availableMethods;',
+        '  return <div>{orderedMethods.map((x) => <ExtensionLogin key={x} />)}</div>;',
+        '};',
+      ].join('\n'),
+    );
+    expect(orderedMethodsMap(sf)).toBeUndefined();
+  });
+
+  it('does not accept the resolver being absent', () => {
+    const sf = from(
+      'export const A = () => <div>{availableMethods.map((x) => <ExtensionLogin key={x} />)}</div>;',
+    );
+    expect(orderedMethodsMap(sf)).toBeUndefined();
+  });
+
+  it('sees a method card rendered beside the map', () => {
+    const sf = from(
+      [
+        'export const A = () => {',
+        '  const ordered = orderAuthMethods(m);',
+        '  return (<div>',
+        '    {ordered.map((x) => <HiveAuthLogin key={x} />)}',
+        "    {available.includes('keychain') && <ExtensionLogin />}",
+        '  </div>);',
+        '};',
+      ].join('\n'),
+    );
+    const map = orderedMethodsMap(sf)!;
+    const inside = new Set(
+      jsxElements(map, sf, METHOD_COMPONENTS).map((e) => e.node),
+    );
+    const outside = jsxElements(sf, sf, METHOD_COMPONENTS)
+      .filter((e) => !inside.has(e.node))
+      .map((e) => e.tag);
+    expect(outside).toEqual(['ExtensionLogin']);
+  });
+
+  it('reads a locale block that is missing the key', () => {
+    const sf = parseSource(
+      [
+        'const translations = {',
+        "  en: { login_owner_hint: 'here' },",
+        "  es: { login: 'hola' },",
+        '};',
+      ].join('\n'),
+      'probe.ts',
+    );
+    expect(localeValues(sf, HINT_KEY)).toEqual({ en: 'here', es: undefined });
+  });
+
+  it('reads a union that is missing the key', () => {
+    const sf = parseSource("type TranslationKey = 'login' | 'logout';", 'probe.ts');
+    expect(unionMembers(sf, 'TranslationKey')).not.toContain(HINT_KEY);
+  });
+});

--- a/apps/self-hosted/src/routes/-login-owner-hint.test.ts
+++ b/apps/self-hosted/src/routes/-login-owner-hint.test.ts
@@ -178,6 +178,63 @@ function orderedMethodsMap(sf: ts.SourceFile): ts.CallExpression | undefined {
   return mapCall;
 }
 
+interface SwitchShape {
+  cases: string[];
+  hasDefault: boolean;
+  /** Whether the default clause returns null or undefined, rendering nothing. */
+  defaultReturnsNothing: boolean;
+}
+
+/**
+ * The shape of the first switch statement inside `root`.
+ *
+ * Read from the syntax tree rather than from the text, because the method names
+ * appear in this file as import paths and component names too. What matters is
+ * which values the switch has a branch for and what it does with the rest.
+ */
+function switchInside(
+  root: ts.Node,
+  sf: ts.SourceFile,
+): SwitchShape | undefined {
+  let shape: SwitchShape | undefined;
+
+  walk(root, (node) => {
+    if (shape || !ts.isSwitchStatement(node)) return;
+
+    const cases: string[] = [];
+    let hasDefault = false;
+    let defaultReturnsNothing = false;
+
+    for (const clause of node.caseBlock.clauses) {
+      if (ts.isCaseClause(clause)) {
+        cases.push(
+          ts.isStringLiteral(clause.expression) ||
+            ts.isNoSubstitutionTemplateLiteral(clause.expression)
+            ? clause.expression.text
+            : `<computed:${clause.expression.getText(sf)}>`,
+        );
+        continue;
+      }
+      hasDefault = true;
+      for (const statement of clause.statements) {
+        if (!ts.isReturnStatement(statement)) continue;
+        const value = statement.expression;
+        if (
+          !value ||
+          value.kind === ts.SyntaxKind.NullKeyword ||
+          (ts.isIdentifier(value) && value.text === 'undefined')
+        ) {
+          defaultReturnsNothing = true;
+        }
+      }
+    }
+
+    shape = { cases, hasDefault, defaultReturnsNothing };
+  });
+
+  return shape;
+}
+
 /** Locales in `i18n.ts`, each mapped to its value for `key`, if it has one. */
 function localeValues(
   sf: ts.SourceFile,
@@ -313,6 +370,25 @@ describe('the login methods are offered in the order the resolver returns', () =
     );
     expect([...rendered].sort()).toEqual([...METHOD_COMPONENTS].sort());
   });
+
+  it('renders a card only for a method it knows, and nothing for one it does not', () => {
+    // `orderAuthMethods` reorders and deduplicates but never filters, so a name
+    // the config accepted and this page cannot render still arrives here. The
+    // shape this replaced tested `includes()` per known method and so could not
+    // render an unknown one by construction; mapping the list can, unless the
+    // switch is closed with a default.
+    const map = orderedMethodsMap(page)!;
+    const [callback] = map.arguments;
+    const shape = switchInside(callback, page);
+    expect(shape).toBeDefined();
+    expect([...shape!.cases].sort()).toEqual([
+      'hiveauth',
+      'hivesigner',
+      'keychain',
+    ]);
+    expect(shape!.hasDefault).toBe(true);
+    expect(shape!.defaultReturnsNothing).toBe(true);
+  });
 });
 
 describe('the hint is translated everywhere the app claims to be', () => {
@@ -427,6 +503,38 @@ describe('the guard catches the ways around it', () => {
       .filter((e) => !inside.has(e.node))
       .map((e) => e.tag);
     expect(outside).toEqual(['ExtensionLogin']);
+  });
+
+  it('sees a switch that lost its default, so an unknown method would render nothing safely', () => {
+    const open = parseSource(
+      [
+        'export const A = () => {',
+        '  const ordered = orderAuthMethods(m);',
+        '  return <div>{ordered.map((x) => {',
+        "    switch (x) { case 'hiveauth': return <HiveAuthLogin />; }",
+        '  })}</div>;',
+        '};',
+      ].join('\n'),
+    );
+    const shape = switchInside(orderedMethodsMap(open)!.arguments[0], open)!;
+    expect(shape.cases).toEqual(['hiveauth']);
+    expect(shape.hasDefault).toBe(false);
+  });
+
+  it('sees a default that renders something instead of nothing', () => {
+    const loud = parseSource(
+      [
+        'export const A = () => {',
+        '  const ordered = orderAuthMethods(m);',
+        '  return <div>{ordered.map((x) => {',
+        "    switch (x) { case 'hiveauth': return <HiveAuthLogin />; default: return <Unknown />; }",
+        '  })}</div>;',
+        '};',
+      ].join('\n'),
+    );
+    const shape = switchInside(orderedMethodsMap(loud)!.arguments[0], loud)!;
+    expect(shape.hasDefault).toBe(true);
+    expect(shape.defaultReturnsNothing).toBe(false);
   });
 
   it('reads a locale block that is missing the key', () => {

--- a/apps/self-hosted/src/routes/login.tsx
+++ b/apps/self-hosted/src/routes/login.tsx
@@ -1,12 +1,17 @@
 'use client';
 
 import { createFileRoute, useNavigate, useSearch } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
-import { useAuth, useIsAuthenticated, useIsAuthEnabled, useAvailableAuthMethods } from '@/features/auth';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  useIsAuthenticated,
+  useIsAuthEnabled,
+  useAvailableAuthMethods,
+  orderAuthMethods,
+} from '@/features/auth';
 import { ExtensionLogin } from '@/features/auth/components/extension-login';
 import { HiveAuthLogin } from '@/features/auth/components/hiveauth-login';
 import { HivesignerLogin } from '@/features/auth/components/hivesigner-login';
-import { InstanceConfigManager } from '@/core';
+import { InstanceConfigManager, t } from '@/core';
 
 /**
  * Validates that a redirect URL is safe (internal path only).
@@ -59,6 +64,13 @@ function LoginPage() {
     ({ configuration }) => configuration.instanceConfiguration.meta.title
   );
 
+  // Which method can actually complete depends on the device, not on the order
+  // the config happens to list them in. See orderAuthMethods.
+  const orderedMethods = useMemo(
+    () => orderAuthMethods(availableMethods),
+    [availableMethods]
+  );
+
   // Redirect if already authenticated
   useEffect(() => {
     if (isAuthenticated) {
@@ -90,9 +102,26 @@ function LoginPage() {
     <div className="min-h-screen flex items-center justify-center p-4 bg-theme-primary">
       <div className="w-full max-w-md">
         <div className="card-theme p-6 sm:p-8">
-          <div className="text-center mb-8">
-            <h1 className="text-2xl font-bold heading-theme mb-2">Login to {blogTitle}</h1>
-            <p className="text-theme-muted font-theme-ui">Choose your preferred login method</p>
+          <div className="mb-8">
+            <h1 className="text-2xl font-bold heading-theme mb-1 text-center">
+              {t('login')}
+            </h1>
+            {blogTitle && (
+              <p className="text-theme-muted font-theme-ui text-center">
+                {blogTitle}
+              </p>
+            )}
+            {/* The only place a hosted site says it is configurable at all.
+                Deliberately not gated on anything: who the owner is cannot be
+                known before they authenticate, and this page is what tells them
+                authenticating is worth doing. Without it a site can run
+                indefinitely on the stock template, because the panel that
+                changes it only exists once you are already signed in. Phrased so
+                a reader who is not the owner reads one sentence that does not
+                apply to them and moves on. */}
+            <p className="mt-4 text-sm text-theme-muted font-theme-ui">
+              {t('login_owner_hint')}
+            </p>
           </div>
 
           {error && (
@@ -102,13 +131,32 @@ function LoginPage() {
           )}
 
           <div className="space-y-3">
-            {availableMethods.includes('keychain') && (
-              <ExtensionLogin onSuccess={handleSuccess} onError={handleError} />
-            )}
-            {availableMethods.includes('hivesigner') && <HivesignerLogin />}
-            {availableMethods.includes('hiveauth') && (
-              <HiveAuthLogin onSuccess={handleSuccess} onError={handleError} />
-            )}
+            {orderedMethods.map((method) => {
+              switch (method) {
+                case 'keychain':
+                  return (
+                    <ExtensionLogin
+                      key={method}
+                      onSuccess={handleSuccess}
+                      onError={handleError}
+                    />
+                  );
+                case 'hivesigner':
+                  return <HivesignerLogin key={method} />;
+                case 'hiveauth':
+                  return (
+                    <HiveAuthLogin
+                      key={method}
+                      onSuccess={handleSuccess}
+                      onError={handleError}
+                    />
+                  );
+                default:
+                  // A method name the config accepted but this page cannot
+                  // render. Nothing, rather than a blank card.
+                  return null;
+              }
+            })}
           </div>
 
           <div className="mt-8 text-center">
@@ -117,7 +165,7 @@ function LoginPage() {
               onClick={() => navigate({ to: '/' })}
               className="text-sm text-theme-muted hover:text-theme-primary transition-theme font-theme-ui"
             >
-              Back to blog
+              {t('back_to_blog')}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Why

The Configuration Editor renders only through `AuthorizedFloatingMenu` (`src/routes/__root.tsx`), gated on `useIsBlogOwner()`. It exists only for a viewer who has already signed in as the instance owner. Nothing outside it says so, so the one instruction that matters was reachable only by someone who had already followed it. A site can run indefinitely on whatever it was provisioned with for that reason alone.

The signup flow does say it, once: the "What's next?" block on the in-session success screen (`apps/web/src/features/hosting-signup/hosting-signup.tsx`) tells the buyer to sign in on their new site and press the settings button. That block is skipped whenever the card poll times out, the broadcast is not confirmed inside the poll window, the buyer pays from another wallet, or the tab is closed. A returning owner lands on the manage panel, which says nothing about it. So the instruction cannot be relied on to have been read.

## What changed

**The login page carries the note.** It is the only surface that is both reachable while logged out and reached deliberately, so it is where an owner can be told before they authenticate. The note sits above the method list and is gated on nothing: ownership cannot be known before authentication, so gating it would restore the same circularity. It is written so a visitor who is not the owner reads one sentence that does not apply to them and moves on.

Nothing new is added to the blog itself. A reader sees exactly what they saw before; the existing `Login` control in `BlogNavigation` is unchanged.

**Login methods are ranked by what can complete the task the page advertises.** Only two sessions can save a configuration change: `getHostingToken` mints a hosting token from a Hivesigner access token verified server side, or from a login challenge signed offline by a browser extension. Every other session falls to `default` and throws. A HiveAuth session can broadcast, so it votes, comments and publishes, but `hive-auth-wrapper` exposes no `broadcast: false` mode, so it cannot sign the challenge and cannot save anything.

So `CONFIG_SAVING_METHODS` records that capability, both saving methods are offered first, and `hivesigner` leads them because it is the only one that both saves and works on a phone. `hiveauth` is last. That is not a demotion of the reader path: a reader only needs to vote and comment, which it does, and it is still on the page.

**The hint says what saving needs**, rather than promising a panel that a chosen method cannot use: it names the methods that can save and states that a HiveAuth session cannot yet. All six shipped locales updated.

**`orderAuthMethods` deduplicates.** The shape this replaced tested `includes()` per known method, so a config naming one twice still rendered a single card. Mapping the list rendered two cards under one React key. First occurrence wins, so an unranked duplicate cannot jump its position, and an unknown method still reaches the page and still renders nothing.

**The page's hardcoded English goes through the locale system.** `Choose your preferred login method`, `Back to blog` and `Login to <title>` were literals.

## The gap this makes visible

On a stock instance the set of methods that are offered, can save config, and work on a phone is **empty**. `hivesigner` is listed in both seed configs but `availableAuthMethods` drops it, because neither seed sets `general.hivesigner.clientId`. That leaves the extension, which is desktop only, and HiveAuth, which cannot save. Configuring a site from a phone is currently impossible.

This PR does not close that; the wrapper limitation is real and out of scope here. It stops the page from leading an owner into it, and states the constraint plainly instead. The actual unlock is issue #1318, seeding `general.hivesigner.clientId`, which would make a mobile-capable saving method available immediately. The redirect URIs are already registered for existing instances; the reason it is not seeded is that a newly provisioned instance would carry an unregistered URI and the button would fail, which is exactly why `availableAuthMethods` hides it.

## What an owner sees now

1. Opens their site on any device and taps `Login` in the header (already there, already visible on mobile).
2. Reads, before choosing a method, that signing in with the owning account is how the title, logo, theme and layout are changed, and which methods can save them.
3. Signs in with a method that can finish, which the page now offers first.
4. The settings button appears and opens the Configuration Editor as before.

## Tests

`src/features/auth/utils/auth-methods.test.ts`: ordering (savers first, `hivesigner` leading, what the stock config actually produces), reorder-never-filter, unranked methods kept in configured position, no mutation of the caller's array, deduplication including first-occurrence-wins and unknown methods, and the capability predicate.

`src/features/auth/utils/config-saving-capability.test.ts`: reads the case labels of the `user.loginType` switch in `hosting-token.ts` off the syntax tree and asserts they are exactly `CONFIG_SAVING_METHODS`, that the `default` still throws, that no non-saving method is ever ordered ahead of a saving one for any subset an instance may offer, and that the hint names every method on both sides of that line. Reading labels rather than searching text matters: the module's own doc comment names all three methods in prose, so a text search reads the opposite of the truth off it.

`src/routes/-login-owner-hint.test.ts`: AST guard (vitest here is `environment: 'node'`, `include: ['src/**/*.test.ts']`, so `.tsx` is not testable). The hint renders through a `t()` call inside JSX under no enclosing condition; the cards are rendered by mapping the value `orderAuthMethods` was declared into, followed by value rather than by variable name; no card is rendered outside that map; the switch inside the map has exactly the three known cases and a `default` that renders nothing; the removed literals do not come back; the key is a declared `TranslationKey` present with real text in every locale block. Each analysis function is exercised against snippets for the ways around it.

**Mutations verified**, each failing the intended tests and no others:

Round 1: ordering made an identity function; made a filter; sorting the caller's array in place; tiebreak reversed; hint gated on `isAuthenticated`; hint written as an English literal; methods rendered in source order again; a card rendered beside the map; `Back to blog` hardcoded again; `ru` locale losing the key; `ko` locale set to whitespace; key removed from the `TranslationKey` union; the `translations` object renamed, so the locale reader cannot pass vacuously.

Round 2: `hiveauth` promoted back to first; deduplication removed; deduplication keeping the last occurrence instead of the first; `hiveauth` declared able to save; `hosting-token.ts` gaining a `hiveauth` case; its `default` returning instead of throwing; its `keychain` case removed; the hint reverted to the old unqualified promise; the hint dropping the extension as a way to save; the hint dropping the HiveAuth warning; the login switch losing its `default`; its `default` rendering a card; its `hivesigner` case removed.

`vitest run` 52 files / 591 tests pass, including the internal-link route guard. `tsc --noEmit` clean. `rsbuild build` plus `scripts/check-node-globals.mjs` clean.

## Not done here, and why

- **No config field.** The note is not configurable; another agent owns `config-fields.ts`. If it should be suppressible per instance, that is a separate change.
- **Issue #1318, seeding the Hivesigner client id**, is the change that actually makes configuring from a phone possible. Stated above so it is on the record.
- **The owner notice specced for the panel** has the same circularity as everything else inside the panel: it cannot be read by someone who cannot open the panel. Worth having for a signed-in owner, but it cannot be the thing that gets them signed in.
- **The signup and manage flows** are the other half. `hosting-manage.tsx` has no customization copy at all, and the success-screen block that does is unreachable in several ordinary payment paths. Not touched here to keep this to the self-hosted app.
- **The floating menu still bypasses i18n entirely** (`src/features/floating-menu/**`), including its own `Settings` button label. Left alone; the new strings follow the correct pattern rather than the nearest one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a localized hint explaining ownership during self-hosted sign-in.
  * Login options are now displayed in a consistent order, prioritizing methods that can save configuration.
  * Improved localization for login headings and navigation text across supported languages.
  * Unsupported authentication methods are safely excluded from the login interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->