### PR TITLE
Translate: run server /detect escalation only for logged-in readers

### DIFF
--- a/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
+++ b/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import i18next from "i18next";
 import { postBodySummary } from "@ecency/render-helper";
 import { detectLanguage } from "@/api/translation";
+import { useGlobalStore } from "@/core/global-store";
 import {
   francToIso1,
   LIBRETRANSLATE_TARGETS,
@@ -83,7 +84,11 @@ interface GateOptions {
   // Full-post view: confirm/refine the franc guess with the server /detect
   // endpoint (accurate source-language name, catches franc-unsupported langs,
   // corrects confident misdetections). NEVER enable for feed/wave chips — it
-  // would fan out one network call per rendered item.
+  // would fan out one network call per rendered item. Only honored for
+  // logged-in readers: search crawlers and headless scrapers execute this
+  // code while rendering post pages, and their per-view /detect calls were
+  // enough traffic to overload the translate backend. Logged-out readers get
+  // the franc guess, the same fallback as when /detect is unreachable.
   serverConfirm?: boolean;
   // Skip detection entirely (e.g. raw/edit view, NSFW not yet revealed).
   disabled?: boolean;
@@ -106,6 +111,9 @@ export function useContentLanguageGate(
   { serverConfirm = false, disabled = false }: GateOptions = {}
 ): TranslateCtaDecision | null {
   const [decision, setDecision] = useState<TranslateCtaDecision | null>(null);
+  const activeUsername = useGlobalStore((state) => state.activeUser?.username);
+  // Server /detect is a logged-in-only escalation (see GateOptions.serverConfirm).
+  const canServerConfirm = serverConfirm && !!activeUsername;
 
   const author = entry?.author;
   const permlink = entry?.permlink;
@@ -128,7 +136,7 @@ export function useContentLanguageGate(
     const reader = resolveReaderLang();
 
     const cached = contentLangCache.get(key);
-    if (cached && (cached.confirmed || !serverConfirm)) {
+    if (cached && (cached.confirmed || !canServerConfirm)) {
       // A cached lang implies the body was already long enough when detected.
       setDecision(
         resolveTranslateCta({ detected: cached.lang, reader, textLength: MIN_DETECT_CHARS })
@@ -165,7 +173,7 @@ export function useContentLanguageGate(
           // franc is confident it's the reader's own language — no CTA, and no
           // need to spend a /detect call. Safe to treat as confirmed.
           confirmed = true;
-        } else if (serverConfirm) {
+        } else if (canServerConfirm) {
           // Full-post: get the authoritative source language. Covers franc
           // 'und'/unsupported langs and corrects confident misdetections
           // (e.g. Danish reported as Dutch) so the banner names the real one.
@@ -199,7 +207,7 @@ export function useContentLanguageGate(
     return () => {
       cancelled = true;
     };
-  }, [author, permlink, body, serverConfirm, disabled]);
+  }, [author, permlink, body, canServerConfirm, disabled]);
 
   return decision;
 }

--- a/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
+++ b/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import i18next from "i18next";
 import { postBodySummary } from "@ecency/render-helper";
 import { detectLanguage } from "@/api/translation";
-import { useGlobalStore } from "@/core/global-store";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
 import {
   francToIso1,
   LIBRETRANSLATE_TARGETS,
@@ -111,7 +111,7 @@ export function useContentLanguageGate(
   { serverConfirm = false, disabled = false }: GateOptions = {}
 ): TranslateCtaDecision | null {
   const [decision, setDecision] = useState<TranslateCtaDecision | null>(null);
-  const activeUsername = useGlobalStore((state) => state.activeUser?.username);
+  const { username: activeUsername } = useActiveAccount();
   // Server /detect is a logged-in-only escalation (see GateOptions.serverConfirm).
   const canServerConfirm = serverConfirm && !!activeUsername;
 

--- a/apps/web/src/specs/features/entry-translate-language-gate.spec.tsx
+++ b/apps/web/src/specs/features/entry-translate-language-gate.spec.tsx
@@ -1,0 +1,66 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActiveUser } from "@/entities";
+import { useGlobalStore } from "@/core/global-store";
+import { useContentLanguageGate } from "@/features/shared/entry-translate/use-content-language-gate";
+import { detectLanguage } from "@/api/translation";
+
+vi.mock("@/api/translation", () => ({
+  detectLanguage: vi.fn(async () => [{ language: "da", confidence: 99 }])
+}));
+
+vi.mock("franc-min", () => ({
+  franc: vi.fn(() => "spa")
+}));
+
+// Long enough to clear MIN_DETECT_CHARS after markdown summarization.
+const SPANISH_BODY =
+  "Este es un texto de prueba lo suficientemente largo para que la deteccion " +
+  "de idioma funcione correctamente en la vista completa de la publicacion.";
+
+const loggedIn = { username: "alice", data: {} } as ActiveUser;
+
+describe("useContentLanguageGate server /detect gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useGlobalStore.setState({ activeUser: null });
+  });
+
+  it("does not call /detect for logged-out readers even with serverConfirm", async () => {
+    const { result } = renderHook(() =>
+      useContentLanguageGate(
+        { author: "author1", permlink: "gate-logged-out", body: SPANISH_BODY },
+        { serverConfirm: true }
+      )
+    );
+
+    // Resolves from the franc guess alone (es vs en reader).
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(detectLanguage).not.toHaveBeenCalled();
+  });
+
+  it("calls /detect for logged-in readers with serverConfirm", async () => {
+    useGlobalStore.setState({ activeUser: loggedIn });
+
+    const { result } = renderHook(() =>
+      useContentLanguageGate(
+        { author: "author2", permlink: "gate-logged-in", body: SPANISH_BODY },
+        { serverConfirm: true }
+      )
+    );
+
+    await waitFor(() => expect(detectLanguage).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current).not.toBeNull());
+  });
+
+  it("never calls /detect on the feed path regardless of login", async () => {
+    useGlobalStore.setState({ activeUser: loggedIn });
+
+    const { result } = renderHook(() =>
+      useContentLanguageGate({ author: "author3", permlink: "gate-feed", body: SPANISH_BODY })
+    );
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(detectLanguage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/specs/features/entry-translate-language-gate.spec.tsx
+++ b/apps/web/src/specs/features/entry-translate-language-gate.spec.tsx
@@ -1,7 +1,6 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ActiveUser } from "@/entities";
-import { useGlobalStore } from "@/core/global-store";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useContentLanguageGate } from "@/features/shared/entry-translate/use-content-language-gate";
 import { detectLanguage } from "@/api/translation";
 
@@ -18,12 +17,26 @@ const SPANISH_BODY =
   "Este es un texto de prueba lo suficientemente largo para que la deteccion " +
   "de idioma funcione correctamente en la vista completa de la publicacion.";
 
-const loggedIn = { username: "alice", data: {} } as ActiveUser;
+// useActiveAccount is globally mocked (setup-any-spec) to a logged-out shape;
+// tests override the resolved username per case.
+function setLoggedIn(username: string | null) {
+  vi.mocked(useActiveAccount).mockReturnValue({
+    activeUser: username ? { username } : null,
+    username,
+    account: null,
+    isLoading: false,
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+    error: null,
+    refetch: vi.fn()
+  } as unknown as ReturnType<typeof useActiveAccount>);
+}
 
 describe("useContentLanguageGate server /detect gating", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useGlobalStore.setState({ activeUser: null });
+    setLoggedIn(null);
   });
 
   it("does not call /detect for logged-out readers even with serverConfirm", async () => {
@@ -40,7 +53,7 @@ describe("useContentLanguageGate server /detect gating", () => {
   });
 
   it("calls /detect for logged-in readers with serverConfirm", async () => {
-    useGlobalStore.setState({ activeUser: loggedIn });
+    setLoggedIn("alice");
 
     const { result } = renderHook(() =>
       useContentLanguageGate(
@@ -54,7 +67,7 @@ describe("useContentLanguageGate server /detect gating", () => {
   });
 
   it("never calls /detect on the feed path regardless of login", async () => {
-    useGlobalStore.setState({ activeUser: loggedIn });
+    setLoggedIn("alice");
 
     const { result } = renderHook(() =>
       useContentLanguageGate({ author: "author3", permlink: "gate-feed", body: SPANISH_BODY })


### PR DESCRIPTION
Closes #1373.

The full-post language-CTA escalates from the client-side franc guess to the server /detect endpoint. Bots that execute JS while rendering post pages (search crawlers and headless scrapers) fire that call on every rendered view, which recently overloaded the translate backend.

- serverConfirm is now honored only when there is an active user; logged-out readers keep the franc guess, the same fallback used today when /detect is unreachable.
- The CTA itself and tap-to-translate stay available to everyone; feed and wave chips were already franc-only.
- Cache semantics unchanged: a franc-only cached entry can still be upgraded by a later confirmed detection once a user logs in.

Tests: new spec covering logged-out (no /detect), logged-in (/detect fires) and feed path (never fires). Full vitest suite, tsc and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language detection behavior based on sign-in status and server confirmation settings.
  * Prevented unnecessary language-detection requests for signed-out readers and feed content.

* **Tests**
  * Added coverage for language detection across signed-in, signed-out, server-confirmed, and feed scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->