### PR TITLE
Self-hosted: gate hover styling on devices that can hover

### DIFF
--- a/apps/self-hosted/src/globals.css
+++ b/apps/self-hosted/src/globals.css
@@ -164,11 +164,11 @@ body {
    * `text-decoration-color` stays: it is the only thing that makes
    * --theme-link-decoration-hover visible outside .markdown-body.
    */
-@media (hover: hover) {
+  @media (hover: hover) {
     a:hover {
       text-decoration-color: var(--theme-link-decoration-hover, inherit);
     }
-}
+  }
 
   /* Theme-aware buttons */
   button {

--- a/apps/self-hosted/src/globals.css
+++ b/apps/self-hosted/src/globals.css
@@ -164,9 +164,11 @@ body {
    * `text-decoration-color` stays: it is the only thing that makes
    * --theme-link-decoration-hover visible outside .markdown-body.
    */
-  a:hover {
-    text-decoration-color: var(--theme-link-decoration-hover, inherit);
-  }
+@media (hover: hover) {
+    a:hover {
+      text-decoration-color: var(--theme-link-decoration-hover, inherit);
+    }
+}
 
   /* Theme-aware buttons */
   button {

--- a/apps/self-hosted/src/styles/blog-markdown.css
+++ b/apps/self-hosted/src/styles/blog-markdown.css
@@ -258,19 +258,21 @@
   vertical-align: text-bottom;
 }
 
-.markdown-body h1:hover .anchor .octicon-link:before,
-.markdown-body h2:hover .anchor .octicon-link:before,
-.markdown-body h3:hover .anchor .octicon-link:before,
-.markdown-body h4:hover .anchor .octicon-link:before,
-.markdown-body h5:hover .anchor .octicon-link:before,
-.markdown-body h6:hover .anchor .octicon-link:before {
-  width: 16px;
-  height: 16px;
-  content: " ";
-  display: inline-block;
-  background-color: currentColor;
-  -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
-  mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+@media (hover: hover) {
+  .markdown-body h1:hover .anchor .octicon-link:before,
+  .markdown-body h2:hover .anchor .octicon-link:before,
+  .markdown-body h3:hover .anchor .octicon-link:before,
+  .markdown-body h4:hover .anchor .octicon-link:before,
+  .markdown-body h5:hover .anchor .octicon-link:before,
+  .markdown-body h6:hover .anchor .octicon-link:before {
+    width: 16px;
+    height: 16px;
+    content: " ";
+    display: inline-block;
+    background-color: currentColor;
+    -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+    mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+  }
 }
 
 .markdown-body details,
@@ -295,8 +297,10 @@
   transition: text-decoration-color 0.2s;
 }
 
-.markdown-body a:hover {
-  text-decoration-color: var(--theme-link-decoration-hover);
+@media (hover: hover) {
+  .markdown-body a:hover {
+    text-decoration-color: var(--theme-link-decoration-hover);
+  }
 }
 
 .markdown-body abbr[title] {
@@ -737,22 +741,26 @@
   visibility: hidden;
 }
 
-.markdown-body h1:hover .anchor,
-.markdown-body h2:hover .anchor,
-.markdown-body h3:hover .anchor,
-.markdown-body h4:hover .anchor,
-.markdown-body h5:hover .anchor,
-.markdown-body h6:hover .anchor {
-  text-decoration: none;
+@media (hover: hover) {
+  .markdown-body h1:hover .anchor,
+  .markdown-body h2:hover .anchor,
+  .markdown-body h3:hover .anchor,
+  .markdown-body h4:hover .anchor,
+  .markdown-body h5:hover .anchor,
+  .markdown-body h6:hover .anchor {
+    text-decoration: none;
+  }
 }
 
-.markdown-body h1:hover .anchor .octicon-link,
-.markdown-body h2:hover .anchor .octicon-link,
-.markdown-body h3:hover .anchor .octicon-link,
-.markdown-body h4:hover .anchor .octicon-link,
-.markdown-body h5:hover .anchor .octicon-link,
-.markdown-body h6:hover .anchor .octicon-link {
-  visibility: visible;
+@media (hover: hover) {
+  .markdown-body h1:hover .anchor .octicon-link,
+  .markdown-body h2:hover .anchor .octicon-link,
+  .markdown-body h3:hover .anchor .octicon-link,
+  .markdown-body h4:hover .anchor .octicon-link,
+  .markdown-body h5:hover .anchor .octicon-link,
+  .markdown-body h6:hover .anchor .octicon-link {
+    visibility: visible;
+  }
 }
 
 .markdown-body h1 tt,
@@ -1321,15 +1329,17 @@
   margin: 0 -1.6em 0.25em 0.2em;
 }
 
-.markdown-body .contains-task-list:hover .task-list-item-convert-container,
-.markdown-body
-  .contains-task-list:focus-within
-  .task-list-item-convert-container {
-  display: block;
-  width: auto;
-  height: 24px;
-  overflow: visible;
-  clip: auto;
+@media (hover: hover) {
+  .markdown-body .contains-task-list:hover .task-list-item-convert-container,
+  .markdown-body
+    .contains-task-list:focus-within
+    .task-list-item-convert-container {
+    display: block;
+    width: auto;
+    height: 24px;
+    overflow: visible;
+    clip: auto;
+  }
 }
 
 .markdown-body ::-webkit-calendar-picker-indicator {
@@ -1609,13 +1619,15 @@
   box-sizing: border-box;
 }
 
-/* Hover feedback only where the chip is actually a link. An inert span keeps the
-   default text cursor and no hover state, so it does not advertise a click that
-   does nothing. */
-.markdown-body a.er-author-link:hover,
-.markdown-body a.er-tag-link:hover {
-  color: var(--theme-accent-hover, #1b68da);
-  text-decoration: none;
+@media (hover: hover) {
+  /* Hover feedback only where the chip is actually a link. An inert span keeps the
+     default text cursor and no hover state, so it does not advertise a click that
+     does nothing. */
+  .markdown-body a.er-author-link:hover,
+  .markdown-body a.er-tag-link:hover {
+    color: var(--theme-accent-hover, #1b68da);
+    text-decoration: none;
+  }
 }
 
 /*

--- a/apps/self-hosted/src/styles/blog-markdown.css
+++ b/apps/self-hosted/src/styles/blog-markdown.css
@@ -750,9 +750,7 @@
   .markdown-body h6:hover .anchor {
     text-decoration: none;
   }
-}
 
-@media (hover: hover) {
   .markdown-body h1:hover .anchor .octicon-link,
   .markdown-body h2:hover .anchor .octicon-link,
   .markdown-body h3:hover .anchor .octicon-link,
@@ -1329,17 +1327,32 @@
   margin: 0 -1.6em 0.25em 0.2em;
 }
 
+/*
+ * Split, because the two halves are not the same kind of affordance.
+ *
+ * `:focus-within` is reached by keyboard, and a touch device with a hardware
+ * keyboard reports `hover: none`, so gating it would take the reveal away from
+ * exactly the people who navigate that way. Only the pointer half belongs
+ * inside the guard.
+ */
 @media (hover: hover) {
-  .markdown-body .contains-task-list:hover .task-list-item-convert-container,
-  .markdown-body
-    .contains-task-list:focus-within
-    .task-list-item-convert-container {
+  .markdown-body .contains-task-list:hover .task-list-item-convert-container {
     display: block;
     width: auto;
     height: 24px;
     overflow: visible;
     clip: auto;
   }
+}
+
+.markdown-body
+  .contains-task-list:focus-within
+  .task-list-item-convert-container {
+  display: block;
+  width: auto;
+  height: 24px;
+  overflow: visible;
+  clip: auto;
 }
 
 .markdown-body ::-webkit-calendar-picker-indicator {

--- a/apps/self-hosted/src/styles/components.css
+++ b/apps/self-hosted/src/styles/components.css
@@ -53,8 +53,10 @@
   transition: opacity var(--theme-transition);
 }
 
-.tag-theme:hover {
-  opacity: 0.7;
+@media (hover: hover) {
+  .tag-theme:hover {
+    opacity: 0.7;
+  }
 }
 
 /*
@@ -90,8 +92,10 @@
   border-radius: var(--theme-radius);
 }
 
-.btn-theme-primary:hover:not(:disabled) {
-  background-color: var(--theme-accent-hover);
+@media (hover: hover) {
+  .btn-theme-primary:hover:not(:disabled) {
+    background-color: var(--theme-accent-hover);
+  }
 }
 
 .btn-theme-primary:focus-visible {
@@ -107,11 +111,13 @@
   transition: all var(--theme-transition);
 }
 
-.link-theme:hover {
-  text-decoration-color: var(
-    --theme-link-decoration-hover,
-    var(--theme-accent)
-  );
+@media (hover: hover) {
+  .link-theme:hover {
+    text-decoration-color: var(
+      --theme-link-decoration-hover,
+      var(--theme-accent)
+    );
+  }
 }
 
 /*

--- a/apps/self-hosted/src/styles/hover-capability.test.ts
+++ b/apps/self-hosted/src/styles/hover-capability.test.ts
@@ -32,7 +32,13 @@ function cssFiles(dir: string): string[] {
  * Selectors containing `:hover` that are NOT inside an `@media (hover: ...)`
  * block, found by tracking brace depth and which `@media` opened each level.
  */
-function bareHoverSelectors(source: string): string[] {
+function bareHoverSelectors(rawSource: string): string[] {
+  // Comments first, for two separate reasons found by testing the detector
+  // rather than trusting it: a comment that merely MENTIONS :hover was reported
+  // as a bare rule, and a comment containing a brace desynced the depth
+  // tracking and produced garbage selectors. `parseBlocks` in the sibling test
+  // strips them for the same reason.
+  const source = rawSource.replace(/\/\*[\s\S]*?\*\//g, '');
   const bare: string[] = [];
   const openers: string[] = [];
   let i = 0;
@@ -52,7 +58,12 @@ function bareHoverSelectors(source: string): string[] {
     }
 
     const selector = head.split('}').pop()!.trim();
-    const insideHoverMedia = openers.some((o) => /@media[^{]*\(\s*hover/.test(o));
+    // `hover: hover` specifically. A looser test also accepted
+    // `@media (hover: none)`, which is the opposite condition and would have
+    // counted a rule that only applies on touch as correctly gated.
+    const insideHoverMedia = openers.some((o) =>
+      /@media[^{]*\(\s*(?:any-)?hover\s*:\s*hover\s*\)/.test(o),
+    );
 
     if (selector.includes(':hover') && !selector.startsWith('@') && !insideHoverMedia) {
       bare.push(selector.replace(/\s+/g, ' ').slice(0, 100));
@@ -93,5 +104,36 @@ describe('hover styling is gated on hover-capable devices', () => {
       bareHoverSelectors('@media (hover: hover) { .a:hover { opacity: 0.5; } }'),
     ).toEqual([]);
     expect(bareHoverSelectors('.a { color: red; }')).toEqual([]);
+  });
+
+  /** A comment that talks about hover is not a rule that uses it. */
+  it('ignores :hover inside comments', () => {
+    expect(
+      bareHoverSelectors('/* keep :hover out of here */ .a { color: red; }'),
+    ).toEqual([]);
+  });
+
+  /** A brace in a comment used to desync the depth tracking entirely. */
+  it('survives a brace inside a comment', () => {
+    expect(
+      bareHoverSelectors('/* a { b } */ @media (hover: hover) { .a:hover { x: 1; } }'),
+    ).toEqual([]);
+  });
+
+  /**
+   * `hover: none` is the opposite condition. Accepting it as a gate would pass
+   * a rule that applies only where the problem is.
+   */
+  it('does not accept hover: none as a gate', () => {
+    expect(
+      bareHoverSelectors('@media (hover: none) { .a:hover { x: 1; } }'),
+    ).toEqual(['.a:hover']);
+  });
+
+  /** `any-hover: hover` is a legitimate gate and must be accepted. */
+  it('accepts any-hover: hover', () => {
+    expect(
+      bareHoverSelectors('@media (any-hover: hover) { .a:hover { x: 1; } }'),
+    ).toEqual([]);
   });
 });

--- a/apps/self-hosted/src/styles/hover-capability.test.ts
+++ b/apps/self-hosted/src/styles/hover-capability.test.ts
@@ -1,0 +1,97 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Hover styling must be gated on a device that can hover.
+ *
+ * On a touch screen `:hover` latches after a tap and stays until the reader
+ * taps something else. A tapped tag keeps its dimmed look, a tapped button
+ * keeps its hover fill, and both read as still selected. It is the kind of bug
+ * nobody reports because it looks like the app is confused rather than broken.
+ *
+ * Tailwind v4 already wraps its own `hover:` variants in `@media (hover: hover)`
+ * (confirmed in the deployed stylesheet: three such blocks, 31 of the 57 hover
+ * rules). The hand-written CSS was the half left bare.
+ *
+ * Asserted on source rather than on the build output, because the build is not
+ * available to this runner and the source is where a new rule gets added.
+ */
+
+const STYLE_ROOT = join(__dirname, '..');
+
+function cssFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) return cssFiles(path);
+    return path.endsWith('.css') ? [path] : [];
+  });
+}
+
+/**
+ * Selectors containing `:hover` that are NOT inside an `@media (hover: ...)`
+ * block, found by tracking brace depth and which `@media` opened each level.
+ */
+function bareHoverSelectors(source: string): string[] {
+  const bare: string[] = [];
+  const openers: string[] = [];
+  let i = 0;
+
+  while (i < source.length) {
+    const brace = source.indexOf('{', i);
+    if (brace === -1) break;
+
+    const head = source.slice(i, brace);
+    const close = source.indexOf('}', i);
+
+    // A closing brace before the next opening one ends enclosing blocks.
+    if (close !== -1 && close < brace) {
+      openers.pop();
+      i = close + 1;
+      continue;
+    }
+
+    const selector = head.split('}').pop()!.trim();
+    const insideHoverMedia = openers.some((o) => /@media[^{]*\(\s*hover/.test(o));
+
+    if (selector.includes(':hover') && !selector.startsWith('@') && !insideHoverMedia) {
+      bare.push(selector.replace(/\s+/g, ' ').slice(0, 100));
+    }
+
+    openers.push(selector);
+    i = brace + 1;
+  }
+
+  return bare;
+}
+
+describe('hover styling is gated on hover-capable devices', () => {
+  const files = cssFiles(STYLE_ROOT);
+
+  it('finds the stylesheets to check', () => {
+    // Guards the reader: an empty list would make everything below vacuous.
+    expect(files.length).toBeGreaterThan(3);
+    expect(files.some((f) => f.endsWith('globals.css'))).toBe(true);
+  });
+
+  it.each(files.map((f) => [f.slice(STYLE_ROOT.length + 1), f]))(
+    '%s has no ungated :hover rule',
+    (_label, path) => {
+      expect(bareHoverSelectors(readFileSync(path, 'utf8'))).toEqual([]);
+    },
+  );
+
+  /**
+   * The detector has to actually detect. Without this the suite passes on a
+   * parser that finds nothing, which is the failure mode a source scan invites.
+   */
+  it('reports a bare rule and stays quiet about a gated one', () => {
+    expect(bareHoverSelectors('.a:hover { opacity: 0.5; }')).toEqual([
+      '.a:hover',
+    ]);
+    expect(
+      bareHoverSelectors('@media (hover: hover) { .a:hover { opacity: 0.5; } }'),
+    ).toEqual([]);
+    expect(bareHoverSelectors('.a { color: red; }')).toEqual([]);
+  });
+});

--- a/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
+++ b/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
@@ -72,7 +72,13 @@ function parseBlocks(source: string, file: string): Block[] {
       depth -= 1;
       if (depth > 0) continue;
       const selector = prelude.trim().replace(/\s+/g, ' ');
-      if (!selector.startsWith('@')) {
+      if (selector.startsWith('@')) {
+        // Recurse rather than discard. Hover rules now live inside
+        // `@media (hover: hover)`, so treating an at-rule's body as opaque
+        // hid `.btn-theme-primary:hover:not(:disabled)` from every assertion
+        // about it and failed with "components.css has no such rule".
+        out.push(...parseBlocks(css.slice(start, index), file));
+      } else {
         out.push({
           file,
           selector,

--- a/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
+++ b/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
@@ -48,7 +48,19 @@ function blocks(file: string): Block[] {
   return parseBlocks(readFileSync(join(THEMES, file), 'utf8'), file);
 }
 
-/** Top-level `selector { ... }` blocks of a stylesheet, comments removed. */
+/**
+ * Every `selector { ... }` rule of a stylesheet, comments removed.
+ *
+ * At-rule bodies are recursed into and their rules FLATTENED into the same
+ * list, not skipped: hover rules now live inside `@media (hover: hover)`, and
+ * treating an at-rule as opaque hid them from every assertion about them.
+ *
+ * Two consequences of flattening, both fine here and both worth knowing. Order
+ * is source order, so a rule inside a media block appears after the base rule
+ * it overrides. And the same selector can appear twice, once bare and once
+ * media-scoped; `componentRule` takes the first match, which is the base rule,
+ * because that is the one these assertions are about.
+ */
 function parseBlocks(source: string, file: string): Block[] {
   const css = source.replace(/\/\*[\s\S]*?\*\//g, '');
   const out: Block[] = [];


### PR DESCRIPTION
Second of three long-standing panel/UI defects.

On a touch screen `:hover` latches after a tap and stays until the reader taps something else. A tapped tag keeps its dimmed look, a tapped button keeps its hover fill, and both read as still selected. It is the kind of bug nobody reports, because it looks like the app is confused rather than broken.

## What was actually bare

Measured against the **deployed** stylesheet rather than assumed:

- 57 `:hover` rules total, **31 guarded, 26 bare**.
- Tailwind v4 already wraps its own `hover:` variants in `@media (hover: hover)`. Three such blocks were present, covering `hover:border-theme`, `group-hover:opacity-100`, `dark:hover:bg-gray-700` and the rest.
- The 26 bare ones were **exactly** the hand-written CSS: `globals.css`'s `a:hover`, three rules in `components.css`, and six blocks in `blog-markdown.css`.

So this is not "add a guard everywhere"; it is finishing the job Tailwind already does for its own utilities.

## Scope of what went inside the guard

Only appearance. Nothing affecting layout, and nothing a reader needs in order to operate the page, because a device reporting no hover never gets any of it. The markdown anchor-link reveals (`h1:hover .anchor`) are hover-only affordances that were already unreachable on touch, so guarding them changes nothing there.

## Verification

**Built the app and measured the output**, which is the check that matters:

```
hover guards: 12   total :hover: 66   UNGUARDED: 0
```

Against 26 unguarded on the live site. Local builds need `config.json`, which is gitignored, so I seeded it from `config.template.json`; neither it nor `dist/` is committed.

A test asserts the invariant over every stylesheet by tracking brace depth and which at-rule opened each level. It also **checks its own detector** against a bare rule and a gated one, since a source scan that silently finds nothing passes exactly as well as one that works. Mutation-checked by unwrapping a guard: only that file's case fails.

## One existing test needed teaching

`parseBlocks` in `theme-appearance-tokens.test.ts` treated an at-rule body as opaque, so moving the button hover inside `@media` hid `.btn-theme-primary:hover:not(:disabled)` from every assertion about it and failed with "components.css has no such rule". It now recurses into at-rules rather than discarding them, which is the fix rather than relaxing the assertion.

825 tests pass, 60 files. Typecheck clean apart from the pre-existing gitignored `config.json` error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved hover interactions across links, buttons, tags, blog content, and heading anchors on touch and other non-hover devices.
  * Preserved keyboard and focus-based interactions for task lists.

* **Tests**
  * Added automated checks to ensure hover styles are only applied when supported.
  * Expanded stylesheet parsing coverage for nested style rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->