### PR TITLE
Self-hosted: side thumbnails on Journal entries

### DIFF
--- a/apps/self-hosted/src/themes/journal/journal-post-card.tsx
+++ b/apps/self-hosted/src/themes/journal/journal-post-card.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import type { Entry } from '@ecency/sdk';
-import { postBodySummary } from '@ecency/render-helper';
+import { catchPostImage, postBodySummary } from '@ecency/render-helper';
 import { useMemo } from 'react';
 import { formatDate } from '@/core';
 
@@ -10,9 +10,10 @@ interface Props {
 }
 
 /**
- * A Journal entry: date, large serif title, excerpt, hairline rule. No card
- * chrome, no image, no counters; the entry is the page surface, the way a
- * personal publication reads. Stats and actions live on the post page.
+ * A Journal entry: date, large serif title, excerpt and a small side
+ * thumbnail when the post carries one, separated by hairline rules. No card
+ * chrome and no counters; the entry is the page surface, the way a personal
+ * publication reads. Stats and actions live on the post page.
  */
 export function JournalPostCard({ entry }: Props) {
   const entryData = entry.original_entry || entry;
@@ -21,6 +22,14 @@ export function JournalPostCard({ entry }: Props) {
     () =>
       entryData.json_metadata?.description ||
       postBodySummary(entryData.body, 220),
+    [entryData],
+  );
+
+  // Resolved and proxied by render-helper exactly like the default card:
+  // json_metadata is authored on-chain, so the raw value is untrusted and
+  // only a proxy URL (or null) ever reaches the src.
+  const imageUrl = useMemo(
+    () => catchPostImage(entryData, 400, 300) || null,
     [entryData],
   );
 
@@ -34,25 +43,51 @@ export function JournalPostCard({ entry }: Props) {
 
   return (
     <article className="py-8 border-b border-theme last:border-b-0">
-      <p className="text-sm text-theme-muted font-theme-ui mb-2">
-        <time dateTime={entryData.created}>{formatDate(entryData.created)}</time>
-        {entryData.community && entryData.community_title && (
-          <span> · {entryData.community_title}</span>
+      <div className="flex gap-5 items-start">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm text-theme-muted font-theme-ui mb-2">
+            <time dateTime={entryData.created}>
+              {formatDate(entryData.created)}
+            </time>
+            {entryData.community && entryData.community_title && (
+              <span> · {entryData.community_title}</span>
+            )}
+          </p>
+          <h2 className="heading-theme text-2xl sm:text-3xl leading-[1.2] mb-3">
+            <Link
+              to="/$author/$permlink"
+              params={postParams}
+              search={postSearch}
+              className="no-underline text-theme-primary hover:opacity-80 transition-theme"
+            >
+              {entryData.title}
+            </Link>
+          </h2>
+          {summary && (
+            <p className="text-theme-secondary leading-relaxed">{summary}</p>
+          )}
+        </div>
+        {imageUrl && (
+          <Link
+            to="/$author/$permlink"
+            params={postParams}
+            search={postSearch}
+            className="shrink-0 mt-1"
+            tabIndex={-1}
+            aria-hidden="true"
+          >
+            {/* A quiet side thumbnail, sized like marginalia rather than a
+                hero: hidden on the narrowest screens where it would crowd
+                the measure-width column. */}
+            <img
+              src={imageUrl}
+              alt=""
+              loading="lazy"
+              className="hidden sm:block size-28 object-cover post-card-image-theme"
+            />
+          </Link>
         )}
-      </p>
-      <h2 className="heading-theme text-2xl sm:text-3xl leading-[1.2] mb-3">
-        <Link
-          to="/$author/$permlink"
-          params={postParams}
-          search={postSearch}
-          className="no-underline text-theme-primary hover:opacity-80 transition-theme"
-        >
-          {entryData.title}
-        </Link>
-      </h2>
-      {summary && (
-        <p className="text-theme-secondary leading-relaxed">{summary}</p>
-      )}
+      </div>
     </article>
   );
 }

--- a/apps/self-hosted/src/themes/journal/journal-post-card.tsx
+++ b/apps/self-hosted/src/themes/journal/journal-post-card.tsx
@@ -67,23 +67,26 @@ export function JournalPostCard({ entry }: Props) {
             <p className="text-theme-secondary leading-relaxed">{summary}</p>
           )}
         </div>
+        {/* A quiet side thumbnail, sized like marginalia rather than a hero:
+            the whole flex item disappears on the narrowest screens (hiding
+            only the img would leave a zero-width item still costing the
+            parent's gap), and the size stays a fixed square here rather
+            than the shared post-card-image-theme class, whose unlayered
+            height token would override the Tailwind size. */}
         {imageUrl && (
           <Link
             to="/$author/$permlink"
             params={postParams}
             search={postSearch}
-            className="shrink-0 mt-1"
+            className="hidden sm:block shrink-0 mt-1"
             tabIndex={-1}
             aria-hidden="true"
           >
-            {/* A quiet side thumbnail, sized like marginalia rather than a
-                hero: hidden on the narrowest screens where it would crowd
-                the measure-width column. */}
             <img
               src={imageUrl}
               alt=""
               loading="lazy"
-              className="hidden sm:block size-28 object-cover post-card-image-theme"
+              className="size-28 object-cover rounded-[var(--theme-post-card-image-radius)]"
             />
           </Link>
         )}


### PR DESCRIPTION
Owner feedback from Journal's first visual pass: entries should show the post's image.

Adds a quiet side thumbnail beside the excerpt (marginalia, not a hero): resolved and proxied through render-helper exactly like the default card so no author-controlled URL ever reaches the src, lazy-loaded, radius from the theme token and hidden on the narrowest screens where it would crowd the 680px column. Entries without an image keep the pure text layout.

SPA suite 906 tests, typecheck green.
