### PR TITLE
Hosting: auto-login on the new instance via carried session

### DIFF
--- a/apps/self-hosted/src/features/auth/auth-provider.tsx
+++ b/apps/self-hosted/src/features/auth/auth-provider.tsx
@@ -3,10 +3,10 @@
 import { createContext, type ReactNode, useEffect, useMemo } from 'react';
 import { InstanceConfigManager } from '@/core';
 import { useAuthStore } from '@/store';
-import { clearHiveAuthSession, clearUser } from './storage';
+import { clearHiveAuthSession, clearUser, saveUser } from './storage';
 import type { AuthContextValue, AuthUser } from './types';
 import { availableAuthMethods } from './utils/auth-methods';
-import { actOnLoginRequest } from './setup-handoff';
+import { actOnLoginRequest, actOnTokenHandoff } from './setup-handoff';
 import { resolveHivesignerClientId } from './utils/hivesigner';
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -61,6 +61,28 @@ export function AuthProvider({ children }: AuthProviderProps) {
   useEffect(() => {
     actOnLoginRequest({ canLoginWithHivesigner: canHandoffLogin, isAuthenticated });
   }, [canHandoffLogin, isAuthenticated]);
+
+  // A session carried over from ecency.com (boot-captured fragment token):
+  // identity resolves from Hivesigner /me, never from the URL, and only the
+  // instance owner's own session is accepted (any other account is refused —
+  // see actOnTokenHandoff). Works for every ecency.com login method, since
+  // they all hold a Hivesigner-compatible access token. The attempt is shared
+  // module-wide, so StrictMode's replayed setup observes the same outcome.
+  useEffect(() => {
+    let cancelled = false;
+    actOnTokenHandoff({
+      isAuthEnabled,
+      isAuthenticated,
+      ownerUsername: blogOwner,
+    }).then((carried) => {
+      if (cancelled || !carried) return;
+      setUser(carried);
+      saveUser(carried);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthEnabled, isAuthenticated, blogOwner, setUser]);
 
   // Check if current user is the instance owner
   const isBlogOwner = useMemo(() => {

--- a/apps/self-hosted/src/features/auth/auth-provider.tsx
+++ b/apps/self-hosted/src/features/auth/auth-provider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, type ReactNode, useEffect, useMemo } from 'react';
 import { InstanceConfigManager } from '@/core';
-import { useAuthStore } from '@/store';
+import { authenticationStore, useAuthStore } from '@/store';
 import { clearHiveAuthSession, clearUser, saveUser } from './storage';
 import type { AuthContextValue, AuthUser } from './types';
 import { availableAuthMethods } from './utils/auth-methods';
@@ -76,6 +76,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
       ownerUsername: blogOwner,
     }).then((carried) => {
       if (cancelled || !carried) return;
+      // A manual login (Keychain, HiveAuth) can complete while /me is in
+      // flight, and the shared attempt closed over the boot-time context, so
+      // its own isAuthenticated check cannot see it. Recheck the live store
+      // at install time: an established session always wins over the carried
+      // one.
+      if (authenticationStore.getState().user) return;
       setUser(carried);
       saveUser(carried);
     });

--- a/apps/self-hosted/src/features/auth/components/user-menu.tsx
+++ b/apps/self-hosted/src/features/auth/components/user-menu.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import { useCallback, useRef, useState, useEffect } from 'react';
 import { logout } from '../auth-actions';
 import { useAuth, useIsAuthenticated, useIsAuthEnabled } from '../hooks';
-import { t } from '@/core';
+import { InstanceConfigManager, t } from '@/core';
 
 interface UserMenuProps {
   className?: string;
@@ -18,6 +18,18 @@ export function UserMenu({ className }: UserMenuProps) {
   const isAuthEnabled = useIsAuthEnabled();
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+
+  // The signed-in account's avatar through the instance's image proxy, the
+  // same base every other avatar on the page resolves through. The letter
+  // circle stays as the fallback for accounts without one (the proxy answers
+  // errors for those) rather than the resting state for everybody.
+  const proxyBase = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.general.imageProxy || 'https://i.ecency.com',
+  );
+  const username = user?.username;
+  const avatarUrl = username ? `${proxyBase}/u/${username}/avatar/small` : null;
+  const [avatarFailed, setAvatarFailed] = useState(false);
+  useEffect(() => setAvatarFailed(false), [username]);
 
   // Close menu when clicking outside
   useEffect(() => {
@@ -66,9 +78,19 @@ export function UserMenu({ className }: UserMenuProps) {
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center gap-2 px-3 py-1.5 rounded-md hover:bg-theme-hover transition-colors"
       >
-        <div className="size-7 rounded-full bg-blue-600 flex items-center justify-center text-white text-sm font-medium">
-          {user?.username?.charAt(0).toUpperCase()}
-        </div>
+        {avatarUrl && !avatarFailed ? (
+          <img
+            src={avatarUrl}
+            alt=""
+            aria-hidden="true"
+            onError={() => setAvatarFailed(true)}
+            className="size-7 rounded-full object-cover"
+          />
+        ) : (
+          <div className="size-7 rounded-full bg-blue-600 flex items-center justify-center text-white text-sm font-medium">
+            {user?.username?.charAt(0).toUpperCase()}
+          </div>
+        )}
         <span className="text-sm text-theme-primary font-medium hidden sm:inline">
           {user?.username}
         </span>

--- a/apps/self-hosted/src/features/auth/setup-handoff.test.ts
+++ b/apps/self-hosted/src/features/auth/setup-handoff.test.ts
@@ -115,6 +115,9 @@ describe('carried-session token handoff', () => {
   beforeEach(async () => {
     const { resetCarriedToken } = await import('./setup-handoff');
     resetCarriedToken();
+    sessionStorage.clear();
+    localStorage.clear();
+    window.history.replaceState(null, '', '/');
   });
 
   it('captures the #hs fragment at boot, scrubs it and keeps other params', async () => {

--- a/apps/self-hosted/src/features/auth/setup-handoff.test.ts
+++ b/apps/self-hosted/src/features/auth/setup-handoff.test.ts
@@ -110,3 +110,175 @@ describe('setup handoff', () => {
     expect(hasSeenFirstRun('bob')).toBe(false);
   });
 });
+
+describe('carried-session token handoff', () => {
+  beforeEach(async () => {
+    const { resetCarriedToken } = await import('./setup-handoff');
+    resetCarriedToken();
+  });
+
+  it('captures the #hs fragment at boot, scrubs it and keeps other params', async () => {
+    const { actOnTokenHandoff } = await import('./setup-handoff');
+    window.history.replaceState(null, '', '/?setup=1#hs=tok-abc');
+    captureSetupParams();
+    // The bearer is gone from the URL before anything renders...
+    expect(window.location.hash).toBe('');
+    expect(window.location.search).toBe('');
+    expect(isSetupPending()).toBe(true);
+    // ...and lives only in module memory until the one decisive act.
+    const resolve = vi.fn(async () => 'alice');
+    const user = await actOnTokenHandoff({
+      isAuthEnabled: true,
+      isAuthenticated: false,
+      ownerUsername: 'alice',
+      resolveAccount: resolve,
+    });
+    expect(resolve).toHaveBeenCalledWith('tok-abc');
+    expect(user).toMatchObject({
+      username: 'alice',
+      accessToken: 'tok-abc',
+      loginType: 'hivesigner',
+    });
+  });
+
+  it('identity comes from the resolver, never the URL, and one act consumes the token', async () => {
+    const { actOnTokenHandoff } = await import('./setup-handoff');
+    window.history.replaceState(null, '', '/#hs=tok-xyz');
+    captureSetupParams();
+    const resolve = vi.fn(async () => null); // forged or expired token
+    const first = await actOnTokenHandoff({
+      isAuthEnabled: true,
+      isAuthenticated: false,
+      ownerUsername: 'alice',
+      resolveAccount: resolve,
+    });
+    expect(first).toBeNull();
+    // Consumed whatever the outcome: a second run cannot retry the bearer.
+    const second = await actOnTokenHandoff({
+      isAuthEnabled: true,
+      isAuthenticated: false,
+      ownerUsername: 'alice',
+      resolveAccount: resolve,
+    });
+    expect(second).toBeNull();
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the one attempt across effect replays instead of dropping the session', async () => {
+    // StrictMode replays an effect's setup on mount: run 1 consumes the token,
+    // run 1's cleanup discards its result, run 2 must still land the session.
+    const { actOnTokenHandoff } = await import('./setup-handoff');
+    window.history.replaceState(null, '', '/#hs=tok-replay');
+    captureSetupParams();
+    const resolve = vi.fn(async () => 'alice');
+    const context = {
+      isAuthEnabled: true,
+      isAuthenticated: false,
+      ownerUsername: 'alice',
+      resolveAccount: resolve,
+    };
+    const first = actOnTokenHandoff(context); // run 1, result discarded
+    const second = await actOnTokenHandoff(context); // run 2 lands it
+    expect(second).toMatchObject({ username: 'alice', accessToken: 'tok-replay' });
+    expect(await first).toBe(second);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses any account that is not the instance owner (login CSRF gate)', async () => {
+    const { actOnTokenHandoff, resetCarriedToken } = await import('./setup-handoff');
+    // A visitor clicks a crafted link carrying a REAL token for the
+    // attacker's own account: /me resolves it, but it is not the owner.
+    window.history.replaceState(null, '', '/#hs=tok-mallory');
+    captureSetupParams();
+    const resolveMallory = vi.fn(async () => 'mallory');
+    expect(
+      await actOnTokenHandoff({
+        isAuthEnabled: true,
+        isAuthenticated: false,
+        ownerUsername: 'alice',
+        resolveAccount: resolveMallory,
+      }),
+    ).toBeNull();
+
+    // No owner known means refuse, never fall open.
+    resetCarriedToken();
+    window.history.replaceState(null, '', '/#hs=tok-x');
+    captureSetupParams();
+    expect(
+      await actOnTokenHandoff({
+        isAuthEnabled: true,
+        isAuthenticated: false,
+        ownerUsername: undefined,
+        resolveAccount: vi.fn(async () => 'alice'),
+      }),
+    ).toBeNull();
+
+    // The owner matches case-insensitively (account names are lowercase on
+    // chain, but a hand-typed config field may not be).
+    resetCarriedToken();
+    window.history.replaceState(null, '', '/#hs=tok-owner');
+    captureSetupParams();
+    expect(
+      await actOnTokenHandoff({
+        isAuthEnabled: true,
+        isAuthenticated: false,
+        ownerUsername: 'Alice ',
+        resolveAccount: vi.fn(async () => 'alice'),
+      }),
+    ).toMatchObject({ username: 'alice' });
+  });
+
+  it('drops the token unseen when auth is off or somebody is signed in', async () => {
+    const { actOnTokenHandoff, resetCarriedToken } = await import('./setup-handoff');
+    window.history.replaceState(null, '', '/#hs=tok-1');
+    captureSetupParams();
+    const resolve = vi.fn(async () => 'alice');
+    expect(
+      await actOnTokenHandoff({
+        isAuthEnabled: false,
+        isAuthenticated: false,
+        ownerUsername: 'alice',
+        resolveAccount: resolve,
+      }),
+    ).toBeNull();
+    expect(resolve).not.toHaveBeenCalled();
+
+    resetCarriedToken();
+    window.history.replaceState(null, '', '/#hs=tok-2');
+    captureSetupParams();
+    expect(
+      await actOnTokenHandoff({
+        isAuthEnabled: true,
+        isAuthenticated: true,
+        ownerUsername: 'alice',
+        resolveAccount: resolve,
+      }),
+    ).toBeNull();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('survives a malformed fragment: no token, but the URL is still scrubbed', async () => {
+    // captureSetupParams runs before anything renders, so a crafted `#hs=%`
+    // link must not be able to throw and blank the page.
+    const { actOnTokenHandoff } = await import('./setup-handoff');
+    window.history.replaceState(null, '', '/#hs=%');
+    expect(() => captureSetupParams()).not.toThrow();
+    expect(window.location.hash).toBe('');
+    const resolve = vi.fn(async () => 'alice');
+    expect(
+      await actOnTokenHandoff({
+        isAuthEnabled: true,
+        isAuthenticated: false,
+        ownerUsername: 'alice',
+        resolveAccount: resolve,
+      }),
+    ).toBeNull();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('leaves a foreign fragment untouched', () => {
+    window.history.replaceState(null, '', '/page#section-2');
+    captureSetupParams();
+    expect(window.location.hash).toBe('#section-2');
+  });
+});

--- a/apps/self-hosted/src/features/auth/setup-handoff.ts
+++ b/apps/self-hosted/src/features/auth/setup-handoff.ts
@@ -1,4 +1,6 @@
 import { loginWithHivesigner } from './auth-actions';
+import { resolveHivesignerAccount } from './utils/hivesigner';
+import type { AuthUser } from './types';
 
 /**
  * The signed-in handoff from the signup success screen, and the first-run
@@ -23,6 +25,27 @@ import { loginWithHivesigner } from './auth-actions';
 export const SETUP_PARAM = 'setup';
 export const LOGIN_PARAM = 'login';
 
+/**
+ * The carried session token, captured from the URL FRAGMENT at boot and held
+ * in module memory only: a fragment never reaches any server or log, the URL
+ * is scrubbed before React renders, and nothing persists a bearer that was
+ * not first verified. Every ecency.com login method holds a
+ * Hivesigner-compatible access token, so this carries the session over for
+ * all of them; identity is never taken from the URL, it is resolved from
+ * Hivesigner /me by the token itself.
+ */
+let carriedToken: string | null = null;
+
+/** The one attempt this page load makes at the carried session, shared so
+ * every effect replay observes the same outcome (see actOnTokenHandoff). */
+let handoffAttempt: Promise<AuthUser | null> | null = null;
+
+/** Test seam: module memory otherwise leaks between cases. */
+export function resetCarriedToken(): void {
+  carriedToken = null;
+  handoffAttempt = null;
+}
+
 const SETUP_PENDING_KEY = 'ecency:setup-pending';
 const LOGIN_REQUEST_KEY = 'ecency:setup-login-request';
 const firstRunKey = (account: string) =>
@@ -38,7 +61,24 @@ export function captureSetupParams(): void {
   const params = new URLSearchParams(window.location.search);
   const wantsSetup = params.get(SETUP_PARAM) === '1';
   const wantsLogin = params.get(LOGIN_PARAM) === 'hivesigner';
-  if (!wantsSetup && !wantsLogin) return;
+
+  // The handoff fragment is `#hs=<token>` and owns the whole hash when
+  // present; any other fragment passes through untouched. The decode must not
+  // be able to throw: this runs before anything renders, so a crafted
+  // `#hs=%` link would otherwise blank the page permanently (the fragment
+  // survives reloads until scrubbed). Undecodable means no token, but the
+  // scrub below still runs.
+  let hash = window.location.hash;
+  if (hash.startsWith('#hs=')) {
+    try {
+      carriedToken = decodeURIComponent(hash.slice(4)) || null;
+    } catch {
+      carriedToken = null;
+    }
+    hash = '';
+  }
+
+  if (!wantsSetup && !wantsLogin && hash === window.location.hash) return;
 
   params.delete(SETUP_PARAM);
   params.delete(LOGIN_PARAM);
@@ -46,13 +86,82 @@ export function captureSetupParams(): void {
   window.history.replaceState(
     null,
     '',
-    window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash,
+    window.location.pathname + (qs ? `?${qs}` : '') + hash,
   );
 
   try {
     if (wantsSetup) sessionStorage.setItem(SETUP_PENDING_KEY, '1');
     if (wantsLogin) sessionStorage.setItem(LOGIN_REQUEST_KEY, 'hivesigner');
   } catch {}
+}
+
+export interface TokenHandoffContext {
+  /** Sessions are off entirely on this instance; drop the token unseen. */
+  isAuthEnabled: boolean;
+  /** Somebody is already signed in; the carried session is moot. */
+  isAuthenticated: boolean;
+  /**
+   * The instance owner (nullable but must be passed): the carried session is
+   * only ever for landing the owner on their own new site, so any other
+   * account is refused. No owner known means refuse.
+   */
+  ownerUsername: string | null | undefined;
+  /** Injectable for tests; defaults to the real Hivesigner /me lookup. */
+  resolveAccount?: (token: string) => Promise<string | null>;
+}
+
+/**
+ * Turn a captured token into a signed-in session, once per page load.
+ *
+ * Identity comes from Hivesigner /me and nowhere else: a forged link with a
+ * random token resolves to nothing, and a real token resolves to exactly the
+ * account it belongs to. That alone is not enough, though. Without a further
+ * gate, a crafted link carrying a stranger's real token would silently sign
+ * the visitor in as that stranger (login CSRF); the /auth route's state nonce
+ * cannot exist here because the flow starts on ecency.com, so the equivalent
+ * fail-closed gate is that the resolved account must BE the instance owner —
+ * the only account this handoff exists to land.
+ *
+ * The token is consumed on the first call whatever the outcome, so a failed
+ * resolve cannot be retried into a different result and nothing holds the
+ * bearer afterwards. The attempt itself is shared module-wide: StrictMode
+ * replays an effect's setup on mount, so a second run must await the first
+ * attempt's outcome instead of finding the token gone and dropping the
+ * session (the same shape hivesigner-callback.ts uses for its nonce).
+ */
+export function actOnTokenHandoff(
+  context: TokenHandoffContext,
+): Promise<AuthUser | null> {
+  if (handoffAttempt) return handoffAttempt;
+
+  const token = carriedToken;
+  if (!token) return Promise.resolve(null);
+  carriedToken = null;
+
+  handoffAttempt = (async (): Promise<AuthUser | null> => {
+    if (!context.isAuthEnabled || context.isAuthenticated) return null;
+
+    const account = await (context.resolveAccount ?? resolveHivesignerAccount)(
+      token,
+    );
+    if (!account) return null;
+
+    const owner = context.ownerUsername?.trim().toLowerCase();
+    if (!owner || account.toLowerCase() !== owner) return null;
+
+    return {
+      username: account,
+      accessToken: token,
+      loginType: 'hivesigner',
+      // The carried token's real TTL is not knowable here; a conservative day
+      // keeps the session honest and the periodic expiry check in the provider
+      // logs it out cleanly. Any earlier upstream expiry just fails a broadcast
+      // into the normal re-login prompt.
+      expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+    };
+  })();
+
+  return handoffAttempt;
 }
 
 /** The captured login intent, if any. Reading does not consume it. */

--- a/apps/self-hosted/src/features/auth/utils/hivesigner.ts
+++ b/apps/self-hosted/src/features/auth/utils/hivesigner.ts
@@ -51,6 +51,34 @@ export function consumeHivesignerState(state: string | null): boolean {
  * else's valid token logs the visitor in as that account, and everything they
  * then write is attributed to it.
  */
+/**
+ * Whose token is this, straight from Hivesigner /me, or null when the token
+ * is invalid. The handoff path has no claimed identity to check against: the
+ * account IS the answer, which is what keeps identity out of URLs entirely.
+ */
+export async function resolveHivesignerAccount(
+  accessToken: string,
+): Promise<string | null> {
+  try {
+    const response = await fetch(HIVESIGNER_ME_URL, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!response.ok) return null;
+    const body = (await response.json()) as {
+      account?: { name?: string };
+      user?: string;
+      _id?: string;
+    };
+    const resolved = body.account?.name || body.user || body._id;
+    return typeof resolved === 'string' && resolved.length > 0
+      ? resolved.toLowerCase()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function verifyHivesignerToken(
   accessToken: string,
   username: string,

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -2,7 +2,7 @@
 
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useTransferMutation } from "@/api/sdk-mutations";
-import { getLoginType } from "@/utils/user-token";
+import { ensureValidToken, getAccessToken, getLoginType } from "@/utils/user-token";
 import { useGlobalStore } from "@/core/global-store";
 import { getUsernameError } from "@/utils/username-validation";
 import { Alert } from "@ui/alert";
@@ -398,6 +398,15 @@ export function HostingSignup() {
       setBusy(false);
     }
   }, [tenantUsername, isCommunity, title, description, styleTemplate, accent, fontPreset, activeUser]);
+
+  // Warm the session token as soon as the success screen shows: the Customize
+  // link carries it over to the new instance at CLICK time (see the anchor's
+  // onClick), and a long-lived login's stored token may be stale. Refreshing
+  // here means the synchronous read at click time finds a fresh one.
+  useEffect(() => {
+    if (step !== "success" || !activeUser) return;
+    ensureValidToken(activeUser.username).catch(() => {});
+  }, [step, activeUser]);
 
   // The reservation is made and paid for; the in-progress draft has served its purpose.
   useEffect(() => {
@@ -1013,19 +1022,40 @@ export function HostingSignup() {
             </div>
           </Alert>
 
-          {/* Land the owner on their new site with the settings panel opening by itself.
-              A Hivesigner session can carry over: the link only asks the instance to START
-              its own OAuth flow, so identity is verified there exactly like a manual login.
-              Other login types sign in on the instance with their extension as usual. */}
+          {/* Land the owner on their new site signed in, with the settings panel
+              opening by itself. Every ecency.com login method holds a
+              Hivesigner-compatible access token, so the session carries over as a
+              URL FRAGMENT (never a query param: fragments reach no server or log).
+              The instance resolves identity from Hivesigner /me by the token
+              itself, accepts only the instance owner's session, and scrubs the
+              fragment before rendering. The token is attached at CLICK time and
+              never sits in the DOM: an href holding a bearer is one right-click
+              "Copy link address" away from being pasted somewhere public. The
+              at-rest href is the safe fallback — the instance-side OAuth start
+              for Hivesigner sessions, or a plain setup intent that opens the
+              panel after a manual login — and is what a middle-click gets. */}
           {safeBlogUrl && (
             <a
-              href={`${safeBlogUrl}${
+              href={`${safeBlogUrl}?setup=1${
                 activeUser && getLoginType(activeUser.username) === "hivesigner"
-                  ? "?login=hivesigner&setup=1"
-                  : "?setup=1"
+                  ? "&login=hivesigner"
+                  : ""
               }`}
               target="_blank"
               rel="noreferrer"
+              onClick={(e) => {
+                // Synchronous within the gesture: popup blockers allow it, and
+                // the freshest token is read here (a stale one was refreshed
+                // when this screen mounted; getAccessToken re-reads storage).
+                const token = activeUser && getAccessToken(activeUser.username);
+                if (!token) return;
+                e.preventDefault();
+                window.open(
+                  `${safeBlogUrl}?setup=1#hs=${encodeURIComponent(token)}`,
+                  "_blank",
+                  "noopener,noreferrer"
+                );
+              }}
               className="inline-block text-center px-4 py-3 rounded-lg bg-blue-dark-sky text-white font-semibold hover:opacity-90"
             >
               {i18next.t("hosting.customize-your-blog")}

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -2,7 +2,7 @@
 
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useTransferMutation } from "@/api/sdk-mutations";
-import { ensureValidToken, getAccessToken, getLoginType } from "@/utils/user-token";
+import { ensureValidToken, getLoginType } from "@/utils/user-token";
 import { useGlobalStore } from "@/core/global-store";
 import { getUsernameError } from "@/utils/username-validation";
 import { Alert } from "@ui/alert";
@@ -399,13 +399,25 @@ export function HostingSignup() {
     }
   }, [tenantUsername, isCommunity, title, description, styleTemplate, accent, fontPreset, activeUser]);
 
-  // Warm the session token as soon as the success screen shows: the Customize
-  // link carries it over to the new instance at CLICK time (see the anchor's
-  // onClick), and a long-lived login's stored token may be stale. Refreshing
-  // here means the synchronous read at click time finds a fresh one.
+  // Resolve the session token as soon as the success screen shows: the
+  // Customize link carries it over to the new instance at CLICK time (see the
+  // anchor's onClick), and a long-lived login's stored token may be stale.
+  // Only a token that survived ensureValidToken is ever carried; while the
+  // refresh is in flight, or if it fails, the click takes the credential-free
+  // fallback href instead of shipping a stale bearer the instance would
+  // reject.
+  const [handoffToken, setHandoffToken] = useState<string | null>(null);
   useEffect(() => {
     if (step !== "success" || !activeUser) return;
-    ensureValidToken(activeUser.username).catch(() => {});
+    let cancelled = false;
+    ensureValidToken(activeUser.username)
+      .then((token) => {
+        if (!cancelled && token) setHandoffToken(token);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
   }, [step, activeUser]);
 
   // The reservation is made and paid for; the in-progress draft has served its purpose.
@@ -1044,14 +1056,13 @@ export function HostingSignup() {
               target="_blank"
               rel="noreferrer"
               onClick={(e) => {
-                // Synchronous within the gesture: popup blockers allow it, and
-                // the freshest token is read here (a stale one was refreshed
-                // when this screen mounted; getAccessToken re-reads storage).
-                const token = activeUser && getAccessToken(activeUser.username);
-                if (!token) return;
+                // Synchronous within the gesture, so popup blockers allow the
+                // open. Only the mount-resolved token is carried; without it
+                // the default navigation takes the fallback href.
+                if (!handoffToken) return;
                 e.preventDefault();
                 window.open(
-                  `${safeBlogUrl}?setup=1#hs=${encodeURIComponent(token)}`,
+                  `${safeBlogUrl}?setup=1#hs=${encodeURIComponent(handoffToken)}`,
                   "_blank",
                   "noopener,noreferrer"
                 );

--- a/apps/web/src/specs/features/hosting-signup/hosting-signup.spec.tsx
+++ b/apps/web/src/specs/features/hosting-signup/hosting-signup.spec.tsx
@@ -10,6 +10,7 @@ import { renderWithQueryClient } from "@/specs/test-utils";
 const mocks = vi.hoisted(() => ({
   mutateAsync: vi.fn(),
   authLoginType: "keychain" as string,
+  accessToken: undefined as string | undefined,
   profiles: {} as Record<string, any>,
   hostingApi: {
     paymentMethods: vi.fn(),
@@ -38,7 +39,9 @@ vi.mock("@/core/hooks/use-active-account", () => ({
 // getLoginType drives whether the in-page one-click button is offered: Keychain-family extensions
 // sign in-page, while HiveSigner/keychain-mobile redirect and must fall back to manual.
 vi.mock("@/utils/user-token", () => ({
-  getLoginType: () => mocks.authLoginType
+  getLoginType: () => mocks.authLoginType,
+  getAccessToken: () => mocks.accessToken,
+  ensureValidToken: vi.fn(async () => mocks.accessToken)
 }));
 
 vi.mock("@/core/global-store", () => ({
@@ -57,6 +60,7 @@ describe("HostingSignup one-click HBD pay", () => {
     localStorage.clear();
     window.history.replaceState(null, "", "/"); // clear any ?resume= from a prior test
     mocks.authLoginType = "keychain";
+    mocks.accessToken = "tok-alice";
     // Card disabled so the payment step defaults to the HBD rail (where the one-click lives).
     hostingApi.paymentMethods.mockResolvedValue({
       hbd: { enabled: true, monthly: "2.000", account: "ecency.hosting" },
@@ -168,10 +172,66 @@ describe("HostingSignup one-click HBD pay", () => {
     // Poll saw an active tenant -> success screen (findByText throws if absent).
     await screen.findByText("hosting.success-title");
 
-    // The primary action lands the owner on their site with setup pending. A keychain
-    // session cannot carry over, so no login param is attached for it.
+    // The primary action lands the owner on their site with setup pending and
+    // the session carried as a FRAGMENT token, attached at CLICK time only: the
+    // at-rest href must stay credential-free ("Copy link address" on the most
+    // prominent button must never yield a bearer).
     const customize = screen.getByText("hosting.customize-your-blog") as HTMLAnchorElement;
     expect(customize.getAttribute("href")).toBe("https://alice.blogs.ecency.com/?setup=1");
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    fireEvent.click(customize);
+    expect(open).toHaveBeenCalledWith(
+      "https://alice.blogs.ecency.com/?setup=1#hs=tok-alice",
+      "_blank",
+      "noopener,noreferrer"
+    );
+    // The tokened URL replaced the default navigation; the clean href never
+    // gained the fragment.
+    expect(customize.getAttribute("href")).toBe("https://alice.blogs.ecency.com/?setup=1");
+  });
+
+  it("falls back to a plain setup intent when no access token is stored", async () => {
+    mocks.accessToken = undefined;
+    hostingApi.tenantsByOwner.mockResolvedValue({ tenants: [] });
+    renderWithQueryClient(<HostingSignup />);
+    fireEvent.click(screen.getByText("g.continue"));
+    fireEvent.click(await screen.findByText("g.continue"));
+    const payBtn = (await screen.findByRole("button", {
+      name: "hosting.pay-hbd-oneclick"
+    })) as HTMLButtonElement;
+    await waitFor(() => expect(payBtn.disabled).toBe(false));
+    fireEvent.click(payBtn);
+    await screen.findByText("hosting.success-title");
+    const customize = screen.getByText("hosting.customize-your-blog") as HTMLAnchorElement;
+    expect(customize.getAttribute("href")).toBe("https://alice.blogs.ecency.com/?setup=1");
+    // Without a token the click takes the default navigation (no window.open).
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    fireEvent.click(customize);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("offers the instance-side OAuth fallback for Hivesigner sessions", async () => {
+    // A hivesigner login's at-rest href carries the login hint (safe, not a
+    // credential), so a middle-click or a failed token read still lands the
+    // owner in a login flow instead of stranding them logged out. Hivesigner
+    // logins have no one-click pay button, so the flow is driven as keychain
+    // and the login type flips before the success render computes the href.
+    mocks.accessToken = undefined;
+    hostingApi.tenantsByOwner.mockResolvedValue({ tenants: [] });
+    renderWithQueryClient(<HostingSignup />);
+    fireEvent.click(screen.getByText("g.continue"));
+    fireEvent.click(await screen.findByText("g.continue"));
+    const payBtn = (await screen.findByRole("button", {
+      name: "hosting.pay-hbd-oneclick"
+    })) as HTMLButtonElement;
+    await waitFor(() => expect(payBtn.disabled).toBe(false));
+    fireEvent.click(payBtn);
+    mocks.authLoginType = "hivesigner";
+    await screen.findByText("hosting.success-title");
+    const customize = screen.getByText("hosting.customize-your-blog") as HTMLAnchorElement;
+    expect(customize.getAttribute("href")).toBe(
+      "https://alice.blogs.ecency.com/?setup=1&login=hivesigner"
+    );
   });
 
   it("does not broadcast until the user clicks pay (no accidental transfer)", async () => {

--- a/apps/web/src/specs/features/hosting-signup/hosting-signup.spec.tsx
+++ b/apps/web/src/specs/features/hosting-signup/hosting-signup.spec.tsx
@@ -179,12 +179,16 @@ describe("HostingSignup one-click HBD pay", () => {
     const customize = screen.getByText("hosting.customize-your-blog") as HTMLAnchorElement;
     expect(customize.getAttribute("href")).toBe("https://alice.blogs.ecency.com/?setup=1");
     const open = vi.spyOn(window, "open").mockImplementation(() => null);
-    fireEvent.click(customize);
-    expect(open).toHaveBeenCalledWith(
-      "https://alice.blogs.ecency.com/?setup=1#hs=tok-alice",
-      "_blank",
-      "noopener,noreferrer"
-    );
+    // The carried token resolves asynchronously on success-screen mount
+    // (ensureValidToken), so retry the click until the state lands.
+    await waitFor(() => {
+      fireEvent.click(customize);
+      expect(open).toHaveBeenCalledWith(
+        "https://alice.blogs.ecency.com/?setup=1#hs=tok-alice",
+        "_blank",
+        "noopener,noreferrer"
+      );
+    });
     // The tokened URL replaced the default navigation; the clean href never
     // gained the fragment.
     expect(customize.getAttribute("href")).toBe("https://alice.blogs.ecency.com/?setup=1");


### PR DESCRIPTION
## What

The signup success screen's Customize link now signs the owner in on their new instance automatically, for every ecency.com login method (all of them hold a Hivesigner-compatible access token).

## How

- **apps/web**: the token is attached to the Customize link at click time only, as a URL fragment (`#hs=...`), so the at-rest href stays credential-free and copyable. A stale stored token is refreshed when the success screen mounts. Without a token, Hivesigner sessions fall back to `?login=hivesigner` (instance-side OAuth start) and other methods to the plain setup intent.
- **apps/self-hosted**: the fragment is captured at boot and scrubbed from the URL before anything renders; a malformed fragment is dropped safely. Identity is resolved from Hivesigner `/me` by the token itself, never taken from the URL, and the carried session is accepted only for the instance owner's account. The one attempt per page load is shared across effect replays (same shape as the Hivesigner callback nonce handling), the token is consumed whatever the outcome and the session gets a conservative 24h expiry.

## Tests

- 21 web specs (at-rest href stays clean, click opens the tokened URL, no-token and Hivesigner fallbacks)
- 14 SPA handoff tests (capture + scrub, owner gate, replay sharing, malformed fragment, drop-unseen paths)
- Full suites green: 2625 web, 913 self-hosted; both typechecks; SPA production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seamless sign-in handoff when opening a self-hosted site from the hosting setup flow.
  * Setup links can securely include a temporary session token for automatic authentication.
  * Added validation to ensure only the instance owner’s account is accepted.
  * Preserved existing setup links when no session token is available.

* **Bug Fixes**
  * Improved handling of invalid, expired, or malformed sign-in tokens.
  * Removed authentication tokens from the browser URL after capture while preserving other URL fragments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->