### PR TITLE
Self-hosted: remove the config-version control, which could blank a whole site

### DIFF
--- a/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
+++ b/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
@@ -183,37 +183,6 @@ const ConfigFieldEditor = memo<ConfigFieldEditorProps>(
         );
       }
 
-      case 'number': {
-        const numValue = typeof value === 'number' ? value : undefined;
-        return (
-          <div className="mb-4">
-            <label
-              htmlFor={fullPath}
-              className="block text-sm font-medium text-gray-200 mb-2 font-sans"
-            >
-              {field.label}
-            </label>
-            {field.description && (
-              <p className="text-xs text-gray-400 mb-2 font-sans">
-                {field.description}
-              </p>
-            )}
-            <input
-              id={fullPath}
-              type="number"
-              value={numValue ?? ''}
-              onChange={(e) =>
-                handleChange(
-                  e.target.value === '' ? null : Number(e.target.value),
-                )
-              }
-              className={inputClassName}
-              style={inputStyle}
-            />
-          </div>
-        );
-      }
-
       case 'array': {
         return (
           <ArrayFieldEditor

--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -607,3 +607,45 @@ describe('create post url on a community instance', () => {
     expect(validate('example.com/write')).toMatch(/not a web address/i);
   });
 });
+
+/**
+ * The panel must not offer a control that can blank the whole site.
+ *
+ * `configuration-loader` applies a served config only when
+ * `runtimeConfig?.version` is truthy. The editor's number input writes `null`
+ * when cleared, and `version` was the one field using it, so an owner who
+ * emptied that box shipped `version: null` and every visitor's browser then
+ * discarded the entire document and rendered the bare skeleton: no title, no
+ * logo, no theme, default everything.
+ *
+ * A schema version is not an owner setting. The value still rides along in the
+ * saved document, which goes out whole, so removing the control loses nothing.
+ */
+describe('fields that must not be editable', () => {
+  it('offers no control for the config version', () => {
+    expect(fieldAt(['version'])).toBeUndefined();
+  });
+
+  /**
+   * The general rule, not just the one field. Asserted over the whole map
+   * because the hazard is the input type rather than the path: null erases the
+   * stored section on merge wherever it lands.
+   */
+  it('offers no number input anywhere', () => {
+    const numeric: string[] = [];
+    const visit = (
+      fields: Record<string, ConfigField>,
+      path: string[],
+    ): void => {
+      for (const [key, field] of Object.entries(fields)) {
+        if ((field.type as string) === 'number') {
+          numeric.push([...path, key].join('.'));
+        }
+        if (field.fields) visit(field.fields, [...path, key]);
+      }
+    };
+    visit(configFieldsMap, []);
+
+    expect(numeric).toEqual([]);
+  });
+});

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -19,7 +19,22 @@ export type ConfigFieldType =
   // express "unset", which is the value every instance holds today and the one
   // an owner has to be able to get back to.
   | 'color'
-  | 'number'
+  /*
+   * No `number`.
+   *
+   * The number input writes `null` when cleared, and `null` erases the stored
+   * section on merge. Every section below already carries a comment saying so,
+   * which is a convention held by memory; the type not existing makes it
+   * unreachable instead.
+   *
+   * The one field that used it was `version`, and that was the worst possible
+   * place for it: `configuration-loader` applies a served config only when
+   * `runtimeConfig?.version` is truthy, so an owner who cleared that box
+   * shipped `version: null` and every visitor's browser then discarded the
+   * whole document and rendered the bare skeleton. No title, no logo, no theme.
+   * A schema version is not an owner setting, so it has no control at all now;
+   * the value still rides along in the document, which is saved whole.
+   */
   | 'boolean'
   | 'array'
   | 'section'
@@ -89,11 +104,6 @@ export interface ConfigField {
 }
 
 export const configFieldsMap: Record<string, ConfigField> = {
-  version: {
-    label: 'Version',
-    type: 'number',
-    description: 'Configuration version number',
-  },
   configuration: {
     label: 'Configuration',
     type: 'section',


### PR DESCRIPTION
One of three long-standing panel defects. This is the consequential one.

## The chain

1. The panel offered **Version** as `type: 'number'`.
2. `config-editor.tsx`'s number input writes `null` when the box is cleared: `e.target.value === '' ? null : Number(...)`.
3. `configuration-loader.ts:197` applies a served config **only** when `runtimeConfig?.version` is truthy.

So an owner who cleared that one box shipped `version: null`, and every visitor's browser then discarded the **entire** document and rendered `CONFIG_SKELETON`. No title, no logo, no theme, default everything, on a live site.

Nothing about the field invited care: it is labelled "Configuration version number" and sits at the top of the panel, above the settings an owner actually wants.

## The fix

A schema version is not an owner setting, so it has no control at all now. The value still rides along in the saved document, since `floating-menu-window` sends `config` whole rather than reconstructing it from the field map, so removing the input loses nothing.

`number` is also gone from `ConfigFieldType` and from the renderer. Every section in the field map already carried a comment warning against it:

> No `number` field, because the number input writes null when cleared

That is a convention held by memory, and memory is what failed here. Not having the type makes the hazard unreachable.

## Tests

Two, and the general one matters more: no number input anywhere in the map, asserted by walking it, because the hazard is the input type rather than the path. `null` erases the stored section on merge wherever it lands; `version` was simply the worst place for it.

Mutation-checked by putting the field back with a cast: both cases fail, and only those.

## Verification

813 passed, 59 files. Typecheck clean apart from the pre-existing gitignored `config.json` error.