### PR TITLE
Tests: stabilize two merged-develop CI failures

### DIFF
--- a/apps/self-hosted/src/themes/registry.test.ts
+++ b/apps/self-hosted/src/themes/registry.test.ts
@@ -30,11 +30,16 @@ describe('theme manifest registry', () => {
   });
 });
 
+// Imported at module scope: the resolver drags the whole component graph in,
+// and paying that import inside the test body spends the 5s test budget on
+// cold-transform time in CI (it timed out on the merged develop). Collection
+// time is not budgeted.
+const { DEFAULT_THEME_COMPONENTS, resolveThemeComponents } = await import(
+  './use-theme-components'
+);
+
 describe('component resolution', () => {
-  it('every roster template resolves to exactly the shared defaults today', async () => {
-    const { DEFAULT_THEME_COMPONENTS, resolveThemeComponents } = await import(
-      './use-theme-components'
-    );
+  it('every roster template resolves to exactly the shared defaults today', () => {
     for (const id of STYLE_TEMPLATES) {
       const resolved = resolveThemeComponents(id);
       // Identity per seam, not just deep equality: the no-op migration means

--- a/apps/web/src/specs/features/hosting-signup/hosting-signup.spec.tsx
+++ b/apps/web/src/specs/features/hosting-signup/hosting-signup.spec.tsx
@@ -430,7 +430,11 @@ describe("HostingSignup customize step: coverage the mutation review demanded", 
     await waitFor(() => expect(payBtn.disabled).toBe(false));
     fireEvent.click(payBtn);
     await screen.findByText("hosting.success-title");
-    expect(localStorage.getItem("ecency:hosting:customize:alice")).toBeNull();
+    // The cleanup runs in an effect after the success commit; on a slow CI
+    // runner the paint can beat the effect, so poll rather than read once.
+    await waitFor(() =>
+      expect(localStorage.getItem("ecency:hosting:customize:alice")).toBeNull()
+    );
   });
 
   it("prefills empty identity from the profile and takes it back out on a name change", async () => {


### PR DESCRIPTION
Unblocks the Staging CI/CD pipeline on develop after the six-PR merge. No production code changes; two test stabilizations:

- The theme registry's identity test imported the component resolver inside the test body, paying the whole component graph's cold transform against its own 5s budget. On the merged develop that import grew past the budget and timed out in the Staging pipeline's runner (the Self-Hosted workflow's runner squeaked past, which is why that pipeline went green and deployed). The import moves to module scope, where collection time is not budgeted.
- The draft-restore signup spec read localStorage immediately after the success screen appeared, but the cleanup runs in an effect after that commit, so a slow runner can paint before the effect. The assertion now polls with waitFor.

Verified: both suites pass locally on the merged head (self-hosted 899, signup spec 19).
