### PR TITLE
Self-hosted: say the Hivesigner client id is filled in for hosted blogs

### DIFF
--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -83,6 +83,23 @@ describe('hivesigner client id', () => {
     expect(description).toMatch(/never overwritten|not be overwritten/i);
   });
 
+  /**
+   * The email route is only half an instruction. Nothing writes the field on a
+   * self-hosted instance: the reconcile iterates the hosting database, so an
+   * owner who emails us and waits sees the button stay hidden for a step that
+   * was never going to happen on its own.
+   *
+   * `gives both routes to a working setup` does not cover this. It asserts the
+   * three substrings are present, and they all were in a revision that had
+   * dropped the save step, which is how this shipped for review.
+   */
+  it('tells a self-hoster taking the email route to save ecency.app themselves', () => {
+    const description = fieldAt(CLIENT_ID_PATH)?.description ?? '';
+
+    expect(description).toMatch(/self-hosted/i);
+    expect(description).toMatch(/put ecency\.app here/i);
+  });
+
   it('is pointed at from the login methods field', () => {
     expect(fieldAt(METHODS_PATH)?.description).toContain('Hivesigner');
   });

--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -64,6 +64,25 @@ describe('hivesigner client id', () => {
     expect(description).toContain('ecency.app');
   });
 
+  /**
+   * A managed tenant's client id is written by the registration job, not by the
+   * owner, so copy telling them to set it themselves describes work they will
+   * never do and a login they will believe is broken until they do it.
+   *
+   * Asserted on the field an owner actually reads rather than on the job, because
+   * the job being right is what makes this text wrong: the two drifted apart once
+   * already, with the editor promising a manual step the reconcile had removed.
+   */
+  it('says the hosted case is automatic, and that an own id survives it', () => {
+    const description = fieldAt(CLIENT_ID_PATH)?.description ?? '';
+
+    expect(description).toMatch(/hosted by Ecency/i);
+    expect(description).toMatch(/filled in for you|automatically/i);
+    // The reconcile leaves a non-shared value alone; the owner has to be told so,
+    // or setting their own app reads as a change something else may undo.
+    expect(description).toMatch(/never overwritten|not be overwritten/i);
+  });
+
   it('is pointed at from the login methods field', () => {
     expect(fieldAt(METHODS_PATH)?.description).toContain('Hivesigner');
   });

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -455,7 +455,7 @@ export const configFieldsMap: Record<string, ConfigField> = {
                 // when cleared, and null erases the stored section on merge.
                 type: 'string',
                 description:
-                  "Hivesigner login stays hidden until this is set. On a blog hosted by Ecency the shared ecency.app app is filled in for you, once this site's /auth address has been registered on chain, so there is normally nothing to do here. To use a different app, register your own and put its id here; it is never overwritten. On a self-hosted instance, register your own app or email hello@ecency.com.",
+                  "Hivesigner login stays hidden until this is set. On a blog hosted by Ecency the shared ecency.app app is filled in for you, once this site's /auth address has been registered on chain, so there is normally nothing to do here. To use a different app instead, register your own and put its id here; it is never overwritten. On a self-hosted instance nothing fills this in for you: either register your own app and put its id here, or email hello@ecency.com to get this site's /auth address registered on the shared app and then put ecency.app here.",
               },
             },
           },

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -356,7 +356,7 @@ export const configFieldsMap: Record<string, ConfigField> = {
                     type: 'array',
                     allowedValues: AUTH_METHODS,
                     description:
-                      'Available login methods: keychain, hivesigner, hiveauth. Hivesigner also needs a client id, set under General Settings > Hivesigner.',
+                      'Available login methods: keychain, hivesigner, hiveauth. Hivesigner also needs a client id under General Settings > Hivesigner, which blogs hosted by Ecency are given automatically.',
                   },
                 },
               },
@@ -455,7 +455,7 @@ export const configFieldsMap: Record<string, ConfigField> = {
                 // when cleared, and null erases the stored section on merge.
                 type: 'string',
                 description:
-                  "Hivesigner login stays hidden until this is set. Either register your own Hivesigner app and put its id here, or email hello@ecency.com to get this site's /auth address registered on the shared ecency.app app, then put ecency.app here.",
+                  "Hivesigner login stays hidden until this is set. On a blog hosted by Ecency the shared ecency.app app is filled in for you, once this site's /auth address has been registered on chain, so there is normally nothing to do here. To use a different app, register your own and put its id here; it is never overwritten. On a self-hosted instance, register your own app or email hello@ecency.com.",
               },
             },
           },


### PR DESCRIPTION
Follow-up to #1354, which is now live: the registration job has run against production and all eight active tenants carry `ecency.app`, served and on chain.

That makes the Configuration Editor's own text wrong. It still says:

> Hivesigner login stays hidden until this is set. Either register your own Hivesigner app and put its id here, or email hello@ecency.com to get this site's /auth address registered on the shared ecency.app app, then put ecency.app here.

A managed tenant never does any of that. The job sets the id for them, so the instruction describes work that will not happen and makes a working login look broken until the owner acts on it.

## Changes

- Client id description leads with the hosted case, keeps the self-hosted route (own app, or email us), and adds that an owner's own id is never overwritten. The reconcile already guarantees that, via `decideClientId` returning `leave` for any non-shared value, but nothing said so, and without it setting your own app reads as a change something else may undo.
- Login methods description notes hosted blogs are given a client id automatically.
- Test asserting the hosted case is described as automatic and that the own-id guarantee is stated. The existing `gives both routes to a working setup` case is untouched.

`hivesigner-setup.ts`'s notice is deliberately left alone: it fires only when no client id is set, which on managed hosting no longer happens, and it stays correct for self-hosters, where nothing registers on their behalf.

## Verification

- `vitest run src/features/floating-menu/` 83 passed.
- Mutation check: reverting the description to the pre-existing copy fails the new test, and only that test.
- Typecheck clean apart from the pre-existing gitignored `config.json` resolution error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified authentication setup for hosted blogs, including automatic Hivesigner client ID assignment after on-chain registration.
  - Explained that self-hosted installations can use custom Hivesigner client IDs, which will not be overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->