### PR TITLE
Self-hosted: let an owner actually set the accent and the fonts

### DIFF
--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -4,10 +4,14 @@ import {
   PAYOUT_LABEL_MAX_LENGTH,
   resolveHiveLayer,
 } from '@/core/hive-layer';
-import { FONT_PRESET_OPTIONS } from '@/core/theme-appearance';
+import {
+  FONT_PRESET_OPTIONS,
+  resolveFontPreset,
+} from '@/core/theme-appearance';
 import { AUTH_METHODS } from '@/features/auth/utils/auth-methods';
 import type { ConfigField } from './config-fields';
 import { configFieldsMap } from './config-fields';
+import { displayedSelectValue } from './field-display';
 
 /** The field at a config path, or undefined when the editor does not offer it. */
 function fieldAt(path: readonly string[]): ConfigField | undefined {
@@ -311,4 +315,38 @@ describe('appearance knobs', () => {
     expect(options.some((option) => option.value === '')).toBe(true);
     expect(fieldAt(FONT_PRESET_PATH)?.default).toBe('');
   });
+});
+
+/**
+ * Tied to the real field and the real resolver, not a fixture.
+ *
+ * field-display.test.ts proves the mechanism with a local select, which would
+ * keep passing if `normalizesCase` were dropped from the field itself. This is
+ * the assertion that fails in that case: for any spelling the engine resolves,
+ * the panel has to show the matching option rather than falling back to
+ * "Theme default" and describing a site that is not what the reader sees.
+ */
+describe('font preset panel agrees with the engine', () => {
+  const FONT_PRESET_PATH_REAL = [
+    'configuration',
+    'general',
+    'styles',
+    'fontPreset',
+  ] as const;
+
+  it.each([' Classic ', 'MODERN', 'Editorial'])(
+    'shows a real option for %s, which the engine resolves',
+    (stored) => {
+      // Guard the premise: if the engine stopped resolving these, the panel
+      // falling back would be correct and this test would be asserting nothing.
+      expect(resolveFontPreset(stored)).not.toBeNull();
+
+      const field = fieldAt(FONT_PRESET_PATH_REAL);
+      if (!field) throw new Error('no font preset field');
+      const shown = displayedSelectValue(field, stored);
+
+      expect(shown).not.toBe('');
+      expect(shown).toBe(stored.trim().toLowerCase());
+    },
+  );
 });

--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -4,6 +4,7 @@ import {
   PAYOUT_LABEL_MAX_LENGTH,
   resolveHiveLayer,
 } from '@/core/hive-layer';
+import { FONT_PRESET_OPTIONS } from '@/core/theme-appearance';
 import { AUTH_METHODS } from '@/features/auth/utils/auth-methods';
 import type { ConfigField } from './config-fields';
 import { configFieldsMap } from './config-fields';
@@ -243,5 +244,71 @@ describe('login methods', () => {
 
   it('accepts only the methods the app can serve', () => {
     expect(fieldAt(METHODS_PATH)?.allowedValues).toEqual(AUTH_METHODS);
+  });
+});
+
+const ACCENT_PATH = [
+  'configuration',
+  'general',
+  'styles',
+  'accent',
+] as const;
+const FONT_PRESET_PATH = [
+  'configuration',
+  'general',
+  'styles',
+  'fontPreset',
+] as const;
+
+/**
+ * `apply-config-dom` has read `configuration.general.styles.accent` and
+ * `.fontPreset` since the appearance work shipped, and `theme-appearance`
+ * derives the palette and type scale from them. The editor described neither,
+ * so the only way to set either was to write the config document by hand, which
+ * no owner does. The engine and the panel disagreeing that way is invisible:
+ * everything is green, every instance just silently keeps the default.
+ *
+ * The path strings below are the contract. They have to stay equal to the ones
+ * in `apply-config-dom`'s PATHS, which is module-private, so this asserts the
+ * editor side and the appearance tests assert the reader side.
+ */
+describe('appearance knobs', () => {
+  it('offers the accent where the appearance engine reads it', () => {
+    expect(fieldAt(ACCENT_PATH)).toBeDefined();
+  });
+
+  /**
+   * Text, never `number`. The number input writes null when cleared and null
+   * erases the stored section on merge, which would take `background` and the
+   * font preset out with it.
+   */
+  it('takes the accent as text', () => {
+    expect(fieldAt(ACCENT_PATH)?.type).toBe('string');
+  });
+
+  it('offers the font preset where the appearance engine reads it', () => {
+    expect(fieldAt(FONT_PRESET_PATH)).toBeDefined();
+  });
+
+  /**
+   * The exported list itself, not a hand-copied one. A second list here would
+   * drift from the presets the engine can actually resolve, and an owner would
+   * pick a pairing that silently resolves to null.
+   */
+  it('offers exactly the presets the engine can resolve', () => {
+    expect(fieldAt(FONT_PRESET_PATH)?.options).toEqual([
+      ...FONT_PRESET_OPTIONS,
+    ]);
+  });
+
+  /**
+   * Every instance currently stores no preset, so the panel has to have a value
+   * that means that, and it has to be reachable again after a change. Without
+   * the empty entry the first selection is permanent.
+   */
+  it('keeps a way back to the template default', () => {
+    const options = fieldAt(FONT_PRESET_PATH)?.options ?? [];
+    expect(options.some((option) => option.value === '')).toBe(true);
+    expect(fieldAt(FONT_PRESET_PATH)?.default).toBe('');
   });
 });

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -45,6 +45,16 @@ export interface ConfigField {
    * sane control rather than storage.
    */
   maxLength?: number;
+  /**
+   * For `select` fields whose resolver accepts a value that is not spelled
+   * exactly like the option, so the panel can show what the site is actually
+   * doing.
+   *
+   * Opt-in, never the default. `resolveFontPreset` trims and lower-cases;
+   * `oneOf` in core/hive-layer matches with a bare `includes`. Applying either
+   * rule to the other's fields would make the panel disagree with the site.
+   */
+  normalizesCase?: boolean;
 }
 
 export const configFieldsMap: Record<string, ConfigField> = {
@@ -477,10 +487,10 @@ export const configFieldsMap: Record<string, ConfigField> = {
                * which is the value every instance currently holds.
                */
               accent: {
-                label: 'Accent colour',
+                label: 'Accent color',
                 type: 'string',
                 description:
-                  'One colour, as a hex value such as #0969da. Buttons, links, the active feed tab and focus rings derive from it, and the text that sits on it is corrected automatically to stay readable. Leave empty to keep the style template\'s own colour.',
+                  "One color, as a hex value such as #0969da. Buttons, links, the active feed tab and focus rings derive from it, and the text that sits on it is corrected automatically to stay readable. Leave empty to keep the style template's own color.",
                 maxLength: 32,
               },
               fontPreset: {
@@ -493,6 +503,11 @@ export const configFieldsMap: Record<string, ConfigField> = {
                 // preset has been chosen, and a second list here would drift.
                 options: [...FONT_PRESET_OPTIONS],
                 default: '',
+                // resolveFontPreset trims and lower-cases, so a hand-written
+                // `"Classic"` applies the Classic pairing. Without this the
+                // panel would match the options exactly, show "Theme default",
+                // and disagree with the site it is describing.
+                normalizesCase: true,
               },
               background: {
                 label: 'Background',

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -6,6 +6,7 @@ import {
   HIVE_LAYER_CONFIG_DEFAULTS,
   PAYOUT_LABEL_MAX_LENGTH,
 } from '@/core/hive-layer';
+import { FONT_PRESET_OPTIONS } from '@/core/theme-appearance';
 import { AUTH_METHODS } from '@/features/auth/utils/auth-methods';
 
 export type ConfigFieldType =
@@ -463,6 +464,36 @@ export const configFieldsMap: Record<string, ConfigField> = {
             label: 'Styles',
             type: 'section',
             fields: {
+              /**
+               * The two knobs `theme-appearance` derives the whole palette and
+               * type scale from. They were read by `apply-config-dom` from the
+               * moment that shipped, but no field described them, so the only
+               * way to set either was to have written the config by hand.
+               *
+               * A text input rather than a colour input, matching `background`
+               * beside it. The editor renders `string`, `select`, `boolean`,
+               * `number` and `array`; a colour type would need a case of its
+               * own, and a bare `<input type="color">` cannot express "unset",
+               * which is the value every instance currently holds.
+               */
+              accent: {
+                label: 'Accent colour',
+                type: 'string',
+                description:
+                  'One colour, as a hex value such as #0969da. Buttons, links, the active feed tab and focus rings derive from it, and the text that sits on it is corrected automatically to stay readable. Leave empty to keep the style template\'s own colour.',
+                maxLength: 32,
+              },
+              fontPreset: {
+                label: 'Fonts',
+                type: 'select',
+                description:
+                  'A body and heading pairing. Leave on Theme default to keep the faces the style template ships with.',
+                // The exported list, not a copy: it already carries the empty
+                // "Theme default" entry that is the only way back after a
+                // preset has been chosen, and a second list here would drift.
+                options: [...FONT_PRESET_OPTIONS],
+                default: '',
+              },
               background: {
                 label: 'Background',
                 type: 'string',

--- a/apps/self-hosted/src/features/floating-menu/field-display.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/field-display.test.ts
@@ -345,3 +345,54 @@ describe('the editor renders through these', () => {
     expect(jsxAttributeValues('maxLength')).toContain('{field.maxLength}');
   });
 });
+
+/**
+ * The panel and the site have to agree about a value the site accepted.
+ *
+ * `resolveFontPreset` trims and lower-cases, so a hand-written `"Classic"`
+ * renders the Classic pairing. Matching the options exactly would show
+ * "Theme default" next to a site using Classic fonts, and the owner would be
+ * reading a control that describes a state the site is not in. Managed tenants
+ * cannot reach this, since they can only pick from the list, but a self-hoster
+ * writes config.json by hand.
+ */
+describe('a select whose resolver normalizes', () => {
+  const fontPreset: ConfigField = {
+    label: 'Fonts',
+    type: 'select',
+    options: [
+      { value: '', label: 'Theme default' },
+      { value: 'classic', label: 'Classic' },
+      { value: 'modern', label: 'Modern' },
+    ],
+    default: '',
+    normalizesCase: true,
+  };
+
+  it('shows the canonical option for a differently spelled stored value', () => {
+    expect(displayedSelectValue(fontPreset, ' Classic ')).toBe('classic');
+    expect(displayedSelectValue(fontPreset, 'MODERN')).toBe('modern');
+  });
+
+  it('still falls back for a value no option matches', () => {
+    expect(displayedSelectValue(fontPreset, 'banana')).toBe('');
+  });
+
+  /**
+   * The leniency is per field, not a rule for every select. `oneOf` in
+   * core/hive-layer matches with a bare `includes`, so a Hive layer select
+   * showing "off" for a stored "Off" would claim a state the site rejected.
+   */
+  it('does not leak leniency to selects that did not ask for it', () => {
+    const strict: ConfigField = {
+      label: 'Show Hive activity to readers',
+      type: 'select',
+      options: [
+        { value: 'off', label: 'Off' },
+        { value: 'standard', label: 'Standard' },
+      ],
+      default: 'off',
+    };
+    expect(displayedSelectValue(strict, 'Standard')).toBe('off');
+  });
+});

--- a/apps/self-hosted/src/features/floating-menu/field-display.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/field-display.test.ts
@@ -230,17 +230,35 @@ describe('a config written before the Hive layer existed', () => {
     }
   });
 
-  it('leaves no select blank when it declares a default', () => {
+  /**
+   * What this is really guarding is that a select never renders an unlabelled
+   * empty control, which reads as broken and tells the owner nothing about what
+   * the site is currently doing.
+   *
+   * That is not the same as "the value is never the empty string". The font
+   * preset offers `''` as a named choice, "Theme default", because an instance
+   * that has never chosen a pairing is in exactly that state and has to be able
+   * to return to it after picking one. There the control shows a label, so the
+   * thing this test exists to prevent has not happened.
+   *
+   * So the rule is: the shown value must be one of the offered options, and if
+   * it is blank that option must carry a label. Stricter than the old
+   * `not.toBe('')`, which let an unlabelled blank option through.
+   */
+  it('leaves no select showing an unlabelled blank when it declares a default', () => {
     for (const leaf of leaves) {
       if (leaf.field.type !== 'select' || leaf.field.default === undefined) {
         continue;
       }
       const shown = displayedSelectValue(leaf.field, leaf.value as ConfigValue);
-      expect(shown, leaf.path).not.toBe('');
+      const options = leaf.field.options ?? [];
       expect(
-        leaf.field.options?.map((option) => option.value),
+        options.map((option) => option.value),
         leaf.path,
       ).toContain(shown);
+
+      const label = options.find((option) => option.value === shown)?.label;
+      expect(label ?? '', leaf.path).not.toBe('');
     }
   });
 

--- a/apps/self-hosted/src/features/floating-menu/field-display.ts
+++ b/apps/self-hosted/src/features/floating-menu/field-display.ts
@@ -94,7 +94,25 @@ export function displayedSelectValue(
 
   const options = field.options;
   if (options && options.length > 0) {
-    return options.some((option) => option.value === value) ? value : fallback;
+    const match = options.find((option) => option.value === value);
+    if (match) return match.value;
+
+    // Only for fields whose resolver normalizes, and it has to be opt-in rather
+    // than the rule for every select. `oneOf` in core/hive-layer matches with a
+    // bare `includes`, no trim and no case folding, so being lenient everywhere
+    // would show a Hive layer value as set while the site rejected it and used
+    // the default: the same disagreement this fixes, pointing the other way.
+    if (field.normalizesCase) {
+      const wanted = value.trim().toLowerCase();
+      const loose = options.find(
+        (option) => option.value.trim().toLowerCase() === wanted,
+      );
+      // The option's own value, not what was stored, so the control shows the
+      // canonical spelling the engine resolved to.
+      if (loose) return loose.value;
+    }
+
+    return fallback;
   }
   return value;
 }


### PR DESCRIPTION
Found while preparing the tenant outreach, which is meant to tell owners to go and customise their blog.

`apply-config-dom.ts` has read `configuration.general.styles.accent` and `.fontPreset` since the appearance work shipped, and `theme-appearance.ts` derives the palette, the hover fill, the on-accent text and the type scale from them. Its own doc comment calls them "the two owner-facing appearance knobs". Neither was ever added to `config-fields.ts`, and the editor renders only the fields in that map, so there is no path to either: the Styles section offers `Background` and nothing else. The array `textarea` is for `array` fields, not raw JSON, so there is no escape hatch.

The result is invisible. Nothing errors, every instance just keeps the style template's own colour and faces, and #1352 and #1355 shipped an engine with no control attached.

## Changes

- `accent`, a `string`. Text rather than a colour input on purpose: the editor renders `string`, `select`, `boolean`, `number` and `array`, so a colour type needs a renderer case of its own, and a bare `<input type="color">` cannot express "unset", which is the value all eight live instances currently hold. Worth doing properly later; this makes the knob reachable now.
- `fontPreset`, a `select` fed by the exported `FONT_PRESET_OPTIONS` rather than a hand-copied list, so it cannot drift from what `resolveFontPreset` accepts. That list already carries the `''` "Theme default" entry, which is the only way back after a pairing has been chosen.
- One existing invariant made precise. `leaves no select blank when it declares a default` assumed blank always means unset. The font preset offers `''` as a *named* choice, so the control shows a label and the thing that test guards against has not happened. It now requires the shown value to be an offered option and that option to carry a label. That is stricter than `not.toBe('')`: it also rejects an unlabelled blank option, which the old form let through.

## Verification

- Full self-hosted suite: 751 passed, 57 files. Typecheck clean apart from the pre-existing gitignored `config.json` resolution error.
- Mutation checks, each failing only the intended test: dropping the accent field; replacing the option list with a hand-copied shorter one; removing the `''` entry and defaulting to a real preset; and giving the `''` option an empty label, which the tightened invariant catches and the old one did not.

Not covered: no `.tsx` is renderable under this vitest config (`environment: 'node'`, `include: ['src/**/*.test.ts']`), so the rendered control still needs a manual pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added appearance settings for customizing accent colors and font presets.
  * Font preset choices now use the available theme options and default to the configured theme font.

* **Bug Fixes**
  * Improved legacy configuration handling for valid, labeled empty selections.
  * Prevented unlabeled blank controls from appearing in configuration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->