### PR TITLE
waves: warn that a wave too short to earn points will not count

### DIFF
--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -3312,6 +3312,7 @@
       "all-done-subtitle": "You're all set. Keep the waves coming!"
     },
     "sources": "Sources",
+    "short-content-hint": "Too short to earn points ({{n}} characters or fewer, links excluded)",
     "reply-form-title": "Replying to",
     "hide-replies": "Hide replies",
     "no-replies": "There aren't replies yet. Be first!",

--- a/apps/web/src/features/shared/comment/index.tsx
+++ b/apps/web/src/features/shared/comment/index.tsx
@@ -27,13 +27,13 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import { useQuery } from "@tanstack/react-query";
 import {
-  earnsQuestContentCredit,
   getCommunityContextQueryOptions,
   getCommunityPermissions,
   getCommunityType,
   QUEST_MIN_CONTENT_LENGTH
 } from "@ecency/sdk";
 import { isCommunity } from "@/utils";
+import { shouldShowShortContentHint } from "@/utils/short-content-hint";
 import { EntryPageContext } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/context";
 import { RcPrecheckBanner } from "@/features/shared/rc-precheck";
 
@@ -262,8 +262,11 @@ export function Comment({
   // The backend drops a reply this short without telling anyone, so the user posts,
   // watches the quest counter stay put and reports it as a bug. An edit never earns
   // either (the original already claimed the reward), so there is nothing to say there.
-  const showShortReplyHint =
-    !!activeUser && !isEdit && !!text?.trim() && !earnsQuestContentCredit(text);
+  const showShortReplyHint = shouldShowShortContentHint({
+    username: activeUser?.username,
+    isEditing: isEdit,
+    text
+  });
 
   return (
     <>

--- a/apps/web/src/features/waves/components/wave-form/index.tsx
+++ b/apps/web/src/features/waves/components/wave-form/index.tsx
@@ -16,7 +16,8 @@ import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import { WaveFormToolbar } from "@/features/waves/components/wave-form/wave-form-toolbar";
 import { useWaveSubmit } from "@/features/waves";
 import axios from "axios";
-import { uploadImage } from "@ecency/sdk";
+import { QUEST_MIN_CONTENT_LENGTH, uploadImage } from "@ecency/sdk";
+import { shouldShowShortContentHint } from "@/utils/short-content-hint";
 import { ensureValidToken } from "@/utils";
 import { error } from "@/features/shared";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -83,6 +84,16 @@ const WaveFormComponent = ({
   const characterLimit = isReply ? 750 : 250;
   const textLength = text?.length ?? 0;
   const exceedsCharacterLimit = textLength > characterLimit;
+
+  // A wave is a comment on the chain, so the points backend applies the same minimum
+  // length to it as to a reply, silently. Waves are short by design, which is exactly why
+  // it bites here. Not gated on `isReply`: a reply to a wave is a comment too and earns
+  // on the same rule.
+  const showShortContentHint = shouldShowShortContentHint({
+    username: activeUsername,
+    isEditing: !!entry,
+    text
+  });
 
   const poll = useEntryPollExtractor(entry);
   useEffect(() => {
@@ -340,6 +351,12 @@ const WaveFormComponent = ({
         )}
 
         <QuestStreakChip className="mb-1.5" />
+
+        {showShortContentHint && (
+          <div className="mb-1.5 text-xs opacity-60" role="status">
+            {i18next.t("waves.short-content-hint", { n: QUEST_MIN_CONTENT_LENGTH })}
+          </div>
+        )}
 
         <WaveFormToolbar
           isEdit={!!entry}

--- a/apps/web/src/specs/utils/short-content-hint.spec.ts
+++ b/apps/web/src/specs/utils/short-content-hint.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowShortContentHint } from "@/utils/short-content-hint";
+
+const draft = (overrides: Record<string, unknown> = {}) => ({
+  username: "alice",
+  isEditing: false,
+  text: "Thank you",
+  ...overrides
+});
+
+describe("shouldShowShortContentHint", () => {
+  it("warns on the short content the backend refuses", () => {
+    expect(shouldShowShortContentHint(draft({ text: "Thank you" }))).toBe(true);
+    expect(shouldShowShortContentHint(draft({ text: "Lol 😂" }))).toBe(true);
+    expect(shouldShowShortContentHint(draft({ text: "❤️" }))).toBe(true);
+  });
+
+  it("counts a link-only body as too short, matching the backend rule", () => {
+    expect(
+      shouldShowShortContentHint(draft({ text: "https://i.example.com/a-very-long-url.gif" }))
+    ).toBe(true);
+  });
+
+  it("counts emoji as code points, as the backend does", () => {
+    // 13 astral emoji are 13 code points to Python's len() but 26 UTF-16 units. Getting
+    // this wrong would stay silent and promise points the backend then refuses.
+    expect(shouldShowShortContentHint(draft({ text: "😂".repeat(13) }))).toBe(true);
+  });
+
+  it("stays quiet once the body is long enough to earn", () => {
+    expect(
+      shouldShowShortContentHint(
+        draft({ text: "Thank you, this is a genuinely useful reply with something to say" })
+      )
+    ).toBe(false);
+  });
+
+  it("stays quiet on an untouched composer", () => {
+    expect(shouldShowShortContentHint(draft({ text: "" }))).toBe(false);
+    expect(shouldShowShortContentHint(draft({ text: "   " }))).toBe(false);
+    expect(shouldShowShortContentHint(draft({ text: undefined }))).toBe(false);
+  });
+
+  it("stays quiet when there is nothing to earn", () => {
+    // Logged out earns nothing, and an edit never earns again: the original already
+    // claimed the reward.
+    expect(shouldShowShortContentHint(draft({ username: undefined }))).toBe(false);
+    expect(shouldShowShortContentHint(draft({ username: "" }))).toBe(false);
+    expect(shouldShowShortContentHint(draft({ isEditing: true }))).toBe(false);
+  });
+});

--- a/apps/web/src/utils/short-content-hint.ts
+++ b/apps/web/src/utils/short-content-hint.ts
@@ -1,0 +1,41 @@
+import { earnsQuestContentCredit } from "@ecency/sdk";
+
+interface ShortContentHintInput {
+  /** Signed-in account name, if any. */
+  username?: string | null;
+  /** Editing existing content rather than creating new content. */
+  isEditing?: boolean;
+  /** Current composer body. */
+  text?: string | null;
+}
+
+/**
+ * Whether to warn that this content is too short to earn points or quest credit.
+ *
+ * The points backend drops a comment whose body is at or under a minimum length once
+ * URLs are stripped, so a one-word reply, an emoji, or an image-only post earns nothing
+ * and never reaches the daily comment quest. The rule is deliberate but invisible, and
+ * it is the single biggest source of "quests do not show my action" reports.
+ *
+ * Shared by the reply composer and the wave composer, because a wave is a comment on the
+ * chain and goes through exactly the same rule. Kept in one place so the two cannot
+ * drift apart, and so the rule is testable without standing up either composer.
+ *
+ * Quiet for logged-out users (nothing to earn), while editing (the original already
+ * claimed the reward), and on an untouched composer (nothing to nag about yet).
+ */
+export function shouldShowShortContentHint({
+  username,
+  isEditing,
+  text
+}: ShortContentHintInput): boolean {
+  if (!username || isEditing) {
+    return false;
+  }
+
+  if (!text?.trim()) {
+    return false;
+  }
+
+  return !earnsQuestContentCredit(text);
+}


### PR DESCRIPTION
Closes #1399.

A wave is a comment on the chain, so the points backend applies the same minimum length to it as to a reply: at or under the threshold once URLs are stripped, it earns nothing and never reaches the daily comment quest. #1392 closed this for the reply composer and left waves out of scope.

About one in six waves posted from Ecency falls under the threshold. Waves are short by design, which is exactly why the rule bites here. The indexer and the points backend agree on the same set over the same window, so that is a count rather than an estimate.

## Shared, not duplicated

Adding the hint here would have written the same predicate a second time, on a rule the backend owns and can move. So it moves to `shouldShowShortContentHint`, and the reply composer now uses it too. The two composers cannot drift apart, and the rule is testable without standing up either of them.

The hint is deliberately **not** gated on the reply case: a reply to a wave is a comment as well and earns on the same rule.

Same behaviour as the reply composer: it does not block submitting, and it stays quiet for logged-out users, on an empty composer, and while editing (the original already claimed the reward).

No SDK change needed. `earnsQuestContentCredit` and `QUEST_MIN_CONTENT_LENGTH` landed with #1394 and are already in the committed dist, so typecheck is green without a label this time.

## Verification

```
pnpm test       Test Files 271 passed (271)   Tests 2596 passed (2596)
pnpm typecheck  clean across all packages
pnpm lint       0 errors
```

The new spec covers the refused cases, the link-only case, emoji counted as code points rather than UTF-16 units, a body long enough to earn, an untouched composer, and the logged-out and editing gates. The existing reply composer render tests still pass unchanged through the shared helper, which is what confirms the refactor is behaviour-preserving.

Not covered by tests: the wave form's own rendering, which needs the full composer stood up. Worth a look that the hint sits sensibly next to the streak chip and reads right alongside the character counter at the other end of the range.

Mirrored for the app in ecency/vision-mobile#3485.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a localized notice explaining when short content does not earn points, including the minimum character requirement and link exclusions.
  - Short-content guidance now appears while composing comments and wave posts when applicable.
  - The guidance accounts for emoji characters and excludes edits, untouched composers, and logged-out users.

- **Bug Fixes**
  - Standardized short-content eligibility checks across supported posting experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->