### PR TITLE
chore: rename repository to vision-web

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@changesets/changelog-github",
     {
-      "repo": "ecency/vision-next"
+      "repo": "ecency/vision-web"
     }
   ],
   "commit": false,

--- a/.claude/skills/add-test/instructions.md
+++ b/.claude/skills/add-test/instructions.md
@@ -1,6 +1,6 @@
 ---
 name: add-test
-description: Add tests for a component or utility in the vision-next web app following established patterns and avoiding common pitfalls
+description: Add tests for a component or utility in the vision-web app following established patterns and avoiding common pitfalls
 argument-hint: [component-or-file-path]
 disable-model-invocation: true
 ---

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Review code changes for bugs, patterns violations, and common pitfalls in the vision-next codebase
+description: Review code changes for bugs, patterns violations, and common pitfalls in the vision-web codebase
 argument-hint: [file-or-branch]
 disable-model-invocation: true
 ---

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-description: Debug common issues in the vision-next Hive web app with known solutions and investigation patterns
+description: Debug common issues in the vision-web Hive web app with known solutions and investigation patterns
 argument-hint: [issue-description]
 disable-model-invocation: true
 ---

--- a/.github/PUBLISHING.md
+++ b/.github/PUBLISHING.md
@@ -1,6 +1,6 @@
 # Package Publishing Guide
 
-This document explains how packages in the vision-next monorepo are published to npm.
+This document explains how packages in the vision-web monorepo are published to npm.
 
 ## Overview
 

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -51,7 +51,7 @@ jobs:
           download_translations: true
           # Strings live under a Crowdin branch (created by the old GitHub
           # integration); without this the CLI can't match files to crowdin.yml.
-          crowdin_branch_name: '[ecency.vision-next] develop'
+          crowdin_branch_name: '[ecency.vision-web] develop'
           # Use the develop checkout above as the base for l10n/crowdin. Without
           # this the action checks out the trigger PR's head ref, which fails (or
           # bases the translations PR on unrelated feature changes).

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -25,7 +25,7 @@ jobs:
           download_translations: false
           # Upload into the same Crowdin branch the translations live under, so
           # sources don't fork off into a separate branchless copy.
-          crowdin_branch_name: '[ecency.vision-next] develop'
+          crowdin_branch_name: '[ecency.vision-web] develop'
         env:
           CROWDIN_PROJECT_ID: "340923"
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -73,7 +73,7 @@ jobs:
           context: .
           file: ./apps/web/Dockerfile
           push: true
-          tags: ecency/vision-next:latest
+          tags: ecency/vision-web:latest
           build-args: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=ecency
@@ -156,12 +156,12 @@ jobs:
           export SEO_CRON_SECRET=$SEO_CRON_SECRET
           export SEO_BLACKLIST_URL=$SEO_BLACKLIST_URL
           export TURNSTILE_SECRET=$TURNSTILE_SECRET
-          cd ~/vision-next
+          cd ~/vision-web
           git pull origin main
           cd apps/web
           docker network inspect vision >/dev/null 2>&1 || docker network create --driver overlay vision
           docker pull ecency/api:latest
-          web_pull="$(docker pull ecency/vision-next:latest)"; printf '%s\n' "$web_pull"
+          web_pull="$(docker pull ecency/vision-web:latest)"; printf '%s\n' "$web_pull"
           STACK_FILE="$(mktemp)"; trap 'rm -f "$STACK_FILE"' EXIT
           docker-compose -f docker-compose.production.yml config > "$STACK_FILE"
           docker stack deploy -c "$STACK_FILE" vision
@@ -254,12 +254,12 @@ jobs:
           export SEO_BLACKLIST_URL=$SEO_BLACKLIST_URL
           export TURNSTILE_SECRET=$TURNSTILE_SECRET
           export WEB_REPLICAS=$WEB_REPLICAS
-          cd ~/vision-next
+          cd ~/vision-web
           git pull origin main
           cd apps/web
           docker network inspect vision >/dev/null 2>&1 || docker network create --driver overlay vision
           docker pull ecency/api:latest
-          web_pull="$(docker pull ecency/vision-next:latest)"; printf '%s\n' "$web_pull"
+          web_pull="$(docker pull ecency/vision-web:latest)"; printf '%s\n' "$web_pull"
           STACK_FILE="$(mktemp)"; trap 'rm -f "$STACK_FILE"' EXIT
           docker-compose -f docker-compose.production.yml config > "$STACK_FILE"
           docker stack deploy -c "$STACK_FILE" vision

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -76,7 +76,7 @@ jobs:
           context: .
           file: ./apps/web/Dockerfile
           push: true
-          tags: ecency/vision-next:develop
+          tags: ecency/vision-web:develop
           build-args: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=ecency
@@ -156,11 +156,11 @@ jobs:
           export SEO_CRON_SECRET=$SEO_CRON_SECRET
           export SEO_BLACKLIST_URL=$SEO_BLACKLIST_URL
           export TURNSTILE_SECRET=$TURNSTILE_SECRET
-          cd ~/vision-next
+          cd ~/vision-web
           git pull origin develop
           cd apps/web
           docker network create --driver overlay vision || true
-          web_pull="$(docker pull ecency/vision-next:develop)"; printf '%s\n' "$web_pull"
+          web_pull="$(docker pull ecency/vision-web:develop)"; printf '%s\n' "$web_pull"
           docker stack deploy -c <(docker-compose config) vision
           # Don't report a green deploy unless the new image actually rolled out.
           # `docker stack deploy` returns as soon as the spec is committed to Raft

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://discord.gg/WywwJEu">![Discord](https://img.shields.io/discord/385034494555455488?label=Ecency%20discord&logo=discord)</a> <a href="https://x.com/ecency_official">![Twitter Follow](https://img.shields.io/twitter/follow/ecency_official?style=social)</a> <a href="https://github.com/ecency/vision-next/stargazers">![GitHub Repo stars](https://img.shields.io/github/stars/ecency/vision-next?style=social)</a>
+<a href="https://discord.gg/WywwJEu">![Discord](https://img.shields.io/discord/385034494555455488?label=Ecency%20discord&logo=discord)</a> <a href="https://x.com/ecency_official">![Twitter Follow](https://img.shields.io/twitter/follow/ecency_official?style=social)</a> <a href="https://github.com/ecency/vision-web/stargazers">![GitHub Repo stars](https://img.shields.io/github/stars/ecency/vision-web?style=social)</a>
 
 # [Ecency vision][ecency_vision] – Ecency Web client
 
@@ -171,9 +171,9 @@ cookie**, and **preserve `x-cache-tier`** in the response headers.
 
 ##### Clone
 
-`$ git clone https://github.com/ecency/vision-next`
+`$ git clone https://github.com/ecency/vision-web`
 
-`$ cd vision-next`
+`$ cd vision-web`
 
 ### Working with pnpm
 
@@ -281,10 +281,10 @@ See `src/config/vision-config.template.yml`.
 ***
 ## Docker
 
-You can use official `ecency/vision-next:latest` image to run Vision locally, deploy it to staging or even production environment. The simplest way is to run it with following command:
+You can use official `ecency/vision-web:latest` image to run Vision locally, deploy it to staging or even production environment. The simplest way is to run it with following command:
 
 ```bash
-docker run -it --rm -p 3000:3000 ecency/vision-next:latest
+docker run -it --rm -p 3000:3000 ecency/vision-web:latest
 ```
 
 Configure the instance using following environment variables:
@@ -292,7 +292,7 @@ Configure the instance using following environment variables:
 - ~~`USE_PRIVATE`~~ See extended configuration above.
 
 ```bash
-docker run -it --rm -p 3000:3000 -e USE_PRIVATE=1 ecency/vision-next:latest
+docker run -it --rm -p 3000:3000 -e USE_PRIVATE=1 ecency/vision-web:latest
 ```
 
 ### Swarm
@@ -306,7 +306,7 @@ docker stack deploy -c docker-compose.yml -c docker-compose.production.yml visio
 ***
 ## Contributors
 
-[![Contributors](https://contrib.rocks/image?repo=ecency/vision-next)](https://github.com/ecency/vision-next/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=ecency/vision-web)](https://github.com/ecency/vision-web/graphs/contributors)
 
 
 ***
@@ -338,4 +338,4 @@ We will evaluate the risk and make a patch available before filing the issue.
 [//]: # "LINKS"
 [ecency_vision]: https://ecency.com
 [ecency_alpha]: https://alpha.ecency.com
-[ecency_release]: https://github.com/ecency/vision-next/releases
+[ecency_release]: https://github.com/ecency/vision-web/releases

--- a/apps/self-hosted/DEPLOYMENT.md
+++ b/apps/self-hosted/DEPLOYMENT.md
@@ -24,8 +24,8 @@ Deploy your own blog powered by the Hive blockchain. This guide covers Docker de
 
 ```bash
 # Clone the repository
-git clone https://github.com/ecency/vision-next.git
-cd vision-next/apps/self-hosted
+git clone https://github.com/ecency/vision-web.git
+cd vision-web/apps/self-hosted
 
 # Copy the config template
 cp config.template.json config.json
@@ -511,7 +511,7 @@ Memo: blog:YOUR_HIVE_USERNAME:6
 
 ## Support
 
-- GitHub Issues: https://github.com/ecency/vision-next/issues
+- GitHub Issues: https://github.com/ecency/vision-web/issues
 - Discord: https://discord.me/ecency
 - Hive: @ecency
 

--- a/apps/self-hosted/Dockerfile
+++ b/apps/self-hosted/Dockerfile
@@ -94,7 +94,7 @@ FROM nginx:alpine AS production
 # Add labels for container metadata
 LABEL org.opencontainers.image.title="Ecency Self-Hosted Blog"
 LABEL org.opencontainers.image.description="Self-hosted blog powered by Hive blockchain"
-LABEL org.opencontainers.image.source="https://github.com/ecency/vision-next"
+LABEL org.opencontainers.image.source="https://github.com/ecency/vision-web"
 LABEL org.opencontainers.image.vendor="Ecency"
 
 # Copy nginx configuration

--- a/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.service
+++ b/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Register managed-blog Hivesigner redirect URIs and enable the login method
-Documentation=https://github.com/ecency/vision-next/blob/develop/apps/self-hosted/hosting/README.md
+Documentation=https://github.com/ecency/vision-web/blob/develop/apps/self-hosted/hosting/README.md
 # Nothing to do without a network, and a run that fails on DNS is noise.
 After=network-online.target
 Wants=network-online.target

--- a/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.timer
+++ b/apps/self-hosted/hosting/scripts/hivesigner-redirect-uris.timer
@@ -1,6 +1,6 @@
 [Unit]
 Description=Periodic Hivesigner redirect-URI registration for managed blogs
-Documentation=https://github.com/ecency/vision-next/blob/develop/apps/self-hosted/hosting/README.md
+Documentation=https://github.com/ecency/vision-web/blob/develop/apps/self-hosted/hosting/README.md
 
 [Timer]
 # Five minutes, matching the two sync loops a new instance already waits on: the

--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -44,7 +44,7 @@ services:
       - vision
 
   web:
-    image: ecency/vision-next:latest
+    image: ecency/vision-web:latest
     stop_grace_period: 30s
     deploy:
       replicas: ${WEB_REPLICAS:-4}

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - vision
 
   web:
-    image: ecency/vision-next:develop
+    image: ecency/vision-web:develop
     stop_grace_period: 30s
     deploy:
       # Staging runs a single web replica — the staging environment serves

--- a/apps/web/src/app/(staticPages)/mobile/page.tsx
+++ b/apps/web/src/app/(staticPages)/mobile/page.tsx
@@ -75,7 +75,7 @@ export default function MobilePage() {
       external: false
     },
     {
-      href: "https://github.com/ecency/ecency-mobile",
+      href: "https://github.com/ecency/vision-mobile",
       label: i18next.t("static.mobile.resources.github"),
       external: true
     }

--- a/apps/web/src/app/_components/hiring-console-log.tsx
+++ b/apps/web/src/app/_components/hiring-console-log.tsx
@@ -18,7 +18,7 @@ export function HiringConsoleLog() {
       console.log(
         "%c%s",
         "font-size: 12px;",
-        "Are you developer, looking ways to contribute? Website is opensource: \nhttps://github.com/ecency/vision-next \n\n"
+        "Are you developer, looking ways to contribute? Website is opensource: \nhttps://github.com/ecency/vision-web \n\n"
       );
     }
   });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vision-next",
+  "name": "vision-web",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/render-helper/README.md
+++ b/packages/render-helper/README.md
@@ -19,7 +19,7 @@ Built and maintained by [Ecency](https://ecency.com), an open-source social plat
 - `pnpm publish:render-helper` - Manually publish to npm
 
 ### CI/CD
-- Part of vision-next monorepo with centralized GitHub Actions (`.github/workflows/packages.yml`)
+- Part of vision-web monorepo with centralized GitHub Actions (`.github/workflows/packages.yml`)
 - Automatically detects changes to `packages/render-helper/**` using git diff
 - On push to `develop` branch, builds and publishes to npm
 - Uses OIDC (OpenID Connect) for secure npm authentication
@@ -128,7 +128,7 @@ src/
 
 ## Build System
 
-- Uses **tsup** for bundling (shared with other vision-next packages)
+- Uses **tsup** for bundling (shared with other vision-web packages)
 - TypeScript 5.6+ with strict mode enabled
 - Outputs three bundles:
     - `dist/browser/index.js` - Browser ESM with TypeScript declarations
@@ -173,6 +173,6 @@ const summary = postBodySummary(entry, 200, 'react-native')
 - When adding embed support for new platforms, implement server-side rendering only
 - All external content must go through sanitization
 - Version bumps required for auto-publish via CI
-- Part of vision-next monorepo - changes require updating across dependent packages
+- Part of vision-web monorepo - changes require updating across dependent packages
 - The `@ecency/renderer` package uses this as a workspace dependency
 - Exports are optimized for tree-shaking with proper ESM structure

--- a/packages/render-helper/package.json
+++ b/packages/render-helper/package.json
@@ -5,12 +5,12 @@
   "description": "Markdown+Html Render helper",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ecency/vision-next.git",
+    "url": "https://github.com/ecency/vision-web.git",
     "directory": "packages/render-helper"
   },
   "homepage": "https://ecency.com",
   "bugs": {
-    "url": "https://github.com/ecency/vision-next/issues"
+    "url": "https://github.com/ecency/vision-web/issues"
   },
   "type": "module",
   "license": "MIT",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,12 +5,12 @@
   "description": "Ecency SDK",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ecency/vision-next.git",
+    "url": "https://github.com/ecency/vision-web.git",
     "directory": "packages/sdk"
   },
   "homepage": "https://ecency.com",
   "bugs": {
-    "url": "https://github.com/ecency/vision-next/issues"
+    "url": "https://github.com/ecency/vision-web/issues"
   },
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,12 +5,12 @@
   "description": "Shared UI components for Ecency applications",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ecency/vision-next.git",
+    "url": "https://github.com/ecency/vision-web.git",
     "directory": "packages/ui"
   },
   "homepage": "https://ecency.com",
   "bugs": {
-    "url": "https://github.com/ecency/vision-next/issues"
+    "url": "https://github.com/ecency/vision-web/issues"
   },
   "type": "module",
   "license": "MIT",

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -5,12 +5,12 @@
   "description": "Ecency wallets",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ecency/vision-next.git",
+    "url": "https://github.com/ecency/vision-web.git",
     "directory": "packages/wallets"
   },
   "homepage": "https://ecency.com",
   "bugs": {
-    "url": "https://github.com/ecency/vision-next/issues"
+    "url": "https://github.com/ecency/vision-web/issues"
   },
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Repository was renamed from `vision-next` to `vision-web` (with `ecency-mobile` becoming `vision-mobile`). This updates all self-references:

- CI: Docker Hub image tags `ecency/vision-web:latest|develop` and deploy path `~/vision-web` (server checkouts are already moved with a compatibility symlink, so deploys keep working before and after merge)
- Crowdin branch label `[ecency.vision-web] develop` (Crowdin-side branch renamed to match)
- npm package `repository`/`bugs` fields (required for provenance publishes) and changeset config
- README, PUBLISHING, deployment docs, skills, hiring console log, mobile repo link

Sentry project names and on-chain client-id strings (`ecency-mobile` in source-badge/specs) are intentionally unchanged.