### PR TITLE
Self-hosted: route editor preview through the config store

### DIFF
--- a/apps/self-hosted/src/core/apply-config-dom.ts
+++ b/apps/self-hosted/src/core/apply-config-dom.ts
@@ -73,9 +73,12 @@ export interface ApplyConfigDomOptions {
   declaration?: ConfigDomDeclaration;
   /**
    * Keep data-theme in step with the operating system while the configured
-   * theme is 'system'. Only the paths that establish a new baseline (boot, a
-   * successful save) ask for this; preview must not, so a keystroke in the
-   * editor cannot register a listener per render.
+   * theme is 'system'. Boot, a successful save and both directions of the
+   * editor's preview (config-preview.ts) ask for this, each keyed to the
+   * document being applied, so the listener always answers for what is on
+   * screen. Safe to request on every apply: syncSystemTheme holds a single
+   * module-level listener slot and removes the previous listener before
+   * registering, so repeated applies cannot accumulate listeners.
    */
   syncSystemTheme?: boolean;
 }

--- a/apps/self-hosted/src/core/config-preview.test.ts
+++ b/apps/self-hosted/src/core/config-preview.test.ts
@@ -201,4 +201,112 @@ describe('config preview through the store', () => {
     expect(listener).not.toHaveBeenCalled();
     unsubscribe();
   });
+
+  describe('system-theme listener across preview', () => {
+    /**
+     * jsdom has no matchMedia, so syncSystemTheme is inert in every other
+     * case. This stub makes the OS theme controllable: flip() plays an OS
+     * appearance change into whatever listener applyConfigDom registered.
+     */
+    function stubMatchMedia() {
+      const listeners = new Set<(event: { matches: boolean }) => void>();
+      let matches = false;
+      const mql = {
+        get matches() {
+          return matches;
+        },
+        addEventListener: (_type: string, fn: (event: { matches: boolean }) => void) =>
+          listeners.add(fn),
+        removeEventListener: (_type: string, fn: (event: { matches: boolean }) => void) =>
+          listeners.delete(fn),
+      };
+      window.matchMedia = (() => mql) as unknown as typeof window.matchMedia;
+      return {
+        flip(next: boolean) {
+          matches = next;
+          for (const fn of listeners) fn({ matches: next });
+        },
+        listenerCount: () => listeners.size,
+        cleanup() {
+          // Re-apply a fixed-theme document with sync on, which removes any
+          // registered listener, then drop the stub so later cases see the
+          // plain jsdom environment again.
+          applyConfigDom(structuredClone(BASE), { syncSystemTheme: true });
+          window.matchMedia = undefined as unknown as typeof window.matchMedia;
+        },
+      };
+    }
+
+    function withTheme(theme: string) {
+      const doc = structuredClone(BASE) as unknown as {
+        configuration: { general: Record<string, unknown> };
+      };
+      doc.configuration.general.theme = theme;
+      return doc;
+    }
+
+    it('an OS flip cannot overwrite a previewed fixed theme', () => {
+      const os = stubMatchMedia();
+      try {
+        // Baseline follows the OS: boot registers the listener.
+        const systemBase = withTheme('system');
+        InstanceConfigManager.updateConfig(
+          systemBase as unknown as InstanceConfig,
+        );
+        applyConfigDom(systemBase, { syncSystemTheme: true });
+        expect(os.listenerCount()).toBe(1);
+
+        // Previewing a FIXED theme suspends the OS listener for the duration.
+        previewConfigDraft(withTheme('dark'));
+        expect(document.documentElement.getAttribute('data-theme')).toBe(
+          'dark',
+        );
+        expect(os.listenerCount()).toBe(0);
+        os.flip(false);
+        expect(document.documentElement.getAttribute('data-theme')).toBe(
+          'dark',
+        );
+
+        // Exiting re-synchronizes to the baseline: system again, listener back.
+        endConfigPreview();
+        expect(os.listenerCount()).toBe(1);
+        os.flip(true);
+        expect(document.documentElement.getAttribute('data-theme')).toBe(
+          'dark',
+        );
+        os.flip(false);
+        expect(document.documentElement.getAttribute('data-theme')).toBe(
+          'light',
+        );
+      } finally {
+        os.cleanup();
+      }
+    });
+
+    it('previewing system over a fixed baseline follows the OS, then stops', () => {
+      const os = stubMatchMedia();
+      try {
+        // BASE is theme light: fixed, so no listener after baseline apply.
+        applyConfigDom(InstanceConfigManager.getBaseConfig(), {
+          syncSystemTheme: true,
+        });
+        expect(os.listenerCount()).toBe(0);
+
+        previewConfigDraft(withTheme('system'));
+        expect(os.listenerCount()).toBe(1);
+        os.flip(true);
+        expect(document.documentElement.getAttribute('data-theme')).toBe(
+          'dark',
+        );
+
+        endConfigPreview();
+        expect(os.listenerCount()).toBe(0);
+        expect(document.documentElement.getAttribute('data-theme')).toBe(
+          'light',
+        );
+      } finally {
+        os.cleanup();
+      }
+    });
+  });
 });

--- a/apps/self-hosted/src/core/config-preview.test.ts
+++ b/apps/self-hosted/src/core/config-preview.test.ts
@@ -215,10 +215,14 @@ describe('config preview through the store', () => {
         get matches() {
           return matches;
         },
-        addEventListener: (_type: string, fn: (event: { matches: boolean }) => void) =>
-          listeners.add(fn),
-        removeEventListener: (_type: string, fn: (event: { matches: boolean }) => void) =>
-          listeners.delete(fn),
+        addEventListener: (
+          _type: string,
+          fn: (event: { matches: boolean }) => void,
+        ) => listeners.add(fn),
+        removeEventListener: (
+          _type: string,
+          fn: (event: { matches: boolean }) => void,
+        ) => listeners.delete(fn),
       };
       window.matchMedia = (() => mql) as unknown as typeof window.matchMedia;
       return {

--- a/apps/self-hosted/src/core/config-preview.test.ts
+++ b/apps/self-hosted/src/core/config-preview.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The build-time config.json is generated at image build and gitignored, so it
+ * does not exist in CI; the loader must be fed a stub before it is imported
+ * (same pattern as config-merge-wiring.test.ts). BASE is hoisted so the mock
+ * factory and the tests share one document.
+ */
+const BASE = vi.hoisted(() => ({
+  version: 1,
+  configuration: {
+    general: {
+      theme: 'light',
+      styleTemplate: 'medium',
+      language: 'en',
+      styles: {},
+    },
+    instanceConfiguration: {
+      type: 'blog',
+      username: 'alice',
+      owner: 'alice',
+      meta: { title: 'Base blog' },
+      layout: { sidebar: {} },
+      features: { postsFilters: ['posts'] },
+    },
+  },
+}));
+
+vi.mock('../../config.json', () => ({ default: BASE }));
+
+const { InstanceConfigManager } = await import('./configuration-loader');
+const { endConfigPreview, previewConfigDraft } = await import(
+  './config-preview'
+);
+const { applyConfigDom, CONFIG_DOM_DECLARATION, resetConfigDomBaseline } =
+  await import('./apply-config-dom');
+type InstanceConfig = import('./configuration-loader').InstanceConfig;
+
+const DRAFT = {
+  version: 1,
+  configuration: {
+    general: {
+      theme: 'dark',
+      styleTemplate: 'magazine',
+      language: 'fr',
+      styles: { accent: '#ff0000' },
+    },
+    instanceConfiguration: {
+      type: 'blog',
+      username: 'alice',
+      owner: 'alice',
+      meta: { title: 'Draft blog' },
+      layout: { sidebar: {} },
+      features: { postsFilters: ['posts'] },
+    },
+  },
+} as unknown as InstanceConfig;
+
+/** Everything the declaration owns, read straight off the document. */
+function domState() {
+  const root = document.documentElement;
+  const attributes: Record<string, string | null> = {};
+  for (const { attribute } of CONFIG_DOM_DECLARATION.attributes) {
+    attributes[attribute] = root.getAttribute(attribute);
+  }
+  const cssVariables: Record<string, string> = {};
+  for (const { variable } of CONFIG_DOM_DECLARATION.cssVariables) {
+    cssVariables[variable] = root.style.getPropertyValue(variable);
+  }
+  return { attributes, cssVariables, title: document.title };
+}
+
+describe('config preview through the store', () => {
+  beforeEach(() => {
+    resetConfigDomBaseline();
+    document.title = 'Booted';
+    // The store is a module singleton: put the baseline back and drop any
+    // overlay a previous case left behind, the way boot establishes it.
+    InstanceConfigManager.updateConfig(
+      structuredClone(BASE) as unknown as InstanceConfig,
+    );
+    applyConfigDom(InstanceConfigManager.getConfig());
+  });
+
+  it('serves the draft to every ordinary read and re-renders subscribers', () => {
+    const listener = vi.fn();
+    const store = InstanceConfigManager.getStore();
+    const unsubscribe = store.subscribe(listener);
+
+    previewConfigDraft(DRAFT);
+
+    // Ordinary reads see the draft...
+    expect(
+      InstanceConfigManager.getConfigValue(
+        ({ configuration }) => configuration.general.styleTemplate,
+      ),
+    ).toBe('magazine');
+    // ...useSyncExternalStore consumers were told and get a new snapshot...
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(store.getSnapshot()).toBe(DRAFT);
+    // ...and the DOM followed.
+    const root = document.documentElement;
+    expect(root.getAttribute('data-style-template')).toBe('magazine');
+    expect(root.getAttribute('data-theme')).toBe('dark');
+    expect(root.style.getPropertyValue('--theme-accent')).toBe('#ff0000');
+    expect(document.title).toBe('Draft blog');
+
+    unsubscribe();
+  });
+
+  it('keeps the baseline underneath for identity reads', () => {
+    const mallory = structuredClone(DRAFT) as unknown as {
+      configuration: { instanceConfiguration: Record<string, unknown> };
+    };
+    mallory.configuration.instanceConfiguration.owner = 'mallory';
+    mallory.configuration.instanceConfiguration.username = 'mallory';
+
+    previewConfigDraft(mallory);
+
+    // The overlay is what ordinary reads see...
+    expect(
+      InstanceConfigManager.getConfigValue(
+        ({ configuration }) => configuration.instanceConfiguration.owner,
+      ),
+    ).toBe('mallory');
+    // ...but authority reads answer from the baseline, so a drafted identity
+    // cannot change who the owner is or which tenant a save targets.
+    expect(
+      InstanceConfigManager.getBaseConfigValue(
+        ({ configuration }) =>
+          configuration.instanceConfiguration.owner ||
+          configuration.instanceConfiguration.username,
+      ),
+    ).toBe('alice');
+  });
+
+  it('ending preview restores exactly the pre-preview document, repeatedly', () => {
+    const before = domState();
+    const store = InstanceConfigManager.getStore();
+    const baseline = store.getSnapshot();
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      previewConfigDraft(DRAFT);
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      endConfigPreview();
+      expect(InstanceConfigManager.isPreviewing()).toBe(false);
+      // The whole declared surface is back, including properties that were
+      // absent before preview (the accent must be REMOVED, not blanked).
+      expect(domState()).toEqual(before);
+      // Subscribers were notified in BOTH directions (enter and exit) and the
+      // snapshot they read is the baseline object again: without the exit
+      // notify, React components would keep rendering the draft after the DOM
+      // went back.
+      expect(listener).toHaveBeenCalledTimes((cycle + 1) * 2);
+      expect(store.getSnapshot()).toBe(baseline);
+    }
+    expect(
+      InstanceConfigManager.getConfigValue(
+        ({ configuration }) => configuration.general.styleTemplate,
+      ),
+    ).toBe('medium');
+    unsubscribe();
+  });
+
+  it('ending twice is safe: exit button then unmount cleanup', () => {
+    const before = domState();
+    previewConfigDraft(DRAFT);
+    endConfigPreview();
+    endConfigPreview();
+    expect(domState()).toEqual(before);
+    expect(InstanceConfigManager.isPreviewing()).toBe(false);
+  });
+
+  it('a save while previewing becomes the baseline and drops the overlay', () => {
+    previewConfigDraft(DRAFT);
+
+    const saved = structuredClone(BASE) as unknown as {
+      configuration: { instanceConfiguration: { meta: { title: string } } };
+    };
+    saved.configuration.instanceConfiguration.meta.title = 'Saved blog';
+    InstanceConfigManager.updateConfig(saved as unknown as InstanceConfig);
+
+    // The overlay is gone without an explicit endConfigPreview, so exiting
+    // preview later cannot roll the document back past the save.
+    expect(InstanceConfigManager.isPreviewing()).toBe(false);
+    expect(
+      InstanceConfigManager.getConfigValue(
+        ({ configuration }) => configuration.instanceConfiguration.meta.title,
+      ),
+    ).toBe('Saved blog');
+    expect(InstanceConfigManager.getBaseConfig()).toBe(saved);
+  });
+
+  it('clearing without an active overlay does not notify subscribers', () => {
+    const listener = vi.fn();
+    const unsubscribe = InstanceConfigManager.getStore().subscribe(listener);
+    InstanceConfigManager.clearPreviewConfig();
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+});

--- a/apps/self-hosted/src/core/config-preview.ts
+++ b/apps/self-hosted/src/core/config-preview.ts
@@ -1,0 +1,36 @@
+/**
+ * The Configuration Editor's preview, as one lifecycle over two surfaces.
+ *
+ * A draft config renders through the same two paths a real config does: the
+ * store, so React subscribers re-render with the draft, and applyConfigDom,
+ * which owns the <html> attributes and custom properties no component renders.
+ * Ending preview drops the overlay and re-applies the baseline through the
+ * same declaration, so there is no snapshot to drift from what boot produces:
+ * restore IS a fresh apply of the running config.
+ *
+ * applyConfigDom runs without syncSystemTheme in both directions. The listener
+ * the boot path registered stays in place and keeps answering for the baseline
+ * theme, and a keystroke in the editor cannot register listeners.
+ */
+
+import { applyConfigDom } from './apply-config-dom';
+import {
+  type InstanceConfig,
+  InstanceConfigManager,
+} from './configuration-loader';
+
+/** Begin preview, or update the active one with a newer draft. */
+export function previewConfigDraft(draft: unknown): void {
+  InstanceConfigManager.setPreviewConfig(draft as InstanceConfig);
+  applyConfigDom(draft);
+}
+
+/**
+ * End preview and land back on the baseline. Idempotent: ending twice (the
+ * exit button, then the unmount cleanup) re-applies the baseline twice, which
+ * produces the same document both times.
+ */
+export function endConfigPreview(): void {
+  InstanceConfigManager.clearPreviewConfig();
+  applyConfigDom(InstanceConfigManager.getBaseConfig());
+}

--- a/apps/self-hosted/src/core/config-preview.ts
+++ b/apps/self-hosted/src/core/config-preview.ts
@@ -8,9 +8,13 @@
  * same declaration, so there is no snapshot to drift from what boot produces:
  * restore IS a fresh apply of the running config.
  *
- * applyConfigDom runs without syncSystemTheme in both directions. The listener
- * the boot path registered stays in place and keeps answering for the baseline
- * theme, and a keystroke in the editor cannot register listeners.
+ * applyConfigDom runs WITH syncSystemTheme in both directions, keyed to the
+ * document being applied: a draft with a fixed theme removes the baseline's
+ * OS listener for the duration of the preview, so an OS flip cannot overwrite
+ * what the owner is looking at, and a draft with `theme: system` follows the
+ * OS while previewed. Ending preview re-synchronizes to the baseline. The
+ * listener is a single idempotent module slot (remove then add), so applying
+ * on every draft change cannot accumulate listeners.
  */
 
 import { applyConfigDom } from './apply-config-dom';
@@ -22,7 +26,7 @@ import {
 /** Begin preview, or update the active one with a newer draft. */
 export function previewConfigDraft(draft: unknown): void {
   InstanceConfigManager.setPreviewConfig(draft as InstanceConfig);
-  applyConfigDom(draft);
+  applyConfigDom(draft, { syncSystemTheme: true });
 }
 
 /**
@@ -32,5 +36,7 @@ export function previewConfigDraft(draft: unknown): void {
  */
 export function endConfigPreview(): void {
   InstanceConfigManager.clearPreviewConfig();
-  applyConfigDom(InstanceConfigManager.getBaseConfig());
+  applyConfigDom(InstanceConfigManager.getBaseConfig(), {
+    syncSystemTheme: true,
+  });
 }

--- a/apps/self-hosted/src/core/configuration-loader.ts
+++ b/apps/self-hosted/src/core/configuration-loader.ts
@@ -150,6 +150,13 @@ type ConfigListener = () => void;
 
 class ConfigStore {
   private config: InstanceConfig;
+  /**
+   * The Configuration Editor's preview overlay. While set, every read that
+   * drives rendering serves it, so React subscribers re-render with the draft.
+   * The baseline underneath stays untouched, which is what ending preview and
+   * every identity read (getBaseConfig) go back to.
+   */
+  private previewConfig: InstanceConfig | null = null;
   private listeners: Set<ConfigListener> = new Set();
   private initialized = false;
   private initPromise: Promise<void> | null = null;
@@ -219,9 +226,20 @@ class ConfigStore {
   }
 
   /**
-   * Get current config (synchronous)
+   * Get current config (synchronous). Serves the preview overlay while one is
+   * active, so a component reading during preview renders the draft.
    */
   getConfig(): InstanceConfig {
+    return this.previewConfig ?? this.config;
+  }
+
+  /**
+   * The baseline config, ignoring any active preview overlay. Reads that decide
+   * authority or identity (the ownership gate, managed-hosting detection, the
+   * pinned instance type) belong here: a drafted document must never change who
+   * the owner is or which server contract applies.
+   */
+  getBaseConfig(): InstanceConfig {
     return this.config;
   }
 
@@ -229,7 +247,7 @@ class ConfigStore {
    * Get snapshot for useSyncExternalStore
    */
   getSnapshot = (): InstanceConfig => {
-    return this.config;
+    return this.previewConfig ?? this.config;
   };
 
   /**
@@ -252,7 +270,27 @@ class ConfigStore {
    */
   updateConfig(newConfig: InstanceConfig): void {
     this.config = newConfig;
+    // A successful save establishes a new baseline. An overlay left in place
+    // would keep serving the pre-save draft over the document just stored.
+    this.previewConfig = null;
     this.notifyListeners();
+  }
+
+  /** Set or replace the preview overlay and re-render subscribers with it. */
+  setPreviewConfig(draft: InstanceConfig): void {
+    this.previewConfig = draft;
+    this.notifyListeners();
+  }
+
+  /** Drop the preview overlay. No-op (and no notify) when none is active. */
+  clearPreviewConfig(): void {
+    if (this.previewConfig === null) return;
+    this.previewConfig = null;
+    this.notifyListeners();
+  }
+
+  isPreviewing(): boolean {
+    return this.previewConfig !== null;
   }
 
   /**
@@ -425,6 +463,34 @@ export namespace InstanceConfigManager {
    */
   export function updateConfig(newConfig: InstanceConfig): void {
     configStore.updateConfig(newConfig);
+  }
+
+  /**
+   * The baseline config, ignoring any active editor preview. Use for reads
+   * that decide authority or identity; see ConfigStore.getBaseConfig.
+   */
+  export function getBaseConfig(): InstanceConfig {
+    return configStore.getBaseConfig();
+  }
+
+  export function getBaseConfigValue<T>(condition: ConfigBasedCondition<T>): T {
+    return condition(configStore.getBaseConfig());
+  }
+
+  /**
+   * Store half of the preview lifecycle. Callers should go through
+   * config-preview.ts, which pairs these with the DOM apply.
+   */
+  export function setPreviewConfig(draft: InstanceConfig): void {
+    configStore.setPreviewConfig(draft);
+  }
+
+  export function clearPreviewConfig(): void {
+    configStore.clearPreviewConfig();
+  }
+
+  export function isPreviewing(): boolean {
+    return configStore.isPreviewing();
   }
 
   /**

--- a/apps/self-hosted/src/core/index.ts
+++ b/apps/self-hosted/src/core/index.ts
@@ -1,4 +1,5 @@
 export * from './apply-config-dom';
+export * from './config-preview';
 export * from './configuration-loader';
 export * from './date-formatter';
 export * from './hive-layer';

--- a/apps/self-hosted/src/features/auth/auth-provider.tsx
+++ b/apps/self-hosted/src/features/auth/auth-provider.tsx
@@ -18,13 +18,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const { user, setUser, setSession } = useAuthStore();
 
   // Get auth config
-  const authConfig = InstanceConfigManager.getConfigValue(
+  const authConfig = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.instanceConfiguration.features.auth,
   );
 
   const isAuthEnabled = authConfig?.enabled ?? false;
   const hivesignerClientId = resolveHivesignerClientId(
-    InstanceConfigManager.getConfigValue(
+    InstanceConfigManager.useConfig(
       ({ configuration }) => configuration.general?.hivesigner?.clientId,
     ),
   );
@@ -43,7 +43,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // configs that predate the `owner` field (blog instances where the owner and
   // the showcased account are the same). In community instances the showcased
   // username is the community (hive-NNNNN), so the owner must be used instead.
-  const blogOwner = InstanceConfigManager.getConfigValue(
+  // Read from the BASELINE config: the Configuration Editor's preview overlays
+  // a drafted document over every ordinary read, and a drafted identity field
+  // must not change who the owner is mid-preview.
+  const blogOwner = InstanceConfigManager.getBaseConfigValue(
     ({ configuration }) =>
       configuration.instanceConfiguration.owner ||
       configuration.instanceConfiguration.username,

--- a/apps/self-hosted/src/features/auth/components/create-post-button.tsx
+++ b/apps/self-hosted/src/features/auth/components/create-post-button.tsx
@@ -19,14 +19,16 @@ export function CreatePostButton() {
   const isAuthenticated = useIsAuthenticated();
   const { isCommunityMode } = useInstanceConfig();
 
+  const createPostUrl = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.general.createPostUrl,
+  );
+
   // Blog instances use the built-in editor by default too, so the owner writes
   // on their own domain instead of being handed off elsewhere. An owner who has
   // deliberately set general.createPostUrl still goes there. resolveCreatePostTarget
   // owns the whole decision, including why community mode ignores the config.
   const target = resolveCreatePostTarget({
-    createPostUrl: InstanceConfigManager.getConfigValue(
-      ({ configuration }) => configuration.general.createPostUrl,
-    ),
+    createPostUrl,
     isCommunityMode,
   });
 

--- a/apps/self-hosted/src/features/blog/components/blog-discussion-item.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-discussion-item.tsx
@@ -29,7 +29,7 @@ export function BlogDiscussionItem({
   // consumer because the preview flow applies edits via DOM attributes, not the config store;
   // making it live is an app-wide preview change (store-based preview re-renders the whole
   // tree per keystroke), out of scope here. For real visitors the config is static per load.
-  const showLikes = InstanceConfigManager.getConfigValue(
+  const showLikes = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.features.likes?.enabled ?? true,
   );

--- a/apps/self-hosted/src/features/blog/components/blog-post-footer.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-footer.tsx
@@ -20,15 +20,15 @@ export function BlogPostFooter({ entry }: Props) {
   const hiveLayer = useHiveLayer();
   const isAuthEnabled = useIsAuthEnabled();
 
-  const showLikes = InstanceConfigManager.getConfigValue(
+  const showLikes = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.features.likes?.enabled ?? true,
   );
-  const showComments = InstanceConfigManager.getConfigValue(
+  const showComments = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.features.comments?.enabled ?? true,
   );
-  const showTippingPost = InstanceConfigManager.getConfigValue(
+  const showTippingPost = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.features.tipping?.post?.enabled ?? false,
   );

--- a/apps/self-hosted/src/features/blog/components/blog-post-header.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-header.tsx
@@ -31,10 +31,10 @@ function calculateReadTime(body: string): number {
 export function BlogPostHeader({ entry }: Props) {
   const { user } = useAuth();
   const entryData = entry.original_entry || entry;
-  const instanceType = InstanceConfigManager.getConfigValue(
+  const instanceType = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.instanceConfiguration.type ?? 'blog',
   );
-  const profileBaseUrl = InstanceConfigManager.getConfigValue(
+  const profileBaseUrl = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.general.profileBaseUrl || 'https://ecency.com/@',
   );
   const isCommunity = instanceType === 'community';

--- a/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
@@ -24,21 +24,21 @@ interface Props {
 
 export function BlogPostItem({ entry }: Props) {
   const hiveLayer = useHiveLayer();
-  const listType = InstanceConfigManager.getConfigValue(
+  const listType = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.instanceConfiguration.layout.listType,
   );
-  const showLikes = InstanceConfigManager.getConfigValue(
+  const showLikes = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.features.likes?.enabled ?? true,
   );
-  const showComments = InstanceConfigManager.getConfigValue(
+  const showComments = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.features.comments?.enabled ?? true,
   );
-  const instanceType = InstanceConfigManager.getConfigValue(
+  const instanceType = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.instanceConfiguration.type ?? 'blog',
   );
-  const profileBaseUrl = InstanceConfigManager.getConfigValue(
+  const profileBaseUrl = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.general.profileBaseUrl || 'https://ecency.com/@',
   );
   const entryData = entry.original_entry || entry;

--- a/apps/self-hosted/src/features/blog/components/blog-post-page.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-page.tsx
@@ -23,7 +23,7 @@ export function BlogPostPage() {
   const params = useParams({ strict: false });
   const search = useSearch({ strict: false });
 
-  const showComments = InstanceConfigManager.getConfigValue(
+  const showComments = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.features.comments?.enabled ?? true,
   );

--- a/apps/self-hosted/src/features/blog/components/hive-post-note.tsx
+++ b/apps/self-hosted/src/features/blog/components/hive-post-note.tsx
@@ -27,8 +27,6 @@ export function HivePostNote({
   showPermalink,
   learnMoreUrl,
 }: Props) {
-  if (!showNote && !showPermalink) return null;
-
   /*
    * Ecency, not a third-party frontend.
    *
@@ -47,10 +45,14 @@ export function HivePostNote({
    * dead-route guard files it as unresolved and it keeps its DYNAMIC_LINKS
    * entry.
    */
-  const profileBaseUrl = InstanceConfigManager.getConfigValue(
+  const profileBaseUrl = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.general.profileBaseUrl || 'https://ecency.com/@',
   );
+
+  // A hook cannot sit below a conditional return, so the guard follows the read.
+  if (!showNote && !showPermalink) return null;
+
   const hiveUrl = `${profileBaseUrl}${author}/${permlink}`;
 
   return (

--- a/apps/self-hosted/src/features/blog/components/search-input.tsx
+++ b/apps/self-hosted/src/features/blog/components/search-input.tsx
@@ -11,7 +11,7 @@ export function SearchInput() {
   const [query, setQuery] = useState('');
   const navigate = useNavigate();
 
-  const isSearchEnabled = InstanceConfigManager.getConfigValue(
+  const isSearchEnabled = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.layout.search?.enabled ?? false,
   );

--- a/apps/self-hosted/src/features/blog/components/text-to-speech-button.tsx
+++ b/apps/self-hosted/src/features/blog/components/text-to-speech-button.tsx
@@ -18,12 +18,12 @@ export function TextToSpeechButton({ text, title, className }: Props) {
   const [status, setStatus] = useState<TTSStatus>('idle');
   const [isSupported, setIsSupported] = useState(false);
 
-  const isEnabled = InstanceConfigManager.getConfigValue(
+  const isEnabled = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.features.post?.text2Speech?.enabled ?? false,
   );
 
-  const language = InstanceConfigManager.getConfigValue(
+  const language = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.general.language || 'en',
   );
 

--- a/apps/self-hosted/src/features/blog/hooks/use-hive-layer.ts
+++ b/apps/self-hosted/src/features/blog/hooks/use-hive-layer.ts
@@ -7,16 +7,16 @@ import { resolveCreatePostTarget } from '@/features/auth/utils/create-post-targe
 /**
  * The resolved Hive layer for this instance.
  *
- * A non-reactive `getConfig()` read behind a `useMemo`, in exactly the shape
- * `use-tipping-config.ts` already uses. Config is loaded once before the app
- * renders and the editor's preview channel is DOM attributes, which cannot
- * express a React render decision anyway. Introducing a second, reactive read
- * idiom for one corner of the app is how the panel and the site end up
- * disagreeing; saving and reloading is how every other field behaves today.
+ * A reactive read: the Configuration Editor's preview serves a draft config
+ * through the store, so this hook must recompute when the store notifies, or
+ * a page opened mid-preview would keep rendering drafted payout labels and
+ * composer targets after preview ends. The memo is keyed on the config object
+ * the store served, which changes identity exactly when a notify fires.
  */
 export function useHiveLayer(): ResolvedHiveLayer {
+  const config = InstanceConfigManager.useFullConfig();
   return useMemo(() => {
-    const { configuration } = InstanceConfigManager.getConfig();
+    const { configuration } = config;
     const instance = configuration.instanceConfiguration;
 
     // One definition, in core/instance-mode. This used to be the same
@@ -33,5 +33,5 @@ export function useHiveLayer(): ResolvedHiveLayer {
       features: instance?.features,
       composerIsInternal: composer.kind === 'internal',
     });
-  }, []);
+  }, [config]);
 }

--- a/apps/self-hosted/src/features/blog/hooks/use-instance-config.ts
+++ b/apps/self-hosted/src/features/blog/hooks/use-instance-config.ts
@@ -6,16 +6,16 @@ import { getCommunityQueryOptions } from '../queries/community-queries';
 export type InstanceType = 'blog' | 'community';
 
 export function useInstanceConfig() {
-  const type = InstanceConfigManager.getConfigValue(
+  const type = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       (configuration.instanceConfiguration.type as InstanceType) || 'blog'
   );
 
-  const username = InstanceConfigManager.getConfigValue(
+  const username = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.instanceConfiguration.username
   );
 
-  const communityId = InstanceConfigManager.getConfigValue(
+  const communityId = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       (configuration.instanceConfiguration.communityId as string) || ''
   );

--- a/apps/self-hosted/src/features/blog/layout/blog-navigation.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-navigation.tsx
@@ -39,28 +39,29 @@ export function BlogNavigation() {
     return defaultFilter;
   }, [location.search, availableFilters]);
 
-  const blogTitle = InstanceConfigManager.getConfigValue(
+  const blogTitle = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.instanceConfiguration.meta.title,
   );
 
-  const blogLogo = InstanceConfigManager.getConfigValue(
+  const blogLogo = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.instanceConfiguration.meta.logo,
   );
 
   // Use community title if available and in community mode
   const displayTitle = isCommunityMode && community?.title ? community.title : blogTitle;
 
+  const proxyBase = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.general.imageProxy || 'https://i.ecency.com',
+  );
+
   // Use community avatar from image proxy if no custom logo
   const displayLogo = useMemo(() => {
     if (blogLogo) return blogLogo;
     if (isCommunityMode && community?.name) {
-      const proxyBase = InstanceConfigManager.getConfigValue(
-        ({ configuration }) => configuration.general.imageProxy || 'https://i.ecency.com',
-      );
       return `${proxyBase}/u/${community.name}/avatar/medium`;
     }
     return null;
-  }, [blogLogo, isCommunityMode, community?.name]);
+  }, [blogLogo, isCommunityMode, community?.name, proxyBase]);
 
   // Get localized filter label
   const getFilterLabel = (filter: string): string => {

--- a/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
@@ -43,7 +43,7 @@ function BlogSidebarContent({ username }: { username: string }) {
     enabled: !!username,
   });
 
-  const showTippingGeneral = InstanceConfigManager.getConfigValue(
+  const showTippingGeneral = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.features.tipping?.general?.enabled ?? false
   );
@@ -182,16 +182,17 @@ function CommunitySidebar() {
   );
   const isModerator = isModeratorRole(context?.role);
 
+  const proxyBase = InstanceConfigManager.useConfig(
+    ({ configuration }) =>
+      configuration.general.imageProxy || "https://i.ecency.com",
+  );
+
   // Get the community avatar URL from the image proxy
   const communityAvatarUrl = useMemo(() => {
     if (!community?.name) return null;
-    const proxyBase = InstanceConfigManager.getConfigValue(
-      ({ configuration }) =>
-        configuration.general.imageProxy || "https://i.ecency.com",
-    );
     // Community avatars use the same pattern as user avatars
     return `${proxyBase}/u/${community.name}/avatar/medium`;
-  }, [community?.name]);
+  }, [community?.name, proxyBase]);
 
   // Was: `if (!community)` renders "Community not found.", which is what the
   // owner of a running community was shown whenever one bridge call failed.

--- a/apps/self-hosted/src/features/floating-menu/components/floating-menu-window.tsx
+++ b/apps/self-hosted/src/features/floating-menu/components/floating-menu-window.tsx
@@ -1,13 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   applyConfigDom,
-  type ConfigDomSnapshot,
   defaultPostsFiltersFor,
+  endConfigPreview,
   type InstanceConfig,
   InstanceConfigManager,
   type InstanceType,
-  restoreConfigDom,
-  snapshotConfigDom,
+  previewConfigDraft,
   toInstanceType,
   withPinnedInstanceType,
 } from '@/core';
@@ -35,9 +34,11 @@ function isManagedHosting(): boolean {
   if (typeof window === 'undefined') return false;
   if (window.location.hostname.endsWith('.blogs.ecency.com')) return true;
   // Verified custom domains serve a config with the managed flag injected by the hosting
-  // API; a truly self-hosted config never carries it.
+  // API; a truly self-hosted config never carries it. Read from the baseline:
+  // a drafted document under preview must not change which server contract
+  // applies.
   return (
-    InstanceConfigManager.getConfigValue(
+    InstanceConfigManager.getBaseConfigValue(
       ({ configuration }) => configuration.instanceConfiguration.managed,
     ) === true
   );
@@ -49,9 +50,11 @@ function getTenantUsername(): string | null {
   const match = hostname.match(/^([a-z0-9-]+)\.blogs\.ecency\.com$/);
   if (match) return match[1];
   if (!isManagedHosting()) return null;
-  // Custom domain: the tenant name comes from the served config instead of the hostname.
+  // Custom domain: the tenant name comes from the served config instead of the
+  // hostname. Baseline read: the save must target the real tenant even if the
+  // draft edited the username field.
   return (
-    InstanceConfigManager.getConfigValue(
+    InstanceConfigManager.getBaseConfigValue(
       ({ configuration }) => configuration.instanceConfiguration.username,
     ) || null
   );
@@ -70,7 +73,7 @@ const POSTS_FILTERS_PATH =
 function getPinnedInstanceType(): InstanceType | null {
   if (!isManagedHosting()) return null;
   return toInstanceType(
-    InstanceConfigManager.getConfigValue(
+    InstanceConfigManager.getBaseConfigValue(
       ({ configuration }) => configuration.instanceConfiguration.type,
     ),
   );
@@ -101,7 +104,6 @@ export function FloatingMenuWindow({
   );
   const [saveError, setSaveError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
-  const originalStateRef = useRef<ConfigDomSnapshot | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
   const managed = useMemo(() => isManagedHosting(), []);
 
@@ -229,23 +231,20 @@ export function FloatingMenuWindow({
             `Save failed (${response.status})`,
         );
       }
-      // A save becomes the new baseline. Without this the PATCH landed but the
-      // running app kept the old config, and leaving preview restored the
-      // pre-save snapshot, so the owner watched the saved change revert and
-      // concluded the save had failed.
+      // A save becomes the new baseline. updateConfig also drops any active
+      // preview overlay, so exiting preview later lands on the document that
+      // was just stored instead of rolling it back; while preview mode stays
+      // on, the config-change effect below re-previews the saved draft, which
+      // is now identical to the baseline.
       const payload = await response.json().catch(() => null);
       const saved = readSavedConfig(payload);
-      // Read before updateConfig replaces what isManagedHosting() consults.
-      const managed = InstanceConfigManager.getConfigValue(
+      const managed = InstanceConfigManager.getBaseConfigValue(
         ({ configuration }) => configuration.instanceConfiguration.managed,
       );
       const baseline = saved ? withServedOnlyMarkers(saved, managed) : outgoing;
       setConfig(baseline);
       InstanceConfigManager.updateConfig(baseline as unknown as InstanceConfig);
       applyConfigDom(baseline, { syncSystemTheme: true });
-      // Re-take the restore point so exiting preview cannot roll back what was
-      // just saved.
-      originalStateRef.current = snapshotConfigDom();
 
       const discarded = readDiscarded(payload);
       setNotice(
@@ -273,50 +272,37 @@ export function FloatingMenuWindow({
   }, [config]);
 
   const handleTogglePreview = useCallback(() => {
-    setIsPreviewMode((prev) => {
-      if (!prev) {
-        // Entering preview mode - capture everything the config can touch
-        originalStateRef.current = snapshotConfigDom();
-        applyConfigDom(config);
-      } else {
-        // Exiting preview mode - restore original state
-        if (originalStateRef.current) {
-          restoreConfigDom(originalStateRef.current);
-          originalStateRef.current = null;
-        }
-      }
-      return !prev;
-    });
-  }, [config]);
+    // Preview runs through the config store, so components re-render with the
+    // draft, plus applyConfigDom for what no component renders. Exiting drops
+    // the overlay and re-applies the baseline; there is no snapshot to manage.
+    if (!isPreviewMode) {
+      previewConfigDraft(config);
+    } else {
+      endConfigPreview();
+    }
+    setIsPreviewMode(!isPreviewMode);
+  }, [isPreviewMode, config]);
 
-  // Handle cleanup when exiting preview mode or unmounting
-  // This effect ONLY depends on isPreviewMode to avoid restore/reapply loops
+  // End preview when the window unmounts mid-preview. endConfigPreview is
+  // idempotent, so the exit button having already run it is fine.
   useEffect(() => {
     if (!isPreviewMode) {
       return;
     }
-
-    // Cleanup: restore original state only when exiting preview mode
     return () => {
-      if (originalStateRef.current) {
-        restoreConfigDom(originalStateRef.current);
-      }
+      endConfigPreview();
     };
   }, [isPreviewMode]);
 
-  // Apply preview config when config changes while in preview mode
-  // This effect has NO cleanup to avoid restore/reapply flicker
+  // Re-preview when the draft changes while in preview mode
   useEffect(() => {
     if (isPreviewMode) {
-      applyConfigDom(config);
+      previewConfigDraft(config);
     }
   }, [config, isPreviewMode]);
 
   const handleExitPreview = useCallback(() => {
-    if (originalStateRef.current) {
-      restoreConfigDom(originalStateRef.current);
-      originalStateRef.current = null;
-    }
+    endConfigPreview();
     setIsPreviewMode(false);
   }, []);
 

--- a/apps/self-hosted/src/features/shared/user-avatar.tsx
+++ b/apps/self-hosted/src/features/shared/user-avatar.tsx
@@ -10,7 +10,7 @@ export type UserAvatarProps = Omit<BaseUserAvatarProps, 'imageProxyBase'>;
  * Re-exports @ecency/ui UserAvatar with imageProxyBase pre-filled from config.
  */
 export function UserAvatar(props: UserAvatarProps) {
-  const imageProxyBase = InstanceConfigManager.getConfigValue(
+  const imageProxyBase = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.general.imageProxy || 'https://i.ecency.com',
   );
 

--- a/apps/self-hosted/src/features/tipping/hooks/use-tipping-config.ts
+++ b/apps/self-hosted/src/features/tipping/hooks/use-tipping-config.ts
@@ -6,8 +6,10 @@ const DEFAULT_PRESETS = [1, 5, 10];
 const DEFAULT_BUTTON_LABEL = 'Tip';
 
 export function useTippingConfig(variant: TippingVariant) {
+  // Reactive: the Configuration Editor's preview serves a draft through the
+  // store, and drafted tipping labels must leave with the preview.
+  const config = InstanceConfigManager.useFullConfig();
   return useMemo(() => {
-    const config = InstanceConfigManager.getConfig();
     const tipping = config.configuration.instanceConfiguration.features?.tipping;
     if (!tipping) {
       return { enabled: false, buttonLabel: DEFAULT_BUTTON_LABEL, presetAmounts: DEFAULT_PRESETS };
@@ -19,5 +21,5 @@ export function useTippingConfig(variant: TippingVariant) {
       ? tipping.amounts
       : DEFAULT_PRESETS;
     return { enabled, buttonLabel, presetAmounts };
-  }, [variant]);
+  }, [config, variant]);
 }

--- a/apps/self-hosted/src/routes/login.tsx
+++ b/apps/self-hosted/src/routes/login.tsx
@@ -60,7 +60,7 @@ function LoginPage() {
   const availableMethods = useAvailableAuthMethods();
   const [error, setError] = useState<string | null>(null);
 
-  const blogTitle = InstanceConfigManager.getConfigValue(
+  const blogTitle = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.instanceConfiguration.meta.title
   );
 

--- a/apps/self-hosted/src/routes/search.tsx
+++ b/apps/self-hosted/src/routes/search.tsx
@@ -19,7 +19,7 @@ function RouteComponent() {
   // bookmarked /search?q= would still query Hive; send it home instead. Snapshot read (as
   // elsewhere in the app); a live owner-preview toggle isn't reflected because preview edits
   // are applied via DOM attributes, not the config store. Config is static per real load.
-  const searchEnabled = InstanceConfigManager.getConfigValue(
+  const searchEnabled = InstanceConfigManager.useConfig(
     ({ configuration }) =>
       configuration.instanceConfiguration.layout.search?.enabled ?? true,
   );

--- a/apps/self-hosted/src/utils/use-document-meta.ts
+++ b/apps/self-hosted/src/utils/use-document-meta.ts
@@ -55,9 +55,14 @@ function restoreOrRemoveMeta(
  * Sets document title and OG/Twitter meta tags. Restores previous values on unmount.
  */
 export function useDocumentMeta(meta: DocumentMeta) {
+  // Subscribed, not a one-shot read: the Configuration Editor's preview serves
+  // a draft through the store, and the page title must follow it in and back
+  // out again when preview ends.
+  const defaultTitle = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.instanceConfiguration.meta.title || "Blog",
+  );
+
   useEffect(() => {
-    const config = InstanceConfigManager.getConfig();
-    const defaultTitle = config.configuration.instanceConfiguration.meta.title || "Blog";
     const previousTitle = document.title;
 
     // Snapshot current meta values before overwriting
@@ -98,5 +103,5 @@ export function useDocumentMeta(meta: DocumentMeta) {
         restoreOrRemoveMeta(property, previous, attribute);
       }
     };
-  }, [meta.title, meta.description, meta.ogTitle, meta.ogDescription, meta.ogImage, meta.ogType, meta.ogUrl, meta.twitterCard]);
+  }, [defaultTitle, meta.title, meta.description, meta.ogTitle, meta.ogDescription, meta.ogImage, meta.ogType, meta.ogUrl, meta.twitterCard]);
 }

--- a/apps/self-hosted/vitest.config.ts
+++ b/apps/self-hosted/vitest.config.ts
@@ -3,6 +3,25 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   css: { postcss: {} },
+  resolve: {
+    alias: [
+      // config.json is generated at image build and gitignored, so tests must
+      // not depend on it existing. Mirrors the Dockerfile and CI build
+      // fallback (config.template.json stands in). Matched against the RAW
+      // specifier configuration-loader writes, because alias runs before
+      // relative resolution; and top-level resolve.alias, not test.alias,
+      // because the jsdom environment resolves through the client pipeline,
+      // whose import analysis hard-fails on the missing file. Node-environment
+      // tests survived without this only because the SSR pipeline
+      // externalises the missing import and vi.mock intercepts it at runtime.
+      {
+        find: /^\.\.\/\.\.\/config\.json$/,
+        replacement: fileURLToPath(
+          new URL('./config.template.json', import.meta.url),
+        ),
+      },
+    ],
+  },
   test: {
     environment: 'node',
     globals: true,


### PR DESCRIPTION
Closes #1412.

The Configuration Editor's preview applied a draft config to the DOM by snapshot/apply and never re-rendered React, which worked only because style templates are CSS-only. This routes preview through the config store so a draft that changes component structure can preview too.

What changed:

- `ConfigStore` gains a preview overlay: `getConfig`/`getSnapshot` serve the draft while it is set, so `useConfig` subscribers re-render with it. `updateConfig` (a save) sets the new baseline and drops the overlay, so exiting preview can no longer roll back a saved change.
- New `core/config-preview.ts` pairs the overlay with `applyConfigDom`. Ending preview re-applies the baseline through the same declaration instead of restoring a snapshot, so restore cannot drift from what boot produces. The floating menu window loses its snapshot ref entirely.
- Render-path config reads convert from `getConfigValue` to `useConfig` subscriptions (navigation, post cards, footers, sidebar, search, TTS button, login, avatar, document meta, hive layer, tipping). Without this the notify would stop at the router's memoized `Outlet` and nothing would re-render.
- Identity and authority reads pin to the new `getBaseConfig`: the ownership gate in the auth provider, managed-hosting detection, the tenant username a save targets and the pinned instance type. A drafted document cannot change who the owner is.

Tests: `core/config-preview.test.ts` covers the draft being served and painted, exact restore over repeated cycles including subscriber notifies in both directions, idempotent double-exit, save-during-preview dropping the overlay and identity reads ignoring the overlay. The exit-notify assertion specifically kills a mutant (clearing the overlay without notifying) that the initial suite missed. Full suite 872 passing, typecheck clean, production build clean.

Known limitation: strings rendered through `t()` and plain utility reads (date formatting, posts-filter clamping) refresh only when a subscribed component re-renders, so a drafted language change does not live-preview UI strings. Same behavior as before this change.

Follow-up commits: the vitest config aliases the raw `config.json` specifier to `config.template.json` so tests run on checkouts without the generated file (the jsdom pipeline hard-fails on it where node-environment tests get externalised), and preview now synchronizes the system-theme listener with the draft: a fixed-theme draft suspends the OS listener so an appearance flip cannot overwrite the preview, a `system` draft follows the OS while previewed and exit re-synchronizes to the baseline. Both covered by tests (874 total).
