### PR TITLE
self-hosted: derive the appearance from one accent and one font pairing

### DIFF
--- a/apps/self-hosted/src/core/apply-config-dom.test.ts
+++ b/apps/self-hosted/src/core/apply-config-dom.test.ts
@@ -1,4 +1,7 @@
 // @vitest-environment jsdom
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   applyConfigDom,
@@ -8,6 +11,27 @@ import {
   restoreConfigDom,
   snapshotConfigDom,
 } from './apply-config-dom';
+import { FONT_PRESETS } from './theme-appearance';
+
+const APP = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function declaredVariables(): string[] {
+  return CONFIG_DOM_DECLARATION.cssVariables.map(({ variable }) => variable);
+}
+
+function inlineVariables(): Record<string, string> {
+  const root = document.documentElement;
+  const out: Record<string, string> = {};
+  for (const variable of declaredVariables()) {
+    const value = root.style.getPropertyValue(variable);
+    if (value !== '') out[variable] = value;
+  }
+  return out;
+}
+
+function styles(value: Record<string, unknown>) {
+  return { configuration: { general: { styles: value } } };
+}
 
 function configWithTitle(title: string) {
   return { configuration: { instanceConfiguration: { meta: { title } } } };
@@ -239,6 +263,201 @@ describe('declared CSS variables', () => {
     expect(
       document.documentElement.style.getPropertyValue('--instance-accent'),
     ).toBe('#0000ff');
+  });
+});
+
+describe('the appearance knobs', () => {
+  /**
+   * The claim this file exists to pin: no instance changes because these knobs
+   * shipped. Nothing is written to any tenant document, and every config on
+   * disk carries neither field, so every resolver reads undefined and every
+   * property is removed rather than set.
+   */
+  it('sets nothing at all for the configs that are actually deployed', () => {
+    const seeds: Array<[string, unknown]> = [
+      [
+        'config.template.json',
+        JSON.parse(readFileSync(join(APP, 'config.template.json'), 'utf8')),
+      ],
+      [
+        'hosting/default-config.json',
+        JSON.parse(
+          readFileSync(join(APP, 'hosting', 'default-config.json'), 'utf8'),
+        ),
+      ],
+    ];
+
+    for (const [name, seed] of seeds) {
+      applyConfigDom(seed);
+      expect(`${name}: ${JSON.stringify(inlineVariables())}`).toBe(
+        `${name}: {}`,
+      );
+    }
+  });
+
+  it('is absent from the document the hosting API seeds', () => {
+    // getDefaultConfig is only exercised at tenant creation, so the seed is
+    // read as source here rather than imported: a styles block that gained an
+    // accent would put a colour on every new instance without anyone choosing
+    // it.
+    const source = readFileSync(
+      join(APP, 'hosting', 'api', 'src', 'services', 'tenant-service.ts'),
+      'utf8',
+    );
+    const seeded = /styles:\s*\{([\s\S]*?)\}/.exec(source);
+
+    expect(seeded).not.toBeNull();
+    expect(seeded?.[1]).toContain('background:');
+    expect(seeded?.[1]).not.toContain('accent');
+    expect(seeded?.[1]).not.toContain('fontPreset');
+  });
+
+  it('treats every unusable value exactly as it treats absence', () => {
+    // '' is the only "unset" the editor can produce, so it has to mean the same
+    // thing as a key that was never written; the rest are what the server will
+    // happily store and the client must refuse to put on the page. An accent
+    // that reached CSS as `banana` would make every
+    // `background-color: var(--theme-accent)` invalid at computed-value time.
+    for (const accent of [
+      '',
+      '   ',
+      null,
+      'banana',
+      'rgb(0, 0, 0)',
+      'var(--x)',
+      '#12345',
+      '#8b4513ff',
+      123,
+      {},
+      [],
+    ]) {
+      applyConfigDom(styles({ accent }));
+      expect(
+        `${JSON.stringify(accent)}: ${JSON.stringify(inlineVariables())}`,
+      ).toBe(`${JSON.stringify(accent)}: {}`);
+    }
+
+    for (const fontPreset of ['', 'comic-sans', 'toString', 42, null]) {
+      applyConfigDom(styles({ fontPreset }));
+      expect(
+        `${JSON.stringify(fontPreset)}: ${JSON.stringify(inlineVariables())}`,
+      ).toBe(`${JSON.stringify(fontPreset)}: {}`);
+    }
+  });
+
+  it('writes one colour as the five values the page reads', () => {
+    applyConfigDom(styles({ accent: '#8B4513' }));
+
+    const inline = inlineVariables();
+    expect(inline['--theme-accent']).toBe('#8b4513');
+    expect(inline['--theme-accent-contrast']).toBe('#ffffff');
+    // The hover is a constant string containing var(--theme-accent-shade), so
+    // an OS flip re-substitutes it with no JS and no stale value.
+    expect(inline['--theme-accent-hover']).toContain(
+      'var(--theme-accent-shade)',
+    );
+    // Both mode variants are written and CSS picks, which is what lets the
+    // system-theme listener stay untouched and a preview survive an OS flip.
+    expect(inline['--theme-accent-text-light']).toBe('#8b4513');
+    expect(inline['--theme-accent-text-dark']).not.toBe(
+      inline['--theme-accent-text-light'],
+    );
+    expect(inline['--theme-font-body']).toBeUndefined();
+  });
+
+  it('writes all three faces for a pairing, never one of them', () => {
+    applyConfigDom(styles({ fontPreset: 'technical' }));
+
+    const inline = inlineVariables();
+    expect(inline['--theme-font-body']).toBe(FONT_PRESETS.technical.body);
+    expect(inline['--theme-font-heading']).toBe(FONT_PRESETS.technical.heading);
+    expect(inline['--theme-font-ui']).toBe(FONT_PRESETS.technical.ui);
+    expect(inline['--theme-accent']).toBeUndefined();
+  });
+
+  it('clears everything again when the owner clears the field', () => {
+    applyConfigDom(styles({ accent: '#8b4513', fontPreset: 'classic' }));
+    expect(Object.keys(inlineVariables()).length).toBe(
+      declaredVariables().length,
+    );
+
+    applyConfigDom(styles({ accent: '', fontPreset: '' }));
+    expect(inlineVariables()).toEqual({});
+  });
+
+  it('is snapshotted and restored without naming a single property', () => {
+    // Preview is generic over the declaration, so a knob added without a
+    // restore path fails here rather than leaking styling out of preview.
+    const snapshot = snapshotConfigDom();
+    expect(Object.keys(snapshot.cssVariables).sort()).toEqual(
+      declaredVariables().sort(),
+    );
+
+    applyConfigDom(styles({ accent: '#7c3aed', fontPreset: 'modern' }));
+    restoreConfigDom(snapshot);
+
+    expect(inlineVariables()).toEqual({});
+  });
+
+  it('writes only properties a stylesheet reads', () => {
+    // Nine token families shipped with no consumer the last time appearance
+    // work landed here. A property nothing reads is a knob that does nothing.
+    const stylesheets: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) walk(path);
+        else if (entry.name.endsWith('.css'))
+          stylesheets.push(readFileSync(path, 'utf8'));
+      }
+    };
+    walk(join(APP, 'src', 'styles'));
+
+    const unread = declaredVariables().filter(
+      (variable) => !stylesheets.some((css) => css.includes(`var(${variable}`)),
+    );
+    expect(unread).toEqual([]);
+  });
+});
+
+describe('the configured theme', () => {
+  it('is matched case-insensitively', () => {
+    // text() neither lowercased nor validated, so `theme: "Dark"` reached the
+    // document as data-theme="Dark", which matches no block in any stylesheet:
+    // the instance asked for dark and rendered light.
+    applyConfigDom({ configuration: { general: { theme: 'Dark' } } });
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    applyConfigDom({ configuration: { general: { theme: ' LIGHT ' } } });
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('never reaches the document as a value no block matches', () => {
+    for (const theme of ['sepia', 'Dark mode', 'system ', 42, {}, null, '']) {
+      applyConfigDom({ configuration: { general: { theme } } });
+      expect(
+        `${JSON.stringify(theme)}: ${document.documentElement.getAttribute('data-theme')}`,
+      ).toMatch(/: (light|dark)$/);
+    }
+  });
+
+  it('follows the operating system whatever case it is written in', () => {
+    let listening = false;
+    (window as { matchMedia?: unknown }).matchMedia = () => ({
+      matches: true,
+      addEventListener() {
+        listening = true;
+      },
+      removeEventListener() {},
+    });
+
+    applyConfigDom(
+      { configuration: { general: { theme: 'System' } } },
+      { syncSystemTheme: true },
+    );
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(listening).toBe(true);
   });
 });
 

--- a/apps/self-hosted/src/core/apply-config-dom.ts
+++ b/apps/self-hosted/src/core/apply-config-dom.ts
@@ -13,6 +13,13 @@
  * holds the raw JSON document it is editing.
  */
 
+import {
+  type AccentAppearance,
+  type FontPreset,
+  resolveAccent,
+  resolveFontPreset,
+} from './theme-appearance';
+
 export type ConfigReader = (path: string) => unknown;
 
 export interface ConfigDomAttribute {
@@ -126,6 +133,8 @@ const PATHS = {
   styleTemplate: 'configuration.general.styleTemplate',
   language: 'configuration.general.language',
   background: 'configuration.general.styles.background',
+  accent: 'configuration.general.styles.accent',
+  fontPreset: 'configuration.general.styles.fontPreset',
   instanceType: 'configuration.instanceConfiguration.type',
   title: 'configuration.instanceConfiguration.meta.title',
   listType: 'configuration.instanceConfiguration.layout.listType',
@@ -141,12 +150,45 @@ const PATHS = {
 
 export const DEFAULT_THEME = 'light';
 
+/** Everything `data-theme` is allowed to be, plus the one that resolves. */
+const THEMES = new Set(['system', 'light', 'dark']);
+
+/**
+ * The configured theme, lowercased and held to the closed set.
+ *
+ * `text()` neither lowercases nor validates, so `theme: "Dark"` used to reach
+ * the document as `data-theme="Dark"`, which matches no block in any stylesheet:
+ * the tenant asked for dark and got the light palette, silently. Anything
+ * outside the set resolves to the same default an absent value does, so the
+ * attribute this function feeds is always `light` or `dark` and always matches
+ * the blocks the templates declare. Normalising to a value that matched nothing
+ * would be the failure this replaces.
+ */
+function configuredTheme(read: ConfigReader): string {
+  const configured = text(read(PATHS.theme), DEFAULT_THEME).toLowerCase();
+  return THEMES.has(configured) ? configured : DEFAULT_THEME;
+}
+
 function resolveTheme(read: ConfigReader): string {
-  const configured = text(read(PATHS.theme), DEFAULT_THEME);
+  const configured = configuredTheme(read);
   if (configured === 'system') {
     return prefersDarkColorScheme() ? 'dark' : 'light';
   }
   return configured;
+}
+
+/**
+ * The accent knob is one colour and the font knob is one key; the properties
+ * below are derived from them. Resolving the whole set once per property keeps
+ * every entry a pure function of the config, which is what lets preview,
+ * snapshot and restore stay generic over the declaration.
+ */
+function accentOf(read: ConfigReader): AccentAppearance | null {
+  return resolveAccent(read(PATHS.accent));
+}
+
+function fontsOf(read: ConfigReader): FontPreset | null {
+  return resolveFontPreset(read(PATHS.fontPreset));
 }
 
 export const CONFIG_DOM_DECLARATION: ConfigDomDeclaration = {
@@ -186,11 +228,54 @@ export const CONFIG_DOM_DECLARATION: ConfigDomDeclaration = {
       resolve: (read) => flag(read(PATHS.hiveInformation)),
     },
   ],
-  // Nothing is driven by an inline custom property yet: the style templates
-  // declare their variables in CSS. This is where accent color and font
-  // presets attach, and the apply/snapshot/restore machinery already covers
-  // them.
-  cssVariables: [],
+  /**
+   * The owner-facing appearance knobs, as inline custom properties on <html>.
+   *
+   * An inline property beats every stylesheet block, so one accent applies in
+   * both modes and under every style template. A resolver returning null makes
+   * applyConfigDom remove the property, which is how "not configured" and "not
+   * a colour" both land on the template's own value rather than on nothing.
+   *
+   * Two knobs, eight properties: an owner picks one colour and one pairing, and
+   * a config that stored the derived values instead would have them go stale
+   * the moment the source changed.
+   */
+  cssVariables: [
+    {
+      variable: '--theme-accent',
+      resolve: (read) => accentOf(read)?.accent ?? null,
+    },
+    {
+      variable: '--theme-accent-hover',
+      resolve: (read) => accentOf(read)?.hover ?? null,
+    },
+    {
+      variable: '--theme-accent-contrast',
+      resolve: (read) => accentOf(read)?.contrast ?? null,
+    },
+    // Both mode variants are written and CSS picks between them, so an OS flip
+    // under `theme: system` re-resolves with no JS and cannot revert a preview.
+    {
+      variable: '--theme-accent-text-light',
+      resolve: (read) => accentOf(read)?.textLight ?? null,
+    },
+    {
+      variable: '--theme-accent-text-dark',
+      resolve: (read) => accentOf(read)?.textDark ?? null,
+    },
+    {
+      variable: '--theme-font-body',
+      resolve: (read) => fontsOf(read)?.body ?? null,
+    },
+    {
+      variable: '--theme-font-heading',
+      resolve: (read) => fontsOf(read)?.heading ?? null,
+    },
+    {
+      variable: '--theme-font-ui',
+      resolve: (read) => fontsOf(read)?.ui ?? null,
+    },
+  ],
   bodyClasses: {
     prefixes: ['bg-', 'from-', 'via-', 'to-'],
     resolve: (read) =>
@@ -334,7 +419,7 @@ export function applyConfigDom(
   document.title = title ?? baseline;
 
   if (options.syncSystemTheme) {
-    syncSystemTheme(text(read(PATHS.theme), DEFAULT_THEME) === 'system');
+    syncSystemTheme(configuredTheme(read) === 'system');
   }
 }
 

--- a/apps/self-hosted/src/core/configuration-loader.ts
+++ b/apps/self-hosted/src/core/configuration-loader.ts
@@ -63,6 +63,14 @@ export interface InstanceConfig {
     };
       styles: {
         background: string;
+        /**
+         * `#rgb` or `#rrggbb`. Absent, empty and unparseable all mean "the
+         * style template's own accent stands", which is what every instance
+         * written before this field existed renders.
+         */
+        accent?: string;
+        /** A key of FONT_PRESETS, or absent for the template's own faces. */
+        fontPreset?: string;
       };
     };
     instanceConfiguration: {

--- a/apps/self-hosted/src/core/index.ts
+++ b/apps/self-hosted/src/core/index.ts
@@ -4,3 +4,4 @@ export * from './date-formatter';
 export * from './hive-layer';
 export * from './i18n';
 export * from './instance-type-filters';
+export * from './theme-appearance';

--- a/apps/self-hosted/src/core/theme-appearance.test.ts
+++ b/apps/self-hosted/src/core/theme-appearance.test.ts
@@ -1,0 +1,394 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  ACCENT_CONTRAST_TARGET,
+  ACCENT_TINT_PERCENT,
+  accentContrastColor,
+  accentTextFor,
+  accentTextForMode,
+  contrastRatio,
+  DARK_WORST_SURFACE,
+  FONT_PRESET_OPTIONS,
+  FONT_PRESETS,
+  formatHexColor,
+  LIGHT_WORST_SURFACE,
+  parseHexColor,
+  type Rgb,
+  relativeLuminance,
+  resolveAccent,
+  resolveFontPreset,
+  tintedSurface,
+} from './theme-appearance';
+
+/**
+ * The accent knob's promise is that an owner cannot produce an unreadable site
+ * from a valid colour. That is a claim about all 16.7 million of them, so it is
+ * checked by sweeping rather than by naming a few, and the surfaces it is swept
+ * against are read out of the theme files rather than copied into this file: a
+ * template added with a lighter dark surface has to fail here instead of
+ * shipping a sub-AA link to a paying instance.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const STYLES = resolve(HERE, '..', 'styles');
+const THEMES = join(STYLES, 'themes');
+
+/** Every `--theme-bg-primary` the templates declare, split by mode. */
+function declaredSurfaces(): { light: string[]; dark: string[] } {
+  const light = new Set<string>();
+  const dark = new Set<string>();
+
+  for (const file of readdirSync(THEMES)) {
+    if (!file.endsWith('.css')) continue;
+    const css = readFileSync(join(THEMES, file), 'utf8');
+    for (const match of css.matchAll(/--theme-bg-primary:\s*([^;]+);/g)) {
+      const value = match[1].trim();
+      const parsed = parseHexColor(value);
+      if (!parsed) continue;
+      (relativeLuminance(parsed) >= 0.5 ? light : dark).add(
+        value.toLowerCase(),
+      );
+    }
+  }
+
+  return { light: [...light], dark: [...dark] };
+}
+
+const SURFACES = declaredSurfaces();
+
+/** Every 17th value per channel: 16^3 = 4096 colours. */
+function sweep(): string[] {
+  const steps = Array.from({ length: 16 }, (_, index) => index * 17);
+  const out: string[] = [];
+  for (const r of steps)
+    for (const g of steps)
+      for (const b of steps) out.push(formatHexColor([r, g, b]));
+  return out;
+}
+
+const COLOURS = sweep();
+
+function worstRatio(pairs: Array<{ text: string; surface: string }>): {
+  ratio: number;
+  text: string;
+  surface: string;
+} {
+  let worst = { ratio: Number.POSITIVE_INFINITY, text: '', surface: '' };
+  for (const { text, surface } of pairs) {
+    const ratio = contrastRatio(
+      parseHexColor(text) as Rgb,
+      parseHexColor(surface) as Rgb,
+    );
+    if (ratio < worst.ratio) worst = { ratio, text, surface };
+  }
+  return worst;
+}
+
+describe('declared surfaces', () => {
+  it('reads a surface out of every theme file', () => {
+    // Six templates' worth of light and dark palettes. A regex that stopped
+    // matching would otherwise make every sweep below pass vacuously.
+    expect(SURFACES.light.length).toBeGreaterThanOrEqual(3);
+    expect(SURFACES.dark.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('corrects against the hardest surface of each mode', () => {
+    // Dark text is hardest to read on the darkest light surface, and light text
+    // on the lightest dark one.
+    const darkestLight = [...SURFACES.light].sort(
+      (a, b) =>
+        relativeLuminance(parseHexColor(a) as Rgb) -
+        relativeLuminance(parseHexColor(b) as Rgb),
+    )[0];
+    const lightestDark = [...SURFACES.dark].sort(
+      (a, b) =>
+        relativeLuminance(parseHexColor(b) as Rgb) -
+        relativeLuminance(parseHexColor(a) as Rgb),
+    )[0];
+
+    expect(darkestLight).toBe(LIGHT_WORST_SURFACE);
+    expect(lightestDark).toBe(DARK_WORST_SURFACE);
+  });
+});
+
+describe('accentTextFor', () => {
+  it('clears 4.5:1 on every declared surface, over an exhaustive sweep', () => {
+    const failures: string[] = [];
+    const pairs: Array<{ text: string; surface: string }> = [];
+
+    for (const colour of COLOURS) {
+      for (const surface of [...SURFACES.light, ...SURFACES.dark]) {
+        const text = accentTextFor(colour, surface);
+        if (!text) {
+          failures.push(`${colour} on ${surface}: no correction`);
+          continue;
+        }
+        pairs.push({ text, surface });
+      }
+    }
+
+    const worst = worstRatio(pairs);
+    expect(failures).toEqual([]);
+    expect(pairs.length).toBe(
+      COLOURS.length * (SURFACES.light.length + SURFACES.dark.length),
+    );
+    // The walk stops at the first lightness that clears, so the worst case
+    // sitting just above the target is the evidence that it is the target doing
+    // the work rather than the colours happening to be easy.
+    expect(worst.ratio).toBeGreaterThanOrEqual(ACCENT_CONTRAST_TARGET);
+    expect(worst.ratio).toBeLessThan(ACCENT_CONTRAST_TARGET + 0.05);
+  });
+});
+
+describe('accentTextForMode', () => {
+  it('stays readable on the page and on the tag chip it tints', () => {
+    // The chip is the page surface with ACCENT_TINT_PERCENT of the accent mixed
+    // in, which moves the background toward the text. Correcting against the
+    // page alone would leave the chips below the target: the worst case of the
+    // single-surface correction is exactly the target, so any tint at all
+    // pushes it under.
+    const failures: string[] = [];
+
+    for (const colour of COLOURS) {
+      const accent = parseHexColor(colour) as Rgb;
+      for (const mode of ['light', 'dark'] as const) {
+        const text = accentTextForMode(colour, mode);
+        if (!text) {
+          failures.push(`${colour} ${mode}: no correction`);
+          continue;
+        }
+        const parsed = parseHexColor(text) as Rgb;
+        for (const surface of SURFACES[mode]) {
+          const background = parseHexColor(surface) as Rgb;
+          const chip = tintedSurface(accent, background);
+          for (const [what, against] of [
+            ['page', background],
+            ['chip', chip],
+          ] as const) {
+            const ratio = contrastRatio(parsed, against);
+            if (ratio < ACCENT_CONTRAST_TARGET) {
+              failures.push(
+                `${colour} ${mode} on ${surface} ${what}: ${ratio.toFixed(3)}`,
+              );
+            }
+          }
+        }
+      }
+    }
+
+    expect(failures.slice(0, 10)).toEqual([]);
+  });
+
+  it('leaves a colour that is already readable alone', () => {
+    // The correction must not repaint an accent that needs no help, or every
+    // owner gets a colour they did not pick.
+    expect(accentTextForMode('#8b4513', 'light')).toBe('#8b4513');
+    expect(accentTextForMode('#ffff00', 'light')).not.toBe('#ffff00');
+    expect(accentTextForMode('#ffff00', 'dark')).toBe('#ffff00');
+  });
+});
+
+describe('accentContrastColor', () => {
+  it('clears 4.5:1 on the fill, over an exhaustive sweep', () => {
+    const worst = worstRatio(
+      COLOURS.map((colour) => ({
+        text: accentContrastColor(colour) as string,
+        surface: colour,
+      })),
+    );
+
+    expect(worst.ratio).toBeGreaterThanOrEqual(ACCENT_CONTRAST_TARGET);
+  });
+});
+
+describe('parseHexColor', () => {
+  it('accepts the two shorthands and nothing else', () => {
+    expect(parseHexColor('#abc')).toEqual([0xaa, 0xbb, 0xcc]);
+    expect(parseHexColor('#AABBCC')).toEqual([0xaa, 0xbb, 0xcc]);
+    expect(parseHexColor('  #8b4513  ')).toEqual([0x8b, 0x45, 0x13]);
+  });
+
+  it('refuses everything a custom property would swallow', () => {
+    // A custom property parses any token sequence and only fails at
+    // substitution, so an unvalidated value would make every
+    // `background-color: var(--theme-accent)` invalid at computed-value time
+    // and render those surfaces transparent rather than falling back.
+    for (const value of [
+      '',
+      '   ',
+      'banana',
+      'rgb(0, 0, 0)',
+      'rgba(300, 0, 0, 1)',
+      'var(--x)',
+      '#12345',
+      '#8b4513ff',
+      '#',
+      'red',
+      123,
+      null,
+      undefined,
+      {},
+      [],
+      ['#ffffff'],
+    ]) {
+      expect(`${JSON.stringify(value)}: ${parseHexColor(value)}`).toBe(
+        `${JSON.stringify(value)}: null`,
+      );
+    }
+  });
+});
+
+describe('resolveAccent', () => {
+  it('derives every value from the one colour', () => {
+    const resolved = resolveAccent('#8B4513');
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.accent).toBe('#8b4513');
+    expect(resolved?.contrast).toBe('#ffffff');
+    expect(resolved?.textLight).toBe('#8b4513');
+    expect(resolved?.textDark).not.toBe('#8b4513');
+    // The hover is a constant string so it re-substitutes on a mode change
+    // rather than going stale: nothing recomputes it when data-theme flips.
+    expect(resolved?.hover).toContain('var(--theme-accent-shade)');
+    expect(resolved?.hover).toContain('var(--theme-accent)');
+  });
+
+  it('is null for absence and for every unusable value', () => {
+    for (const value of [
+      '',
+      '  ',
+      'banana',
+      '#12345',
+      123,
+      null,
+      undefined,
+      {},
+    ]) {
+      expect(resolveAccent(value)).toBeNull();
+    }
+  });
+});
+
+describe('font presets', () => {
+  const fontsCss = readFileSync(join(STYLES, 'fonts.css'), 'utf8');
+
+  /** The families fonts.css actually downloads, from its Google Fonts URLs. */
+  const loaded = new Set(
+    [...fontsCss.matchAll(/family=([^:&"]+)/g)].map((match) =>
+      match[1].replace(/\+/g, ' '),
+    ),
+  );
+
+  const GENERIC = new Set([
+    'serif',
+    'sans-serif',
+    'monospace',
+    'system-ui',
+    'ui-serif',
+    'ui-sans-serif',
+    'ui-monospace',
+  ]);
+
+  /** Faces the operating system ships. None of these is a download. */
+  const INSTALLED = new Set([
+    '-apple-system',
+    'BlinkMacSystemFont',
+    'Segoe UI',
+    'Roboto',
+    'Arial',
+    'Helvetica Neue',
+    'Georgia',
+    'Times New Roman',
+    'SFMono-Regular',
+    'Menlo',
+    'Consolas',
+  ]);
+
+  function families(stack: string): string[] {
+    return stack.split(',').map((part) => part.trim().replace(/^"|"$/g, ''));
+  }
+
+  it('reads the families fonts.css loads', () => {
+    expect([...loaded].sort()).toEqual([
+      'Inter',
+      'JetBrains Mono',
+      'Playfair Display',
+      'Source Serif 4',
+    ]);
+  });
+
+  it('names no family that nothing loads and nothing ships', () => {
+    // A preset naming an unloaded family renders a silent fallback, which is
+    // the dead-surface pattern the whole appearance track exists to end.
+    const unknown: string[] = [];
+    for (const [key, preset] of Object.entries(FONT_PRESETS)) {
+      for (const face of ['body', 'heading', 'ui'] as const) {
+        for (const family of families(preset[face])) {
+          if (
+            loaded.has(family) ||
+            GENERIC.has(family) ||
+            INSTALLED.has(family)
+          )
+            continue;
+          unknown.push(`${key}.${face}: ${family}`);
+        }
+      }
+    }
+    expect(unknown).toEqual([]);
+  });
+
+  it('sets all three faces in every preset', () => {
+    // --theme-font-ui alone has 29 call sites through font-theme-ui; a preset
+    // that changed body and heading only would read as a bug.
+    for (const preset of Object.values(FONT_PRESETS)) {
+      expect(preset.body.length).toBeGreaterThan(0);
+      expect(preset.heading.length).toBeGreaterThan(0);
+      expect(preset.ui.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('offers exactly the presets it can resolve, plus an explicit unset', () => {
+    // The select renderer falls back to '' for an unconfigured field, so
+    // without an option carrying that value the panel would show the first
+    // preset as selected while the config held nothing, and there would be no
+    // way back to the template's own faces.
+    const values = FONT_PRESET_OPTIONS.map((option) => option.value);
+    expect(values).toContain('');
+    expect(values.filter((value) => value !== '').sort()).toEqual(
+      Object.keys(FONT_PRESETS).sort(),
+    );
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it('resolves a key and refuses anything else', () => {
+    expect(resolveFontPreset('classic')).toBe(FONT_PRESETS.classic);
+    expect(resolveFontPreset(' Classic ')).toBe(FONT_PRESETS.classic);
+    for (const value of ['', '  ', 'comic-sans', 'toString', 123, null, {}]) {
+      expect(resolveFontPreset(value)).toBeNull();
+    }
+  });
+});
+
+describe('the tint the chips use', () => {
+  it('is the mix declared in variables.css', () => {
+    // The correction has to know the surface the corrected text lands on. If
+    // the stylesheet's mix and this constant drift apart, the sweep above is
+    // proving a chip nobody renders.
+    const css = readFileSync(join(THEMES, 'variables.css'), 'utf8');
+    // Transparent-first, so the build's pre-color-mix fallback is an unfilled
+    // chip rather than one filled with the accent at full strength. The share
+    // of the accent is therefore what is left over.
+    const declarations = [
+      ...css.matchAll(
+        /--theme-tag-bg:\s*color-mix\(in srgb, transparent (\d+)%, var\(--theme-accent\)\)/g,
+      ),
+    ];
+
+    expect(declarations.length).toBe(2);
+    for (const declaration of declarations) {
+      expect(100 - Number(declaration[1])).toBe(ACCENT_TINT_PERCENT);
+    }
+  });
+});

--- a/apps/self-hosted/src/core/theme-appearance.ts
+++ b/apps/self-hosted/src/core/theme-appearance.ts
@@ -1,0 +1,392 @@
+/**
+ * The maths behind the two owner-facing appearance knobs.
+ *
+ * `general.styles.accent` is one colour and `general.styles.fontPreset` is one
+ * key. Everything the page needs beyond those two values is derived here: the
+ * hover fill, the text that sits on the accent, and a text colour that stays
+ * readable on every surface the five templates declare. A config that stored
+ * five colours instead would have four of them go stale the moment the fifth
+ * changed.
+ *
+ * Pure: no DOM, no getComputedStyle, no config reading, so the whole thing is
+ * testable and the sweep in theme-appearance.test.ts can prove the contrast
+ * claim over every colour rather than over the handful someone thought of.
+ *
+ * Both mode variants of the corrected text colour are computed and CSS picks
+ * between them (`--theme-accent-text-light` / `--theme-accent-text-dark`), so
+ * nothing has to re-run when the operating system flips light to dark under
+ * `theme: system`, and an active preview is never reverted by a listener.
+ */
+
+export type Rgb = readonly [number, number, number];
+
+/** WCAG 1.4.3 AA for body text. */
+export const ACCENT_CONTRAST_TARGET = 4.5;
+
+/**
+ * How much of the accent a tag chip's background carries, as a percentage.
+ * Kept in step with the `color-mix()` in themes/variables.css by
+ * theme-appearance-tokens.test.ts: the correction below has to know the surface
+ * the corrected text actually lands on, and the chip is the darkest (in light
+ * mode) or lightest (in dark mode) of them.
+ */
+export const ACCENT_TINT_PERCENT = 12;
+
+/**
+ * The hardest surface of each mode, out of every `--theme-bg-primary` the
+ * templates declare. Dark text is hardest to read on the darkest light surface
+ * and light text on the lightest dark one, so correcting against these two
+ * covers all of them. theme-appearance.test.ts derives both from the theme
+ * files and fails if a new template moves the worst case.
+ */
+export const LIGHT_WORST_SURFACE = '#eff1f5';
+export const DARK_WORST_SURFACE = '#1e1e2e';
+
+/**
+ * The candidates for text placed on the accent fill.
+ *
+ * The softer near-black is preferred, and pure black is the fallback for the
+ * band of mid-tone accents where neither white nor #111827 reaches the target:
+ * measured over the 4096-colour sweep, 254 of them fall short that way, worst
+ * case 4.213:1 on #dd4444. A design that named only the first two would ship
+ * sub-AA text on the accent for one accent in sixteen. With pure black in the
+ * set the sweep's worst case is 4.500:1, which the guard asserts.
+ */
+export const CONTRAST_INK_DARK = '#111827';
+export const CONTRAST_INK_LIGHT = '#ffffff';
+export const CONTRAST_INK_DARKEST = '#000000';
+
+/**
+ * Set inline as a constant string rather than as a computed colour.
+ * Custom-property substitution happens at computed-value time on the element,
+ * so this one declaration re-substitutes with the other shade when
+ * `[data-theme]` changes on <html>, with no JS.
+ */
+export const ACCENT_HOVER =
+  'color-mix(in oklab, var(--theme-accent) 85%, var(--theme-accent-shade))';
+
+const HEX_COLOR = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/**
+ * `#rgb` and `#rrggbb` only, case-insensitive.
+ *
+ * The validation is load-bearing rather than cosmetic: a custom property
+ * accepts any token sequence and only fails at substitution, so writing
+ * `--theme-accent: banana` would make every `background-color:
+ * var(--theme-accent)` invalid at computed-value time and render those surfaces
+ * transparent. A refused value has to fall back to the template's own accent,
+ * never to nothing. `#rrggbbaa` is refused too: alpha on a fill is a
+ * readability hole that no correction can close.
+ */
+export function parseHexColor(value: unknown): Rgb | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!HEX_COLOR.test(trimmed)) return null;
+
+  const digits = trimmed.slice(1);
+  const full =
+    digits.length === 3
+      ? digits
+          .split('')
+          .map((digit) => digit + digit)
+          .join('')
+      : digits;
+  const packed = Number.parseInt(full, 16);
+  return [(packed >> 16) & 255, (packed >> 8) & 255, packed & 255];
+}
+
+export function formatHexColor(rgb: Rgb): string {
+  return `#${rgb
+    .map((channel) =>
+      Math.round(Math.min(255, Math.max(0, channel)))
+        .toString(16)
+        .padStart(2, '0'),
+    )
+    .join('')}`;
+}
+
+/** WCAG relative luminance. */
+export function relativeLuminance(rgb: Rgb): number {
+  const [r, g, b] = rgb.map((channel) => {
+    const value = channel / 255;
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+export function contrastRatio(a: Rgb, b: Rgb): number {
+  const first = relativeLuminance(a);
+  const second = relativeLuminance(b);
+  const lighter = Math.max(first, second);
+  const darker = Math.min(first, second);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** `percent` of `colour` composited over `surface`, both opaque. */
+export function tintedSurface(
+  colour: Rgb,
+  surface: Rgb,
+  percent: number = ACCENT_TINT_PERCENT,
+): Rgb {
+  const alpha = percent / 100;
+  return [
+    colour[0] * alpha + surface[0] * (1 - alpha),
+    colour[1] * alpha + surface[1] * (1 - alpha),
+    colour[2] * alpha + surface[2] * (1 - alpha),
+  ];
+}
+
+function rgbToHsl(rgb: Rgb): [number, number, number] {
+  const [r, g, b] = rgb.map((channel) => channel / 255);
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const lightness = (max + min) / 2;
+
+  if (max === min) return [0, 0, lightness * 100];
+
+  const delta = max - min;
+  const saturation =
+    lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+
+  let hue: number;
+  if (max === r) hue = ((g - b) / delta + (g < b ? 6 : 0)) / 6;
+  else if (max === g) hue = ((b - r) / delta + 2) / 6;
+  else hue = ((r - g) / delta + 4) / 6;
+
+  return [hue * 360, saturation * 100, lightness * 100];
+}
+
+function hslToRgb(h: number, s: number, l: number): Rgb {
+  const hue = ((h % 360) + 360) % 360;
+  const saturation = Math.min(100, Math.max(0, s)) / 100;
+  const lightness = Math.min(100, Math.max(0, l)) / 100;
+
+  const c = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const m = lightness - c / 2;
+
+  const sextant = Math.floor(hue / 60) % 6;
+  const [r, g, b] = [
+    [c, x, 0],
+    [x, c, 0],
+    [0, c, x],
+    [0, x, c],
+    [x, 0, c],
+    [c, 0, x],
+  ][sextant];
+
+  return [
+    Math.round((r + m) * 255),
+    Math.round((g + m) * 255),
+    Math.round((b + m) * 255),
+  ];
+}
+
+/**
+ * The accent walked in HSL lightness, 1% at a time, until it clears
+ * `ACCENT_CONTRAST_TARGET` against every surface given. Toward black when the
+ * surfaces are light, toward white when they are dark; black or white if the
+ * walk exhausts, which both clear every declared surface by a wide margin.
+ *
+ * Hue and saturation are kept, so the result still reads as the owner's colour.
+ */
+function correctedText(accent: Rgb, surfaces: readonly Rgb[]): Rgb {
+  const clears = (candidate: Rgb) =>
+    surfaces.every(
+      (surface) => contrastRatio(candidate, surface) >= ACCENT_CONTRAST_TARGET,
+    );
+  if (clears(accent)) return accent;
+
+  // Every surface passed in one call is the same mode: the chip tint of a light
+  // surface is still light, and of a dark surface still dark.
+  const towardBlack = relativeLuminance(surfaces[0]) >= 0.5;
+  const [hue, saturation, lightness] = rgbToHsl(accent);
+
+  for (let step = 1; step <= 100; step += 1) {
+    const next = towardBlack ? lightness - step : lightness + step;
+    if (next < 0 || next > 100) break;
+    const candidate = hslToRgb(hue, saturation, next);
+    if (clears(candidate)) return candidate;
+  }
+
+  return towardBlack ? [0, 0, 0] : [255, 255, 255];
+}
+
+/**
+ * The accent corrected until it is readable as text on one surface.
+ *
+ * Exported in the single-surface shape the contrast sweep exercises;
+ * `accentTextForMode` is what the knob actually writes.
+ */
+export function accentTextFor(hex: string, surface: string): string | null {
+  const accent = parseHexColor(hex);
+  const background = parseHexColor(surface);
+  if (!accent || !background) return null;
+  return formatHexColor(correctedText(accent, [background]));
+}
+
+/**
+ * The accent corrected for a whole mode: readable both on the mode's hardest
+ * page surface and on the tag chip, which is that surface with
+ * `ACCENT_TINT_PERCENT` of the accent mixed in and is therefore harder still.
+ */
+export function accentTextForMode(
+  hex: string,
+  mode: 'light' | 'dark',
+): string | null {
+  const accent = parseHexColor(hex);
+  const surface = parseHexColor(
+    mode === 'light' ? LIGHT_WORST_SURFACE : DARK_WORST_SURFACE,
+  );
+  if (!accent || !surface) return null;
+  return formatHexColor(
+    correctedText(accent, [surface, tintedSurface(accent, surface)]),
+  );
+}
+
+function requireHexColor(value: string): Rgb {
+  const parsed = parseHexColor(value);
+  if (!parsed) throw new Error(`Not a hex colour: ${value}`);
+  return parsed;
+}
+
+const INK_DARK = requireHexColor(CONTRAST_INK_DARK);
+const INK_LIGHT = requireHexColor(CONTRAST_INK_LIGHT);
+const INK_DARKEST = requireHexColor(CONTRAST_INK_DARKEST);
+
+/** The most readable text colour for the accent fill. */
+export function accentContrastColor(hex: string): string | null {
+  const accent = parseHexColor(hex);
+  if (!accent) return null;
+
+  const onLight = contrastRatio(accent, INK_LIGHT);
+  const onDark = contrastRatio(accent, INK_DARK);
+  if (Math.max(onLight, onDark) >= ACCENT_CONTRAST_TARGET) {
+    return onLight >= onDark ? CONTRAST_INK_LIGHT : CONTRAST_INK_DARK;
+  }
+
+  // Neither preferred ink clears the target on this accent, so take the end of
+  // the range that does. White is already the light extreme, so the only colour
+  // left to try is pure black.
+  return contrastRatio(accent, INK_DARKEST) >= onLight
+    ? CONTRAST_INK_DARKEST
+    : CONTRAST_INK_LIGHT;
+}
+
+export interface AccentAppearance {
+  /** The owner's colour, normalised to `#rrggbb`. */
+  accent: string;
+  hover: string;
+  contrast: string;
+  textLight: string;
+  textDark: string;
+}
+
+/**
+ * Every derived accent value, or null for a value that is absent, empty or not
+ * a hex colour. Null means "the template's own accent stands", which is what
+ * every instance renders today.
+ */
+export function resolveAccent(value: unknown): AccentAppearance | null {
+  const parsed = parseHexColor(value);
+  if (!parsed) return null;
+
+  const accent = formatHexColor(parsed);
+  const contrast = accentContrastColor(accent);
+  const textLight = accentTextForMode(accent, 'light');
+  const textDark = accentTextForMode(accent, 'dark');
+  if (!contrast || !textLight || !textDark) return null;
+
+  return { accent, hover: ACCENT_HOVER, contrast, textLight, textDark };
+}
+
+// =============================================================================
+// Font pairings
+// =============================================================================
+
+const SYSTEM_SANS =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif';
+const SYSTEM_SERIF = 'Georgia, "Times New Roman", serif';
+const SYSTEM_MONO = 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+
+export interface FontPreset {
+  body: string;
+  heading: string;
+  ui: string;
+}
+
+/**
+ * All four downloaded families are already loaded unconditionally by
+ * styles/fonts.css, so no preset adds a network request and `system` removes
+ * none. font-presets is asserted against that file by theme-appearance.test.ts:
+ * a preset naming a family nobody loads renders a silent fallback, which is the
+ * dead-surface pattern this work exists to end.
+ *
+ * Each preset sets all three faces. `--theme-font-ui` alone has 29 call sites
+ * through `font-theme-ui`, so changing body and heading while the UI stayed on
+ * the template's face would read as a bug.
+ */
+export const FONT_PRESETS: Record<string, FontPreset> = {
+  classic: {
+    body: `"Source Serif 4", ${SYSTEM_SERIF}`,
+    heading: `"Playfair Display", ${SYSTEM_SERIF}`,
+    ui: SYSTEM_SANS,
+  },
+  editorial: {
+    body: `"Source Serif 4", ${SYSTEM_SERIF}`,
+    heading: `"Inter", ${SYSTEM_SANS}`,
+    ui: `"Inter", ${SYSTEM_SANS}`,
+  },
+  modern: {
+    body: `"Inter", ${SYSTEM_SANS}`,
+    heading: `"Inter", ${SYSTEM_SANS}`,
+    ui: `"Inter", ${SYSTEM_SANS}`,
+  },
+  technical: {
+    body: `"Inter", ${SYSTEM_SANS}`,
+    heading: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    ui: `"Inter", ${SYSTEM_SANS}`,
+  },
+  system: {
+    body: SYSTEM_SANS,
+    heading: SYSTEM_SANS,
+    ui: SYSTEM_SANS,
+  },
+};
+
+/**
+ * The options for the editor's select, including the empty one.
+ *
+ * The empty option is required rather than decorative: the select renderer
+ * falls back to `''` for an unconfigured field, so without an option carrying
+ * that value an instance with no preset would show the first option as
+ * selected, and there would be no way back to the template's own faces after
+ * the first change.
+ */
+export const FONT_PRESET_OPTIONS: ReadonlyArray<{
+  value: string;
+  label: string;
+}> = [
+  { value: '', label: 'Theme default' },
+  {
+    value: 'classic',
+    label: 'Classic (Source Serif 4 body, Playfair Display headings)',
+  },
+  {
+    value: 'editorial',
+    label: 'Editorial (Source Serif 4 body, Inter headings)',
+  },
+  { value: 'modern', label: 'Modern (Inter throughout)' },
+  {
+    value: 'technical',
+    label: 'Technical (Inter body, JetBrains Mono headings)',
+  },
+  { value: 'system', label: 'System (no downloaded font used)' },
+];
+
+/** The named preset, or null for absent, empty and unknown keys alike. */
+export function resolveFontPreset(value: unknown): FontPreset | null {
+  if (typeof value !== 'string') return null;
+  const key = value.trim().toLowerCase();
+  return FONT_PRESETS[key] ?? null;
+}

--- a/apps/self-hosted/src/styles/components.css
+++ b/apps/self-hosted/src/styles/components.css
@@ -72,12 +72,27 @@
   );
 }
 
-/* Card Styles */
+/*
+ * Card Styles
+ *
+ * The three --theme-card-* tokens are how a template states what a card is.
+ * Four of the five say "the page surface with a hairline rule"; modern-gradient
+ * says glass, which is the treatment its name promises and which used to hang
+ * off a class no component renders. `background` rather than `background-color`
+ * for the same reason .tag-theme uses it: a template is free to name a gradient,
+ * and background-color drops a non-<color> at computed-value time.
+ *
+ * No hand-written -webkit-backdrop-filter. The build adds the prefix, and
+ * writing both makes its minifier keep only the prefixed one: the old glass
+ * rule shipped that way, so it would not have blurred outside WebKit even if
+ * something had rendered the class it named.
+ */
 .card-theme {
-  background-color: var(--theme-bg-card);
-  border: 1px solid var(--theme-border);
+  background: var(--theme-card-bg, var(--theme-bg-card));
+  border: var(--theme-card-border, 1px solid var(--theme-border));
   border-radius: var(--theme-radius);
   box-shadow: var(--theme-shadow);
+  backdrop-filter: var(--theme-card-backdrop, none);
 }
 
 /* Divider */

--- a/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
+++ b/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
@@ -1,0 +1,388 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  ACCENT_CONTRAST_TARGET,
+  ACCENT_TINT_PERCENT,
+  contrastRatio,
+  parseHexColor,
+  type Rgb,
+  relativeLuminance,
+} from '../core/theme-appearance';
+
+/**
+ * What the theme files must keep true for the accent knob to be safe.
+ *
+ * The accent now drives the tag chips: their fill is a tint of it, declared
+ * once in variables.css, and their text is the corrected accent as soon as an
+ * owner configures one. With no accent configured the chip text stays the
+ * template's own colour, so the pairing that ships to an instance that
+ * configures nothing is the pairing that shipped before. Both of those states
+ * have to clear 4.5:1, and only one of them is provable from the stylesheet;
+ * the other is proved over every colour in core/theme-appearance.test.ts.
+ *
+ * Also here: the card treatment. modern-gradient's glass used to hang off
+ * `.bg-theme-card`, a Tailwind utility name no component renders, so the
+ * default template's defining look painted on nothing at all. It is now three
+ * tokens that `.card-theme` reads, which means every template has to have an
+ * opinion about what a card is rather than inheriting one by accident.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const THEMES = join(HERE, 'themes');
+const COMPONENTS = join(HERE, 'components.css');
+const TOKENS = join(HERE, 'theme-tokens.css');
+
+interface Block {
+  file: string;
+  selector: string;
+  declarations: Map<string, string>;
+}
+
+/** Top-level `selector { ... }` blocks of a stylesheet, comments removed. */
+function blocks(file: string): Block[] {
+  const css = readFileSync(join(THEMES, file), 'utf8').replace(
+    /\/\*[\s\S]*?\*\//g,
+    '',
+  );
+  const out: Block[] = [];
+  let prelude = '';
+  let depth = 0;
+  let start = 0;
+
+  for (let index = 0; index < css.length; index += 1) {
+    const char = css[index];
+    if (depth === 0) {
+      if (char === '{') {
+        depth = 1;
+        start = index + 1;
+      } else {
+        prelude += char;
+      }
+      continue;
+    }
+    if (char === '{') depth += 1;
+    else if (char === '}') {
+      depth -= 1;
+      if (depth > 0) continue;
+      const selector = prelude.trim().replace(/\s+/g, ' ');
+      if (!selector.startsWith('@')) {
+        out.push({
+          file,
+          selector,
+          declarations: declarations(css.slice(start, index)),
+        });
+      }
+      prelude = '';
+    }
+  }
+  return out;
+}
+
+function declarations(body: string): Map<string, string> {
+  const out = new Map<string, string>();
+  let depth = 0;
+  let current = '';
+  for (const char of body) {
+    if (char === '(') depth += 1;
+    if (char === ')') depth -= 1;
+    if (char === ';' && depth === 0) {
+      const at = current.indexOf(':');
+      if (at > 0)
+        out.set(current.slice(0, at).trim(), current.slice(at + 1).trim());
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  return out;
+}
+
+const ALL_BLOCKS = readdirSync(THEMES)
+  .filter((file) => file.endsWith('.css'))
+  .flatMap(blocks);
+
+/** `rgba(0, 0, 0, 0.84)` and `#rrggbb` alike, as colour plus alpha. */
+function parseColor(value: string): { rgb: Rgb; alpha: number } | null {
+  const hex = parseHexColor(value);
+  if (hex) return { rgb: hex, alpha: 1 };
+  const match = /^rgba?\(([^)]+)\)$/i.exec(value.trim());
+  if (!match) return null;
+  const parts = match[1].split(',').map((part) => Number.parseFloat(part));
+  if (parts.length < 3 || parts.some((part) => Number.isNaN(part))) return null;
+  return {
+    rgb: [parts[0], parts[1], parts[2]],
+    alpha: parts.length > 3 ? parts[3] : 1,
+  };
+}
+
+function composite(
+  over: { rgb: Rgb; alpha: number },
+  onto: Rgb,
+  scale = 1,
+): Rgb {
+  const alpha = over.alpha * scale;
+  return [
+    over.rgb[0] * alpha + onto[0] * (1 - alpha),
+    over.rgb[1] * alpha + onto[1] * (1 - alpha),
+    over.rgb[2] * alpha + onto[2] * (1 - alpha),
+  ];
+}
+
+/** The literal a `var(--x, literal)` falls back to, resolved within one block. */
+function fallbackOf(value: string, block: Block): string | null {
+  const match = /^var\(\s*(--[a-z0-9-]+)\s*,\s*([\s\S]+)\)$/i.exec(
+    value.trim(),
+  );
+  if (!match) return value.trim();
+  const fallback = match[2].trim();
+  if (fallback.startsWith('var(')) {
+    const inner = /^var\(\s*(--[a-z0-9-]+)\s*\)$/.exec(fallback);
+    const referenced = inner && block.declarations.get(inner[1]);
+    return referenced ? referenced.trim() : null;
+  }
+  return fallback;
+}
+
+const accentBlocks = ALL_BLOCKS.filter((block) =>
+  block.declarations.has('--theme-accent'),
+);
+
+describe('accent blocks', () => {
+  it('are every light and dark palette the templates declare', () => {
+    // Five templates in two modes, plus the two base blocks in variables.css.
+    // A parser that stopped seeing them would make every check below vacuous.
+    expect(accentBlocks.length).toBe(12);
+    expect(new Set(accentBlocks.map((block) => block.file)).size).toBe(6);
+  });
+
+  it('declare the chip text next to the accent that fills the chip', () => {
+    // The pair is what the contrast check below is computed from. A block that
+    // declared one without the other would take its chip text from another
+    // block's palette, and neither block would be wrong on its own.
+    const missing = accentBlocks
+      .filter((block) => !block.declarations.has('--theme-tag-text'))
+      .map((block) => `${block.file} ${block.selector}`);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('read the correction variant that belongs to their own mode', () => {
+    // developer is the trap: its base block is the DARK palette and
+    // [data-theme="light"] is the override, so matching on the selector rather
+    // than on the surface would give it the light correction in dark mode.
+    const wrong: string[] = [];
+
+    for (const block of accentBlocks) {
+      const surface = parseColor(
+        block.declarations.get('--theme-bg-primary') ?? '',
+      );
+      const tagText = block.declarations.get('--theme-tag-text') ?? '';
+      if (!surface) {
+        wrong.push(`${block.file} ${block.selector}: no --theme-bg-primary`);
+        continue;
+      }
+      const expected =
+        relativeLuminance(surface.rgb) >= 0.5
+          ? '--theme-accent-text-light'
+          : '--theme-accent-text-dark';
+      if (!tagText.includes(expected)) {
+        wrong.push(`${block.file} ${block.selector}: ${tagText}`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
+  it('produce a readable tag chip with no accent configured', () => {
+    // The chip is ACCENT_TINT_PERCENT of the block's own accent composited over
+    // its own page, and the text is the fallback the template keeps for an
+    // instance that configures nothing. That is what all 27 live instances
+    // render, so it is the pairing that must not regress.
+    const failures: string[] = [];
+
+    for (const block of accentBlocks) {
+      const accent = parseColor(block.declarations.get('--theme-accent') ?? '');
+      const surface = parseColor(
+        block.declarations.get('--theme-bg-primary') ?? '',
+      );
+      const fallback = fallbackOf(
+        block.declarations.get('--theme-tag-text') ?? '',
+        block,
+      );
+      const text = fallback ? parseColor(fallback) : null;
+
+      if (!accent || !surface || !text) {
+        failures.push(
+          `${block.file} ${block.selector}: unreadable declarations`,
+        );
+        continue;
+      }
+
+      const chip = composite(accent, surface.rgb, ACCENT_TINT_PERCENT / 100);
+      const ratio = contrastRatio(composite(text, chip), chip);
+      if (ratio < ACCENT_CONTRAST_TARGET) {
+        failures.push(
+          `${block.file} ${block.selector}: ${ratio.toFixed(2)}:1 on the chip`,
+        );
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+});
+
+describe('derived accent tokens', () => {
+  const variables = blocks('variables.css');
+  const derived = [
+    '--theme-accent-shade',
+    '--theme-accent-text',
+    '--theme-tag-bg',
+    '--theme-tag-text',
+  ];
+
+  it('are declared for both modes, never on :root alone', () => {
+    // var() substitutes at computed-value time on the element carrying the
+    // declaration and the RESULT inherits, so a derived property declared only
+    // on :root resolves once against <html> and hands that one concrete colour
+    // to every descendant, including a subtree that carries its own data-theme.
+    const missing: string[] = [];
+    for (const property of derived) {
+      for (const mode of ['light', 'dark']) {
+        const declared = variables.some(
+          (block) =>
+            block.selector.includes(`[data-theme="${mode}"]`) &&
+            block.declarations.has(property),
+        );
+        if (!declared) missing.push(`${property} (${mode})`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('mix the chip fill from the accent, at the percentage the module corrects for', () => {
+    const mixes = variables
+      .map((block) => block.declarations.get('--theme-tag-bg'))
+      .filter((value): value is string => Boolean(value));
+
+    expect(mixes.length).toBe(2);
+    for (const mix of mixes) {
+      expect(mix).toContain('var(--theme-accent)');
+      // Transparent-first: the build turns a color-mix into a plain fallback by
+      // taking its first colour, and a chip filled with the accent at full
+      // strength would put the template's quiet chip text on the accent itself.
+      expect(mix).toMatch(/color-mix\(in srgb, transparent (\d+)%/);
+      expect(100 - Number(/transparent (\d+)%/.exec(mix)?.[1])).toBe(
+        ACCENT_TINT_PERCENT,
+      );
+    }
+  });
+
+  it('leave an unconfigured instance on the template accent', () => {
+    // The fallback in each var() is what makes "no accent configured" render
+    // byte-identically to the day before this knob existed.
+    for (const block of variables) {
+      const accentText = block.declarations.get('--theme-accent-text');
+      if (!accentText) continue;
+      expect(accentText).toMatch(
+        /var\(--theme-accent-text-(light|dark), var\(--theme-accent\)\)/,
+      );
+    }
+  });
+});
+
+describe('card treatment', () => {
+  const CARD_TOKENS = [
+    '--theme-card-bg',
+    '--theme-card-border',
+    '--theme-card-backdrop',
+  ];
+  const templates = ALL_BLOCKS.filter((block) =>
+    /^\[data-style-template="[a-z-]+"\]$/.test(block.selector),
+  );
+
+  it('is stated by every template rather than inherited by accident', () => {
+    expect(templates.length).toBe(5);
+    const missing: string[] = [];
+    for (const block of templates) {
+      for (const token of CARD_TOKENS) {
+        if (!block.declarations.has(token)) {
+          missing.push(`${block.file}: ${token}`);
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('is glass on exactly the template named after it', () => {
+    const glass = templates.filter((block) =>
+      (block.declarations.get('--theme-card-backdrop') ?? 'none').includes(
+        'blur',
+      ),
+    );
+    expect(glass.map((block) => block.file)).toEqual(['modern-gradient.css']);
+  });
+
+  it('is read by .card-theme, so a template token is not decoration', () => {
+    const card = readFileSync(COMPONENTS, 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .match(/\.card-theme\s*\{([^}]*)\}/);
+
+    expect(card).not.toBeNull();
+    for (const token of CARD_TOKENS) {
+      expect(card?.[1]).toContain(`var(${token}`);
+    }
+  });
+});
+
+describe('theme files', () => {
+  /** The utility class names theme-tokens.css makes Tailwind generate. */
+  function generatedClasses(): Set<string> {
+    const css = readFileSync(TOKENS, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
+    const namespaces: Array<[string, string[]]> = [
+      ['--background-color-', ['bg-']],
+      ['--text-color-', ['text-']],
+      ['--border-color-', ['border-']],
+      ['--radius-', ['rounded-']],
+      ['--font-', ['font-']],
+      ['--shadow-', ['shadow-']],
+      ['--color-', ['bg-', 'text-', 'border-', 'ring-', 'fill-', 'stroke-']],
+    ];
+
+    const out = new Set<string>();
+    for (const [property] of [...css.matchAll(/(--[a-z0-9-]+):/g)].map(
+      (match) => [match[1]],
+    )) {
+      for (const [prefix, utilities] of namespaces) {
+        if (!property.startsWith(prefix)) continue;
+        const name = property.slice(prefix.length);
+        for (const utility of utilities) out.add(`${utility}${name}`);
+        break;
+      }
+    }
+    return out;
+  }
+
+  it('style no class that Tailwind generates from a theme namespace', () => {
+    // `[data-style-template="modern-gradient"] .bg-theme-card` is why this
+    // exists: a template rule aimed at a utility class name is unreachable when
+    // no component writes it, and a cascade landmine when one does, since the
+    // theme files are unlayered and would beat the utility.
+    const generated = generatedClasses();
+    expect(generated.size).toBeGreaterThan(20);
+
+    const offenders: string[] = [];
+    for (const block of ALL_BLOCKS) {
+      for (const match of block.selector.matchAll(
+        /\.([a-z0-9][a-z0-9_-]*)/gi,
+      )) {
+        if (generated.has(match[1])) {
+          offenders.push(`${block.file}: ${block.selector}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/self-hosted/src/styles/themes/developer.css
+++ b/apps/self-hosted/src/styles/themes/developer.css
@@ -52,10 +52,19 @@
   --theme-link-decoration-color: rgba(137, 180, 250, 0.4);
   --theme-link-decoration-hover: #89b4fa;
 
-  /* Tag style - Code-like */
-  --theme-tag-bg: #313244;
-  --theme-tag-text: #cdd6f4;
+  /*
+   * Tag style - Code-like. The fill comes from the accent tint in
+   * variables.css. This block is the DARK palette (developer is dark by
+   * default and [data-theme="light"] is the override), so the text reads the
+   * dark-mode correction.
+   */
+  --theme-tag-text: var(--theme-accent-text-dark, #cdd6f4);
   --theme-tag-radius: 4px;
+
+  /* Card treatment: terminal panel, same fill as the page, visible rule */
+  --theme-card-bg: var(--theme-bg-card);
+  --theme-card-border: 1px solid var(--theme-border);
+  --theme-card-backdrop: none;
 
   /* Code syntax colors (Catppuccin-inspired) */
   --theme-code-bg: #1e1e2e;
@@ -98,8 +107,7 @@
   --theme-border: #ccd0da;
   --theme-border-strong: #bcc0cc;
 
-  --theme-tag-bg: #ccd0da;
-  --theme-tag-text: #4c4f69;
+  --theme-tag-text: var(--theme-accent-text-light, #4c4f69);
 
   --theme-code-bg: #e6e9ef;
   --theme-code-text: #4c4f69;

--- a/apps/self-hosted/src/styles/themes/magazine.css
+++ b/apps/self-hosted/src/styles/themes/magazine.css
@@ -47,10 +47,14 @@
   --theme-link-decoration-color: #c5c0b8;
   --theme-link-decoration-hover: #8b4513;
 
-  /* Tag style */
-  --theme-tag-bg: #ebe7e0;
-  --theme-tag-text: #4a4540;
+  /* Tag style - fill comes from the accent tint in variables.css */
+  --theme-tag-text: var(--theme-accent-text-light, #4a4540);
   --theme-tag-radius: 2px;
+
+  /* Card treatment: white paper on the cream page, hairline rule */
+  --theme-card-bg: var(--theme-bg-card);
+  --theme-card-border: 1px solid var(--theme-border);
+  --theme-card-backdrop: none;
 
   /* Layout - Magazine: Wide, editorial, dramatic */
   --theme-content-width: 720px;
@@ -90,8 +94,7 @@
   --theme-link-decoration-color: #4a4540;
   --theme-link-decoration-hover: #d4a574;
 
-  --theme-tag-bg: #302d28;
-  --theme-tag-text: #c5c0b8;
+  --theme-tag-text: var(--theme-accent-text-dark, #c5c0b8);
 
   --theme-divider-style: 1px solid #4a4540;
 }

--- a/apps/self-hosted/src/styles/themes/medium.css
+++ b/apps/self-hosted/src/styles/themes/medium.css
@@ -49,10 +49,22 @@
   --theme-link-decoration-color: rgba(0, 0, 0, 0.3);
   --theme-link-decoration-hover: rgba(0, 0, 0, 0.84);
 
-  /* Tag style */
-  --theme-tag-bg: rgba(0, 0, 0, 0.05);
-  --theme-tag-text: rgba(0, 0, 0, 0.68);
+  /*
+   * Tag style. The chip fill is a tint of the accent and is declared once in
+   * variables.css, so an owner's accent reaches the chips; the text stays the
+   * template's own until an accent is configured, and the radius is always the
+   * template's.
+   */
+  --theme-tag-text: var(--theme-accent-text-light, rgba(0, 0, 0, 0.68));
   --theme-tag-radius: 9999px;
+
+  /*
+   * Card treatment: none. Classic sets nothing apart from the page - the card
+   * is the page surface with a hairline rule, and --theme-shadow is none.
+   */
+  --theme-card-bg: var(--theme-bg-card);
+  --theme-card-border: 1px solid var(--theme-border);
+  --theme-card-backdrop: none;
 
   /* Layout - Medium: Classic editorial, comfortable reading */
   --theme-content-width: 680px;
@@ -88,6 +100,5 @@
   --theme-link-decoration-color: rgba(255, 255, 255, 0.3);
   --theme-link-decoration-hover: rgba(255, 255, 255, 0.92);
 
-  --theme-tag-bg: rgba(255, 255, 255, 0.08);
-  --theme-tag-text: rgba(255, 255, 255, 0.68);
+  --theme-tag-text: var(--theme-accent-text-dark, rgba(255, 255, 255, 0.68));
 }

--- a/apps/self-hosted/src/styles/themes/minimal.css
+++ b/apps/self-hosted/src/styles/themes/minimal.css
@@ -51,10 +51,14 @@
   --theme-link-decoration-color: rgba(0, 102, 204, 0.3);
   --theme-link-decoration-hover: #0066cc;
 
-  /* Tag style */
-  --theme-tag-bg: #f5f5f5;
-  --theme-tag-text: #4a4a4a;
+  /* Tag style - fill comes from the accent tint in variables.css */
+  --theme-tag-text: var(--theme-accent-text-light, #4a4a4a);
   --theme-tag-radius: 4px;
+
+  /* Card treatment: hairline rule on the page surface, soft shadow */
+  --theme-card-bg: var(--theme-bg-card);
+  --theme-card-border: 1px solid var(--theme-border);
+  --theme-card-backdrop: none;
 
   /* Layout - Minimal: Clean, spacious, focused */
   --theme-content-width: 640px;
@@ -87,6 +91,5 @@
   --theme-border: #2a2a2a;
   --theme-border-strong: #3a3a3a;
 
-  --theme-tag-bg: #222222;
-  --theme-tag-text: #b0b0b0;
+  --theme-tag-text: var(--theme-accent-text-dark, #b0b0b0);
 }

--- a/apps/self-hosted/src/styles/themes/modern-gradient.css
+++ b/apps/self-hosted/src/styles/themes/modern-gradient.css
@@ -54,19 +54,24 @@
   --theme-link-decoration-color: color-mix(in srgb, var(--theme-accent) 40%, transparent);
   --theme-link-decoration-hover: var(--theme-accent);
 
-  /* Tag style - Gradient-friendly */
-  --theme-tag-bg: linear-gradient(
-    135deg,
-    rgba(124, 58, 237, 0.1),
-    rgba(37, 99, 235, 0.1)
-  );
-  --theme-tag-text: #7c3aed;
+  /* Tag style - fill comes from the accent tint in variables.css */
+  --theme-tag-text: var(--theme-accent-text-light, #7c3aed);
   --theme-tag-radius: 9999px;
 
   /* Glass morphism */
   --theme-glass-bg: rgba(255, 255, 255, 0.6);
   --theme-glass-border: rgba(255, 255, 255, 0.3);
   --theme-glass-blur: blur(20px);
+
+  /*
+   * Card treatment: glass. This is the one template whose cards are not a flat
+   * surface, and it is the reason the template is called modern-gradient. The
+   * tokens are var() references, so the dark block re-declaring --theme-glass-*
+   * re-substitutes here with no second card rule.
+   */
+  --theme-card-bg: var(--theme-glass-bg);
+  --theme-card-border: 1px solid var(--theme-glass-border);
+  --theme-card-backdrop: var(--theme-glass-blur);
 
   /* Gradients */
   --theme-gradient-primary: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -106,12 +111,7 @@
   --theme-border: rgba(148, 163, 184, 0.15);
   --theme-border-strong: rgba(148, 163, 184, 0.25);
 
-  --theme-tag-bg: linear-gradient(
-    135deg,
-    rgba(167, 139, 250, 0.15),
-    rgba(96, 165, 250, 0.15)
-  );
-  --theme-tag-text: #a78bfa;
+  --theme-tag-text: var(--theme-accent-text-dark, #a78bfa);
 
   --theme-glass-bg: rgba(30, 30, 50, 0.7);
   --theme-glass-border: rgba(255, 255, 255, 0.1);
@@ -120,17 +120,18 @@
   --theme-gradient-subtle: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%);
 }
 
-/* Modern Gradient specific styles */
-[data-style-template="modern-gradient"] .bg-theme-card {
-  background: var(--theme-glass-bg);
-  backdrop-filter: var(--theme-glass-blur);
-  -webkit-backdrop-filter: var(--theme-glass-blur);
-  border: 1px solid var(--theme-glass-border);
-}
+/*
+ * The glass card used to live here as `.bg-theme-card`, a rule no component
+ * could reach: `bg-theme-card` is a Tailwind utility name and nothing renders
+ * it, so the default template's defining treatment painted on nothing. It is
+ * now three card tokens in the block above, which `.card-theme` reads, and
+ * every other template states its own card treatment the same way.
+ */
 
 /* `.tag-theme` is the class the chips actually carry; `.theme-tag` matched
-   nothing, so this rule never applied. The gradient background now comes from
-   the shared .tag-theme rule; only the border is specific to this template. */
+   nothing, so this rule never applied. The chip fill is now a tint of the
+   accent, mixed once in variables.css so that an owner's accent reaches the
+   chips on every template; only the border is specific to this one. */
 [data-style-template="modern-gradient"] .tag-theme {
   border: 1px solid var(--theme-border);
 }

--- a/apps/self-hosted/src/styles/themes/variables.css
+++ b/apps/self-hosted/src/styles/themes/variables.css
@@ -1,6 +1,17 @@
 /* Base CSS Variables - Default values overridden by theme files */
 
-:root {
+/*
+ * `[data-theme="light"]` as well as `:root`, matching the dark block below.
+ *
+ * A value derived from another with var() substitutes at computed-value time on
+ * the element carrying the declaration, and the RESULT is what inherits. A
+ * derived property declared on :root alone would resolve once against <html>
+ * and hand that one concrete colour to every descendant, including a subtree
+ * carrying its own data-theme. Both selectors match the same element today, so
+ * this changes nothing on the page and keeps every future derived token honest.
+ */
+:root,
+[data-theme="light"] {
   /* Typography - Font Families */
   --theme-font-body: "Georgia", "Times New Roman", serif;
   --theme-font-heading:
@@ -91,6 +102,36 @@
   /* Layout - Post Cards */
   --theme-post-card-image-height: 200px;
   --theme-post-card-image-radius: var(--theme-radius);
+
+  /* Card treatment: default surface, hairline rule, no glass */
+  --theme-card-bg: var(--theme-bg-card);
+  --theme-card-border: 1px solid var(--theme-border);
+  --theme-card-backdrop: none;
+
+  /*
+   * Values derived from --theme-accent.
+   *
+   * --theme-accent-text-light and -dark are written inline on <html> when an
+   * owner configures an accent, and nowhere else, so the fallback in each var()
+   * is what an instance that configures nothing renders: the template's own
+   * accent, and the template's own chip text. That is why this whole knob adds
+   * no pixel of change until someone uses it.
+   *
+   * The chip fill is the one exception and it is deliberate: it is a tint of
+   * whatever --theme-accent resolves to in this block, so the accent reaches
+   * the tag chips on every instance.
+   *
+   * The mix is written transparent-first on purpose. The build emits a
+   * pre-color-mix fallback for older browsers by taking the mix's FIRST colour,
+   * so `var(--theme-accent) 12%, transparent` would hand them a chip filled with
+   * the accent at full strength, with the template's quiet chip text on it: on
+   * medium that is near-black text on a near-black chip. Transparent-first makes
+   * the same fallback an unfilled chip, which is flat but readable everywhere.
+   */
+  --theme-accent-shade: #000000;
+  --theme-accent-text: var(--theme-accent-text-light, var(--theme-accent));
+  --theme-tag-bg: color-mix(in srgb, transparent 88%, var(--theme-accent));
+  --theme-tag-text: var(--theme-accent-text-light, var(--theme-text-secondary));
 }
 
 /* Dark Mode Overrides */
@@ -114,4 +155,10 @@
   --theme-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
   --theme-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
   --theme-shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.4);
+
+  /* Derived from --theme-accent; see the light block above */
+  --theme-accent-shade: #ffffff;
+  --theme-accent-text: var(--theme-accent-text-dark, var(--theme-accent));
+  --theme-tag-bg: color-mix(in srgb, transparent 88%, var(--theme-accent));
+  --theme-tag-text: var(--theme-accent-text-dark, var(--theme-text-secondary));
 }


### PR DESCRIPTION
## What this adds

The two owner-facing appearance knobs, as entries in `CONFIG_DOM_DECLARATION.cssVariables`, which was `[]`:

- `configuration.general.styles.accent`, one colour, `#rgb` or `#rrggbb`
- `configuration.general.styles.fontPreset`, one key out of `classic`, `editorial`, `modern`, `technical`, `system`

Eight inline custom properties on `<html>` come out of those two strings: `--theme-accent`, `--theme-accent-hover`, `--theme-accent-contrast`, `--theme-accent-text-light`, `--theme-accent-text-dark`, `--theme-font-body`, `--theme-font-heading`, `--theme-font-ui`. Everything derived is computed in a new pure module (`src/core/theme-appearance.ts`) rather than stored, so a config cannot hold five colours of which four go stale when the fifth changes. Preview, snapshot and restore already iterate the declaration, so there is no new plumbing and no React re-render involved.

Both mode variants of the corrected text colour are written and CSS picks between them, so an OS flip under `theme: system` re-resolves with no JS. The system-theme listener is deliberately untouched, which is what keeps an active preview from being reverted.

## What changes on a live instance

Only one thing, and it is the accepted decision below: **tag chips**. Their fill is now a 12% tint of whatever `--theme-accent` resolves to in the winning block, so it follows the template today and the owner's accent as soon as one is set. On `medium` that is `rgba(0,0,0,0.05)` becoming a 12% tint of the template's own near-black accent; the chip text stays the template's own colour until an accent is configured.

Everything else is unchanged with no owner action. With no accent and no preset, every resolver reads `undefined`, returns `null`, and `applyConfigDom` removes the property, so each `var()` falls back to the template's own value. The three deployed seeds are asserted to produce zero inline properties.

## Decisions carried in this PR

**The accent drives the tag chips.** `--theme-tag-bg` is mixed once in `variables.css` and the ten per-template declarations are gone; `--theme-tag-text` keeps the template's colour as the fallback and takes the corrected accent when one is configured. Both states are asserted at 4.5:1 for all twelve palette blocks.

The mix is written transparent-first, `color-mix(in srgb, transparent 88%, var(--theme-accent))`, on purpose: the build emits a pre-`color-mix` fallback by taking the mix's first colour, so accent-first would hand an older browser a chip filled with the accent at full strength carrying the template's quiet chip text, which on `medium` is near-black on near-black. Transparent-first makes that fallback an unfilled chip, which is flat but readable everywhere.

**modern-gradient's glass card is reachable.** It hung off `[data-style-template="modern-gradient"] .bg-theme-card`, a Tailwind utility name no component renders, so the default template's defining treatment painted on nothing. It is now three `--theme-card-*` tokens that `.card-theme` reads, and the other four templates state their own card treatment in the same shape rather than inheriting one by accident. A guard fails on any theme rule aimed at a class a `@theme` namespace generates, computed from `theme-tokens.css` rather than hardcoded.

Two things surfaced while doing it. The old rule shipped `-webkit-backdrop-filter` only, because writing both spellings makes the minifier keep just the prefixed one, so the glass would not have blurred outside WebKit even if something had rendered the class. `.card-theme` now writes the standard property alone and the build adds the prefix. No live instance runs `modern-gradient`, so this changes nothing on the fleet.

**`general.theme` is normalised.** `text()` neither lowercased nor validated, so `theme: "Dark"` reached the document as `data-theme="Dark"` and matched no block: the instance asked for dark and rendered light. The value is now lowercased and held to `system`, `light`, `dark`, with anything else resolving to the same default an absent value does. The attribute is therefore always `light` or `dark`, so the normalisation cannot itself emit a value nothing matches. No stored config has a mis-cased or unknown value.

The theme gallery is not in this track.

## Contrast

Swept over 4096 colours, every 17th value per channel, against every `--theme-bg-primary` the theme files declare, both parsed rather than hardcoded:

| sweep | worst |
|---|---|
| corrected text on each declared surface | 4.500:1 light, 4.500:1 dark |
| corrected text on the page and on the chip it tints | 4.500:1 light, 4.500:1 dark |
| text on the accent fill | 4.500:1 |

The fill row needed a fix. White and `#111827` alone leave 254 of the 4096 colours short of 4.5:1, worst 4.213:1 on `#dd4444`, so pure black joins them as a fallback for that band. The worst-surface pair (`#eff1f5` light, `#1e1e2e` dark) is derived from the theme files in the test, so a template added with a lighter dark surface fails CI rather than shipping a sub-AA link.

## Evidence

`52 files, 566 tests` green. `tsc --noEmit` clean. `rsbuild build` clean, `check-node-globals` reports 3 chunks clean.

Compiled stylesheet, before and after:

| | before | after |
|---|---|---|
| bytes | 109594 | 111010 |
| top-level rules | 345 | 348 |
| `@supports color-mix` blocks | 17 | 19 |

Selector-level diff: `:root` becomes `:root,[data-theme=light]` and gains the three card tokens and the four derived accent tokens; `[data-theme=dark]` gains the four derived tokens; each of the five template blocks gains the three card tokens, loses `--theme-tag-bg` and wraps `--theme-tag-text` in the mode's correction variant; `[data-style-template=modern-gradient] .bg-theme-card` is gone; `.card-theme` moves from `background-color`/fixed border to the card tokens and gains `backdrop-filter`. Nothing else in the stylesheet moved.

CSS cannot be asserted from a unit test and the `.tsx` here is not testable, so the guards assert behaviour or the syntax tree, and every one was mutation-verified. 22 mutations, all caught: re-adding the glass rule on a generated class name; dropping a card token from a template; `.card-theme` no longer reading one; a dark palette block reading the light correction; a template's chip text dropped to a low-contrast colour; the tint changed to 50%; the dark block losing `--theme-accent-text`; the correction ignoring the chip tint; `parseHexColor` accepting 8-digit hex; the fill colour losing its black fallback; the theme value not lowercased; an unknown theme passing through to the document; a declared property misspelled; the accent written unvalidated; either seed gaining an accent; a preset losing a face or naming a font nothing loads; the font select losing its empty option; snapshot skipping a property; an unknown preset resolving to `undefined`; the worst light surface claimed to be white.

## Follow-up needed in the editor

`src/features/floating-menu/config-fields.ts` is owned by another change right now, so the two fields are not declared there and the knobs are reachable only through the stored config. What has to be added under `configuration.general.styles.fields`, needing no new editor code, is in the PR thread.
