### PR TITLE
Self-hosted: close the two gaps where the panel and the site disagree

### DIFF
--- a/apps/self-hosted/src/core/index.ts
+++ b/apps/self-hosted/src/core/index.ts
@@ -3,5 +3,6 @@ export * from './configuration-loader';
 export * from './date-formatter';
 export * from './hive-layer';
 export * from './i18n';
+export * from './instance-mode';
 export * from './instance-type-filters';
 export * from './theme-appearance';

--- a/apps/self-hosted/src/core/instance-mode.test.ts
+++ b/apps/self-hosted/src/core/instance-mode.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { isCommunityConfig, isCommunityInstance } from './instance-mode';
+
+/**
+ * One definition of "is a community", because there were two and a third was
+ * about to be written.
+ *
+ * The nuance that makes a single definition necessary: `type: 'community'` with
+ * no `communityId` is NOT a community. Every community behaviour is built from
+ * that id, so such an instance behaves as a blog everywhere, and a definition
+ * that ignored the id would disagree with the sidebar.
+ */
+describe('isCommunityInstance', () => {
+  it('needs both the type and an id', () => {
+    expect(isCommunityInstance({ type: 'community', communityId: 'hive-125125' })).toBe(true);
+  });
+
+  it('is not a community when the id is missing, which is the whole point', () => {
+    expect(isCommunityInstance({ type: 'community' })).toBe(false);
+    expect(isCommunityInstance({ type: 'community', communityId: '' })).toBe(false);
+    // Whitespace is not an id either: it would pass a bare truthiness check and
+    // produce a community with nothing to query.
+    expect(isCommunityInstance({ type: 'community', communityId: '   ' })).toBe(false);
+  });
+
+  it('is not a community for a blog, whatever else is set', () => {
+    expect(isCommunityInstance({ type: 'blog', communityId: 'hive-125125' })).toBe(false);
+  });
+
+  /** The document is unvalidated, so none of this is guaranteed at runtime. */
+  it('survives absent and wrongly typed input', () => {
+    expect(isCommunityInstance(null)).toBe(false);
+    expect(isCommunityInstance(undefined)).toBe(false);
+    expect(isCommunityInstance({})).toBe(false);
+    expect(isCommunityInstance({ type: 'community', communityId: 42 })).toBe(false);
+    expect(isCommunityInstance({ type: 42, communityId: 'hive-1' })).toBe(false);
+  });
+});
+
+describe('isCommunityConfig', () => {
+  const community = {
+    configuration: {
+      instanceConfiguration: { type: 'community', communityId: 'hive-125125' },
+    },
+  };
+
+  it('reads the instance out of a whole document', () => {
+    expect(isCommunityConfig(community)).toBe(true);
+  });
+
+  it('agrees with isCommunityInstance on the same instance', () => {
+    const cases = [
+      { type: 'community', communityId: 'hive-1' },
+      { type: 'community', communityId: '' },
+      { type: 'blog', communityId: 'hive-1' },
+      { type: 'blog' },
+      {},
+    ];
+    for (const instance of cases) {
+      expect(
+        isCommunityConfig({
+          configuration: { instanceConfiguration: instance },
+        }),
+        JSON.stringify(instance),
+      ).toBe(isCommunityInstance(instance));
+    }
+  });
+
+  /**
+   * Every node on the path is checked rather than assumed. The config editor
+   * hands this whatever is in the document, and the hosting API will store a
+   * string or an array where an object belongs.
+   */
+  it('survives a malformed document at every level', () => {
+    for (const bad of [
+      null,
+      undefined,
+      'a string',
+      [],
+      { configuration: 'nope' },
+      { configuration: { instanceConfiguration: 'nope' } },
+      { configuration: { instanceConfiguration: [] } },
+      { configuration: null },
+      {},
+    ]) {
+      expect(isCommunityConfig(bad), JSON.stringify(bad)).toBe(false);
+    }
+  });
+});

--- a/apps/self-hosted/src/core/instance-mode.ts
+++ b/apps/self-hosted/src/core/instance-mode.ts
@@ -1,0 +1,53 @@
+/**
+ * What kind of instance this is, in one place.
+ *
+ * "Community" is not simply `type === 'community'`: it also needs a
+ * `communityId`, because that id is what every community behaviour is built
+ * from. An instance typed community with no id behaves as a blog everywhere,
+ * and a definition that ignored the id would disagree with the sidebar.
+ *
+ * This existed twice before, in `use-instance-config` and `use-hive-layer`, the
+ * second carrying a comment saying it was deliberately the same expression as
+ * the first. Two copies kept in step by a comment is the drift this module
+ * removes; a third was about to be written for the configuration editor, which
+ * is what prompted it.
+ *
+ * Pure and shape-tolerant on purpose: the callers read from a store selector, a
+ * resolved instance object and an unvalidated config document respectively, and
+ * none of those is guaranteed to hold what its type says at runtime.
+ */
+
+/** The two fields the answer depends on, from wherever the caller has them. */
+export interface InstanceModeInput {
+  type?: unknown;
+  communityId?: unknown;
+}
+
+export function isCommunityInstance(
+  instance: InstanceModeInput | null | undefined,
+): boolean {
+  if (!instance) return false;
+  const communityId =
+    typeof instance.communityId === 'string' ? instance.communityId.trim() : '';
+  return instance.type === 'community' && communityId !== '';
+}
+
+/**
+ * The same question asked of a whole config document.
+ *
+ * The configuration editor holds the document rather than a resolved instance,
+ * and the document is unvalidated: any node on the path may be absent or hold
+ * something that is not an object, so each step is checked rather than assumed.
+ */
+export function isCommunityConfig(config: unknown): boolean {
+  const node = (value: unknown, key: string): unknown =>
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)[key]
+      : undefined;
+
+  const instance = node(node(config, 'configuration'), 'instanceConfiguration');
+  if (!instance || typeof instance !== 'object' || Array.isArray(instance)) {
+    return false;
+  }
+  return isCommunityInstance(instance as InstanceModeInput);
+}

--- a/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
@@ -536,33 +536,56 @@ export async function signBufferWithExtension(
 }
 
 /** Broadcast operations with the account's chosen extension (or best available). */
-export function broadcastWithExtension(
+export async function broadcastWithExtension(
   account: string,
   operations: Operation[],
   authType: AuthorityType = 'Posting',
   preferredId?: HiveExtensionId,
-): Promise<KeychainResponse> {
+): Promise<SignedByExtension> {
   const extId = preferredId ?? getPreferredExtensionId(account);
   if (extId === 'peakvault') {
     const pv = getPeakVaultInstance();
-    if (pv) return broadcastViaPeakVault(pv, account, operations, authType);
+    if (pv) {
+      return withSigner(
+        'peakvault',
+        broadcastViaPeakVault(pv, account, operations, authType),
+      );
+    }
   } else if (extId) {
     const instance =
       extId === 'hive-keeper' ? getHiveKeeperInstance() : getKeychainInstance();
-    if (instance)
-      return broadcastViaKeychainLike(instance, account, operations, authType);
+    if (instance) {
+      return withSigner(
+        extId,
+        broadcastViaKeychainLike(instance, account, operations, authType),
+      );
+    }
     if (!preferredId) setPreferredExtensionId(account, null);
   }
 
-  const keychainLike = resolveKeychainLikeInstance();
-  if (keychainLike)
-    return broadcastViaKeychainLike(
-      keychainLike,
-      account,
-      operations,
-      authType,
+  // The same uninstalled-mid-session fall-through the signing path has, and the
+  // same reason for reporting it: nothing names a wallet on this path today,
+  // but the first broadcast failure message that does would name the stale
+  // preference rather than the wallet that actually prompted.
+  const keychainLike = resolveKeychainLikeDetected();
+  if (keychainLike) {
+    return withSigner(
+      keychainLike.id,
+      broadcastViaKeychainLike(
+        keychainLike.instance,
+        account,
+        operations,
+        authType,
+      ),
     );
+  }
   const pv = getPeakVaultInstance();
-  if (pv) return broadcastViaPeakVault(pv, account, operations, authType);
+  if (pv) {
+    return withSigner(
+      'peakvault',
+      broadcastViaPeakVault(pv, account, operations, authType),
+    );
+  }
   return Promise.reject(new Error(NO_EXTENSION_ERROR));
 }
+

--- a/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
@@ -588,4 +588,3 @@ export async function broadcastWithExtension(
   }
   return Promise.reject(new Error(NO_EXTENSION_ERROR));
 }
-

--- a/apps/self-hosted/src/features/blog/hooks/use-hive-layer.ts
+++ b/apps/self-hosted/src/features/blog/hooks/use-hive-layer.ts
@@ -1,3 +1,4 @@
+import { isCommunityInstance } from '@/core/instance-mode';
 import { useMemo } from 'react';
 import type { ResolvedHiveLayer } from '@/core';
 import { InstanceConfigManager, resolveHiveLayer } from '@/core';
@@ -18,12 +19,10 @@ export function useHiveLayer(): ResolvedHiveLayer {
     const { configuration } = InstanceConfigManager.getConfig();
     const instance = configuration.instanceConfiguration;
 
-    // Same expression as use-instance-config, deliberately: a second definition
-    // of "is a community" would disagree with the sidebar on an instance typed
-    // community with no communityId. The resolver does not take it today; the
-    // downvote clamp that needs it returns with the vote controls.
-    const isCommunityMode =
-      instance?.type === 'community' && !!instance?.communityId;
+    // One definition, in core/instance-mode. This used to be the same
+    // expression written out again, kept in step with use-instance-config by a
+    // comment; a third copy was about to be written for the config editor.
+    const isCommunityMode = isCommunityInstance(instance);
 
     const composer = resolveCreatePostTarget({
       createPostUrl: configuration.general?.createPostUrl,

--- a/apps/self-hosted/src/features/blog/hooks/use-instance-config.ts
+++ b/apps/self-hosted/src/features/blog/hooks/use-instance-config.ts
@@ -1,3 +1,4 @@
+import { isCommunityInstance } from '@/core/instance-mode';
 import { useQuery } from '@tanstack/react-query';
 import { InstanceConfigManager } from '@/core';
 import { getCommunityQueryOptions } from '../queries/community-queries';
@@ -19,7 +20,7 @@ export function useInstanceConfig() {
       (configuration.instanceConfiguration.communityId as string) || ''
   );
 
-  const isCommunityMode = type === 'community' && !!communityId;
+  const isCommunityMode = isCommunityInstance({ type, communityId });
   const isBlogMode = type === 'blog';
 
   return {

--- a/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
+++ b/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
@@ -100,7 +100,7 @@ function ArrayFieldEditor({
 }
 
 const ConfigFieldEditor = memo<ConfigFieldEditorProps>(
-  ({ field, fieldKey, value, path, onUpdate }) => {
+  ({ field, fieldKey, value, path, onUpdate, root }) => {
     const fullPath = path ? `${path}.${fieldKey}` : fieldKey;
 
     if (field.type === 'section' && field.fields) {
@@ -124,6 +124,7 @@ const ConfigFieldEditor = memo<ConfigFieldEditorProps>(
               fields={field.fields}
               path={fullPath}
               onUpdate={onUpdate}
+              root={root}
             />
           </div>
         </section>
@@ -357,7 +358,7 @@ const ConfigFieldEditor = memo<ConfigFieldEditorProps>(
         const stringValue = displayedStringValue(field, value);
         // Only fields whose resolver refuses something carry `validate`, so
         // most string inputs are unchanged and render no region at all.
-        const stringNote = field.validate?.(stringValue) ?? null;
+        const stringNote = field.validate?.(stringValue, root) ?? null;
         return (
           <div className="mb-4">
             <label
@@ -412,7 +413,10 @@ const ConfigFieldEditor = memo<ConfigFieldEditorProps>(
 ConfigFieldEditor.displayName = 'ConfigFieldEditor';
 
 export const ConfigEditor = memo<ConfigEditorProps>(
-  ({ config, fields, path, onUpdate }) => {
+  ({ config, fields, path, onUpdate, root }) => {
+    // The top call has no `root`, and there `config` IS the whole document.
+    // Every deeper call receives it unchanged.
+    const document = root ?? config;
     const { sections, regularFields } = useMemo(() => {
       const sectionsList: Array<[string, ConfigField]> = [];
       const regularList: Array<[string, ConfigField]> = [];
@@ -446,6 +450,7 @@ export const ConfigEditor = memo<ConfigEditorProps>(
                   value={value}
                   path={path}
                   onUpdate={onUpdate}
+                  root={document}
                 />
               );
             })}
@@ -463,6 +468,7 @@ export const ConfigEditor = memo<ConfigEditorProps>(
               value={value}
               path={path}
               onUpdate={onUpdate}
+              root={document}
             />
           );
         })}

--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -520,3 +520,90 @@ describe('string field validation', () => {
     }
   });
 });
+
+
+/**
+ * The composer rule depends on the instance TYPE, not just the value.
+ *
+ * A community instance ignores this field entirely, valid address or not: the
+ * built-in editor carries the community target, which an external composer
+ * would lose. So the owner most likely to set it is the one it does nothing
+ * for, and before this they got no composer and no explanation.
+ *
+ * This is why `validate` takes the whole document. The instance type lives in a
+ * different branch of the tree from the field being validated.
+ */
+describe('create post url on a community instance', () => {
+  const CREATE_POST_PATH = [
+    'configuration',
+    'general',
+    'createPostUrl',
+  ] as const;
+
+  const doc = (type: string, communityId?: string) => ({
+    configuration: {
+      instanceConfiguration: {
+        type,
+        ...(communityId === undefined ? {} : { communityId }),
+      },
+    },
+  });
+
+  const validate = (value: string, config?: unknown) =>
+    fieldAt(CREATE_POST_PATH)?.validate?.(
+      value,
+      config as Record<string, never>,
+    ) ?? null;
+
+  it('says the address is unused, even when it is a valid one', () => {
+    const note = validate(
+      'https://example.com/write',
+      doc('community', 'hive-125125'),
+    );
+    expect(note).not.toBeNull();
+    expect(note).toMatch(/built-in editor/i);
+  });
+
+  /**
+   * Different sentence from the blog-mode one. "Not a web address" would be a
+   * lie here: the address is fine, the instance type is what ignores it.
+   */
+  it('does not call a valid address invalid', () => {
+    const note = validate(
+      'https://example.com/write',
+      doc('community', 'hive-125125'),
+    );
+    expect(note).not.toMatch(/not a web address/i);
+  });
+
+  /**
+   * Typed community with no id is a blog everywhere else in the app, so the
+   * blog rule applies and a valid address is honoured.
+   */
+  it('treats a community with no id as a blog, like the rest of the app', () => {
+    expect(validate('https://example.com/write', doc('community'))).toBeNull();
+    expect(validate('https://example.com/write', doc('community', ''))).toBeNull();
+  });
+
+  it('still flags a refused address on a blog instance', () => {
+    expect(validate('example.com/write', doc('blog'))).toMatch(
+      /not a web address/i,
+    );
+  });
+
+  /** Empty means the built-in editor everywhere, and is never an error. */
+  it('says nothing about an empty value on either kind', () => {
+    expect(validate('', doc('community', 'hive-1'))).toBeNull();
+    expect(validate('', doc('blog'))).toBeNull();
+  });
+
+  /**
+   * The document is optional on the hook. Without it the field falls back to
+   * the blog rule rather than throwing, since that is what a config with no
+   * instance type resolves to.
+   */
+  it('falls back to the blog rule when handed no document', () => {
+    expect(validate('https://example.com/write')).toBeNull();
+    expect(validate('example.com/write')).toMatch(/not a web address/i);
+  });
+});

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -7,7 +7,9 @@ import {
   PAYOUT_LABEL_MAX_LENGTH,
   resolveLearnMoreUrl,
 } from '@/core/hive-layer';
+import { isCommunityConfig } from '@/core/instance-mode';
 import { FONT_PRESET_OPTIONS } from '@/core/theme-appearance';
+import type { ConfigValue } from './types';
 import { AUTH_METHODS } from '@/features/auth/utils/auth-methods';
 import { isRefusedCreatePostUrl } from '@/features/auth/utils/create-post-target';
 
@@ -74,8 +76,16 @@ export interface ConfigField {
    * Only fields whose resolver already refuses a value have one. Inventing a
    * rule the app does not enforce would reject input the site would have
    * accepted.
+   *
+   * `config` is the WHOLE document, not the section this field sits in, because
+   * some rules are about combinations rather than single values: an external
+   * composer is ignored outright on a community instance, and the instance type
+   * lives in a different branch of the tree.
    */
-  validate?: (value: string) => string | null;
+  validate?: (
+    value: string,
+    config?: Record<string, ConfigValue>,
+  ) => string | null;
 }
 
 export const configFieldsMap: Record<string, ConfigField> = {
@@ -485,15 +495,26 @@ export const configFieldsMap: Record<string, ConfigField> = {
             type: 'string',
             description:
               'Optional external composer for the Create post button. Leave empty to write here with the built-in editor. The old default https://ecency.com/publish also means the built-in editor.',
-            // Asked of the module that owns the rule. `resolveCreatePostTarget`
-            // collapses "left empty" and "refused" into the same `internal`
-            // result, so the panel cannot tell them apart; the owner who typed
-            // an external composer and silently got the built-in editor is the
-            // case worth naming.
-            validate: (value) =>
-              isRefusedCreatePostUrl(value)
+            // Two different silences, and they need different sentences.
+            //
+            // A community instance ignores this field entirely, valid or not:
+            // the built-in editor is what carries the community target, and an
+            // external composer would publish to the member's own blog instead.
+            // So a community owner setting a perfectly good address gets no
+            // composer and, before this, no explanation either.
+            //
+            // On a blog instance the question is the resolver's, asked of the
+            // module that owns it, since `resolveCreatePostTarget` collapses
+            // "left empty" and "refused" into one `internal` result.
+            validate: (value, config) => {
+              if (value.trim() === '') return null;
+              if (isCommunityConfig(config)) {
+                return 'Community sites always use the built-in editor, so this address is not used. It carries the community target, which an external composer would lose.';
+              }
+              return isRefusedCreatePostUrl(value)
                 ? 'Not a web address the site will open, so the Create post button uses the built-in editor. Use a full https address.'
-                : null,
+                : null;
+            },
           },
           hivesigner: {
             label: 'Hivesigner',

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -509,7 +509,7 @@ export const configFieldsMap: Record<string, ConfigField> = {
             validate: (value, config) => {
               if (value.trim() === '') return null;
               if (isCommunityConfig(config)) {
-                return 'Community sites always use the built-in editor, so this address is not used. It carries the community target, which an external composer would lose.';
+                return 'Community sites always use the built-in editor, so this address is not used. The built-in editor carries the community target, which an external composer would lose.';
               }
               return isRefusedCreatePostUrl(value)
                 ? 'Not a web address the site will open, so the Create post button uses the built-in editor. Use a full https address.'

--- a/apps/self-hosted/src/features/floating-menu/field-display.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/field-display.test.ts
@@ -561,7 +561,7 @@ describe('the editor runs string validators', () => {
       ts.ScriptKind.TSX,
     );
 
-    let calls = 0;
+    const argumentLists: string[][] = [];
     const visit = (node: ts.Node): void => {
       // `field.validate?.(...)` parses as a call whose expression is the
       // property access, so match on the accessed name.
@@ -572,12 +572,23 @@ describe('the editor runs string validators', () => {
           : ts.isNonNullExpression(target) || ts.isParenthesizedExpression(target)
             ? ''
             : '';
-        if (text === 'validate') calls += 1;
+        if (text === 'validate') {
+          argumentLists.push(node.arguments.map((a) => a.getText(file)));
+        }
       }
       ts.forEachChild(node, visit);
     };
     visit(file);
 
-    expect(calls).toBeGreaterThan(0);
+    expect(argumentLists.length).toBeGreaterThan(0);
+
+    // With the value AND the whole document. Asserting only that the call
+    // happens let the document argument be dropped silently, which turns every
+    // rule about a combination of fields into a rule about one field: the
+    // community-mode composer check then reads as though it were a blog.
+    for (const args of argumentLists) {
+      expect(args).toHaveLength(2);
+      expect(args[1]).toBe('root');
+    }
   });
 });

--- a/apps/self-hosted/src/features/floating-menu/types.ts
+++ b/apps/self-hosted/src/features/floating-menu/types.ts
@@ -12,12 +12,25 @@ export interface ConfigEditorProps {
   fields: Record<string, ConfigField>;
   path?: string;
   onUpdate: (path: string, value: ConfigValue) => void;
+  /**
+   * The whole document, threaded down unchanged through the recursion.
+   *
+   * `config` is the node at the current path, so a validator reached from a
+   * nested section can only see its own siblings. Some rules are about
+   * combinations: an external composer URL is ignored entirely on a community
+   * instance, and the instance type lives in a different branch of the tree.
+   *
+   * Absent at the top call, where `config` already is the whole document.
+   */
+  root?: Record<string, ConfigValue>;
 }
 
 export interface ConfigFieldEditorProps {
   field: ConfigField;
   fieldKey: string;
   value: ConfigValue;
+  /** The whole document; see ConfigEditorProps.root. */
+  root?: Record<string, ConfigValue>;
   path?: string;
   onUpdate: (path: string, value: ConfigValue) => void;
 }


### PR DESCRIPTION
Closes #1368, both halves.

## 1. A community instance ignored a valid composer URL, silently

A community site always uses the built-in editor, because that is what carries the community target; an external composer would publish to the member's own blog instead. So the owner most likely to set **Create post URL** is the one it does nothing for, and they got no composer and no explanation.

It now says so, in a **different sentence** from the blog-mode one. "Not a web address" would be a lie here: the address is fine, the instance type is what ignores it.

That required `validate` to see the whole document rather than just the value, since the instance type lives in a different branch of the tree. `ConfigEditor` threads the root down through the recursion, defaulting to its own `config` at the top call where the two are the same thing.

## The part that was not in the issue

Answering "is this a community" needed a rule that **already existed twice** — `use-instance-config.ts:22` and `use-hive-layer.ts:25` — the second carrying this comment:

> Same expression as use-instance-config, deliberately: a second definition of "is a community" would disagree with the sidebar on an instance typed community with no communityId.

Two copies kept in step by a comment, and I was about to write a third. It is now one function in `core/instance-mode.ts` and all three read it.

The nuance that makes a single definition necessary is worth stating: `type: 'community'` with **no `communityId`** is a blog everywhere else in the app, so the composer field honours a valid address there. A definition that ignored the id would disagree with the sidebar, which is what that comment was warning about.

## 2. `broadcastWithExtension` now reports its signer

It has the identical uninstalled-mid-session fall-through as the signing path and could not say which wallet actually prompted. Nothing names a wallet on that path today, which is exactly why this is worth doing now rather than later: the first broadcast failure message to name one would reintroduce the bug in a place no existing guard watches.

## The guard was wrong again, and this is the fifth time

Dropping the document argument from the editor's `validate` call left every test green. The guard asserted the call *happened*, not what it was called *with* — so every rule about a combination of fields would silently degrade into a rule about one field, and the community check would read as though it were a blog. It now pins both arguments.

Running total for this series: the payment dialog label, `getHostingToken`'s wallet name, the colour `case` block, `field.validate` existing, and now `field.validate`'s arguments. Each was caught by mutation testing, none by review or the type checker.

## Verification

- 824 passed, 60 files. Typecheck clean apart from the pre-existing gitignored `config.json` error.
- Mutations, each failing only its own cases: dropping the document argument; and making the community rule ignore `communityId`, which correctly breaks the "typed community with no id is a blog" case in three places.
- `instance-mode.test.ts` asserts `isCommunityConfig` and `isCommunityInstance` agree on the same instance, and that a malformed document at any level resolves to `false` rather than throwing, since the hosting API will store a string or an array where an object belongs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable detection of community-mode instances and configurations.
  * Configuration validation can now consider the full document, including community-specific Create Post URL rules.
  * Broadcast results now identify the extension that signed the transaction.

* **Bug Fixes**
  * Improved handling of malformed or incomplete configuration data.
  * Preserved blog validation behavior while correctly treating community configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->