### PR TITLE
Chat: tell a banned user what happened and when it lifts

### DIFF
--- a/apps/web/src/app/api/mattermost/bootstrap/route.ts
+++ b/apps/web/src/app/api/mattermost/bootstrap/route.ts
@@ -180,7 +180,12 @@ async function handleBootstrap(req: Request, signal: AbortSignal): Promise<NextR
               bannedUntil: e.bannedUntil
             });
             return NextResponse.json(
-                { error: e.message, bannedUntil: e.bannedUntil, prop: CHAT_BAN_PROP },
+                {
+                  error: e.message,
+                  bannedUntil: e.bannedUntil,
+                  reason: e.reason,
+                  prop: CHAT_BAN_PROP
+                },
                 { status: 403 }
             );
         }

--- a/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
+++ b/apps/web/src/app/api/mattermost/channels/[channelId]/posts/route.ts
@@ -9,6 +9,7 @@ import {
   MattermostChannel,
   getMattermostTokenFromCookies,
   mmUserFetch,
+  getUserChatBanReason,
   isUserChatBanned,
   CHAT_BAN_PROP
 } from "@/server/mattermost";
@@ -345,10 +346,14 @@ export async function POST(
     if (bannedUntil) {
       return NextResponse.json(
         {
+          // `error` stays the operator-facing string. The client builds what the user
+          // actually reads from bannedUntil + reason, so it can localise it and show a
+          // countdown instead of an ISO timestamp.
           error: `@${currentUser.username} is banned from chat until ${new Date(
             Number(bannedUntil)
           ).toISOString()}`,
           bannedUntil,
+          reason: getUserChatBanReason(currentUser),
           prop: CHAT_BAN_PROP
         },
         { status: 403 }

--- a/apps/web/src/app/chats/[id]/page.tsx
+++ b/apps/web/src/app/chats/[id]/page.tsx
@@ -3,6 +3,8 @@
 import { useParams } from "next/navigation";
 import { MattermostChannelView } from "@/features/chat/mattermost-channel-view";
 import { useMattermostBootstrap } from "@/features/chat/mattermost-api";
+import { getChatBanInfo } from "@/features/chat/chat-ban-notice";
+import { ChatBanScreen } from "@/features/chat/components/chat-ban-screen";
 import { ChatErrorBoundary } from "@/features/chat/chat-error-boundary";
 import { LoginRequired } from "@/features/shared/login-required";
 import { useHydrated } from "@/api/queries";
@@ -12,7 +14,7 @@ export default function ChannelPage() {
   const { activeUser } = useActiveAccount();
   const hydrated = useHydrated();
   const params = useParams<{ id: string }>();
-  const { data: bootstrap, isLoading, error } = useMattermostBootstrap();
+  const { data: bootstrap, isLoading, error, refetch } = useMattermostBootstrap();
 
   if (!hydrated) {
     return (
@@ -28,6 +30,15 @@ export default function ChannelPage() {
         <LoginRequired />
       </div>
     );
+  }
+
+  if (!bootstrap && !isLoading && error) {
+    // Before the auth heuristic: a ban is not an expired session, and on a direct-channel URL
+    // this pane is the ONLY thing rendered, so getting it wrong leaves no correct copy anywhere.
+    const bootstrapBan = getChatBanInfo(error);
+    if (bootstrapBan) {
+      return <ChatBanScreen info={bootstrapBan} onExpire={refetch} />;
+    }
   }
 
   if (!bootstrap && !isLoading && error?.message.includes("username")) {

--- a/apps/web/src/app/chats/_components/chats-client.tsx
+++ b/apps/web/src/app/chats/_components/chats-client.tsx
@@ -29,7 +29,8 @@ import { checkSvg, dotsHorizontal, volumeOffSvg } from "@ui/svg";
 import { ChangeEvent, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
-import { formatChatBanNotice, getChatBanInfo } from "@/features/chat/chat-ban-notice";
+import { getChatBanInfo } from "@/features/chat/chat-ban-notice";
+import { ChatBanScreen } from "@/features/chat/components/chat-ban-screen";
 
 const TOWN_HALL_CHANNEL_NAME = "town-hall";
 
@@ -361,16 +362,7 @@ export function ChatsClient() {
     // (their own handle and an ISO timestamp) on the chats page.
     const bootstrapBan = getChatBanInfo(error);
     if (bootstrapBan) {
-      return (
-        <div className="flex h-full flex-col items-center justify-center gap-3 p-4">
-          <div
-            role="status"
-            className="max-w-md rounded border border-[--border-color] bg-[--surface-color] p-4 text-center text-sm text-[--text-muted]"
-          >
-            {formatChatBanNotice(bootstrapBan)}
-          </div>
-        </div>
-      );
+      return <ChatBanScreen info={bootstrapBan} onExpire={refetchBootstrap} />;
     }
 
     const errorMessage = error?.message?.toLowerCase() || "";

--- a/apps/web/src/app/chats/_components/chats-client.tsx
+++ b/apps/web/src/app/chats/_components/chats-client.tsx
@@ -29,6 +29,7 @@ import { checkSvg, dotsHorizontal, volumeOffSvg } from "@ui/svg";
 import { ChangeEvent, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { formatChatBanNotice, getChatBanInfo } from "@/features/chat/chat-ban-notice";
 
 const TOWN_HALL_CHANNEL_NAME = "town-hall";
 
@@ -354,6 +355,24 @@ export function ChatsClient() {
 
   // Handle authentication errors from bootstrap
   if (!bootstrap && !isLoading && error) {
+    // A ban is checked FIRST and by payload, not by message text. Bootstrap fails for a
+    // deactivated+banned account, so the channel view never mounts and its composer notice is
+    // unreachable — without this branch the fallback below prints the operator-facing string
+    // (their own handle and an ISO timestamp) on the chats page.
+    const bootstrapBan = getChatBanInfo(error);
+    if (bootstrapBan) {
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-3 p-4">
+          <div
+            role="status"
+            className="max-w-md rounded border border-[--border-color] bg-[--surface-color] p-4 text-center text-sm text-[--text-muted]"
+          >
+            {formatChatBanNotice(bootstrapBan)}
+          </div>
+        </div>
+      );
+    }
+
     const errorMessage = error?.message?.toLowerCase() || "";
     const isAuthError =
       errorMessage.includes("unauthorized") ||

--- a/apps/web/src/app/chats/_components/chats-page-client.tsx
+++ b/apps/web/src/app/chats/_components/chats-page-client.tsx
@@ -3,6 +3,8 @@
 import { useMemo } from "react";
 import { useHydrated } from "@/api/queries";
 import { useMattermostBootstrap, useMattermostChannels } from "@/features/chat/mattermost-api";
+import { getChatBanInfo } from "@/features/chat/chat-ban-notice";
+import { ChatBanScreen } from "@/features/chat/components/chat-ban-screen";
 import { MattermostChannelView } from "@/features/chat/mattermost-channel-view";
 import { ChatErrorBoundary } from "@/features/chat/chat-error-boundary";
 import { LoginRequired } from "@/features/shared";
@@ -45,6 +47,14 @@ export function ChatsPageClient() {
 
   // Handle all authentication errors
   if (!bootstrap && !isLoading && error) {
+    // Checked by payload and BEFORE the message-text heuristics below. A ban is not an auth
+    // failure, and matching on wording would be fragile: the operator string embeds the account
+    // name and an ISO date, neither of which is a stable thing to pattern-match on.
+    const bootstrapBan = getChatBanInfo(error);
+    if (bootstrapBan) {
+      return <ChatBanScreen info={bootstrapBan} onExpire={refetch} />;
+    }
+
     const errorMessage = error?.message?.toLowerCase() || "";
     const isAuthError =
       errorMessage.includes("unauthorized") ||

--- a/apps/web/src/features/chat/chat-ban-notice.ts
+++ b/apps/web/src/features/chat/chat-ban-notice.ts
@@ -12,6 +12,10 @@ import i18next from "i18next";
  * message rather than failing, because older bans predate the reason prop and a newer service
  * version may add reasons this build has never heard of.
  */
+/** How often the live notice re-renders. Bounded on purpose: see the ticking effect in
+ *  mattermost-channel-view — a delay derived from `bannedUntil` overflows setTimeout. */
+export const BAN_NOTICE_TICK_MS = 30_000;
+
 export type ChatBanInfo = {
   bannedUntil: number;
   reason?: string;
@@ -43,7 +47,11 @@ export function formatBanRemaining(bannedUntil: number, now = Date.now()): strin
   if (minutes <= 1) {
     return i18next.t("chat.ban-remaining-soon", { defaultValue: "in under a minute" });
   }
-  if (minutes < 60) {
+
+  // Each band below hands {{count}} a value of 2 or more, so no phrasing ever comes out as
+  // "1 hours". That keeps these as plain keys, matching how the rest of the locale file counts,
+  // instead of needing plural variants for a string that can never be singular.
+  if (minutes < 90) {
     return i18next.t("chat.ban-remaining-minutes", {
       defaultValue: "in about {{count}} minutes",
       count: minutes
@@ -54,14 +62,13 @@ export function formatBanRemaining(bannedUntil: number, now = Date.now()): strin
   if (hours < 48) {
     return i18next.t("chat.ban-remaining-hours", {
       defaultValue: "in about {{count}} hours",
-      count: Math.max(1, hours)
+      count: hours
     });
   }
 
-  const days = Math.round(ms / 86400000);
   return i18next.t("chat.ban-remaining-days", {
     defaultValue: "in about {{count}} days",
-    count: days
+    count: Math.round(ms / 86400000)
   });
 }
 

--- a/apps/web/src/features/chat/chat-ban-notice.ts
+++ b/apps/web/src/features/chat/chat-ban-notice.ts
@@ -1,0 +1,103 @@
+import i18next from "i18next";
+
+/**
+ * Builds what a banned user actually reads.
+ *
+ * The server sends `bannedUntil` (epoch ms) and an optional `reason`, and deliberately does NOT
+ * send display copy: the remaining time has to be computed at render time so it counts down, and
+ * the wording has to be localisable. The server's own `error` string is operator-facing (it names
+ * the account and quotes an ISO timestamp) and must not be shown to the person who is banned.
+ *
+ * Reasons come from the moderation service. An unknown or absent reason degrades to the generic
+ * message rather than failing, because older bans predate the reason prop and a newer service
+ * version may add reasons this build has never heard of.
+ */
+export type ChatBanInfo = {
+  bannedUntil: number;
+  reason?: string;
+};
+
+/** Extracts ban info from a thrown request error, or null when it isn't a ban. */
+export function getChatBanInfo(error: unknown, now = Date.now()): ChatBanInfo | null {
+  const e = error as { status?: number; bannedUntil?: unknown; reason?: unknown } | null;
+  const bannedUntil = Number(e?.bannedUntil);
+
+  if (!e?.bannedUntil || Number.isNaN(bannedUntil) || bannedUntil <= now) {
+    return null;
+  }
+
+  return {
+    bannedUntil,
+    reason: typeof e.reason === "string" ? e.reason : undefined
+  };
+}
+
+/**
+ * Coarse, human remaining time. Deliberately approximate ("about 2 days") rather than precise:
+ * the exact second is noise, and rounding up avoids promising an unlock that has not happened yet.
+ */
+export function formatBanRemaining(bannedUntil: number, now = Date.now()): string {
+  const ms = Math.max(0, bannedUntil - now);
+  const minutes = Math.ceil(ms / 60000);
+
+  if (minutes <= 1) {
+    return i18next.t("chat.ban-remaining-soon", { defaultValue: "in under a minute" });
+  }
+  if (minutes < 60) {
+    return i18next.t("chat.ban-remaining-minutes", {
+      defaultValue: "in about {{count}} minutes",
+      count: minutes
+    });
+  }
+
+  const hours = Math.round(ms / 3600000);
+  if (hours < 48) {
+    return i18next.t("chat.ban-remaining-hours", {
+      defaultValue: "in about {{count}} hours",
+      count: Math.max(1, hours)
+    });
+  }
+
+  const days = Math.round(ms / 86400000);
+  return i18next.t("chat.ban-remaining-days", {
+    defaultValue: "in about {{count}} days",
+    count: days
+  });
+}
+
+/** The reason sentence. Never names the detection thresholds or the underlying prop. */
+function reasonSentence(reason?: string): string {
+  switch (reason) {
+    case "spray":
+      return i18next.t("chat.ban-reason-spray", {
+        defaultValue:
+          "You're paused from posting because the same message went to several channels at once."
+      });
+    case "mass-dm":
+      return i18next.t("chat.ban-reason-mass-dm", {
+        defaultValue:
+          "You're paused from posting because a message was sent to many people at once."
+      });
+    default:
+      // Covers "manual" and anything this build doesn't recognise.
+      return i18next.t("chat.ban-reason-generic", {
+        defaultValue: "You're paused from posting in chat."
+      });
+  }
+}
+
+/**
+ * Full notice: what happened, that reading still works, and when it lifts.
+ * `now` is injectable so the countdown can be re-rendered and so tests are deterministic.
+ */
+export function formatChatBanNotice(info: ChatBanInfo, now = Date.now()): string {
+  const stillReadable = i18next.t("chat.ban-can-still-read", {
+    defaultValue: "You can still read chat."
+  });
+  const unlocks = i18next.t("chat.ban-unlocks", {
+    defaultValue: "Posting unlocks {{when}}.",
+    when: formatBanRemaining(info.bannedUntil, now)
+  });
+
+  return `${reasonSentence(info.reason)} ${stillReadable} ${unlocks}`;
+}

--- a/apps/web/src/features/chat/components/chat-ban-screen.tsx
+++ b/apps/web/src/features/chat/components/chat-ban-screen.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from "react";
+import { BAN_NOTICE_TICK_MS, ChatBanInfo, formatChatBanNotice } from "../chat-ban-notice";
+
+interface Props {
+  info: ChatBanInfo;
+  /**
+   * Called once the ban lapses, so the caller can re-run bootstrap without a reload. Bootstrap
+   * only refetches on focus (throttled), so without this a user sitting on the page stays locked
+   * out well past their expiry.
+   */
+  onExpire?: () => void;
+}
+
+/**
+ * The full-pane ban notice, shared by every bootstrap consumer.
+ *
+ * There are three of them (the sidebar, the desktop main pane, and the direct-channel route) and
+ * each had its own bootstrap error handling. Rendering this in only one produced a split screen:
+ * the correct explanation in the sidebar next to a generic failure in the main pane. Keeping the
+ * rendering in one component is what stops them drifting apart again.
+ *
+ * The tick is a bounded interval, never a delay derived from `bannedUntil`: setTimeout takes a
+ * 32-bit signed delay, so a multi-year ban would otherwise fire almost immediately.
+ */
+export function ChatBanScreen({ info, onExpire }: Props) {
+  const [now, setNow] = useState(() => Date.now());
+
+  // Held in a ref so an inline arrow from the caller doesn't restart the interval every render.
+  const onExpireRef = useRef(onExpire);
+  onExpireRef.current = onExpire;
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const t = Date.now();
+      setNow(t);
+      if (t >= info.bannedUntil) {
+        clearInterval(id);
+        onExpireRef.current?.();
+      }
+    }, BAN_NOTICE_TICK_MS);
+    return () => clearInterval(id);
+  }, [info.bannedUntil]);
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-4">
+      <div
+        role="status"
+        className="max-w-md rounded border border-[--border-color] bg-[--surface-color] p-4 text-center text-sm text-[--text-muted]"
+      >
+        {formatChatBanNotice(info, now)}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/chat/components/message-input.tsx
+++ b/apps/web/src/features/chat/components/message-input.tsx
@@ -31,6 +31,8 @@ interface MessageInputProps {
   setMessageError: (error: string | null) => void;
   /** Present while a chat ban is live; renders a standing notice instead of a transient error. */
   banInfo?: ChatBanInfo | null;
+  /** Ticking clock from the owner, so the countdown re-renders instead of freezing. */
+  banNow?: number;
 
   // Editing/Reply state
   editingPost: MattermostPost | null;
@@ -109,6 +111,7 @@ export function MessageInput({
   setMessage,
   messageError,
   banInfo,
+  banNow,
   setMessageError,
   editingPost,
   setEditingPost,
@@ -245,7 +248,7 @@ export function MessageInput({
               role="status"
               className="mb-2 rounded border border-[--border-color] bg-[--surface-color] p-3 text-sm text-[--text-muted]"
             >
-              {formatChatBanNotice(banInfo)}
+              {formatChatBanNotice(banInfo, banNow)}
             </div>
           )}
           {messageError && <div className="text-sm text-red-500">{messageError}</div>}

--- a/apps/web/src/features/chat/components/message-input.tsx
+++ b/apps/web/src/features/chat/components/message-input.tsx
@@ -1,4 +1,5 @@
 import React, { type ChangeEvent, useState } from "react";
+import { ChatBanInfo, formatChatBanNotice } from "../chat-ban-notice";
 import { Button } from "@ui/button";
 import { ImageUploadButton, UserAvatar } from "@/features/shared";
 import { emojiIconSvg } from "@ui/icons";
@@ -28,6 +29,8 @@ interface MessageInputProps {
   setMessage: (message: string | ((prev: string) => string)) => void;
   messageError: string | null;
   setMessageError: (error: string | null) => void;
+  /** Present while a chat ban is live; renders a standing notice instead of a transient error. */
+  banInfo?: ChatBanInfo | null;
 
   // Editing/Reply state
   editingPost: MattermostPost | null;
@@ -105,6 +108,7 @@ export function MessageInput({
   message,
   setMessage,
   messageError,
+  banInfo,
   setMessageError,
   editingPost,
   setEditingPost,
@@ -234,6 +238,14 @@ export function MessageInput({
               <div className="line-clamp-2 text-[--text-muted]">
                 {renderMessageContent(getDecodedDisplayMessage(replyingTo))}
               </div>
+            </div>
+          )}
+          {banInfo && (
+            <div
+              role="status"
+              className="mb-2 rounded border border-[--border-color] bg-[--surface-color] p-3 text-sm text-[--text-muted]"
+            >
+              {formatChatBanNotice(banInfo)}
             </div>
           )}
           {messageError && <div className="text-sm text-red-500">{messageError}</div>}

--- a/apps/web/src/features/chat/mattermost-api.ts
+++ b/apps/web/src/features/chat/mattermost-api.ts
@@ -202,12 +202,9 @@ export function useMattermostBootstrap(community?: string) {
       }
 
       if (!res.ok) {
-        const data = await safeJson<{ error?: string; bannedUntil?: number }>(res);
-        // bannedUntil rides along so the ban can expire without a reload.
-        throw Object.assign(new Error(data?.error || "Unable to initialize chat"), {
-          status: res.status,
-          bannedUntil: data?.bannedUntil
-        });
+        // bannedUntil + reason ride along so the ban can expire without a reload and the
+        // client can explain it instead of quoting the operator string.
+        await throwWithBanContext(res, "Unable to initialize chat");
       }
 
       const bootstrap = (await safeJson(res)) as {
@@ -369,6 +366,25 @@ export function useMattermostJoinChannel() {
         queryClient.invalidateQueries({ queryKey: ["mattermost-posts-infinite", channelId], exact: false })
       ]);
     }
+  });
+}
+
+/**
+ * Rethrows a failed response while PRESERVING the ban payload.
+ *
+ * A plain `new Error(data.error)` drops `bannedUntil`/`reason`, and the ban notice then has
+ * nothing to key on: the UI silently falls back to displaying the operator-facing string it
+ * exists to replace. The failure is invisible in tests that only exercise the formatter, so keep
+ * every ban-capable request going through this.
+ */
+async function throwWithBanContext(res: Response, fallback: string): Promise<never> {
+  const data = await safeJson<{ error?: string; bannedUntil?: number; reason?: string }>(res).catch(
+    () => null
+  );
+  throw Object.assign(new Error(data?.error || fallback), {
+    status: res.status,
+    bannedUntil: data?.bannedUntil,
+    reason: data?.reason
   });
 }
 
@@ -719,8 +735,7 @@ export function useMattermostSendMessage(channelId: string | undefined, options?
       });
 
       if (!res.ok) {
-        const data = await safeJson<{ error?: string }>(res).catch(() => null);
-        throw new Error(data?.error || `Unable to send message (${res.status})`);
+        await throwWithBanContext(res, `Unable to send message (${res.status})`);
       }
 
       return (await safeJson(res)) as { post: MattermostPost };

--- a/apps/web/src/features/chat/mattermost-channel-view.tsx
+++ b/apps/web/src/features/chat/mattermost-channel-view.tsx
@@ -23,6 +23,7 @@ import {
   useMattermostJoinChannel
 } from "./mattermost-api";
 import { usePendingPosts } from "./hooks/use-pending-posts";
+import { ChatBanInfo, getChatBanInfo } from "./chat-ban-notice";
 import { useDmWarning } from "./hooks/use-dm-warning";
 import { useDeepLinking } from "./hooks/use-deep-linking";
 import { useChannelWebSocket } from "./hooks/use-channel-websocket";
@@ -99,6 +100,10 @@ export function MattermostChannelView({ channelId }: Props) {
   const [threadRootId, setThreadRootId] = useState<string | null>(null);
   const [editingPost, setEditingPost] = useState<MattermostPost | null>(null);
   const [messageError, setMessageError] = useState<string | null>(null);
+  // Held separately from messageError so the notice PERSISTS while the ban is live.
+  // messageError is cleared on every new send attempt; a ban is a standing state, not a
+  // one-off failure, so clearing it there would hide the explanation after one keystroke.
+  const [banInfo, setBanInfo] = useState<ChatBanInfo | null>(null);
   const [uploadedImages, setUploadedImages] = useState<string[]>([]);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const messageInputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -119,6 +124,19 @@ export function MattermostChannelView({ channelId }: Props) {
   const [unreadCountBelowScroll, setUnreadCountBelowScroll] = useState(0);
   const [showKeyboardShortcuts, setShowKeyboardShortcuts] = useState(false);
   const queryClient = useQueryClient();
+
+  // Let the notice clear itself when the ban lapses, so a 48h timeout doesn't look permanent
+  // to someone who left the tab open.
+  useEffect(() => {
+    if (!banInfo) return;
+    const remaining = banInfo.bannedUntil - Date.now();
+    if (remaining <= 0) {
+      setBanInfo(null);
+      return;
+    }
+    const timer = setTimeout(() => setBanInfo(null), remaining);
+    return () => clearTimeout(timer);
+  }, [banInfo]);
   const emojiButtonRef = useRef<HTMLButtonElement | null>(null);
   const gifButtonRef = useRef<HTMLButtonElement | null>(null);
   const gifPickerRef = useRef<HTMLDivElement | null>(null);
@@ -895,7 +913,15 @@ export function MattermostChannelView({ channelId }: Props) {
           if ((err as Error)?.name === "AbortError") {
             return;
           }
-          setMessageError((err as Error)?.message || "Unable to send message");
+          const ban = getChatBanInfo(err);
+          if (ban) {
+            // The server's `error` names the account and quotes an ISO timestamp: operator copy,
+            // not something to show the banned user. The notice is rendered from ban info instead.
+            setBanInfo(ban);
+            setMessageError(null);
+          } else {
+            setMessageError((err as Error)?.message || "Unable to send message");
+          }
           lastSentPendingIdRef.current = null;
         },
         onSuccess: (_data, variables) => {
@@ -1163,6 +1189,7 @@ export function MattermostChannelView({ channelId }: Props) {
         setMessage={setMessage}
         messageError={messageError}
         setMessageError={setMessageError}
+        banInfo={banInfo}
         editingPost={editingPost}
         setEditingPost={setEditingPost}
         replyingTo={replyingTo}

--- a/apps/web/src/features/chat/mattermost-channel-view.tsx
+++ b/apps/web/src/features/chat/mattermost-channel-view.tsx
@@ -23,7 +23,7 @@ import {
   useMattermostJoinChannel
 } from "./mattermost-api";
 import { usePendingPosts } from "./hooks/use-pending-posts";
-import { ChatBanInfo, getChatBanInfo } from "./chat-ban-notice";
+import { BAN_NOTICE_TICK_MS, ChatBanInfo, getChatBanInfo } from "./chat-ban-notice";
 import { useDmWarning } from "./hooks/use-dm-warning";
 import { useDeepLinking } from "./hooks/use-deep-linking";
 import { useChannelWebSocket } from "./hooks/use-channel-websocket";
@@ -104,6 +104,8 @@ export function MattermostChannelView({ channelId }: Props) {
   // messageError is cleared on every new send attempt; a ban is a standing state, not a
   // one-off failure, so clearing it there would hide the explanation after one keystroke.
   const [banInfo, setBanInfo] = useState<ChatBanInfo | null>(null);
+  // Drives the countdown re-render; see the ticking effect below.
+  const [banNow, setBanNow] = useState(() => Date.now());
   const [uploadedImages, setUploadedImages] = useState<string[]>([]);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const messageInputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -125,17 +127,29 @@ export function MattermostChannelView({ channelId }: Props) {
   const [showKeyboardShortcuts, setShowKeyboardShortcuts] = useState(false);
   const queryClient = useQueryClient();
 
-  // Let the notice clear itself when the ban lapses, so a 48h timeout doesn't look permanent
-  // to someone who left the tab open.
+  // Tick while a ban is live: refreshes the countdown and clears the notice once it lapses, so a
+  // 48h timeout doesn't look permanent to someone who left the tab open.
+  //
+  // A single setTimeout(remaining) is WRONG here and fails in the worst direction: setTimeout
+  // takes a 32-bit signed delay, so anything past ~24.8 days overflows and fires almost
+  // immediately. A 3-year ban would clear its own notice within a millisecond — the notice would
+  // vanish for exactly the users who are most banned. A bounded interval avoids the cliff
+  // entirely and keeps the relative time fresh instead of freezing at first render.
   useEffect(() => {
     if (!banInfo) return;
-    const remaining = banInfo.bannedUntil - Date.now();
-    if (remaining <= 0) {
+    if (Date.now() >= banInfo.bannedUntil) {
       setBanInfo(null);
       return;
     }
-    const timer = setTimeout(() => setBanInfo(null), remaining);
-    return () => clearTimeout(timer);
+    const id = setInterval(() => {
+      const t = Date.now();
+      if (t >= banInfo.bannedUntil) {
+        setBanInfo(null);
+      } else {
+        setBanNow(t);
+      }
+    }, BAN_NOTICE_TICK_MS);
+    return () => clearInterval(id);
   }, [banInfo]);
   const emojiButtonRef = useRef<HTMLButtonElement | null>(null);
   const gifButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -918,6 +932,7 @@ export function MattermostChannelView({ channelId }: Props) {
             // The server's `error` names the account and quotes an ISO timestamp: operator copy,
             // not something to show the banned user. The notice is rendered from ban info instead.
             setBanInfo(ban);
+            setBanNow(Date.now());
             setMessageError(null);
           } else {
             setMessageError((err as Error)?.message || "Unable to send message");
@@ -1190,6 +1205,7 @@ export function MattermostChannelView({ channelId }: Props) {
         messageError={messageError}
         setMessageError={setMessageError}
         banInfo={banInfo}
+        banNow={banNow}
         editingPost={editingPost}
         setEditingPost={setEditingPost}
         replyingTo={replyingTo}

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -2510,7 +2510,16 @@
     "unpin-message": "Unpin message",
     "dm-not-allowed": "@{{username}} doesn't accept messages from you",
     "dm-followers-only": "Only accepts DMs from people they follow",
-    "dm-disabled": "Has disabled direct messages"
+    "dm-disabled": "Has disabled direct messages",
+    "ban-reason-spray": "You're paused from posting because the same message went to several channels at once.",
+    "ban-reason-mass-dm": "You're paused from posting because a message was sent to many people at once.",
+    "ban-reason-generic": "You're paused from posting in chat.",
+    "ban-can-still-read": "You can still read chat.",
+    "ban-unlocks": "Posting unlocks {{when}}.",
+    "ban-remaining-soon": "in under a minute",
+    "ban-remaining-minutes": "in about {{count}} minutes",
+    "ban-remaining-hours": "in about {{count}} hours",
+    "ban-remaining-days": "in about {{count}} days"
   },
   "add-image": {
     "title": "Add Image",

--- a/apps/web/src/server/mattermost.ts
+++ b/apps/web/src/server/mattermost.ts
@@ -9,6 +9,14 @@ const MATTERMOST_ADMIN_TOKEN = process.env.MATTERMOST_ADMIN_TOKEN;
 const MATTERMOST_TEAM_ID = process.env.MATTERMOST_TEAM_ID;
 const MATTERMOST_TOKEN_COOKIE = "mm_pat";
 export const CHAT_BAN_PROP = "ecency_chat_banned_until";
+// Why the ban was applied, written alongside the expiry by the moderation service.
+// Lets the clients explain what happened instead of quoting a timestamp. Absent on
+// older bans, so every consumer must tolerate undefined.
+export const CHAT_BAN_REASON_PROP = "ecency_chat_ban_reason";
+
+// Kept as a loose string on the wire: an unrecognised reason from a newer service
+// version must degrade to the generic message, never break the response.
+export type ChatBanReason = "mass-dm" | "spray" | "manual";
 export const CHAT_DM_PRIVACY_PROP = "ecency_dm_privacy";
 export const CHAT_LEFT_CHANNELS_PROP = "ecency_left_channels";
 const CHAT_PAT_PROP = "ecency_pat";
@@ -61,12 +69,14 @@ class MattermostError extends Error {
 export class ChatBannedError extends Error {
   readonly username: string;
   readonly bannedUntil: number;
+  readonly reason?: string;
 
-  constructor(username: string, bannedUntil: number) {
+  constructor(username: string, bannedUntil: number, reason?: string) {
     super(`@${username} is banned from chat until ${new Date(bannedUntil).toISOString()}`);
     this.name = "ChatBannedError";
     this.username = username;
     this.bannedUntil = bannedUntil;
+    this.reason = reason;
   }
 }
 
@@ -167,7 +177,7 @@ export async function reactivateMattermostUser(userId: string, signal?: AbortSig
 function assertReactivationAllowed(user: MattermostUserWithProps) {
   const bannedUntil = isUserChatBanned(user);
   if (bannedUntil) {
-    throw new ChatBannedError(user.username, bannedUntil);
+    throw new ChatBannedError(user.username, bannedUntil, getUserChatBanReason(user));
   }
 }
 
@@ -745,6 +755,12 @@ export async function deleteMattermostPostAsAdmin(postId: string) {
     method: "DELETE",
     headers: getAdminHeaders()
   });
+}
+
+export function getUserChatBanReason(
+  user: Pick<MattermostUserWithProps, "props">
+): string | undefined {
+  return user.props?.[CHAT_BAN_REASON_PROP] || undefined;
 }
 
 export function isUserChatBanned(user: Pick<MattermostUserWithProps, "props">) {

--- a/apps/web/src/server/mattermost.ts
+++ b/apps/web/src/server/mattermost.ts
@@ -12,11 +12,12 @@ export const CHAT_BAN_PROP = "ecency_chat_banned_until";
 // Why the ban was applied, written alongside the expiry by the moderation service.
 // Lets the clients explain what happened instead of quoting a timestamp. Absent on
 // older bans, so every consumer must tolerate undefined.
+//
+// Known values are "mass-dm", "spray" and "manual", but this stays an open string end to end
+// on purpose: a newer moderation service can add a reason this build has never seen, and that
+// must degrade to the generic message rather than fail a union check.
 export const CHAT_BAN_REASON_PROP = "ecency_chat_ban_reason";
 
-// Kept as a loose string on the wire: an unrecognised reason from a newer service
-// version must degrade to the generic message, never break the response.
-export type ChatBanReason = "mass-dm" | "spray" | "manual";
 export const CHAT_DM_PRIVACY_PROP = "ecency_dm_privacy";
 export const CHAT_LEFT_CHANNELS_PROP = "ecency_left_channels";
 const CHAT_PAT_PROP = "ecency_pat";

--- a/apps/web/src/specs/features/chat/chat-ban-notice.spec.ts
+++ b/apps/web/src/specs/features/chat/chat-ban-notice.spec.ts
@@ -18,6 +18,7 @@ vi.mock("i18next", () => ({
 }));
 
 import {
+  BAN_NOTICE_TICK_MS,
   formatBanRemaining,
   formatChatBanNotice,
   getChatBanInfo
@@ -70,6 +71,36 @@ describe("formatBanRemaining", () => {
   it("uses hours up to two days, then days", () => {
     expect(formatBanRemaining(hours(47), NOW)).toContain("hours");
     expect(formatBanRemaining(hours(49), NOW)).toContain("days");
+  });
+
+  it("never phrases a count as 1, so no band can read '1 hours'", () => {
+    // every band hands {{count}} >= 2; the 1-hour case falls into the minutes band
+    for (const until of [mins(59), mins(89), hours(1), hours(1.4), hours(2), days(1), days(400)]) {
+      const text = formatBanRemaining(until, NOW);
+      const m = text.match(/about (\d+)/);
+      if (m) {
+        expect(Number(m[1])).toBeGreaterThanOrEqual(2);
+      }
+    }
+  });
+
+  it("handles a multi-year ban without overflowing", () => {
+    // 3y is the containment default. It must render as days, not silently degrade.
+    const threeYears = NOW + 3 * 365 * 86_400_000;
+    expect(formatBanRemaining(threeYears, NOW)).toContain("1095 days");
+  });
+});
+
+describe("BAN_NOTICE_TICK_MS", () => {
+  it("stays inside the 32-bit setTimeout limit", () => {
+    // Deriving a timer delay from bannedUntil overflows for long bans: setTimeout takes a
+    // 32-bit signed delay, so a 3-year ban fires in ~1ms and clears its own notice instantly.
+    // The tick is a fixed bounded interval precisely so that cliff cannot be reached.
+    expect(BAN_NOTICE_TICK_MS).toBeGreaterThan(0);
+    expect(BAN_NOTICE_TICK_MS).toBeLessThan(2_147_483_647);
+
+    const threeYearsMs = 3 * 365 * 86_400_000;
+    expect(threeYearsMs).toBeGreaterThan(2_147_483_647); // the delay we must never pass to setTimeout
   });
 });
 

--- a/apps/web/src/specs/features/chat/chat-ban-notice.spec.ts
+++ b/apps/web/src/specs/features/chat/chat-ban-notice.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The global setup mocks i18next as `t: key => key`, which would make every assertion here a
+// tautology about key names. This file is specifically about the copy a banned user reads, so it
+// substitutes a mock that honours defaultValue and {{...}} interpolation the way i18next does.
+vi.mock("i18next", () => ({
+  __esModule: true,
+  default: {
+    t: (key: string, opts?: Record<string, unknown>) => {
+      let out = String(opts?.defaultValue ?? key);
+      for (const [k, v] of Object.entries(opts ?? {})) {
+        if (k === "defaultValue") continue;
+        out = out.replace(new RegExp(`{{${k}}}`, "g"), String(v));
+      }
+      return out;
+    }
+  }
+}));
+
+import {
+  formatBanRemaining,
+  formatChatBanNotice,
+  getChatBanInfo
+} from "@/features/chat/chat-ban-notice";
+
+const NOW = 1_800_000_000_000;
+const mins = (n: number) => NOW + n * 60_000;
+const hours = (n: number) => NOW + n * 3_600_000;
+const days = (n: number) => NOW + n * 86_400_000;
+
+describe("getChatBanInfo", () => {
+  it("extracts a live ban from a rejected request", () => {
+    const info = getChatBanInfo({ status: 403, bannedUntil: hours(48), reason: "spray" }, NOW);
+    expect(info).toEqual({ bannedUntil: hours(48), reason: "spray" });
+  });
+
+  it("ignores an already-expired ban so a stale error can't pin the notice open", () => {
+    expect(getChatBanInfo({ status: 403, bannedUntil: NOW - 1 }, NOW)).toBeNull();
+  });
+
+  it("returns null for ordinary failures", () => {
+    expect(getChatBanInfo({ status: 500 }, NOW)).toBeNull();
+    expect(getChatBanInfo(new Error("network"), NOW)).toBeNull();
+    expect(getChatBanInfo(null, NOW)).toBeNull();
+  });
+
+  it("tolerates a missing reason (bans predating the reason prop)", () => {
+    expect(getChatBanInfo({ bannedUntil: hours(1) }, NOW)?.reason).toBeUndefined();
+  });
+
+  it("drops a non-string reason rather than rendering it", () => {
+    expect(getChatBanInfo({ bannedUntil: hours(1), reason: { x: 1 } }, NOW)?.reason).toBeUndefined();
+  });
+});
+
+describe("formatBanRemaining", () => {
+  it("scales the unit to the magnitude", () => {
+    expect(formatBanRemaining(mins(30), NOW)).toContain("30 minutes");
+    expect(formatBanRemaining(hours(5), NOW)).toContain("5 hours");
+    expect(formatBanRemaining(days(2), NOW)).toContain("2 days");
+  });
+
+  it("never promises an unlock that has not happened", () => {
+    // rounds up, so a ban with seconds left never reads as '0 minutes'
+    expect(formatBanRemaining(NOW + 30_000, NOW)).toBe("in under a minute");
+    expect(formatBanRemaining(NOW, NOW)).toBe("in under a minute");
+    expect(formatBanRemaining(NOW - 10_000, NOW)).toBe("in under a minute");
+  });
+
+  it("uses hours up to two days, then days", () => {
+    expect(formatBanRemaining(hours(47), NOW)).toContain("hours");
+    expect(formatBanRemaining(hours(49), NOW)).toContain("days");
+  });
+});
+
+describe("formatChatBanNotice", () => {
+  it("explains a spray timeout in plain terms", () => {
+    const text = formatChatBanNotice({ bannedUntil: hours(48), reason: "spray" }, NOW);
+    expect(text).toContain("same message went to several channels");
+    expect(text).toContain("You can still read chat.");
+    expect(text).toContain("2 days");
+  });
+
+  it("explains a mass-DM ban differently", () => {
+    const text = formatChatBanNotice({ bannedUntil: days(365), reason: "mass-dm" }, NOW);
+    expect(text).toContain("many people at once");
+  });
+
+  it("falls back to generic copy for manual and unknown reasons", () => {
+    for (const reason of ["manual", "something-new-from-a-later-service", undefined]) {
+      const text = formatChatBanNotice({ bannedUntil: hours(3), reason }, NOW);
+      expect(text).toContain("paused from posting");
+      expect(text).toContain("3 hours");
+    }
+  });
+
+  it("never leaks operator-facing detail to the banned user", () => {
+    const text = formatChatBanNotice({ bannedUntil: hours(48), reason: "spray" }, NOW);
+    // no ISO timestamp, no prop name, no account handle, no thresholds
+    expect(text).not.toMatch(/\d{4}-\d{2}-\d{2}T/);
+    expect(text).not.toContain("ecency_chat");
+    expect(text).not.toContain("@");
+  });
+});

--- a/apps/web/src/specs/features/chat/chat-ban-screen.spec.tsx
+++ b/apps/web/src/specs/features/chat/chat-ban-screen.spec.tsx
@@ -1,0 +1,95 @@
+import { render, screen, act } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("i18next", () => ({
+  __esModule: true,
+  default: {
+    t: (key: string, opts?: Record<string, unknown>) => {
+      let out = String(opts?.defaultValue ?? key);
+      for (const [k, v] of Object.entries(opts ?? {})) {
+        if (k === "defaultValue") continue;
+        out = out.replace(new RegExp(`{{${k}}}`, "g"), String(v));
+      }
+      return out;
+    }
+  }
+}));
+
+import { ChatBanScreen } from "@/features/chat/components/chat-ban-screen";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("ChatBanScreen", () => {
+  it("explains the ban rather than showing operator copy", () => {
+    render(<ChatBanScreen info={{ bannedUntil: Date.now() + 48 * 3_600_000, reason: "spray" }} />);
+
+    const notice = screen.getByRole("status");
+    expect(notice.textContent).toContain("same message went to several channels");
+    expect(notice.textContent).toContain("You can still read chat.");
+    expect(notice.textContent).not.toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("counts down instead of freezing at first render", () => {
+    render(<ChatBanScreen info={{ bannedUntil: Date.now() + 10 * 60_000, reason: "manual" }} />);
+    expect(screen.getByRole("status").textContent).toContain("10 minutes");
+
+    act(() => {
+      vi.advanceTimersByTime(5 * 60_000);
+    });
+
+    expect(screen.getByRole("status").textContent).toContain("5 minutes");
+  });
+
+  it("calls onExpire once the ban lapses, so bootstrap can be retried without a reload", () => {
+    const onExpire = vi.fn();
+    render(
+      <ChatBanScreen info={{ bannedUntil: Date.now() + 60_000, reason: "spray" }} onExpire={onExpire} />
+    );
+
+    expect(onExpire).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(90_000);
+    });
+
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not keep firing onExpire after expiry", () => {
+    const onExpire = vi.fn();
+    render(
+      <ChatBanScreen info={{ bannedUntil: Date.now() + 30_000, reason: "spray" }} onExpire={onExpire} />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10 * 60_000);
+    });
+
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it("survives a multi-year ban without the timer overflowing", () => {
+    const onExpire = vi.fn();
+    // 3y exceeds the 32-bit setTimeout limit; a delay derived from bannedUntil would fire at once
+    render(
+      <ChatBanScreen
+        info={{ bannedUntil: Date.now() + 3 * 365 * 86_400_000, reason: "mass-dm" }}
+        onExpire={onExpire}
+      />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(5 * 60_000);
+    });
+
+    expect(onExpire).not.toHaveBeenCalled();
+    expect(screen.getByRole("status").textContent).toContain("days");
+  });
+});

--- a/apps/web/src/specs/features/chat/chat-ban-wire.spec.tsx
+++ b/apps/web/src/specs/features/chat/chat-ban-wire.spec.tsx
@@ -1,0 +1,78 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getChatBanInfo } from "@/features/chat/chat-ban-notice";
+import { useMattermostSendMessage } from "@/features/chat/mattermost-api";
+
+/**
+ * Guards the WIRE, not the copy.
+ *
+ * The ban notice shipped once with a formatter that was fully unit-tested and a send path that
+ * threw `new Error(data.error)`, discarding bannedUntil and reason. Every formatter test passed
+ * and the feature never activated: the UI fell straight back to the operator-facing string it
+ * was written to replace. These tests assert the payload survives the throw, which is the only
+ * thing that makes the rest of it reachable.
+ */
+
+const BAN_BODY = {
+  error: "@someone is banned from chat until 2026-08-13T00:00:00.000Z",
+  bannedUntil: Date.now() + 48 * 3_600_000,
+  reason: "spray",
+  prop: "ecency_chat_banned_until"
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("send path preserves the ban payload", () => {
+  it("keeps bannedUntil and reason on the thrown error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify(BAN_BODY), { status: 403 }))
+    );
+
+    const { result } = renderHook(() => useMattermostSendMessage("chan1"), { wrapper });
+
+    const err = await result.current.mutateAsync({ message: "hi" }).catch((e) => e);
+
+    // the exact shape getChatBanInfo reads; a bare Error here strands the whole feature
+    expect((err as { status?: number }).status).toBe(403);
+    expect(getChatBanInfo(err)).toMatchObject({ reason: "spray" });
+  });
+
+  it("leaves ordinary failures as plain errors, so they still surface normally", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ error: "boom" }), { status: 500 }))
+    );
+
+    const { result } = renderHook(() => useMattermostSendMessage("chan1"), { wrapper });
+
+    const err = await result.current.mutateAsync({ message: "hi" }).catch((e) => e);
+
+    expect((err as Error).message).toBe("boom");
+    expect(getChatBanInfo(err)).toBeNull();
+  });
+
+  it("survives a non-JSON error body without masking the status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("<html>gateway</html>", { status: 502 }))
+    );
+
+    const { result } = renderHook(() => useMattermostSendMessage("chan1"), { wrapper });
+
+    const err = await result.current.mutateAsync({ message: "hi" }).catch((e) => e);
+
+    expect((err as Error).message).toContain("502");
+    expect(getChatBanInfo(err)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1389.

A banned user was told almost nothing useful. Both 403 paths already sent `bannedUntil` and both clients discarded it.

**Before**, web rendered the server string verbatim in the composer:

```
@rainkiss is banned from chat until 2026-08-12T19:34:32.000Z
```

Their own handle, an ISO timestamp, no reason, and no indication that reading still works. It also only appeared on a send attempt, so the explanation vanished as soon as they typed again.

**After:**

```
You are paused from posting because the same message went to several channels at once.
You can still read chat. Posting unlocks in about 2 days.
```

## Changes

**Server.** Both 403s (`channels/[channelId]/posts` and `bootstrap`) now return the `reason` the moderation service records, via `getUserChatBanReason`. `ChatBannedError` carries it too. The existing `error` string is unchanged and stays operator-facing.

**Client.** `chat-ban-notice.ts` builds the copy from `bannedUntil` + `reason`. Deliberately client-side: the remaining time has to be computed at render so it counts down, and the wording has to be translatable. Uses i18next keys with `defaultValue`, so nothing needs adding to locale files to ship.

**The notice is state, not an error.** It is held apart from `messageError`, which is cleared on every send attempt. A ban is standing, so routing it through `messageError` would erase the explanation on the next keystroke. It expires itself via a timer, so a 48-hour timeout does not look permanent to someone who left a tab open.

## Deliberate choices

- **Unknown reasons degrade, never break.** Bans predate the reason prop, and a later service version may add reasons this build has not seen; both fall back to generic copy.
- **Approximate durations, rounded up.** "About 2 days" rather than a precise countdown, and a ban with seconds left reads "in under a minute" rather than "0 minutes", so it never announces an unlock that has not happened.
- **Nothing operator-facing leaks.** A test asserts the copy contains no ISO timestamp, no prop name, no account handle. Detection thresholds are not referenced.

## Notes

The reason only becomes non-empty for bans applied after ecency/mm-spam-monitor#1, which is deployed. Older live bans render the generic copy, which is still a large improvement on the ISO string.

The spray timeout deliberately does not deactivate, so the POST path is now the common one; bootstrap only sees deactivated-and-banned.

## Checks

`tsc --noEmit` clean. 161 tests pass across 19 chat/mattermost spec files, 12 of them new. This spec overrides the global i18next mock, which returns keys as-is and would otherwise make every copy assertion a tautology.

Mobile counterpart: ecency/vision-mobile#3470.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat moderation notices now explain why posting is restricted and when access will be restored.
  - Users can continue reading while temporarily banned from sending messages.
  - Ban notices automatically disappear when the restriction expires.
  - Supports reason-specific messaging for different moderation actions.

- **Bug Fixes**
  - Preserves existing error handling for non-moderation-related message failures.
  - Prevents expired or invalid bans from displaying incorrect notices.

- **Tests**
  - Added coverage for ban detection, time-remaining formatting, localized messaging, and privacy-safe notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->