### PR TITLE
Self-hosted: per-theme option visibility in the Configuration Editor

### DIFF
--- a/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
+++ b/apps/self-hosted/src/features/floating-menu/components/config-editor.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useMemo, useState } from 'react';
+import { isFieldVisible } from '../config-fields';
 import { LiveRegion } from '@/features/shared/live-region';
 import { validateArrayDraft, validateArrayEntries } from '../array-field';
 import type { ConfigField } from '../config-fields';
@@ -391,6 +392,9 @@ export const ConfigEditor = memo<ConfigEditorProps>(
       const regularList: Array<[string, ConfigField]> = [];
 
       Object.entries(fields).forEach(([key, field]) => {
+        // Visibility is decided against the whole document, so an option can
+        // depend on a value in another branch (the style template, above all).
+        if (!isFieldVisible(field, document)) return;
         if (field.type === 'section') {
           sectionsList.push([key, field]);
         } else {
@@ -402,7 +406,7 @@ export const ConfigEditor = memo<ConfigEditorProps>(
         sections: sectionsList,
         regularFields: regularList,
       };
-    }, [fields]);
+    }, [fields, document]);
 
     return (
       <div className="space-y-4">

--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -13,7 +13,9 @@ import { AUTH_METHODS } from '@/features/auth/utils/auth-methods';
 import { resolveCreatePostTarget } from '@/features/auth/utils/create-post-target';
 import type { ConfigField } from './config-fields';
 import { translations } from '@/core/i18n-strings';
-import { buildConfigFields } from './config-fields';
+import { buildConfigFields,
+  isFieldVisible,
+} from './config-fields';
 
 /*
  * English, read from the strings module directly.
@@ -815,4 +817,41 @@ describe('panel translations, per locale', () => {
       expect(panelKeys(locale)).toEqual([]);
     },
   );
+});
+
+describe('isFieldVisible (the visibleWhen capability)', () => {
+  const doc = {
+    configuration: {
+      general: { styleTemplate: 'magazine' },
+    },
+  } as unknown as Record<string, import('./types').ConfigValue>;
+
+  it('a field with no predicate is always visible', () => {
+    expect(isFieldVisible({ label: 'X', type: 'string' } as any, doc)).toBe(true);
+  });
+
+  it('the predicate decides against the WHOLE document', () => {
+    const onlyMagazine = {
+      label: 'X',
+      type: 'select',
+      visibleWhen: (d: any) => d?.configuration?.general?.styleTemplate === 'magazine',
+    } as any;
+    expect(isFieldVisible(onlyMagazine, doc)).toBe(true);
+    expect(
+      isFieldVisible(onlyMagazine, {
+        configuration: { general: { styleTemplate: 'medium' } },
+      } as any),
+    ).toBe(false);
+  });
+
+  it('a throwing predicate hides nothing (no panel lockout)', () => {
+    const broken = {
+      label: 'X',
+      type: 'string',
+      visibleWhen: () => {
+        throw new Error('boom');
+      },
+    } as any;
+    expect(isFieldVisible(broken, doc)).toBe(true);
+  });
 });

--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -820,38 +820,46 @@ describe('panel translations, per locale', () => {
 });
 
 describe('isFieldVisible (the visibleWhen capability)', () => {
-  const doc = {
-    configuration: {
-      general: { styleTemplate: 'magazine' },
-    },
-  } as unknown as Record<string, import('./types').ConfigValue>;
+  type Document = Record<string, import('./types').ConfigValue>;
+
+  function documentWithTemplate(styleTemplate: string): Document {
+    return {
+      configuration: { general: { styleTemplate } },
+    } as unknown as Document;
+  }
+
+  function templateOf(document: Document): unknown {
+    const configuration = document.configuration as
+      | { general?: { styleTemplate?: unknown } }
+      | undefined;
+    return configuration?.general?.styleTemplate;
+  }
+
+  const doc = documentWithTemplate('magazine');
 
   it('a field with no predicate is always visible', () => {
-    expect(isFieldVisible({ label: 'X', type: 'string' } as any, doc)).toBe(true);
+    const field: ConfigField = { label: 'X', type: 'string' };
+    expect(isFieldVisible(field, doc)).toBe(true);
   });
 
   it('the predicate decides against the WHOLE document', () => {
-    const onlyMagazine = {
+    const onlyMagazine: ConfigField = {
       label: 'X',
       type: 'select',
-      visibleWhen: (d: any) => d?.configuration?.general?.styleTemplate === 'magazine',
-    } as any;
+      visibleWhen: (document) => templateOf(document) === 'magazine',
+    };
     expect(isFieldVisible(onlyMagazine, doc)).toBe(true);
-    expect(
-      isFieldVisible(onlyMagazine, {
-        configuration: { general: { styleTemplate: 'medium' } },
-      } as any),
-    ).toBe(false);
+    expect(isFieldVisible(onlyMagazine, documentWithTemplate('medium'))).toBe(false);
   });
 
   it('a throwing predicate hides nothing (no panel lockout)', () => {
-    const broken = {
+    const broken: ConfigField = {
       label: 'X',
       type: 'string',
       visibleWhen: () => {
         throw new Error('boom');
       },
-    } as any;
+    };
     expect(isFieldVisible(broken, doc)).toBe(true);
   });
 });

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -121,6 +121,33 @@ export interface ConfigField {
     value: string,
     config?: Record<string, ConfigValue>,
   ) => string | null;
+  /**
+   * Render this field or section only while the predicate holds against the
+   * WHOLE document, for choices that only exist under certain conditions
+   * (a theme manifest's own options are the intended consumer: "choices
+   * depend on the theme"). Visibility is presentation, never data: a hidden
+   * field's stored value is untouched, exactly as if the panel had not been
+   * opened. Absent means always visible.
+   */
+  visibleWhen?: (document: Record<string, ConfigValue>) => boolean;
+}
+
+/**
+ * The renderer's visibility gate, separated so it can be tested without
+ * rendering: a field with no predicate is always visible, and a predicate
+ * that throws hides nothing (a broken predicate must not make a control
+ * unreachable, which is the panel's own lockout class of bug).
+ */
+export function isFieldVisible(
+  field: ConfigField,
+  document: Record<string, ConfigValue>,
+): boolean {
+  if (!field.visibleWhen) return true;
+  try {
+    return field.visibleWhen(document);
+  } catch {
+    return true;
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #1419. Independent (base develop); the first consumer is the Journal theme's option set (#1420).

The editor's field tree is data walked by a generic renderer, but option sets were static: every theme showed the same fields. This adds the capability that lets a theme's own choices appear only while that theme is active:

- `ConfigField` gains `visibleWhen(document)`, decided against the WHOLE document (the renderer already threads it as `root`), so an option can depend on the style template living in another branch of the tree.
- Visibility is presentation, never data: a hidden field's stored value is untouched, exactly as if the panel had not been opened.
- The gate is a separated pure helper (`isFieldVisible`) so it tests without rendering, and a throwing predicate hides nothing: a broken predicate must not make a control unreachable from the only surface that could fix it.

Server-side note recorded for future keys rather than changed now: any NEW config key a themed option writes must be accepted by the hosting API before the client ships it (the guarded merge silently drops unknown shapes while reporting them on the discarded channel); the keys the first themed options will use live under `general.styles`, which the API already stores.

Tests pin the helper (always-visible default, whole-document decision, throw-hides-nothing). SPA 882 tests, typecheck and production build green.
