### PR TITLE
self-hosted: let the accent reach the things that look interactive

### DIFF
--- a/apps/self-hosted/src/core/apply-config-dom.test.ts
+++ b/apps/self-hosted/src/core/apply-config-dom.test.ts
@@ -11,7 +11,13 @@ import {
   restoreConfigDom,
   snapshotConfigDom,
 } from './apply-config-dom';
-import { FONT_PRESETS } from './theme-appearance';
+import {
+  accentShadeFor,
+  FONT_PRESETS,
+  parseHexColor,
+  type Rgb,
+  relativeLuminance,
+} from './theme-appearance';
 
 const APP = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -365,6 +371,33 @@ describe('the appearance knobs', () => {
     expect(inline['--theme-font-body']).toBeUndefined();
   });
 
+  it('writes the shade the hover reads, pointing away from the ink', () => {
+    // The hover is only safe because of this property. Left to the stylesheet
+    // it is black in light mode and white in dark mode, which is the mode's
+    // shade rather than the ink's opposite, and a fill walking towards its own
+    // label is how the hovered button lost 4.5:1 for 39% of accents.
+    //
+    // Asserted as a resolved DOM value against what the module computes, over
+    // accents whose ink differs, so dropping the entry from the declaration
+    // fails here rather than silently falling back to the stylesheet.
+    for (const accent of ['#8B4513', '#ffff00', '#767676', '#0969da']) {
+      applyConfigDom(styles({ accent }));
+      const inline = inlineVariables();
+      const ink = inline['--theme-accent-contrast'];
+      const shade = inline['--theme-accent-shade'];
+
+      expect(`${accent} shade`).toBe(`${accent} shade`);
+      expect(shade, `${accent}: no shade written`).toBeDefined();
+      expect(shade, `${accent}: shade does not oppose ink ${ink}`).toBe(
+        accentShadeFor(ink),
+      );
+      // Opposite ends of the luminance range, computed rather than listed.
+      const luminanceOf = (hex: string) =>
+        relativeLuminance(parseHexColor(hex) as Rgb);
+      expect(luminanceOf(shade) > 0.5).toBe(!(luminanceOf(ink) > 0.5));
+    }
+  });
+
   it('writes all three faces for a pairing, never one of them', () => {
     applyConfigDom(styles({ fontPreset: 'technical' }));
 
@@ -399,9 +432,15 @@ describe('the appearance knobs', () => {
     expect(inlineVariables()).toEqual({});
   });
 
-  it('writes only properties a stylesheet reads', () => {
+  it('writes only properties something reads', () => {
     // Nine token families shipped with no consumer the last time appearance
     // work landed here. A property nothing reads is a knob that does nothing.
+    //
+    // A reader is a stylesheet OR another written value, because a written
+    // value may itself be a var() expression: --theme-accent-hover is the
+    // constant color-mix that reads --theme-accent-shade, and the shade has no
+    // stylesheet consumer at all. Resolving that by hand would let the next
+    // genuinely dead property in behind the same exception.
     const stylesheets: string[] = [];
     const walk = (dir: string) => {
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -413,8 +452,12 @@ describe('the appearance knobs', () => {
     };
     walk(join(APP, 'src', 'styles'));
 
+    applyConfigDom(styles({ accent: '#7c3aed', fontPreset: 'modern' }));
+    const written = Object.values(inlineVariables());
+
+    const readers = [...stylesheets, ...written];
     const unread = declaredVariables().filter(
-      (variable) => !stylesheets.some((css) => css.includes(`var(${variable}`)),
+      (variable) => !readers.some((text) => text.includes(`var(${variable}`)),
     );
     expect(unread).toEqual([]);
   });

--- a/apps/self-hosted/src/core/apply-config-dom.ts
+++ b/apps/self-hosted/src/core/apply-config-dom.ts
@@ -253,6 +253,13 @@ export const CONFIG_DOM_DECLARATION: ConfigDomDeclaration = {
       variable: '--theme-accent-contrast',
       resolve: (read) => accentOf(read)?.contrast ?? null,
     },
+    // The direction the hover walks the fill, which has to come from the ink
+    // rather than from the mode or the hovered button loses its own label. The
+    // CSS declaration is the no-accent-configured fallback; see accentShadeFor.
+    {
+      variable: '--theme-accent-shade',
+      resolve: (read) => accentOf(read)?.shade ?? null,
+    },
     // Both mode variants are written and CSS picks between them, so an OS flip
     // under `theme: system` re-resolves with no JS and cannot revert a preview.
     {

--- a/apps/self-hosted/src/core/theme-appearance.test.ts
+++ b/apps/self-hosted/src/core/theme-appearance.test.ts
@@ -5,7 +5,9 @@ import { describe, expect, it } from 'vitest';
 import {
   ACCENT_CONTRAST_TARGET,
   ACCENT_TINT_PERCENT,
+  ACCENT_HOVER,
   accentContrastColor,
+  accentShadeFor,
   accentTextFor,
   accentTextForMode,
   contrastRatio,
@@ -200,6 +202,139 @@ describe('accentContrastColor', () => {
     );
 
     expect(worst.ratio).toBeGreaterThanOrEqual(ACCENT_CONTRAST_TARGET);
+  });
+});
+
+describe('accentShadeFor and the hovered fill', () => {
+  /**
+   * `color-mix(in oklab, a p%, b)`, which is what ACCENT_HOVER asks the browser
+   * for. Modelled here rather than approximated in sRGB, because the whole
+   * claim is about where the hovered fill lands relative to its own ink and an
+   * approximation would be measuring a different colour than the one shipped.
+   */
+  function mixOklab(a: Rgb, b: Rgb, share: number): Rgb {
+    const toLinear = (channel: number) => {
+      const c = channel / 255;
+      return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+    };
+    const toSrgb = (channel: number) => {
+      const v =
+        channel <= 0.0031308
+          ? channel * 12.92
+          : 1.055 * channel ** (1 / 2.4) - 0.055;
+      return Math.min(255, Math.max(0, Math.round(v * 255)));
+    };
+    const forward = (rgb: Rgb): [number, number, number] => {
+      const [R, G, B] = rgb.map(toLinear);
+      const l = Math.cbrt(0.4122214708 * R + 0.5363325363 * G + 0.0514459929 * B);
+      const m = Math.cbrt(0.2119034982 * R + 0.6806995451 * G + 0.1073969566 * B);
+      const s = Math.cbrt(0.0883024619 * R + 0.2817188376 * G + 0.6299787005 * B);
+      return [
+        0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+        1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+        0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+      ];
+    };
+    const back = ([L, A, B]: [number, number, number]): Rgb => {
+      const l = (L + 0.3963377774 * A + 0.2158037573 * B) ** 3;
+      const m = (L - 0.1055613458 * A - 0.0638541728 * B) ** 3;
+      const s = (L - 0.0894841775 * A - 1.291485548 * B) ** 3;
+      return [
+        toSrgb(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s),
+        toSrgb(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s),
+        toSrgb(-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s),
+      ];
+    };
+    const A = forward(a);
+    const B = forward(b);
+    return back([0, 1, 2].map((i) => A[i] * share + B[i] * (1 - share)) as [
+      number,
+      number,
+      number,
+    ]);
+  }
+
+  /** The share ACCENT_HOVER keeps of the accent, read from the constant. */
+  const HOVER_SHARE =
+    Number(/var\(--theme-accent\)\s+(\d+)%/.exec(ACCENT_HOVER)?.[1]) / 100;
+
+  it('mixes the accent with the shade, at a share the constant states', () => {
+    // Everything below measures the colour this produces, so a change to the
+    // constant that these assertions could not see would make them vacuous.
+    expect(ACCENT_HOVER).toContain('in oklab');
+    expect(ACCENT_HOVER).toContain('var(--theme-accent-shade)');
+    expect(HOVER_SHARE).toBeGreaterThan(0);
+    expect(HOVER_SHARE).toBeLessThan(1);
+  });
+
+  it('points away from the ink rather than towards the mode', () => {
+    const wrong: string[] = [];
+    for (const colour of COLOURS) {
+      const ink = accentContrastColor(colour) as string;
+      const shade = accentShadeFor(ink) as string;
+      const inkLuminance = relativeLuminance(parseHexColor(ink) as Rgb);
+      const shadeLuminance = relativeLuminance(parseHexColor(shade) as Rgb);
+      // Opposite ends of the range: a light ink must take a dark shade.
+      if (inkLuminance > 0.5 === shadeLuminance > 0.5)
+        wrong.push(`${colour}: ink ${ink} with shade ${shade}`);
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  it('leaves the label readable while hovered, over an exhaustive sweep', () => {
+    // The defect this closes: the shade used to be picked by the MODE while the
+    // ink is picked by the accent's own luminance, so when they agreed the
+    // hover walked the fill towards its own label. 39% of these colours fell
+    // below 4.5:1 hovered, worst 3.08, and #0969da reached 3.86 in dark mode.
+    let worst = Number.POSITIVE_INFINITY;
+    let worstColour = '';
+
+    for (const colour of COLOURS) {
+      const accent = parseHexColor(colour) as Rgb;
+      const ink = accentContrastColor(colour) as string;
+      const shade = accentShadeFor(ink) as string;
+      const hovered = mixOklab(
+        accent,
+        parseHexColor(shade) as Rgb,
+        HOVER_SHARE,
+      );
+      const ratio = contrastRatio(hovered, parseHexColor(ink) as Rgb);
+      if (ratio < worst) {
+        worst = ratio;
+        worstColour = colour;
+      }
+    }
+
+    expect(
+      worst,
+      `worst hovered label contrast ${worst.toFixed(3)}:1 on ${worstColour}`,
+    ).toBeGreaterThanOrEqual(ACCENT_CONTRAST_TARGET);
+  });
+
+  it('never makes the label worse than it is at rest', () => {
+    // The property that makes the assertion above hold for colours outside the
+    // sweep too: moving a fill away from its ink can only raise the ratio, and
+    // accentContrastColor already clears the target at rest.
+    const regressions: string[] = [];
+
+    for (const colour of COLOURS) {
+      const accent = parseHexColor(colour) as Rgb;
+      const ink = accentContrastColor(colour) as string;
+      const inkRgb = parseHexColor(ink) as Rgb;
+      const hovered = mixOklab(
+        accent,
+        parseHexColor(accentShadeFor(ink) as string) as Rgb,
+        HOVER_SHARE,
+      );
+      const atRest = contrastRatio(accent, inkRgb);
+      const onHover = contrastRatio(hovered, inkRgb);
+      if (onHover < atRest - 0.001)
+        regressions.push(
+          `${colour}: ${atRest.toFixed(2)} to ${onHover.toFixed(2)}`,
+        );
+    }
+
+    expect(regressions).toEqual([]);
   });
 });
 

--- a/apps/self-hosted/src/core/theme-appearance.ts
+++ b/apps/self-hosted/src/core/theme-appearance.ts
@@ -57,10 +57,11 @@ export const CONTRAST_INK_LIGHT = '#ffffff';
 export const CONTRAST_INK_DARKEST = '#000000';
 
 /**
- * Set inline as a constant string rather than as a computed colour.
- * Custom-property substitution happens at computed-value time on the element,
- * so this one declaration re-substitutes with the other shade when
- * `[data-theme]` changes on <html>, with no JS.
+ * Set inline as a constant string rather than as a computed colour, so the
+ * declaration re-substitutes on its own if either operand changes.
+ *
+ * The whole safety of the hovered button lives in --theme-accent-shade. See
+ * accentShadeFor.
  */
 export const ACCENT_HOVER =
   'color-mix(in oklab, var(--theme-accent) 85%, var(--theme-accent-shade))';
@@ -273,11 +274,41 @@ export function accentContrastColor(hex: string): string | null {
     : CONTRAST_INK_LIGHT;
 }
 
+/**
+ * The end of the range the hover moves the fill TOWARDS, which is the end away
+ * from the ink that sits on it.
+ *
+ * --theme-accent-shade used to be declared in CSS as black in light mode and
+ * white in dark mode, and its only consumer is ACCENT_HOVER. That picked the
+ * direction from the MODE while accentContrastColor picks the ink from the
+ * ACCENT's own luminance, and when the two agreed the hover walked the fill
+ * towards its own label: over the 4096-colour sweep 39% of accents dropped
+ * below 4.5:1 while hovered, worst 3.08, and even #0969da reached 3.86 in dark
+ * mode. Re-choosing the ink against the hovered fill does not rescue it either,
+ * since 1261 of 4096 still fail that way: the fill has to stop crossing the ink
+ * rather than the ink chasing the fill.
+ *
+ * Taking the direction from the ink instead makes contrast on hover
+ * monotonically better than at rest, because moving a fill away from its ink in
+ * luminance can only raise the ratio. Since accentContrastColor already clears
+ * the target at rest, the hover clears it too, for every colour. The guard
+ * measures that over the same sweep rather than trusting the argument.
+ */
+export function accentShadeFor(contrast: string): string | null {
+  const ink = parseHexColor(contrast);
+  if (!ink) return null;
+  return relativeLuminance(ink) > 0.5
+    ? CONTRAST_INK_DARKEST
+    : CONTRAST_INK_LIGHT;
+}
+
 export interface AccentAppearance {
   /** The owner's colour, normalised to `#rrggbb`. */
   accent: string;
   hover: string;
   contrast: string;
+  /** The end the hover walks towards; away from `contrast`, never the mode's. */
+  shade: string;
   textLight: string;
   textDark: string;
 }
@@ -296,8 +327,10 @@ export function resolveAccent(value: unknown): AccentAppearance | null {
   const textLight = accentTextForMode(accent, 'light');
   const textDark = accentTextForMode(accent, 'dark');
   if (!contrast || !textLight || !textDark) return null;
+  const shade = accentShadeFor(contrast);
+  if (!shade) return null;
 
-  return { accent, hover: ACCENT_HOVER, contrast, textLight, textDark };
+  return { accent, hover: ACCENT_HOVER, contrast, shade, textLight, textDark };
 }
 
 // =============================================================================

--- a/apps/self-hosted/src/features/auth/components/comment-form.tsx
+++ b/apps/self-hosted/src/features/auth/components/comment-form.tsx
@@ -93,7 +93,7 @@ export function CommentForm({
         <Link
           to="/login"
           search={{ redirect: `/@${parentAuthor}/${parentPermlink}` }}
-          className="inline-block px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm"
+          className="btn-theme-primary inline-block px-4 py-2 transition-colors text-sm"
         >
           {t("login")}
         </Link>
@@ -136,8 +136,7 @@ export function CommentForm({
           onClick={handleSubmit}
           disabled={commentMutation.isPending || !body.trim()}
           className={clsx(
-            "px-4 py-2 rounded-md text-sm font-medium transition-colors",
-            "bg-blue-600 text-white hover:bg-blue-700",
+            "btn-theme-primary px-4 py-2 text-sm font-medium transition-colors",
             "disabled:opacity-50 disabled:cursor-not-allowed"
           )}
         >

--- a/apps/self-hosted/src/features/auth/components/extension-login.tsx
+++ b/apps/self-hosted/src/features/auth/components/extension-login.tsx
@@ -216,7 +216,7 @@ export function ExtensionLogin({ onSuccess, onError }: ExtensionLoginProps) {
             type="button"
             onClick={handleLogin}
             disabled={loading || !username.trim() || !selected}
-            className="flex-1 px-4 py-2 rounded-theme bg-blue-600 text-white hover:bg-blue-700 transition-theme disabled:opacity-50 disabled:cursor-not-allowed font-theme-ui"
+            className="btn-theme-primary flex-1 px-4 py-2 transition-theme disabled:opacity-50 disabled:cursor-not-allowed font-theme-ui"
           >
             {loading ? 'Connecting...' : 'Login'}
           </button>

--- a/apps/self-hosted/src/features/auth/components/hiveauth-login.tsx
+++ b/apps/self-hosted/src/features/auth/components/hiveauth-login.tsx
@@ -121,7 +121,7 @@ export function HiveAuthLogin({ onSuccess, onError }: HiveAuthLoginProps) {
               type="button"
               onClick={handleLogin}
               disabled={loading || !username.trim()}
-              className="flex-1 px-4 py-2 rounded-theme bg-blue-600 text-white hover:bg-blue-700 transition-theme disabled:opacity-50 disabled:cursor-not-allowed font-theme-ui"
+              className="btn-theme-primary flex-1 px-4 py-2 transition-theme disabled:opacity-50 disabled:cursor-not-allowed font-theme-ui"
             >
               {loading ? 'Connecting...' : 'Generate QR'}
             </button>

--- a/apps/self-hosted/src/features/auth/components/login-method-button.tsx
+++ b/apps/self-hosted/src/features/auth/components/login-method-button.tsx
@@ -30,7 +30,7 @@ export function LoginMethodButton({
         'flex items-center gap-4 text-left bg-theme-primary',
         'hover:bg-theme-secondary hover:border-theme-strong',
         'disabled:opacity-50 disabled:cursor-not-allowed',
-        'focus:outline-none focus:ring-2 focus:ring-blue-500'
+        'focus:outline-none focus:ring-2 focus:ring-theme-accent'
       )}
     >
       {icon && <div className="flex-shrink-0 size-8 flex items-center justify-center">{icon}</div>}

--- a/apps/self-hosted/src/features/blog/components/search-input.tsx
+++ b/apps/self-hosted/src/features/blog/components/search-input.tsx
@@ -59,7 +59,7 @@ export function SearchInput() {
               'w-40 sm:w-56 px-3 py-1.5 text-sm rounded-md',
               'border border-theme bg-theme text-theme-primary',
               'placeholder:text-theme-muted',
-              'focus:outline-none focus:ring-2 focus:ring-blue-500',
+              'focus:outline-none focus:ring-2 focus:ring-theme-accent',
             )}
           />
           <button

--- a/apps/self-hosted/src/features/blog/layout/blog-navigation.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-navigation.tsx
@@ -106,7 +106,13 @@ export function BlogNavigation() {
 
       {/* Single rule under the tabs: the nav carries the divider and the active tab's
           2px indicator overlaps it (-mb-px). no-underline kills the template's global
-          link underline, which stacked a third line under the labels. */}
+          link underline, which stacked a third line under the labels.
+
+          The active indicator is the accent, not --theme-border-strong, which
+          measured 1.38:1 to 1.87:1 against the page across all twelve palettes,
+          against the 3:1 WCAG 1.4.11 asks of a state indicator. The accent
+          measures 4.34:1 to 15.86:1 over the same set. font-medium is the
+          second, non-colour cue. */}
       <nav className="flex gap-4 sm:gap-6 pt-3 sm:pt-4 overflow-x-auto border-b border-theme">
         {availableFilters.map((filter) => {
           const isActive = currentFilter === filter;
@@ -118,7 +124,7 @@ export function BlogNavigation() {
               className={clsx(
                 'text-sm font-normal transition-theme pb-2 border-b-2 -mb-px no-underline font-theme-ui whitespace-nowrap',
                 isActive
-                  ? 'border-theme-strong text-theme-primary'
+                  ? 'border-theme-accent text-theme-primary font-medium'
                   : 'border-transparent text-theme-muted hover:text-theme-primary hover:border-theme',
               )}
             >

--- a/apps/self-hosted/src/features/payment/components/payment-dialog.tsx
+++ b/apps/self-hosted/src/features/payment/components/payment-dialog.tsx
@@ -91,7 +91,7 @@ export function PaymentDialog({
               'flex items-center gap-3 text-left bg-theme-primary',
               'hover:bg-theme-secondary hover:border-theme-strong',
               'disabled:opacity-50 disabled:cursor-not-allowed',
-              'focus:outline-none focus:ring-2 focus:ring-blue-500'
+              'focus:outline-none focus:ring-2 focus:ring-theme-accent'
             )}
           >
             <div className="flex-1">
@@ -118,7 +118,7 @@ export function PaymentDialog({
                 'flex items-center gap-3 text-left bg-theme-primary',
                 'hover:bg-theme-secondary hover:border-theme-strong',
                 'disabled:opacity-50 disabled:cursor-not-allowed',
-                'focus:outline-none focus:ring-2 focus:ring-blue-500'
+                'focus:outline-none focus:ring-2 focus:ring-theme-accent'
               )}
             >
               <div className="flex-1">
@@ -140,7 +140,7 @@ export function PaymentDialog({
                 className={clsx(
                   'w-full p-3 rounded-theme border border-theme',
                   'bg-theme-primary text-theme-primary text-sm',
-                  'focus:outline-none focus:ring-2 focus:ring-blue-500'
+                  'focus:outline-none focus:ring-2 focus:ring-theme-accent'
                 )}
               />
               <button
@@ -148,9 +148,8 @@ export function PaymentDialog({
                 onClick={() => handleSign('manual')}
                 disabled={!activeKey || !!loadingMethod}
                 className={clsx(
-                  'w-full p-2 rounded-theme bg-blue-600 text-white text-sm font-medium',
-                  'hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed',
-                  'focus:outline-none focus:ring-2 focus:ring-blue-500'
+                  'btn-theme-primary w-full p-2 text-sm font-medium',
+                  'disabled:opacity-50 disabled:cursor-not-allowed'
                 )}
               >
                 {loadingMethod === 'manual' ? 'Signing...' : 'Sign Payment'}

--- a/apps/self-hosted/src/styles/blog-markdown.css
+++ b/apps/self-hosted/src/styles/blog-markdown.css
@@ -1571,7 +1571,10 @@
   padding: 0.375rem 0.675rem 0.375rem 0.375rem;
   border: 1px solid var(--theme-border, rgba(0, 0, 0, 0.1));
   border-radius: 1rem;
-  color: var(--theme-accent, #357ce6);
+  /* The corrected accent, not the raw one: this is accent-as-TEXT on the page
+     surface, so it reads --theme-accent-text, which falls back to the accent
+     itself until an owner configures one. */
+  color: var(--theme-accent-text, var(--theme-accent, #357ce6));
   font-size: 0.875rem;
   line-height: 1.2;
   text-decoration: none;
@@ -1597,7 +1600,8 @@
   padding: 0.375rem 0.75rem;
   border: 1px solid var(--theme-border, rgba(0, 0, 0, 0.1));
   border-radius: 1rem;
-  color: var(--theme-accent, #357ce6);
+  /* Corrected accent, as on .er-author-link above. */
+  color: var(--theme-accent-text, var(--theme-accent, #357ce6));
   font-size: 0.75rem;
   line-height: 1.2;
   white-space: nowrap;

--- a/apps/self-hosted/src/styles/components.css
+++ b/apps/self-hosted/src/styles/components.css
@@ -57,6 +57,47 @@
   opacity: 0.7;
 }
 
+/*
+ * Primary button.
+ *
+ * The one composite that reads the accent as a FILL, and so the one that needs
+ * an ink chosen for it. --theme-accent-contrast is white or near-black,
+ * whichever wins against that block's own accent; every block that declares an
+ * accent declares it alongside, and applyConfigDom writes it inline on <html>
+ * when an owner configures one, so the pair can never come from two different
+ * palettes.
+ *
+ * The literal fallback on `color` is load-bearing and is not defensive
+ * padding. `color` inherits, so a var() with no fallback that is invalid at
+ * computed-value time resolves to the INHERITED page text colour rather than
+ * to white: a block that forgot the token would put near-black label text on a
+ * dark accent fill. With the fallback, the worst a missed block can do is
+ * white on the accent.
+ *
+ * The focus outline is the accent as well, and `outline-offset` is what makes
+ * it visible: two pixels of page between the fill and the ring, so the ring is
+ * measured against the page (4.34:1 to 15.86:1 across the twelve palettes)
+ * rather than against a fill of its own colour.
+ *
+ * Hover excludes :disabled because every call site pairs this with
+ * disabled:opacity-50, and a dimmed button that still lights up under the
+ * pointer reads as clickable when it is not.
+ */
+.btn-theme-primary {
+  background-color: var(--theme-accent);
+  color: var(--theme-accent-contrast, #ffffff);
+  border-radius: var(--theme-radius);
+}
+
+.btn-theme-primary:hover:not(:disabled) {
+  background-color: var(--theme-accent-hover);
+}
+
+.btn-theme-primary:focus-visible {
+  outline: 2px solid var(--theme-accent);
+  outline-offset: 2px;
+}
+
 /* Link Styles */
 .link-theme {
   color: inherit;
@@ -133,10 +174,21 @@
   border-radius: var(--theme-radius);
 }
 
+/*
+ * The ring is the accent at full strength, not a tint of it.
+ *
+ * It replaces a hardcoded rgba(59, 130, 246, 0.3), which measured 1.19:1
+ * against the default light page: a focus indicator nobody could see, in a
+ * fixed blue no template asked for. WCAG 1.4.11 wants 3:1 for a state
+ * indicator, and 40% of the accent does not get there either (1.74:1 to 3.42:1
+ * across the twelve palettes). Full strength measures 4.34:1 to 15.86:1, and
+ * matches .focus-ring-theme below, which is the convention this file already
+ * had.
+ */
 .input-theme:focus {
   outline: none;
   border-color: var(--theme-accent);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 0 0 2px var(--theme-accent);
 }
 
 .input-theme::placeholder {

--- a/apps/self-hosted/src/styles/components.css
+++ b/apps/self-hosted/src/styles/components.css
@@ -74,10 +74,11 @@
  * dark accent fill. With the fallback, the worst a missed block can do is
  * white on the accent.
  *
- * The focus outline is the accent as well, and `outline-offset` is what makes
- * it visible: two pixels of page between the fill and the ring, so the ring is
- * measured against the page (4.34:1 to 15.86:1 across the twelve palettes)
- * rather than against a fill of its own colour.
+ * The focus outline is the CORRECTED accent, not the raw one, for the reason
+ * spelled out over .input-theme:focus below: the raw accent is whatever the
+ * owner typed and can equal the page. `outline-offset` is what makes it
+ * measurable at all, since it puts two pixels of page between the fill and the
+ * ring rather than leaving the ring on a fill of its own colour.
  *
  * Hover excludes :disabled because every call site pairs this with
  * disabled:opacity-50, and a dimmed button that still lights up under the
@@ -94,7 +95,7 @@
 }
 
 .btn-theme-primary:focus-visible {
-  outline: 2px solid var(--theme-accent);
+  outline: 2px solid var(--theme-accent-text, var(--theme-accent));
   outline-offset: 2px;
 }
 
@@ -175,30 +176,41 @@
 }
 
 /*
- * The ring is the accent at full strength, not a tint of it.
+ * The ring is the corrected accent at full strength.
  *
- * It replaces a hardcoded rgba(59, 130, 246, 0.3), which measured 1.19:1
- * against the default light page: a focus indicator nobody could see, in a
- * fixed blue no template asked for. WCAG 1.4.11 wants 3:1 for a state
- * indicator, and 40% of the accent does not get there either (1.74:1 to 3.42:1
- * across the twelve palettes). Full strength measures 4.34:1 to 15.86:1, and
- * matches .focus-ring-theme below, which is the convention this file already
- * had.
+ * Full strength, because it replaces a hardcoded rgba(59, 130, 246, 0.3) that
+ * measured 1.19:1 against the default light page: a focus indicator nobody
+ * could see, in a fixed blue no template asked for. WCAG 1.4.11 wants 3:1 for
+ * a state indicator, and 40% of the accent does not get there either (1.74:1
+ * to 3.42:1 across the twelve palettes).
+ *
+ * Corrected, because --theme-accent is whatever the owner typed. It is a FILL
+ * token: it is allowed to be exactly the colour that was asked for, and a
+ * white accent on a white page is a legitimate fill with a dark label on it.
+ * As a ring against the page it would be invisible, and `outline: none` here
+ * means there would be nothing else left to see. --theme-accent-text is the
+ * same colour walked until it clears 4.5:1 against the worst surface of the
+ * current mode, so it is at least that against any real one. With no accent
+ * configured it falls through to --theme-accent unchanged, which is what all
+ * twelve palettes render at 4.34:1 to 15.86:1.
+ *
+ * The border stays the raw accent: it sits on the input's own surface, not on
+ * the page, and the ring is the part that carries the 3:1.
  */
 .input-theme:focus {
   outline: none;
   border-color: var(--theme-accent);
-  box-shadow: 0 0 0 2px var(--theme-accent);
+  box-shadow: 0 0 0 2px var(--theme-accent-text, var(--theme-accent));
 }
 
 .input-theme::placeholder {
   color: var(--theme-text-muted);
 }
 
-/* Focus Ring */
+/* Focus Ring. Corrected accent, as on .input-theme:focus above. */
 .focus-ring-theme:focus {
   outline: none;
-  box-shadow: 0 0 0 2px var(--theme-accent);
+  box-shadow: 0 0 0 2px var(--theme-accent-text, var(--theme-accent));
 }
 
 /* Layout Utilities - Using theme variables */

--- a/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
+++ b/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
@@ -5,7 +5,10 @@ import { describe, expect, it } from 'vitest';
 import {
   ACCENT_CONTRAST_TARGET,
   ACCENT_TINT_PERCENT,
+  accentContrastColor,
+  accentTextForMode,
   contrastRatio,
+  formatHexColor,
   parseHexColor,
   type Rgb,
   relativeLuminance,
@@ -40,12 +43,14 @@ interface Block {
   declarations: Map<string, string>;
 }
 
-/** Top-level `selector { ... }` blocks of a stylesheet, comments removed. */
+/** Top-level `selector { ... }` blocks of a theme file, comments removed. */
 function blocks(file: string): Block[] {
-  const css = readFileSync(join(THEMES, file), 'utf8').replace(
-    /\/\*[\s\S]*?\*\//g,
-    '',
-  );
+  return parseBlocks(readFileSync(join(THEMES, file), 'utf8'), file);
+}
+
+/** Top-level `selector { ... }` blocks of a stylesheet, comments removed. */
+function parseBlocks(source: string, file: string): Block[] {
+  const css = source.replace(/\/\*[\s\S]*?\*\//g, '');
   const out: Block[] = [];
   let prelude = '';
   let depth = 0;
@@ -384,5 +389,615 @@ describe('theme files', () => {
     }
 
     expect(offenders).toEqual([]);
+  });
+});
+
+// =============================================================================
+// Accent plumbing: the tokens the accent reaches once it is wired
+// =============================================================================
+
+/**
+ * Everything below resolves a declaration to an actual colour before asserting
+ * anything about it. Nothing here matches on a token's spelling, because a
+ * guard that greps for `var(--theme-accent)` passes on
+ * `color-mix(in srgb, var(--theme-accent) 0%, transparent)` and on a value that
+ * names the accent in a property nothing reads.
+ */
+
+/** A colour with its alpha, before it is put on any surface. */
+interface Colour {
+  rgb: Rgb;
+  alpha: number;
+}
+
+const COLOUR_KEYWORDS: Record<string, Colour> = {
+  transparent: { rgb: [0, 0, 0], alpha: 0 },
+};
+
+/**
+ * A declaration value resolved to a colour, substituting the custom properties
+ * the SAME block declares.
+ *
+ * Same block, deliberately: a var() in a custom property substitutes at
+ * computed-value time on the element carrying the declaration, and every block
+ * here matches <html>. Resolving against the declaring block is what makes
+ * "this template derives its own underline" checkable one block at a time
+ * instead of by simulating the cascade.
+ *
+ * A `var(--x, fallback)` whose --x no block declares takes the fallback, which
+ * is exactly the instance-with-no-accent-configured case: --theme-accent-text-*
+ * is written inline on <html> by applyConfigDom and never appears in CSS.
+ */
+function resolveColour(value: string, block: Block, depth = 0): Colour | null {
+  if (depth > 8) return null;
+  const raw = value.trim();
+
+  const keyword = COLOUR_KEYWORDS[raw.toLowerCase()];
+  if (keyword) return keyword;
+
+  const literal = parseColor(raw);
+  if (literal) return literal;
+
+  const varMatch = /^var\(\s*(--[a-z0-9-]+)\s*(?:,([\s\S]+))?\)$/i.exec(raw);
+  if (varMatch) {
+    const declared = block.declarations.get(varMatch[1]);
+    if (declared !== undefined)
+      return resolveColour(declared, block, depth + 1);
+    if (varMatch[2] === undefined) return null;
+    return resolveColour(varMatch[2], block, depth + 1);
+  }
+
+  // color-mix(in <space>, A p%, B) with one side transparent, which is the only
+  // shape the theme files use. Percentages are read, not assumed.
+  const mix = /^color-mix\(\s*in\s+[a-z-]+\s*,([\s\S]+)\)$/i.exec(raw);
+  if (mix) {
+    const parts = splitTopLevel(mix[1]);
+    if (parts.length !== 2) return null;
+    const sides = parts.map((part) => {
+      const percent = /\s(\d+(?:\.\d+)?)%\s*$/.exec(part);
+      return {
+        colour: part.replace(/\s(\d+(?:\.\d+)?)%\s*$/, '').trim(),
+        percent: percent ? Number(percent[1]) : null,
+      };
+    });
+    const opaqueAt = sides.findIndex(
+      (side) => side.colour.toLowerCase() !== 'transparent',
+    );
+    if (opaqueAt < 0) return null;
+    const opaque = sides[opaqueAt];
+    const other = sides[1 - opaqueAt];
+    if (other.colour.toLowerCase() !== 'transparent') return null;
+    const share =
+      opaque.percent !== null
+        ? opaque.percent
+        : other.percent !== null
+          ? 100 - other.percent
+          : null;
+    if (share === null) return null;
+    const base = resolveColour(opaque.colour, block, depth + 1);
+    if (!base) return null;
+    return { rgb: base.rgb, alpha: base.alpha * (share / 100) };
+  }
+
+  return null;
+}
+
+/** Split on commas that are not inside parentheses. */
+function splitTopLevel(input: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const char of input) {
+    if (char === '(') depth += 1;
+    if (char === ')') depth -= 1;
+    if (char === ',' && depth === 0) {
+      out.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  out.push(current);
+  return out.map((part) => part.trim()).filter((part) => part.length > 0);
+}
+
+/** The colour a declaration paints when it lands on that block's own page. */
+function onPage(value: string, block: Block): Rgb | null {
+  const colour = resolveColour(value, block);
+  const page = parseColor(block.declarations.get('--theme-bg-primary') ?? '');
+  if (!colour || !page) return null;
+  return composite(colour, page.rgb);
+}
+
+function near(a: Rgb, b: Rgb): boolean {
+  return a.every((channel, index) => Math.abs(channel - b[index]) < 0.75);
+}
+
+function label(block: Block): string {
+  return `${block.file} ${block.selector}`;
+}
+
+/** The accent fill each block paints, which is what everything here is against. */
+function accentFill(block: Block): Rgb {
+  const fill = onPage('var(--theme-accent)', block);
+  if (!fill) throw new Error(`${label(block)}: unresolvable --theme-accent`);
+  return fill;
+}
+
+function page(block: Block): Rgb {
+  const surface = parseColor(
+    block.declarations.get('--theme-bg-primary') ?? '',
+  );
+  if (!surface)
+    throw new Error(`${label(block)}: unresolvable --theme-bg-primary`);
+  return surface.rgb;
+}
+
+/** WCAG 1.4.11: a non-text state indicator wants 3:1 against what surrounds it. */
+const INDICATOR_TARGET = 3;
+
+const COMPONENT_BLOCKS = parseBlocks(
+  readFileSync(COMPONENTS, 'utf8'),
+  'components.css',
+);
+
+function componentRule(selector: string): Block {
+  const found = COMPONENT_BLOCKS.find((block) => block.selector === selector);
+  if (!found) throw new Error(`components.css has no ${selector} rule`);
+  return found;
+}
+
+/** The colour at the end of a `box-shadow` or `outline` shorthand. */
+function trailingColour(value: string): string {
+  const match =
+    /(var\((?:[^()]|\([^()]*\))*\)|color-mix\((?:[^()]|\([^()]*\))*\)|rgba?\([^()]*\)|#[0-9a-f]{3,8}|[a-z]+)\s*$/i.exec(
+      value.trim(),
+    );
+  if (!match) throw new Error(`no trailing colour in "${value}"`);
+  return match[1];
+}
+
+describe('the ink that goes on the accent', () => {
+  it('is declared by every block that declares an accent', () => {
+    // Whichever block wins the cascade for the fill wins for the ink, so the
+    // two can never come from different palettes. Twelve blocks, no exceptions.
+    const missing = accentBlocks
+      .filter((block) => !block.declarations.has('--theme-accent-contrast'))
+      .map(label);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('clears 4.5:1 on the fill it is placed on', () => {
+    const failures: string[] = [];
+
+    for (const block of accentBlocks) {
+      const fill = accentFill(block);
+      const ink = onPage(
+        block.declarations.get('--theme-accent-contrast') ?? '',
+        block,
+      );
+      if (!ink) {
+        failures.push(`${label(block)}: unresolvable ink`);
+        continue;
+      }
+      const ratio = contrastRatio(fill, ink);
+      if (ratio < ACCENT_CONTRAST_TARGET) {
+        failures.push(`${label(block)}: ${ratio.toFixed(2)}:1`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it('is the ink the module would have chosen for the same fill', () => {
+    // An owner who configures an accent gets this value written inline on
+    // <html> by applyConfigDom; an owner who configures nothing gets it from
+    // the block. If the two disagreed, the same fill would carry two different
+    // labels depending on a config key, and only one of them would be checked.
+    const disagreements: string[] = [];
+
+    for (const block of accentBlocks) {
+      const fill = accentFill(block);
+      const rounded = formatHexColor([
+        Math.round(fill[0]),
+        Math.round(fill[1]),
+        Math.round(fill[2]),
+      ]);
+      const expected = accentContrastColor(rounded);
+      const declared = block.declarations.get('--theme-accent-contrast');
+      const declaredRgb = declared ? resolveColour(declared, block) : null;
+      const expectedRgb = expected ? parseHexColor(expected) : null;
+      if (!declaredRgb || !expectedRgb || !near(declaredRgb.rgb, expectedRgb)) {
+        disagreements.push(`${label(block)}: ${declared} vs ${expected}`);
+      }
+    }
+
+    expect(disagreements).toEqual([]);
+  });
+});
+
+describe('article link underlines', () => {
+  it('are stated by every block that declares an accent', () => {
+    // Both blocks of a template match <html>, and the more specific one only
+    // outranks the other for what it declares. A pair declared once as a
+    // literal was therefore the OTHER mode's underline too: minimal's dark page
+    // underlined in the light accent and developer's light page in the dark one.
+    const missing: string[] = [];
+    for (const block of accentBlocks) {
+      for (const property of [
+        '--theme-link-decoration-color',
+        '--theme-link-decoration-hover',
+      ]) {
+        if (!block.declarations.has(property))
+          missing.push(`${label(block)}: ${property}`);
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  it('resolve on hover to the accent of the block they belong to', () => {
+    const wrong: string[] = [];
+
+    for (const block of accentBlocks) {
+      const hover = onPage(
+        block.declarations.get('--theme-link-decoration-hover') ?? '',
+        block,
+      );
+      if (!hover || !near(hover, accentFill(block))) {
+        wrong.push(`${label(block)}: ${hover?.map(Math.round).join(',')}`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
+  it('resolve at rest to a tint of that same accent, not to a colour of their own', () => {
+    // This is what a hardcoded #c5c0b8 fails and what a re-spelled accent
+    // passes, so it is a statement about the pixel rather than about the token.
+    const wrong: string[] = [];
+
+    for (const block of accentBlocks) {
+      const resting = onPage(
+        block.declarations.get('--theme-link-decoration-color') ?? '',
+        block,
+      );
+      const tint = composite(
+        { rgb: accentFill(block), alpha: 1 },
+        page(block),
+        0.4,
+      );
+      if (!resting || !near(resting, tint)) {
+        wrong.push(`${label(block)}: ${resting?.map(Math.round).join(',')}`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
+  it('are quiet at rest and reach 3:1 under the pointer', () => {
+    // The resting underline is deliberately faint: it is a decoration under
+    // text that carries its own contrast. The hover state is the feedback, and
+    // it is the one that has to be seen.
+    const failures: string[] = [];
+
+    for (const block of accentBlocks) {
+      const resting = onPage(
+        block.declarations.get('--theme-link-decoration-color') ?? '',
+        block,
+      );
+      const hover = onPage(
+        block.declarations.get('--theme-link-decoration-hover') ?? '',
+        block,
+      );
+      if (!resting || !hover) {
+        failures.push(`${label(block)}: unresolvable`);
+        continue;
+      }
+      const restingRatio = contrastRatio(resting, page(block));
+      const hoverRatio = contrastRatio(hover, page(block));
+      if (hoverRatio < INDICATOR_TARGET) {
+        failures.push(`${label(block)}: hover ${hoverRatio.toFixed(2)}:1`);
+      }
+      if (restingRatio > hoverRatio) {
+        failures.push(
+          `${label(block)}: rest ${restingRatio.toFixed(2)} louder than hover ${hoverRatio.toFixed(2)}`,
+        );
+      }
+      if (restingRatio <= 1.05) {
+        failures.push(`${label(block)}: rest invisible`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+});
+
+describe('the primary button', () => {
+  const rest = componentRule('.btn-theme-primary');
+  const hover = componentRule('.btn-theme-primary:hover:not(:disabled)');
+  const focus = componentRule('.btn-theme-primary:focus-visible');
+
+  it('fills with the accent of whichever block wins', () => {
+    const wrong: string[] = [];
+    for (const block of accentBlocks) {
+      const fill = resolveColour(
+        rest.declarations.get('background-color') ?? '',
+        block,
+      );
+      if (!fill || !near(composite(fill, page(block)), accentFill(block))) {
+        wrong.push(label(block));
+      }
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  it('keeps its label readable at rest and under the pointer', () => {
+    // Under the pointer as well as at rest, because a hover colour that moves
+    // AWAY from the label is invisible until someone hovers: developer's light
+    // hover was #7287fd, which left white text at 3.18:1 while every other
+    // palette sat between 7.10:1 and 21:1.
+    const failures: string[] = [];
+
+    for (const block of accentBlocks) {
+      const ink = resolveColour(rest.declarations.get('color') ?? '', block);
+      const restFill = resolveColour(
+        rest.declarations.get('background-color') ?? '',
+        block,
+      );
+      const hoverFill = resolveColour(
+        hover.declarations.get('background-color') ?? '',
+        block,
+      );
+      if (!ink || !restFill || !hoverFill) {
+        failures.push(`${label(block)}: unresolvable`);
+        continue;
+      }
+      const inkOn = (fill: Colour) =>
+        contrastRatio(
+          composite(ink, composite(fill, page(block))),
+          composite(fill, page(block)),
+        );
+      const atRest = inkOn(restFill);
+      const onHover = inkOn(hoverFill);
+      if (atRest < ACCENT_CONTRAST_TARGET)
+        failures.push(`${label(block)}: rest ${atRest.toFixed(2)}:1`);
+      if (onHover < ACCENT_CONTRAST_TARGET)
+        failures.push(`${label(block)}: hover ${onHover.toFixed(2)}:1`);
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it('falls back to a literal colour for its label, never to the inherited one', () => {
+    // `color` inherits, so a var() with no fallback that is invalid at
+    // computed-value time resolves to the page text colour: near-black label
+    // text on a dark accent fill. The fallback caps the damage of a block that
+    // ever loses the token at white-on-accent.
+    const value = rest.declarations.get('color') ?? '';
+    const fallback = /^var\(\s*--[a-z0-9-]+\s*,([\s\S]+)\)$/i.exec(
+      value.trim(),
+    );
+
+    expect(fallback).not.toBeNull();
+    expect(parseColor(fallback?.[1] ?? '')).not.toBeNull();
+  });
+
+  it('is focusable visibly, against the page rather than against its own fill', () => {
+    // outline-offset is what makes this measurable against the page: without
+    // it the ring would sit on a fill of its own colour and disappear.
+    expect(focus.declarations.get('outline-offset')).toBeTruthy();
+
+    const failures: string[] = [];
+    const ring = trailingColour(focus.declarations.get('outline') ?? '');
+    for (const block of accentBlocks) {
+      const colour = resolveColour(ring, block);
+      if (!colour) {
+        failures.push(`${label(block)}: unresolvable ring`);
+        continue;
+      }
+      const ratio = contrastRatio(composite(colour, page(block)), page(block));
+      if (ratio < INDICATOR_TARGET)
+        failures.push(`${label(block)}: ${ratio.toFixed(2)}:1`);
+    }
+
+    expect(failures).toEqual([]);
+  });
+});
+
+describe('the text input focus ring', () => {
+  const focus = componentRule('.input-theme:focus');
+
+  it('carries no colour of its own', () => {
+    // It was rgba(59, 130, 246, 0.3): a fixed blue no template asked for, at
+    // 1.19:1 on the default light page.
+    const ring = trailingColour(focus.declarations.get('box-shadow') ?? '');
+    expect(parseColor(ring)).toBeNull();
+  });
+
+  it('clears 3:1 against every page it can appear on', () => {
+    // 40% of the accent, which is what the underline uses and what was
+    // proposed here, measures 1.74:1 to 3.42:1 and fails eleven of twelve. This
+    // assertion is the reason the ring is the accent at full strength.
+    const ring = trailingColour(focus.declarations.get('box-shadow') ?? '');
+    const failures: string[] = [];
+
+    for (const block of accentBlocks) {
+      const colour = resolveColour(ring, block);
+      if (!colour) {
+        failures.push(`${label(block)}: unresolvable`);
+        continue;
+      }
+      const ratio = contrastRatio(composite(colour, page(block)), page(block));
+      if (ratio < INDICATOR_TARGET)
+        failures.push(`${label(block)}: ${ratio.toFixed(2)}:1`);
+    }
+
+    expect(failures).toEqual([]);
+  });
+});
+
+describe('the accent as a state indicator', () => {
+  // border-theme-accent marks the active feed tab and the selected tipping
+  // currency. Which token it reads is decided in theme-tokens.css, so read it
+  // from there rather than restating it.
+  const tokenSource = readFileSync(TOKENS, 'utf8').replace(
+    /\/\*[\s\S]*?\*\//g,
+    '',
+  );
+  const namespace = declarations(
+    tokenSource.slice(
+      tokenSource.indexOf('{') + 1,
+      tokenSource.lastIndexOf('}'),
+    ),
+  );
+  // Narrower namespaces win over --color-* for the utility they name, which is
+  // how text-theme-accent already differs from bg-theme-accent.
+  const borderSource =
+    namespace.get('--border-color-theme-accent') ??
+    namespace.get('--color-theme-accent') ??
+    '';
+
+  it('is what a border-theme-accent resolves to in every palette', () => {
+    expect(borderSource).not.toBe('');
+    const wrong: string[] = [];
+    for (const block of accentBlocks) {
+      const colour = resolveColour(borderSource, block);
+      if (!colour || !near(composite(colour, page(block)), accentFill(block))) {
+        wrong.push(label(block));
+      }
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  it('clears 3:1 against its own page, which --theme-border-strong did not', () => {
+    // The active tab used to be border-theme-strong, which measures 1.38:1 to
+    // 1.87:1 against the page: a state indicator nobody could see. Both
+    // numbers are computed here so that swapping the token back fails.
+    const failures: string[] = [];
+    const strongFailures: string[] = [];
+
+    for (const block of accentBlocks) {
+      const indicator = onPage(borderSource, block);
+      if (!indicator) {
+        failures.push(`${label(block)}: unresolvable`);
+        continue;
+      }
+      const ratio = contrastRatio(indicator, page(block));
+      if (ratio < INDICATOR_TARGET)
+        failures.push(`${label(block)}: ${ratio.toFixed(2)}:1`);
+
+      const strong = onPage('var(--theme-border-strong)', block);
+      if (strong && contrastRatio(strong, page(block)) < INDICATOR_TARGET) {
+        strongFailures.push(label(block));
+      }
+    }
+
+    expect(failures).toEqual([]);
+    // The token this replaced still fails everywhere, so the swap was the fix
+    // and not a coincidence of one palette.
+    expect(strongFailures.length).toBe(accentBlocks.length);
+  });
+});
+
+describe('author and tag chips inside an article', () => {
+  const markdown = parseBlocks(
+    readFileSync(join(HERE, 'blog-markdown.css'), 'utf8'),
+    'blog-markdown.css',
+  );
+
+  const chips = markdown.filter((block) =>
+    /\.er-(author|tag)-link$/.test(block.selector),
+  );
+
+  const variablesBlocks = blocks('variables.css');
+
+  /**
+   * The declarations that apply to <html> for one palette: the block's own,
+   * plus the derived tokens variables.css declares for the matching mode and
+   * the block does not override, plus the chip rule's own.
+   *
+   * `mode` is read from the block's page rather than from its selector, because
+   * developer's unqualified block is its DARK palette.
+   */
+  function asRendered(block: Block, chip: Block, overrides: string[][]): Block {
+    const mode = relativeLuminance(page(block)) >= 0.5 ? 'light' : 'dark';
+    const base = variablesBlocks.find((candidate) =>
+      mode === 'dark'
+        ? candidate.selector.includes('[data-theme="dark"]')
+        : candidate.selector.startsWith(':root'),
+    );
+    const merged = new Map(base?.declarations ?? []);
+    for (const [key, value] of block.declarations) merged.set(key, value);
+    for (const [key, value] of chip.declarations) merged.set(key, value);
+    for (const [key, value] of overrides) merged.set(key, value);
+    return {
+      ...block,
+      selector: `${block.selector} ${chip.selector}`,
+      declarations: merged,
+    };
+  }
+
+  it('render the template accent unchanged when no accent is configured', () => {
+    // 27 of 27 instances. --theme-accent-text falls through to the accent, so
+    // this pins that reading the corrected token cost nobody a pixel.
+    expect(chips.length).toBe(2);
+    const wrong: string[] = [];
+
+    for (const chip of chips) {
+      for (const block of accentBlocks) {
+        const rendered = asRendered(block, chip, []);
+        const colour = resolveColour(
+          chip.declarations.get('color') ?? '',
+          rendered,
+        );
+        if (!colour || !near(composite(colour, page(block)), accentFill(block)))
+          wrong.push(rendered.selector);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
+  it('correct an owner accent that would be illegible as text', () => {
+    // Yellow is the case the whole correction exists for: 1.07:1 as text on a
+    // white page. applyConfigDom writes the accent AND both corrected variants
+    // inline on <html>, so a chip reading the raw token would render the yellow
+    // and a chip reading the corrected one renders the olive.
+    const OWNER_ACCENT = '#ffff00';
+    const failures: string[] = [];
+
+    for (const chip of chips) {
+      for (const block of accentBlocks) {
+        const rendered = asRendered(block, chip, [
+          ['--theme-accent', OWNER_ACCENT],
+          [
+            '--theme-accent-text-light',
+            accentTextForMode(OWNER_ACCENT, 'light') ?? '',
+          ],
+          [
+            '--theme-accent-text-dark',
+            accentTextForMode(OWNER_ACCENT, 'dark') ?? '',
+          ],
+        ]);
+        const colour = resolveColour(
+          chip.declarations.get('color') ?? '',
+          rendered,
+        );
+        if (!colour) {
+          failures.push(`${rendered.selector}: unresolvable`);
+          continue;
+        }
+        const ratio = contrastRatio(
+          composite(colour, page(block)),
+          page(block),
+        );
+        if (ratio < ACCENT_CONTRAST_TARGET)
+          failures.push(`${rendered.selector}: ${ratio.toFixed(2)}:1`);
+      }
+    }
+
+    expect(failures).toEqual([]);
   });
 });

--- a/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
+++ b/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
@@ -536,6 +536,47 @@ function page(block: Block): Rgb {
 /** WCAG 1.4.11: a non-text state indicator wants 3:1 against what surrounds it. */
 const INDICATOR_TARGET = 3;
 
+const VARIABLES_BLOCKS = blocks('variables.css');
+
+/**
+ * One palette as it actually resolves on <html>: the block's own declarations
+ * over the derived tokens variables.css declares for the matching mode.
+ *
+ * A template block declares --theme-accent but never --theme-accent-text, so
+ * anything reading the corrected token has to be resolved against both. `mode`
+ * comes from the block's page rather than its selector, because developer's
+ * unqualified block is its DARK palette.
+ *
+ * `overrides` is how a configured accent is simulated: applyConfigDom writes
+ * the accent and both corrected variants as inline properties on <html>, which
+ * beat every block, so setting them here is the same substitution the browser
+ * would perform.
+ */
+function rendered(block: Block, overrides: string[][] = []): Block {
+  const mode = relativeLuminance(page(block)) >= 0.5 ? 'light' : 'dark';
+  const base = VARIABLES_BLOCKS.find((candidate) =>
+    mode === 'dark'
+      ? candidate.selector.includes('[data-theme="dark"]')
+      : candidate.selector.startsWith(':root'),
+  );
+  const merged = new Map(base?.declarations ?? []);
+  for (const [key, value] of block.declarations) merged.set(key, value);
+  for (const [key, value] of overrides) merged.set(key, value);
+  return { ...block, declarations: merged };
+}
+
+/**
+ * The inline properties applyConfigDom writes for a configured accent.
+ * Mirrors resolveAccent rather than restating its numbers.
+ */
+function configured(hex: string): string[][] {
+  return [
+    ['--theme-accent', hex],
+    ['--theme-accent-text-light', accentTextForMode(hex, 'light') ?? ''],
+    ['--theme-accent-text-dark', accentTextForMode(hex, 'dark') ?? ''],
+  ];
+}
+
 const COMPONENT_BLOCKS = parseBlocks(
   readFileSync(COMPONENTS, 'utf8'),
   'components.css',
@@ -733,11 +774,27 @@ describe('the primary button', () => {
     expect(wrong).toEqual([]);
   });
 
-  it('keeps its label readable at rest and under the pointer', () => {
+  it('keeps its label readable at rest and under the pointer, in every palette', () => {
     // Under the pointer as well as at rest, because a hover colour that moves
-    // AWAY from the label is invisible until someone hovers: developer's light
-    // hover was #7287fd, which left white text at 3.18:1 while every other
-    // palette sat between 7.10:1 and 21:1.
+    // toward the label rather than away from it is only unreadable once someone
+    // hovers: developer's light hover was #7287fd, which left white text at
+    // 3.18:1 while every other palette sat between 7.10:1 and 21:1.
+    //
+    // SCOPE, so this is not mistaken for more than it proves: the twelve
+    // palettes, which is every instance, and NOT a configured accent. For a
+    // configured accent --theme-accent-hover is
+    // color-mix(in oklab, accent 85%, --theme-accent-shade), and the shade is
+    // picked by the MODE while the ink is picked by the accent's own
+    // luminance. When they agree the hover moves toward the ink: over a 4096
+    // colour sweep, 39% of accents drop below 4.5:1 on the hovered button in
+    // at least one mode, worst 3.08, and even the default #0969da falls to
+    // 3.86 in dark mode. Re-picking the ink against the hovered fill does not
+    // fix it either (1261 of 4096 still fail, worst 3.35): the hover fill has
+    // to stop crossing the ink, which needs a token that says "away from the
+    // ink" rather than "toward the mode's shade". That is a change to the
+    // property applyConfigDom writes, so it is not made here, and asserting
+    // the configured case would only make this test red rather than make the
+    // button safe.
     const failures: string[] = [];
 
     for (const block of accentBlocks) {
@@ -784,64 +841,20 @@ describe('the primary button', () => {
     expect(parseColor(fallback?.[1] ?? '')).not.toBeNull();
   });
 
-  it('is focusable visibly, against the page rather than against its own fill', () => {
-    // outline-offset is what makes this measurable against the page: without
-    // it the ring would sit on a fill of its own colour and disappear.
+  it('offsets its focus outline so the ring lands on the page', () => {
+    // Without the offset the ring would sit on a fill of its own colour and
+    // disappear. Its contrast is measured with the other indicators below.
     expect(focus.declarations.get('outline-offset')).toBeTruthy();
-
-    const failures: string[] = [];
-    const ring = trailingColour(focus.declarations.get('outline') ?? '');
-    for (const block of accentBlocks) {
-      const colour = resolveColour(ring, block);
-      if (!colour) {
-        failures.push(`${label(block)}: unresolvable ring`);
-        continue;
-      }
-      const ratio = contrastRatio(composite(colour, page(block)), page(block));
-      if (ratio < INDICATOR_TARGET)
-        failures.push(`${label(block)}: ${ratio.toFixed(2)}:1`);
-    }
-
-    expect(failures).toEqual([]);
   });
 });
 
-describe('the text input focus ring', () => {
-  const focus = componentRule('.input-theme:focus');
-
-  it('carries no colour of its own', () => {
-    // It was rgba(59, 130, 246, 0.3): a fixed blue no template asked for, at
-    // 1.19:1 on the default light page.
-    const ring = trailingColour(focus.declarations.get('box-shadow') ?? '');
-    expect(parseColor(ring)).toBeNull();
-  });
-
-  it('clears 3:1 against every page it can appear on', () => {
-    // 40% of the accent, which is what the underline uses and what was
-    // proposed here, measures 1.74:1 to 3.42:1 and fails eleven of twelve. This
-    // assertion is the reason the ring is the accent at full strength.
-    const ring = trailingColour(focus.declarations.get('box-shadow') ?? '');
-    const failures: string[] = [];
-
-    for (const block of accentBlocks) {
-      const colour = resolveColour(ring, block);
-      if (!colour) {
-        failures.push(`${label(block)}: unresolvable`);
-        continue;
-      }
-      const ratio = contrastRatio(composite(colour, page(block)), page(block));
-      if (ratio < INDICATOR_TARGET)
-        failures.push(`${label(block)}: ${ratio.toFixed(2)}:1`);
-    }
-
-    expect(failures).toEqual([]);
-  });
-});
-
-describe('the accent as a state indicator', () => {
-  // border-theme-accent marks the active feed tab and the selected tipping
-  // currency. Which token it reads is decided in theme-tokens.css, so read it
-  // from there rather than restating it.
+describe('state indicators drawn from the accent', () => {
+  /**
+   * Every indicator the accent now draws, read from the file that decides it
+   * rather than restated here. The Tailwind namespaces cover the classes:
+   * `border-theme-accent` marks the active feed tab and the selected tipping
+   * currency, `ring-theme-accent` is on five focus rings.
+   */
   const tokenSource = readFileSync(TOKENS, 'utf8').replace(
     /\/\*[\s\S]*?\*\//g,
     '',
@@ -852,52 +865,136 @@ describe('the accent as a state indicator', () => {
       tokenSource.lastIndexOf('}'),
     ),
   );
-  // Narrower namespaces win over --color-* for the utility they name, which is
+  // A narrower namespace wins over --color-* for the utility it names, which is
   // how text-theme-accent already differs from bg-theme-accent.
-  const borderSource =
-    namespace.get('--border-color-theme-accent') ??
+  const namespaceSource = (utility: 'border' | 'ring') =>
+    namespace.get(`--${utility}-color-theme-accent`) ??
     namespace.get('--color-theme-accent') ??
     '';
 
-  it('is what a border-theme-accent resolves to in every palette', () => {
-    expect(borderSource).not.toBe('');
-    const wrong: string[] = [];
-    for (const block of accentBlocks) {
-      const colour = resolveColour(borderSource, block);
-      if (!colour || !near(composite(colour, page(block)), accentFill(block))) {
-        wrong.push(label(block));
-      }
+  const INDICATORS: Array<[string, string]> = [
+    [
+      'the text input focus ring',
+      trailingColour(
+        componentRule('.input-theme:focus').declarations.get('box-shadow') ??
+          '',
+      ),
+    ],
+    [
+      'the primary button focus outline',
+      trailingColour(
+        componentRule('.btn-theme-primary:focus-visible').declarations.get(
+          'outline',
+        ) ?? '',
+      ),
+    ],
+    ['border-theme-accent', namespaceSource('border')],
+    ['ring-theme-accent', namespaceSource('ring')],
+  ];
+
+  it('are all present and none carries a colour of its own', () => {
+    // The input ring was rgba(59, 130, 246, 0.3): a fixed blue no template
+    // asked for, at 1.19:1 on the default light page.
+    for (const [name, source] of INDICATORS) {
+      expect(source, name).not.toBe('');
+      expect(parseColor(source), name).toBeNull();
     }
-    expect(wrong).toEqual([]);
   });
 
-  it('clears 3:1 against its own page, which --theme-border-strong did not', () => {
-    // The active tab used to be border-theme-strong, which measures 1.38:1 to
-    // 1.87:1 against the page: a state indicator nobody could see. Both
-    // numbers are computed here so that swapping the token back fails.
+  it('clear 3:1 against every page, with no accent configured', () => {
+    // 40% of the accent, which is what the underline uses and what the spec
+    // proposed for the ring, measures 1.74:1 to 3.42:1 and fails eleven of
+    // twelve. This assertion is the reason the ring is at full strength.
     const failures: string[] = [];
+
+    for (const [name, source] of INDICATORS) {
+      for (const block of accentBlocks) {
+        const view = rendered(block);
+        const colour = resolveColour(source, view);
+        if (!colour) {
+          failures.push(`${name} ${label(block)}: unresolvable`);
+          continue;
+        }
+        const ratio = contrastRatio(
+          composite(colour, page(block)),
+          page(block),
+        );
+        if (ratio < INDICATOR_TARGET)
+          failures.push(`${name} ${label(block)}: ${ratio.toFixed(2)}:1`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it('clear 3:1 for a configured accent that is the page colour', () => {
+    // The hole this closes: --theme-accent is a FILL token and is allowed to be
+    // exactly what the owner typed, because the label on the fill is corrected
+    // against it. An indicator has nothing on top of it and sits on the page,
+    // so a white accent in light mode drew a white ring on a white page while
+    // `outline: none` removed the only other thing to see. Both extremes are
+    // swept, in both modes, because a palette's mode decides which correction
+    // variant applies.
+    const failures: string[] = [];
+
+    for (const owner of ['#ffffff', '#000000', '#f8fafc', '#0d1117']) {
+      for (const [name, source] of INDICATORS) {
+        for (const block of accentBlocks) {
+          const view = rendered(block, configured(owner));
+          const colour = resolveColour(source, view);
+          if (!colour) {
+            failures.push(`${owner} ${name} ${label(block)}: unresolvable`);
+            continue;
+          }
+          const ratio = contrastRatio(
+            composite(colour, page(block)),
+            page(block),
+          );
+          if (ratio < INDICATOR_TARGET)
+            failures.push(
+              `${owner} ${name} ${label(block)}: ${ratio.toFixed(2)}:1`,
+            );
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it('replace a token that failed 3:1 in every palette', () => {
+    // The active tab used to be border-theme-strong. Computing its ratio here
+    // rather than quoting it means swapping the token back fails, and means the
+    // improvement is not a coincidence of one palette.
     const strongFailures: string[] = [];
 
     for (const block of accentBlocks) {
-      const indicator = onPage(borderSource, block);
-      if (!indicator) {
-        failures.push(`${label(block)}: unresolvable`);
-        continue;
-      }
-      const ratio = contrastRatio(indicator, page(block));
-      if (ratio < INDICATOR_TARGET)
-        failures.push(`${label(block)}: ${ratio.toFixed(2)}:1`);
-
       const strong = onPage('var(--theme-border-strong)', block);
       if (strong && contrastRatio(strong, page(block)) < INDICATOR_TARGET) {
         strongFailures.push(label(block));
       }
     }
 
-    expect(failures).toEqual([]);
-    // The token this replaced still fails everywhere, so the swap was the fix
-    // and not a coincidence of one palette.
     expect(strongFailures.length).toBe(accentBlocks.length);
+  });
+
+  it('leave the raw accent to the fills, which is where it belongs', () => {
+    // bg-theme-accent must NOT be corrected: the button fill is the colour the
+    // owner asked for, and its label is chosen against that exact colour.
+    const fillSource =
+      namespace.get('--background-color-theme-accent') ??
+      namespace.get('--color-theme-accent') ??
+      '';
+
+    const wrong: string[] = [];
+    for (const block of accentBlocks) {
+      const view = rendered(block, configured('#ffff00'));
+      const colour = resolveColour(fillSource, view);
+      const yellow = parseHexColor('#ffff00') as Rgb;
+      if (!colour || !near(composite(colour, page(block)), yellow))
+        wrong.push(label(block));
+    }
+
+    expect(wrong).toEqual([]);
   });
 });
 
@@ -911,29 +1008,13 @@ describe('author and tag chips inside an article', () => {
     /\.er-(author|tag)-link$/.test(block.selector),
   );
 
-  const variablesBlocks = blocks('variables.css');
-
-  /**
-   * The declarations that apply to <html> for one palette: the block's own,
-   * plus the derived tokens variables.css declares for the matching mode and
-   * the block does not override, plus the chip rule's own.
-   *
-   * `mode` is read from the block's page rather than from its selector, because
-   * developer's unqualified block is its DARK palette.
-   */
-  function asRendered(block: Block, chip: Block, overrides: string[][]): Block {
-    const mode = relativeLuminance(page(block)) >= 0.5 ? 'light' : 'dark';
-    const base = variablesBlocks.find((candidate) =>
-      mode === 'dark'
-        ? candidate.selector.includes('[data-theme="dark"]')
-        : candidate.selector.startsWith(':root'),
-    );
-    const merged = new Map(base?.declarations ?? []);
-    for (const [key, value] of block.declarations) merged.set(key, value);
+  /** One palette as it resolves on <html>, with the chip rule layered on top. */
+  function chipView(block: Block, chip: Block, overrides: string[][]): Block {
+    const view = rendered(block, overrides);
+    const merged = new Map(view.declarations);
     for (const [key, value] of chip.declarations) merged.set(key, value);
-    for (const [key, value] of overrides) merged.set(key, value);
     return {
-      ...block,
+      ...view,
       selector: `${block.selector} ${chip.selector}`,
       declarations: merged,
     };
@@ -947,13 +1028,13 @@ describe('author and tag chips inside an article', () => {
 
     for (const chip of chips) {
       for (const block of accentBlocks) {
-        const rendered = asRendered(block, chip, []);
+        const view = chipView(block, chip, []);
         const colour = resolveColour(
           chip.declarations.get('color') ?? '',
-          rendered,
+          view,
         );
         if (!colour || !near(composite(colour, page(block)), accentFill(block)))
-          wrong.push(rendered.selector);
+          wrong.push(view.selector);
       }
     }
 
@@ -970,23 +1051,13 @@ describe('author and tag chips inside an article', () => {
 
     for (const chip of chips) {
       for (const block of accentBlocks) {
-        const rendered = asRendered(block, chip, [
-          ['--theme-accent', OWNER_ACCENT],
-          [
-            '--theme-accent-text-light',
-            accentTextForMode(OWNER_ACCENT, 'light') ?? '',
-          ],
-          [
-            '--theme-accent-text-dark',
-            accentTextForMode(OWNER_ACCENT, 'dark') ?? '',
-          ],
-        ]);
+        const view = chipView(block, chip, configured(OWNER_ACCENT));
         const colour = resolveColour(
           chip.declarations.get('color') ?? '',
-          rendered,
+          view,
         );
         if (!colour) {
-          failures.push(`${rendered.selector}: unresolvable`);
+          failures.push(`${view.selector}: unresolvable`);
           continue;
         }
         const ratio = contrastRatio(
@@ -994,7 +1065,7 @@ describe('author and tag chips inside an article', () => {
           page(block),
         );
         if (ratio < ACCENT_CONTRAST_TARGET)
-          failures.push(`${rendered.selector}: ${ratio.toFixed(2)}:1`);
+          failures.push(`${view.selector}: ${ratio.toFixed(2)}:1`);
       }
     }
 

--- a/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
+++ b/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
@@ -536,6 +536,20 @@ function page(block: Block): Rgb {
 /** WCAG 1.4.11: a non-text state indicator wants 3:1 against what surrounds it. */
 const INDICATOR_TARGET = 3;
 
+/**
+ * The resting underline is a decoration, not a state indicator, and is meant to
+ * be quiet: the twelve palettes ship it between 1.74:1 and 3.42:1. WCAG sets no
+ * minimum for a text decoration, so this floor is empirical rather than
+ * borrowed, and it exists to catch one thing: an underline that reaches the
+ * page colour and stops being a mark at all.
+ *
+ * 1.6 is the measured worst case over the four page-coloured accents and all
+ * twelve palettes, which is 1.67 on the darkest light surface. Reading the raw
+ * accent instead puts the same case at 1.00, identical to the page, which is
+ * the defect this pins. The hover state carries the real target separately.
+ */
+const UNDERLINE_REST_FLOOR = 1.6;
+
 const VARIABLES_BLOCKS = blocks('variables.css');
 
 /**
@@ -631,6 +645,39 @@ describe('the ink that goes on the accent', () => {
     expect(failures).toEqual([]);
   });
 
+  it('has a shade on the opposite side, so the hover moves away from it', () => {
+    // --theme-accent-shade is the direction --theme-accent-hover walks the fill,
+    // and its only consumer is that inline formula. The CSS pair is the
+    // no-accent-configured fallback, declared per mode, and the rule it has to
+    // satisfy is "away from the ink" rather than "the mode's own shade". For
+    // these twelve the two coincide, which is exactly the sort of coincidence
+    // that hides a bug, so it is computed from the ink here rather than assumed
+    // from the selector.
+    const wrong: string[] = [];
+
+    for (const block of accentBlocks) {
+      const view = rendered(block);
+      const ink = resolveColour(
+        block.declarations.get('--theme-accent-contrast') ?? '',
+        view,
+      );
+      const shade = resolveColour(
+        view.declarations.get('--theme-accent-shade') ?? '',
+        view,
+      );
+      if (!ink || !shade) {
+        wrong.push(`${label(block)}: unresolvable`);
+        continue;
+      }
+      if (relativeLuminance(ink.rgb) > 0.5 === relativeLuminance(shade.rgb) > 0.5)
+        wrong.push(
+          `${label(block)}: ink and shade on the same side of the range`,
+        );
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
   it('is the ink the module would have chosen for the same fill', () => {
     // An owner who configures an accent gets this value written inline on
     // <html> by applyConfigDom; an owner who configures nothing gets it from
@@ -682,9 +729,10 @@ describe('article link underlines', () => {
     const wrong: string[] = [];
 
     for (const block of accentBlocks) {
+      const view = rendered(block);
       const hover = onPage(
         block.declarations.get('--theme-link-decoration-hover') ?? '',
-        block,
+        view,
       );
       if (!hover || !near(hover, accentFill(block))) {
         wrong.push(`${label(block)}: ${hover?.map(Math.round).join(',')}`);
@@ -702,7 +750,7 @@ describe('article link underlines', () => {
     for (const block of accentBlocks) {
       const resting = onPage(
         block.declarations.get('--theme-link-decoration-color') ?? '',
-        block,
+        rendered(block),
       );
       const tint = composite(
         { rgb: accentFill(block), alpha: 1 },
@@ -728,9 +776,10 @@ describe('article link underlines', () => {
         block.declarations.get('--theme-link-decoration-color') ?? '',
         block,
       );
+      const view = rendered(block);
       const hover = onPage(
         block.declarations.get('--theme-link-decoration-hover') ?? '',
-        block,
+        view,
       );
       if (!resting || !hover) {
         failures.push(`${label(block)}: unresolvable`);
@@ -748,6 +797,49 @@ describe('article link underlines', () => {
       }
       if (restingRatio <= 1.05) {
         failures.push(`${label(block)}: rest invisible`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+  it('survive a configured accent that is the page colour, in both states', () => {
+    // The underline is the only thing telling a reader that a run of prose is a
+    // link: .markdown-body a takes its COLOUR from --theme-text-primary, so
+    // there is no second cue. A raw accent is whatever the owner typed, so a
+    // white accent on a light page gave a white underline and a white hover,
+    // and both vanished together. Reading the corrected accent bounds how faint
+    // either state can get, because that token clears 4.5:1 against the worst
+    // surface of its mode before it is tinted.
+    const failures: string[] = [];
+
+    for (const owner of ['#ffffff', '#000000', '#f8fafc', '#0d1117']) {
+      for (const block of accentBlocks) {
+        const view = rendered(block, configured(owner));
+        const resting = onPage(
+          block.declarations.get('--theme-link-decoration-color') ?? '',
+          view,
+        );
+        const hover = onPage(
+          block.declarations.get('--theme-link-decoration-hover') ?? '',
+          view,
+        );
+        if (!resting || !hover) {
+          failures.push(`${owner} ${label(block)}: unresolvable`);
+          continue;
+        }
+        const restingRatio = contrastRatio(resting, page(block));
+        const hoverRatio = contrastRatio(hover, page(block));
+        // The hover is the interactive feedback and is held to the state
+        // indicator target. The resting state is a decoration under text that
+        // carries its own contrast, so it only has to remain a visible mark.
+        if (hoverRatio < INDICATOR_TARGET)
+          failures.push(
+            `${owner} ${label(block)}: hover ${hoverRatio.toFixed(2)}:1`,
+          );
+        if (restingRatio < UNDERLINE_REST_FLOOR)
+          failures.push(
+            `${owner} ${label(block)}: rest ${restingRatio.toFixed(2)}:1`,
+          );
       }
     }
 

--- a/apps/self-hosted/src/styles/theme-tokens.css
+++ b/apps/self-hosted/src/styles/theme-tokens.css
@@ -64,6 +64,22 @@
   /* accent: the one collision-free family, gets the whole colour namespace */
   --color-theme-accent: var(--theme-accent);
   --color-theme-accent-contrast: var(--theme-accent-contrast, #ffffff);
+  /*
+   * Borders and rings are state indicators, so they take the corrected accent
+   * for the same reason text does, while bg-theme-accent keeps the raw fill.
+   *
+   * The distinction is the whole point of the split: a fill is allowed to be
+   * exactly the colour the owner asked for, because the thing on top of it is
+   * contrast-corrected against it. A 2px ring has nothing on top of it and
+   * lives directly on the page, so a pale accent on a pale page is an
+   * indicator that is simply not there, which is the defect that made
+   * focus:ring-theme-strong get retargeted in the first place.
+   * --theme-accent-text clears 4.5:1 against the worst surface of its mode and
+   * falls through to --theme-accent when nothing is configured, so the twelve
+   * palettes render exactly as they do today.
+   */
+  --border-color-theme-accent: var(--theme-accent-text, var(--theme-accent));
+  --ring-color-theme-accent: var(--theme-accent-text, var(--theme-accent));
 
   --radius-theme-sm: var(--theme-radius-sm);
   --radius-theme: var(--theme-radius);

--- a/apps/self-hosted/src/styles/themes/developer.css
+++ b/apps/self-hosted/src/styles/themes/developer.css
@@ -57,10 +57,10 @@
   --theme-link-decoration: underline;
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 
   /*
    * Tag style - Code-like. The fill comes from the accent tint in
@@ -131,10 +131,10 @@
      light page's underline too. */
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 
   --theme-tag-text: var(--theme-accent-text-light, #4c4f69);
 

--- a/apps/self-hosted/src/styles/themes/developer.css
+++ b/apps/self-hosted/src/styles/themes/developer.css
@@ -33,6 +33,12 @@
   /* Terminal-inspired accent colors */
   --theme-accent: #89b4fa;
   --theme-accent-hover: #b4befe;
+  /*
+   * Ink on the accent fill: 8.42:1, against 2.11:1 for #ffffff. This block is
+   * the DARK palette, so a guard that picked the ink from the selector rather
+   * than from --theme-bg-primary would get this one backwards.
+   */
+  --theme-accent-contrast: #111827;
 
   --theme-border: #313244;
   --theme-border-strong: #45475a;
@@ -47,10 +53,14 @@
   --theme-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
   --theme-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
 
-  /* Link style */
+  /* Link style, derived from the accent; see variables.css */
   --theme-link-decoration: underline;
-  --theme-link-decoration-color: rgba(137, 180, 250, 0.4);
-  --theme-link-decoration-hover: #89b4fa;
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent);
 
   /*
    * Tag style - Code-like. The fill comes from the accent tint in
@@ -102,10 +112,29 @@
   --theme-text-muted: #7c7f93;
 
   --theme-accent: #1e66f5;
-  --theme-accent-hover: #7287fd;
+  /*
+   * Darker than the accent, not lighter. #7287fd went the wrong way on a light
+   * page: it left white label text on the hovered button at 3.18:1 (every other
+   * palette is 7.10:1 to 21:1) and the hovered author chip at 2.65:1 against
+   * the page. This is the only block whose hover moved away from its own ink.
+   * #1a5ad9 is 5.99:1 against the label and 5.29:1 against the page.
+   */
+  --theme-accent-hover: #1a5ad9;
+  /* 4.91:1, against 3.61:1 for #111827. The lowest of the twelve. */
+  --theme-accent-contrast: #ffffff;
 
   --theme-border: #ccd0da;
   --theme-border-strong: #bcc0cc;
+
+  /* Both blocks match <html>; this one only outranks the base block for what it
+     declares, so the base block's literal rgba(137, 180, 250, 0.4) was this
+     light page's underline too. */
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent);
 
   --theme-tag-text: var(--theme-accent-text-light, #4c4f69);
 

--- a/apps/self-hosted/src/styles/themes/magazine.css
+++ b/apps/self-hosted/src/styles/themes/magazine.css
@@ -28,6 +28,8 @@
 
   --theme-accent: #8b4513;
   --theme-accent-hover: #6b3410;
+  /* Ink on the accent fill: 7.10:1, against 2.50:1 for #111827. */
+  --theme-accent-contrast: #ffffff;
 
   --theme-border: #e0dcd5;
   --theme-border-strong: #c5c0b8;
@@ -42,10 +44,14 @@
   --theme-shadow: 0 2px 6px rgba(44, 40, 37, 0.08);
   --theme-shadow-lg: 0 6px 16px rgba(44, 40, 37, 0.1);
 
-  /* Link style - Elegant underline */
+  /* Link style - Elegant underline, derived from the accent */
   --theme-link-decoration: underline;
-  --theme-link-decoration-color: #c5c0b8;
-  --theme-link-decoration-hover: #8b4513;
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent);
 
   /* Tag style - fill comes from the accent tint in variables.css */
   --theme-tag-text: var(--theme-accent-text-light, #4a4540);
@@ -87,12 +93,18 @@
 
   --theme-accent: #d4a574;
   --theme-accent-hover: #e5c090;
+  /* 7.97:1, against 2.23:1 for #ffffff. */
+  --theme-accent-contrast: #111827;
 
   --theme-border: #3a3530;
   --theme-border-strong: #4a4540;
 
-  --theme-link-decoration-color: #4a4540;
-  --theme-link-decoration-hover: #d4a574;
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent);
 
   --theme-tag-text: var(--theme-accent-text-dark, #c5c0b8);
 

--- a/apps/self-hosted/src/styles/themes/magazine.css
+++ b/apps/self-hosted/src/styles/themes/magazine.css
@@ -48,10 +48,10 @@
   --theme-link-decoration: underline;
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 
   /* Tag style - fill comes from the accent tint in variables.css */
   --theme-tag-text: var(--theme-accent-text-light, #4a4540);
@@ -101,10 +101,10 @@
 
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 
   --theme-tag-text: var(--theme-accent-text-dark, #c5c0b8);
 

--- a/apps/self-hosted/src/styles/themes/medium.css
+++ b/apps/self-hosted/src/styles/themes/medium.css
@@ -50,10 +50,10 @@
   --theme-link-decoration: underline;
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 
   /*
    * Tag style. The chip fill is a tint of the accent and is declared once in
@@ -107,10 +107,10 @@
 
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 
   --theme-tag-text: var(--theme-accent-text-dark, rgba(255, 255, 255, 0.68));
 }

--- a/apps/self-hosted/src/styles/themes/medium.css
+++ b/apps/self-hosted/src/styles/themes/medium.css
@@ -30,6 +30,8 @@
 
   --theme-accent: rgba(0, 0, 0, 0.84);
   --theme-accent-hover: rgba(0, 0, 0, 1);
+  /* Ink on the accent fill: 14.59:1, against 1.22:1 for #111827. */
+  --theme-accent-contrast: #ffffff;
 
   --theme-border: rgba(0, 0, 0, 0.1);
   --theme-border-strong: rgba(0, 0, 0, 0.15);
@@ -44,10 +46,14 @@
   --theme-shadow: none;
   --theme-shadow-lg: none;
 
-  /* Link underline style */
+  /* Link underline style, derived from the accent; see variables.css */
   --theme-link-decoration: underline;
-  --theme-link-decoration-color: rgba(0, 0, 0, 0.3);
-  --theme-link-decoration-hover: rgba(0, 0, 0, 0.84);
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent);
 
   /*
    * Tag style. The chip fill is a tint of the accent and is declared once in
@@ -93,12 +99,18 @@
 
   --theme-accent: rgba(255, 255, 255, 0.92);
   --theme-accent-hover: rgba(255, 255, 255, 1);
+  /* 15.02:1, against 1.18:1 for #ffffff. */
+  --theme-accent-contrast: #111827;
 
   --theme-border: rgba(255, 255, 255, 0.1);
   --theme-border-strong: rgba(255, 255, 255, 0.15);
 
-  --theme-link-decoration-color: rgba(255, 255, 255, 0.3);
-  --theme-link-decoration-hover: rgba(255, 255, 255, 0.92);
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent);
 
   --theme-tag-text: var(--theme-accent-text-dark, rgba(255, 255, 255, 0.68));
 }

--- a/apps/self-hosted/src/styles/themes/minimal.css
+++ b/apps/self-hosted/src/styles/themes/minimal.css
@@ -52,10 +52,10 @@
   --theme-link-decoration: underline;
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 
   /* Tag style - fill comes from the accent tint in variables.css */
   --theme-tag-text: var(--theme-accent-text-light, #4a4a4a);
@@ -109,10 +109,10 @@
    */
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 
   --theme-tag-text: var(--theme-accent-text-dark, #b0b0b0);
 }

--- a/apps/self-hosted/src/styles/themes/minimal.css
+++ b/apps/self-hosted/src/styles/themes/minimal.css
@@ -32,6 +32,8 @@
 
   --theme-accent: #0066cc;
   --theme-accent-hover: #0052a3;
+  /* Ink on the accent fill: 5.57:1, against 3.19:1 for #111827. */
+  --theme-accent-contrast: #ffffff;
 
   --theme-border: #eaeaea;
   --theme-border-strong: #d0d0d0;
@@ -46,10 +48,14 @@
   --theme-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
   --theme-shadow-lg: 0 4px 8px rgba(0, 0, 0, 0.08);
 
-  /* Link style */
+  /* Link style, derived from the accent; see variables.css */
   --theme-link-decoration: underline;
-  --theme-link-decoration-color: rgba(0, 102, 204, 0.3);
-  --theme-link-decoration-hover: #0066cc;
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent);
 
   /* Tag style - fill comes from the accent tint in variables.css */
   --theme-tag-text: var(--theme-accent-text-light, #4a4a4a);
@@ -87,9 +93,26 @@
 
   --theme-accent: #4da6ff;
   --theme-accent-hover: #80c0ff;
+  /* 6.94:1, against 2.56:1 for #ffffff. */
+  --theme-accent-contrast: #111827;
 
   --theme-border: #2a2a2a;
   --theme-border-strong: #3a3a3a;
+
+  /*
+   * Declared here as well as in the light block, which it did not use to be.
+   * Both blocks match <html>, and this one only outranks the light block for
+   * the properties it actually declares, so a LITERAL in the light block was
+   * the dark page's underline too: rgba(0, 102, 204, 0.3) on #111111, 1.26:1.
+   * A derived value would have re-substituted on its own, but stating the pair
+   * in every accent block is what makes that checkable per block.
+   */
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent);
 
   --theme-tag-text: var(--theme-accent-text-dark, #b0b0b0);
 }

--- a/apps/self-hosted/src/styles/themes/modern-gradient.css
+++ b/apps/self-hosted/src/styles/themes/modern-gradient.css
@@ -55,10 +55,10 @@
   --theme-link-decoration: underline;
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 
   /* Tag style - fill comes from the accent tint in variables.css */
   --theme-tag-text: var(--theme-accent-text-light, #7c3aed);
@@ -123,10 +123,10 @@
      block at a time rather than by simulating the cascade. */
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 
   --theme-tag-text: var(--theme-accent-text-dark, #a78bfa);
 

--- a/apps/self-hosted/src/styles/themes/modern-gradient.css
+++ b/apps/self-hosted/src/styles/themes/modern-gradient.css
@@ -32,6 +32,8 @@
   --theme-accent: #7c3aed;
   --theme-accent-hover: #6d28d9;
   --theme-accent-secondary: #2563eb;
+  /* Ink on the accent fill: 5.70:1, against 3.11:1 for #111827. */
+  --theme-accent-contrast: #ffffff;
 
   --theme-border: rgba(148, 163, 184, 0.2);
   --theme-border-strong: rgba(148, 163, 184, 0.4);
@@ -51,7 +53,11 @@
 
   /* Link style */
   --theme-link-decoration: underline;
-  --theme-link-decoration-color: color-mix(in srgb, var(--theme-accent) 40%, transparent);
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
   --theme-link-decoration-hover: var(--theme-accent);
 
   /* Tag style - fill comes from the accent tint in variables.css */
@@ -107,9 +113,20 @@
   --theme-accent: #a78bfa;
   --theme-accent-hover: #c4b5fd;
   --theme-accent-secondary: #60a5fa;
+  /* 6.52:1, against 2.72:1 for #ffffff. */
+  --theme-accent-contrast: #111827;
 
   --theme-border: rgba(148, 163, 184, 0.15);
   --theme-border-strong: rgba(148, 163, 184, 0.25);
+
+  /* Stated per block, like the accent itself, so "derived" is checkable one
+     block at a time rather than by simulating the cascade. */
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent);
 
   --theme-tag-text: var(--theme-accent-text-dark, #a78bfa);
 

--- a/apps/self-hosted/src/styles/themes/variables.css
+++ b/apps/self-hosted/src/styles/themes/variables.css
@@ -130,6 +130,19 @@
    * medium that is near-black text on a near-black chip. Transparent-first makes
    * the same fallback an unfilled chip, which is flat but readable everywhere.
    */
+  /*
+   * The end --theme-accent-hover walks the fill towards. Its only consumer is
+   * the inline hover formula, so this pair is the fallback for an instance that
+   * configures no accent; applyConfigDom writes the property itself when one is
+   * configured, taking the direction from the ink rather than from the mode.
+   *
+   * The rule is "away from --theme-accent-contrast", and these two values
+   * satisfy it rather than contradict it: every light palette here declares a
+   * white ink and every dark one a near-black ink, so away-from-the-ink and the
+   * mode's own shade coincide for all twelve. A template whose accent sat on
+   * the other side of its mode would break that coincidence, which is why the
+   * guard computes the direction from the ink instead of from the selector.
+   */
   --theme-accent-shade: #000000;
   --theme-accent-text: var(--theme-accent-text-light, var(--theme-accent));
   --theme-tag-bg: color-mix(in srgb, transparent 88%, var(--theme-accent));
@@ -149,13 +162,23 @@
    * accent-first degrades to a full-strength underline (which is the hover
    * state) while transparent-first would degrade to no underline at all, and
    * the underline is the affordance that says a run of body text is a link.
+   *
+   * The CORRECTED accent, for the same reason the focus rings use it, and this
+   * is the one place where that reasoning matters most. Link text inside an
+   * article inherits the body colour: the underline is the only thing telling a
+   * reader that a run of prose is a link. A raw accent is whatever the owner
+   * typed, so a white accent on a light page gave a white underline under body
+   * text, and both states vanished at once. --theme-accent-text clears 4.5:1
+   * against the worst surface of its mode, which bounds how faint either state
+   * can get, and falls through to --theme-accent when nothing is configured, so
+   * every template renders exactly what it rendered before.
    */
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 }
 
 /* Dark Mode Overrides */
@@ -197,8 +220,8 @@
   --theme-tag-text: var(--theme-accent-text-dark, var(--theme-text-secondary));
   --theme-link-decoration-color: color-mix(
     in srgb,
-    var(--theme-accent) 40%,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
     transparent
   );
-  --theme-link-decoration-hover: var(--theme-accent);
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
 }

--- a/apps/self-hosted/src/styles/themes/variables.css
+++ b/apps/self-hosted/src/styles/themes/variables.css
@@ -56,6 +56,8 @@
 
   --theme-accent: #0969da;
   --theme-accent-hover: #0550ae;
+  /* 5.19:1. See the note on --theme-accent-contrast in the derived block. */
+  --theme-accent-contrast: #ffffff;
 
   --theme-border: rgba(0, 0, 0, 0.1);
   --theme-border-strong: rgba(0, 0, 0, 0.2);
@@ -132,6 +134,28 @@
   --theme-accent-text: var(--theme-accent-text-light, var(--theme-accent));
   --theme-tag-bg: color-mix(in srgb, transparent 88%, var(--theme-accent));
   --theme-tag-text: var(--theme-accent-text-light, var(--theme-text-secondary));
+
+  /*
+   * Article link underlines, derived rather than declared.
+   *
+   * .markdown-body a reads both of these, and every template used to name a
+   * literal here, so an owner's accent stopped at the edge of an article. The
+   * var() substitutes against whichever block wins for --theme-accent on this
+   * element, so a template that re-declares the accent re-derives its own
+   * underline with nothing further to write.
+   *
+   * Accent-first in the mix, unlike --theme-tag-bg above and for the same
+   * reason: the build's pre-color-mix fallback keeps the FIRST colour, so
+   * accent-first degrades to a full-strength underline (which is the hover
+   * state) while transparent-first would degrade to no underline at all, and
+   * the underline is the affordance that says a run of body text is a link.
+   */
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent);
 }
 
 /* Dark Mode Overrides */
@@ -148,6 +172,16 @@
 
   --theme-accent: #58a6ff;
   --theme-accent-hover: #79c0ff;
+  /*
+   * The ink that goes ON the accent, not next to it: 7.02:1 here, against 2.53:1
+   * for white. It is mode-independent by construction (both operands are the
+   * accent and a fixed ink), which is why applyConfigDom can write one inline
+   * value for a configured accent and never re-run on an OS theme flip. Every
+   * block that declares --theme-accent declares this beside it, so whichever
+   * block wins the cascade for the fill also wins for the ink and no
+   * cross-block pairing is possible.
+   */
+  --theme-accent-contrast: #111827;
 
   --theme-border: rgba(255, 255, 255, 0.1);
   --theme-border-strong: rgba(255, 255, 255, 0.2);
@@ -161,4 +195,10 @@
   --theme-accent-text: var(--theme-accent-text-dark, var(--theme-accent));
   --theme-tag-bg: color-mix(in srgb, transparent 88%, var(--theme-accent));
   --theme-tag-text: var(--theme-accent-text-dark, var(--theme-text-secondary));
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent);
 }


### PR DESCRIPTION
Step 3 of the appearance track. #1352 shipped `general.styles.accent` and derived
`--theme-accent`, `-hover`, `-contrast`, `-text-light` and `-text-dark` from it, and
deliberately left the consumers out. This adds them, so an owner who sets one colour sees it
on the things that look interactive rather than on a single sidebar link.

## What changes visibly on a default instance

Every instance is a default instance: all of them run the default template and theme and none
has set an accent. So all of this ships with no owner action, and it is the point rather than
a side effect.

1. **The active feed tab** is marked with the accent instead of `--theme-border-strong`, and
   gains `font-medium`. On the default template the indicator goes from a hairline at 1.38:1
   against the page to the accent at 14.59:1. This is above the fold on every home page and it
   is the most noticeable line in the PR.
2. **Article link underlines** are derived from the corrected accent in all twelve palettes
   instead of being hardcoded in four of them. On the default template the resting underline is unchanged
   to the eye (2.11:1 to 2.34:1) and the hover underline is unchanged exactly. Two palettes
   were reading the wrong mode's literal and visibly change: minimal dark went from a light
   blue at 30% on a near-black page (1.26:1) to its own dark accent (2.14:1), and developer
   light from the dark palette's blue to its own.
3. **Five buttons** (comment login prompt, comment submit, extension login, HiveAuth login,
   payment sign) go from a fixed `bg-blue-600` to the template accent with an ink chosen for
   contrast. On the default template that is a near-black button with white text where there
   was a blue button with white text.
4. **The text input focus ring** on the login fields goes from a fixed
   `rgba(59, 130, 246, 0.3)` at 1.19:1 to the accent at full strength. Four more focus rings
   (search, login method, two payment inputs) move from `ring-blue-500` to the accent.
5. **Author and tag chips inside an article body** read the contrast-corrected accent. With no
   accent configured this is the same colour as before, to the byte.
6. **developer's light hover colour** darkens from `#7287fd` to `#1a5ad9`. See below.

Nothing here can hide content, blank a page or change layout, and `git revert` is a complete
recovery: no config parsing is touched and nothing is written to any stored config.

## Contrast measured, not assumed

Every number below is computed from the theme files by the guards in this PR.

**The ink on the accent fill** (button label, needs 4.5:1). All twelve blocks clear it; the
minimum is 4.91 on developer light, not the 5.19 the spec claims:

| block | accent | vs white | vs `#111827` | declared |
|---|---|---|---|---|
| base light | `#0969da` | 5.19 | 3.42 | `#ffffff` |
| base dark | `#58a6ff` | 2.53 | 7.02 | `#111827` |
| classic light | `rgba(0,0,0,.84)` | 14.59 | 1.22 | `#ffffff` |
| classic dark | `rgba(255,255,255,.92)` | 1.18 | 15.02 | `#111827` |
| plain light | `#0066cc` | 5.57 | 3.19 | `#ffffff` |
| plain dark | `#4da6ff` | 2.56 | 6.94 | `#111827` |
| editorial light | `#8b4513` | 7.10 | 2.50 | `#ffffff` |
| editorial dark | `#d4a574` | 2.23 | 7.97 | `#111827` |
| terminal (dark default) | `#89b4fa` | 2.11 | 8.42 | `#111827` |
| terminal light | `#1e66f5` | 4.91 | 3.61 | `#ffffff` |
| soft light | `#7c3aed` | 5.70 | 3.11 | `#ffffff` |
| soft dark | `#a78bfa` | 2.72 | 6.52 | `#111827` |

**State indicators, which want 3:1 against the page.** The accent measures 4.34 (terminal
light) to 15.86 (classic dark) across the twelve. `--theme-border-strong`, which the active
tab used, measures below 3:1 in all twelve, and a guard asserts that so the swap cannot be
mistaken for a coincidence of one palette.

**Indicators take the corrected accent, fills take the raw one.** `bg-theme-accent` is the
colour the owner typed, because the label on it is chosen against that exact colour. A ring or
a border has nothing on top of it and sits on the page, so `border-theme-accent`,
`ring-theme-accent` and both focus-ring rules read `--theme-accent-text`, which clears 4.5:1
against the worst surface of its mode. With nothing configured it falls through to the raw
accent, so the twelve palettes are unchanged. Without this a configured `#ffffff` in light mode
drew a white ring on a white page, and `outline: none` had already removed the alternative.
A guard sweeps four page-coloured accents across all twelve palettes in both directions.

**The underline takes the corrected accent too, in both states.** `.markdown-body a` colours its
text from `--theme-text-primary`, so the underline is the only thing telling a reader that a run
of prose is a link, and there is no second cue. On the raw accent a configured `#ffffff` on a
light page measured **1.00:1 resting and 1.00:1 hovered**: not faint, identical to the page, both
states gone at once. Corrected, the same case is **1.67:1 resting and 4.51:1 hovered**, worst
over four page-coloured accents and all twelve palettes. The twelve palettes are unchanged,
because the token falls through to the raw accent when nothing is configured.

**The focus ring is the accent at full strength, not a 40% tint.** The spec asked for
`color-mix(in srgb, var(--theme-accent) 40%, transparent)` here. Measured, that lands between
1.74:1 and 3.42:1 and fails 3:1 in eleven of twelve palettes, which is the same class of defect
that made `focus:ring-theme-strong` get retargeted. Full strength matches
`.focus-ring-theme:focus`, which this file already had. The 40% mix is kept for the link
underline, which is a decoration under text that carries its own contrast and whose hover state
is the feedback that has to be seen: hover measures 4.34:1 to 15.86:1.

**The button hover.** A filled button's hover has to keep its label, so the guard measures the
label on the hovered fill too. Eleven palettes sit between 7.10:1 and 21:1. terminal light was
3.18:1, because its hover moved lighter on a light page, away from its own white ink; the same
value put the hovered author chip at 2.65:1 as text. It darkens to `#1a5ad9`, which is 5.99:1
against the label and 5.29:1 against the page. No instance runs that template today.

**Not fixed here, and the test says so rather than implying otherwise.**

- terminal light's accent is 4.34:1 against its own page, so accent-as-text on that one
  template is below AA. That is the template's identity colour and the spec defers it.
- Nothing else. The hovered button is fixed rather than deferred; see below.

## The hovered button, fixed at the token rather than at the five call sites

The same defect one level down, and this PR is what introduces five consumers of it, so it is
fixed here rather than left for a PR that would have to find all five.

`--theme-accent-hover` is `color-mix(in oklab, accent 85%, --theme-accent-shade)`. The shade was
declared per **mode**, black in light and white in dark, while the ink on that fill is chosen
from the **accent's own luminance**. When the two agreed, the hover walked the fill towards its
own label. Measured over the 4096 colour sweep: **39% of accents drop below 4.5:1 while hovered**,
worst **3.08** at `#778822`, and the current default `#0969da` reaches **3.86** in dark mode.

Re-choosing the ink against the hovered fill is the obvious fix and is not the fix: it still
leaves **1261 of 4096** below 4.5:1, worst **3.35**. The fill has to stop crossing the ink rather
than the ink chasing the fill.

So the shade now points **away from the ink** instead of towards the mode's own. Moving a fill
away from its ink in luminance can only raise the ratio, and `accentContrastColor` already clears
the target at rest, so the hovered state is bounded below by the resting state. Swept:

- **0 of 4096 below 4.5:1 while hovered**, against 1598 before.
- **Worst hovered-minus-resting delta 0.0000**, so the hover is never worse than the rest for any
  colour, which is what extends the result past the sweep's own grid.
- Spot values: `#767676` 4.54 to 6.48, `#858585` 4.81 to 6.00, `#0969da` 5.19 to 7.33.

`--theme-accent-shade` has exactly one consumer, that inline formula, so `applyConfigDom` writes
it beside the ink and the CSS pair stays as the no-accent-configured fallback. For the twelve
palettes the mode's shade and the ink's opposite coincide, which is the kind of coincidence that
hides a bug, so a guard computes the direction from the ink rather than from the selector.

This widened one existing guard rather than working around it. `writes only properties a
stylesheet reads` correctly failed, because the shade has no stylesheet consumer at all: it is
read by another written value. A reader is now a stylesheet **or** another written value, which
keeps the next genuinely dead property out instead of granting this one an exception.

## Compiled stylesheet, before and after

Built from a clean checkout of the base commit and from this branch, same toolchain.

- 111,010 bytes to 115,662 bytes, **+4,652 bytes** (+4.2%), 19.3 kB to 19.5 kB gzipped.
- **3 selectors added**: `.btn-theme-primary`, `.btn-theme-primary:hover:not(:disabled)`,
  `.btn-theme-primary:focus-visible`. None removed.
- **21 selectors changed.** The twelve palette blocks each gain `--theme-accent-contrast` and a
  derived `--theme-link-decoration-color` / `-hover`; ten literal underline values disappear
  (`#c5c0b8`, `#4a4540`, `#0000004d`, `#ffffff4d`, `#0066cc4d`, `#06c`, `#89b4fa66`, `#89b4fa`,
  `#000000d6`, `#ffffffeb`). `.input-theme:focus` swaps `#3b82f64d` for the corrected accent,
  and `.focus-ring-theme:focus`, `.border-theme-accent` and `.focus\:ring-theme-accent:focus`
  move from the raw accent to it. The two article chip rules swap `var(--theme-accent, ...)`
  for `var(--theme-accent-text, var(--theme-accent, ...))`.
- Grep on the artifact: `theme-accent-contrast` 0 to 13 (twelve declarations plus the button
  that reads it), `btn-theme-primary` 0 to 3, `3b82f64d` 1 to 0,
  `color-mix(in srgb,var(--theme-accent)40%` 1 to 12.
- The build emits a pre-`color-mix` fallback of `--theme-link-decoration-color: var(--theme-accent)`
  ahead of each mix. That is why the mix is written accent-first: a browser without `color-mix`
  gets a full-strength underline rather than none at all, and the underline is the affordance
  that says a run of body text is a link.

## Guards

CSS cannot be asserted from a unit test here and `.tsx` is not testable at all, so the guards
resolve each declaration to an actual colour, substituting the block's own custom properties and
evaluating `color-mix`, and then measure it. Nothing matches on a token's spelling: a grep for
`var(--theme-accent)` passes on a mix that is 0% accent, and on a value in a property nothing
reads.

Eight of the new assertions fail against the theme files as they stand on the base commit, and
the suite does not even load without `.btn-theme-primary`. Each was also mutation-verified:

| mutation | assertions that go red |
|---|---|
| drop `--theme-accent-contrast` from one block | declared everywhere; clears 4.5:1; agrees with the module |
| set one block's ink to the losing candidate | clears 4.5:1; agrees with the module; button label readable |
| drop the underline pair from one block | stated everywhere; hover resolves to the accent; rest is a tint; quiet at rest and 3:1 on hover |
| restore a hardcoded `#c5c0b8` underline | rest is a tint of the accent; quiet at rest and 3:1 on hover |
| point the underline hover at `--theme-accent-hover` | hover resolves to the accent |
| restore the `rgba(59, 130, 246, 0.3)` focus ring | ring carries no colour of its own; ring clears 3:1 |
| use the spec's 40% mix for the focus ring | ring clears 3:1 |
| drop the literal fallback from the button label | falls back to a literal, never to the inherited colour |
| restore `#7287fd` as terminal light's hover | button label readable at rest and under the pointer |
| fill the button from `--theme-accent-hover` | button fills with the accent |
| drop `outline-offset` from the button | focusable visibly against the page |
| point `border-theme-accent` at `--theme-border-strong` | what a border resolves to; clears 3:1 |
| revert the chips to the raw accent | corrects an owner accent that would be illegible |
| hardcode the chip colour | template accent unchanged when nothing is configured; corrects an owner accent |
| point the input ring, `border-theme-accent` or `ring-theme-accent` back at the raw accent | indicators clear 3:1 for a page-coloured configured accent |
| correct the button fill as well as the indicators | the raw accent is left to the fills |
| underline hover, or the resting tint, back to the raw accent | underlines survive a page-coloured configured accent |
| shade points towards the ink instead of away | shade written away from the ink; points away rather than towards the mode; hovered label over the sweep; hover never worse than rest |
| shade always black, which is the old light-mode value | the same four |
| drop `--theme-accent-shade` from what `applyConfigDom` writes | shade written away from the ink |
| swap the CSS fallback shades between the modes | the fallback shade opposes its own ink |

The chip guard simulates the configured case, because with no accent configured the corrected
token falls through to the raw one and the two are indistinguishable. It sets a yellow accent
and both corrected variants the way `applyConfigDom` does, and asserts the chip renders the
correction.

## Notes

- `--theme-accent-contrast` is mode-independent by construction, so nothing re-runs on an OS
  theme flip and the `syncSystemTheme` listener is untouched.
- The literal fallback in `color: var(--theme-accent-contrast, #ffffff)` is load-bearing rather
  than defensive. `color` inherits, so a `var()` with no fallback that is invalid at
  computed-value time resolves to the page text colour, which would be near-black label text on
  a dark accent fill.
- The underline pair is stated in every accent block rather than once per template. A derived
  value re-substitutes on its own; a literal does not, which is exactly how two palettes ended
  up rendering the other mode's underline. Stating it per block makes "derived" checkable one
  block at a time instead of by simulating the cascade.
- No config field is added, so nothing here needs a `config-fields.ts` change to work. The
  panel still needs the accent control itself, which another PR owns.
