### PR TITLE
Fix two tests from the #1375 review that passed without testing anything

### DIFF
--- a/apps/self-hosted/src/features/blog/no-third-party-frontends.test.ts
+++ b/apps/self-hosted/src/features/blog/no-third-party-frontends.test.ts
@@ -1,5 +1,6 @@
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 /**
@@ -35,6 +36,38 @@ const FOREIGN = [
   'liketu.com',
 ];
 
+/**
+ * A file's code with comments removed, via the TypeScript scanner.
+ *
+ * Regex stripping cannot do this. Removing whole-line `//` misses a TRAILING
+ * one, so `const u = base + a; // never link to hivehub.dev` still reported an
+ * offender, and widening the regex to any `//` eats the `//` inside every
+ * `https://` URL in the file. The scanner knows which is which because it knows
+ * where strings and comments actually start.
+ */
+function codeOf(file: string): string {
+  const source = readFileSync(file, 'utf8');
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    /* skipTrivia */ false,
+    file.endsWith('.tsx') ? ts.LanguageVariant.JSX : ts.LanguageVariant.Standard,
+    source,
+  );
+
+  let out = '';
+  let kind = scanner.scan();
+  while (kind !== ts.SyntaxKind.EndOfFileToken) {
+    if (
+      kind !== ts.SyntaxKind.SingleLineCommentTrivia &&
+      kind !== ts.SyntaxKind.MultiLineCommentTrivia
+    ) {
+      out += scanner.getTokenText();
+    }
+    kind = scanner.scan();
+  }
+  return out;
+}
+
 function sourceFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
     const path = join(dir, entry);
@@ -55,14 +88,7 @@ describe('outbound Hive links stay ours', () => {
 
   it.each(FOREIGN)('links to no %s', (host) => {
     const offenders = files
-      .filter((file) => {
-        const source = readFileSync(file, 'utf8');
-        // Comments explain WHY a host is not used, so they may name it.
-        const code = source
-          .replace(/\/\*[\s\S]*?\*\//g, '')
-          .replace(/^\s*\/\/.*$/gm, '');
-        return code.includes(host);
-      })
+      .filter((file) => codeOf(file).includes(host))
       .map((file) => file.slice(SRC.length + 1));
 
     expect(offenders).toEqual([]);
@@ -72,11 +98,29 @@ describe('outbound Hive links stay ours', () => {
    * The detector has to detect. Without this the sweep passes on a reader that
    * finds nothing, which is the failure mode a source scan invites.
    */
-  it('would catch a reintroduction', () => {
-    const withLink = "const u = `https://hivehub.dev/@${a}/${p}`;";
-    expect(withLink.includes('hivehub.dev')).toBe(true);
-    const onlyComment = '// never link to hivehub.dev\nconst u = base + a;';
-    const stripped = onlyComment.replace(/^\s*\/\/.*$/gm, '');
-    expect(stripped.includes('hivehub.dev')).toBe(false);
+  it('reads code and ignores comments, including trailing ones', () => {
+    const probe = join(SRC, '__scanner_probe.ts');
+    writeFileSync(
+      probe,
+      [
+        '// leading: never link to hivehub.dev',
+        'const a = "https://ecency.com/@x"; // trailing: not peakd.com either',
+        '/* block: nor hive.blog */',
+        'const b = a;',
+      ].join('\n'),
+    );
+    try {
+      const code = codeOf(probe);
+      // All three comment forms gone, including the trailing one, which a
+      // line-anchored regex leaves behind.
+      expect(code).not.toContain('hivehub.dev');
+      expect(code).not.toContain('peakd.com');
+      expect(code).not.toContain('hive.blog');
+      // And the `//` inside a real URL survives, which is what stops a blunter
+      // strip from being an option.
+      expect(code).toContain('https://ecency.com/@x');
+    } finally {
+      rmSync(probe, { force: true });
+    }
   });
 });

--- a/packages/render-helper/src/methods/linkify.method.spec.ts
+++ b/packages/render-helper/src/methods/linkify.method.spec.ts
@@ -470,15 +470,52 @@ describe('externalProfileBase through markdown2Html', () => {
   })
 
   /**
-   * The cache key has to carry the option or the first render for a body wins
-   * for every later one, and a consumer that passes it would get whatever the
-   * previous consumer got.
+   * The cache key has to carry the option, or the first render of an entry wins
+   * for every later one and a consumer that passes it gets whatever the
+   * previous consumer produced.
+   *
+   * An ENTRY, not a string. `markdown2Html` returns early for a string, before
+   * `cacheGet` and `cacheSet` are ever reached, so the first version of this
+   * test passed with the option removed from the key entirely: it never touched
+   * the cache it claimed to be testing. Only the entry overload does.
+   *
+   * The identity is `author-permlink-last_update-updated`, so both calls use
+   * the same fixture and the key differs only by the option.
    */
   it('does not serve a cached render made without the option', () => {
-    const body = '/@bob/followers is here'
-    const plain = markdown2Html(body, false, false, 'ecency.com', undefined, { inertAuthorAndTagChips: true })
-    const external = markdown2Html(body, false, false, 'ecency.com', undefined, opts)
+    const entry = {
+      author: 'bob',
+      permlink: 'cache-key-fixture',
+      last_update: '2026-08-06T00:00:00',
+      updated: '2026-08-06T00:00:00',
+      body: '/@bob/followers is here',
+    } as never
+
+    const plain = markdown2Html(entry, false, false, 'ecency.com', undefined, {
+      inertAuthorAndTagChips: true,
+    })
+    const external = markdown2Html(entry, false, false, 'ecency.com', undefined, opts)
+
     expect(plain).toContain('href="/@bob/followers"')
     expect(external).toContain('https://ecency.com/@bob/followers')
+  })
+
+  /** Order-independent: the cached-first path must hold in reverse too. */
+  it('does not serve the option render to a caller that passed none', () => {
+    const entry = {
+      author: 'carol',
+      permlink: 'cache-key-fixture-reverse',
+      last_update: '2026-08-06T00:00:00',
+      updated: '2026-08-06T00:00:00',
+      body: '/@carol/followers is here',
+    } as never
+
+    const external = markdown2Html(entry, false, false, 'ecency.com', undefined, opts)
+    const plain = markdown2Html(entry, false, false, 'ecency.com', undefined, {
+      inertAuthorAndTagChips: true,
+    })
+
+    expect(external).toContain('https://ecency.com/@carol/followers')
+    expect(plain).toContain('href="/@carol/followers"')
   })
 })


### PR DESCRIPTION
Both findings from the #1375 review, which landed after the merge. Both are tests that passed while asserting nothing, which is the worst kind to leave in place: they read as coverage.

## 1. The cache-key test never touched the cache

`markdown2Html` returns early for a **string**, before `cacheGet` and `cacheSet` are reached:

```ts
if (typeof obj === 'string') {
  ...
  return res
}
// key is built only below here
```

My test passed strings. I proved the hole before fixing it: deleting `externalProfileBase` from the cache key entirely left **all 54 tests passing**. The claim in the comment above that key, that every flag changing output must appear in it, had no test behind it for this flag.

It now uses an `Entry`, the only overload that caches, with a stable `author-permlink-last_update-updated` identity so the key differs by the option alone. Asserted in **both orders**, since the cached-first path has to hold whichever call lands first, and only one order was covered before.

## 2. The frontend sweep missed trailing comments

The strip handled block comments and whole-line comments, so this still reported an offender:

```ts
const u = base + a; // never link to hivehub.dev
```

Widening the regex is not an option, as the reviewer noted: `//` appears inside every `https://` URL in these files, so a blunter strip would blind the whole check. It uses the **TypeScript scanner** now, which knows where a comment starts and where a string does.

The self-check writes a real file and runs it through the real function, rather than doing string manipulation that stands in for the function and can drift from it. It covers leading, trailing and block comments, and asserts a genuine URL survives.

## Verification

- render-helper 1252 passed, self-hosted 866 passed. Typecheck clean.
- Mutations, each failing only its own case: dropping the option from the cache key (now fails, previously did not); adding a trailing comment naming a host, which must **not** fail; adding a real `peakd.com` link, which must.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link detection so URLs in comments are ignored while valid links remain recognized.
  * Prevented rendered content from incorrectly reusing cached results when external profile settings differ.

* **Tests**
  * Expanded coverage for comment handling, URL detection, and rendering with different external-link configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->