### PR TITLE
Self-hosted: inline validation for string fields, borrowed from the resolvers

### DIFF
--- a/apps/self-hosted/src/core/hive-layer.ts
+++ b/apps/self-hosted/src/core/hive-layer.ts
@@ -138,7 +138,7 @@ function resolvePayoutLabel(value: unknown): string | null {
  * produce a link that goes nowhere, matching `create-post-target.ts`. Refusing
  * renders the Hive note as plain text, which still reads correctly.
  */
-function resolveLearnMoreUrl(value: unknown): string | null {
+export function resolveLearnMoreUrl(value: unknown): string | null {
   if (typeof value !== 'string' || value.trim() === '') return null;
   let url: URL;
   try {

--- a/apps/self-hosted/src/features/auth/utils/create-post-target.ts
+++ b/apps/self-hosted/src/features/auth/utils/create-post-target.ts
@@ -116,3 +116,28 @@ export function resolveCreatePostTarget({
 
   return toExternalTarget(configured) ?? { kind: 'internal' };
 }
+
+/**
+ * Whether a configured composer address was REFUSED, as opposed to meaning the
+ * built-in editor.
+ *
+ * `resolveCreatePostTarget` collapses both into `{ kind: 'internal' }`, so a
+ * caller outside this module cannot tell an owner who left the field empty
+ * from one who typed an address the resolver would not honour. The second is
+ * worth saying out loud: they asked for an external composer and silently got
+ * the built-in one.
+ *
+ * Lives here rather than in the config editor because the rule for what counts
+ * as a legacy default belongs to this module, and a panel restating it would
+ * drift the first time another default is retired.
+ */
+export function isRefusedCreatePostUrl(value: string): boolean {
+  const configured = value.trim();
+  if (!configured) return false;
+
+  const normalized = normalize(configured);
+  if (normalized === INTERNAL_PUBLISH_ROUTE) return false;
+  if (LEGACY_EXTERNAL_DEFAULTS.has(normalized)) return false;
+
+  return toExternalTarget(configured) === null;
+}

--- a/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
+++ b/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
@@ -355,6 +355,9 @@ const ConfigFieldEditor = memo<ConfigFieldEditorProps>(
 
       default: {
         const stringValue = displayedStringValue(field, value);
+        // Only fields whose resolver refuses something carry `validate`, so
+        // most string inputs are unchanged and render no region at all.
+        const stringNote = field.validate?.(stringValue) ?? null;
         return (
           <div className="mb-4">
             <label
@@ -375,8 +378,30 @@ const ConfigFieldEditor = memo<ConfigFieldEditorProps>(
               maxLength={field.maxLength}
               onChange={(e) => handleChange(e.target.value)}
               className={inputClassName}
-              style={inputStyle}
+              style={{
+                ...inputStyle,
+                borderColor: stringNote
+                  ? '#ef4444'
+                  : FLOATING_MENU_THEME.borderColorStrong,
+              }}
+              aria-invalid={stringNote ? true : undefined}
+              aria-describedby={field.validate ? `${fullPath}-note` : undefined}
             />
+            {/*
+              Mounted from the first render whenever the field can produce a
+              message at all, because a live region that appears together with
+              its first message is usually not announced. Fields without
+              `validate` render nothing here.
+            */}
+            {field.validate && (
+              <div id={`${fullPath}-note`}>
+                <LiveRegion
+                  urgency="assertive"
+                  className="block text-xs mt-1 font-sans text-red-400"
+                  message={stringNote}
+                />
+              </div>
+            )}
           </div>
         );
       }

--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -3,12 +3,14 @@ import {
   HIVE_LAYER_CONFIG_DEFAULTS,
   PAYOUT_LABEL_MAX_LENGTH,
   resolveHiveLayer,
+  resolveLearnMoreUrl,
 } from '@/core/hive-layer';
 import {
   FONT_PRESET_OPTIONS,
   resolveFontPreset,
 } from '@/core/theme-appearance';
 import { AUTH_METHODS } from '@/features/auth/utils/auth-methods';
+import { resolveCreatePostTarget } from '@/features/auth/utils/create-post-target';
 import type { ConfigField } from './config-fields';
 import { configFieldsMap } from './config-fields';
 import { displayedSelectValue } from './field-display';
@@ -356,4 +358,165 @@ describe('font preset panel agrees with the engine', () => {
       expect(shown).toBe(stored.trim().toLowerCase());
     },
   );
+});
+
+/**
+ * Inline validation for `string` fields.
+ *
+ * The colour field got its own surface in #1358; every other text field still
+ * accepted anything, stored it, and let the site quietly ignore it. Two fields
+ * have a resolver that genuinely refuses a value, and both fail the same way:
+ * the save succeeds and the site keeps doing what it did before.
+ *
+ * Each rule is checked AGAINST the resolver that owns it, never against a
+ * second copy of the rule, so the panel cannot warn about something the site
+ * accepts or accept something the site drops.
+ */
+describe('string field validation', () => {
+  const LEARN_MORE_PATH = [
+    'configuration',
+    'instanceConfiguration',
+    'features',
+    'hive',
+    'learnMoreUrl',
+  ] as const;
+  const CREATE_POST_PATH = [
+    'configuration',
+    'general',
+    'createPostUrl',
+  ] as const;
+
+  describe('learn more link', () => {
+    const validate = (value: string) =>
+      fieldAt(LEARN_MORE_PATH)?.validate?.(value) ?? null;
+
+    it('has a validator at all', () => {
+      expect(fieldAt(LEARN_MORE_PATH)?.validate).toBeTypeOf('function');
+    });
+
+    it('says nothing about a link the resolver will use', () => {
+      for (const ok of ['https://hive.io', 'http://example.com/x']) {
+        expect(resolveLearnMoreUrl(ok), ok).not.toBeNull();
+        expect(validate(ok), ok).toBeNull();
+      }
+    });
+
+    /**
+     * `javascript:` is the one that matters: the value becomes an href, and the
+     * resolver refuses it so it cannot reach the DOM. The panel accepting it
+     * silently would suggest the site had taken it.
+     */
+    it('warns about anything the resolver refuses', () => {
+      for (const bad of ['hive.io', '/relative', 'javascript:alert(1)']) {
+        expect(resolveLearnMoreUrl(bad), bad).toBeNull();
+        expect(validate(bad), bad).not.toBeNull();
+      }
+    });
+
+    it('treats empty as the documented "plain text" state, not an error', () => {
+      expect(validate('')).toBeNull();
+      expect(validate('   ')).toBeNull();
+    });
+
+    it('flags exactly what the resolver refuses, as a property', () => {
+      const samples = [
+        'https://hive.io',
+        'hive.io',
+        'javascript:alert(1)',
+        'http://a.b',
+        '/x',
+        'ftp://a.b',
+      ];
+      for (const sample of samples) {
+        const refused = resolveLearnMoreUrl(sample) === null;
+        expect(validate(sample) !== null, sample).toBe(refused);
+      }
+    });
+  });
+
+  describe('create post url', () => {
+    const validate = (value: string) =>
+      fieldAt(CREATE_POST_PATH)?.validate?.(value) ?? null;
+
+    it('has a validator at all', () => {
+      expect(fieldAt(CREATE_POST_PATH)?.validate).toBeTypeOf('function');
+    });
+
+    /**
+     * Empty and the legacy defaults all mean the built-in editor deliberately.
+     * Flagging them would tell an owner something is wrong with a setting the
+     * product documents as the normal one.
+     */
+    it('says nothing about the values that mean the built-in editor', () => {
+      for (const internal of [
+        '',
+        '   ',
+        '/publish',
+        'https://ecency.com/publish',
+        'https://ecency.com/submit',
+      ]) {
+        expect(
+          resolveCreatePostTarget({
+            createPostUrl: internal,
+            isCommunityMode: false,
+          }).kind,
+          internal,
+        ).toBe('internal');
+        expect(validate(internal), internal).toBeNull();
+      }
+    });
+
+    it('says nothing about a composer the site will open', () => {
+      const external = 'https://example.com/write';
+      expect(
+        resolveCreatePostTarget({
+          createPostUrl: external,
+          isCommunityMode: false,
+        }).kind,
+      ).toBe('external');
+      expect(validate(external)).toBeNull();
+    });
+
+    /**
+     * The case that was silent: a refused address falls back to the built-in
+     * editor, so the owner who asked for an external composer got the internal
+     * one and no reason.
+     */
+    it('warns about an address that silently falls back', () => {
+      for (const bad of ['example.com/write', 'javascript:alert(1)', 'notaurl']) {
+        expect(
+          resolveCreatePostTarget({
+            createPostUrl: bad,
+            isCommunityMode: false,
+          }).kind,
+          bad,
+        ).toBe('internal');
+        expect(validate(bad), bad).not.toBeNull();
+      }
+    });
+  });
+
+  /**
+   * A validator on a field the editor renders as something other than a text
+   * input would never run. The colour field has its own surface and must not
+   * grow a second one.
+   */
+  it('only puts validators on string fields', () => {
+    const withValidator: string[] = [];
+    const visit = (
+      fields: Record<string, ConfigField>,
+      path: string[],
+    ): void => {
+      for (const [key, field] of Object.entries(fields)) {
+        if (field.validate) withValidator.push(`${[...path, key].join('.')}:${field.type}`);
+        if (field.fields) visit(field.fields, [...path, key]);
+      }
+    };
+    visit(configFieldsMap, []);
+
+    expect(withValidator.length).toBeGreaterThan(0);
+    for (const entry of withValidator) {
+      expect(entry.endsWith(':string'), entry).toBe(true);
+    }
+  });
 });

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -5,9 +5,11 @@
 import {
   HIVE_LAYER_CONFIG_DEFAULTS,
   PAYOUT_LABEL_MAX_LENGTH,
+  resolveLearnMoreUrl,
 } from '@/core/hive-layer';
 import { FONT_PRESET_OPTIONS } from '@/core/theme-appearance';
 import { AUTH_METHODS } from '@/features/auth/utils/auth-methods';
+import { isRefusedCreatePostUrl } from '@/features/auth/utils/create-post-target';
 
 export type ConfigFieldType =
   | 'string'
@@ -59,6 +61,21 @@ export interface ConfigField {
    * rule to the other's fields would make the panel disagree with the site.
    */
   normalizesCase?: boolean;
+  /**
+   * A message for a value the app will not use, or null when there is nothing
+   * to say. `string` fields only; `color` has its own surface.
+   *
+   * Every rule here is BORROWED from the resolver that reads the field, never
+   * restated. A panel that forms its own opinion about the same string is how
+   * the panel and the site come to disagree, and the config editor has no way
+   * to know it has done so: the save succeeds either way and the site quietly
+   * keeps its old behaviour.
+   *
+   * Only fields whose resolver already refuses a value have one. Inventing a
+   * rule the app does not enforce would reject input the site would have
+   * accepted.
+   */
+  validate?: (value: string) => string | null;
 }
 
 export const configFieldsMap: Record<string, ConfigField> = {
@@ -266,6 +283,15 @@ export const configFieldsMap: Record<string, ConfigField> = {
                     default: HIVE_LAYER_CONFIG_DEFAULTS.learnMoreUrl,
                     description:
                       'Leave empty to show the Hive note as plain text. Add a full https address and the note becomes a link to it.',
+                    // The resolver's own rule, not a copy of it. It refuses a
+                    // relative address and any scheme but http(s), because the
+                    // value becomes an href and a javascript: one must not
+                    // reach the DOM. A refused link renders as plain text, so
+                    // without this the owner sees no link and no reason.
+                    validate: (value) =>
+                      value.trim() === '' || resolveLearnMoreUrl(value) !== null
+                        ? null
+                        : 'Not a web address the site will link to, so the note stays plain text. Use a full https address.',
                   },
                 },
               },
@@ -459,6 +485,15 @@ export const configFieldsMap: Record<string, ConfigField> = {
             type: 'string',
             description:
               'Optional external composer for the Create post button. Leave empty to write here with the built-in editor. The old default https://ecency.com/publish also means the built-in editor.',
+            // Asked of the module that owns the rule. `resolveCreatePostTarget`
+            // collapses "left empty" and "refused" into the same `internal`
+            // result, so the panel cannot tell them apart; the owner who typed
+            // an external composer and silently got the built-in editor is the
+            // case worth naming.
+            validate: (value) =>
+              isRefusedCreatePostUrl(value)
+                ? 'Not a web address the site will open, so the Create post button uses the built-in editor. Use a full https address.'
+                : null,
           },
           hivesigner: {
             label: 'Hivesigner',

--- a/apps/self-hosted/src/features/floating-menu/field-display.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/field-display.test.ts
@@ -540,7 +540,6 @@ describe('the editor renders colour fields with the shared validation', () => {
   });
 });
 
-
 /**
  * That the text input actually calls `field.validate`.
  *

--- a/apps/self-hosted/src/features/floating-menu/field-display.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/field-display.test.ts
@@ -539,3 +539,46 @@ describe('the editor renders colour fields with the shared validation', () => {
     expect(called).toContain('colorPickerValue');
   });
 });
+
+
+/**
+ * That the text input actually calls `field.validate`.
+ *
+ * The validators being correct is not the property; the renderer invoking them
+ * is. This is the third time in this series that every behaviour test passed
+ * while the call site was wrong, so it is asserted directly rather than assumed
+ * from the helpers being right.
+ */
+describe('the editor runs string validators', () => {
+  const EDITOR = join(__dirname, 'components', 'config-editor.tsx');
+
+  it('calls field.validate in the text branch', () => {
+    const source = readFileSync(EDITOR, 'utf8');
+    const file = ts.createSourceFile(
+      'config-editor.tsx',
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX,
+    );
+
+    let calls = 0;
+    const visit = (node: ts.Node): void => {
+      // `field.validate?.(...)` parses as a call whose expression is the
+      // property access, so match on the accessed name.
+      if (ts.isCallExpression(node)) {
+        const target = node.expression;
+        const text = ts.isPropertyAccessExpression(target)
+          ? target.name.text
+          : ts.isNonNullExpression(target) || ts.isParenthesizedExpression(target)
+            ? ''
+            : '';
+        if (text === 'validate') calls += 1;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(file);
+
+    expect(calls).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes the remaining half of #1359. #1358 gave the colour field a message surface; every other text field still accepted anything, stored it, and let the site quietly ignore it.

## The two fields that actually refuse something

Both fail the same silent way the accent did: the save succeeds, and nothing on the site changes.

- **Learn more link.** The value becomes an `href`, so `resolveLearnMoreUrl` refuses a relative address and any scheme but http(s) — a `javascript:` one must never reach the DOM. A refused link renders the Hive note as plain text, so the owner saw no link and no reason.
- **Create post URL.** A refused address falls back to `{ kind: 'internal' }`, so an owner who configured an external composer got the built-in editor with no explanation.

## Every rule is borrowed, never restated

This is the point of the change rather than a detail of it. A panel that forms its own opinion about the same string is how the panel and the site come to disagree, and neither side can notice: the save succeeds either way. The mutation below makes that concrete — swapping the learn-more validator for a plausible `/^https?:/i` check fails only the cases that compare it against the resolver.

`resolveCreatePostTarget` collapses "left empty" and "refused" into the same `internal` result, so a caller outside that module cannot tell them apart. Rather than reconstruct the rule in the editor, `isRefusedCreatePostUrl` answers it **inside the module that owns what counts as a legacy default** — a panel restating that list would drift the first time one is retired.

## Scope is deliberately narrow

Only fields whose resolver already refuses a value get a validator. Inventing a rule the app does not enforce would reject input the site would have accepted, which is worse than saying nothing. A test holds validators to `string` fields, since one attached to a select or a toggle would never run.

## The call site is asserted separately

Three times in this series every behaviour test has passed while the call site was wrong — the payment dialog's label, `getHostingToken`'s wallet name, and the colour field's whole `case` block. So the renderer invoking `field.validate` is asserted directly rather than inferred from the validators being correct.

## Verification

- 804 passed, 59 files. Typecheck clean apart from the pre-existing gitignored `config.json` error.
- Mutations, each failing only its own cases: the renderer no longer calling `validate`; the learn-more validator using its own regex instead of the resolver; and dropping the internal-route check from `isRefusedCreatePostUrl`, which makes the relative `/publish` read as refused.
- One mutation was a **no-op and is worth recording**: removing the legacy-defaults check changed nothing, because those defaults are valid https URLs that `toExternalTarget` accepts anyway. That line is defensive and self-documenting rather than load-bearing; the internal-route check is the one that carries weight, because `/publish` is relative and fails `new URL()`.

Not covered: the rendered control still needs a manual pass, since no `.tsx` is renderable under this runner.
