### PR TITLE
Self-hosted: register each instance's Hivesigner redirect URI and enable the method

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -88,6 +88,12 @@ jobs:
       - name: Run hosting API tests
         run: cd apps/self-hosted/hosting/api && npm install && npm test
 
+      # Operator scripts are not part of any package: they run from a timer on the
+      # host that holds the key, so nothing else would ever execute them. stdlib
+      # unittest only, so this needs no more than the python3 already on the runner.
+      - name: Run hosting script tests
+        run: cd apps/self-hosted/hosting/scripts && python3 -m unittest discover -p 'test_*.py'
+
       # The unit tests never compile the app, so a bundle that only fails at
       # load used to reach production uncompiled. This is also what runs
       # scripts/check-node-globals.mjs, which fails on a Node global that

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage/
 *.lcov
 
 packages/*/coverage/
+
+# Byte cache from running the hosting operator scripts and their tests
+__pycache__/

--- a/apps/self-hosted/hosting/README.md
+++ b/apps/self-hosted/hosting/README.md
@@ -123,26 +123,102 @@ account's on-chain `posting_json_metadata`. Exact string match, no wildcards, so
 method when the instance has no usable client, which is why hosted blogs currently offer Keychain
 and HiveAuth only.
 
-`scripts/hivesigner-redirect-uris.py` reconciles that array against the live tenants:
+Registration and enablement are one operation, run on a schedule by
+`scripts/hivesigner-redirect-uris.py`. Each pass:
+
+1. reads the live tenants and the account's current array,
+2. appends whatever is missing (`account_update2`, posting authority),
+3. confirms the additions are actually on chain,
+4. asks the hosting API to reconcile every tenant's `general.hivesigner.clientId`.
+
+**Where the key lives.** Step 2 is the only step that signs, and it does not happen in this
+service. The hosting API is internet-facing, holds tenant and payment data, and has never held a
+key of any kind; it is not going to acquire one so that a scheduled job can be saved a hop. The
+job runs on the host that already runs the key-holding scheduled services, and the API's part of
+the work is read-only: it fetches the account itself and writes a client id only for a tenant
+whose URIs it has confirmed for itself. `api/src/no-signing-capability.test.ts` fails the build if
+anything in the API imports a signing primitive.
+
+**Why the two halves cannot disagree.** A client id on an instance whose URI is not registered is
+a login button that leads to an error page with no explanation, which is the state #1317 exists to
+prevent. So nothing writes a client id except `POST /v1/internal/hivesigner/reconcile`, and that
+endpoint reads **no request body at all**: what it enables is decided from the on-chain array and
+from each tenant's own row. Holding the shared secret is not enough to enable an unregistered
+instance, and neither is a bug in the script.
+
+- **A failed broadcast leaves nothing set.** The additions are confirmed by re-reading the account
+  before anything is enabled, and the reconcile independently refuses any tenant whose URIs it
+  cannot find on chain.
+- **A run that dies between the two halves repairs itself.** The reconcile runs every pass, not
+  only after a broadcast, so a pass that registered a URI and then died enables it on the next
+  tick with nobody told.
+- **An unreadable account writes nothing.** Metadata that fails to parse is an error, never an
+  empty registration; treating it as empty would withdraw the login method from every tenant at
+  once on one bad RPC response.
+- **Overlapping runs are prevented** by a lock file, and would be harmless anyway: every pass
+  merges onto whatever is on chain at the time and never removes an entry.
+
+Report only, writing the payload someone else would broadcast (unchanged behaviour, no key
+needed):
 
 ```
 DATABASE_URL=... ./scripts/hivesigner-redirect-uris.py
 ```
 
-It prints a summary and writes the broadcast payload to a 0600 file. It does **not** broadcast:
-updating the account needs its posting key, and this service holds no signing key of any kind. Run
-the broadcast separately with the payload as `posting_json_metadata` (`account_update2`, posting
-authority).
+Unattended, which is what the timer runs:
+
+```
+./scripts/hivesigner-redirect-uris.py --broadcast \
+  --key-file <path> --api-base <hosting api> --internal-secret-file <path>
+```
+
+`--broadcast` refuses to start without all three, because registering without enabling leaves the
+work invisible and enabling without registering is the broken button.
 
 Notes:
 
 - Existing entries are never dropped, so a URI added by hand for something outside this script's
   view survives. Entries that are registered but no longer live are reported for review rather than
   removed.
-- Only `active` and `trialing` tenants are registered. An unverified custom domain is skipped, since
-  registering a domain someone merely claimed would let whoever controls that name receive callbacks
-  for the app.
+- Only `active` tenants are registered, matching the only status the API will write a client id
+  for. An unverified custom domain is skipped, since registering a domain someone merely claimed
+  would let whoever controls that name receive callbacks for the app.
+- A tenant with a verified custom domain needs **both** its URIs registered before the method is
+  enabled. One config file serves both origins and the SPA builds its `redirect_uri` from
+  `window.location.origin`, so enabling on one would give every visitor on the other a button that
+  fails.
+- An owner who configured their own Hivesigner app is never touched. Only the shared client id is
+  managed, in both directions.
 - The payload carries the account's whole existing profile, which on an app account includes its
   secret. Do not paste it into a shared terminal, and delete the file afterwards.
-- Once the URIs are registered, set `general.hivesigner.clientId` in the tenant config template to
-  turn the method back on. No client code change is needed.
+
+### Installing the scheduled job
+
+`hivesigner-redirect-uris.service` and `.timer` are the unit definitions; nothing in CI installs
+them. On the host that holds the key:
+
+1. Create an unprivileged user for it and a working directory; copy
+   `hivesigner-redirect-uris.py` there.
+2. Make a virtualenv beside it with `psycopg[binary]` (tenant list) and `lighthive` (signing).
+   `lighthive` serialises through the node's own `get_transaction_hex`, so nothing here carries a
+   client-side operation table that could fall behind the chain.
+3. Put the posting key and the hosting API's internal secret in separate **mode 0600** files owned
+   by that user. The script refuses to read either if group or other can. They are passed as paths,
+   never as environment variables, so they do not appear in `systemctl show`, the journal, or
+   `/proc/<pid>/environ`.
+4. Put `DATABASE_URL` and `HOSTING_API_BASE` in the unit's `EnvironmentFile`.
+5. Add the job's address to the API's internal allowlist (`hosting-internal-allow.conf` on the
+   origin, and `HOSTING_INTERNAL_ALLOWED_IPS` if it is set) **before** enabling the timer, or every
+   reconcile returns 403. See `origin/README.md`.
+6. Install both units, then `systemctl enable --now hivesigner-redirect-uris.timer`.
+
+Check it with `systemctl list-timers hivesigner-redirect-uris` and
+`journalctl -u hivesigner-redirect-uris`. A pass that found nothing to do prints `nothing to add`
+and the reconcile summary; that is the steady state.
+
+The interval is five minutes, matching the two loops a new instance already waits on (the API
+regenerates served configs every five minutes, the origin issues certificates and vhosts every
+five). A blog is not finished arriving before those have run, so a shorter interval would not make
+the login button appear any sooner, and a longer one would be the only thing its owner was still
+waiting for. A pass with nothing to do costs one query, one RPC read and one local API call; a
+broadcast happens only when an instance is genuinely unregistered.

--- a/apps/self-hosted/hosting/README.md
+++ b/apps/self-hosted/hosting/README.md
@@ -163,6 +163,12 @@ instance, and neither is a bug in the script.
   Hivesigner app in that window would have it overwritten with the shared one and never
   restored, and a custom domain verified in that window would be enabled on one origin while
   the other was still unregistered.
+- **The served file cannot go stale either.** The same hazard applies one step later: a row
+  committed a moment ago is the wrong thing to write to disk if something else committed after
+  it. Both writers of a tenant's file publish by name through `publishConfigFile`, which
+  re-reads inside the per-tenant write lock, so the file always ends up carrying the newest
+  committed config whichever order they land in. A file and a row that disagree are worse than
+  either being stale on its own, because the row no longer explains what readers are served.
 
 Report only, writing the payload someone else would broadcast (unchanged behaviour, no key
 needed):

--- a/apps/self-hosted/hosting/README.md
+++ b/apps/self-hosted/hosting/README.md
@@ -157,6 +157,12 @@ instance, and neither is a bug in the script.
   once on one bad RPC response.
 - **Overlapping runs are prevented** by a lock file, and would be harmless anyway: every pass
   merges onto whatever is on chain at the time and never removes an entry.
+- **A config save racing the reconcile cannot lose.** The listing the pass iterates is a
+  snapshot, so each tenant's row is re-read `FOR UPDATE` and the decision is taken again from
+  it, inside the transaction that then writes. Without that, an owner saving their own
+  Hivesigner app in that window would have it overwritten with the shared one and never
+  restored, and a custom domain verified in that window would be enabled on one origin while
+  the other was still unregistered.
 
 Report only, writing the payload someone else would broadcast (unchanged behaviour, no key
 needed):

--- a/apps/self-hosted/hosting/api/src/no-signing-capability.test.ts
+++ b/apps/self-hosted/hosting/api/src/no-signing-capability.test.ts
@@ -1,0 +1,239 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The hosting API must not be able to sign a Hive transaction.
+ *
+ * Registering a self-hosted instance's Hivesigner redirect URI is an
+ * `account_update2` broadcast under the app account's posting authority. This
+ * service is internet-facing, it holds tenant data and payment records, and it
+ * has never held a key of any kind. Putting one here to save a scheduled job is
+ * exactly the change this guards against: the broadcast runs elsewhere, and
+ * `/v1/internal/hivesigner/reconcile` only ever READS the chain.
+ *
+ * The check is on the import graph rather than on the presence of a word. A
+ * module cannot sign what it cannot reach, so "no signing primitive is imported
+ * anywhere in this package" states the capability directly. Comments and string
+ * literals are removed first, so prose about signing (this file's own header
+ * included) can never fail the build, and an import cannot be hidden inside one.
+ *
+ * Guards in this repository have false-passed by asserting something that was
+ * never evaluated, so this one proves itself: the parser is exercised on a
+ * fixture it must flag, and the walk is asserted to have reached real modules
+ * with real imports before any conclusion is drawn from its silence.
+ */
+
+const SRC = path.join(import.meta.dirname, '.');
+
+/**
+ * Every name that could give a module a private key or push something signed with
+ * one. `PrivateKey` holds one, `Transaction` signs with one, `Memo` encrypts with
+ * one, and `callRPCBroadcast` is the only call that submits a signed transaction.
+ *
+ * `Signature` and `PublicKey` are deliberately absent and must stay absent.
+ * Verifying a signature is a public operation that needs no key at all, and this
+ * service does it on every hosting-token exchange: `utils/auth.ts` recovers the
+ * signer of a login challenge to decide whether a session may save a config.
+ * Listing them would make this guard fire on a keyless read, which teaches the
+ * next person to weaken it rather than to think about it.
+ */
+const SIGNING_BINDINGS = new Set(['PrivateKey', 'Transaction', 'Memo', 'callRPCBroadcast']);
+
+/** Modules whose whole purpose is signing or key handling. */
+const SIGNING_MODULES = [/^@hiveio\/dhive$/, /^hive-tx/, /^hivesigner$/, /^secp256k1$/, /^bip39$/];
+
+/**
+ * Remove comments and string/template contents, leaving code structure intact.
+ *
+ * Written as a scanner rather than a regex because the two cheap alternatives are
+ * both wrong in ways that matter here: stripping `//` to end of line eats the rest
+ * of any line holding a `https://` literal, and not stripping at all lets a comment
+ * that merely mentions an import fail the build.
+ */
+export function stripCommentsAndStrings(source: string): string {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    const two = source.slice(i, i + 2);
+    if (two === '//') {
+      while (i < source.length && source[i] !== '\n') i++;
+      continue;
+    }
+    if (two === '/*') {
+      i += 2;
+      while (i < source.length && source.slice(i, i + 2) !== '*/') i++;
+      i += 2;
+      continue;
+    }
+    const ch = source[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      // The quotes are kept so an import specifier is still delimited; only what
+      // is between them is dropped.
+      out += ch;
+      i++;
+      let body = '';
+      while (i < source.length && source[i] !== ch) {
+        if (source[i] === '\\') {
+          i += 2;
+          body += ' ';
+          continue;
+        }
+        body += source[i];
+        i++;
+      }
+      // Specifiers are what the guard reads, so a plain (non-template, no escapes,
+      // single-line) literal keeps its text; anything else is blanked.
+      out += ch !== '`' && !body.includes('\n') ? body : '';
+      out += ch;
+      i++;
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+export interface ModuleImport {
+  specifier: string;
+  bindings: string[];
+}
+
+/**
+ * The imports of a module: the specifier, plus the local names bound from it.
+ *
+ * A namespace import binds every export of the module at once, so it is recorded
+ * as `*` and judged on the specifier rather than on names it never spells out.
+ */
+export function parseImports(source: string): ModuleImport[] {
+  const code = stripCommentsAndStrings(source);
+  const found: ModuleImport[] = [];
+
+  const statement = /\bimport\s+([\s\S]*?)\s+from\s*['"]([^'"]*)['"]/g;
+  for (const match of code.matchAll(statement)) {
+    const clause = match[1];
+    const bindings: string[] = [];
+    if (/\*\s+as\s+/.test(clause)) bindings.push('*');
+    const named = clause.match(/\{([\s\S]*?)\}/);
+    if (named) {
+      for (const entry of named[1].split(',')) {
+        const name = entry.trim().split(/\s+as\s+/)[0].trim();
+        if (name) bindings.push(name);
+      }
+    }
+    const defaultBinding = clause.replace(/\{[\s\S]*?\}/, '').replace(/type\s+/, '').trim();
+    const leading = defaultBinding.split(',')[0].trim();
+    if (leading && !leading.startsWith('*')) bindings.push(leading);
+    found.push({ specifier: match[2], bindings });
+  }
+
+  // Side-effect and dynamic imports bind nothing, but they still pull a module in.
+  const bare = /\bimport\s*\(?\s*['"]([^'"]*)['"]\s*\)?/g;
+  for (const match of code.matchAll(bare)) {
+    if (!found.some((f) => f.specifier === match[1])) {
+      found.push({ specifier: match[1], bindings: [] });
+    }
+  }
+
+  return found;
+}
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...sourceFiles(full));
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('parseImports (the guard proves itself before it is trusted)', () => {
+  it('flags a named signing import', () => {
+    expect(parseImports("import { PrivateKey } from '@ecency/sdk/hive';")).toEqual([
+      { specifier: '@ecency/sdk/hive', bindings: ['PrivateKey'] },
+    ]);
+  });
+
+  it('flags a renamed signing import', () => {
+    const [entry] = parseImports("import { PrivateKey as K, callRPC } from '@ecency/sdk/hive';");
+    expect(entry.bindings).toContain('PrivateKey');
+  });
+
+  it('flags a namespace import, which binds every export at once', () => {
+    expect(parseImports("import * as hive from 'hive-tx';")).toEqual([
+      { specifier: 'hive-tx', bindings: ['*'] },
+    ]);
+  });
+
+  it('flags a multi-line import clause', () => {
+    const [entry] = parseImports("import {\n  callRPC,\n  Transaction,\n} from '@ecency/sdk/hive';");
+    expect(entry.bindings).toContain('Transaction');
+  });
+
+  it('flags a dynamic import specifier', () => {
+    expect(parseImports("const hs = await import('hivesigner');")).toEqual([
+      { specifier: 'hivesigner', bindings: [] },
+    ]);
+  });
+
+  it('does not read an import out of a comment', () => {
+    expect(parseImports("// import { PrivateKey } from 'hive-tx';\nconst a = 1;")).toEqual([]);
+    expect(parseImports("/* import { Transaction } from 'hive-tx'; */")).toEqual([]);
+  });
+
+  it('does not lose code that follows a URL in a comment or a string', () => {
+    const code = "const rpc = 'https://api.example'; // see https://example/docs\nimport { PrivateKey } from 'hive-tx';";
+    const [entry] = parseImports(code);
+    expect(entry).toEqual({ specifier: 'hive-tx', bindings: ['PrivateKey'] });
+  });
+});
+
+describe('the hosting API cannot sign a Hive transaction', () => {
+  const files = sourceFiles(SRC);
+
+  it('is looking at the real package, not an empty walk', () => {
+    // Without this the whole suite passes when the walk finds nothing, which is
+    // how a guard in this repository has silently stopped guarding before.
+    expect(files.length).toBeGreaterThan(20);
+    const specifiers = files.flatMap((f) =>
+      parseImports(readFileSync(f, 'utf-8')).map((i) => i.specifier)
+    );
+    expect(specifiers).toContain('@ecency/sdk/hive');
+    expect(specifiers.length).toBeGreaterThan(50);
+  });
+
+  it('imports no signing primitive anywhere', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      for (const entry of parseImports(readFileSync(file, 'utf-8'))) {
+        const bad = entry.bindings.filter((b) => SIGNING_BINDINGS.has(b));
+        if (bad.length > 0) {
+          offenders.push(`${path.relative(SRC, file)} imports ${bad.join(', ')}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('imports no signing or key-handling module anywhere', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      for (const entry of parseImports(readFileSync(file, 'utf-8'))) {
+        if (SIGNING_MODULES.some((re) => re.test(entry.specifier))) {
+          offenders.push(`${path.relative(SRC, file)} imports ${entry.specifier}`);
+        }
+        // A namespace import of the SDK's hive entry point brings PrivateKey and
+        // Transaction with it, whatever the module is called.
+        if (entry.specifier === '@ecency/sdk/hive' && entry.bindings.includes('*')) {
+          offenders.push(`${path.relative(SRC, file)} imports all of @ecency/sdk/hive`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/no-signing-capability.test.ts
+++ b/apps/self-hosted/hosting/api/src/no-signing-capability.test.ts
@@ -139,6 +139,40 @@ export function parseImports(source: string): ModuleImport[] {
   return found;
 }
 
+/**
+ * How many lines plainly begin an import statement.
+ *
+ * The scanner above is not a JavaScript lexer, and the gap it cannot close on
+ * its own is a regex literal holding a quote: `/['"]/` is code, but the scanner
+ * reads that apostrophe as the start of a string and swallows everything up to
+ * the next one. Whatever it swallows is invisible to the guard, and an invisible
+ * import is exactly the false pass this file exists to not have.
+ *
+ * So rather than pretend to lex, the guard checks its own sight. A line starting
+ * with `import` is an import in any style this package is written in, and a
+ * comment never starts one because it starts with a slash. If the parser reports
+ * fewer than this counts, it lost something and the file is reported instead of
+ * being quietly certified clean.
+ */
+export function plainImportLines(source: string): number {
+  return (source.match(/^[ \t]*import[ \t(]/gm) ?? []).length;
+}
+
+/**
+ * The modules whose imports the parser could not fully see.
+ *
+ * A function rather than a loop inside a test so it can be exercised on an input
+ * that must be flagged. A loop that finds nothing passes whether or not it ran,
+ * and a check nobody has ever seen fire is not a check.
+ */
+export function unreadableModules(sources: Iterable<[string, string]>): string[] {
+  const out: string[] = [];
+  for (const [name, source] of sources) {
+    if (parseImports(source).length < plainImportLines(source)) out.push(name);
+  }
+  return out;
+}
+
 function sourceFiles(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir)) {
@@ -193,8 +227,51 @@ describe('parseImports (the guard proves itself before it is trusted)', () => {
   });
 });
 
+describe('plainImportLines (the guard checks its own sight)', () => {
+  it('counts what the parser is expected to find', () => {
+    const code = "import { a } from 'x';\nimport 'y';\nconst z = await import('w');\n";
+    expect(plainImportLines(code)).toBe(2);
+    expect(parseImports(code).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does not count an import inside a comment', () => {
+    expect(plainImportLines("// import { a } from 'x';\n")).toBe(0);
+  });
+
+  it('sees an import the scanner loses to a regex holding a quote', () => {
+    // The scanner reads that apostrophe as a string opener and swallows the
+    // import behind it. This is the case the cross-check exists for, so it is
+    // asserted as a real divergence rather than described in a comment.
+    const code = "const q = /['\"]/;\nimport { PrivateKey } from 'hive-tx';\n";
+    expect(parseImports(code)).toEqual([]);
+    expect(plainImportLines(code)).toBe(1);
+  });
+
+  it('flags the module whose imports were swallowed', () => {
+    const blind = "const q = /['\"]/;\nimport { PrivateKey } from 'hive-tx';\n";
+    expect(unreadableModules([['blind.ts', blind]])).toEqual(['blind.ts']);
+  });
+
+  it('does not flag a module the parser reads completely', () => {
+    expect(unreadableModules([['ok.ts', "import { callRPC } from '@ecency/sdk/hive';\n"]])).toEqual(
+      []
+    );
+  });
+});
+
 describe('the hosting API cannot sign a Hive transaction', () => {
   const files = sourceFiles(SRC);
+
+  it('can see every import the package plainly contains', () => {
+    // A file the parser cannot fully read is not a file it may certify. Anything
+    // reported here is a scanner blind spot, not a signing import, but the guard
+    // has to fail on it rather than conclude the module is clean.
+    expect(
+      unreadableModules(
+        files.map((file) => [path.relative(SRC, file), readFileSync(file, 'utf-8')])
+      )
+    ).toEqual([]);
+  });
 
   it('is looking at the real package, not an empty walk', () => {
     // Without this the whole suite passes when the walk finds nothing, which is

--- a/apps/self-hosted/hosting/api/src/no-signing-capability.test.ts
+++ b/apps/self-hosted/hosting/api/src/no-signing-capability.test.ts
@@ -118,7 +118,14 @@ export function parseImports(source: string): ModuleImport[] {
     const named = clause.match(/\{([\s\S]*?)\}/);
     if (named) {
       for (const entry of named[1].split(',')) {
-        const name = entry.trim().split(/\s+as\s+/)[0].trim();
+        // An inline `type` modifier is part of the syntax, not part of the name.
+        // Without stripping it, `import { type PrivateKey }` records the binding
+        // as "type PrivateKey", which matches nothing and hides the import.
+        const name = entry
+          .trim()
+          .replace(/^type\s+/, '')
+          .split(/\s+as\s+/)[0]
+          .trim();
         if (name) bindings.push(name);
       }
     }
@@ -202,6 +209,25 @@ describe('parseImports (the guard proves itself before it is trusted)', () => {
     expect(parseImports("import * as hive from 'hive-tx';")).toEqual([
       { specifier: 'hive-tx', bindings: ['*'] },
     ]);
+  });
+
+  it('flags a signing import behind an inline type modifier', () => {
+    // A type-only import cannot sign anything on its own, and it is still
+    // reported. Nothing in this package has a reason to name these types, so an
+    // appearance is someone starting to write the code that does sign, which is
+    // the moment this is meant to be discussed rather than after it works.
+    const [entry] = parseImports("import { callRPC, type PrivateKey } from '@ecency/sdk/hive';");
+    expect(entry.bindings).toContain('PrivateKey');
+  });
+
+  it('flags a wholly type-only signing import', () => {
+    const [entry] = parseImports("import type { Transaction } from '@ecency/sdk/hive';");
+    expect(entry.bindings).toContain('Transaction');
+  });
+
+  it('does not mangle the name of an ordinary inline type import', () => {
+    const [entry] = parseImports("import { mapTenantFromDb, type Tenant } from '../types';");
+    expect(entry.bindings).toEqual(expect.arrayContaining(['mapTenantFromDb', 'Tenant']));
   });
 
   it('flags a multi-line import clause', () => {

--- a/apps/self-hosted/hosting/api/src/routes/hivesigner-reconcile.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/hivesigner-reconcile.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  reconcile: vi.fn(),
+  auditLog: vi.fn(),
+}));
+
+const INTERNAL_SECRET = 'test-internal-secret-of-32-chars!!';
+
+vi.mock('../db/client', () => ({ db: { transaction: vi.fn(), queryOne: vi.fn() } }));
+
+vi.mock('../services/hivesigner-registry', () => ({
+  reconcileHivesignerClientIds: mocks.reconcile,
+}));
+
+vi.mock('../services/tenant-service', () => ({
+  TenantService: {},
+  ABANDONED_REREGISTER_QUARANTINE_HOURS: 24,
+  CAUGHT_UP_SQL: 'TRUE',
+  DomainInUseError: class extends Error {},
+}));
+
+vi.mock('../services/config-service', () => ({ ConfigService: {} }));
+vi.mock('../services/domain-service', () => ({ DomainService: {} }));
+vi.mock('../utils/cors-domains', () => ({ addVerifiedDomainOrigin: vi.fn() }));
+
+vi.mock('../services/audit-service', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/audit-service')>()),
+  AuditService: { log: (...args: any[]) => mocks.auditLog(...args) },
+}));
+
+const { internalRoutes } = await import('./internal');
+
+const RESULT = {
+  account: 'ecency.app',
+  registered: 26,
+  enabled: ['alice'],
+  disabled: [],
+  unchanged: 24,
+  failed: [],
+};
+
+function reconcile(headers: Record<string, string> = {}, body?: string) {
+  return internalRoutes.request('/hivesigner/reconcile', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body,
+  });
+}
+
+describe('POST /v1/internal/hivesigner/reconcile', () => {
+  beforeEach(() => {
+    process.env.HOSTING_INTERNAL_SECRET = INTERNAL_SECRET;
+    mocks.reconcile.mockReset().mockResolvedValue(RESULT);
+    mocks.auditLog.mockReset();
+  });
+
+  it('reconciles and reports what it changed', async () => {
+    const response = await reconcile({ 'x-internal-secret': INTERNAL_SECRET });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(RESULT);
+    expect(mocks.reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a caller with no secret', async () => {
+    const response = await reconcile();
+
+    expect(response.status).toBe(403);
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+  });
+
+  it('refuses a caller with the wrong secret', async () => {
+    const response = await reconcile({ 'x-internal-secret': 'x'.repeat(INTERNAL_SECRET.length) });
+
+    expect(response.status).toBe(403);
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+  });
+
+  it('refuses every caller while the shared secret is unset', async () => {
+    delete process.env.HOSTING_INTERNAL_SECRET;
+
+    const response = await reconcile({ 'x-internal-secret': INTERNAL_SECRET });
+
+    expect(response.status).toBe(403);
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+  });
+
+  it('reads NOTHING the caller sends, so the secret cannot enable a chosen instance', async () => {
+    // What gets a client id is decided from the chain and from each tenant's own
+    // row. If the body were read, holding the shared secret would be enough to put
+    // a login button on an instance whose URI was never registered.
+    await reconcile(
+      { 'x-internal-secret': INTERNAL_SECRET },
+      JSON.stringify({ usernames: ['mallory'], clientId: 'attacker.app', force: true })
+    );
+
+    expect(mocks.reconcile).toHaveBeenCalledWith();
+  });
+
+  it('still answers when the caller sends a body that is not JSON at all', async () => {
+    const response = await reconcile({ 'x-internal-secret': INTERNAL_SECRET }, 'not json');
+
+    expect(response.status).toBe(200);
+  });
+
+  it('reports a transient failure when the chain cannot be read', async () => {
+    // The scheduled job retries on its next tick; nothing was written.
+    mocks.reconcile.mockRejectedValueOnce(new Error('ECONNRESET'));
+
+    const response = await reconcile({ 'x-internal-secret': INTERNAL_SECRET });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: 'reconcile_failed' });
+  });
+
+  it('records the outcome, since nothing else can say why a client id changed', async () => {
+    await reconcile({ 'x-internal-secret': INTERNAL_SECRET });
+
+    expect(mocks.auditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'hivesigner.client_ids_reconciled',
+        eventData: expect.objectContaining({ enabled: ['alice'], registered: 26 }),
+      })
+    );
+  });
+});

--- a/apps/self-hosted/hosting/api/src/routes/internal.ts
+++ b/apps/self-hosted/hosting/api/src/routes/internal.ts
@@ -17,6 +17,7 @@ import {
 import { DomainService } from '../services/domain-service';
 import { customDomainCapability, type CapabilityState } from '../services/subscription';
 import { ConfigService } from '../services/config-service';
+import { reconcileHivesignerClientIds } from '../services/hivesigner-registry';
 import { AuditService, parseClientIp } from '../services/audit-service';
 import { mapTenantFromDb, type Tenant } from '../types';
 import { addVerifiedDomainOrigin } from '../utils/cors-domains';
@@ -589,6 +590,49 @@ internalRoutes.post('/claim-blog', async (c) => {
     // rather than a permanent failure or a false success.
     if (err.retryable) return c.json({ error: 'reclaimed_recently' }, 503);
     return c.json({ error: 'claim_failed' }, 500);
+  }
+});
+
+/**
+ * POST /v1/internal/hivesigner/reconcile - bring every served tenant's Hivesigner
+ * client id into agreement with the app account's on-chain redirect_uris.
+ *
+ * Called by the scheduled registration job right after it has confirmed what is on
+ * chain. Registration and enablement have to be inseparable: a client id on an
+ * instance whose URI is not registered is a login button that leads to an error page
+ * with no explanation.
+ *
+ * Deliberately takes NO body. The job says only "look again"; what gets enabled is
+ * decided here, from the chain and from each tenant's own row, so a caller holding
+ * the shared secret still cannot enable an instance whose URI is not registered.
+ *
+ * Idempotent, and safe on a schedule: a pass that failed halfway leaves the tenants it
+ * did not reach for the next one, which repairs them without anybody being told.
+ */
+internalRoutes.post('/hivesigner/reconcile', async (c) => {
+  if (!internalSecretOk(c.req.header('x-internal-secret'))) {
+    return c.json({ error: 'forbidden' }, 403);
+  }
+
+  try {
+    const result = await reconcileHivesignerClientIds();
+
+    auditInternal(c, null, 'hivesigner.client_ids_reconciled', {
+      account: result.account,
+      registered: result.registered,
+      enabled: result.enabled,
+      disabled: result.disabled,
+      unchanged: result.unchanged,
+      failed: result.failed,
+    });
+
+    return c.json(result);
+  } catch (e) {
+    // The chain read failed, so nothing is known about what is registered. Reported as
+    // transient and NOTHING is written: guessing here would switch the login method off
+    // for every tenant at once on a single bad RPC response.
+    console.error('[internal/hivesigner] reconcile failed:', (e as Error).message);
+    return c.json({ error: 'reconcile_failed' }, 503);
   }
 });
 

--- a/apps/self-hosted/hosting/api/src/routes/tenant-config-patch.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenant-config-patch.test.ts
@@ -4,7 +4,7 @@ const mocks = vi.hoisted(() => ({
   getByUsername: vi.fn(),
   applyConfigDocument: vi.fn(),
   updateConfig: vi.fn(),
-  generateConfigFile: vi.fn(),
+  publishConfigFile: vi.fn(),
 }));
 
 vi.mock('../db/client', () => ({ db: { query: vi.fn(), queryOne: vi.fn(), transaction: vi.fn() } }));
@@ -26,7 +26,7 @@ vi.mock('../services/tenant-service', () => ({
 }));
 
 vi.mock('../services/config-service', () => ({
-  ConfigService: { generateConfigFile: mocks.generateConfigFile },
+  ConfigService: { publishConfigFile: mocks.publishConfigFile },
   isPublishableTenant: (tenant: { subscriptionStatus: string }) =>
     tenant.subscriptionStatus === 'active',
 }));
@@ -78,7 +78,7 @@ beforeEach(() => {
     ...TENANT,
     config: { version: 1, configuration: {} },
   }));
-  mocks.generateConfigFile.mockResolvedValue(undefined);
+  mocks.publishConfigFile.mockResolvedValue(undefined);
 });
 
 /**
@@ -88,6 +88,26 @@ beforeEach(() => {
  * and the route answered 200 "Configuration updated" having stored none of it. Clearing the
  * Version field in the editor is enough to trigger it: a cleared number input sends null.
  */
+describe('PATCH /v1/tenants/:username publication', () => {
+  it('hands the publisher a name, never the row it just wrote', async () => {
+    // The served file has more than one writer now: the Hivesigner reconcile can
+    // commit a client id for this tenant while a save is in flight. Whichever of
+    // the two publishes its OWN snapshot last puts the other's change back on
+    // disk while the database keeps both, and nothing afterwards notices the
+    // file and the row disagree. Passing an identifier is what makes that
+    // impossible, because the content is then resolved after the commit, inside
+    // the lock. That the content really is the newest committed config is proven
+    // end to end against the real ConfigService in hivesigner-registry.test.ts.
+    await patch({ version: 1, configuration: { general: { theme: 'dark' } } });
+
+    const args = mocks.publishConfigFile.mock.calls[0];
+    expect(args).toEqual(['alice']);
+    expect(
+      args.some((arg: unknown) => !!arg && typeof arg === 'object' && 'config' in (arg as object))
+    ).toBe(false);
+  });
+});
+
 describe('PATCH /v1/tenants/:username config validation', () => {
   it('rejects a full document with a null version instead of discarding the save', async () => {
     const res = await patch({
@@ -211,7 +231,7 @@ describe('PATCH /v1/tenants/:username config reset', () => {
     expect(res.status).toBe(403);
     expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
     expect(mocks.updateConfig).not.toHaveBeenCalled();
-    expect(mocks.generateConfigFile).not.toHaveBeenCalled();
+    expect(mocks.publishConfigFile).not.toHaveBeenCalled();
   });
 
   it('refuses a reset sent without the document that replaces the value', async () => {

--- a/apps/self-hosted/hosting/api/src/routes/tenants.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tenants.ts
@@ -645,9 +645,16 @@ tenantRoutes.patch('/:username', authMiddleware, zValidator('json', updateTenant
   // exists with no subscription check, so publishing here would put a blog that
   // has never been paid for live until the next sweep removes it. The config
   // itself is always persisted, so the edit is not lost.
+  // Published BY NAME rather than from the row this request just wrote. The
+  // served file now has more than one writer: the Hivesigner reconcile can
+  // commit a client id for this tenant and publish it while this save is in
+  // flight, and whichever of the two writes its own snapshot last would put the
+  // other's change back on disk while the database kept both. publishConfigFile
+  // re-reads inside the same per-tenant lock, so the file always ends up
+  // carrying the newest committed config no matter which order they land in.
   const published = isPublishableTenant(updatedTenant);
   if (published) {
-    await ConfigService.generateConfigFile(updatedTenant);
+    await ConfigService.publishConfigFile(username);
   }
   
   void AuditService.log({

--- a/apps/self-hosted/hosting/api/src/services/config-reset.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-reset.test.ts
@@ -17,8 +17,19 @@ const mocks = vi.hoisted(() => ({
   queryOne: vi.fn(),
 }));
 
+// applyConfigDocument reads and writes through an SqlExecutor so a caller can run
+// it inside its own transaction, and an executor returns a result set rather than
+// a row. The mock keeps ONE implementation and exposes it both ways, so the two
+// cannot answer differently.
 vi.mock('../db/client', () => ({
-  db: { query: vi.fn(), queryOne: mocks.queryOne, transaction: vi.fn() },
+  db: {
+    query: async (sql: string, params: any[]) => {
+      const row = await mocks.queryOne(sql, params);
+      return { rows: row ? [row] : [] };
+    },
+    queryOne: mocks.queryOne,
+    transaction: vi.fn(),
+  },
 }));
 
 const { TenantService, CONFIG_RESET_PATH, MAX_RESET_PATHS, PINNED_INSTANCE_FIELDS } = await import(

--- a/apps/self-hosted/hosting/api/src/services/hivesigner-registry.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/hivesigner-registry.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  callRPC: vi.fn(),
+  getActiveTenants: vi.fn(),
+  applyConfigDocument: vi.fn(),
+  generateConfigFile: vi.fn(),
+}));
+
+vi.mock('@ecency/sdk/hive', () => ({
+  callRPC: mocks.callRPC,
+  config: { nodes: [] },
+  setNodes: vi.fn(),
+}));
+
+vi.mock('./tenant-service', () => ({
+  TenantService: {
+    getActiveTenants: mocks.getActiveTenants,
+    applyConfigDocument: mocks.applyConfigDocument,
+  },
+}));
+
+// isPublishableTenant is deliberately NOT mocked: the rule about which tenants may be
+// served is shared, and a copy of it here would let the two drift.
+vi.mock('./config-service', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    ConfigService: { generateConfigFile: mocks.generateConfigFile },
+  };
+});
+
+const {
+  decideClientId,
+  clientIdDocument,
+  parseRegisteredRedirectUris,
+  reconcileHivesignerClientIds,
+  tenantRedirectUris,
+} = await import('./hivesigner-registry');
+
+const APP = 'ecency.app';
+const BASE = 'blogs.ecency.com';
+
+function tenant(over: Record<string, unknown> = {}) {
+  return {
+    id: 'id-' + (over.username ?? 'alice'),
+    username: 'alice',
+    owner: 'alice',
+    subscriptionStatus: 'active',
+    subscriptionPlan: 'standard',
+    customDomain: null,
+    customDomainVerified: false,
+    config: {},
+    ...over,
+  } as never;
+}
+
+function metadata(uris: unknown) {
+  return JSON.stringify({ profile: { name: 'App', redirect_uris: uris } });
+}
+
+describe('tenantRedirectUris', () => {
+  it('is the tenant subdomain callback for an instance with no custom domain', () => {
+    expect(
+      tenantRedirectUris({ username: 'alice', customDomain: null, customDomainVerified: false }, BASE)
+    ).toEqual(['https://alice.blogs.ecency.com/auth']);
+  });
+
+  it('adds the custom domain once it is VERIFIED, because both origins serve the same config', () => {
+    expect(
+      tenantRedirectUris(
+        { username: 'alice', customDomain: 'alice.example', customDomainVerified: true },
+        BASE
+      )
+    ).toEqual(['https://alice.blogs.ecency.com/auth', 'https://alice.example/auth']);
+  });
+
+  it('never includes a custom domain that has only been CLAIMED', () => {
+    // Registering a name someone merely typed into the form would let whoever
+    // actually controls it receive callbacks carrying tokens for the app.
+    expect(
+      tenantRedirectUris(
+        { username: 'alice', customDomain: 'not-mine.example', customDomainVerified: false },
+        BASE
+      )
+    ).toEqual(['https://alice.blogs.ecency.com/auth']);
+  });
+
+  it('lower-cases both hosts, since the match on chain is exact', () => {
+    expect(
+      tenantRedirectUris(
+        { username: 'Alice', customDomain: 'Alice.Example', customDomainVerified: true },
+        BASE
+      )
+    ).toEqual(['https://alice.blogs.ecency.com/auth', 'https://alice.example/auth']);
+  });
+});
+
+describe('parseRegisteredRedirectUris', () => {
+  it('reads the registered array', () => {
+    expect(parseRegisteredRedirectUris(metadata(['https://a/auth', 'https://b/auth']))).toEqual([
+      'https://a/auth',
+      'https://b/auth',
+    ]);
+  });
+
+  it('keeps only the strings', () => {
+    expect(parseRegisteredRedirectUris(metadata(['https://a/auth', 42, null]))).toEqual([
+      'https://a/auth',
+    ]);
+  });
+
+  it('reports an app that has registered nothing as an empty list', () => {
+    expect(parseRegisteredRedirectUris(JSON.stringify({ profile: { name: 'App' } }))).toEqual([]);
+  });
+
+  it.each([
+    ['absent metadata', undefined],
+    ['an empty string', '   '],
+    ['a non-string', { profile: {} }],
+    ['invalid JSON', '{not json'],
+    ['a JSON array at the root', '[]'],
+    ['no profile', JSON.stringify({ other: 1 })],
+    ['a non-array redirect_uris', metadata('https://a/auth')],
+  ])('THROWS on %s rather than reporting an empty registration', (_label, input) => {
+    // An empty list is a real answer that disables every tenant, so nothing that
+    // merely FAILED to be read may be allowed to look like one.
+    expect(() => parseRegisteredRedirectUris(input)).toThrow();
+  });
+});
+
+describe('decideClientId', () => {
+  const registered = (...uris: string[]) => new Set(uris);
+
+  it('enables when every serving origin is registered and nothing is stored', () => {
+    expect(
+      decideClientId(undefined, ['https://a/auth'], registered('https://a/auth'), APP)
+    ).toBe('enable');
+  });
+
+  it('leaves an instance that is already enabled and still registered', () => {
+    expect(decideClientId(APP, ['https://a/auth'], registered('https://a/auth'), APP)).toBe('leave');
+  });
+
+  it('does NOT enable when only some of the serving origins are registered', () => {
+    // One config file serves the subdomain and the verified custom domain, and the
+    // SPA builds its redirect_uri from window.location.origin. Enabling here gives
+    // every visitor on the unregistered origin a button that fails.
+    expect(
+      decideClientId(
+        undefined,
+        ['https://a/auth', 'https://custom/auth'],
+        registered('https://a/auth'),
+        APP
+      )
+    ).toBe('leave');
+  });
+
+  it('disables when a client id it set points at a URI that has left the array', () => {
+    expect(decideClientId(APP, ['https://a/auth'], registered(), APP)).toBe('disable');
+  });
+
+  it('leaves a blank stored value alone when nothing is registered', () => {
+    expect(decideClientId('', ['https://a/auth'], registered(), APP)).toBe('leave');
+    expect(decideClientId(undefined, ['https://a/auth'], registered(), APP)).toBe('leave');
+  });
+
+  it.each([
+    ['registered', registered('https://a/auth')],
+    ['not registered', registered()],
+  ])("never touches the owner's own Hivesigner app when %s", (_label, set) => {
+    // Their app, their registration, against URIs this service knows nothing about.
+    expect(decideClientId('myblog.app', ['https://a/auth'], set, APP)).toBe('leave');
+  });
+
+  it('does not enable on an empty required list', () => {
+    // `every` is vacuously true on an empty array, which would enable an instance
+    // whose origins were never worked out at all.
+    expect(decideClientId(undefined, [], registered('https://a/auth'), APP)).toBe('leave');
+  });
+
+  it('recognises a stored value that differs only by case or padding', () => {
+    expect(decideClientId('  ECENCY.APP ', ['https://a/auth'], registered(), APP)).toBe('disable');
+  });
+});
+
+describe('clientIdDocument', () => {
+  it('nests the value where the SPA reads it', () => {
+    expect(clientIdDocument(APP)).toEqual({
+      configuration: { general: { hivesigner: { clientId: APP } } },
+    });
+  });
+
+  it('disables with an empty string, which the SPA treats as absent', () => {
+    // The guarded merge has no delete, and a null is stripped from a config
+    // document before it is merged, so an empty string is what withdrawal looks like.
+    expect(clientIdDocument('')).toEqual({
+      configuration: { general: { hivesigner: { clientId: '' } } },
+    });
+  });
+});
+
+describe('reconcileHivesignerClientIds', () => {
+  beforeEach(() => {
+    mocks.callRPC.mockReset();
+    mocks.getActiveTenants.mockReset();
+    mocks.applyConfigDocument.mockReset();
+    mocks.generateConfigFile.mockReset();
+  });
+
+  function chainHas(...uris: string[]) {
+    mocks.callRPC.mockResolvedValue([{ posting_json_metadata: metadata(uris) }]);
+  }
+
+  it('enables a registered tenant through the guarded config path and publishes it', async () => {
+    chainHas('https://alice.blogs.ecency.com/auth');
+    mocks.getActiveTenants.mockResolvedValue([tenant()]);
+    mocks.applyConfigDocument.mockResolvedValue({
+      tenant: tenant({ subscriptionStatus: 'active' }),
+    });
+
+    const result = await reconcileHivesignerClientIds(APP);
+
+    expect(result.enabled).toEqual(['alice']);
+    expect(mocks.applyConfigDocument).toHaveBeenCalledWith('alice', clientIdDocument(APP));
+    expect(mocks.generateConfigFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves an unregistered tenant with no client id and writes nothing for it', async () => {
+    chainHas('https://someone-else.blogs.ecency.com/auth');
+    mocks.getActiveTenants.mockResolvedValue([tenant()]);
+
+    const result = await reconcileHivesignerClientIds(APP);
+
+    expect(result.enabled).toEqual([]);
+    expect(result.unchanged).toBe(1);
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+  });
+
+  it('withdraws a client id whose URI is no longer on chain', async () => {
+    chainHas();
+    mocks.getActiveTenants.mockResolvedValue([
+      tenant({ config: { configuration: { general: { hivesigner: { clientId: APP } } } } }),
+    ]);
+    mocks.applyConfigDocument.mockResolvedValue({ tenant: tenant() });
+
+    const result = await reconcileHivesignerClientIds(APP);
+
+    expect(result.disabled).toEqual(['alice']);
+    expect(mocks.applyConfigDocument).toHaveBeenCalledWith('alice', clientIdDocument(''));
+  });
+
+  it('writes NOTHING when the chain cannot be read', async () => {
+    // Treating an unreadable account as "nothing is registered" would withdraw the
+    // login method from every tenant at once on one bad RPC response.
+    mocks.callRPC.mockRejectedValue(new Error('ECONNRESET'));
+    mocks.getActiveTenants.mockResolvedValue([tenant()]);
+
+    await expect(reconcileHivesignerClientIds(APP)).rejects.toThrow('ECONNRESET');
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+    expect(mocks.getActiveTenants).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing when the app account does not exist', async () => {
+    mocks.callRPC.mockResolvedValue([]);
+    await expect(reconcileHivesignerClientIds(APP)).rejects.toThrow(/does not exist/);
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+  });
+
+  it('carries on past a tenant whose write fails, and names it for the next pass', async () => {
+    chainHas('https://alice.blogs.ecency.com/auth', 'https://bob.blogs.ecency.com/auth');
+    mocks.getActiveTenants.mockResolvedValue([
+      tenant({ username: 'alice' }),
+      tenant({ username: 'bob' }),
+    ]);
+    mocks.applyConfigDocument
+      .mockRejectedValueOnce(new Error('deadlock detected'))
+      .mockResolvedValueOnce({ tenant: tenant({ username: 'bob' }) });
+
+    const result = await reconcileHivesignerClientIds(APP);
+
+    expect(result.failed).toEqual(['alice']);
+    expect(result.enabled).toEqual(['bob']);
+  });
+
+  it('stores the change but does not publish for a tenant that may not be served', async () => {
+    // nginx serves any file that exists with no subscription check.
+    chainHas('https://alice.blogs.ecency.com/auth');
+    mocks.getActiveTenants.mockResolvedValue([tenant()]);
+    mocks.applyConfigDocument.mockResolvedValue({
+      tenant: tenant({ subscriptionStatus: 'expired' }),
+    });
+
+    const result = await reconcileHivesignerClientIds(APP);
+
+    expect(result.enabled).toEqual(['alice']);
+    expect(mocks.generateConfigFile).not.toHaveBeenCalled();
+  });
+
+  it('requires BOTH origins before enabling a tenant that serves a verified custom domain', async () => {
+    chainHas('https://alice.blogs.ecency.com/auth');
+    mocks.getActiveTenants.mockResolvedValue([
+      tenant({ customDomain: 'alice.example', customDomainVerified: true }),
+    ]);
+
+    const result = await reconcileHivesignerClientIds(APP);
+
+    expect(result.enabled).toEqual([]);
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/hivesigner-registry.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/hivesigner-registry.test.ts
@@ -5,12 +5,30 @@ const mocks = vi.hoisted(() => ({
   getActiveTenants: vi.fn(),
   applyConfigDocument: vi.fn(),
   generateConfigFile: vi.fn(),
+  lockedRow: vi.fn(),
+  lockedSql: vi.fn(),
 }));
 
 vi.mock('@ecency/sdk/hive', () => ({
   callRPC: mocks.callRPC,
   config: { nodes: [] },
   setNodes: vi.fn(),
+}));
+
+// The write path re-reads the row FOR UPDATE and decides again from it, so the
+// transaction is modelled rather than stubbed away: `lockedRow` is what the
+// database would hand back at that moment, which is how a config save landing
+// between the listing and the write is expressed.
+vi.mock('../db/client', () => ({
+  db: {
+    transaction: async (fn: (client: unknown) => Promise<unknown>) =>
+      fn({
+        query: async (sql: string, params: unknown[]) => {
+          mocks.lockedSql(sql, params);
+          return { rows: mocks.lockedRow() };
+        },
+      }),
+  },
 }));
 
 vi.mock('./tenant-service', () => ({
@@ -53,6 +71,26 @@ function tenant(over: Record<string, unknown> = {}) {
     config: {},
     ...over,
   } as never;
+}
+
+/** The same tenant as the database row the locked re-read returns. */
+function row(over: Record<string, unknown> = {}) {
+  const t = tenant(over) as unknown as Record<string, unknown>;
+  return {
+    id: t.id,
+    username: t.username,
+    owner: t.owner,
+    subscription_status: t.subscriptionStatus,
+    subscription_plan: t.subscriptionPlan,
+    subscription_started_at: null,
+    subscription_expires_at: null,
+    custom_domain: t.customDomain,
+    custom_domain_verified: t.customDomainVerified,
+    custom_domain_verified_at: null,
+    config: t.config,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
 }
 
 function metadata(uris: unknown) {
@@ -206,6 +244,25 @@ describe('reconcileHivesignerClientIds', () => {
     mocks.getActiveTenants.mockReset();
     mocks.applyConfigDocument.mockReset();
     mocks.generateConfigFile.mockReset();
+    // By default the locked re-read agrees with the listing.
+    mocks.lockedRow.mockReset().mockReturnValue([row()]);
+    mocks.lockedSql.mockReset();
+    mocks.applyConfigDocument.mockResolvedValue({ tenant: tenant() });
+  });
+
+  it('takes a row lock on the re-read, which is what makes the decision safe', async () => {
+    // Re-reading without locking narrows the window instead of closing it: a
+    // config save could still commit between this read and the write. The lock
+    // is what makes a concurrent save either land first and be what this
+    // decides from, or wait and land on top.
+    chainHas('https://alice.blogs.ecency.com/auth');
+    mocks.getActiveTenants.mockResolvedValue([tenant()]);
+
+    await reconcileHivesignerClientIds(APP);
+
+    expect(mocks.lockedSql).toHaveBeenCalledWith(expect.stringMatching(/FOR UPDATE\s*$/), [
+      'alice',
+    ]);
   });
 
   function chainHas(...uris: string[]) {
@@ -215,15 +272,64 @@ describe('reconcileHivesignerClientIds', () => {
   it('enables a registered tenant through the guarded config path and publishes it', async () => {
     chainHas('https://alice.blogs.ecency.com/auth');
     mocks.getActiveTenants.mockResolvedValue([tenant()]);
-    mocks.applyConfigDocument.mockResolvedValue({
-      tenant: tenant({ subscriptionStatus: 'active' }),
-    });
 
     const result = await reconcileHivesignerClientIds(APP);
 
     expect(result.enabled).toEqual(['alice']);
-    expect(mocks.applyConfigDocument).toHaveBeenCalledWith('alice', clientIdDocument(APP));
+    // Fourth argument is the transaction the locked read happened in: the
+    // decision and the write have to be the same unit of work.
+    expect(mocks.applyConfigDocument).toHaveBeenCalledWith(
+      'alice',
+      clientIdDocument(APP),
+      [],
+      expect.objectContaining({ query: expect.any(Function) })
+    );
     expect(mocks.generateConfigFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not overwrite an owner's app saved after the listing was taken", async () => {
+    // The listing said the slot was empty, so the pass intends to enable. By the
+    // time the row is locked the owner has saved their own app. Writing the
+    // shared id here would destroy that value for good: the next pass would see
+    // an id it manages and leave it, so nothing would ever put theirs back.
+    chainHas('https://alice.blogs.ecency.com/auth');
+    mocks.getActiveTenants.mockResolvedValue([tenant()]);
+    mocks.lockedRow.mockReturnValue([
+      row({ config: { configuration: { general: { hivesigner: { clientId: 'myblog.app' } } } } }),
+    ]);
+
+    const result = await reconcileHivesignerClientIds(APP);
+
+    expect(result.enabled).toEqual([]);
+    expect(result.unchanged).toBe(1);
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+  });
+
+  it('does not enable on an origin set that grew after the listing was taken', async () => {
+    // A custom domain verified in that window adds a second serving origin the
+    // listing knew nothing about. Enabling on the strength of the first one is
+    // exactly the button that fails for everyone arriving on the second.
+    chainHas('https://alice.blogs.ecency.com/auth');
+    mocks.getActiveTenants.mockResolvedValue([tenant()]);
+    mocks.lockedRow.mockReturnValue([
+      row({ customDomain: 'alice.example', customDomainVerified: true }),
+    ]);
+
+    const result = await reconcileHivesignerClientIds(APP);
+
+    expect(result.enabled).toEqual([]);
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing for a tenant whose row disappeared after the listing', async () => {
+    chainHas('https://alice.blogs.ecency.com/auth');
+    mocks.getActiveTenants.mockResolvedValue([tenant()]);
+    mocks.lockedRow.mockReturnValue([]);
+
+    const result = await reconcileHivesignerClientIds(APP);
+
+    expect(result.unchanged).toBe(1);
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
   });
 
   it('leaves an unregistered tenant with no client id and writes nothing for it', async () => {
@@ -239,15 +345,19 @@ describe('reconcileHivesignerClientIds', () => {
 
   it('withdraws a client id whose URI is no longer on chain', async () => {
     chainHas();
-    mocks.getActiveTenants.mockResolvedValue([
-      tenant({ config: { configuration: { general: { hivesigner: { clientId: APP } } } } }),
-    ]);
-    mocks.applyConfigDocument.mockResolvedValue({ tenant: tenant() });
+    const enabled = { configuration: { general: { hivesigner: { clientId: APP } } } };
+    mocks.getActiveTenants.mockResolvedValue([tenant({ config: enabled })]);
+    mocks.lockedRow.mockReturnValue([row({ config: enabled })]);
 
     const result = await reconcileHivesignerClientIds(APP);
 
     expect(result.disabled).toEqual(['alice']);
-    expect(mocks.applyConfigDocument).toHaveBeenCalledWith('alice', clientIdDocument(''));
+    expect(mocks.applyConfigDocument).toHaveBeenCalledWith(
+      'alice',
+      clientIdDocument(''),
+      [],
+      expect.anything()
+    );
   });
 
   it('writes NOTHING when the chain cannot be read', async () => {
@@ -273,6 +383,9 @@ describe('reconcileHivesignerClientIds', () => {
       tenant({ username: 'alice' }),
       tenant({ username: 'bob' }),
     ]);
+    mocks.lockedRow
+      .mockReturnValueOnce([row({ username: 'alice' })])
+      .mockReturnValueOnce([row({ username: 'bob' })]);
     mocks.applyConfigDocument
       .mockRejectedValueOnce(new Error('deadlock detected'))
       .mockResolvedValueOnce({ tenant: tenant({ username: 'bob' }) });
@@ -283,17 +396,19 @@ describe('reconcileHivesignerClientIds', () => {
     expect(result.enabled).toEqual(['bob']);
   });
 
-  it('stores the change but does not publish for a tenant that may not be served', async () => {
-    // nginx serves any file that exists with no subscription check.
+  it('neither stores nor publishes for a tenant that stopped being served', async () => {
+    // nginx serves any file that exists with no subscription check, and a tenant
+    // that lapsed between the listing and the locked read is not owed a login
+    // method it never had.
     chainHas('https://alice.blogs.ecency.com/auth');
     mocks.getActiveTenants.mockResolvedValue([tenant()]);
-    mocks.applyConfigDocument.mockResolvedValue({
-      tenant: tenant({ subscriptionStatus: 'expired' }),
-    });
+    mocks.lockedRow.mockReturnValue([row({ subscriptionStatus: 'expired' })]);
 
     const result = await reconcileHivesignerClientIds(APP);
 
-    expect(result.enabled).toEqual(['alice']);
+    expect(result.enabled).toEqual([]);
+    expect(result.unchanged).toBe(1);
+    expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
     expect(mocks.generateConfigFile).not.toHaveBeenCalled();
   });
 

--- a/apps/self-hosted/hosting/api/src/services/hivesigner-registry.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/hivesigner-registry.test.ts
@@ -4,9 +4,10 @@ const mocks = vi.hoisted(() => ({
   callRPC: vi.fn(),
   getActiveTenants: vi.fn(),
   applyConfigDocument: vi.fn(),
-  generateConfigFile: vi.fn(),
+  getByUsername: vi.fn(),
   lockedRow: vi.fn(),
   lockedSql: vi.fn(),
+  written: vi.fn(),
 }));
 
 vi.mock('@ecency/sdk/hive', () => ({
@@ -29,24 +30,34 @@ vi.mock('../db/client', () => ({
         },
       }),
   },
+  // config-service serialises file writes on this; there is one process here.
+  withAdvisoryLock: (_ns: number, _key: number, fn: () => Promise<unknown>) => fn(),
 }));
 
 vi.mock('./tenant-service', () => ({
   TenantService: {
     getActiveTenants: mocks.getActiveTenants,
     applyConfigDocument: mocks.applyConfigDocument,
+    getByUsername: mocks.getByUsername,
   },
 }));
 
-// isPublishableTenant is deliberately NOT mocked: the rule about which tenants may be
-// served is shared, and a copy of it here would let the two drift.
-vi.mock('./config-service', async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown>;
-  return {
-    ...actual,
-    ConfigService: { generateConfigFile: mocks.generateConfigFile },
-  };
-});
+// ConfigService is NOT mocked. What ends up in a tenant's served file is the
+// thing under test here, and a stand-in for the publisher would be a copy of the
+// rule it is supposed to be checked against. The filesystem is mocked instead,
+// so the assertions are about the bytes that reach disk.
+vi.mock('fs', () => ({
+  promises: {
+    mkdir: async () => undefined,
+    readFile: async () => {
+      const missing = new Error('ENOENT') as NodeJS.ErrnoException;
+      missing.code = 'ENOENT';
+      throw missing;
+    },
+    writeFile: async (file: string, contents: string) => mocks.written(file, contents),
+    unlink: async () => undefined,
+  },
+}));
 
 const {
   decideClientId,
@@ -58,6 +69,12 @@ const {
 
 const APP = 'ecency.app';
 const BASE = 'blogs.ecency.com';
+
+/** A stored config that already carries the shared client id. */
+const enabledConfig = { configuration: { general: { hivesigner: { clientId: APP } } } };
+
+/** A stored config carrying an app the owner registered themselves. */
+const ownersConfig = { configuration: { general: { hivesigner: { clientId: 'myblog.app' } } } };
 
 function tenant(over: Record<string, unknown> = {}) {
   return {
@@ -243,12 +260,32 @@ describe('reconcileHivesignerClientIds', () => {
     mocks.callRPC.mockReset();
     mocks.getActiveTenants.mockReset();
     mocks.applyConfigDocument.mockReset();
-    mocks.generateConfigFile.mockReset();
-    // By default the locked re-read agrees with the listing.
+    mocks.written.mockReset();
+    // By default the locked re-read agrees with the listing, and the read that
+    // the publish does afterwards agrees with both.
     mocks.lockedRow.mockReset().mockReturnValue([row()]);
     mocks.lockedSql.mockReset();
-    mocks.applyConfigDocument.mockResolvedValue({ tenant: tenant() });
+    mocks.applyConfigDocument.mockResolvedValue({ tenant: tenant({ config: enabledConfig }) });
+    // Answers for whoever is asked, so a pass over several tenants cannot appear
+    // to publish the same file twice.
+    mocks.getByUsername
+      .mockReset()
+      .mockImplementation(async (username: string) =>
+        tenant({ username, config: enabledConfig })
+      );
   });
+
+  /** The config document written to a tenant's served file, if one was. */
+  function publishedConfig(username: string): any | undefined {
+    const write = mocks.written.mock.calls.find((call: any[]) =>
+      String(call[0]).endsWith(`${username}.json`)
+    );
+    return write ? JSON.parse(write[1]) : undefined;
+  }
+
+  function publishedClientId(username: string): unknown {
+    return publishedConfig(username)?.configuration?.general?.hivesigner?.clientId;
+  }
 
   it('takes a row lock on the re-read, which is what makes the decision safe', async () => {
     // Re-reading without locking narrows the window instead of closing it: a
@@ -284,7 +321,38 @@ describe('reconcileHivesignerClientIds', () => {
       [],
       expect.objectContaining({ query: expect.any(Function) })
     );
-    expect(mocks.generateConfigFile).toHaveBeenCalledTimes(1);
+    expect(publishedClientId('alice')).toBe(APP);
+  });
+
+  it('publishes the row as it stands AFTER the commit, not the row it committed', async () => {
+    // The same hazard as the locked re-read, one step later. The transaction
+    // commits, and before the file is written the owner saves an app of their
+    // own. Publishing the committed snapshot would put the older document on
+    // disk while the database holds the newer one, and that split is the worst
+    // outcome available: readers get a client id the row does not mention, and
+    // nothing afterwards notices the two disagree.
+    chainHas('https://alice.blogs.ecency.com/auth');
+    mocks.getActiveTenants.mockResolvedValue([tenant()]);
+    mocks.applyConfigDocument.mockResolvedValue({ tenant: tenant({ config: enabledConfig }) });
+    // The save lands in the gap between COMMIT and the file write.
+    mocks.getByUsername.mockResolvedValue(tenant({ config: ownersConfig }));
+
+    await reconcileHivesignerClientIds(APP);
+
+    expect(publishedClientId('alice')).toBe('myblog.app');
+  });
+
+  it('does not publish a tenant that lapsed between the commit and the write', async () => {
+    // publishConfigFile re-reads for this reason too: nginx serves any file that
+    // exists, with no subscription check.
+    chainHas('https://alice.blogs.ecency.com/auth');
+    mocks.getActiveTenants.mockResolvedValue([tenant()]);
+    mocks.getByUsername.mockResolvedValue(tenant({ subscriptionStatus: 'expired' }));
+
+    const result = await reconcileHivesignerClientIds(APP);
+
+    expect(result.enabled).toEqual(['alice']);
+    expect(publishedConfig('alice')).toBeUndefined();
   });
 
   it("does not overwrite an owner's app saved after the listing was taken", async () => {
@@ -409,7 +477,7 @@ describe('reconcileHivesignerClientIds', () => {
     expect(result.enabled).toEqual([]);
     expect(result.unchanged).toBe(1);
     expect(mocks.applyConfigDocument).not.toHaveBeenCalled();
-    expect(mocks.generateConfigFile).not.toHaveBeenCalled();
+    expect(publishedConfig('alice')).toBeUndefined();
   });
 
   it('requires BOTH origins before enabling a tenant that serves a verified custom domain', async () => {

--- a/apps/self-hosted/hosting/api/src/services/hivesigner-registry.ts
+++ b/apps/self-hosted/hosting/api/src/services/hivesigner-registry.ts
@@ -26,9 +26,10 @@
  */
 
 import { callRPC } from '@ecency/sdk/hive';
+import { db } from '../db/client';
 import { TenantService } from './tenant-service';
 import { ConfigService, isPublishableTenant } from './config-service';
-import type { Tenant } from '../types';
+import { mapTenantFromDb, type Tenant, type TenantRow } from '../types';
 
 /**
  * The shared Hivesigner app. This is the only client id this service manages: an
@@ -232,33 +233,36 @@ export async function reconcileHivesignerClientIds(
   };
 
   for (const tenant of tenants) {
-    const action = decideClientId(
-      readPath(tenant.config, CLIENT_ID_PATH),
-      tenantRedirectUris(tenant),
-      registered,
-      appAccount
-    );
-
-    if (action === 'leave') {
+    // Decided from the listing only to skip the tenants that plainly need
+    // nothing, which in the steady state is all of them. The decision that is
+    // acted on is taken again below, against a row nobody else can move.
+    if (
+      decideClientId(
+        readPath(tenant.config, CLIENT_ID_PATH),
+        tenantRedirectUris(tenant),
+        registered,
+        appAccount
+      ) === 'leave'
+    ) {
       result.unchanged++;
       continue;
     }
 
     try {
-      const { tenant: updated } = await TenantService.applyConfigDocument(
-        tenant.username,
-        clientIdDocument(action === 'enable' ? appAccount : '')
-      );
-      // Publish so the change is live rather than only stored. Same entitlement
-      // gate every other publication path uses: nginx serves whatever file
-      // exists, with no subscription check.
-      if (isPublishableTenant(updated)) {
-        await ConfigService.generateConfigFile(updated);
+      const applied = await applyClientIdForTenant(tenant.username, registered, appAccount);
+      if (applied.action === 'leave' || !applied.updated) {
+        result.unchanged++;
+        continue;
       }
-      (action === 'enable' ? result.enabled : result.disabled).push(tenant.username);
+      // Publish so the change is live rather than only stored. No second
+      // entitlement check: isPublishableTenant already decided this inside the
+      // transaction, on the locked row, and repeating it here would be a check
+      // that can never fire dressed up as a safeguard.
+      await ConfigService.generateConfigFile(applied.updated);
+      (applied.action === 'enable' ? result.enabled : result.disabled).push(tenant.username);
     } catch (err) {
       console.error(
-        `[HivesignerRegistry] ${action} failed for ${tenant.username}:`,
+        `[HivesignerRegistry] client id update failed for ${tenant.username}:`,
         (err as Error).message
       );
       result.failed.push(tenant.username);
@@ -266,4 +270,62 @@ export async function reconcileHivesignerClientIds(
   }
 
   return result;
+}
+
+/**
+ * Decide and apply one tenant's client id against a row nobody else can move.
+ *
+ * The listing this loop iterates is a snapshot, and the two things the decision
+ * reads can both change under it. If an owner saves a client id of their own in
+ * that window, a decision taken from the snapshot writes the shared app over it
+ * and the value is simply gone: the next pass sees the shared id, recognises it
+ * as one it manages, and leaves it, so nothing ever puts the owner's app back.
+ * If a custom domain is verified in that window, the tenant needs a second URI
+ * that the snapshot did not know about, and enabling on the strength of the
+ * first one is the broken button this whole design exists to avoid.
+ *
+ * So the row is re-read FOR UPDATE and the decision is taken again from it,
+ * inside the transaction that then writes. A concurrent config save either
+ * commits first and is what this decides from, or waits and lands on top; there
+ * is no ordering in which its value is read and then discarded.
+ *
+ * Returns 'leave' when the fresh row no longer wants the change, which is the
+ * normal outcome of losing that race and is not an error.
+ */
+async function applyClientIdForTenant(
+  username: string,
+  registered: ReadonlySet<string>,
+  appAccount: string
+): Promise<{ action: ClientIdAction; updated?: Tenant }> {
+  return db.transaction(async (client) => {
+    const locked = await client.query<TenantRow>(
+      'SELECT * FROM tenants WHERE username = $1 FOR UPDATE',
+      [username.toLowerCase()]
+    );
+    const row = locked.rows[0];
+    if (!row) return { action: 'leave' as ClientIdAction };
+
+    const fresh = mapTenantFromDb(row);
+    // Standing can have changed since the listing too, and a tenant that may no
+    // longer be served should not be given a login method. The shared predicate,
+    // so this agrees with every other publication path by construction rather
+    // than by a copy of the rule that can drift.
+    if (!isPublishableTenant(fresh)) return { action: 'leave' as ClientIdAction };
+
+    const action = decideClientId(
+      readPath(fresh.config, CLIENT_ID_PATH),
+      tenantRedirectUris(fresh),
+      registered,
+      appAccount
+    );
+    if (action === 'leave') return { action };
+
+    const { tenant: updated } = await TenantService.applyConfigDocument(
+      username,
+      clientIdDocument(action === 'enable' ? appAccount : ''),
+      [],
+      client
+    );
+    return { action, updated };
+  });
 }

--- a/apps/self-hosted/hosting/api/src/services/hivesigner-registry.ts
+++ b/apps/self-hosted/hosting/api/src/services/hivesigner-registry.ts
@@ -249,17 +249,26 @@ export async function reconcileHivesignerClientIds(
     }
 
     try {
-      const applied = await applyClientIdForTenant(tenant.username, registered, appAccount);
-      if (applied.action === 'leave' || !applied.updated) {
+      const action = await applyClientIdForTenant(tenant.username, registered, appAccount);
+      if (action === 'leave') {
         result.unchanged++;
         continue;
       }
-      // Publish so the change is live rather than only stored. No second
-      // entitlement check: isPublishableTenant already decided this inside the
-      // transaction, on the locked row, and repeating it here would be a check
-      // that can never fire dressed up as a safeguard.
-      await ConfigService.generateConfigFile(applied.updated);
-      (applied.action === 'enable' ? result.enabled : result.disabled).push(tenant.username);
+      // Published BY NAME, never from the row the transaction returned.
+      //
+      // This is the same hazard the locked re-read above exists for, one step
+      // later. The transaction commits, and in the moment before the file is
+      // written an owner can save a config of their own; publishing the
+      // committed snapshot then puts the older document on disk and leaves the
+      // database holding the newer one. That split is worse than either value
+      // being wrong on its own, because the row no longer explains what readers
+      // are being served and nothing later notices the disagreement.
+      //
+      // publishConfigFile re-reads the row inside the per-tenant write lock, so
+      // the file can only ever receive the newest committed config. It exists
+      // because the payment listener had this exact bug and was fixed this way.
+      await ConfigService.publishConfigFile(tenant.username);
+      (action === 'enable' ? result.enabled : result.disabled).push(tenant.username);
     } catch (err) {
       console.error(
         `[HivesignerRegistry] client id update failed for ${tenant.username}:`,
@@ -291,26 +300,32 @@ export async function reconcileHivesignerClientIds(
  *
  * Returns 'leave' when the fresh row no longer wants the change, which is the
  * normal outcome of losing that race and is not an error.
+ *
+ * Returns ONLY the action, deliberately. Handing the caller the row this wrote
+ * is what makes the next step easy to get wrong: that object is accurate for as
+ * long as the transaction, and stale from the instant it commits, but it looks
+ * exactly like a tenant worth publishing. With nothing to publish from, the only
+ * thing the caller can pass on is a name.
  */
 async function applyClientIdForTenant(
   username: string,
   registered: ReadonlySet<string>,
   appAccount: string
-): Promise<{ action: ClientIdAction; updated?: Tenant }> {
+): Promise<ClientIdAction> {
   return db.transaction(async (client) => {
     const locked = await client.query<TenantRow>(
       'SELECT * FROM tenants WHERE username = $1 FOR UPDATE',
       [username.toLowerCase()]
     );
     const row = locked.rows[0];
-    if (!row) return { action: 'leave' as ClientIdAction };
+    if (!row) return 'leave' as ClientIdAction;
 
     const fresh = mapTenantFromDb(row);
     // Standing can have changed since the listing too, and a tenant that may no
     // longer be served should not be given a login method. The shared predicate,
     // so this agrees with every other publication path by construction rather
     // than by a copy of the rule that can drift.
-    if (!isPublishableTenant(fresh)) return { action: 'leave' as ClientIdAction };
+    if (!isPublishableTenant(fresh)) return 'leave' as ClientIdAction;
 
     const action = decideClientId(
       readPath(fresh.config, CLIENT_ID_PATH),
@@ -318,14 +333,14 @@ async function applyClientIdForTenant(
       registered,
       appAccount
     );
-    if (action === 'leave') return { action };
+    if (action === 'leave') return action;
 
-    const { tenant: updated } = await TenantService.applyConfigDocument(
+    await TenantService.applyConfigDocument(
       username,
       clientIdDocument(action === 'enable' ? appAccount : ''),
       [],
       client
     );
-    return { action, updated };
+    return action;
   });
 }

--- a/apps/self-hosted/hosting/api/src/services/hivesigner-registry.ts
+++ b/apps/self-hosted/hosting/api/src/services/hivesigner-registry.ts
@@ -1,0 +1,269 @@
+/**
+ * Hivesigner registration state, and turning the login method on for exactly the
+ * instances it can actually complete a login for.
+ *
+ * Hivesigner matches an OAuth callback with `redirect_uris.includes(callback)`
+ * against the app account's on-chain `posting_json_metadata`. Exact string
+ * match, no wildcards, no origin matching, so an instance whose `/auth` URI is
+ * not listed verbatim cannot log anyone in. The SPA hides the method unless the
+ * instance names a client id, which is why a hosted blog offers Keychain and
+ * HiveAuth only until its URI is registered.
+ *
+ * The client id must therefore never be set for an instance whose URI is not on
+ * chain: that is precisely the state that produces a login button leading to an
+ * error page with no explanation. This module is what makes the two inseparable.
+ * It reads the array from the chain and derives each tenant's required URIs from
+ * its own row, so a client id is written only for a tenant whose registration
+ * this service has confirmed for itself. Nothing a caller sends can influence
+ * that decision, because nothing a caller sends is read.
+ *
+ * NO SIGNING HAPPENS HERE. Adding a URI is an `account_update2` broadcast under
+ * the app account's posting authority, and this service is internet-facing and
+ * holds tenant data, so it has never held a key and does not gain one for this.
+ * The broadcast runs as a scheduled job elsewhere (see
+ * hosting/scripts/hivesigner-redirect-uris.py) and pokes this reconcile
+ * afterwards. `no-signing-capability.test.ts` holds that line.
+ */
+
+import { callRPC } from '@ecency/sdk/hive';
+import { TenantService } from './tenant-service';
+import { ConfigService, isPublishableTenant } from './config-service';
+import type { Tenant } from '../types';
+
+/**
+ * The shared Hivesigner app. This is the only client id this service manages: an
+ * owner who registered an app of their own owns that value and it is left alone.
+ */
+export const HIVESIGNER_APP_ACCOUNT = (
+  process.env.HIVESIGNER_APP_ACCOUNT || 'ecency.app'
+).toLowerCase();
+
+const baseDomain = process.env.BASE_DOMAIN || 'blogs.ecency.com';
+
+/** Where the SPA takes a Hivesigner callback; must match HIVESIGNER_REDIRECT_PATH. */
+const REDIRECT_PATH = '/auth';
+
+/** Dot path of the client id inside a stored tenant config. */
+export const CLIENT_ID_PATH = ['configuration', 'general', 'hivesigner', 'clientId'] as const;
+
+/**
+ * Every origin a tenant's served config is reachable on, and therefore every URI
+ * that has to be registered before the method may be offered.
+ *
+ * One config file serves both the tenant subdomain and a verified custom domain,
+ * and the SPA builds its redirect_uri from `window.location.origin`. So a client
+ * id set while only one of the two is registered gives visitors on the other a
+ * button that fails, which is the exact state this exists to prevent. Both or
+ * neither.
+ *
+ * An UNVERIFIED custom domain is deliberately not included. The claim is only a
+ * string in a column until DNS proves it; registering it would let whoever
+ * actually controls that name receive callbacks carrying access tokens for the
+ * app. It joins the list when verification succeeds, not when it is asked for.
+ *
+ * This rule is mirrored by hosting/scripts/hivesigner-redirect-uris.py, which
+ * decides what to put ON chain. The two are allowed to drift only in the safe
+ * direction: this side derives what it REQUIRES and checks the chain for it, so
+ * a script that registers too little leaves the method off, and one that
+ * registers too much enables nothing extra. Neither divergence can produce a
+ * broken button.
+ */
+export function tenantRedirectUris(
+  tenant: Pick<Tenant, 'username' | 'customDomain' | 'customDomainVerified'>,
+  base: string = baseDomain
+): string[] {
+  const uris = [`https://${tenant.username.toLowerCase()}.${base}${REDIRECT_PATH}`];
+  if (tenant.customDomain && tenant.customDomainVerified) {
+    uris.push(`https://${tenant.customDomain.toLowerCase()}${REDIRECT_PATH}`);
+  }
+  return uris;
+}
+
+/**
+ * The registered URIs carried by an account's `posting_json_metadata`.
+ *
+ * Throws rather than returning an empty list for metadata it cannot read. An
+ * empty result is a legitimate answer for an app that has registered nothing,
+ * and it disables every tenant, so a parse failure must never be able to
+ * impersonate one: a malformed document, a truncated RPC response or a
+ * `redirect_uris` that is not an array would otherwise switch the login method
+ * off across the whole fleet in a single pass.
+ */
+export function parseRegisteredRedirectUris(postingJsonMetadata: unknown): string[] {
+  if (typeof postingJsonMetadata !== 'string' || postingJsonMetadata.trim() === '') {
+    throw new Error('account has no posting_json_metadata');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(postingJsonMetadata);
+  } catch {
+    throw new Error('posting_json_metadata is not valid JSON');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('posting_json_metadata is not an object');
+  }
+  const profile = (parsed as Record<string, unknown>).profile;
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    throw new Error('posting_json_metadata carries no profile');
+  }
+  const uris = (profile as Record<string, unknown>).redirect_uris;
+  // Absent is a real "nothing is registered"; present-but-not-an-array is a
+  // document this code does not understand and must not act on.
+  if (uris === undefined) return [];
+  if (!Array.isArray(uris)) {
+    throw new Error('redirect_uris is not an array');
+  }
+  return uris.filter((uri): uri is string => typeof uri === 'string');
+}
+
+/** Read the app account's registered redirect URIs from the chain. */
+export async function fetchRegisteredRedirectUris(
+  account: string = HIVESIGNER_APP_ACCOUNT
+): Promise<string[]> {
+  const accounts = (await callRPC('condenser_api.get_accounts', [[account]])) as
+    | { posting_json_metadata?: unknown }[]
+    | null;
+  if (!Array.isArray(accounts) || accounts.length === 0) {
+    throw new Error(`app account ${account} does not exist`);
+  }
+  return parseRegisteredRedirectUris(accounts[0]?.posting_json_metadata);
+}
+
+/** What a reconcile pass should do with one tenant's stored client id. */
+export type ClientIdAction = 'enable' | 'disable' | 'leave';
+
+/**
+ * Decide a tenant's client id from the registration, and nothing else.
+ *
+ * `enable` only when every URI the instance is served on is on chain, so the
+ * value can never exist ahead of the registration. `disable` is the same rule
+ * read backwards: a client id this service set for a URI that has since left the
+ * array is withdrawn, so a hand-edit on chain cannot leave a broken button
+ * behind. Both directions run every pass, which is what makes a run that failed
+ * halfway repair itself on the next one rather than needing anybody.
+ *
+ * A value that is neither blank nor the shared app is the owner's own Hivesigner
+ * app, registered by them against URIs this service knows nothing about. It is
+ * never touched: managing it would mean deleting a working login.
+ */
+export function decideClientId(
+  storedClientId: unknown,
+  requiredUris: readonly string[],
+  registered: ReadonlySet<string>,
+  appAccount: string = HIVESIGNER_APP_ACCOUNT
+): ClientIdAction {
+  const current = typeof storedClientId === 'string' ? storedClientId.trim().toLowerCase() : '';
+  if (current !== '' && current !== appAccount) return 'leave';
+
+  // An empty required list would make `every` vacuously true and enable a tenant
+  // with nothing registered at all.
+  const fullyRegistered =
+    requiredUris.length > 0 && requiredUris.every((uri) => registered.has(uri));
+
+  if (fullyRegistered) return current === appAccount ? 'leave' : 'enable';
+  return current === '' ? 'leave' : 'disable';
+}
+
+/** Read a dot path out of a stored config, own properties only. */
+function readPath(node: unknown, segments: readonly string[]): unknown {
+  let current: unknown = node;
+  for (const segment of segments) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return undefined;
+    if (!Object.prototype.hasOwnProperty.call(current, segment)) return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+/**
+ * The config document that carries a client id change.
+ *
+ * Disabling writes an empty string rather than removing the key: the guarded
+ * merge has no delete, and `resolveHivesignerClientId` in the SPA already treats
+ * a blank value as absent, so the method is hidden either way and the owner is
+ * shown the same setup notice.
+ */
+export function clientIdDocument(clientId: string): Record<string, unknown> {
+  return { configuration: { general: { hivesigner: { clientId } } } };
+}
+
+export interface ReconcileResult {
+  account: string;
+  /** How many URIs the app account currently has registered. */
+  registered: number;
+  enabled: string[];
+  disabled: string[];
+  /** Tenants whose stored client id already agreed with the chain. */
+  unchanged: number;
+  /** Tenants whose write failed; the next scheduled pass retries them. */
+  failed: string[];
+}
+
+/**
+ * Bring every served tenant's client id into agreement with the on-chain array.
+ *
+ * Reads the chain FIRST and aborts the whole pass if that read fails, because
+ * the failure mode of guessing is switching the login method off for every
+ * tenant at once. Individual writes are isolated the way `syncAllConfigs`
+ * isolates them, so one bad tenant cannot cost the rest their pass.
+ *
+ * The config change goes through `applyConfigDocument`, the same guarded merge
+ * and pinned identity fields a save from the Configuration Editor goes through.
+ * Writing the row directly would be a config write that bypasses the service's
+ * own rules, and those produce states nothing can repair.
+ */
+export async function reconcileHivesignerClientIds(
+  appAccount: string = HIVESIGNER_APP_ACCOUNT
+): Promise<ReconcileResult> {
+  const registeredList = await fetchRegisteredRedirectUris(appAccount);
+  const registered = new Set(registeredList);
+
+  const tenants = await TenantService.getActiveTenants();
+
+  const result: ReconcileResult = {
+    account: appAccount,
+    registered: registered.size,
+    enabled: [],
+    disabled: [],
+    unchanged: 0,
+    failed: [],
+  };
+
+  for (const tenant of tenants) {
+    const action = decideClientId(
+      readPath(tenant.config, CLIENT_ID_PATH),
+      tenantRedirectUris(tenant),
+      registered,
+      appAccount
+    );
+
+    if (action === 'leave') {
+      result.unchanged++;
+      continue;
+    }
+
+    try {
+      const { tenant: updated } = await TenantService.applyConfigDocument(
+        tenant.username,
+        clientIdDocument(action === 'enable' ? appAccount : '')
+      );
+      // Publish so the change is live rather than only stored. Same entitlement
+      // gate every other publication path uses: nginx serves whatever file
+      // exists, with no subscription check.
+      if (isPublishableTenant(updated)) {
+        await ConfigService.generateConfigFile(updated);
+      }
+      (action === 'enable' ? result.enabled : result.disabled).push(tenant.username);
+    } catch (err) {
+      console.error(
+        `[HivesignerRegistry] ${action} failed for ${tenant.username}:`,
+        (err as Error).message
+      );
+      result.failed.push(tenant.username);
+    }
+  }
+
+  return result;
+}

--- a/apps/self-hosted/hosting/api/src/services/tenant-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/tenant-service.ts
@@ -157,11 +157,18 @@ export const TenantService = {
   /**
    * Get tenant by username
    */
-  async getByUsername(username: string): Promise<Tenant | null> {
-    const row = await db.queryOne<TenantRow>(
+  /**
+   * `exec` lets a caller read inside its own transaction. A caller that decides
+   * something from a tenant and then writes it back has to see the same row for
+   * both, or it acts on a version that no longer exists; the default keeps every
+   * existing caller on its own connection exactly as before.
+   */
+  async getByUsername(username: string, exec: SqlExecutor = db): Promise<Tenant | null> {
+    const result = await exec.query<TenantRow>(
       'SELECT * FROM tenants WHERE username = $1',
       [username.toLowerCase()]
     );
+    const row = result.rows[0];
     return row ? mapTenantFromDb(row) : null;
   },
   
@@ -324,9 +331,10 @@ export const TenantService = {
   async applyConfigDocument(
     username: string,
     doc: any,
-    resetPaths: readonly string[] = []
+    resetPaths: readonly string[] = [],
+    exec: SqlExecutor = db
   ): Promise<{ tenant: Tenant; discarded: DiscardedField[]; reset: string[] }> {
-    const tenant = await this.getByUsername(username);
+    const tenant = await this.getByUsername(username, exec);
     if (!tenant) throw new Error('Tenant not found');
 
     const current = tenant.config?.configuration?.instanceConfiguration || {};
@@ -366,7 +374,7 @@ export const TenantService = {
     );
     const newConfig = this.mergeConfigGuarded(base, clean, { path: '', discarded });
 
-    const row = await db.queryOne<TenantRow>(
+    const result = await exec.query<TenantRow>(
       `UPDATE tenants
        SET config = $2,
            updated_at = NOW()
@@ -375,7 +383,7 @@ export const TenantService = {
       [username.toLowerCase(), JSON.stringify(newConfig)]
     );
 
-    return { tenant: mapTenantFromDb(row!), discarded, reset };
+    return { tenant: mapTenantFromDb(result.rows[0]!), discarded, reset };
   },
 
   /**

--- a/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
+++ b/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
@@ -347,7 +347,12 @@ def reconcile_client_ids(api_base: str, secret: str) -> dict:
         return json.load(response)
 
 
-def acquire_lock():
+# The open file description the run's lock lives on. Parked at module scope
+# deliberately: see acquire_lock.
+_LOCK_HANDLE = None
+
+
+def acquire_lock() -> None:
     """
     One run at a time.
 
@@ -357,13 +362,21 @@ def acquire_lock():
     whatever is on chain at the time and never removes anything, but it costs a
     broadcast and delays a new owner's login, so it is simply prevented. Exits
     quietly: a run skipped because the previous one is still going is not a fault.
+
+    Returns nothing on purpose. A flock lives on the open file description, so it
+    is released the moment the last reference to the handle goes away. Handing the
+    handle back made staying locked the caller's job, and the caller dropped it on
+    the floor: the lock was taken and released before the account was even read,
+    and the whole thing looked like it was working. There is now no return value
+    to discard, and `test_the_lock_outlives_the_call` fails if this stops holding.
     """
+    global _LOCK_HANDLE
     handle = open(LOCK_FILE, "w", encoding="utf-8")
     try:
         fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except BlockingIOError:
         raise SystemExit(0)
-    return handle
+    _LOCK_HANDLE = handle
 
 
 def report(account_name: str, existing: list[str], missing: list[str], serialized: str) -> None:

--- a/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
+++ b/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
@@ -106,15 +106,31 @@ def log(message: str) -> None:
     print(message, flush=True)
 
 
+class RpcError(Exception):
+    """
+    A node answered, and what it said was an error.
+
+    Its own type because the alternative was reading a response with no `result`
+    as an empty one. That turned every node fault into "account does not exist",
+    which is both the wrong diagnosis and unretryable, so a blip during
+    confirmation ended the run claiming the app account was gone.
+    """
+
+
 def rpc(url: str, method: str, params: list) -> dict:
     payload = json.dumps({"jsonrpc": "2.0", "method": method, "params": params, "id": 1}).encode()
     request = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
     with urllib.request.urlopen(request, timeout=30) as response:
-        return json.load(response)
+        body = json.load(response)
+    if "error" in body:
+        raise RpcError(f"{method}: {body['error']}")
+    if "result" not in body:
+        raise RpcError(f"{method}: response carried neither result nor error")
+    return body
 
 
 def fetch_account(rpc_url: str, account: str) -> dict:
-    result = rpc(rpc_url, "condenser_api.get_accounts", [[account]]).get("result") or []
+    result = rpc(rpc_url, "condenser_api.get_accounts", [[account]])["result"] or []
     if not result:
         raise SystemExit(f"account {account} does not exist")
     return result[0]
@@ -271,14 +287,23 @@ def write_private(contents: str, path: str | None) -> str:
     return path
 
 
-def broadcast_metadata(account: str, serialized: str, key: str, nodes: list[str]) -> None:
+def broadcast_metadata(
+    account: str, serialized: str, json_metadata: str, key: str, nodes: list[str]
+) -> None:
     """
     Update the account's posting_json_metadata.
 
-    account_update2 leaves a field alone when it is sent empty, so json_metadata
-    is passed as "" and only the posting copy is written. lighthive serializes
-    through the node's own get_transaction_hex, so this needs no client-side
-    operation table that could fall behind the chain.
+    The account's CURRENT json_metadata is sent back verbatim rather than left
+    empty. hived's account_update2 evaluator only writes a field whose string is
+    non-empty, so an empty one would in fact be left alone, but that is a detail
+    of an evaluator this script cannot test against, and the cost of being wrong
+    about it is erasing the app account's global metadata on a live account. Both
+    readings of the rule give the same result when the current value is echoed:
+    either it is skipped, or it is written back unchanged. Being explicit costs a
+    few bytes in a transaction that happens only when an instance is unregistered.
+
+    lighthive serializes through the node's own get_transaction_hex, so this needs
+    no client-side operation table that could fall behind the chain.
     """
     try:
         from lighthive.client import Client
@@ -292,7 +317,7 @@ def broadcast_metadata(account: str, serialized: str, key: str, nodes: list[str]
             "account_update2",
             {
                 "account": account,
-                "json_metadata": "",
+                "json_metadata": json_metadata,
                 "posting_json_metadata": serialized,
                 "extensions": [],
             },
@@ -316,7 +341,7 @@ def confirm_registered(rpc_url: str, account: str, wanted: list[str]) -> list[st
             time.sleep(CONFIRM_DELAY_SECONDS)
         try:
             _, seen = current_metadata(fetch_account(rpc_url, account))
-        except (urllib.error.URLError, TimeoutError, ValueError) as error:
+        except (urllib.error.URLError, TimeoutError, ValueError, RpcError) as error:
             log(f"  confirmation read failed ({error}), retrying")
             continue
         if all(uri in seen for uri in wanted):
@@ -325,6 +350,40 @@ def confirm_registered(rpc_url: str, account: str, wanted: list[str]) -> list[st
     raise SystemExit(
         "broadcast did not appear on chain after "
         f"{CONFIRM_ATTEMPTS * CONFIRM_DELAY_SECONDS}s; {len(missing)} URI(s) still missing"
+    )
+
+
+class _RefuseRedirects(urllib.request.HTTPRedirectHandler):
+    """
+    Turn a redirect into an error instead of following it.
+
+    urllib re-sends the request headers to whatever a redirect names, and one of
+    those headers is the shared secret. Anything able to answer this call could
+    then collect it by replying 302, so the reconcile does not follow redirects
+    at all: the endpoint it wants is a fixed path on a host the operator named.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise urllib.error.URLError(f"refusing to follow a redirect to {newurl}")
+
+
+def assert_secret_safe_base(api_base: str) -> None:
+    """
+    Refuse to put the shared secret on a cleartext connection.
+
+    The secret authenticates every internal call to the hosting API, and this
+    sends it as a request header. Over plain http on the network that is simply
+    handing it to anyone on the path. Loopback is allowed because there is no
+    path: an operator running this beside the API is talking to the same kernel.
+    """
+    parts = urllib.parse.urlsplit(api_base)
+    if parts.scheme == "https":
+        return
+    if parts.scheme == "http" and (parts.hostname or "") in ("127.0.0.1", "::1", "localhost"):
+        return
+    raise SystemExit(
+        "--api-base must be https, or http on loopback; the internal secret is sent "
+        "as a header and plain http over the network exposes it"
     )
 
 
@@ -343,7 +402,8 @@ def reconcile_client_ids(api_base: str, secret: str) -> dict:
         method="POST",
         headers={"Content-Type": "application/json", "x-internal-secret": secret},
     )
-    with urllib.request.urlopen(request, timeout=120) as response:
+    opener = urllib.request.build_opener(_RefuseRedirects)
+    with opener.open(request, timeout=120) as response:
         return json.load(response)
 
 
@@ -375,6 +435,7 @@ def acquire_lock() -> None:
     try:
         fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except BlockingIOError:
+        handle.close()
         raise SystemExit(0)
     _LOCK_HANDLE = handle
 
@@ -433,6 +494,9 @@ def main() -> int:
             raise SystemExit("--broadcast needs --key-file or HIVESIGNER_POSTING_KEY")
         if not args.api_base:
             raise SystemExit("--broadcast needs --api-base or HOSTING_API_BASE")
+        # Checked before the key is read, so a misconfigured base cannot get as
+        # far as a broadcast it would then be unable to enable.
+        assert_secret_safe_base(args.api_base)
         if not args.internal_secret_file and not os.environ.get("HOSTING_INTERNAL_SECRET"):
             raise SystemExit("--broadcast needs --internal-secret-file or HOSTING_INTERNAL_SECRET")
         key = (
@@ -501,7 +565,14 @@ def main() -> int:
 
     if missing:
         log(f"\nbroadcasting {len(missing)} addition(s) as {args.account}...")
-        broadcast_metadata(args.account, serialized, key, args.rpc.split(","))
+        broadcast_metadata(
+            args.account,
+            serialized,
+            # Echoed back rather than left empty: see broadcast_metadata.
+            account.get("json_metadata") or "",
+            key,
+            args.rpc.split(","),
+        )
         confirm_registered(args.rpc, args.account, wanted)
         log("confirmed on chain")
     else:

--- a/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
+++ b/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
@@ -203,7 +203,7 @@ def wanted_uris(database_url: str, base_domain: str) -> list[str]:
     try:
         import psycopg
     except ImportError:  # pragma: no cover - depends on the operator's box
-        raise SystemExit("psycopg is required: pip install 'psycopg[binary]'")
+        raise SystemExit("psycopg is required: pip install 'psycopg[binary]'") from None
 
     uris: list[str] = []
     with psycopg.connect(database_url) as connection:
@@ -256,7 +256,7 @@ def read_secret_file(path: str, label: str) -> str:
     try:
         mode = os.stat(path).st_mode
     except OSError as error:
-        raise SystemExit(f"cannot read the {label} file: {error.strerror}")
+        raise SystemExit(f"cannot read the {label} file: {error.strerror}") from error
     if mode & (stat.S_IRWXG | stat.S_IRWXO):
         raise SystemExit(f"the {label} file is readable by group or other; chmod 600 it")
     with open(path, encoding="utf-8") as handle:
@@ -309,7 +309,7 @@ def broadcast_metadata(
         from lighthive.client import Client
         from lighthive.datastructures import Operation
     except ImportError:  # pragma: no cover - depends on the operator's box
-        raise SystemExit("lighthive is required to broadcast: pip install lighthive")
+        raise SystemExit("lighthive is required to broadcast: pip install lighthive") from None
 
     client = Client(nodes=nodes, keys=[key])
     client.broadcast_sync(
@@ -436,7 +436,10 @@ def acquire_lock() -> None:
         fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except BlockingIOError:
         handle.close()
-        raise SystemExit(0)
+        # `from None`: a run skipped because the previous one is still
+        # going is the normal case, not a fault, and chaining the
+        # BlockingIOError onto it prints a traceback for a clean exit.
+        raise SystemExit(0) from None
     _LOCK_HANDLE = handle
 
 

--- a/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
+++ b/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Reconcile the Hivesigner app account's redirect_uris against the live tenants.
+Keep the Hivesigner app account's redirect_uris in step with the live tenants,
+and turn the login method on for exactly the instances that are registered.
 
 Hivesigner validates an OAuth callback with an exact string match against the
 app account's on-chain posting_json_metadata. From hivesigner-ui's login page:
@@ -12,14 +13,23 @@ instance whose /auth URI is not listed verbatim cannot complete a Hivesigner
 login, which is why the self-hosted app hides the method unless the instance
 names a client of its own.
 
-This produces the metadata that would register every live instance. It does not
-broadcast: updating posting_json_metadata needs the app account's posting key,
-and the hosting service deliberately holds no signing key of any kind. Someone
-who holds the key runs the broadcast, with this output as the payload.
+Two halves, and they must not be able to disagree. A client id on an instance
+whose URI is not registered is a login button that leads to an error page with
+no explanation, which is the state this whole exercise exists to avoid. So:
 
-Existing entries are never dropped. The output is the current array plus
-whatever is missing, so a URI added by hand for something this script does not
-know about survives.
+  1. append every missing URI to the account's redirect_uris (a posting-authority
+     broadcast, which is why this runs where a key may live and not inside the
+     hosting service, which is internet-facing and has never held one);
+  2. confirm the array on chain actually carries them;
+  3. ask the hosting API to reconcile the tenant client ids.
+
+Step 3 sends no tenant list and no client id. The API re-reads the chain itself
+and derives each tenant's required URIs from its own row, so the only thing that
+can enable an instance is its registration, and a run that dies between 1 and 3
+is repaired by the next run rather than by a person.
+
+Without --broadcast this only reports and writes the payload someone else would
+broadcast, which is what it did before there was anywhere to run it unattended.
 
 The payload is written to a file rather than stdout. The account's existing
 profile is carried through unchanged, and on a Hivesigner app profile that
@@ -28,46 +38,83 @@ history, shell logs and any CI transcript that ran this. The summary on stdout
 is safe to paste; the file is not.
 
 Usage:
-    hivesigner-redirect-uris.py [--account ecency.app] [--base-domain blogs.ecency.com]
-                               [--database-url postgres://...] [--out PATH]
+    # report only, write the payload for a manual broadcast
+    hivesigner-redirect-uris.py --database-url postgres://...
 
-Exit codes: 0 nothing to add, 10 additions needed, 1 error.
+    # unattended: register, confirm, enable (this is what the timer runs)
+    hivesigner-redirect-uris.py --broadcast --key-file <path> \\
+        --api-base <hosting api> --internal-secret-file <path>
+
+Exit codes:
+    report mode:    0 nothing to add, 10 additions needed, 1 error
+    --broadcast:    0 converged, 1 error (a timer treats anything else as a failure)
 """
 
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import os
+import re
 import stat
 import sys
 import tempfile
+import time
+import urllib.error
+import urllib.parse
 import urllib.request
 
 DEFAULT_ACCOUNT = "ecency.app"
 DEFAULT_BASE_DOMAIN = "blogs.ecency.com"
 DEFAULT_RPC = "https://api.hive.blog"
 
-# Only these pay for a working login. A lapsed instance keeps serving, but
-# registering it spends metadata bytes on a site nobody is maintaining, and the
-# array is a shared resource.
-LIVE_STATUSES = ("active", "trialing")
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+LOCK_FILE = os.path.join(BASE_DIR, ".hivesigner-redirect-uris.lock")
+
+# The array only ever grows here, so registering a tenant that is not currently
+# served costs metadata bytes on the app account forever and buys nothing: the
+# hosting API only writes a client id for a tenant it is willing to serve, which
+# is 'active' and nothing else. An earlier version of this listed 'trialing',
+# which is not a status this schema has ever had, so it matched no rows at all.
+LIVE_STATUSES = ("active",)
+
+# Hostname shape, matching what the hosting API accepts for a custom domain.
+DOMAIN_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$")
+
+# Where the SPA takes a Hivesigner callback.
+REDIRECT_PATH = "/auth"
+
+# A single run adds one entry per new instance. A number far above that is not a
+# busy afternoon, it is a bug or a bad query, and this writes to an account whose
+# metadata every hosted blog's login depends on. Refused rather than truncated: a
+# half-applied array is harder to reason about than one that was never touched.
+DEFAULT_MAX_ADDITIONS = 50
+
+# posting_json_metadata is a string field in a signed transaction. Well under any
+# hard limit, but a runaway array should stop here rather than at the node.
+MAX_METADATA_BYTES = 60_000
+
+# How long to wait for the broadcast to show up in a subsequent read. A block is
+# three seconds, and the node answering the read may not be the node that took
+# the broadcast.
+CONFIRM_ATTEMPTS = 8
+CONFIRM_DELAY_SECONDS = 3
 
 
-def fetch_account(rpc: str, account: str) -> dict:
-    payload = json.dumps(
-        {
-            "jsonrpc": "2.0",
-            "method": "condenser_api.get_accounts",
-            "params": [[account]],
-            "id": 1,
-        }
-    ).encode()
-    request = urllib.request.Request(
-        rpc, data=payload, headers={"Content-Type": "application/json"}
-    )
+def log(message: str) -> None:
+    print(message, flush=True)
+
+
+def rpc(url: str, method: str, params: list) -> dict:
+    payload = json.dumps({"jsonrpc": "2.0", "method": method, "params": params, "id": 1}).encode()
+    request = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
     with urllib.request.urlopen(request, timeout=30) as response:
-        result = json.load(response).get("result") or []
+        return json.load(response)
+
+
+def fetch_account(rpc_url: str, account: str) -> dict:
+    result = rpc(rpc_url, "condenser_api.get_accounts", [[account]]).get("result") or []
     if not result:
         raise SystemExit(f"account {account} does not exist")
     return result[0]
@@ -82,7 +129,61 @@ def current_metadata(account: dict) -> tuple[dict, list[str]]:
     return metadata, [u for u in uris if isinstance(u, str)]
 
 
+def is_safe_redirect_uri(uri: str, base_domain: str) -> bool:
+    """
+    Whether a URI may be put on the app account.
+
+    Everything on that array can receive an OAuth callback carrying an access
+    token for the app, so this is the last check before a name becomes able to.
+    The database is the authority on WHICH hosts belong to tenants; this is the
+    shape check that stops a malformed or surprising value from getting there:
+    exactly https, exactly the callback path, no credentials, no port, no query,
+    and nothing under ecency.com that is not a tenant subdomain.
+    """
+    parts = urllib.parse.urlsplit(uri)
+    if parts.scheme != "https":
+        return False
+    if parts.path != REDIRECT_PATH:
+        return False
+    if parts.query or parts.fragment:
+        return False
+
+    # urlsplit lower-cases the hostname and strips any userinfo and port from it,
+    # so requiring the authority to be EXACTLY the hostname rejects all three at
+    # once: https://ecency.com@evil.example/auth (reads as ours to anyone
+    # skimming the array, resolves as theirs), any :port, and a mixed-case host
+    # that could never match the exact string comparison Hivesigner performs.
+    #
+    # Written as one check rather than as separate tests for username, password,
+    # port and case. Those were all here, and none of them could ever fire,
+    # because this comparison had already refused every input that would have
+    # reached them. Four checks where one is load-bearing reads as depth and is
+    # not: the next person removes the one that works and the tests stay green.
+    host = parts.hostname or ""
+    if not host or host != parts.netloc:
+        return False
+    if not DOMAIN_RE.match(host):
+        return False
+    if host.endswith(f".{base_domain}"):
+        return True
+    # Anything else has to be a custom domain, and a custom domain is never ours.
+    # hosting/origin/sync-custom-domains.py refuses these for the same reason.
+    return host != "ecency.com" and not host.endswith(".ecency.com")
+
+
 def wanted_uris(database_url: str, base_domain: str) -> list[str]:
+    """
+    The URIs every served instance needs, derived from the tenant table.
+
+    Mirrored by tenantRedirectUris() in the hosting API, which decides which
+    tenants may have a client id. The two are allowed to drift only in the safe
+    direction: the API checks the chain for what it REQUIRES, so registering too
+    little leaves the method off and registering too much enables nothing extra.
+
+    One config file serves the subdomain AND the verified custom domain, and the
+    SPA builds its redirect_uri from window.location.origin, so both have to be
+    here or the API will not enable either of them.
+    """
     try:
         import psycopg
     except ImportError:  # pragma: no cover - depends on the operator's box
@@ -101,13 +202,52 @@ def wanted_uris(database_url: str, base_domain: str) -> list[str]:
                 (list(LIVE_STATUSES),),
             )
             for username, custom_domain, verified in cursor.fetchall():
-                uris.append(f"https://{username}.{base_domain}/auth")
+                uris.append(f"https://{username.lower()}.{base_domain}{REDIRECT_PATH}")
                 # An unverified claim is not the tenant's domain yet. Registering
                 # it would let whoever actually controls that name receive
                 # callbacks for the app.
                 if custom_domain and verified:
-                    uris.append(f"https://{custom_domain}/auth")
+                    uris.append(f"https://{custom_domain.lower()}{REDIRECT_PATH}")
     return uris
+
+
+def merge_uris(existing: list[str], wanted: list[str]) -> tuple[list[str], list[str]]:
+    """
+    What is missing, and the array that would replace the current one.
+
+    Purely additive. Existing entries are never dropped, so a URI added by hand
+    for something this script does not know about survives, and an entry that is
+    already there is never duplicated however many times it is asked for.
+    """
+    missing: list[str] = []
+    seen = set(existing)
+    for uri in wanted:
+        if uri in seen:
+            continue
+        seen.add(uri)
+        missing.append(uri)
+    return missing, existing + missing
+
+
+def read_secret_file(path: str, label: str) -> str:
+    """
+    Read a credential from a file, refusing one anything on the box can read.
+
+    A key or shared secret left group- or world-readable is the kind of thing
+    that is noticed after it has been used, so this is a hard failure rather
+    than a warning. The value is never echoed, and never appears in an error.
+    """
+    try:
+        mode = os.stat(path).st_mode
+    except OSError as error:
+        raise SystemExit(f"cannot read the {label} file: {error.strerror}")
+    if mode & (stat.S_IRWXG | stat.S_IRWXO):
+        raise SystemExit(f"the {label} file is readable by group or other; chmod 600 it")
+    with open(path, encoding="utf-8") as handle:
+        value = handle.read().strip()
+    if not value:
+        raise SystemExit(f"the {label} file is empty")
+    return value
 
 
 def write_private(contents: str, path: str | None) -> str:
@@ -131,6 +271,113 @@ def write_private(contents: str, path: str | None) -> str:
     return path
 
 
+def broadcast_metadata(account: str, serialized: str, key: str, nodes: list[str]) -> None:
+    """
+    Update the account's posting_json_metadata.
+
+    account_update2 leaves a field alone when it is sent empty, so json_metadata
+    is passed as "" and only the posting copy is written. lighthive serializes
+    through the node's own get_transaction_hex, so this needs no client-side
+    operation table that could fall behind the chain.
+    """
+    try:
+        from lighthive.client import Client
+        from lighthive.datastructures import Operation
+    except ImportError:  # pragma: no cover - depends on the operator's box
+        raise SystemExit("lighthive is required to broadcast: pip install lighthive")
+
+    client = Client(nodes=nodes, keys=[key])
+    client.broadcast_sync(
+        Operation(
+            "account_update2",
+            {
+                "account": account,
+                "json_metadata": "",
+                "posting_json_metadata": serialized,
+                "extensions": [],
+            },
+        )
+    )
+
+
+def confirm_registered(rpc_url: str, account: str, wanted: list[str]) -> list[str]:
+    """
+    Re-read the array until it carries everything, and return what is on chain.
+
+    A broadcast that was accepted is not yet a fact anyone else can see: it has
+    to land in a block, and the node answering this read may not be the node that
+    took it. Reporting success from the broadcast call alone would let a client
+    id be written for a URI that never made it, which is the one outcome that
+    must be impossible.
+    """
+    seen: list[str] = []
+    for attempt in range(CONFIRM_ATTEMPTS):
+        if attempt:
+            time.sleep(CONFIRM_DELAY_SECONDS)
+        try:
+            _, seen = current_metadata(fetch_account(rpc_url, account))
+        except (urllib.error.URLError, TimeoutError, ValueError) as error:
+            log(f"  confirmation read failed ({error}), retrying")
+            continue
+        if all(uri in seen for uri in wanted):
+            return seen
+    missing = [uri for uri in wanted if uri not in seen]
+    raise SystemExit(
+        "broadcast did not appear on chain after "
+        f"{CONFIRM_ATTEMPTS * CONFIRM_DELAY_SECONDS}s; {len(missing)} URI(s) still missing"
+    )
+
+
+def reconcile_client_ids(api_base: str, secret: str) -> dict:
+    """
+    Ask the hosting API to bring tenant client ids into step with the chain.
+
+    Deliberately sends nothing. The API decides what to enable by reading the
+    chain itself, so this cannot ask it to enable an instance that is not
+    registered, and neither can anything that gets hold of this script.
+    """
+    url = api_base.rstrip("/") + "/v1/internal/hivesigner/reconcile"
+    request = urllib.request.Request(
+        url,
+        data=b"",
+        method="POST",
+        headers={"Content-Type": "application/json", "x-internal-secret": secret},
+    )
+    with urllib.request.urlopen(request, timeout=120) as response:
+        return json.load(response)
+
+
+def acquire_lock():
+    """
+    One run at a time.
+
+    Read-modify-write on the array is not atomic, so two overlapping runs can each
+    merge onto the state they read and the later broadcast loses the earlier one's
+    entries. That self-heals on the next pass, because every run merges onto
+    whatever is on chain at the time and never removes anything, but it costs a
+    broadcast and delays a new owner's login, so it is simply prevented. Exits
+    quietly: a run skipped because the previous one is still going is not a fault.
+    """
+    handle = open(LOCK_FILE, "w", encoding="utf-8")
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        raise SystemExit(0)
+    return handle
+
+
+def report(account_name: str, existing: list[str], missing: list[str], serialized: str) -> None:
+    log(f"account:    {account_name}")
+    log(f"registered: {len(existing)}")
+    log(f"to add:     {len(missing)}")
+    log(f"final:      {len(existing) + len(missing)}")
+    log(f"metadata:   {len(serialized)} bytes")
+    if missing:
+        log("\nwould add:")
+        for uri in missing:
+            log(f"  {uri}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--account", default=os.environ.get("HIVESIGNER_APP_ACCOUNT", DEFAULT_ACCOUNT))
@@ -141,52 +388,134 @@ def main() -> int:
         "--out",
         help="where to write the broadcast payload (default: a 0600 temp file)",
     )
+    parser.add_argument(
+        "--broadcast",
+        action="store_true",
+        help="sign and broadcast the update, then enable the login method for what is registered",
+    )
+    parser.add_argument(
+        "--key-file",
+        default=os.environ.get("HIVESIGNER_POSTING_KEY_FILE"),
+        help="file holding the app account's posting key (mode 0600)",
+    )
+    parser.add_argument("--api-base", default=os.environ.get("HOSTING_API_BASE"))
+    parser.add_argument(
+        "--internal-secret-file",
+        default=os.environ.get("HOSTING_INTERNAL_SECRET_FILE"),
+        help="file holding the hosting API's shared internal secret (mode 0600)",
+    )
+    parser.add_argument("--max-additions", type=int, default=DEFAULT_MAX_ADDITIONS)
     args = parser.parse_args()
 
     if not args.database_url:
         raise SystemExit("--database-url or DATABASE_URL is required")
 
+    key = None
+    secret = None
+    if args.broadcast:
+        # Registering without enabling leaves the work invisible, and enabling
+        # without registering is the broken button. Neither half is optional, so
+        # a run that could only do one is refused before it does anything.
+        if not args.key_file and not os.environ.get("HIVESIGNER_POSTING_KEY"):
+            raise SystemExit("--broadcast needs --key-file or HIVESIGNER_POSTING_KEY")
+        if not args.api_base:
+            raise SystemExit("--broadcast needs --api-base or HOSTING_API_BASE")
+        if not args.internal_secret_file and not os.environ.get("HOSTING_INTERNAL_SECRET"):
+            raise SystemExit("--broadcast needs --internal-secret-file or HOSTING_INTERNAL_SECRET")
+        key = (
+            read_secret_file(args.key_file, "posting key")
+            if args.key_file
+            else os.environ["HIVESIGNER_POSTING_KEY"].strip()
+        )
+        secret = (
+            read_secret_file(args.internal_secret_file, "internal secret")
+            if args.internal_secret_file
+            else os.environ["HOSTING_INTERNAL_SECRET"].strip()
+        )
+        acquire_lock()
+
     account = fetch_account(args.rpc, args.account)
     metadata, existing = current_metadata(account)
     wanted = wanted_uris(args.database_url, args.base_domain)
 
-    missing = [u for u in wanted if u not in existing]
-    merged = existing + missing
+    unsafe = [uri for uri in wanted if not is_safe_redirect_uri(uri, args.base_domain)]
+    if unsafe:
+        raise SystemExit(
+            "refusing to register URIs that are not a plain https callback on a tenant host: "
+            + ", ".join(unsafe)
+        )
+
+    missing, merged = merge_uris(existing, wanted)
+    if len(missing) > args.max_additions:
+        raise SystemExit(
+            f"{len(missing)} additions exceeds the {args.max_additions} cap; "
+            "check the tenant query before raising it with --max-additions"
+        )
 
     metadata.setdefault("profile", {})["redirect_uris"] = merged
     serialized = json.dumps(metadata, separators=(",", ":"))
 
-    print(f"account:    {args.account}")
-    print(f"registered: {len(existing)}")
-    print(f"to add:     {len(missing)}")
-    print(f"final:      {len(merged)}")
-    print(f"metadata:   {len(serialized)} bytes")
+    if len(serialized) > MAX_METADATA_BYTES:
+        raise SystemExit(
+            f"metadata would be {len(serialized)} bytes, over the {MAX_METADATA_BYTES} cap"
+        )
 
-    if missing:
-        print("\nwould add:")
-        for uri in missing:
-            print(f"  {uri}")
-
-        path = write_private(serialized, args.out)
-
-        print(f"\npayload written to {path}")
-        print("broadcast it as posting_json_metadata (account_update2, posting authority).")
-        print("it carries the account's existing profile, including its app secret, so do")
-        print("not paste it into a shared terminal and delete it when you are done.")
+    report(args.account, existing, missing, serialized)
 
     # Reported whether or not anything is being added. Once every live instance
     # is registered there is nothing to add, and that is exactly when a tenant
     # going inactive would otherwise be reported by nobody.
-    stale = [u for u in existing if u.endswith(f".{args.base_domain}/auth") and u not in wanted]
+    stale = [
+        u
+        for u in existing
+        if u.endswith(f".{args.base_domain}{REDIRECT_PATH}") and u not in wanted
+    ]
     if stale:
-        print("\nregistered but no longer live, review by hand before removing:")
+        log("\nregistered but no longer live, review by hand before removing:")
         for uri in stale:
-            print(f"  {uri}")
+            log(f"  {uri}")
+
+    if not args.broadcast:
+        if missing:
+            path = write_private(serialized, args.out)
+            log(f"\npayload written to {path}")
+            log("broadcast it as posting_json_metadata (account_update2, posting authority).")
+            log("it carries the account's existing profile, including its app secret, so do")
+            log("not paste it into a shared terminal and delete it when you are done.")
+            return 10
+        log("\nnothing to add")
+        return 0
 
     if missing:
-        return 10
+        log(f"\nbroadcasting {len(missing)} addition(s) as {args.account}...")
+        broadcast_metadata(args.account, serialized, key, args.rpc.split(","))
+        confirm_registered(args.rpc, args.account, wanted)
+        log("confirmed on chain")
+    else:
+        log("\nnothing to add")
 
-    print("\nnothing to add")
+    # Runs every pass, not only after a broadcast. This is what repairs a run that
+    # registered a URI and then died before the client id was written: the next
+    # pass has nothing to add and still reconciles.
+    result = reconcile_client_ids(args.api_base, secret)
+    log(
+        "reconciled client ids: "
+        f"{len(result.get('enabled') or [])} enabled, "
+        f"{len(result.get('disabled') or [])} disabled, "
+        f"{result.get('unchanged', 0)} unchanged, "
+        f"{len(result.get('failed') or [])} failed"
+    )
+    for username in result.get("enabled") or []:
+        log(f"  enabled  {username}")
+    for username in result.get("disabled") or []:
+        log(f"  disabled {username}")
+
+    # A tenant the API could not write is left for the next pass, but a run that
+    # ends with work outstanding should not look clean to whatever is watching it.
+    if result.get("failed"):
+        log(f"\n{len(result['failed'])} tenant(s) failed to update; the next run retries them")
+        return 1
+
     return 0
 
 

--- a/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.service
+++ b/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.service
@@ -1,0 +1,62 @@
+[Unit]
+Description=Register managed-blog Hivesigner redirect URIs and enable the login method
+Documentation=https://github.com/ecency/vision-next/blob/develop/apps/self-hosted/hosting/README.md
+# Nothing to do without a network, and a run that fails on DNS is noise.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+
+# The only process in this system that holds the app account's posting key. It is
+# deliberately not the hosting API: that service is internet-facing, holds tenant
+# and payment data, and has never held a key of any kind.
+#
+# Create a dedicated unprivileged user for it and give that user exclusive read of
+# the two credential files. Both must be mode 0600 or the script refuses to start.
+User=hivesigner-registrar
+Group=hivesigner-registrar
+
+WorkingDirectory=/opt/hivesigner-registrar
+
+# DATABASE_URL, HOSTING_API_BASE, and optionally HIVE_RPC / BASE_DOMAIN /
+# HIVESIGNER_APP_ACCOUNT. Keep the posting key and the internal secret OUT of this
+# file and out of the environment: they are passed as paths below so they never
+# appear in `systemctl show`, in the journal, or in /proc/<pid>/environ.
+EnvironmentFile=/etc/hivesigner-registrar/registrar.env
+
+ExecStart=/opt/hivesigner-registrar/venv/bin/python \
+    /opt/hivesigner-registrar/hivesigner-redirect-uris.py \
+    --broadcast \
+    --key-file /etc/hivesigner-registrar/posting.key \
+    --internal-secret-file /etc/hivesigner-registrar/internal.secret
+
+# A failed run is repaired by the next one: every pass merges onto whatever is on
+# chain at the time and never removes, and the client-id reconcile runs whether or
+# not anything was broadcast. So there is nothing to retry here, and a restart loop
+# would only broadcast more often on a bad day.
+Restart=no
+
+# A run that cannot finish inside the timer interval is stuck; the lock file stops
+# the next one from starting anyway, so let this one go rather than pile up.
+TimeoutStartSec=240
+
+# The key is the whole risk surface. Nothing here needs to write outside its own
+# directory or see the rest of the filesystem.
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictSUIDSGID=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+# The lock file lives next to the script.
+ReadWritePaths=/opt/hivesigner-registrar
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.timer
+++ b/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.timer
@@ -1,0 +1,30 @@
+[Unit]
+Description=Periodic Hivesigner redirect-URI registration for managed blogs
+Documentation=https://github.com/ecency/vision-next/blob/develop/apps/self-hosted/hosting/README.md
+
+[Timer]
+# Five minutes, matching the two sync loops a new instance already waits on: the
+# hosting API regenerates served config files every five minutes, and the origin
+# issues certificates and writes vhosts every five minutes. A blog is not finished
+# arriving before those have run, so a shorter interval here would not make the
+# login button appear any sooner to its owner, and a longer one would be the only
+# thing they were still waiting for.
+#
+# The cost of a pass that finds nothing to do is one query, one RPC read and one
+# local API call, so the interval is not paid for in broadcasts: a broadcast
+# happens only when an instance is genuinely unregistered.
+OnBootSec=2min
+OnUnitActiveSec=5min
+
+# Runs are independent and each merges onto whatever is on chain, so letting the
+# scheduler spread them costs nothing and keeps this off the same second as every
+# other five-minute job on the host.
+AccuracySec=30s
+RandomizedDelaySec=30s
+
+# A host that was down through a provisioning window should register on the way
+# back up rather than at the next tick.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/apps/self-hosted/hosting/scripts/test_hivesigner_redirect_uris.py
+++ b/apps/self-hosted/hosting/scripts/test_hivesigner_redirect_uris.py
@@ -1,0 +1,188 @@
+"""
+Tests for the pure parts of the Hivesigner redirect-URI registration job.
+
+Nothing here touches the database, the chain or the hosting API: the pieces that
+do are thin wrappers, and the parts that decide what may be written to an account
+every hosted blog's login depends on are the ones worth holding still.
+
+stdlib unittest, no dependencies, because this script runs on a host that has
+only what an operator installed for it and CI should not need more than python3
+to check it.
+
+    python3 -m unittest discover -p 'test_*.py'
+"""
+
+import importlib.util
+import os
+import stat
+import tempfile
+import unittest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "hivesigner_redirect_uris",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "hivesigner-redirect-uris.py"),
+)
+registrar = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(registrar)
+
+BASE = "blogs.ecency.com"
+
+
+class SafeRedirectUri(unittest.TestCase):
+    """
+    Everything on redirect_uris can receive an OAuth callback carrying an access
+    token for the app, so this is the last check before a name becomes able to.
+    """
+
+    def accepts(self, uri):
+        self.assertTrue(registrar.is_safe_redirect_uri(uri, BASE), uri)
+
+    def refuses(self, uri):
+        self.assertFalse(registrar.is_safe_redirect_uri(uri, BASE), uri)
+
+    def test_accepts_a_tenant_subdomain(self):
+        self.accepts("https://alice.blogs.ecency.com/auth")
+
+    def test_accepts_a_dotted_account_name_two_labels_deep(self):
+        # A Hive account may contain a dot, and that tenant's blog lives two
+        # labels under the base domain.
+        self.accepts("https://louis.random.blogs.ecency.com/auth")
+
+    def test_accepts_a_custom_domain(self):
+        self.accepts("https://blog.example.org/auth")
+
+    def test_refuses_plain_http(self):
+        self.refuses("http://alice.blogs.ecency.com/auth")
+
+    def test_refuses_any_path_other_than_the_callback(self):
+        self.refuses("https://alice.blogs.ecency.com/")
+        self.refuses("https://alice.blogs.ecency.com/auth/")
+        self.refuses("https://alice.blogs.ecency.com/auth/extra")
+
+    def test_refuses_a_query_or_fragment(self):
+        self.refuses("https://alice.blogs.ecency.com/auth?next=x")
+        self.refuses("https://alice.blogs.ecency.com/auth#x")
+
+    def test_refuses_embedded_credentials(self):
+        # https://ecency.com@evil.example/auth reads as ecency.com to a person
+        # skimming the array and as evil.example to everything else.
+        self.refuses("https://ecency.com@evil.example/auth")
+
+    def test_refuses_a_port(self):
+        self.refuses("https://alice.blogs.ecency.com:8443/auth")
+
+    def test_refuses_a_malformed_port(self):
+        self.refuses("https://alice.blogs.ecency.com:notaport/auth")
+
+    def test_refuses_mixed_case_since_the_match_on_chain_is_exact(self):
+        self.refuses("https://Alice.blogs.ecency.com/auth")
+
+    def test_refuses_ecency_com_and_anything_under_it(self):
+        # A custom domain is never ours; one claiming to be would take callbacks
+        # for the first-party app.
+        self.refuses("https://ecency.com/auth")
+        self.refuses("https://alpha.ecency.com/auth")
+        self.refuses("https://notblogs.ecency.com/auth")
+
+    def test_refuses_the_base_domain_itself(self):
+        self.refuses("https://blogs.ecency.com/auth")
+
+    def test_refuses_a_hostname_that_is_not_a_hostname(self):
+        self.refuses("https://-bad-.example/auth")
+        self.refuses("https://localhost/auth")
+
+
+class MergeUris(unittest.TestCase):
+    def test_reports_what_is_missing_and_appends_it(self):
+        missing, merged = registrar.merge_uris(["https://a/auth"], ["https://a/auth", "https://b/auth"])
+        self.assertEqual(missing, ["https://b/auth"])
+        self.assertEqual(merged, ["https://a/auth", "https://b/auth"])
+
+    def test_never_drops_an_entry_it_did_not_ask_for(self):
+        # A URI added by hand for something outside this script's view survives.
+        _, merged = registrar.merge_uris(["https://manual/auth"], ["https://a/auth"])
+        self.assertIn("https://manual/auth", merged)
+
+    def test_is_idempotent(self):
+        first_missing, merged = registrar.merge_uris([], ["https://a/auth"])
+        second_missing, again = registrar.merge_uris(merged, ["https://a/auth"])
+        self.assertEqual(first_missing, ["https://a/auth"])
+        self.assertEqual(second_missing, [])
+        self.assertEqual(again, merged)
+
+    def test_does_not_add_the_same_uri_twice_in_one_pass(self):
+        missing, merged = registrar.merge_uris([], ["https://a/auth", "https://a/auth"])
+        self.assertEqual(missing, ["https://a/auth"])
+        self.assertEqual(merged, ["https://a/auth"])
+
+    def test_preserves_the_order_of_what_is_already_registered(self):
+        _, merged = registrar.merge_uris(["https://b/auth", "https://a/auth"], ["https://c/auth"])
+        self.assertEqual(merged, ["https://b/auth", "https://a/auth", "https://c/auth"])
+
+
+class CurrentMetadata(unittest.TestCase):
+    def test_reads_the_registered_array(self):
+        metadata, uris = registrar.current_metadata(
+            {"posting_json_metadata": '{"profile":{"redirect_uris":["https://a/auth"]}}'}
+        )
+        self.assertEqual(uris, ["https://a/auth"])
+        self.assertEqual(metadata["profile"]["redirect_uris"], ["https://a/auth"])
+
+    def test_keeps_the_rest_of_the_profile(self):
+        metadata, _ = registrar.current_metadata(
+            {"posting_json_metadata": '{"profile":{"name":"App","redirect_uris":[]}}'}
+        )
+        self.assertEqual(metadata["profile"]["name"], "App")
+
+    def test_treats_an_account_with_no_metadata_as_registering_nothing(self):
+        _, uris = registrar.current_metadata({})
+        self.assertEqual(uris, [])
+
+    def test_refuses_to_guess_when_redirect_uris_is_not_an_array(self):
+        with self.assertRaises(SystemExit):
+            registrar.current_metadata(
+                {"posting_json_metadata": '{"profile":{"redirect_uris":"https://a/auth"}}'}
+            )
+
+
+class ReadSecretFile(unittest.TestCase):
+    def write(self, contents, mode):
+        handle, path = tempfile.mkstemp()
+        with os.fdopen(handle, "w") as f:
+            f.write(contents)
+        os.chmod(path, mode)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_reads_an_owner_only_file(self):
+        path = self.write("  secret-value\n", stat.S_IRUSR | stat.S_IWUSR)
+        self.assertEqual(registrar.read_secret_file(path, "posting key"), "secret-value")
+
+    def test_refuses_a_group_or_world_readable_file(self):
+        for mode in (0o640, 0o604, 0o644):
+            path = self.write("secret-value", mode)
+            with self.assertRaises(SystemExit) as caught:
+                registrar.read_secret_file(path, "posting key")
+            # The message must name the problem without quoting the value.
+            self.assertNotIn("secret-value", str(caught.exception))
+
+    def test_refuses_an_empty_file(self):
+        path = self.write("\n", stat.S_IRUSR | stat.S_IWUSR)
+        with self.assertRaises(SystemExit):
+            registrar.read_secret_file(path, "posting key")
+
+    def test_refuses_a_file_that_is_not_there(self):
+        with self.assertRaises(SystemExit):
+            registrar.read_secret_file("/nonexistent/posting.key", "posting key")
+
+
+class Statuses(unittest.TestCase):
+    def test_registers_only_tenants_the_api_will_serve(self):
+        # The hosting API writes a client id only for an 'active' tenant, and the
+        # array only ever grows, so anything else spends metadata bytes forever
+        # on a login that is never enabled.
+        self.assertEqual(registrar.LIVE_STATUSES, ("active",))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/self-hosted/hosting/scripts/test_hivesigner_redirect_uris.py
+++ b/apps/self-hosted/hosting/scripts/test_hivesigner_redirect_uris.py
@@ -12,18 +12,28 @@ to check it.
     python3 -m unittest discover -p 'test_*.py'
 """
 
-import importlib.util
+import fcntl
 import os
 import stat
 import tempfile
+import types
 import unittest
 
-_SPEC = importlib.util.spec_from_file_location(
-    "hivesigner_redirect_uris",
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "hivesigner-redirect-uris.py"),
-)
-registrar = importlib.util.module_from_spec(_SPEC)
-_SPEC.loader.exec_module(registrar)
+# The script is not importable by name (it has a dash and no .py-module identity),
+# so it is compiled from source here.
+#
+# Deliberately NOT loaded through importlib's file loader. That caches bytecode in
+# __pycache__ keyed on the source's mtime and size, and a same-second edit that
+# does not change the length silently reuses the stale copy: after a run that
+# flipped `SystemExit(0)` to `SystemExit(1)` and put the original back, the tests
+# went on testing the flipped version and reported a failure that was not in the
+# file. Compiling the bytes that are on disk, every time, cannot do that, and
+# leaves nothing behind in the working tree either.
+_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hivesigner-redirect-uris.py")
+registrar = types.ModuleType("hivesigner_redirect_uris")
+registrar.__file__ = _PATH
+with open(_PATH, encoding="utf-8") as _source:
+    exec(compile(_source.read(), _PATH, "exec"), registrar.__dict__)
 
 BASE = "blogs.ecency.com"
 
@@ -174,6 +184,57 @@ class ReadSecretFile(unittest.TestCase):
     def test_refuses_a_file_that_is_not_there(self):
         with self.assertRaises(SystemExit):
             registrar.read_secret_file("/nonexistent/posting.key", "posting key")
+
+
+class AcquireLock(unittest.TestCase):
+    """
+    The lock is what keeps two runs from each merging onto the state they read
+    and the later broadcast losing the earlier one's entries.
+    """
+
+    def setUp(self):
+        handle, path = tempfile.mkstemp()
+        os.close(handle)
+        self.path = path
+        self.original = registrar.LOCK_FILE
+        registrar.LOCK_FILE = path
+        self.addCleanup(self.restore)
+
+    def restore(self):
+        registrar.LOCK_FILE = self.original
+        if registrar._LOCK_HANDLE is not None:
+            registrar._LOCK_HANDLE.close()
+            registrar._LOCK_HANDLE = None
+        os.unlink(self.path)
+
+    def held(self):
+        """Whether anything currently holds an exclusive flock on the lock file."""
+        with open(self.path, "w", encoding="utf-8") as other:
+            try:
+                fcntl.flock(other, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                return True
+            fcntl.flock(other, fcntl.LOCK_UN)
+            return False
+
+    def test_nothing_holds_the_lock_to_begin_with(self):
+        self.assertFalse(self.held())
+
+    def test_the_lock_outlives_the_call(self):
+        # The regression this exists for: acquire_lock used to RETURN the handle
+        # and the caller dropped it, so CPython closed the file and released the
+        # flock before the first read. The lock was taken and given straight back
+        # while everything still looked like it was working.
+        registrar.acquire_lock()
+        self.assertTrue(self.held())
+
+    def test_a_second_run_exits_quietly_rather_than_waiting(self):
+        registrar.acquire_lock()
+        # A pass skipped because the previous one is still going is not a fault,
+        # so a timer must not see it as one.
+        with self.assertRaises(SystemExit) as caught:
+            registrar.acquire_lock()
+        self.assertEqual(caught.exception.code, 0)
 
 
 class Statuses(unittest.TestCase):

--- a/apps/self-hosted/hosting/scripts/test_hivesigner_redirect_uris.py
+++ b/apps/self-hosted/hosting/scripts/test_hivesigner_redirect_uris.py
@@ -13,8 +13,10 @@ to check it.
 """
 
 import fcntl
+import json
 import os
 import stat
+import sys
 import tempfile
 import types
 import unittest
@@ -184,6 +186,151 @@ class ReadSecretFile(unittest.TestCase):
     def test_refuses_a_file_that_is_not_there(self):
         with self.assertRaises(SystemExit):
             registrar.read_secret_file("/nonexistent/posting.key", "posting key")
+
+
+class RpcErrors(unittest.TestCase):
+    """
+    A node that answers with an error must not read as an empty answer. That
+    turned every node fault into "the app account does not exist", which is the
+    wrong diagnosis and, being a SystemExit, could not be retried during
+    confirmation either.
+    """
+
+    def call(self, body):
+        captured = {}
+
+        class FakeResponse:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *exc):
+                return False
+
+            def read(self_inner):
+                return body.encode()
+
+        original = registrar.urllib.request.urlopen
+        registrar.urllib.request.urlopen = lambda *a, **k: FakeResponse()
+        self.addCleanup(setattr, registrar.urllib.request, "urlopen", original)
+        captured["result"] = registrar.rpc("https://node.example", "m", [])
+        return captured["result"]
+
+    def test_returns_the_body_on_success(self):
+        self.assertEqual(self.call('{"result": [1]}')["result"], [1])
+
+    def test_raises_on_a_json_rpc_error_member(self):
+        with self.assertRaises(registrar.RpcError):
+            self.call('{"error": {"message": "server busy"}}')
+
+    def test_repeats_what_the_node_actually_said(self):
+        # The missing-result check below would also refuse this body, so what the
+        # error member buys is the diagnosis. Without it the operator reads
+        # "response carried neither result nor error" and goes looking for a bug
+        # here instead of at the node that told them why.
+        with self.assertRaises(registrar.RpcError) as caught:
+            self.call('{"error": {"message": "server busy"}}')
+        self.assertIn("server busy", str(caught.exception))
+
+    def test_raises_on_a_response_with_neither_result_nor_error(self):
+        with self.assertRaises(registrar.RpcError):
+            self.call("{}")
+
+    def test_an_rpc_error_is_retryable_during_confirmation(self):
+        # confirm_registered only retries what it catches, so RpcError has to be
+        # in that set or a blip ends the run.
+        import inspect
+
+        source = inspect.getsource(registrar.confirm_registered)
+        self.assertIn("RpcError", source.split("except")[1].split(":")[0])
+
+
+class BroadcastMetadata(unittest.TestCase):
+    """
+    The one operation here that changes something on a live account, and the one
+    whose mistakes are not undoable by running it again.
+    """
+
+    def broadcast(self, json_metadata):
+        sent = {}
+
+        class FakeClient:
+            def __init__(self_inner, nodes=None, keys=None):
+                sent["nodes"] = nodes
+                sent["keys"] = keys
+
+            def broadcast_sync(self_inner, op):
+                sent["op"] = op.to_dict()
+
+        class FakeOperation:
+            def __init__(self_inner, type_, value):
+                self_inner.type = type_
+                self_inner.value = value
+
+            def to_dict(self_inner):
+                return [self_inner.type, self_inner.value]
+
+        client_mod = types.ModuleType("lighthive.client")
+        client_mod.Client = FakeClient
+        data_mod = types.ModuleType("lighthive.datastructures")
+        data_mod.Operation = FakeOperation
+        package = types.ModuleType("lighthive")
+        for name, module in (
+            ("lighthive", package),
+            ("lighthive.client", client_mod),
+            ("lighthive.datastructures", data_mod),
+        ):
+            sys.modules[name] = module
+            self.addCleanup(sys.modules.pop, name, None)
+
+        registrar.broadcast_metadata("app", '{"profile":{}}', json_metadata, "wif", ["n"])
+        return sent
+
+    def test_updates_the_posting_copy(self):
+        sent = self.broadcast("")
+        self.assertEqual(sent["op"][0], "account_update2")
+        self.assertEqual(sent["op"][1]["posting_json_metadata"], '{"profile":{}}')
+
+    def test_echoes_the_accounts_existing_json_metadata_back(self):
+        # Sending an empty string here would rely on the evaluator treating it as
+        # "leave alone". If that reading is ever wrong, or ever changes, the app
+        # account's global metadata is erased and cannot be recovered from here.
+        sent = self.broadcast('{"keep":"me"}')
+        self.assertEqual(sent["op"][1]["json_metadata"], '{"keep":"me"}')
+
+    def test_does_not_put_the_key_in_the_operation(self):
+        sent = self.broadcast("")
+        self.assertNotIn("wif", json.dumps(sent["op"]))
+
+
+class SecretSafeBase(unittest.TestCase):
+    """
+    The shared secret goes out as a request header, so the base it is sent to
+    decides whether it crosses a network in the clear.
+    """
+
+    def test_accepts_https(self):
+        registrar.assert_secret_safe_base("https://api.example")
+
+    def test_accepts_http_on_loopback(self):
+        # No network path, so nothing to intercept.
+        registrar.assert_secret_safe_base("http://127.0.0.1:3001")
+        registrar.assert_secret_safe_base("http://localhost:3001")
+
+    def test_refuses_plain_http_to_a_remote_host(self):
+        with self.assertRaises(SystemExit):
+            registrar.assert_secret_safe_base("http://api.example")
+
+    def test_refuses_a_scheme_that_is_neither(self):
+        for base in ("ftp://api.example", "api.example", ""):
+            with self.assertRaises(SystemExit):
+                registrar.assert_secret_safe_base(base)
+
+    def test_refuses_to_follow_a_redirect(self):
+        # urllib re-sends headers to wherever a redirect points, and one of them
+        # is the secret, so anything able to answer could collect it with a 302.
+        handler = registrar._RefuseRedirects()
+        with self.assertRaises(registrar.urllib.error.URLError):
+            handler.redirect_request(None, None, 302, "Found", {}, "http://evil.example/")
 
 
 class AcquireLock(unittest.TestCase):

--- a/apps/self-hosted/src/features/floating-menu/hivesigner-setup.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/hivesigner-setup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   getHivesignerSetupNotice,
+  HIVESIGNER_MANAGED_SETUP_NOTICE,
   HIVESIGNER_SETUP_NOTICE,
 } from './hivesigner-setup';
 
@@ -8,6 +9,7 @@ function configWith(options: {
   methods?: unknown;
   enabled?: unknown;
   clientId?: unknown;
+  managed?: unknown;
 }) {
   return {
     configuration: {
@@ -16,6 +18,7 @@ function configWith(options: {
           ? {}
           : { hivesigner: { clientId: options.clientId } },
       instanceConfiguration: {
+        ...(options.managed === undefined ? {} : { managed: options.managed }),
         features: {
           auth: {
             enabled: options.enabled ?? true,
@@ -41,6 +44,54 @@ describe('hivesigner setup notice', () => {
   it('tells the owner both routes and where to do each', () => {
     expect(HIVESIGNER_SETUP_NOTICE).toContain('General Settings > Hivesigner');
     expect(HIVESIGNER_SETUP_NOTICE).toContain('hello@ecency.com');
+  });
+
+  /**
+   * On a managed blog the registration is performed by a scheduled job and the
+   * client id is written only once it has landed, so the owner has nothing to
+   * do. Sending them to support would be asking for something already under way.
+   */
+  it('tells a managed blog to wait rather than to email support', () => {
+    const notice = getHivesignerSetupNotice(
+      configWith({ methods: ['hivesigner'], managed: true }),
+    );
+
+    expect(notice).toBe(HIVESIGNER_MANAGED_SETUP_NOTICE);
+    expect(notice).not.toContain('hello@ecency.com');
+  });
+
+  it('still offers the managed owner their own app as a way past the wait', () => {
+    expect(HIVESIGNER_MANAGED_SETUP_NOTICE).toContain(
+      'General Settings > Hivesigner',
+    );
+  });
+
+  it('names the custom-domain case, the one time a working button goes away', () => {
+    expect(HIVESIGNER_MANAGED_SETUP_NOTICE).toContain('custom domain');
+  });
+
+  it.each([
+    ['absent', undefined],
+    ['false', false],
+    ['a string that merely looks true', 'true'],
+  ])('keeps the self-hosted notice when managed is %s', (_label, managed) => {
+    // `managed` is injected by the hosting service and never stored, so a
+    // self-hosted config cannot claim a registration nobody will perform.
+    expect(
+      getHivesignerSetupNotice(configWith({ methods: ['hivesigner'], managed })),
+    ).toBe(HIVESIGNER_SETUP_NOTICE);
+  });
+
+  it('says nothing on a managed blog once the client id has been written', () => {
+    expect(
+      getHivesignerSetupNotice(
+        configWith({
+          methods: ['hivesigner'],
+          managed: true,
+          clientId: 'ecency.app',
+        }),
+      ),
+    ).toBe(null);
   });
 
   it('says nothing once the owner names their own app', () => {

--- a/apps/self-hosted/src/features/floating-menu/hivesigner-setup.ts
+++ b/apps/self-hosted/src/features/floating-menu/hivesigner-setup.ts
@@ -10,6 +10,28 @@ import { resolveHivesignerClientId } from '@/features/auth/utils/hivesigner';
 export const HIVESIGNER_SETUP_NOTICE =
   "Hivesigner is listed as a login method but this site has no Hivesigner client id, so the button stays hidden. Add your own app id under General Settings > Hivesigner, or email hello@ecency.com to get this site's /auth address registered on the shared ecency.app app.";
 
+/**
+ * The same gap on a managed blog, where the owner has nothing to do.
+ *
+ * Registration is automatic there: a scheduled job adds the instance's /auth
+ * address to the shared app and only then writes the client id, so the two can
+ * never disagree. Telling a managed owner to email support would send them to
+ * ask for something that completes on its own within minutes, and the wait is
+ * the only part they need explained.
+ *
+ * A verified custom domain is called out because it is the one case where a
+ * working button goes away again for a few minutes: the new origin has to be
+ * registered before either address may be offered.
+ */
+export const HIVESIGNER_MANAGED_SETUP_NOTICE =
+  "Hivesigner is listed as a login method but this site's address is not registered with the shared Hivesigner app yet, so the button stays hidden. Registration is automatic on a managed blog and completes within a few minutes of the site going live, and again after a custom domain is verified. Add your own app id under General Settings > Hivesigner if you would rather not wait.";
+
+const MANAGED_PATH = [
+  'configuration',
+  'instanceConfiguration',
+  'managed',
+] as const;
+
 const AUTH_PATH = [
   'configuration',
   'instanceConfiguration',
@@ -53,7 +75,14 @@ export function getHivesignerSetupNotice(config: unknown): string | null {
   const methods = readKey(auth, 'methods');
   if (!Array.isArray(methods) || !methods.includes('hivesigner')) return null;
 
-  return resolveHivesignerClientId(readPath(config, CLIENT_ID_PATH)) === null
-    ? HIVESIGNER_SETUP_NOTICE
-    : null;
+  if (resolveHivesignerClientId(readPath(config, CLIENT_ID_PATH)) !== null) {
+    return null;
+  }
+
+  // `managed` is injected into the served config by the hosting service and is
+  // never stored, so it cannot be set by a self-hosted config claiming a
+  // registration nobody is going to perform for it.
+  return readPath(config, MANAGED_PATH) === true
+    ? HIVESIGNER_MANAGED_SETUP_NOTICE
+    : HIVESIGNER_SETUP_NOTICE;
 }


### PR DESCRIPTION
Closes #1318. Follow-up to #1316, #1317 and #1329.

## The problem

Hivesigner matches an OAuth callback with `redirect_uris.includes(callback)` against the app account's on-chain `posting_json_metadata`. Exact string match, no wildcards, no origin matching, so a hosted blog whose `/auth` URI is not listed verbatim cannot complete a login. The SPA hides the method unless the instance names a client id, which is correct but means every hosted blog offers Keychain and HiveAuth only.

`hivesigner-redirect-uris.py` (#1329) already worked out what needed registering, but nothing ran it, and nothing turned the method on afterwards. On a phone that leaves no way to configure a blog at all: `getHostingToken` handles `hivesigner` and `keychain`, Keychain is a desktop extension, and HiveAuth cannot answer an offline challenge because `hive-auth-wrapper` exposes no `broadcast: false`.

## What this does

Registration and enablement become one scheduled operation. Each pass:

1. reads the live tenants and the account's current array,
2. appends whatever is missing (`account_update2`, posting authority),
3. confirms the additions are actually on chain,
4. asks the hosting API to reconcile every tenant's `general.hivesigner.clientId`.

A tenant provisioned overnight is registered and can log in by morning with nobody involved.

## Where the signing runs, and why not here

Step 2 is the only step that signs, and it does not happen in the hosting API. That service is internet-facing, holds tenant and payment data, and has never held a key of any kind; it was not going to acquire one so that a scheduled job could be saved a hop. The broadcast runs from a systemd timer on the host that already runs the key-holding scheduled jobs, and the API's half of the work is read-only: it fetches the account itself.

`api/src/no-signing-capability.test.ts` holds that line. It walks the package's import graph and fails if any module imports `PrivateKey`, `Transaction`, `Memo` or `callRPCBroadcast`, or a signing module. `Signature` and `PublicKey` are deliberately not on that list and the comment says why: verifying a signature needs no key, and `utils/auth.ts` does it on every hosting-token exchange.

## Why the client id and the registration cannot disagree

A client id on an instance whose URI is not registered is a login button that leads to an error page with no explanation, which is what #1317 exists to prevent.

So nothing writes a client id except `POST /v1/internal/hivesigner/reconcile`, and that endpoint **reads no request body at all**. What it enables is decided from the on-chain array and from each tenant's own row, so holding the shared secret is not enough to enable an unregistered instance, and neither is a bug in the script. The two halves are allowed to drift only in the safe direction: registering too little leaves the method off, registering too much enables nothing extra.

## Failure behaviour

- **The broadcast fails.** The additions are confirmed by re-reading the account before anything is enabled, and the reconcile independently refuses any tenant whose URIs it cannot find. Nothing is set.
- **A run dies between the halves.** The reconcile runs every pass, not only after a broadcast, so the next tick enables it with nobody told.
- **The account cannot be read.** Metadata that fails to parse is an error, never an empty registration. Treating it as empty would withdraw the method from every tenant at once on one bad RPC response, so the pass writes nothing.
- **One tenant's write fails.** Isolated the way `syncAllConfigs` isolates them; it is named in the response and retried next pass.

## Other properties, each with a test

- An unverified custom domain is never registered. A tenant serving a verified one needs **both** its origins before either is enabled: one config file serves both and the SPA builds its `redirect_uri` from `window.location.origin`.
- Existing entries are never dropped, the merge is idempotent and does not duplicate, and a lock file keeps two passes from racing the read-modify-write.
- A config save racing the reconcile cannot lose. Each tenant's row is re-read `FOR UPDATE` and the decision taken again from it, inside the transaction that writes, so an owner saving their own Hivesigner app is never overwritten and a domain verified mid-pass cannot be enabled on one origin only.
- The broadcast echoes the account's existing `json_metadata` back rather than sending it empty, so the app account's global metadata cannot be erased whatever the evaluator does with an empty string.
- The internal secret only travels over https or loopback, and redirects are refused rather than followed.
- An owner who configured their own Hivesigner app is never touched, in either direction.
- Only `active` tenants are registered, matching the only status the API will write a client id for. The script previously named a `trialing` status this schema has never had, so that filter matched no rows.

## Client side

The configuration editor now tells a managed owner to wait rather than to email support, since registration completes on its own within minutes. `managed` is injected by the hosting service and never stored, so a self-hosted config cannot claim a registration nobody will perform for it.

## Notes for review

- **No migration.** The client id lives in the tenant config and is written through `applyConfigDocument`, the same guarded merge and pinned identity fields a save from the editor goes through. Disabling writes an empty string, which `resolveHivesignerClientId` already treats as absent, because the guarded merge has no delete.
- **No new required configuration on the API.** `HIVESIGNER_APP_ACCOUNT` is optional and defaults correctly, so the deploy needs no environment change.
- The `.github/workflows/self-hosted.yml` change adds a **test step**, not a schedule. The operator scripts are not part of any package, so their stdlib `unittest` suite would otherwise never run. Nothing about the signing job lives in CI.
- `is_safe_redirect_uri` was written with separate checks for userinfo, port and case. Mutation testing showed none of them could ever fire, because requiring the authority to equal the hostname had already refused every input that would reach them. Four checks where one is load-bearing reads as depth and is not, so they are now one check with a comment saying so.

## Verification

- hosting API: 385 tests pass (37 new), `tsc --noEmit` clean
- self-hosted SPA: 719 tests pass
- operator scripts: 27 tests pass
- 35 mutations applied and caught, covering the verified-domain rule, the both-origins rule, the parse-failure rule, the chain-read abort, the owner's-own-app rule, the body-is-not-read rule, the secret gate, the URI shape checks, the merge, the credential file mode, and the guard's own parser and file walk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Hivesigner redirect URI registration and client-ID reconciliation for active managed blogs.
  * Added scheduled system service support with secure execution and recurring five-minute updates.
  * Added verified custom-domain support and safer HTTPS callback validation.
  * Added a managed-instance notice when Hivesigner setup is handled automatically.

* **Bug Fixes**
  * Improved handling of registration failures, malformed metadata, duplicate URIs, and incomplete blockchain responses.

* **Documentation**
  * Expanded setup, operation, monitoring, credentials, and recovery guidance.

* **Tests**
  * Added comprehensive reconciliation, security, validation, and managed-instance coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
