### PR TITLE
Match web Pro badge to mobile checkmark style

### DIFF
--- a/apps/web/src/features/pro/pro-badge.tsx
+++ b/apps/web/src/features/pro/pro-badge.tsx
@@ -2,7 +2,7 @@
 
 import { getProMembersQueryOptions } from "@ecency/sdk";
 import { useQuery } from "@tanstack/react-query";
-import { checkSvg } from "@ui/svg";
+import { checkDecagramSvg } from "@ui/svg";
 import clsx from "clsx";
 import i18next from "i18next";
 import { isProMember } from "./pro-config";
@@ -13,9 +13,10 @@ interface Props {
 }
 
 /**
- * Small X-style verified checkmark shown next to a username when it belongs to an
- * active Ecency Pro member. The roster is a single cached, public query, so this is
- * cheap to drop wherever a username renders.
+ * Small verified checkmark shown next to a username when it belongs to an active
+ * Ecency Pro member. The roster is a single cached, public query, so this is cheap
+ * to drop wherever a username renders. The seal shape and blue match the mobile
+ * app's ProBadge so the same member reads the same on both clients.
  */
 export function ProBadge({ username, className }: Props) {
   const { data } = useQuery(getProMembersQueryOptions());
@@ -31,11 +32,11 @@ export function ProBadge({ username, className }: Props) {
       title={label}
       aria-label={label}
       className={clsx(
-        "inline-flex items-center justify-center align-middle rounded-full bg-blue-dark-sky text-white size-4 shrink-0 [&>svg]:size-3",
+        "inline-flex items-center justify-center align-middle text-blue-dark-sky size-4 shrink-0 [&>svg]:size-full",
         className
       )}
     >
-      {checkSvg}
+      {checkDecagramSvg}
     </span>
   );
 }

--- a/apps/web/src/features/ui/svg.tsx
+++ b/apps/web/src/features/ui/svg.tsx
@@ -290,6 +290,18 @@ export const deleteForeverSvg = (
 
 export const checkSvg = <UilCheck className="size-6" />;
 
+// Decagram seal with a knocked-out check, matching the mobile app's Pro badge
+// (MaterialCommunityIcons `check-decagram`). The check is a reverse-wound subpath,
+// so it stays a cutout under the default nonzero fill rule. Do not split the path.
+export const checkDecagramSvg = (
+  <svg viewBox="0 0 24 24">
+    <path
+      fill="currentColor"
+      d="M23,12L20.56,9.22L20.9,5.54L17.29,4.72L15.4,1.54L12,3L8.6,1.54L6.71,4.72L3.1,5.54L3.44,9.22L1,12L3.44,14.78L3.1,18.46L6.71,19.28L8.6,22.46L12,21L15.4,22.46L17.29,19.28L20.9,18.46L20.56,14.78L23,12M10,17L6,13L7.41,11.59L10,14.17L16.59,7.58L18,9L10,17Z"
+    />
+  </svg>
+);
+
 export const alertCircleSvg = (
   <svg viewBox="0 0 24 24">
     <path


### PR DESCRIPTION
## What

The Ecency Pro checkmark rendered differently on the two clients: web drew a plain filled circle with a white check inside, while mobile uses the MaterialCommunityIcons `check-decagram` seal. This aligns web with mobile.

- Adds `checkDecagramSvg` to `features/ui/svg.tsx`. The path was extracted from the same font glyph mobile renders (`check-decagram`, U+F0791) and matches it point for point.
- `ProBadge` now renders that seal in `text-blue-dark-sky` (#357ce6, the same value as mobile's `$primaryBlue`) instead of the blue circle plus white check.
- The check stays a knocked-out cutout, as it is in the font, so it picks up the page background in both light and dark themes exactly like the app does.

Badge footprint is unchanged (`size-4`), the icon sink follows docs/icons.md (`[&>svg]:size-full`), and the `title`/`aria-label` wiring is untouched, so every existing placement keeps its current spacing and accessible name.

## Test plan

- `pnpm --filter @ecency/web test` -> 273 files, 2623 tests passing (includes the Pro badge specs).
- `node scripts/icon-tsx-audit.mjs --fail` and `node scripts/icon-scss-audit.mjs` -> clean.
- `eslint` on both changed files -> clean.
- Rendered the new path next to the real mobile font glyph in a browser at light and dark: identical shape, identical blue.