### PR TITLE
Chat ban notice: reject non-finite expiry, move ref write into an effect

### DIFF
--- a/apps/web/src/features/chat/chat-ban-notice.ts
+++ b/apps/web/src/features/chat/chat-ban-notice.ts
@@ -26,7 +26,10 @@ export function getChatBanInfo(error: unknown, now = Date.now()): ChatBanInfo | 
   const e = error as { status?: number; bannedUntil?: unknown; reason?: unknown } | null;
   const bannedUntil = Number(e?.bannedUntil);
 
-  if (!e?.bannedUntil || Number.isNaN(bannedUntil) || bannedUntil <= now) {
+  // isFinite, not isNaN: Infinity survives an isNaN check and is also greater than `now`, so
+  // both guards would let it through. The notice would then show an endless duration and never
+  // expire. Returning null routes the caller to its ordinary error handling instead.
+  if (!e?.bannedUntil || !Number.isFinite(bannedUntil) || bannedUntil <= now) {
     return null;
   }
 

--- a/apps/web/src/features/chat/components/chat-ban-screen.tsx
+++ b/apps/web/src/features/chat/components/chat-ban-screen.tsx
@@ -26,8 +26,12 @@ export function ChatBanScreen({ info, onExpire }: Props) {
   const [now, setNow] = useState(() => Date.now());
 
   // Held in a ref so an inline arrow from the caller doesn't restart the interval every render.
+  // Assigned in an effect rather than during render: a render React discards could otherwise
+  // mutate the ref that the already-committed interval reads from.
   const onExpireRef = useRef(onExpire);
-  onExpireRef.current = onExpire;
+  useEffect(() => {
+    onExpireRef.current = onExpire;
+  }, [onExpire]);
 
   useEffect(() => {
     const id = setInterval(() => {

--- a/apps/web/src/specs/features/chat/chat-ban-notice.spec.ts
+++ b/apps/web/src/specs/features/chat/chat-ban-notice.spec.ts
@@ -49,6 +49,15 @@ describe("getChatBanInfo", () => {
     expect(getChatBanInfo({ bannedUntil: hours(1) }, NOW)?.reason).toBeUndefined();
   });
 
+  it("rejects a non-finite expiry", () => {
+    // Infinity survives an isNaN check and is also greater than now, so both original guards
+    // passed it: the notice would render an endless duration and never expire.
+    expect(getChatBanInfo({ bannedUntil: Infinity }, NOW)).toBeNull();
+    expect(getChatBanInfo({ bannedUntil: -Infinity }, NOW)).toBeNull();
+    expect(getChatBanInfo({ bannedUntil: "Infinity" }, NOW)).toBeNull();
+    expect(getChatBanInfo({ bannedUntil: "not-a-number" }, NOW)).toBeNull();
+  });
+
   it("drops a non-string reason rather than rendering it", () => {
     expect(getChatBanInfo({ bannedUntil: hours(1), reason: { x: 1 } }, NOW)?.reason).toBeUndefined();
   });


### PR DESCRIPTION
Two defects in #1390, both surfaced by review on the mobile counterpart (ecency/vision-mobile#3479). Porting the fixes here rather than leaving the two clients divergent.

## Non-finite expiry

`getChatBanInfo` guarded with `Number.isNaN`, which `Infinity` passes. `Infinity` is also greater than `now`, so the expiry check passed it too. The notice would then render an endless duration and never expire, leaving someone who cannot post with no indication it would ever lift.

`Number.isFinite` rejects `Infinity`, `-Infinity` and `NaN` in one check, and returning null routes the caller to its ordinary error handling. Covered by a test over all four inputs.

## Ref written during render

`onExpireRef.current = onExpire` ran during render, so a render React discards could mutate the ref the already-committed interval reads from. Moved into an effect.

## Checks

`tsc --noEmit` clean. 173 tests across 21 chat/mattermost spec files, 4 new assertions.