### PR TITLE
fix(wallet): drop RPC nodes that serve accounts without metadata

### DIFF
--- a/apps/web/public/public-nodes.json
+++ b/apps/web/public/public-nodes.json
@@ -2,9 +2,7 @@
   "https://api.hive.blog",
   "https://api.deathwing.me",
   "https://api.openhive.network",
-  "https://techcoderx.com",
   "https://rpc.mahdiyari.info",
-  "https://hiveapi.actifit.io",
   "https://hive.atexoras.com:2096",
   "https://api.c0ff33a.uk"
 ]

--- a/packages/sdk/src/hive-tx/config.ts
+++ b/packages/sdk/src/hive-tx/config.ts
@@ -9,11 +9,27 @@ export const config = {
   /**
    * Array of Hive API node endpoints for load balancing and failover.
    */
+  /*
+   * techcoderx.com is deliberately absent: its condenser_api.get_accounts serves
+   * account rows with posting_json_metadata stripped to "" while balances and
+   * reputation are correct. That is a well-formed result, so it passes shape
+   * validation and the health tracker keeps it ranked by latency alone.
+   *
+   * Wallet token visibility is read entirely from profile.tokens[].meta.show in
+   * that metadata, so a stripped row reads as "this user enabled nothing" and the
+   * wallet silently falls back to HIVE/HP/HBD/Points. getAccountFullQueryOptions
+   * cross-checks against the hivemind profile and re-reads, but that guard only
+   * fires when hivemind reports profile *values* — an account whose metadata is
+   * just `tokens` (no name/about/image) has none, so it would slip through.
+   * Keeping the node out of the pool removes the dependency on that guard.
+   *
+   * Note this is RPC-only: the same host serves full metadata over its REST
+   * (hafbe) endpoint, so it remains valid in `restNodes`.
+   */
   nodes: [
     'https://api.hive.blog',
     'https://api.deathwing.me',
     'https://api.openhive.network',
-    'https://techcoderx.com',
     'https://api.syncad.com',
     'https://rpc.mahdiyari.info',
   ],


### PR DESCRIPTION
Fixes #1393.

## Problem

Two nodes answer `condenser_api.get_accounts` with `posting_json_metadata` stripped to `""` while balances and reputation are correct:

| node | `posting_json_metadata` |
| --- | --- |
| `techcoderx.com` | empty, every account tested |
| `hiveapi.actifit.io` | empty, every account tested |
| `api.hive.blog`, `api.deathwing.me`, `api.openhive.network`, `rpc.mahdiyari.info`, `hive.atexoras.com` | full |

That is a well-formed result, so it passes shape validation and the health tracker ranks it on latency alone — and both are among the fastest in the pool, so they win.

Wallet token visibility is read entirely from `profile.tokens[].meta.show` in that metadata, so a stripped row reads as *"this user enabled nothing"* and the wallet silently falls back to HIVE/HP/HBD/Points. `getAccountFullQueryOptions` does cross-check against the hivemind profile and re-read, but that guard only fires when hivemind reports profile **values** — an account whose metadata is just `tokens` (no name/about/image) has none, so it slips through.

## Change

- **`apps/web/public/public-nodes.json`** — the authoritative pool. `sdk-init` feeds it to `ConfigManager.setHiveNodes()`, so it overrides the SDK defaults for ecency.com.
- **`packages/sdk/src/hive-tx/config.ts`** — the SDK default list, for consumers that never call `setHiveNodes()`.

The mobile app fetches `public-nodes.json` at runtime, so this also fixes mobile **without an app release** (ecency/vision-mobile#3477 covers its local fallback list and the stored-server preference, which needs a denylist because a saved node is prepended to the pool).

RPC-only: both hosts serve full metadata over their REST (hafbe) endpoints — verified — so `hiveapi.actifit.io` deliberately stays in `restNodes`.

`api.c0ff33a.uk` is currently returning 502 but is kept: that is a transient outage, which the health tracker already handles, not a correctness problem.

## Verification

Audited every node in `public-nodes.json` against the same account; only the two above return empty metadata, consistently rather than intermittently.

The matching backend fix (ecency/vision-api#66) is deployed, and production `portfolio-v2` now returns the correct token set on 8/8 consecutive runs where it previously returned zero on 30/30.

## Tests

`packages/sdk` `config.spec.ts`: 10 passed. No test asserts the node list contents. This is a data change with no logic, so the full monorepo suite was left to CI.