### PR TITLE
Self-hosted: stop naming Keychain on the three remaining signing surfaces

### DIFF
--- a/apps/self-hosted/src/features/auth/auth-actions.ts
+++ b/apps/self-hosted/src/features/auth/auth-actions.ts
@@ -187,7 +187,11 @@ export async function broadcast(
       // that tells the author nothing about why their tip did not send.
       if (authorityType !== 'Posting') {
         throw new Error(
-          `Hivesigner cannot sign with ${authorityType.toLowerCase()} authority. Sign in with Keychain or HiveAuth to do this.`,
+          // "a browser extension", not "Keychain": `keychain` is the login type
+          // for every Hive wallet extension, and this sentence is instructional,
+          // so naming one product sends Keeper and Peak Vault users to install
+          // something they do not need.
+          `Hivesigner cannot sign with ${authorityType.toLowerCase()} authority. Sign in with a browser extension or HiveAuth to do this.`,
         );
       }
       return broadcastWithHivesigner(user.accessToken, operations);

--- a/apps/self-hosted/src/features/auth/utils/extension-labels.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/extension-labels.test.ts
@@ -1,11 +1,14 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import ts from 'typescript';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   BROWSER_EXTENSION_LABEL,
+  callbackCapableExtensions,
   extensionMethodLabel,
+  getDetectedExtensions,
   getExtensionName,
+  hasKeychainLikeExtension,
   VALID_EXTENSION_IDS,
   type DetectedExtension,
 } from './hive-extensions';
@@ -119,5 +122,133 @@ describe('no call site hardcodes one wallet', () => {
         name,
       );
     }
+  });
+});
+
+/**
+ * The gate and the label have to be reading the same list.
+ *
+ * `payment-dialog` disabled its button on `hasKeychainLikeExtension`, which
+ * excludes Peak Vault because x402 signing needs the callback API, while
+ * labelling itself from every detected wallet. A browser with only Peak Vault
+ * installed therefore rendered "Peak Vault" as the method above the words
+ * "Extension not detected", disabled: the one wallet the user had installed,
+ * named and declared missing in the same control.
+ *
+ * The AST scan in this file cannot see this. It polices product names in
+ * literals, not which list was fed to the label, so the behaviour is the guard.
+ */
+describe('callback-capable list', () => {
+  const realWindow = (globalThis as { window?: unknown }).window;
+
+  function withWallets(w: Record<string, unknown>): void {
+    (globalThis as { window?: unknown }).window = w;
+  }
+
+  afterEach(() => {
+    if (realWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window?: unknown }).window = realWindow;
+    }
+  });
+
+  it('drops Peak Vault, which cannot sign a transaction here', () => {
+    withWallets({ peakvault: {} });
+
+    expect(getDetectedExtensions().map((e) => e.id)).toEqual(['peakvault']);
+    expect(callbackCapableExtensions()).toEqual([]);
+  });
+
+  /**
+   * The exact contradiction: named as the method, and declared missing.
+   */
+  it('does not name Peak Vault as the method it cannot be', () => {
+    withWallets({ peakvault: {} });
+
+    expect(hasKeychainLikeExtension()).toBe(false);
+    expect(extensionMethodLabel(callbackCapableExtensions())).toBe(
+      BROWSER_EXTENSION_LABEL,
+    );
+    expect(extensionMethodLabel(callbackCapableExtensions())).not.toBe(
+      getExtensionName('peakvault'),
+    );
+  });
+
+  /**
+   * Filtering also buys precision the unfiltered list lost: two wallets are
+   * detected but only one of them can pop up, so it can be named.
+   */
+  it('names Hive Keeper when it is the only one that can sign', () => {
+    withWallets({ hive: { isKeeper: true }, peakvault: {} });
+
+    expect(getDetectedExtensions()).toHaveLength(2);
+    expect(extensionMethodLabel(callbackCapableExtensions())).toBe(
+      getExtensionName('hive-keeper'),
+    );
+  });
+
+  /** The gate cannot say yes while the list it is defined from is empty. */
+  it('agrees with the gate in every arrangement', () => {
+    const arrangements = [
+      {},
+      { peakvault: {} },
+      { hive: { isKeeper: true } },
+      { hive_keychain: {} },
+      { hive: { isKeeper: true }, hive_keychain: {}, peakvault: {} },
+    ];
+
+    for (const wallets of arrangements) {
+      withWallets(wallets);
+      expect(hasKeychainLikeExtension(), JSON.stringify(wallets)).toBe(
+        callbackCapableExtensions().length > 0,
+      );
+    }
+  });
+});
+
+/**
+ * That the dialog feeds the label from the SAME list it gates on.
+ *
+ * The behaviour tests above prove `callbackCapableExtensions` filters
+ * correctly, and every one of them still passed when the call site was reverted
+ * to `getDetectedExtensions()`, which is the whole bug. Nothing in a `.tsx` is
+ * renderable under this runner, so which function supplies the argument is the
+ * only thing left to assert, and it is the mechanism rather than a proxy for it.
+ */
+describe('the payment dialog labels from the list it gates on', () => {
+  const DIALOG = join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'features/payment/components/payment-dialog.tsx',
+  );
+
+  it('passes callbackCapableExtensions() to extensionMethodLabel', () => {
+    const file = ts.createSourceFile(
+      'payment-dialog.tsx',
+      readFileSync(DIALOG, 'utf8'),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX,
+    );
+
+    const argumentSources: string[] = [];
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'extensionMethodLabel'
+      ) {
+        argumentSources.push(
+          ...node.arguments.map((argument) => argument.getText(file)),
+        );
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(file);
+
+    expect(argumentSources).toEqual(['callbackCapableExtensions()']);
   });
 });

--- a/apps/self-hosted/src/features/auth/utils/extension-labels.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/extension-labels.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import {
+  BROWSER_EXTENSION_LABEL,
+  extensionMethodLabel,
+  getExtensionName,
+  VALID_EXTENSION_IDS,
+  type DetectedExtension,
+} from './hive-extensions';
+
+/**
+ * `keychain` is the login type for every Hive wallet extension, not the
+ * Keychain product, so copy naming Keychain is shown to Hive Keeper and Peak
+ * Vault users too. This app recommends Keeper first, which makes the wrong
+ * name most likely for the users it is most wrong for.
+ */
+
+function meta(id: (typeof VALID_EXTENSION_IDS)[number]): DetectedExtension {
+  return { id, name: getExtensionName(id), icon: '' };
+}
+
+describe('extensionMethodLabel', () => {
+  it('names the wallet when exactly one is installed', () => {
+    for (const id of VALID_EXTENSION_IDS) {
+      expect(extensionMethodLabel([meta(id)]), id).toBe(getExtensionName(id));
+    }
+  });
+
+  /**
+   * Nothing can honestly name a single wallet here: which one signs is decided
+   * later from the stored preference, so a name would be a guess presented as
+   * fact.
+   */
+  it('stays generic when several are installed', () => {
+    const several = VALID_EXTENSION_IDS.map(meta);
+    expect(extensionMethodLabel(several)).toBe(BROWSER_EXTENSION_LABEL);
+    expect(extensionMethodLabel(several.slice(0, 2))).toBe(
+      BROWSER_EXTENSION_LABEL,
+    );
+  });
+
+  it('stays generic when none is installed', () => {
+    expect(extensionMethodLabel([])).toBe(BROWSER_EXTENSION_LABEL);
+  });
+
+  it('never names one wallet while another is also installed', () => {
+    const several = VALID_EXTENSION_IDS.map(meta);
+    const label = extensionMethodLabel(several);
+    for (const id of VALID_EXTENSION_IDS) {
+      expect(label, id).not.toContain(getExtensionName(id));
+    }
+  });
+});
+
+/**
+ * The call sites are `.tsx` and `.ts` files this runner cannot render, and the
+ * point of the change is the ABSENCE of a hardcoded product name rather than
+ * the presence of anything, so there is no value to assert on. A source scan is
+ * the only guarantee available, the same approach
+ * `config-saving-capability.test.ts` takes for `hosting-token.ts`.
+ *
+ * String literals only, via the AST. A plain text search fails here for a
+ * reason worth recording: these files are full of identifiers like
+ * `hasKeychainLikeExtension` and `signBufferViaKeychain`, which are correct and
+ * must stay. Only what can reach a user is copy.
+ */
+describe('no call site hardcodes one wallet', () => {
+  const SRC = join(__dirname, '..', '..', '..');
+
+  const SURFACES = [
+    'features/payment/components/payment-dialog.tsx',
+    'features/payment/sign-payment.ts',
+    'features/auth/auth-actions.ts',
+  ];
+
+  /** Every string and template literal in a file, excluding import paths. */
+  function stringLiterals(source: string, fileName: string): string[] {
+    const file = ts.createSourceFile(
+      fileName,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+    );
+    const found: string[] = [];
+
+    const visit = (node: ts.Node): void => {
+      if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) return;
+      if (
+        ts.isStringLiteral(node) ||
+        ts.isNoSubstitutionTemplateLiteral(node) ||
+        ts.isTemplateHead(node) ||
+        ts.isTemplateMiddle(node) ||
+        ts.isTemplateTail(node) ||
+        // JsxText, or the whole guard is decorative on the file it exists for.
+        // The label this replaced was `<div>Hive Keychain</div>`: literal text
+        // between tags, which is a JsxText node and not a StringLiteral. Caught
+        // by putting the hardcoded label back and watching the test still pass.
+        ts.isJsxText(node)
+      ) {
+        found.push(node.text);
+      }
+      ts.forEachChild(node, visit);
+    };
+
+    visit(file);
+    return found;
+  }
+
+  it.each(SURFACES)('%s names no single wallet in its copy', (relative) => {
+    const source = readFileSync(join(SRC, relative), 'utf8');
+    const literals = stringLiterals(source, relative).join('\n');
+
+    for (const id of VALID_EXTENSION_IDS) {
+      const name = getExtensionName(id);
+      expect(literals, `${relative} has "${name}" in a string`).not.toContain(
+        name,
+      );
+    }
+  });
+});

--- a/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
@@ -146,6 +146,30 @@ export function hasKeychainLikeExtension(): boolean {
   return getDetectedExtensions().some((e) => e.id !== 'peakvault');
 }
 
+/** The generic name for the method, used whenever one wallet cannot be named. */
+export const BROWSER_EXTENSION_LABEL = 'Browser extension';
+
+/**
+ * What to call the extension signing method on a button.
+ *
+ * A fixed "Hive Keychain" label was wrong for two of the three wallets this app
+ * supports, and it is the one it recommends first that it was most wrong for.
+ * Naming the wallet when exactly one is installed is both accurate and more
+ * useful than the generic term, since it tells the owner which popup to expect.
+ *
+ * With several installed, no single name is right: the choice is made later,
+ * from the stored preference. With none, the generic term is all that can
+ * honestly be said, and the button is disabled anyway.
+ *
+ * Takes the detected list rather than reading `window`, so it is testable under
+ * a `node` runner. Nothing in a `.tsx` file is.
+ */
+export function extensionMethodLabel(
+  detected: readonly DetectedExtension[],
+): string {
+  return detected.length === 1 ? detected[0].name : BROWSER_EXTENSION_LABEL;
+}
+
 // ---------------------------------------------------------------------------
 // Per-user preference (same storage keys as the main web app)
 // ---------------------------------------------------------------------------

--- a/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
@@ -141,9 +141,29 @@ export function getExtensionName(id: HiveExtensionId): string {
   return EXTENSION_META[id]?.name ?? id;
 }
 
-/** True when a Keychain-compatible (callback API) extension is present. */
+/**
+ * The detected extensions that can sign a transaction here.
+ *
+ * Peak Vault is a real, detected wallet, but it exposes only a promise-based
+ * API with no callback path for specialized requests, so transaction signing
+ * cannot use it. Anything that gates on that capability and anything that
+ * describes it have to be reading the same list: the payment dialog gated on
+ * `hasKeychainLikeExtension` while labelling itself from the unfiltered set,
+ * so a browser with only Peak Vault installed rendered a button named
+ * "Peak Vault" above the words "Extension not detected", disabled.
+ */
+export function callbackCapableExtensions(): DetectedExtension[] {
+  return getDetectedExtensions().filter((e) => e.id !== 'peakvault');
+}
+
+/**
+ * True when a Keychain-compatible (callback API) extension is present.
+ *
+ * Defined in terms of the list above so the gate and the label cannot disagree
+ * about what counts, which is how they came apart.
+ */
 export function hasKeychainLikeExtension(): boolean {
-  return getDetectedExtensions().some((e) => e.id !== 'peakvault');
+  return callbackCapableExtensions().length > 0;
 }
 
 /** The generic name for the method, used whenever one wallet cannot be named. */

--- a/apps/self-hosted/src/features/payment/components/payment-dialog.tsx
+++ b/apps/self-hosted/src/features/payment/components/payment-dialog.tsx
@@ -4,7 +4,11 @@ import clsx from 'clsx';
 import { useState } from 'react';
 import type { PaymentRequirements } from '../x402-client';
 import { signX402Payment, type PaymentSignMethod } from '../sign-payment';
-import { hasKeychainLikeExtension } from '../../auth/utils/hive-extensions';
+import {
+  extensionMethodLabel,
+  getDetectedExtensions,
+  hasKeychainLikeExtension,
+} from '../../auth/utils/hive-extensions';
 
 interface PaymentDialogProps {
   requirements: PaymentRequirements;
@@ -26,6 +30,9 @@ export function PaymentDialog({
 
   // Transaction signing needs the callback API (Keychain or Hive Keeper).
   const keychainAvailable = hasKeychainLikeExtension();
+  // Named when exactly one wallet is installed, generic otherwise. A fixed
+  // "Hive Keychain" was wrong for two of the three this app supports.
+  const extensionLabel = extensionMethodLabel(getDetectedExtensions());
 
   async function handleSign(method: PaymentSignMethod) {
     setLoadingMethod(method);
@@ -96,7 +103,7 @@ export function PaymentDialog({
           >
             <div className="flex-1">
               <div className="font-medium text-theme-primary">
-                Hive Keychain
+                {extensionLabel}
               </div>
               <div className="text-xs text-theme-muted">
                 {keychainAvailable

--- a/apps/self-hosted/src/features/payment/components/payment-dialog.tsx
+++ b/apps/self-hosted/src/features/payment/components/payment-dialog.tsx
@@ -5,8 +5,8 @@ import { useState } from 'react';
 import type { PaymentRequirements } from '../x402-client';
 import { signX402Payment, type PaymentSignMethod } from '../sign-payment';
 import {
+  callbackCapableExtensions,
   extensionMethodLabel,
-  getDetectedExtensions,
   hasKeychainLikeExtension,
 } from '../../auth/utils/hive-extensions';
 
@@ -30,9 +30,10 @@ export function PaymentDialog({
 
   // Transaction signing needs the callback API (Keychain or Hive Keeper).
   const keychainAvailable = hasKeychainLikeExtension();
-  // Named when exactly one wallet is installed, generic otherwise. A fixed
-  // "Hive Keychain" was wrong for two of the three this app supports.
-  const extensionLabel = extensionMethodLabel(getDetectedExtensions());
+  // From the SAME list the gate above reads. Labelling from every detected
+  // wallet named Peak Vault as the method while the button said "Extension not
+  // detected" and stayed disabled, because Peak Vault cannot sign here.
+  const extensionLabel = extensionMethodLabel(callbackCapableExtensions());
 
   async function handleSign(method: PaymentSignMethod) {
     setLoadingMethod(method);

--- a/apps/self-hosted/src/features/payment/sign-payment.ts
+++ b/apps/self-hosted/src/features/payment/sign-payment.ts
@@ -65,7 +65,9 @@ export async function signX402Payment(
       try {
         signedTx = JSON.parse(resp.result);
       } catch (e) {
-        throw new Error(`Failed to parse Keychain signed transaction: ${e instanceof Error ? e.message : e}`);
+        // The line above already says "the extension"; this one named Keychain,
+        // which is the login type rather than the product that signed.
+        throw new Error(`Failed to parse the signed transaction from the extension: ${e instanceof Error ? e.message : e}`);
       }
       break;
     }


### PR DESCRIPTION
Closes the copy half of #1361. Stacked on #1360: **merge #1360 first**, since this uses the `VALID_EXTENSION_IDS` export it adds, and both touch `hive-extensions.ts`.

`keychain` is the login type for every Hive wallet extension, not the Keychain product, so all three of these strings were shown to Hive Keeper and Peak Vault users. This app recommends Keeper first, so the wrong name went to the users it was most wrong for.

## Changes

- `auth-actions.ts:190` - "Sign in with Keychain or HiveAuth to do this." This one is instructional, so it was actively telling a Keeper user to go and install something they do not need. Now "a browser extension", matching `hosting-token.ts`'s existing wording.
- `sign-payment.ts:68` - "Failed to parse Keychain signed transaction", reached by whichever wallet signed. The line directly above it already says "the extension".
- `payment-dialog.tsx:99` - a button labelled "Hive Keychain" for the callback-API path all three wallets use. Now named when exactly one is installed, which is both accurate and more useful since it says which popup to expect, and generic when several are, because which one signs is decided later from the stored preference.

The label rule is `extensionMethodLabel(detected)` in a `.ts` module taking the detected list rather than reading `window`, since nothing in a `.tsx` is testable under this runner.

## On the guard

Two things it took a mutation check to get right, both worth recording because the first is a mistake I have made before.

**A raw text search does not work here.** These files are full of identifiers like `hasKeychainLikeExtension` and `signBufferViaKeychain`, which are correct and must stay. The scan reads string literals through the TypeScript AST instead, so it only sees what can reach a user.

**The first AST version was decorative.** It collected `StringLiteral` and template nodes. The label it replaced was `<div>Hive Keychain</div>`, which is a **JsxText** node, so putting the hardcoded label back left the guard passing. Caught by running exactly that mutation, and fixed by reading `JsxText` too.

## Verification

- 756 passed, 59 files. Typecheck clean apart from the pre-existing gitignored `config.json` error.
- Mutation checks, each failing only its own case: hardcoding the JSX label back; reverting the `auth-actions` sentence; and making the label name a wallet while several are installed.

## Still open in #1361

The residual case where the message can name the wrong wallet after a mid-session uninstall, which needs `signBufferWithExtension` to report which wallet actually signed. Not a copy change, so it is not here.


## Follow-up from review: the label and the gate disagreed about Peak Vault

A regression this PR introduced, now fixed in `02562b0`.

The button is disabled on `hasKeychainLikeExtension()`, which excludes Peak Vault because x402 signing needs the callback API, but it was labelled from `getDetectedExtensions()`, which includes it. A browser with only Peak Vault installed rendered **"Peak Vault"** as the method above the words **"Extension not detected"**, disabled. The user's one installed wallet, named as the method and declared missing in the same control. The old hardcoded label was wrong, but it was not self-refuting.

Fixed structurally rather than with a filter at the call site: `callbackCapableExtensions()` is the filtered list and `hasKeychainLikeExtension` is now defined from it, so the gate and the label cannot come apart again. It also recovers the precision the unfiltered list lost, since with Keeper and Peak Vault both installed only Keeper can prompt, so it can be named.

`extensionMethodLabel` stays generic, as reviewed: a login button would rightly count Peak Vault, so the filtering belongs to the caller that cannot use it.

**The AST scan cannot catch this class**, as noted in review: it polices product names in literals, not which list fed the label. So the behaviour is tested against a stubbed `window` for each arrangement, and, because every one of those tests still passed with the call site reverted, the argument the dialog actually passes is asserted too. Both verified by mutation: reverting the call site fails only the call-site case, and removing the filter fails only the three behaviour cases.

772 passed, 59 files.
