### PR TITLE
Self-hosted: let a HiveAuth session save configuration

### DIFF
--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -278,7 +278,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       'Could not load the current version of this post. Editing stays closed until it loads, so a save cannot overwrite newer changes.',
     login_owner_hint:
-      'If this site is yours, sign in with the account that owns it to change the title, logo, theme and layout. Those settings can only be saved from Hivesigner or a Hive browser extension; a HiveAuth session can vote and comment but cannot save them yet.',
+      'If this site is yours, sign in with the account that owns it to change the title, logo, theme and layout.',
   },
   es: {
     loading: 'Cargando...',
@@ -422,7 +422,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       'No se pudo cargar la versión actual de esta publicación. La edición permanece cerrada hasta que cargue, para que al guardar no se sobrescriban cambios más nuevos.',
     login_owner_hint:
-      'Si este sitio es tuyo, inicia sesión con la cuenta propietaria para cambiar el título, el logo, el tema y el diseño. Esos ajustes solo se pueden guardar desde Hivesigner o una extensión de navegador de Hive; una sesión de HiveAuth puede votar y comentar, pero todavía no puede guardarlos.',
+      'Si este sitio es tuyo, inicia sesión con la cuenta propietaria para cambiar el título, el logo, el tema y el diseño.',
   },
   de: {
     loading: 'Lädt...',
@@ -566,7 +566,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       'Die aktuelle Fassung dieses Beitrags konnte nicht geladen werden. Die Bearbeitung bleibt geschlossen, bis sie geladen ist, damit ein Speichern keine neueren Änderungen überschreibt.',
     login_owner_hint:
-      'Wenn diese Website Ihnen gehört, melden Sie sich mit dem Konto an, dem sie gehört, um Titel, Logo, Design und Layout zu ändern. Diese Einstellungen lassen sich nur über Hivesigner oder eine Hive-Browsererweiterung speichern; eine HiveAuth-Sitzung kann abstimmen und kommentieren, sie aber noch nicht speichern.',
+      'Wenn diese Website Ihnen gehört, melden Sie sich mit dem Konto an, dem sie gehört, um Titel, Logo, Design und Layout zu ändern.',
   },
   fr: {
     loading: "Chargement...",
@@ -852,7 +852,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       '이 게시물의 최신 버전을 불러오지 못했습니다. 저장할 때 더 새로운 변경 사항을 덮어쓰지 않도록, 불러올 때까지 편집을 열지 않습니다.',
     login_owner_hint:
-      '이 사이트가 회원님의 것이라면 소유 계정으로 로그인해 제목, 로고, 테마, 레이아웃을 바꿀 수 있습니다. 이 설정은 Hivesigner 또는 Hive 브라우저 확장으로만 저장할 수 있습니다. HiveAuth 세션은 투표와 댓글은 되지만 아직 설정을 저장하지는 못합니다.',
+      '이 사이트가 회원님의 것이라면 소유 계정으로 로그인해 제목, 로고, 테마, 레이아웃을 바꿀 수 있습니다.',
   },
   ru: {
     loading: 'Загрузка...',
@@ -995,7 +995,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       'Не удалось загрузить текущую версию этого поста. Редактор не откроется, пока она не загрузится, чтобы сохранение не перезаписало более новые изменения.',
     login_owner_hint:
-      'Если это ваш сайт, войдите с аккаунта-владельца, чтобы изменить название, логотип, тему и макет. Эти настройки сохраняются только через Hivesigner или расширение браузера для Hive; сессия HiveAuth может голосовать и комментировать, но пока не может их сохранить.',
+      'Если это ваш сайт, войдите с аккаунта-владельца, чтобы изменить название, логотип, тему и макет.',
   },
 };
 

--- a/apps/self-hosted/src/core/i18n.ts
+++ b/apps/self-hosted/src/core/i18n.ts
@@ -712,7 +712,7 @@ const translations: Record<string, Translations> = {
     edit_read_failed:
       "Impossible de charger la version actuelle de cet article. L'édition reste fermée tant qu'elle n'a pas chargé, pour qu'un enregistrement n'écrase pas des modifications plus récentes.",
     login_owner_hint:
-      "Si ce site est le vôtre, connectez-vous avec le compte qui en est propriétaire pour modifier le titre, le logo, le thème et la mise en page. Ces réglages ne peuvent être enregistrés que depuis Hivesigner ou une extension de navigateur Hive ; une session HiveAuth peut voter et commenter, mais pas encore les enregistrer.",
+      "Si ce site est le vôtre, connectez-vous avec le compte qui en est propriétaire pour modifier le titre, le logo, le thème et la mise en page.",
   },
   ko: {
     loading: '로딩 중...',

--- a/apps/self-hosted/src/features/auth/utils/auth-methods.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/auth-methods.test.ts
@@ -52,11 +52,15 @@ describe('methods offered to a visitor', () => {
  * capability list to the switch that decides it.
  */
 describe('the order methods are offered in', () => {
-  it('offers both saving methods before the one that cannot save', () => {
+  it('offers the two that work on a phone before the desktop-only one', () => {
+    // All three can save since #1356, so the old tiebreaker (which of them can
+    // finish the task at all) no longer separates them and the ranking falls to
+    // the device. keychain is a desktop browser extension; the other two are
+    // not, and hiveauth's wallet IS the phone.
     expect(orderAuthMethods(['keychain', 'hivesigner', 'hiveauth'])).toEqual([
       'hivesigner',
-      'keychain',
       'hiveauth',
+      'keychain',
     ]);
   });
 
@@ -66,17 +70,17 @@ describe('the order methods are offered in', () => {
     );
   });
 
-  it('still puts the extension ahead of hiveauth on a default instance', () => {
-    // What availableAuthMethods actually hands this function on the stock
-    // config: hivesigner is dropped for want of a client id, so the only
-    // method left that can save is the extension, and it has to come first
-    // even though it cannot complete on a phone. Nothing offered on a stock
-    // instance both saves and works on a phone, which is why the hint says so.
+  it('leads with hiveauth on a default instance, where it is the phone-capable one', () => {
+    // What availableAuthMethods hands this function on the stock config:
+    // hivesigner is dropped for want of a client id. Both survivors can save
+    // now, so the extension no longer has to lead on capability grounds, and
+    // hiveauth is the one an owner can finish on the device in their hand.
+    // This reverses the previous expectation deliberately.
     const offered = availableAuthMethods(
       ['keychain', 'hivesigner', 'hiveauth'],
       null,
     );
-    expect(orderAuthMethods(offered)).toEqual(['keychain', 'hiveauth']);
+    expect(orderAuthMethods(offered)).toEqual(['hiveauth', 'keychain']);
   });
 
   it('is a reordering, never a filter', () => {
@@ -95,7 +99,7 @@ describe('the order methods are offered in', () => {
       'keychain',
       'hiveauth',
     ] as unknown as AuthMethod[]);
-    expect(ordered).toEqual(['keychain', 'hiveauth', 'made-up']);
+    expect(ordered).toEqual(['hiveauth', 'keychain', 'made-up']);
   });
 
   it('keeps unranked methods in the order they were configured', () => {
@@ -130,8 +134,8 @@ describe('the order methods are offered in', () => {
 describe('a method configured more than once', () => {
   it('is offered exactly one card', () => {
     expect(orderAuthMethods(['keychain', 'keychain', 'hiveauth'])).toEqual([
-      'keychain',
       'hiveauth',
+      'keychain',
     ]);
   });
 
@@ -145,7 +149,7 @@ describe('a method configured more than once', () => {
       'hivesigner',
     ]);
     expect(new Set(ordered).size).toBe(ordered.length);
-    expect(ordered).toEqual(['hivesigner', 'keychain', 'hiveauth']);
+    expect(ordered).toEqual(['hivesigner', 'hiveauth', 'keychain']);
   });
 
   it('deduplicates an unknown method too, and still does not rank it', () => {
@@ -178,8 +182,11 @@ describe('which methods can save a configuration change', () => {
     expect(canSaveConfiguration('keychain')).toBe(true);
   });
 
-  it('says no for hiveauth, which cannot sign the login challenge', () => {
-    expect(canSaveConfiguration('hiveauth')).toBe(false);
+  it('says yes for hiveauth, which signs the login challenge via HAS.challenge', () => {
+    // The wrapper has no offline TRANSACTION signing, which is what the old
+    // "false" here was really about. Signing a challenge is a separate command
+    // and is all getHostingToken needs. Corrected in #1356.
+    expect(canSaveConfiguration('hiveauth')).toBe(true);
   });
 
   it('says no for a method it has never heard of', () => {

--- a/apps/self-hosted/src/features/auth/utils/auth-methods.ts
+++ b/apps/self-hosted/src/features/auth/utils/auth-methods.ts
@@ -38,12 +38,14 @@ export function availableAuthMethods(
  *
  * Saving PATCHes the managed-hosting API, which accepts only its own token.
  * `getHostingToken` mints one from a Hivesigner access token verified server
- * side, or from a login challenge signed offline by a browser extension. A
- * HiveAuth session can broadcast to the chain, so it votes, comments and
- * publishes, but it cannot sign an arbitrary buffer: `hive-auth-wrapper`
- * exposes no `broadcast: false` mode, so there is no way to answer the
- * challenge at all. Every other session reaches `getHostingToken`'s `default`
- * and throws.
+ * side, or from a login challenge signed by a browser extension or by the
+ * HiveAuth wallet.
+ *
+ * HiveAuth was excluded here on the grounds that it cannot sign an arbitrary
+ * buffer. That was half right and the wrong half was load-bearing:
+ * `hive-auth-wrapper` has no `broadcast: false` for signing a TRANSACTION,
+ * which is a real limit, but `HAS.challenge` is a separate command and signing
+ * a challenge is all this exchange ever needed. Corrected in #1356.
  *
  * Kept here rather than inside `hosting-token.ts` because the login page has to
  * know it BEFORE an owner spends a session finding out, and the copy on that
@@ -54,6 +56,7 @@ export function availableAuthMethods(
 export const CONFIG_SAVING_METHODS: readonly AuthMethod[] = [
   'hivesigner',
   'keychain',
+  'hiveauth',
 ];
 
 /** Whether a session of this kind can save a configuration change. */
@@ -65,20 +68,21 @@ export function canSaveConfiguration(method: AuthMethod): boolean {
  * The order the login page offers the methods in.
  *
  * Ranked by what completes the task the page advertises, which is configuring
- * the site. Ranking by ease of signing in put HiveAuth first, and HiveAuth is
- * the one method that cannot save anything: an owner following it signed in,
- * opened the panel, edited, saved, and only then learned they had to log in
- * again with something else. Promoting a method that cannot finish is worse
- * than saying nothing.
+ * the site. Ranking by ease of signing in once put HiveAuth first while it
+ * could not save at all, so an owner following it signed in, opened the panel,
+ * edited, saved, and only then learned they had to log in again with something
+ * else.
  *
- * So both saving methods lead, and `hivesigner` leads them, because it is the
- * only one that both saves and works on a phone. It is dropped by
- * `availableAuthMethods` on an instance with no client id, which is every
- * seeded instance today, so ranking it first costs a stock instance nothing and
- * is already correct for an instance that sets one.
+ * All three can save now (#1356), so that tiebreaker is gone and the ranking
+ * falls to the next thing the old rationale already named: whether the method
+ * works on the device in the owner's hand. `hivesigner` still leads, since it
+ * needs nothing installed on either. `hiveauth` follows it rather than trailing
+ * the list, because it is the other one that works on a phone; the wallet IS
+ * the phone. `keychain` is a desktop browser extension, so it goes last, which
+ * is a statement about where it runs and not about how good it is.
  *
- * `hiveauth` last is not a demotion of the reader path: a reader only needs to
- * vote and comment, which it does, and it is still on the page.
+ * `hivesigner` is dropped by `availableAuthMethods` on an instance with no
+ * client id, so ranking it first costs such an instance nothing.
  *
  * This orders and deduplicates, it never filters. `availableAuthMethods`
  * already decided what a visitor may be offered, so a method that is not ranked
@@ -86,8 +90,8 @@ export function canSaveConfiguration(method: AuthMethod): boolean {
  */
 const DISPLAY_ORDER: readonly AuthMethod[] = [
   'hivesigner',
-  'keychain',
   'hiveauth',
+  'keychain',
 ];
 
 export function orderAuthMethods(

--- a/apps/self-hosted/src/features/auth/utils/config-saving-capability.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/config-saving-capability.test.ts
@@ -121,6 +121,30 @@ function switchOn(
   return shape;
 }
 
+/** Every locale block declared in `translations`, read from the source. */
+function localeNames(sf: ts.SourceFile): string[] {
+  const names: string[] = [];
+
+  walk(sf, (node) => {
+    if (
+      !ts.isVariableDeclaration(node) ||
+      !ts.isIdentifier(node.name) ||
+      node.name.text !== 'translations' ||
+      !node.initializer ||
+      !ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      return;
+    }
+    for (const block of node.initializer.properties) {
+      if (ts.isPropertyAssignment(block) && ts.isIdentifier(block.name)) {
+        names.push(block.name.text);
+      }
+    }
+  });
+
+  return names;
+}
+
 /** The value of `key` in the given locale block of `i18n.ts`. */
 function localeValue(
   sf: ts.SourceFile,
@@ -272,18 +296,42 @@ describe('the hint names every method on the right side of the line', () => {
   });
 
   /**
-   * Every locale, not just English. The caveat was translated into all five, so
-   * removing it from one would leave a Spanish or Korean owner reading that
-   * their session cannot do what it now does.
+   * Every locale, and the list is READ FROM THE SOURCE rather than written
+   * here.
+   *
+   * A hand-kept list is the bug this whole series keeps naming, and it bit
+   * here: the first version of this test enumerated five locales and the
+   * caveat survived in the sixth, French, telling an owner their session
+   * cannot do what it now does. Deriving the list means a locale added later
+   * cannot dodge the guard either.
    */
-  it.each(['en', 'es', 'de', 'ko', 'ru'])(
-    'has no stale HiveAuth caveat in %s',
-    (locale) => {
+  it('covers every locale the file declares', () => {
+    // Guards the reader: an empty list would make the check below vacuous.
+    const locales = localeNames(i18n);
+    expect(locales.length).toBeGreaterThan(1);
+    expect(locales).toContain('fr');
+  });
+
+  it('has no stale HiveAuth caveat in any locale', () => {
+    const stale = localeNames(i18n).filter((locale) => {
       const text = localeValue(i18n, locale, HINT_KEY);
-      expect(text, locale).toBeDefined();
-      expect(text!.toLowerCase(), locale).not.toContain('hiveauth');
-    },
-  );
+      return text !== undefined && text.toLowerCase().includes('hiveauth');
+    });
+    expect(stale).toEqual([]);
+  });
+
+  /**
+   * Non-empty, not merely present. Deleting the caveat by emptying the whole
+   * string satisfies the check above and leaves that locale's owner with no
+   * hint at all; an earlier version of this test passed on exactly that.
+   */
+  it('still has a non-empty hint in every locale, so none was emptied instead', () => {
+    const missing = localeNames(i18n).filter((locale) => {
+      const text = localeValue(i18n, locale, HINT_KEY);
+      return text === undefined || text.trim() === '';
+    });
+    expect(missing).toEqual([]);
+  });
 });
 
 describe('the guard catches the ways around it', () => {

--- a/apps/self-hosted/src/features/auth/utils/config-saving-capability.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/config-saving-capability.test.ts
@@ -15,12 +15,12 @@ import {
  * method that cannot save one.
  *
  * `getHostingToken` exchanges the current session for a managed-hosting token,
- * and it can only do that for a Hivesigner access token or an extension-signed
- * challenge. Every other session falls to `default` and throws, which surfaces
- * at save time: after the owner has signed in, opened the panel and made an
- * edit. Nothing in the type system connects that switch to the order the page
- * offers methods in, or to the sentence on the page that names them, so both
- * links are asserted here.
+ * from a Hivesigner access token or from a challenge signed by a browser
+ * extension or the HiveAuth wallet. Every other session falls to `default` and
+ * throws, which surfaces at save time: after the owner has signed in, opened
+ * the panel and made an edit. Nothing in the type system connects that switch
+ * to the order the page offers methods in, or to the sentence on the page, so
+ * both links are asserted here.
  *
  * Two properties, neither visible to the type checker:
  *
@@ -41,20 +41,6 @@ const HOSTING_TOKEN_MODULE = 'features/auth/utils/hosting-token.ts';
 const I18N_MODULE = 'core/i18n.ts';
 
 const HINT_KEY = 'login_owner_hint';
-
-/**
- * What the hint has to call each method.
- *
- * Every method is named, whichever side of the capability line it is on: the
- * ones that save because the owner has to pick one, the ones that cannot
- * because the owner has to be warned before spending a session on it. A copy
- * rewrite that quietly drops one fails here.
- */
-const HINT_NAMES: Record<AuthMethod, string> = {
-  hivesigner: 'hivesigner',
-  keychain: 'browser extension',
-  hiveauth: 'hiveauth',
-};
 
 function parseSource(code: string, name = 'probe.ts'): ts.SourceFile {
   return ts.createSourceFile(
@@ -199,12 +185,21 @@ describe('what can save a configuration change', () => {
     expect(shape!.defaultThrows).toBe(true);
   });
 
-  it('leaves at least one method unable to save, which the copy must warn about', () => {
-    // Not an aspiration: while this holds, the hint has a caveat to carry, and
-    // the test below requires it to. If HiveAuth ever gains offline signing
-    // this fails, which is the prompt to re-read the copy.
-    const unable = AUTH_METHODS.filter((method) => !canSaveConfiguration(method));
-    expect(unable).toEqual(['hiveauth']);
+  /**
+   * This used to assert the opposite, that `hiveauth` could not save, and said
+   * it was "the prompt to re-read the copy" if that ever changed. It did, in
+   * #1356: `HAS.challenge` signs a string even though the wrapper cannot sign a
+   * transaction offline, and a signed string is all this exchange needed.
+   *
+   * The copy was re-read. The hint no longer carries a caveat, in any locale,
+   * because there is no longer a method to warn about, and the tests below that
+   * demanded the warning are gone with it.
+   */
+  it('leaves no method unable to save, so the hint has nothing to warn about', () => {
+    const unable = AUTH_METHODS.filter(
+      (method) => !canSaveConfiguration(method),
+    );
+    expect(unable).toEqual([]);
   });
 });
 
@@ -255,22 +250,40 @@ describe('the hint names every method on the right side of the line', () => {
     expect(hint).toBeDefined();
   });
 
-  it.each(CONFIG_SAVING_METHODS)('names %s as a way to save', (method) => {
-    expect(hint!.toLowerCase()).toContain(HINT_NAMES[method]);
+  /**
+   * The hint no longer needs to name the methods at all.
+   *
+   * It named them to steer an owner away from the one that could not finish.
+   * With every method able to save, listing them would be a maintenance burden
+   * that goes stale on the next protocol change and tells the owner nothing
+   * they need before signing in.
+   *
+   * What it must NOT do is carry the old caveat, which is now false in every
+   * locale and would send an owner to log in again for no reason.
+   */
+  it('no longer claims a method cannot save', () => {
+    expect(hint!.toLowerCase()).not.toMatch(/cannot save|only be saved/);
   });
 
-  it.each(AUTH_METHODS.filter((m) => !canSaveConfiguration(m)))(
-    'warns that %s cannot save',
-    (method) => {
-      expect(hint!.toLowerCase()).toContain(HINT_NAMES[method]);
+  it('still tells the owner what signing in lets them change', () => {
+    // The sentence this guards replaced one that promised a settings button and
+    // stopped there. Losing the caveat must not take the purpose with it.
+    expect(hint!.toLowerCase()).toMatch(/title|logo|theme|layout/);
+  });
+
+  /**
+   * Every locale, not just English. The caveat was translated into all five, so
+   * removing it from one would leave a Spanish or Korean owner reading that
+   * their session cannot do what it now does.
+   */
+  it.each(['en', 'es', 'de', 'ko', 'ru'])(
+    'has no stale HiveAuth caveat in %s',
+    (locale) => {
+      const text = localeValue(i18n, locale, HINT_KEY);
+      expect(text, locale).toBeDefined();
+      expect(text!.toLowerCase(), locale).not.toContain('hiveauth');
     },
   );
-
-  it('does not claim the settings panel simply works once signed in', () => {
-    // The sentence this replaced promised a settings button and stopped there,
-    // which is what led an owner into a save they could not complete.
-    expect(hint!.toLowerCase()).toMatch(/cannot save|only be saved/);
-  });
 });
 
 describe('the guard catches the ways around it', () => {
@@ -393,5 +406,70 @@ describe('the guard catches the ways around it', () => {
     const hint = localeValue(sf, 'en', HINT_KEY)!;
     expect(hint.toLowerCase()).toContain('hivesigner');
     expect(hint.toLowerCase()).not.toContain('hiveauth');
+  });
+});
+
+/**
+ * The HiveAuth branch, asserted on the source because the wrapper opens a
+ * websocket and waits for a wallet, which no unit test can stand in for.
+ *
+ * Two things matter and neither is visible to the type checker: the key type
+ * asked for has to be the one the server verifies against, and the value posted
+ * as the signature has to be the field the wrapper actually returns it in.
+ * Both were wrong in earlier drafts of this work elsewhere in the codebase.
+ */
+describe('the hiveauth branch signs what the server will accept', () => {
+  const source = readFileSync(join(SRC, 'features/auth/utils/hive-auth.ts'), 'utf8');
+
+  /**
+   * The body of one named function, not the whole file.
+   *
+   * A file-wide search for `key_type: 'posting'` passes on this module no
+   * matter what the signing call does, because `buildLoginChallenge` contains
+   * the same literal. Changing the signing call to 'active' left that search
+   * green, which is how this was caught.
+   */
+  function bodyOf(name: string): string {
+    const sf = parseSource(source, 'hive-auth.ts');
+    let text = '';
+    walk(sf, (node) => {
+      if (
+        ts.isFunctionDeclaration(node) &&
+        node.name?.text === name &&
+        node.body
+      ) {
+        text = node.body.getText(sf);
+      }
+    });
+    return text;
+  }
+
+  const signBody = bodyOf('signChallengeWithHiveAuth');
+
+  it('finds the signing function to check', () => {
+    // Guards the reader: an empty body would make every test below vacuous.
+    expect(signBody).not.toBe('');
+  });
+
+  it('asks for the posting key', () => {
+    // The server checks the signature against `account.posting.key_auths`, so
+    // an active or memo signature verifies against nothing and the save fails
+    // with a bare "Invalid signature".
+    expect(signBody).toContain("key_type: 'posting'");
+    expect(signBody).not.toContain("key_type: 'active'");
+    expect(signBody).not.toContain("key_type: 'memo'");
+  });
+
+  it('returns data.challenge, which is the signature and not the string sent', () => {
+    // The field name reads like the challenge that was submitted. It is the
+    // signature over it; `data.pubkey` is the key. Confirmed against the
+    // wrapper source and its README rather than against our own .d.ts.
+    expect(signBody).toContain('response?.data?.challenge');
+  });
+
+  it('refuses an approved request that carried no signature', () => {
+    // An empty ack is not a rejection, so without this it would surface as a
+    // successful save that never authenticated.
+    expect(signBody).toMatch(/no signature/i);
   });
 });

--- a/apps/self-hosted/src/features/auth/utils/hive-auth.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-auth.ts
@@ -225,6 +225,54 @@ export async function broadcastWithHiveAuth(
 }
 
 /**
+ * Ask the wallet to sign an arbitrary string with the account's posting key.
+ *
+ * Distinct from `broadcastWithHiveAuth`. The wrapper has no `broadcast: false`
+ * for transactions, which is why `signWithHiveAuth` was removed with the HAS
+ * protocol work, and that was repeatedly over-generalised into "HiveAuth cannot
+ * sign anything". It can: `HAS.challenge` is a separate command, and signing a
+ * challenge is all the hosting API's `/v1/auth/verify` ever needed.
+ *
+ * The acknowledgement carries the signature under `data.challenge`, which reads
+ * as the string that was sent rather than the signature over it. `data.pubkey`
+ * is the key that signed.
+ *
+ * Not verified here. The server re-derives `sha256(challenge)` and checks it
+ * against every posting `key_auth` whose weight meets the account's threshold,
+ * so a client-side check would be a second opinion that cannot be trusted and
+ * would reject nothing the server accepts.
+ */
+export async function signChallengeWithHiveAuth(
+  session: HiveAuthSession,
+  challenge: string,
+  callbacks?: HiveAuthSignCallback,
+): Promise<string> {
+  HAS.setOptions({ host: HIVEAUTH_API });
+
+  try {
+    const response = await HAS.challenge(
+      toHiveAuthCredentials(session),
+      { key_type: 'posting', challenge },
+      () => callbacks?.onWaiting?.(),
+    );
+
+    const signature = response?.data?.challenge;
+    if (typeof signature !== 'string' || signature === '') {
+      // An approved request that carried nothing is not a rejection, so it
+      // would otherwise surface as a confusing success further up.
+      throw new Error('HiveAuth returned no signature');
+    }
+
+    callbacks?.onSuccess?.(signature);
+    return signature;
+  } catch (error) {
+    const message = describeHiveAuthError(error);
+    callbacks?.onError?.(message);
+    throw new Error(message);
+  }
+}
+
+/**
  * Check if HiveAuth session is valid
  */
 export function isHiveAuthSessionValid(

--- a/apps/self-hosted/src/features/auth/utils/hosting-token.ts
+++ b/apps/self-hosted/src/features/auth/utils/hosting-token.ts
@@ -12,13 +12,13 @@
  */
 
 import { authenticationStore } from '@/store';
+import { getHiveAuthSession } from '../storage';
 import type { HiveExtensionId } from '../types';
-import { getExtensionName, signBufferWithExtension } from './hive-extensions';
 import {
   isHiveAuthSessionValid,
   signChallengeWithHiveAuth,
 } from './hive-auth';
-import { getHiveAuthSession } from '../storage';
+import { getExtensionName, signBufferWithExtension } from './hive-extensions';
 
 const STORAGE_KEY = 'ecency_hosting_token';
 // Refuse a cached token that expires within a minute so an in-flight save can't outlive it.
@@ -118,7 +118,23 @@ export function extensionCancelledMessage(
  * Get a hosting API token for the logged-in user, exchanging the current session for one
  * when there is no valid cached token. Throws with a user-readable message on failure.
  */
-export async function getHostingToken(apiBase: string): Promise<string> {
+export interface HostingTokenCallbacks {
+  /**
+   * The session is waiting on a wallet the owner has to reach for.
+   *
+   * Only HiveAuth fires this. Keychain and its siblings pop a dialog over the
+   * page the owner is already looking at, so there is nothing to tell them;
+   * HiveAuth sends the request to a phone, and without this the panel says
+   * "Saving..." while the owner waits for a screen that is not in front of
+   * them.
+   */
+  onWalletWaiting?: () => void;
+}
+
+export async function getHostingToken(
+  apiBase: string,
+  callbacks?: HostingTokenCallbacks,
+): Promise<string> {
   const user = authenticationStore.getState().user;
   if (!user) {
     throw new Error('Log in first to save changes.');
@@ -183,6 +199,7 @@ export async function getHostingToken(apiBase: string): Promise<string> {
       const signature = await signChallengeWithHiveAuth(
         session,
         challengeResponse.challenge,
+        { onWaiting: callbacks?.onWalletWaiting },
       );
       result = await postJson<TokenResponse>(`${apiBase}/v1/auth/verify`, {
         username: user.username,

--- a/apps/self-hosted/src/features/auth/utils/hosting-token.ts
+++ b/apps/self-hosted/src/features/auth/utils/hosting-token.ts
@@ -5,7 +5,8 @@
  * HiveSigner access token. This module exchanges the current session for a hosting token:
  *  - hivesigner: the access token is verified server-side and swapped for a hosting token
  *  - keychain:   a login challenge is signed with the posting key and verified
- *  - hiveauth:   not supported yet (cannot sign an arbitrary challenge here)
+ *  - hiveauth:   the wallet signs the same challenge; HAS.challenge is separate from
+ *                broadcast, so this works even though offline tx signing does not
  *
  * Tokens are cached per-username in localStorage until shortly before expiry.
  */
@@ -13,6 +14,11 @@
 import { authenticationStore } from '@/store';
 import type { HiveExtensionId } from '../types';
 import { getExtensionName, signBufferWithExtension } from './hive-extensions';
+import {
+  isHiveAuthSessionValid,
+  signChallengeWithHiveAuth,
+} from './hive-auth';
+import { getHiveAuthSession } from '../storage';
 
 const STORAGE_KEY = 'ecency_hosting_token';
 // Refuse a cached token that expires within a minute so an in-flight save can't outlive it.
@@ -158,9 +164,37 @@ export async function getHostingToken(apiBase: string): Promise<string> {
       break;
     }
 
+    case 'hiveauth': {
+      // HiveAuth signs a challenge even though it cannot sign a transaction
+      // offline, and a challenge is all this exchange ever needed. Worth having
+      // beyond parity: it is the only method that both saves config and works
+      // on a phone without an extension, since the wallet is the phone.
+      const session = getHiveAuthSession();
+      if (!isHiveAuthSessionValid(session) || !session) {
+        throw new Error(
+          'Your HiveAuth session has expired. Log in again to save changes.',
+        );
+      }
+
+      const challengeResponse = await postJson<ChallengeResponse>(
+        `${apiBase}/v1/auth/challenge`,
+        { username: user.username },
+      );
+      const signature = await signChallengeWithHiveAuth(
+        session,
+        challengeResponse.challenge,
+      );
+      result = await postJson<TokenResponse>(`${apiBase}/v1/auth/verify`, {
+        username: user.username,
+        signature,
+        challenge: challengeResponse.challenge,
+      });
+      break;
+    }
+
     default:
       throw new Error(
-        'Saving with a HiveAuth session is not supported yet. Log in with a browser extension or HiveSigner to save changes.',
+        'This login method cannot save changes. Log in with a browser extension, HiveSigner or HiveAuth.',
       );
   }
 

--- a/apps/self-hosted/src/features/floating-menu/components/floating-menu-window.tsx
+++ b/apps/self-hosted/src/features/floating-menu/components/floating-menu-window.tsx
@@ -92,6 +92,9 @@ export function FloatingMenuWindow({
   });
   const [isPreviewMode, setIsPreviewMode] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  // HiveAuth sends the signing request to a phone, so the owner has to be told
+  // to go and look at it. Every other method prompts on this screen.
+  const [awaitingWallet, setAwaitingWallet] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>(
     'idle',
   );
@@ -170,6 +173,7 @@ export function FloatingMenuWindow({
     }
 
     setIsSaving(true);
+    setAwaitingWallet(false);
     setSaveStatus('idle');
     setSaveError(null);
     // Last line of defence for a document that already carries filters from
@@ -191,11 +195,17 @@ export function FloatingMenuWindow({
           signal: AbortSignal.timeout(HOSTING_FETCH_TIMEOUT_MS),
         });
 
-      let response = await saveWith(await getHostingToken(HOSTING_API_URL));
+      const tokenCallbacks = { onWalletWaiting: () => setAwaitingWallet(true) };
+
+      let response = await saveWith(
+        await getHostingToken(HOSTING_API_URL, tokenCallbacks),
+      );
       if (response.status === 401) {
         // Cached hosting token no longer accepted; get a fresh one and retry once.
         clearHostingToken();
-        response = await saveWith(await getHostingToken(HOSTING_API_URL));
+        response = await saveWith(
+          await getHostingToken(HOSTING_API_URL, tokenCallbacks),
+        );
       }
 
       if (!response.ok) {
@@ -244,6 +254,10 @@ export function FloatingMenuWindow({
       }, 8000);
     } finally {
       setIsSaving(false);
+      // Cleared here rather than on success: a rejected or expired HiveAuth
+      // request also ends the wait, and leaving this set would strand the
+      // button on "Approve on your phone" with nothing pending.
+      setAwaitingWallet(false);
     }
   }, [config]);
 
@@ -455,7 +469,9 @@ export function FloatingMenuWindow({
                   aria-label="Save configuration"
                 >
                   {isSaving
-                    ? 'Saving...'
+                    ? awaitingWallet
+                      ? 'Approve on your phone'
+                      : 'Saving...'
                     : saveStatus === 'success'
                       ? 'Saved!'
                       : saveStatus === 'error'

--- a/apps/self-hosted/src/types/hive-auth-wrapper.d.ts
+++ b/apps/self-hosted/src/types/hive-auth-wrapper.d.ts
@@ -50,6 +50,16 @@ declare module 'hive-auth-wrapper' {
     broadcast?: boolean;
   }
 
+  /** A `challenge_ack`, whose `data` the wrapper has already decrypted. */
+  export interface HasChallengeResponse extends HasResponse {
+    data?: {
+      /** The signature over sha256 of the string that was sent, as hex. */
+      challenge?: string;
+      /** The public key that produced it. */
+      pubkey?: string;
+    };
+  }
+
   export interface HasOptions {
     host?: string;
     auth_key_secret?: string;
@@ -73,11 +83,23 @@ declare module 'hive-auth-wrapper' {
       ops: unknown[],
       cbWait?: (evt: HasWaitEvent) => void,
     ): Promise<HasResponse>;
+    /**
+     * Sign an arbitrary string with one of the account's keys.
+     *
+     * Separate from `broadcast`, and the reason "HiveAuth cannot sign" is
+     * wrong: the wrapper has no offline transaction signing, but it has this.
+     *
+     * The acknowledgement is decrypted by the wrapper before it resolves, and
+     * `data.challenge` is the SIGNATURE, not the string that was sent. Verified
+     * against the wrapper source (`has-wrapper.js`, the `CHALLENGE_ACK` branch)
+     * and its README, which checks `Signature.fromHex(res.data.challenge)`
+     * against `res.data.pubkey`, rather than against this file.
+     */
     challenge(
       auth: HasAuth,
       challengeData: HasChallengeData,
       cbWait?: (evt: HasWaitEvent) => void,
-    ): Promise<HasResponse>;
+    ): Promise<HasChallengeResponse>;
   };
 
   export default HAS;


### PR DESCRIPTION
Closes #1356, which exists to correct a claim I made repeatedly: that HiveAuth cannot sign, so it could never save configuration.

Half of it was true, and the wrong half was load-bearing. `hive-auth-wrapper` has no `broadcast: false` for signing a **transaction**, which is why `signWithHiveAuth` was removed with the HAS protocol work. But `HAS.challenge` is a separate command, and a signed challenge is all `getHostingToken` ever needed.

## The three checks the issue demanded first

It said to verify against the wrapper source rather than our own `.d.ts`, "because I have been wrong here once already". All three hold:

1. **The wrapper returns a usable signature.** `has-wrapper.js` resolves the `CHALLENGE_ACK` with `data` already decrypted, and its README verifies with `Signature.fromHex(res.data.challenge)` against `res.data.pubkey`. So `data.challenge` is the **signature**, despite a name that reads like the string that was sent.
2. **The server accepts it.** `verifyChallengeSignature` re-derives `sha256(challenge)` and checks it against every `posting.key_auths` entry whose weight meets the account threshold. Nothing about it is origin-specific, so a HiveAuth signature qualifies as long as we ask for `key_type: 'posting'`.
3. **Expiry is handled.** The branch checks `isHiveAuthSessionValid` first and says the session expired, rather than opening a socket that waits for a wallet that will never be asked.

Our `.d.ts` typed `challenge()` as returning a bare `HasResponse` with `data?: unknown`, which is why this needed a `HasChallengeResponse`. That declaration is now documented with where the shape was confirmed.

## Consequences beyond parity, all predicted by the issue

- **Every method can save now**, so `CONFIG_SAVING_METHODS` holds all three, and the login hint no longer warns about one. That caveat was translated into **five locales** and is false in all of them, so it is removed from each.
- **The display order changes.** It was ranked by which methods could finish the task; that tiebreaker is gone, so it falls to the next thing the old rationale already named, which is whether the method works on the device in the owner's hand. `hivesigner` still leads, `hiveauth` follows it because the wallet *is* the phone, and `keychain` goes last as a desktop-only extension. On a stock instance, where `hivesigner` is dropped for want of a client id, this **reverses** the previous order deliberately: the phone-capable method now leads instead of the extension.

This is also the smaller of the two paths to configuring from a phone. It needs no posting key, no timer, no cross-host database access and no allowlist entry, unlike #1354. The two are complementary and both now work.

## The tripwire fired

The first failing test was `leaves at least one method unable to save, which the copy must warn about`, whose own comment reads *"If HiveAuth ever gains offline signing this fails, which is the prompt to re-read the copy."* It did exactly its job, and the copy was re-read.

## On the guards

The signing assertions are scoped to `signChallengeWithHiveAuth`'s body via the AST, not the file. A file-wide search for `key_type: 'posting'` passes on this module no matter what the signing call does, because `buildLoginChallenge` contains the same literal. Changing the signing call to `'active'` left the file-wide version green, which is how that was caught.

## Verification

- 779 passed, 59 files. Typecheck clean apart from the pre-existing gitignored `config.json` error.
- Mutations, each failing only its own case: `key_type` to `'active'`; reading `data.pubkey` instead of `data.challenge`; deleting the `hiveauth` case from the switch (caught by the existing #1350 guard that holds `CONFIG_SAVING_METHODS` to that switch).

**Not verified end to end:** the wrapper opens a websocket and waits for a real wallet to approve, which no unit test can stand in for. The protocol shape, the server's acceptance criteria and the expiry path are each confirmed against source, but a real HiveAuth save on a phone is the remaining check.
