### PR TITLE
fix(web): sentry triage for editor drag crash, ui store fan-out and ciphers noise

### DIFF
--- a/apps/web/src/core/global-store/modules/ui-module.ts
+++ b/apps/web/src/core/global-store/modules/ui-module.ts
@@ -8,21 +8,28 @@ export function createUiState() {
 type State = ReturnType<typeof createUiState>;
 
 export function createUiActions(set: (state: Partial<State>) => void, getState: () => State) {
+  // Write only on a real change. zustand's set() always builds a new state object
+  // and notifies EVERY subscriber, so a write of the value the store already holds
+  // is pure fan-out: ~130 useGlobalStore call sites re-run their selectors, and any
+  // subscriber whose commit writes back to the store closes a loop that React ends
+  // with "Maximum update depth exceeded" (ECENCY-NEXT-1GJW, issue #1432). Redundant
+  // writes are routine here — the modal's onHide re-asserts the flag the closing
+  // click already cleared — so this is the cheapest place to break that class.
+  const setIfChanged = <K extends keyof State>(key: K, value: State[K]) => {
+    if (getState()[key] !== value) {
+      set({ [key]: value } as Partial<State>);
+    }
+  };
+
   return {
     setLogin: (value: boolean) => {
-      set({
-        login: value
-      });
+      setIfChanged("login", value);
     },
     toggleUiProp: (type: "login" | "notifications", value?: boolean) => {
       if (type === "login") {
-        set({
-          login: value ?? !getState().login
-        });
+        setIfChanged("login", value ?? !getState().login);
       } else if (type === "notifications") {
-        set({
-          uiNotifications: value ?? !getState().uiNotifications
-        });
+        setIfChanged("uiNotifications", value ?? !getState().uiNotifications);
       }
     }
   };

--- a/apps/web/src/specs/core/global-store/ui-module.spec.ts
+++ b/apps/web/src/specs/core/global-store/ui-module.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { createUiActions, createUiState } from "@/core/global-store/modules/ui-module";
+
+/**
+ * The store write itself is what fans out: zustand's set() builds a new state object
+ * and notifies every subscriber, so re-writing a value the store already holds costs a
+ * full selector pass across ~130 call sites and can feed a commit→write→commit loop
+ * (ECENCY-NEXT-1GJW, issue #1432). These specs pin the writes as idempotent.
+ */
+function setup(initial: Partial<ReturnType<typeof createUiState>> = {}) {
+  const state = { ...createUiState(), ...initial };
+  const set = vi.fn((patch: Partial<typeof state>) => Object.assign(state, patch));
+  const actions = createUiActions(set, () => state);
+  return { state, set, actions };
+}
+
+describe("ui-module — writes are idempotent", () => {
+  it("does not call set() when toggleUiProp is given the value already held", () => {
+    const { set, actions } = setup({ uiNotifications: false });
+    actions.toggleUiProp("notifications", false);
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("does not call set() when setLogin is given the value already held", () => {
+    const { set, actions } = setup({ login: false });
+    actions.setLogin(false);
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("does not call set() for a redundant login write via toggleUiProp", () => {
+    const { set, actions } = setup({ login: true });
+    actions.toggleUiProp("login", true);
+    expect(set).not.toHaveBeenCalled();
+  });
+});
+
+describe("ui-module — real changes still write", () => {
+  it("writes when toggleUiProp flips notifications on", () => {
+    const { state, set, actions } = setup({ uiNotifications: false });
+    actions.toggleUiProp("notifications", true);
+    expect(set).toHaveBeenCalledWith({ uiNotifications: true });
+    expect(state.uiNotifications).toBe(true);
+  });
+
+  it("toggles notifications when no explicit value is given", () => {
+    const { state, set, actions } = setup({ uiNotifications: false });
+    actions.toggleUiProp("notifications");
+    expect(state.uiNotifications).toBe(true);
+    actions.toggleUiProp("notifications");
+    expect(state.uiNotifications).toBe(false);
+    expect(set).toHaveBeenCalledTimes(2);
+  });
+
+  it("writes when setLogin changes the value", () => {
+    const { state, set, actions } = setup({ login: false });
+    actions.setLogin(true);
+    expect(set).toHaveBeenCalledWith({ login: true });
+    expect(state.login).toBe(true);
+  });
+
+  it("leaves the sibling flag untouched", () => {
+    const { state, actions } = setup({ login: true, uiNotifications: false });
+    actions.toggleUiProp("notifications", true);
+    expect(state.login).toBe(true);
+  });
+});

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -675,21 +675,47 @@ describe("beforeSend — @noble/ciphers module-init self-test failure is reclass
 
   it("groups every importing module's copy into the SAME bucket", () => {
     // The 29 buckets differed only by which module the require chain was in, i.e.
-    // by frames — so the rule must not read frames at all.
-    const a = beforeSend(makeEvent(NOBLE_MESSAGE, [WEBPACK_FRAME], { type: "Error" }));
+    // by frames, so the rule must not read frames at all.
+    const a = beforeSend(
+      makeEvent(NOBLE_MESSAGE, [WEBPACK_FRAME], { type: "Error", handled: true })
+    );
     const b = beforeSend(
       makeEvent(NOBLE_MESSAGE, [{ filename: "app:///_next/static/chunks/4821-abc.js" }], {
-        type: "Error"
+        type: "Error",
+        handled: true
       })
     );
-    expect(a!.fingerprint).toEqual(b!.fingerprint);
+    expect(a!.fingerprint).toEqual(["noble-ciphers-module-init"]);
+    expect(b!.fingerprint).toEqual(a!.fingerprint);
+  });
+
+  it("does NOT downgrade an UNHANDLED copy of the same assertion", () => {
+    // Every observed event was caught and the page kept working, which is what makes
+    // warning honest. An unhandled one escaped, so it may have taken a chunk down with
+    // it: that must stay an error with its own grouping, not be buried in this bucket.
+    const ev = makeEvent(NOBLE_MESSAGE, [WEBPACK_FRAME], { type: "Error", handled: false });
+    const out = beforeSend(ev);
+    expect(out).not.toBeNull();
+    expect(out!.level).toBeUndefined();
+    expect(out!.tags?.crypto_module_init).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT downgrade when the mechanism is absent (no evidence it was caught)", () => {
+    const ev = makeEvent(NOBLE_MESSAGE, [WEBPACK_FRAME], { type: "Error" });
+    const out = beforeSend(ev);
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
   });
 
   it("does NOT touch the CBC runtime path's length-16 assertion (titled 'nonce')", () => {
     // aes.js asserts `abytes(nonce, BLOCK_SIZE, "nonce")` — a real bug in our memo
     // encryption must stay an error-level issue with its own grouping.
+    // handled: true on purpose, so this proves the MESSAGE gate rejects it rather than
+    // passing only because the mechanism gate did.
     const ev = makeEvent('"nonce" expected Uint8Array of length 16, got type=undefined', [], {
-      type: "Error"
+      type: "Error",
+      handled: true
     });
     const out = beforeSend(ev);
     expect(out!.level).toBeUndefined();
@@ -697,7 +723,10 @@ describe("beforeSend — @noble/ciphers module-init self-test failure is reclass
   });
 
   it("does NOT touch an untitled Uint8Array assertion (bad key handed to encrypt)", () => {
-    const ev = makeEvent("expected Uint8Array, got type=string", [], { type: "Error" });
+    const ev = makeEvent("expected Uint8Array, got type=string", [], {
+      type: "Error",
+      handled: true
+    });
     const out = beforeSend(ev);
     expect(out!.level).toBeUndefined();
     expect(out!.fingerprint).toBeUndefined();

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -653,3 +653,53 @@ describe("beforeSend — unhandled cancellation AbortError is reclassified", () 
     expect(out!.fingerprint).toBeUndefined();
   });
 });
+
+describe("beforeSend — @noble/ciphers module-init self-test failure is reclassified", () => {
+  // ECENCY-NEXT-1GKP and 28 siblings (issue #1433). One visitor on a games-console
+  // browser produced 29 separate issues, because the throw happens while a module is
+  // being required and Sentry grouped on the minified require frame — which differs per
+  // importing module. One fingerprint, one bucket.
+  const NOBLE_MESSAGE = '"key" expected Uint8Array of length 16, got type=object';
+
+  it("reclassifies the module-init assertion into a single fingerprint", () => {
+    const ev = makeEvent(NOBLE_MESSAGE, [WEBPACK_FRAME, APP_FRAME], {
+      type: "Error",
+      handled: true
+    });
+    const out = beforeSend(ev);
+    expect(out).not.toBeNull();
+    expect(out!.level).toBe("warning");
+    expect(out!.tags?.crypto_module_init).toBe("true");
+    expect(out!.fingerprint).toEqual(["noble-ciphers-module-init"]);
+  });
+
+  it("groups every importing module's copy into the SAME bucket", () => {
+    // The 29 buckets differed only by which module the require chain was in, i.e.
+    // by frames — so the rule must not read frames at all.
+    const a = beforeSend(makeEvent(NOBLE_MESSAGE, [WEBPACK_FRAME], { type: "Error" }));
+    const b = beforeSend(
+      makeEvent(NOBLE_MESSAGE, [{ filename: "app:///_next/static/chunks/4821-abc.js" }], {
+        type: "Error"
+      })
+    );
+    expect(a!.fingerprint).toEqual(b!.fingerprint);
+  });
+
+  it("does NOT touch the CBC runtime path's length-16 assertion (titled 'nonce')", () => {
+    // aes.js asserts `abytes(nonce, BLOCK_SIZE, "nonce")` — a real bug in our memo
+    // encryption must stay an error-level issue with its own grouping.
+    const ev = makeEvent('"nonce" expected Uint8Array of length 16, got type=undefined', [], {
+      type: "Error"
+    });
+    const out = beforeSend(ev);
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch an untitled Uint8Array assertion (bad key handed to encrypt)", () => {
+    const ev = makeEvent("expected Uint8Array, got type=string", [], { type: "Error" });
+    const out = beforeSend(ev);
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+});

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -336,5 +336,31 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
     return null;
   }
 
+  // ECENCY-NEXT-1GKP + 28 sibling buckets (issue #1433): @noble/ciphers fails its OWN
+  // module-init self-test on some engines. `_polyval.js` builds a throwaway instance at
+  // module evaluation (`hashCons(new Uint8Array(16), 0)`), whose GHASH constructor runs
+  // `abytes(key, 16, "key")`. On the browser that reported this (a games console's
+  // WebKit) the intermediate `Uint8Array.from()` returns a value that fails the library's
+  // own isBytes check, so a freshly-built 16-byte array is rejected. Nothing we pass is
+  // wrong and there is no fix on our side; it is an engine defect on one device family.
+  // Because it throws during module evaluation the failure is per-require, so a single
+  // visitor produced 29 SEPARATE issues: Sentry grouped them by the minified webpack
+  // require frame, which differs per importing module. Reclassify into ONE fingerprint
+  // so the fan-out stops, at warning level (the page still worked — every event is
+  // handled), while a spike stays visible if this ever reaches real traffic.
+  // Gated on the message alone ON PURPOSE: beforeSend runs in the browser, BEFORE
+  // symbolication, so frames here carry minified chunk URLs — a `_polyval.js` frame gate
+  // would look tighter and never match. The message is precise enough on its own: the
+  // `"key"` title with length 16 exists only in GHASH's constructor, i.e. GCM/POLYVAL,
+  // which nothing in the app calls (we use CBC, whose length-16 asserts are titled
+  // "nonce"/"block"). A genuine runtime memo-encryption failure therefore still reports
+  // at error level.
+  if (/"key" expected Uint8Array of length 16/.test(message)) {
+    event.level = "warning";
+    event.tags = { ...event.tags, crypto_module_init: "true" };
+    event.fingerprint = ["noble-ciphers-module-init"];
+    return event;
+  }
+
   return event;
 }

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -346,16 +346,24 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
   // Because it throws during module evaluation the failure is per-require, so a single
   // visitor produced 29 SEPARATE issues: Sentry grouped them by the minified webpack
   // require frame, which differs per importing module. Reclassify into ONE fingerprint
-  // so the fan-out stops, at warning level (the page still worked — every event is
-  // handled), while a spike stays visible if this ever reaches real traffic.
-  // Gated on the message alone ON PURPOSE: beforeSend runs in the browser, BEFORE
-  // symbolication, so frames here carry minified chunk URLs — a `_polyval.js` frame gate
-  // would look tighter and never match. The message is precise enough on its own: the
+  // so the fan-out stops, while a spike stays visible if this ever reaches real traffic.
+  // ONLY for events the app caught (`mechanism.handled === true`), which is what every
+  // observed event was: the visitor still got a working page, so warning is the honest
+  // level. An UNHANDLED copy of the same assertion is a different severity claim - it
+  // escaped, so it may have taken a chunk down with it - and an unknown mechanism is no
+  // evidence either way. Both are left exactly as they arrive, at error level with their
+  // own grouping, rather than being buried in this bucket.
+  // Gated on the message otherwise, ON PURPOSE: beforeSend runs in the browser, BEFORE
+  // symbolication, so frames here carry minified chunk URLs and a `_polyval.js` frame
+  // gate would look tighter while never matching. The message is precise on its own: the
   // `"key"` title with length 16 exists only in GHASH's constructor, i.e. GCM/POLYVAL,
   // which nothing in the app calls (we use CBC, whose length-16 asserts are titled
   // "nonce"/"block"). A genuine runtime memo-encryption failure therefore still reports
   // at error level.
-  if (/"key" expected Uint8Array of length 16/.test(message)) {
+  if (
+    /"key" expected Uint8Array of length 16/.test(message) &&
+    event.exception?.values?.[0]?.mechanism?.handled === true
+  ) {
     event.level = "warning";
     event.tags = { ...event.tags, crypto_module_init: "true" };
     event.fingerprint = ["noble-ciphers-module-init"];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,8 @@ overrides:
   js-cookie: ^3.0.6
   uuid: ^11.1.1
   esbuild: ^0.28.1
+  prosemirror-view: ^1.42.2
+  prosemirror-model: ^1.25.11
 
 patchedDependencies:
   '@tooni/iconscout-unicons-react@1.0.1': 529dcaad27cdc40b6705670614309c0bafc343d53992d1b95604510d0cc9a96d
@@ -7092,8 +7094,8 @@ packages:
   prosemirror-menu@1.2.5:
     resolution: {integrity: sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==}
 
-  prosemirror-model@1.25.3:
-    resolution: {integrity: sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==}
+  prosemirror-model@1.25.11:
+    resolution: {integrity: sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==}
 
   prosemirror-schema-basic@1.2.4:
     resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
@@ -7110,15 +7112,15 @@ packages:
   prosemirror-trailing-node@3.0.0:
     resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
+      prosemirror-model: ^1.25.11
       prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-view: ^1.42.2
 
   prosemirror-transform@1.10.4:
     resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
 
-  prosemirror-view@1.41.2:
-    resolution: {integrity: sha512-PGS/jETmh+Qjmre/6vcG7SNHAKiGc4vKOJmHMPRmvcUl7ISuVtrtHmH06UDUwaim4NDJfZfVMl7U7JkMMETa6g==}
+  prosemirror-view@1.42.2:
+    resolution: {integrity: sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==}
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
@@ -11874,14 +11876,14 @@ snapshots:
       prosemirror-keymap: 1.2.3
       prosemirror-markdown: 1.13.2
       prosemirror-menu: 1.2.5
-      prosemirror-model: 1.25.3
+      prosemirror-model: 1.25.11
       prosemirror-schema-basic: 1.2.4
       prosemirror-schema-list: 1.5.1
       prosemirror-state: 1.4.3
       prosemirror-tables: 1.8.1
-      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.2)
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.11)(prosemirror-state@1.4.3)(prosemirror-view@1.42.2)
       prosemirror-transform: 1.10.4
-      prosemirror-view: 1.41.2
+      prosemirror-view: 1.42.2
 
   '@tiptap/react@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -15365,7 +15367,7 @@ snapshots:
 
   prosemirror-commands@1.7.1:
     dependencies:
-      prosemirror-model: 1.25.3
+      prosemirror-model: 1.25.11
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
 
@@ -15373,20 +15375,20 @@ snapshots:
     dependencies:
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
-      prosemirror-view: 1.41.2
+      prosemirror-view: 1.42.2
 
   prosemirror-gapcursor@1.3.2:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.3
+      prosemirror-model: 1.25.11
       prosemirror-state: 1.4.3
-      prosemirror-view: 1.41.2
+      prosemirror-view: 1.42.2
 
   prosemirror-history@1.4.1:
     dependencies:
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
-      prosemirror-view: 1.41.2
+      prosemirror-view: 1.42.2
       rope-sequence: 1.3.4
 
   prosemirror-inputrules@1.5.0:
@@ -15403,7 +15405,7 @@ snapshots:
     dependencies:
       '@types/markdown-it': 14.1.2
       markdown-it: 14.2.0
-      prosemirror-model: 1.25.3
+      prosemirror-model: 1.25.11
 
   prosemirror-menu@1.2.5:
     dependencies:
@@ -15412,49 +15414,49 @@ snapshots:
       prosemirror-history: 1.4.1
       prosemirror-state: 1.4.3
 
-  prosemirror-model@1.25.3:
+  prosemirror-model@1.25.11:
     dependencies:
       orderedmap: 2.1.1
 
   prosemirror-schema-basic@1.2.4:
     dependencies:
-      prosemirror-model: 1.25.3
+      prosemirror-model: 1.25.11
 
   prosemirror-schema-list@1.5.1:
     dependencies:
-      prosemirror-model: 1.25.3
+      prosemirror-model: 1.25.11
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
 
   prosemirror-state@1.4.3:
     dependencies:
-      prosemirror-model: 1.25.3
+      prosemirror-model: 1.25.11
       prosemirror-transform: 1.10.4
-      prosemirror-view: 1.41.2
+      prosemirror-view: 1.42.2
 
   prosemirror-tables@1.8.1:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.3
+      prosemirror-model: 1.25.11
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
-      prosemirror-view: 1.41.2
+      prosemirror-view: 1.42.2
 
-  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.2):
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.11)(prosemirror-state@1.4.3)(prosemirror-view@1.42.2):
     dependencies:
       '@remirror/core-constants': 3.0.0
       escape-string-regexp: 4.0.0
-      prosemirror-model: 1.25.3
+      prosemirror-model: 1.25.11
       prosemirror-state: 1.4.3
-      prosemirror-view: 1.41.2
+      prosemirror-view: 1.42.2
 
   prosemirror-transform@1.10.4:
     dependencies:
-      prosemirror-model: 1.25.3
+      prosemirror-model: 1.25.11
 
-  prosemirror-view@1.41.2:
+  prosemirror-view@1.42.2:
     dependencies:
-      prosemirror-model: 1.25.3
+      prosemirror-model: 1.25.11
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,17 @@ overrides:
   js-cookie: "^3.0.6"
   uuid: "^11.1.1"
   esbuild: "^0.28.1"
+  # Crash fix, not an advisory: 1.41.2's updateDraggedNode resolved a drag position
+  # captured against the PREVIOUS doc against the new one with no upper bound, so a
+  # paste that shrinks the doc threw "Position N outside of fragment" out of the
+  # publish editor (ECENCY-NEXT-1GK1, issue #1431). Upstream added both bounds checks.
+  # Transitive via @tiptap/pm, so an override is the only place to pin it forward.
+  # prosemirror-model rides along: 1.42.2 wants a newer patch than the 1.25.3 the rest
+  # of the ProseMirror graph resolved to, and without this it installs a SECOND copy —
+  # two prosemirror-model instances mean nodes and schemas fail cross-copy identity
+  # checks inside the editor. Both must stay single-version.
+  prosemirror-view: "^1.42.2"
+  prosemirror-model: "^1.25.11"
   # NOTE: @opentelemetry/core is intentionally NOT overridden — forcing 2.8.x breaks
   # @sentry/nextjs' pinned OpenTelemetry graph (undefined `AlwaysOn`). Its advisory stays
   # until @sentry/nextjs is bumped.


### PR DESCRIPTION
Triage of five Sentry reports (`1GKP`, `1GKN`, `1GKQ`, `1GK1`, `1GJW`), which turned out to be three distinct problems. Closes #1431. Closes #1432. Closes #1433.

### 1. Publish editor crash on paste after a node drag (#1431)

`RangeError: Position N outside of fragment`, `1GK1` + `1GJZ` + `1GK0` + `1FVV`, ~37 events / ~6 users since 2026-06-08, unhandled.

`prosemirror-view@1.41.2` `updateDraggedNode` resolves a drag position captured against the *previous* doc against the new one, guarding only `movedPos > 0`. Paste shrinks the doc, the stale position lands past the end, `Fragment.findIndex` throws. Upstream added both bounds checks (`sel.from < doc.content.size`, `movedPos < doc.content.size`).

It is transitive via `@tiptap/pm`, so it is pinned with an override. **`prosemirror-model` is pinned with it on purpose**: 1.42.2 wants a newer patch than the 1.25.3 the rest of the graph resolved to, and without the second override the install ends up with two `prosemirror-model` copies, which breaks cross-copy node/schema identity checks inside the editor. Verified single-version after install:

```
node_modules/.pnpm/prosemirror-model@1.25.11
node_modules/.pnpm/prosemirror-view@1.42.2
```

### 2. Redundant global-store writes (#1432)

`Maximum update depth exceeded`, `1GJW`, 63 events / 1 user in 56 seconds, unhandled.

Trigger path is confirmed from the stack (keyboard activation of a notification row → `afterClick` → `toggleUiProp` → zustand notify → React). **Which subscriber loops is not identified** — the throw happens inside an event handler, so no boundary catches it and no component stack is captured. `Modal.onHide` is edge-guarded, `useMountTransition` is idempotent, and no global-store selector returns a fresh object, so the obvious candidates are ruled out.

What this PR changes is the write itself: `toggleUiProp` / `setLogin` wrote unconditionally, so re-asserting a flag the store already held still built a new state object and notified every subscriber. Redundant writes are routine here (the modal's `onHide` re-asserts the flag the closing click already cleared). **This is a mitigation for the class, not a proven fix for that event.**

### 3. @noble/ciphers module-init noise (#1433)

`"key" expected Uint8Array of length 16`, `1GKP` / `1GKN` / `1GKQ` and 26 more buckets: 29 buckets, 62 events, one anonymous visitor, one URL, a single 0.2 second burst.

Every event carries `device.family = PlayStation 5`. `_polyval.js` self-tests at module evaluation, and the frame order shows `Polyval`'s own `abytes(key)` passing for the raw `new Uint8Array(16)` before `GHASH`'s `abytes(key, 16, "key")` fails on the value derived through `copyBytes` = `Uint8Array.from()`. That engine's `Uint8Array.from()` returns something the library's own `isBytes` rejects. Nothing we pass is wrong and there is no fix on our side, but because the throw happens per-require it spawned one issue per importing module.

Reclassified into a single fingerprint at warning level, kept visible rather than dropped, and **only for events the app caught** (`mechanism.handled === true`), which is what every observed event was. An unhandled copy of the same assertion escaped and may have taken a chunk down with it, so it stays an error with its own grouping rather than being buried here; an unknown mechanism is no evidence either way and is likewise left alone. Gated on the message alone deliberately: `beforeSend` runs pre-symbolication, so a `_polyval.js` frame gate would look tighter and never match. The `"key"` title with length 16 exists only in GHASH's constructor, i.e. GCM/POLYVAL, which nothing in the app calls — our CBC path's length-16 asserts are titled `"nonce"` / `"block"`, so a genuine memo-encryption failure still reports at error level.

Not included here: splitting `Memo`/AES out of the eager `hive-tx` barrel so RPC-only pages stop pulling ciphers in at all. That changes SDK export shape and needs its own release cycle, tracked in #1434.

### Verification

- `pnpm test` 273 files / 2612 tests green, including 11 new regression specs (6 for the fingerprint rule, 5 for the store writes). The fingerprint rule's two gates are mutation-checked: breaking either the message match or the `handled` gate fails exactly two specs
- `pnpm typecheck` clean across all 6 projects
- `pnpm lint` no errors
- `prosemirror-view` / `prosemirror-model` each resolve to exactly one version in the lockfile

Not covered by tests: the editor itself. A manual pass on `/publish` (drag a node, then paste) is worth doing before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced unnecessary UI updates when settings are unchanged, improving state-change efficiency.
  - Improved error reporting for a specific cryptography initialization issue by grouping related events and labeling them appropriately.
  - Ensured compatible editor component versions are used consistently.

- **Tests**
  - Added coverage for redundant and meaningful UI updates.
  - Added validation for cryptography error classification and grouping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

