### PR TITLE
Self-hosted: have the signer report which wallet actually signed

### DIFF
--- a/apps/self-hosted/src/features/auth/auth-actions.ts
+++ b/apps/self-hosted/src/features/auth/auth-actions.ts
@@ -52,16 +52,28 @@ export async function login(
 
       // Prove control of a posting key by signing a throwaway challenge.
       const challenge = `Login to Ecency Blog: ${Date.now()}`;
-      await signBufferWithExtension(username, challenge, 'Posting', chosen);
+      const signed = await signBufferWithExtension(
+        username,
+        challenge,
+        'Posting',
+        chosen,
+      );
+
+      // The wallet that signed, not the one asked for. `chosen` can name an
+      // extension that is no longer installed, in which case the request fell
+      // through to auto-detect and a different wallet prompted. Recording the
+      // asked-for one would persist a preference the browser cannot honour,
+      // and every later message about signing would name it.
+      const signer = signed.extension;
 
       const newUser: AuthUser = {
         username,
         loginType: 'keychain',
-        ...(chosen ? { extension: chosen } : {}),
+        extension: signer,
       };
       setUser(newUser);
       saveUser(newUser);
-      if (chosen) setPreferredExtensionId(username, chosen);
+      setPreferredExtensionId(username, signer);
       break;
     }
 

--- a/apps/self-hosted/src/features/auth/utils/extension-labels.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/extension-labels.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import ts from 'typescript';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   BROWSER_EXTENSION_LABEL,
   callbackCapableExtensions,
@@ -9,9 +9,11 @@ import {
   getDetectedExtensions,
   getExtensionName,
   hasKeychainLikeExtension,
+  signBufferWithExtension,
   VALID_EXTENSION_IDS,
   type DetectedExtension,
 } from './hive-extensions';
+import { extensionCancelledMessage } from './hosting-token';
 
 /**
  * `keychain` is the login type for every Hive wallet extension, not the
@@ -250,5 +252,170 @@ describe('the payment dialog labels from the list it gates on', () => {
     visit(file);
 
     expect(argumentSources).toEqual(['callbackCapableExtensions()']);
+  });
+});
+
+/**
+ * Which wallet actually signed, as opposed to which one was asked for.
+ *
+ * `signBufferWithExtension` takes a preferred id, and when that wallet has been
+ * uninstalled mid-session it falls through to Keeper-first detection rather
+ * than failing. The caller then knows only the id it passed in, so a message
+ * about the prompt the user just saw named a wallet they no longer have. That
+ * is the same wrong-name class #1360 and #1362 fixed on other surfaces, and the
+ * only one those could not reach, because it is not a hardcoded string.
+ */
+describe('the signer reports itself', () => {
+  const realWindow = (globalThis as { window?: unknown }).window;
+
+  /** A Keychain-shaped stub whose callback resolves with a signature. */
+  function wallet(): Record<string, unknown> {
+    return {
+      requestSignBuffer: (
+        _account: string,
+        _message: string,
+        _authType: string,
+        cb: (r: { success: boolean; result: string }) => void,
+      ) => cb({ success: true, result: 'SIGNATURE' }),
+      requestHandshake: (cb: () => void) => cb(),
+    };
+  }
+
+  function withWallets(w: Record<string, unknown>): void {
+    (globalThis as { window?: unknown }).window = w;
+  }
+
+  // The preference store reads localStorage, which this runner has no DOM for.
+  // Its own try/catch would swallow the absence and return null, which happens
+  // to be the value these cases want, but that would mean the tests pass for a
+  // reason unrelated to what they assert. A real store makes the preference
+  // path actually run.
+  const store = new Map<string, string>();
+  beforeEach(() => {
+    store.clear();
+    (globalThis as { localStorage?: unknown }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+    };
+  });
+
+  afterEach(() => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+    if (realWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window?: unknown }).window = realWindow;
+    }
+  });
+
+  it('names the wallet it was asked for when that one is installed', async () => {
+    withWallets({ hive_keychain: wallet() });
+
+    const signed = await signBufferWithExtension(
+      'alice',
+      'challenge',
+      'Posting',
+      'keychain',
+    );
+    expect(signed.extension).toBe('keychain');
+    expect(signed.result).toBe('SIGNATURE');
+  });
+
+  /**
+   * The case the issue is about. Keychain was recorded for the session, has
+   * since been uninstalled, and Keeper is present: Keeper prompts, so Keeper is
+   * what any message about that prompt has to name.
+   */
+  it('names the wallet that actually prompted after a mid-session uninstall', async () => {
+    withWallets({ hive: { isKeeper: true, ...wallet() } });
+
+    const signed = await signBufferWithExtension(
+      'alice',
+      'challenge',
+      'Posting',
+      'keychain',
+    );
+    expect(signed.extension).toBe('hive-keeper');
+    expect(signed.extension).not.toBe('keychain');
+  });
+
+  /**
+   * Keeper aliases itself onto `window.hive_keychain`, so an implementation
+   * that mapped the resolved instance back to an id by object identity would
+   * call Keeper "Keychain" on a Keeper-only browser. That is the confusion this
+   * work exists to remove, so it must not be reintroduced by the fix.
+   */
+  it('does not call Keeper "Keychain" via its backward-compat alias', async () => {
+    const keeper = { isKeeper: true, ...wallet() };
+    withWallets({ hive: keeper, hive_keychain: keeper });
+
+    const signed = await signBufferWithExtension('alice', 'challenge');
+    expect(signed.extension).toBe('hive-keeper');
+  });
+
+  it('still rejects when nothing is installed', async () => {
+    withWallets({});
+    await expect(
+      signBufferWithExtension('alice', 'challenge'),
+    ).rejects.toThrow(/no hive browser extension/i);
+  });
+
+  /**
+   * The message and the signer have to agree. Asserted together because each is
+   * right on its own in the bug: the message function names whatever id it is
+   * handed, and the id it was handed was the stale one.
+   */
+  it('produces a cancellation message naming the wallet that prompted', async () => {
+    withWallets({ hive: { isKeeper: true, ...wallet() } });
+
+    const signed = await signBufferWithExtension(
+      'alice',
+      'challenge',
+      'Posting',
+      'keychain',
+    );
+    const message = extensionCancelledMessage(signed.extension);
+    expect(message).toContain(getExtensionName('hive-keeper'));
+    expect(message).not.toContain(getExtensionName('keychain'));
+  });
+});
+
+/**
+ * That the save path names the wallet the signer reported.
+ *
+ * Every behaviour test above passed with `getHostingToken` reverted to
+ * `user.extension`, the stale session preference, which is the entire bug. The
+ * pieces being right is not the property; the caller using them is, and
+ * `getHostingToken` cannot be driven here because it opens a real socket to the
+ * hosting API.
+ */
+describe('the save path names the reported signer', () => {
+  it('passes signed.extension to the cancellation message', () => {
+    const source = readFileSync(join(__dirname, 'hosting-token.ts'), 'utf8');
+    const sf = ts.createSourceFile(
+      'hosting-token.ts',
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+
+    const args: string[] = [];
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'extensionCancelledMessage'
+      ) {
+        args.push(...node.arguments.map((a) => a.getText(sf)));
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+
+    // Exactly one call, and it reads the signing result rather than the user.
+    expect(args).toEqual(['signed.extension']);
   });
 });

--- a/apps/self-hosted/src/features/auth/utils/extension-labels.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/extension-labels.test.ts
@@ -419,3 +419,52 @@ describe('the save path names the reported signer', () => {
     expect(args).toEqual(['signed.extension']);
   });
 });
+
+/**
+ * That the instance-only resolver delegates rather than repeating the decision
+ * tree.
+ *
+ * They were two copies of the same preference branches and Keeper-first
+ * fallback, which is the lockstep-drift class this module keeps running into.
+ * `sign-payment.ts` and `broadcastWithExtension` still use the instance-only
+ * one, so a divergence would send those to a different wallet than the signing
+ * path names.
+ *
+ * Delegation makes that impossible by construction, so there is no behaviour
+ * left to compare: a test calling both would be comparing a function with
+ * itself. What can regress is someone re-inlining the tree, and that is what
+ * this pins.
+ */
+describe('the instance resolver does not repeat the decision tree', () => {
+  it('delegates to the resolver that reports its id', () => {
+    const source = readFileSync(join(__dirname, 'hive-extensions.ts'), 'utf8');
+    const sf = ts.createSourceFile(
+      'hive-extensions.ts',
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+
+    let body = '';
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isFunctionDeclaration(node) &&
+        node.name?.text === 'resolveKeychainLikeInstance' &&
+        node.body
+      ) {
+        body = node.body.getText(sf);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+
+    expect(body).not.toBe('');
+    expect(body).toContain('resolveKeychainLikeDetected');
+    // The branches belong to the delegate now. Any of these reappearing here
+    // means the tree was copied back.
+    expect(body).not.toContain("'peakvault'");
+    expect(body).not.toContain('getHiveKeeperInstance');
+    expect(body).not.toContain('getKeychainInstance');
+  });
+});

--- a/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
@@ -328,6 +328,59 @@ const NO_EXTENSION_ERROR =
   'No Hive browser extension found. Please install Hive Keeper, Keychain, or Peak Vault.';
 
 /**
+ * A signing result together with the wallet that actually produced it.
+ *
+ * The wallet that signs is not always the one the caller asked for: an explicit
+ * preference whose extension has been uninstalled falls through to Keeper-first
+ * auto-detect. A caller naming the id it passed in is then describing a popup
+ * the user never saw.
+ */
+export interface SignedByExtension extends KeychainResponse {
+  /** The wallet that was actually asked to sign. */
+  extension: HiveExtensionId;
+}
+
+async function withSigner(
+  extension: HiveExtensionId,
+  signing: Promise<KeychainResponse>,
+): Promise<SignedByExtension> {
+  return { ...(await signing), extension };
+}
+
+/**
+ * `resolveKeychainLikeInstance`, but reporting which wallet it resolved to.
+ *
+ * The instance alone cannot be mapped back to an id: Keeper aliases itself onto
+ * `window.hive_keychain`, so comparing object identity against
+ * `getKeychainInstance()` would call Keeper "Keychain" on a Keeper-only
+ * browser, which is the exact confusion this whole line of work exists to
+ * remove.
+ */
+function resolveKeychainLikeDetected(
+  username?: string,
+): { id: HiveExtensionId; instance: HiveKeychain } | null {
+  if (typeof window === 'undefined') return null;
+
+  const preferred = getPreferredExtensionId(username);
+  if (preferred === 'keychain') {
+    const instance = getKeychainInstance();
+    return instance ? { id: 'keychain', instance } : null;
+  }
+  if (preferred === 'hive-keeper') {
+    const instance = getHiveKeeperInstance();
+    return instance ? { id: 'hive-keeper', instance } : null;
+  }
+  // Peak Vault has no callback API for these requests, and prompting a
+  // different wallet than the one chosen is worse than a clear error.
+  if (preferred === 'peakvault') return null;
+
+  const keeper = getHiveKeeperInstance();
+  if (keeper) return { id: 'hive-keeper', instance: keeper };
+  const keychain = getKeychainInstance();
+  return keychain ? { id: 'keychain', instance: keychain } : null;
+}
+
+/**
  * Fast liveness ping (ported from the main app). Keychain-compatible extensions
  * run a Manifest V3 service worker that idles after ~30s; the first request to
  * a sleeping or crashed worker can silently never call back. requestHandshake
@@ -432,30 +485,54 @@ async function broadcastViaPeakVault(
  * `preferredId` overrides the stored preference, e.g. during login before the
  * choice is persisted.
  */
-export function signBufferWithExtension(
+export async function signBufferWithExtension(
   account: string,
   message: string,
   authType: AuthorityType = 'Posting',
   preferredId?: HiveExtensionId,
-): Promise<KeychainResponse> {
+): Promise<SignedByExtension> {
   const extId = preferredId ?? getPreferredExtensionId(account);
   if (extId === 'peakvault') {
     const pv = getPeakVaultInstance();
-    if (pv) return signBufferViaPeakVault(pv, account, message, authType);
+    if (pv) {
+      return withSigner(
+        'peakvault',
+        signBufferViaPeakVault(pv, account, message, authType),
+      );
+    }
   } else if (extId) {
     const instance =
       extId === 'hive-keeper' ? getHiveKeeperInstance() : getKeychainInstance();
-    if (instance)
-      return signViaKeychainLike(instance, account, message, authType);
+    if (instance) {
+      return withSigner(
+        extId,
+        signViaKeychainLike(instance, account, message, authType),
+      );
+    }
     // Chosen extension is gone (uninstalled); forget the stale preference.
     if (!preferredId) setPreferredExtensionId(account, null);
   }
 
-  const keychainLike = resolveKeychainLikeInstance();
-  if (keychainLike)
-    return signViaKeychainLike(keychainLike, account, message, authType);
+  // Fallback, and the reason this function reports its signer at all.
+  //
+  // An explicit `preferredId` whose wallet has been uninstalled mid-session
+  // lands here, and this is Keeper-first regardless of what was asked for. The
+  // caller knows only the id it passed in, so naming that in a message about
+  // the prompt the user just saw names the wrong wallet.
+  const keychainLike = resolveKeychainLikeDetected();
+  if (keychainLike) {
+    return withSigner(
+      keychainLike.id,
+      signViaKeychainLike(keychainLike.instance, account, message, authType),
+    );
+  }
   const pv = getPeakVaultInstance();
-  if (pv) return signBufferViaPeakVault(pv, account, message, authType);
+  if (pv) {
+    return withSigner(
+      'peakvault',
+      signBufferViaPeakVault(pv, account, message, authType),
+    );
+  }
   return Promise.reject(new Error(NO_EXTENSION_ERROR));
 }
 

--- a/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
@@ -312,12 +312,11 @@ function getPeakVaultInstance(): PeakVaultApi | null {
 export function resolveKeychainLikeInstance(
   username?: string,
 ): HiveKeychain | null {
-  if (typeof window === 'undefined') return null;
-  const extId = getPreferredExtensionId(username);
-  if (extId === 'keychain') return getKeychainInstance();
-  if (extId === 'hive-keeper') return getHiveKeeperInstance();
-  if (extId === 'peakvault') return null;
-  return getHiveKeeperInstance() || getKeychainInstance();
+  // Delegates rather than repeating the decision tree. Two hand-kept copies of
+  // the same resolution order is the lockstep-drift class this module keeps
+  // running into, and the one that reports its id is the one that must stay
+  // authoritative, since a wrong id is how the wrong wallet gets named.
+  return resolveKeychainLikeDetected(username)?.instance ?? null;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/self-hosted/src/features/auth/utils/hosting-token.ts
+++ b/apps/self-hosted/src/features/auth/utils/hosting-token.ts
@@ -170,7 +170,11 @@ export async function getHostingToken(
         user.extension,
       );
       if (typeof signed.result !== 'string' || signed.result.length === 0) {
-        throw new Error(extensionCancelledMessage(user.extension));
+        // The wallet that SIGNED, not the one recorded for the session. They
+        // differ when the recorded one was uninstalled mid-session and the
+        // request fell through to Keeper-first detection, which is exactly the
+        // case that would otherwise name a wallet the owner no longer has.
+        throw new Error(extensionCancelledMessage(signed.extension));
       }
       result = await postJson<TokenResponse>(`${apiBase}/v1/auth/verify`, {
         username: user.username,


### PR DESCRIPTION
Closes the residual case in #1361, the one #1360 and #1362 could not reach because it is not a hardcoded string.

`signBufferWithExtension` takes a preferred wallet id, and when that extension has been uninstalled mid-session it deliberately does not clear the stored preference and falls through to Keeper-first detection:

```ts
if (instance) return signViaKeychainLike(instance, ...);
// Chosen extension is gone (uninstalled); forget the stale preference.
if (!preferredId) setPreferredExtensionId(account, null);
```

So Keychain is recorded, Keychain is uninstalled, Keeper prompts, the user cancels, and the message named **Keychain** — the right name for the recorded preference, the wrong name for the wallet that actually appeared.

## The fix

The additive option the issue named, not the behaviour-changing one. Nothing about which wallet gets asked to sign changes; only what the caller is told afterwards.

- `signBufferWithExtension` returns `SignedByExtension`, the signing result plus the id it actually used.
- `getHostingToken` names `signed.extension` instead of the session's stored `user.extension`.
- **Login records the wallet that signed** rather than the one it asked for, so a preference the browser cannot honour is never written. That is where the mismatch begins.

Resolution reports its own id rather than mapping the resolved instance back to one. Keeper aliases itself onto `window.hive_keychain`, so comparing object identity against `getKeychainInstance()` would label Keeper "Keychain" on a Keeper-only browser, reintroducing the exact confusion this work removes.

## Tests

Driven against a stubbed `window` **and a real `localStorage`**. The preference store's own try/catch would swallow a missing `localStorage` and return `null`, which happens to be the value these cases want, so the tests would have passed for a reason unrelated to what they assert.

Cases: the asked-for wallet when present; the mid-session uninstall naming Keeper; Keeper's alias not being reported as Keychain; rejection when nothing is installed; and the cancellation message agreeing with the signer.

## The call site is asserted separately, and here is why

Every behaviour test above passed with `getHostingToken` reverted to `user.extension`. The pieces being correct is not the property under test; the caller using them is. `getHostingToken` cannot be driven here because it opens a real socket to the hosting API, so the argument it passes is asserted through the AST.

Mutations run, each failing only its own case: reverting the call site to `user.extension`; reporting `extId ?? resolved.id` in the fallback, which is the bug restated; and reordering resolution to prefer Keychain over Keeper.

## Verification

799 passed, 59 files. Typecheck clean apart from the pre-existing gitignored `config.json` error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet sign-in to correctly identify and remember the extension that actually completes the signing request, including fallback wallets.
  * Updated cancellation and error messages to name the extension that attempted to sign.
  * Preserved correct handling for wallet aliases, unavailable extensions, and cancelled signing requests.

* **Tests**
  * Added coverage for fallback signing, extension identification, cancellation messaging, and hosting-token saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->