### PR TITLE
Self-hosted: theme manifests so a template can own its layout

### DIFF
--- a/apps/self-hosted/src/features/blog/components/blog-posts-list.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-posts-list.tsx
@@ -7,7 +7,7 @@ import {
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef } from 'react';
 import { t } from '@/core';
-import { BlogPostItem } from './blog-post-item';
+import { useThemeComponents } from '@/themes/use-theme-components';
 import { DetectBottom } from './detect-bottom';
 import { useInstanceConfig } from '../hooks/use-instance-config';
 import { chooseFeedRetry } from '../utils/feed-retry';
@@ -35,6 +35,9 @@ const communityFilterMap: Record<string, string> = {
 };
 
 export function BlogPostsList({ filter = 'posts', limit = 20 }: Props) {
+  // The card resolves through the theme registry: a theme can restyle every
+  // entry without owning the whole feed (fetching, paging, error states).
+  const { PostCard } = useThemeComponents();
   const { username, communityId, isCommunityMode } = useInstanceConfig();
 
   // Use different query based on instance type
@@ -121,7 +124,7 @@ export function BlogPostsList({ filter = 'posts', limit = 20 }: Props) {
         const isNewItem = index >= previousLengthRef.current;
         const batchIndex = isNewItem ? index - previousLengthRef.current : 0;
         return (
-          <BlogPostItem
+          <PostCard
             key={`${post.author}/${post.permlink}`}
             entry={post}
             index={batchIndex}

--- a/apps/self-hosted/src/features/blog/layout/blog-layout.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-layout.tsx
@@ -1,26 +1,13 @@
 import type { PropsWithChildren } from 'react';
-import { BlogNavigation } from './blog-navigation';
-import { BlogPage } from './blog-page';
-import { BlogSidebar } from './blog-sidebar';
+import { useThemeComponents } from '@/themes/use-theme-components';
 
+/**
+ * The page shell, resolved through the theme registry. Every CSS-only
+ * template resolves to DefaultShell and renders exactly what this component
+ * used to hardcode; a layout-level theme overrides the Shell seam in its
+ * manifest and owns the frame.
+ */
 export function BlogLayout(props: PropsWithChildren) {
-  return (
-    <div className="min-h-screen bg-theme-primary">
-      <div className="container mx-auto container-padding-theme">
-        {/* Mobile/Tablet: Single column with sidebar on top */}
-        <div className="blog-layout-grid flex flex-col lg:grid layout-gap-theme">
-          {/* Sidebar - appears first on mobile/tablet */}
-          <div className="blog-sidebar-container order-1">
-            <BlogSidebar />
-          </div>
-
-          {/* Main content - appears second on mobile/tablet */}
-          <main id="main-content" className="blog-main-container order-2 items-start mt-4 sm:mt-8 section-gap-theme">
-            <BlogNavigation />
-            <BlogPage>{props.children}</BlogPage>
-          </main>
-        </div>
-      </div>
-    </div>
-  );
+  const { Shell } = useThemeComponents();
+  return <Shell>{props.children}</Shell>;
 }

--- a/apps/self-hosted/src/features/blog/layout/default-shell.tsx
+++ b/apps/self-hosted/src/features/blog/layout/default-shell.tsx
@@ -1,0 +1,33 @@
+import type { PropsWithChildren } from 'react';
+import { useThemeComponents } from '@/themes/use-theme-components';
+import { BlogPage } from './blog-page';
+
+/**
+ * The shared page frame every CSS-only template renders: sidebar and content
+ * column in the attribute-driven grid (sidebar placement and visibility stay
+ * pure CSS via [data-sidebar-placement] and [data-show-*]). Navigation and
+ * Sidebar resolve through the theme registry, so a theme can replace either
+ * without owning the whole frame.
+ */
+export function DefaultShell(props: PropsWithChildren) {
+  const { Navigation, Sidebar } = useThemeComponents();
+  return (
+    <div className="min-h-screen bg-theme-primary">
+      <div className="container mx-auto container-padding-theme">
+        {/* Mobile/Tablet: Single column with sidebar on top */}
+        <div className="blog-layout-grid flex flex-col lg:grid layout-gap-theme">
+          {/* Sidebar - appears first on mobile/tablet */}
+          <div className="blog-sidebar-container order-1">
+            <Sidebar />
+          </div>
+
+          {/* Main content - appears second on mobile/tablet */}
+          <main id="main-content" className="blog-main-container order-2 items-start mt-4 sm:mt-8 section-gap-theme">
+            <Navigation />
+            <BlogPage>{props.children}</BlogPage>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/self-hosted/src/routes/blog/route.tsx
+++ b/apps/self-hosted/src/routes/blog/route.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { useMemo } from 'react';
 import { BlogLayout } from '@/features/blog';
-import { BlogPostsList } from '@/features/blog/components/blog-posts-list';
+import { useThemeComponents } from '@/themes/use-theme-components';
 import { resolvePostsFilter } from '@/features/blog/utils/post-filters';
 
 export const Route = createFileRoute('/blog')({
@@ -44,11 +44,12 @@ function HostingBanner() {
 
 function RouteComponent() {
   const { filter } = Route.useSearch();
+  const { ArchiveList } = useThemeComponents();
   return (
     <>
       <HostingBanner />
       <BlogLayout>
-        <BlogPostsList filter={filter} />
+        <ArchiveList filter={filter} />
       </BlogLayout>
     </>
   );

--- a/apps/self-hosted/src/themes/manifest.ts
+++ b/apps/self-hosted/src/themes/manifest.ts
@@ -1,0 +1,50 @@
+import type { ComponentType, PropsWithChildren } from 'react';
+import type { StyleTemplate } from '../../hosting/api/src/style-templates';
+import type { Entry } from '@ecency/sdk';
+
+/**
+ * A style template as a MANIFEST: its id, its plan tier and, optionally, its
+ * own components for the named layout seams. Until now every template rendered
+ * the identical component tree and differed only through CSS custom
+ * properties, which caps how different two templates can look; a manifest
+ * lets a template own navigation patterns, archive structures and card
+ * anatomy while everything absent falls back to the shared defaults.
+ *
+ * Contracts every theme keeps, whatever its components do:
+ * - The full `--theme-*` token contract (the accent correction sweep derives
+ *   its guarantees from the theme CSS files).
+ * - Route topology is global (routeTree.gen.ts is codegen): layout variants
+ *   render INSIDE existing routes, so deep links never fork per theme.
+ * - The config toggles that exist today (sidebar placement and visibility,
+ *   list type) keep working, or the theme's own options declare them
+ *   unsupported explicitly. Never silently inert.
+ */
+
+export interface ThemeComponents {
+  /** The whole page frame: sidebar, navigation and the content column. */
+  Shell: ComponentType<PropsWithChildren>;
+  /** The masthead: title, logo, filter tabs, search, user menu. */
+  Navigation: ComponentType;
+  /** The profile / community rail. */
+  Sidebar: ComponentType;
+  /** The feed container: fetching, infinite scroll, empty and error states. */
+  ArchiveList: ComponentType<{ filter?: string; limit?: number }>;
+  /** One entry in the archive. */
+  PostCard: ComponentType<{ entry: Entry; index?: number }>;
+}
+
+export interface ThemeManifest {
+  id: StyleTemplate;
+  /**
+   * Availability by hosting plan. Enforcement happens server-side at save and
+   * activation; this field is what the server and the pickers read.
+   */
+  tier: 'free' | 'premium';
+  /**
+   * Component overrides for the named seams. Absent entirely for a CSS-only
+   * template, which is what all five existing templates are: their manifests
+   * carry no components key, proving the migration to this architecture
+   * changes nothing rendered.
+   */
+  components?: Partial<ThemeComponents>;
+}

--- a/apps/self-hosted/src/themes/registry.test.ts
+++ b/apps/self-hosted/src/themes/registry.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { STYLE_TEMPLATES } from '../../hosting/api/src/style-templates';
+import { allThemeManifests, getThemeManifest } from './registry';
+
+/**
+ * The no-op migration proof: every roster template has a manifest, none of
+ * the five carries component overrides (they are CSS-only, so the resolved
+ * tree is exactly the pre-manifest tree), and unknown ids resolve to the
+ * default template's manifest the same way apply-config-dom resolves the
+ * data-style-template attribute.
+ */
+describe('theme manifest registry', () => {
+  it('is total over the roster with matching ids', () => {
+    const manifests = allThemeManifests();
+    expect(manifests.map((m) => m.id).sort()).toEqual([...STYLE_TEMPLATES].sort());
+  });
+
+  it('all five existing templates are CSS-only no-op manifests', () => {
+    for (const manifest of allThemeManifests()) {
+      expect(manifest.components, `${manifest.id} must not override components yet`).toBeUndefined();
+      expect(manifest.tier).toBe('free');
+    }
+  });
+
+  it('unknown and absent ids resolve to the default template', () => {
+    expect(getThemeManifest(undefined).id).toBe('medium');
+    expect(getThemeManifest('no-such-theme').id).toBe('medium');
+    expect(getThemeManifest(42).id).toBe('medium');
+    expect(getThemeManifest('magazine').id).toBe('magazine');
+  });
+});

--- a/apps/self-hosted/src/themes/registry.test.ts
+++ b/apps/self-hosted/src/themes/registry.test.ts
@@ -29,3 +29,24 @@ describe('theme manifest registry', () => {
     expect(getThemeManifest('magazine').id).toBe('magazine');
   });
 });
+
+describe('component resolution', () => {
+  it('every roster template resolves to exactly the shared defaults today', async () => {
+    const { DEFAULT_THEME_COMPONENTS, resolveThemeComponents } = await import(
+      './use-theme-components'
+    );
+    for (const id of STYLE_TEMPLATES) {
+      const resolved = resolveThemeComponents(id);
+      // Identity per seam, not just deep equality: the no-op migration means
+      // the very same component functions render, so nothing remounts.
+      for (const key of Object.keys(DEFAULT_THEME_COMPONENTS) as Array<
+        keyof typeof DEFAULT_THEME_COMPONENTS
+      >) {
+        expect(resolved[key], `${id}.${key}`).toBe(DEFAULT_THEME_COMPONENTS[key]);
+      }
+    }
+    expect(resolveThemeComponents(undefined)).toEqual(
+      resolveThemeComponents('medium'),
+    );
+  });
+});

--- a/apps/self-hosted/src/themes/registry.ts
+++ b/apps/self-hosted/src/themes/registry.ts
@@ -1,0 +1,42 @@
+import {
+  DEFAULT_STYLE_TEMPLATE,
+  STYLE_TEMPLATES,
+  type StyleTemplate,
+} from '../../hosting/api/src/style-templates';
+import type { ThemeManifest } from './manifest';
+
+/**
+ * Every template id from the roster gets a manifest here; the roster guard
+ * suite keeps ids in lockstep with the CSS registry, and the registry test in
+ * this directory keeps this map total over the roster. All five existing
+ * templates are CSS-only, so none carries a components key: rendering is
+ * byte-identical to the pre-manifest architecture, which is the point of the
+ * migration.
+ */
+const MANIFESTS: Record<StyleTemplate, ThemeManifest> = {
+  medium: { id: 'medium', tier: 'free' },
+  minimal: { id: 'minimal', tier: 'free' },
+  magazine: { id: 'magazine', tier: 'free' },
+  developer: { id: 'developer', tier: 'free' },
+  'modern-gradient': { id: 'modern-gradient', tier: 'free' },
+};
+
+function isStyleTemplate(value: unknown): value is StyleTemplate {
+  return (
+    typeof value === 'string' &&
+    (STYLE_TEMPLATES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * The manifest for a configured template id, falling back to the default
+ * template's manifest for absent or unknown ids, mirroring how
+ * apply-config-dom resolves data-style-template.
+ */
+export function getThemeManifest(configured: unknown): ThemeManifest {
+  return MANIFESTS[isStyleTemplate(configured) ? configured : DEFAULT_STYLE_TEMPLATE];
+}
+
+export function allThemeManifests(): readonly ThemeManifest[] {
+  return STYLE_TEMPLATES.map((id) => MANIFESTS[id]);
+}

--- a/apps/self-hosted/src/themes/use-theme-components.ts
+++ b/apps/self-hosted/src/themes/use-theme-components.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import { InstanceConfigManager } from '@/core';
+import { BlogPostsList } from '@/features/blog/components/blog-posts-list';
+import { BlogPostItem } from '@/features/blog/components/blog-post-item';
+import { DefaultShell } from '@/features/blog/layout/default-shell';
+import { BlogNavigation } from '@/features/blog/layout/blog-navigation';
+import { BlogSidebar } from '@/features/blog/layout/blog-sidebar';
+import type { ThemeComponents } from './manifest';
+import { getThemeManifest } from './registry';
+
+/**
+ * The shared defaults behind every seam: exactly the components every
+ * template rendered before manifests existed. A theme overrides seams through
+ * its manifest; everything absent falls back here, so a CSS-only theme
+ * renders the identical tree it always has.
+ */
+export const DEFAULT_THEME_COMPONENTS: ThemeComponents = {
+  Shell: DefaultShell,
+  Navigation: BlogNavigation,
+  Sidebar: BlogSidebar,
+  ArchiveList: BlogPostsList,
+  PostCard: BlogPostItem,
+};
+
+/**
+ * Resolve the active template's components, reactively: a subscriber, so the
+ * Configuration Editor's preview (which serves a draft config through the
+ * store) restyles AND restructures live, and exiting preview restores the
+ * baseline components.
+ */
+export function useThemeComponents(): ThemeComponents {
+  const styleTemplate = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.general.styleTemplate,
+  );
+  return useMemo(
+    () => ({
+      ...DEFAULT_THEME_COMPONENTS,
+      ...getThemeManifest(styleTemplate).components,
+    }),
+    [styleTemplate],
+  );
+}

--- a/apps/self-hosted/src/themes/use-theme-components.ts
+++ b/apps/self-hosted/src/themes/use-theme-components.ts
@@ -28,15 +28,17 @@ export const DEFAULT_THEME_COMPONENTS: ThemeComponents = {
  * store) restyles AND restructures live, and exiting preview restores the
  * baseline components.
  */
+/** The pure half of the hook, separated so the resolution is testable. */
+export function resolveThemeComponents(styleTemplate: unknown): ThemeComponents {
+  return {
+    ...DEFAULT_THEME_COMPONENTS,
+    ...getThemeManifest(styleTemplate).components,
+  };
+}
+
 export function useThemeComponents(): ThemeComponents {
   const styleTemplate = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.general.styleTemplate,
   );
-  return useMemo(
-    () => ({
-      ...DEFAULT_THEME_COMPONENTS,
-      ...getThemeManifest(styleTemplate).components,
-    }),
-    [styleTemplate],
-  );
+  return useMemo(() => resolveThemeComponents(styleTemplate), [styleTemplate]);
 }

--- a/apps/self-hosted/vitest.config.ts
+++ b/apps/self-hosted/vitest.config.ts
@@ -20,6 +20,16 @@ export default defineConfig({
           new URL('./config.template.json', import.meta.url),
         ),
       },
+      // Mirrors the rsbuild alias: the workspace package resolves through its
+      // committed dist, exactly what the shipped bundle uses. Without this,
+      // any test that imports a component chain touching @ecency/ui fails at
+      // resolution.
+      {
+        find: /^@ecency\/ui$/,
+        replacement: fileURLToPath(
+          new URL('../../packages/ui/dist/index.js', import.meta.url),
+        ),
+      },
     ],
   },
   test: {


### PR DESCRIPTION
Closes #1418. Independent of the signup chain (base develop); pairs with the merged #1436, whose config-store preview is what lets a structural theme preview correctly.

No component read `general.styleTemplate`: all five templates rendered the identical component tree and differed only through CSS custom properties, which caps how different two templates can look. This introduces the architecture that lifts that cap without changing a rendered byte today:

- `src/themes/manifest.ts` defines a theme as `{ id, tier, components? }` over five named seams: Shell (the page frame), Navigation, Sidebar, ArchiveList (the feed container) and PostCard. Absent entries fall back to shared defaults.
- `src/themes/registry.ts` holds one manifest per roster id. All five existing templates carry NO components key: they are CSS-only, so resolution falls back to exactly the components the shell used to hardcode. The registry test pins this no-op (registry total over the roster, no overrides, unknown ids resolving to the default the same way `apply-config-dom` resolves the attribute).
- `useThemeComponents` resolves the active template's components reactively through the config store, so the Configuration Editor's preview restructures live and exiting preview restores the baseline components.
- `BlogLayout` becomes the Shell resolver; the previous frame moves to `DefaultShell`, which itself resolves Navigation and Sidebar through the registry, so a theme can replace the masthead or the rail without owning the whole frame. The feed resolves ArchiveList and PostCard the same way.
- Standing constraints hold: sidebar placement and visibility stay pure CSS through the existing attribute contract, the full `--theme-*` token contract stays mandatory per theme and route topology stays global so deep links never fork per theme.

Deliberately deferred: an EmptyState seam and per-theme option sets (#1419) join when the first layout-level theme (Journal, #1420) actually needs them; the search results card call site joins the PostCard seam at the same time. `tier` is carried but not yet enforced; server-side enforcement lands with the first premium theme (#1421).

SPA 882 tests, typecheck and production build green.
