### PR TITLE
Self-hosted: Reader theme with a split archive view

### DIFF
--- a/apps/self-hosted/hosting/api/src/style-template-display.ts
+++ b/apps/self-hosted/hosting/api/src/style-template-display.ts
@@ -92,6 +92,17 @@ export const STYLE_TEMPLATE_DISPLAY = {
     },
     headingStyle: 'serif',
   },
+  reader: {
+    name: 'Reader',
+    tagline: 'Your archive beside the open post, the way a feed reader works',
+    colors: {
+      background: '#ffffff',
+      surface: '#f6f6f4',
+      accent: '#17677a',
+      text: '#1c1e21',
+    },
+    headingStyle: 'sans',
+  },
 } satisfies Record<StyleTemplate, StyleTemplateDisplay>;
 
 export function templateCatalog() {

--- a/apps/self-hosted/hosting/api/src/style-templates.ts
+++ b/apps/self-hosted/hosting/api/src/style-templates.ts
@@ -24,6 +24,7 @@ export const STYLE_TEMPLATES = Object.freeze([
   'developer',
   'modern-gradient',
   'journal',
+  'reader',
 ] as const);
 
 export type StyleTemplate = (typeof STYLE_TEMPLATES)[number];

--- a/apps/self-hosted/src/core/i18n-strings.ts
+++ b/apps/self-hosted/src/core/i18n-strings.ts
@@ -259,6 +259,9 @@ export type TranslationKey =
   | 'panel_configuration_general_style_template_developer_option'
   | 'panel_configuration_general_style_template_modern_gradient_option'
   | 'panel_configuration_general_style_template_journal_option'
+  | 'panel_configuration_general_style_template_reader_option'
+  | 'reader_home_hint'
+  | 'reader_home_keys'
   | 'panel_configuration_general_language_label'
   | 'panel_configuration_general_language_description'
   | 'panel_configuration_general_language_en_option'
@@ -593,6 +596,10 @@ export const translations: { en: Translations } & Record<
     panel_configuration_general_style_template_modern_gradient_option: 'Modern Gradient',
     panel_configuration_general_style_template_journal_option:
       'Journal (single column, serif, no sidebar)',
+    panel_configuration_general_style_template_reader_option:
+      'Reader (split view, archive rail beside the post)',
+    reader_home_hint: 'Pick a post from the list to start reading.',
+    reader_home_keys: 'Tip: j and k move between posts.',
     panel_configuration_general_language_label: 'Language',
     panel_configuration_general_language_description: 'Default language',
     panel_configuration_general_language_en_option: 'English',

--- a/apps/self-hosted/src/features/blog/components/blog-posts-list.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-posts-list.tsx
@@ -1,15 +1,10 @@
 'use client';
 
-import {
-  getAccountPostsInfiniteQueryOptions,
-  getPostsRankedInfiniteQueryOptions,
-} from '@ecency/sdk';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { t } from '@/core';
 import { useThemeComponents } from '@/themes/use-theme-components';
 import { DetectBottom } from './detect-bottom';
-import { useInstanceConfig } from '../hooks/use-instance-config';
+import { useArchiveFeed } from '../hooks/use-archive-feed';
 import { chooseFeedRetry } from '../utils/feed-retry';
 import { ErrorMessage } from '@/features/shared/error-message';
 import { InlineError } from '@/features/shared/inline-error';
@@ -23,57 +18,13 @@ interface Props {
   limit?: number;
 }
 
-// Map blog filters to community sort options
-const communityFilterMap: Record<string, string> = {
-  posts: 'created',
-  blog: 'created',
-  trending: 'trending',
-  hot: 'hot',
-  new: 'created',
-  payout: 'payout',
-  muted: 'muted',
-};
-
 export function BlogPostsList({ filter = 'posts', limit = 20 }: Props) {
   // The card resolves through the theme registry: a theme can restyle every
   // entry without owning the whole feed (fetching, paging, error states).
   const { PostCard } = useThemeComponents();
-  const { username, communityId, isCommunityMode } = useInstanceConfig();
 
-  // Use different query based on instance type
-  const communitySort = communityFilterMap[filter] || 'created';
-
-  // Memoize select function to avoid creating new reference on each render
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const selectPosts = useCallback(
-    (data: { pages: any[][] }) => data.pages.flat(),
-    []
-  );
-
-  // Get query options and preserve their built-in enabled guards
-  const accountOptions = getAccountPostsInfiniteQueryOptions(username, filter, limit);
-  // The SDK's ranked-posts query, not a local bridge call: it is the path that
-  // applies DMCA post filtering and drops a tag that is itself listed. A
-  // bespoke get_ranked_posts call here served takedown-listed content.
-  const communityOptions = getPostsRankedInfiniteQueryOptions(
-    communitySort,
-    communityId,
-    limit,
-    '',
-    !!communityId && isCommunityMode,
-  );
-
-  const blogQuery = useInfiniteQuery({
-    ...accountOptions,
-    select: selectPosts,
-    enabled: accountOptions.enabled && !isCommunityMode,
-  });
-
-  const communityQuery = useInfiniteQuery({
-    ...communityOptions,
-    select: selectPosts,
-  });
-
+  // Fetching lives in the shared hook, so a theme's own archive surface (the
+  // Reader rail) pages through exactly the same queries as this seam default.
   const {
     data = [],
     fetchNextPage,
@@ -85,7 +36,7 @@ export function BlogPostsList({ filter = 'posts', limit = 20 }: Props) {
     isRefetchError,
     isSuccess,
     refetch,
-  } = isCommunityMode ? communityQuery : blogQuery;
+  } = useArchiveFeed(filter, limit);
 
   // Was: `if (isError) return <ErrorMessage />` above the map. query-core keeps
   // `data` through an error, so that discarded every page already rendered and

--- a/apps/self-hosted/src/features/blog/hooks/use-archive-feed.ts
+++ b/apps/self-hosted/src/features/blog/hooks/use-archive-feed.ts
@@ -3,6 +3,7 @@
 import {
   getAccountPostsInfiniteQueryOptions,
   getPostsRankedInfiniteQueryOptions,
+  type Entry,
 } from '@ecency/sdk';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
@@ -36,9 +37,8 @@ export function useArchiveFeed(filter = 'posts', limit = 20) {
   const communitySort = communityFilterMap[filter] || 'created';
 
   // Memoize select function to avoid creating new reference on each render
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const selectPosts = useCallback(
-    (data: { pages: any[][] }) => data.pages.flat(),
+    (data: { pages: Entry[][] }) => data.pages.flat(),
     []
   );
 

--- a/apps/self-hosted/src/features/blog/hooks/use-archive-feed.ts
+++ b/apps/self-hosted/src/features/blog/hooks/use-archive-feed.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import {
+  getAccountPostsInfiniteQueryOptions,
+  getPostsRankedInfiniteQueryOptions,
+} from '@ecency/sdk';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { useInstanceConfig } from './use-instance-config';
+
+// Map blog filters to community sort options
+const communityFilterMap: Record<string, string> = {
+  posts: 'created',
+  blog: 'created',
+  trending: 'trending',
+  hot: 'hot',
+  new: 'created',
+  payout: 'payout',
+  muted: 'muted',
+};
+
+/**
+ * The archive feed as one infinite query, flattened. Extracted from
+ * BlogPostsList so a theme's own archive surface (the Reader rail) cannot
+ * drift from the seam default's fetching: same queries, same enabled guards,
+ * same paging.
+ *
+ * Community instances go through the SDK's ranked-posts query, not a local
+ * bridge call: it is the path that applies DMCA post filtering and drops a
+ * tag that is itself listed. A bespoke get_ranked_posts call here served
+ * takedown-listed content.
+ */
+export function useArchiveFeed(filter = 'posts', limit = 20) {
+  const { username, communityId, isCommunityMode } = useInstanceConfig();
+
+  const communitySort = communityFilterMap[filter] || 'created';
+
+  // Memoize select function to avoid creating new reference on each render
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const selectPosts = useCallback(
+    (data: { pages: any[][] }) => data.pages.flat(),
+    []
+  );
+
+  // Get query options and preserve their built-in enabled guards
+  const accountOptions = getAccountPostsInfiniteQueryOptions(username, filter, limit);
+  const communityOptions = getPostsRankedInfiniteQueryOptions(
+    communitySort,
+    communityId,
+    limit,
+    '',
+    !!communityId && isCommunityMode,
+  );
+
+  const blogQuery = useInfiniteQuery({
+    ...accountOptions,
+    select: selectPosts,
+    enabled: accountOptions.enabled && !isCommunityMode,
+  });
+
+  const communityQuery = useInfiniteQuery({
+    ...communityOptions,
+    select: selectPosts,
+  });
+
+  return isCommunityMode ? communityQuery : blogQuery;
+}

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -46,6 +46,7 @@ const STYLE_TEMPLATE_LABEL_KEYS = {
   'modern-gradient':
     'panel_configuration_general_style_template_modern_gradient_option',
   journal: 'panel_configuration_general_style_template_journal_option',
+  reader: 'panel_configuration_general_style_template_reader_option',
 } satisfies Record<StyleTemplate, TranslationKey>;
 
 export type ConfigFieldType =

--- a/apps/self-hosted/src/features/shared/failure-states.test.ts
+++ b/apps/self-hosted/src/features/shared/failure-states.test.ts
@@ -45,6 +45,7 @@ const EMPTINESS_CLAIMS = new Set([
  */
 const GUARDED_CLAIMS: Record<string, number> = {
   'src/features/blog/components/blog-posts-list.tsx:noPosts': 1,
+  'src/themes/reader/reader-rail.tsx:noPosts': 1,
   'src/features/blog/components/blog-post-page.tsx:postNotFound': 1,
   'src/features/blog/components/blog-post-discussion.tsx:comments_empty': 1,
   'src/features/blog/layout/blog-sidebar.tsx:community_not_found': 1,

--- a/apps/self-hosted/src/routes/$author.$permlink.tsx
+++ b/apps/self-hosted/src/routes/$author.$permlink.tsx
@@ -1,11 +1,23 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { BlogPostPage } from '@/features/blog/components/blog-post-page';
+import { resolvePostsFilter } from '@/features/blog/utils/post-filters';
 
 export const Route = createFileRoute('/$author/$permlink')({
   component: BlogPostPage,
-  validateSearch: (search: Record<string, unknown>) => {
+  // Optional keys in the annotation, so post links that carry no search at
+  // all keep typechecking; the inferred shape would demand every key.
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { raw?: true; filter?: string } => {
     return {
       raw: search.raw !== undefined ? true : undefined,
+      // Retained (clamped) so a theme whose archive stays visible beside the
+      // open post (Reader) keeps showing the feed the reader was browsing.
+      // Absent on canonical deep links, so ordinary post URLs are unchanged.
+      filter:
+        search.filter !== undefined
+          ? resolvePostsFilter(search.filter)
+          : undefined,
     };
   },
 });

--- a/apps/self-hosted/src/routes/$category.$author.$permlink.tsx
+++ b/apps/self-hosted/src/routes/$category.$author.$permlink.tsx
@@ -1,11 +1,20 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { BlogPostPage } from '@/features/blog/components/blog-post-page';
+import { resolvePostsFilter } from '@/features/blog/utils/post-filters';
 
 export const Route = createFileRoute('/$category/$author/$permlink')({
   component: BlogPostPage,
-  validateSearch: (search: Record<string, unknown>) => {
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { raw?: true; filter?: string } => {
     return {
       raw: search.raw !== undefined ? true : undefined,
+      // Same retention as /$author/$permlink: the Reader rail reads it to
+      // stay on the feed the reader was browsing.
+      filter:
+        search.filter !== undefined
+          ? resolvePostsFilter(search.filter)
+          : undefined,
     };
   },
 });

--- a/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
+++ b/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
@@ -174,10 +174,10 @@ const accentBlocks = ALL_BLOCKS.filter((block) =>
 
 describe('accent blocks', () => {
   it('are every light and dark palette the templates declare', () => {
-    // Six templates in two modes, plus the two base blocks in variables.css.
+    // Seven templates in two modes, plus the two base blocks in variables.css.
     // A parser that stopped seeing them would make every check below vacuous.
-    expect(accentBlocks.length).toBe(14);
-    expect(new Set(accentBlocks.map((block) => block.file)).size).toBe(7);
+    expect(accentBlocks.length).toBe(16);
+    expect(new Set(accentBlocks.map((block) => block.file)).size).toBe(8);
   });
 
   it('declare the chip text next to the accent that fills the chip', () => {
@@ -326,7 +326,7 @@ describe('card treatment', () => {
   );
 
   it('is stated by every template rather than inherited by accident', () => {
-    expect(templates.length).toBe(6);
+    expect(templates.length).toBe(7);
     const missing: string[] = [];
     for (const block of templates) {
       for (const token of CARD_TOKENS) {

--- a/apps/self-hosted/src/styles/themes/index.css
+++ b/apps/self-hosted/src/styles/themes/index.css
@@ -10,3 +10,4 @@
 @import "./developer.css";
 @import "./modern-gradient.css";
 @import "./journal.css";
+@import "./reader.css";

--- a/apps/self-hosted/src/styles/themes/reader.css
+++ b/apps/self-hosted/src/styles/themes/reader.css
@@ -1,0 +1,119 @@
+/* Reader Theme - Your archive beside the open post
+ *
+ * The second layout-level design: a split frame with the post archive as a
+ * persistent rail beside whatever is open, the way a feed reader lays out.
+ * Sans UI around a serif reading surface, cool porcelain neutrals, a deep
+ * teal accent. The structural half lives in src/themes/reader/ (Shell and
+ * ArchiveList manifest overrides); these tokens carry the full --theme-*
+ * contract so the accent correction sweep and every token utility keep
+ * working.
+ */
+
+[data-style-template="reader"] {
+  /* Typography: sans chrome, serif articles */
+  --theme-font-body: "Source Serif 4", "Georgia", "Times New Roman", serif;
+  --theme-font-heading:
+    -apple-system, "BlinkMacSystemFont", "Segoe UI", "Helvetica Neue", "Arial",
+    sans-serif;
+  --theme-font-ui:
+    -apple-system, "BlinkMacSystemFont", "Segoe UI", "Helvetica Neue", "Arial",
+    sans-serif;
+
+  /* Typography Sizes */
+  --theme-text-base: 18px;
+  --theme-leading-normal: 1.6;
+  --theme-tracking-normal: 0;
+  --theme-tracking-tight: -0.01em;
+
+  /* Colors - Light: porcelain surfaces, near-black ink, deep teal accent */
+  --theme-bg-primary: #ffffff;
+  --theme-bg-secondary: #f6f6f4;
+  --theme-bg-tertiary: rgba(28, 30, 33, 0.05);
+  --theme-bg-card: #ffffff;
+
+  --theme-text-primary: #1c1e21;
+  --theme-text-secondary: rgba(28, 30, 33, 0.75);
+  /* 0.62 composites to ~4.8:1 over white: rail dates and marginalia stay
+   * quiet but AA-readable at small sizes. */
+  --theme-text-muted: rgba(28, 30, 33, 0.62);
+
+  --theme-accent: #17677a;
+  --theme-accent-hover: #125363;
+  /* Ink on the accent fill: white on #17677a is 6.4:1. */
+  --theme-accent-contrast: #ffffff;
+
+  --theme-border: rgba(28, 30, 33, 0.12);
+  --theme-border-strong: rgba(28, 30, 33, 0.2);
+
+  /* Effects: an app frame, so gentle rounding and soft elevation */
+  --theme-radius-sm: 4px;
+  --theme-radius: 6px;
+  --theme-radius-lg: 10px;
+  --theme-radius-full: 9999px;
+
+  --theme-shadow-sm: 0 1px 2px rgba(28, 30, 33, 0.06);
+  --theme-shadow: 0 2px 8px rgba(28, 30, 33, 0.08);
+  --theme-shadow-lg: 0 8px 24px rgba(28, 30, 33, 0.12);
+
+  /* Link underline style, derived from the accent; see variables.css */
+  --theme-link-decoration: underline;
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
+
+  /* Tag style: quiet chips in the UI face */
+  --theme-tag-text: var(--theme-accent-text-light, rgba(28, 30, 33, 0.65));
+  --theme-tag-radius: 4px;
+
+  /* Card treatment: flat surfaces separated by hairlines, no glass */
+  --theme-card-bg: var(--theme-bg-card);
+  --theme-card-border: 1px solid var(--theme-border);
+  --theme-card-backdrop: none;
+
+  /* Layout: the sidebar width IS the rail width in the Reader shell; the
+   * content width bounds the open article inside the reading pane. */
+  --theme-content-width: 720px;
+  --theme-sidebar-width: 340px;
+  --theme-layout-gap: 2rem;
+  --theme-layout-container-padding: 1.25rem;
+  --theme-layout-section-gap: 2rem;
+  --theme-card-padding: 1rem;
+  --theme-grid-gap: 1.5rem;
+  --theme-grid-columns-tablet: 1;
+  --theme-grid-columns-desktop: 1;
+  --theme-post-card-image-height: 200px;
+  --theme-post-card-image-radius: 6px;
+}
+
+/* Reader Dark Mode: graphite, never blue-black */
+[data-style-template="reader"][data-theme="dark"] {
+  --theme-bg-primary: #15171a;
+  --theme-bg-secondary: #1b1e22;
+  --theme-bg-tertiary: rgba(236, 239, 244, 0.07);
+  --theme-bg-card: #15171a;
+
+  --theme-text-primary: rgba(236, 239, 244, 0.92);
+  --theme-text-secondary: rgba(236, 239, 244, 0.75);
+  --theme-text-muted: rgba(236, 239, 244, 0.62);
+
+  --theme-accent: #58a6c4;
+  --theme-accent-hover: #74b9d3;
+  /* Ink on the accent fill: the same choice the correction module makes for
+   * this fill, so static CSS and runtime preview agree. 5.7:1. */
+  --theme-accent-contrast: #111827;
+
+  --theme-border: rgba(236, 239, 244, 0.12);
+  --theme-border-strong: rgba(236, 239, 244, 0.2);
+
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
+
+  --theme-tag-text: var(--theme-accent-text-dark, rgba(236, 239, 244, 0.65));
+}

--- a/apps/self-hosted/src/themes/reader/reader-home.tsx
+++ b/apps/self-hosted/src/themes/reader/reader-home.tsx
@@ -1,0 +1,49 @@
+import { InstanceConfigManager, t } from '@/core';
+import {
+  useCommunityData,
+  useInstanceConfig,
+} from '@/features/blog/hooks/use-instance-config';
+
+interface Props {
+  filter?: string;
+  limit?: number;
+}
+
+/**
+ * What the Reader theme renders where the feed route mounts the ArchiveList
+ * seam: the rail already IS the archive, so the reading pane greets instead
+ * of repeating it. Only ever seen at the desktop split; on small screens the
+ * shell gives the feed route to the rail and hides this pane entirely. The
+ * props are the seam's contract and deliberately unused.
+ */
+export function ReaderHome(_props: Props) {
+  const { username, isCommunityMode } = useInstanceConfig();
+  const { data: community } = useCommunityData();
+
+  const blogTitle = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.instanceConfiguration.meta.title,
+  );
+  const blogDescription = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.instanceConfiguration.meta.description,
+  );
+
+  const displayTitle =
+    isCommunityMode && community?.title ? community.title : blogTitle || username;
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center">
+      <div className="max-w-md text-center">
+        <h2 className="heading-theme text-2xl mb-3">{displayTitle}</h2>
+        {blogDescription && (
+          <p className="text-theme-secondary mb-6">{blogDescription}</p>
+        )}
+        <p className="text-sm text-theme-muted font-theme-ui">
+          {t('reader_home_hint')}
+        </p>
+        <p className="text-sm text-theme-muted font-theme-ui mt-1">
+          {t('reader_home_keys')}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/self-hosted/src/themes/reader/reader-rail.tsx
+++ b/apps/self-hosted/src/themes/reader/reader-rail.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { Entry } from '@ecency/sdk';
-import { Link, useNavigate, useParams } from '@tanstack/react-router';
+import { Link, useLocation, useNavigate, useParams } from '@tanstack/react-router';
 import clsx from 'clsx';
 import { useEffect, useRef } from 'react';
 import { formatDate, t } from '@/core';
@@ -87,17 +87,33 @@ export function ReaderRail() {
     );
   };
 
-  // Refs, not deps: the key handler reads the CURRENT list, selection and
-  // filter without re-subscribing on every feed page or route change.
+  // j/k are only navigation where the archive is part of the page: the feed
+  // and open posts. The rail stays mounted (CSS-hidden) on search, publish
+  // and edit, and a stray keypress there must never navigate away from a
+  // composer or a search. Post routes stay active even where the rail is
+  // hidden on small screens: next and previous post is exactly what those
+  // keys mean while reading.
+  const location = useLocation();
+  const pathname = location.pathname.replace(/\/+$/, '') || '/';
+  const keyboardActive =
+    pathname === '/' ||
+    pathname === '/blog' ||
+    (!!activePermlink && !pathname.startsWith('/edit'));
+
+  // Refs, not deps: the key handler reads the CURRENT list, selection, route
+  // and filter without re-subscribing on every feed page or route change.
   const entriesRef = useRef(entries);
   entriesRef.current = entries;
   const isOpenRef = useRef(isOpen);
   isOpenRef.current = isOpen;
   const carriedFilterRef = useRef(carriedFilter);
   carriedFilterRef.current = carriedFilter;
+  const keyboardActiveRef = useRef(keyboardActive);
+  keyboardActiveRef.current = keyboardActive;
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      if (!keyboardActiveRef.current) return;
       if (event.defaultPrevented) return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       if (isTypingTarget(event.target)) return;

--- a/apps/self-hosted/src/themes/reader/reader-rail.tsx
+++ b/apps/self-hosted/src/themes/reader/reader-rail.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef } from 'react';
 import { formatDate, t } from '@/core';
 import { DetectBottom } from '@/features/blog/components/detect-bottom';
 import { useArchiveFeed } from '@/features/blog/hooks/use-archive-feed';
+import { usePostsFilterState } from '@/features/blog/hooks/use-posts-filter-state';
 import { chooseFeedRetry } from '@/features/blog/utils/feed-retry';
 import { ErrorMessage } from '@/features/shared/error-message';
 import { InlineError } from '@/features/shared/inline-error';
@@ -14,10 +15,6 @@ import {
   nothingToShow,
   resolveQueryOutcome,
 } from '@/features/shared/query-outcome';
-
-interface Props {
-  filter?: string;
-}
 
 /** Keystrokes typed into a field are never navigation. */
 function isTypingTarget(target: EventTarget | null): boolean {
@@ -31,13 +28,30 @@ function isTypingTarget(target: EventTarget | null): boolean {
  * one highlighted, paged by the same shared hook the seam default uses. j and
  * k move to the next and previous entry without leaving the page (the arrow
  * keys are left alone: they scroll the article). Deep links need nothing
- * special, since the rail only marks whatever permlink the route already
- * carries.
+ * special, since the rail only marks whatever author and permlink the route
+ * already carries.
+ *
+ * The filter comes from the shared filter state, and every post link carries
+ * a non-default filter along (the post routes retain it): the rail must keep
+ * showing the feed the reader was browsing after a post opens, or "the
+ * archive never leaves the page" quietly turns into "opening a post resets
+ * the archive to the default feed".
  */
-export function ReaderRail({ filter = 'posts' }: Props) {
-  const params = useParams({ strict: false }) as { permlink?: string };
+export function ReaderRail() {
+  const params = useParams({ strict: false }) as {
+    author?: string;
+    permlink?: string;
+  };
+  // The route's author param keeps its '@'; entries do not.
+  const activeAuthor = (params.author ?? '').replace(/^@/, '');
   const activePermlink = params.permlink;
   const navigate = useNavigate();
+
+  const { availableFilters, currentFilter } = usePostsFilterState();
+  const defaultFilter = availableFilters[0] || 'posts';
+  // Canonical post URLs stay clean: only a non-default feed travels along.
+  const carriedFilter =
+    currentFilter === defaultFilter ? undefined : currentFilter;
 
   const {
     data = [],
@@ -50,7 +64,7 @@ export function ReaderRail({ filter = 'posts' }: Props) {
     isRefetchError,
     isSuccess,
     refetch,
-  } = useArchiveFeed(filter);
+  } = useArchiveFeed(currentFilter);
 
   const entries = data as Entry[];
   const outcome = resolveQueryOutcome({
@@ -60,12 +74,27 @@ export function ReaderRail({ filter = 'posts' }: Props) {
     hasContent: entries.length > 0,
   });
 
-  // Refs, not deps: the key handler reads the CURRENT list and selection
-  // without re-subscribing on every feed page or route change.
+  // The row a link opens is the EFFECTIVE entry (a reblog navigates to its
+  // original), so active detection and the keyboard lookup must compare that
+  // same identity, author included: a community feed can hold the same
+  // permlink from two authors, and a cross-post's wrapper permlink never
+  // matches the route.
+  const isOpen = (entry: Entry) => {
+    const effective = entry.original_entry || entry;
+    return (
+      effective.permlink === activePermlink &&
+      effective.author === activeAuthor
+    );
+  };
+
+  // Refs, not deps: the key handler reads the CURRENT list, selection and
+  // filter without re-subscribing on every feed page or route change.
   const entriesRef = useRef(entries);
   entriesRef.current = entries;
-  const activeRef = useRef(activePermlink);
-  activeRef.current = activePermlink;
+  const isOpenRef = useRef(isOpen);
+  isOpenRef.current = isOpen;
+  const carriedFilterRef = useRef(carriedFilter);
+  carriedFilterRef.current = carriedFilter;
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -78,9 +107,7 @@ export function ReaderRail({ filter = 'posts' }: Props) {
 
       const list = entriesRef.current;
       if (!list.length) return;
-      const current = list.findIndex(
-        (entry) => entry.permlink === activeRef.current,
-      );
+      const current = list.findIndex((entry) => isOpenRef.current(entry));
       // Nothing open yet: either key starts at the top.
       const next =
         current === -1
@@ -93,7 +120,7 @@ export function ReaderRail({ filter = 'posts' }: Props) {
       navigate({
         to: '/$author/$permlink',
         params: { author: `@${target.author}`, permlink: target.permlink },
-        search: { raw: undefined },
+        search: { raw: undefined, filter: carriedFilterRef.current },
       });
     };
 
@@ -106,7 +133,7 @@ export function ReaderRail({ filter = 'posts' }: Props) {
   const activeItemRef = useRef<HTMLAnchorElement | null>(null);
   useEffect(() => {
     activeItemRef.current?.scrollIntoView({ block: 'nearest' });
-  }, [activePermlink]);
+  }, [activeAuthor, activePermlink]);
 
   if (outcome === 'failed') {
     return (
@@ -126,7 +153,7 @@ export function ReaderRail({ filter = 'posts' }: Props) {
 
       {entries.map((entry) => {
         const entryData = entry.original_entry || entry;
-        const active = entry.permlink === activePermlink;
+        const active = isOpen(entry);
         return (
           <Link
             key={`${entry.author}/${entry.permlink}`}
@@ -136,7 +163,7 @@ export function ReaderRail({ filter = 'posts' }: Props) {
               author: `@${entryData.author}`,
               permlink: entryData.permlink,
             }}
-            search={{ raw: undefined }}
+            search={{ raw: undefined, filter: carriedFilter }}
             aria-current={active ? 'page' : undefined}
             className={clsx(
               'block px-4 py-3 no-underline border-b border-theme transition-theme',

--- a/apps/self-hosted/src/themes/reader/reader-rail.tsx
+++ b/apps/self-hosted/src/themes/reader/reader-rail.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import type { Entry } from '@ecency/sdk';
+import { Link, useNavigate, useParams } from '@tanstack/react-router';
+import clsx from 'clsx';
+import { useEffect, useRef } from 'react';
+import { formatDate, t } from '@/core';
+import { DetectBottom } from '@/features/blog/components/detect-bottom';
+import { useArchiveFeed } from '@/features/blog/hooks/use-archive-feed';
+import { chooseFeedRetry } from '@/features/blog/utils/feed-retry';
+import { ErrorMessage } from '@/features/shared/error-message';
+import { InlineError } from '@/features/shared/inline-error';
+import {
+  nothingToShow,
+  resolveQueryOutcome,
+} from '@/features/shared/query-outcome';
+
+interface Props {
+  filter?: string;
+}
+
+/** Keystrokes typed into a field are never navigation. */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName);
+}
+
+/**
+ * The Reader archive rail: every entry in the feed as a compact row, the open
+ * one highlighted, paged by the same shared hook the seam default uses. j and
+ * k move to the next and previous entry without leaving the page (the arrow
+ * keys are left alone: they scroll the article). Deep links need nothing
+ * special, since the rail only marks whatever permlink the route already
+ * carries.
+ */
+export function ReaderRail({ filter = 'posts' }: Props) {
+  const params = useParams({ strict: false }) as { permlink?: string };
+  const activePermlink = params.permlink;
+  const navigate = useNavigate();
+
+  const {
+    data = [],
+    fetchNextPage,
+    isFetching,
+    hasNextPage,
+    isEnabled,
+    isError,
+    isFetchNextPageError,
+    isRefetchError,
+    isSuccess,
+    refetch,
+  } = useArchiveFeed(filter);
+
+  const entries = data as Entry[];
+  const outcome = resolveQueryOutcome({
+    isEnabled,
+    isError,
+    isSuccess,
+    hasContent: entries.length > 0,
+  });
+
+  // Refs, not deps: the key handler reads the CURRENT list and selection
+  // without re-subscribing on every feed page or route change.
+  const entriesRef = useRef(entries);
+  entriesRef.current = entries;
+  const activeRef = useRef(activePermlink);
+  activeRef.current = activePermlink;
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isTypingTarget(event.target)) return;
+      const forward = event.key === 'j';
+      const back = event.key === 'k';
+      if (!forward && !back) return;
+
+      const list = entriesRef.current;
+      if (!list.length) return;
+      const current = list.findIndex(
+        (entry) => entry.permlink === activeRef.current,
+      );
+      // Nothing open yet: either key starts at the top.
+      const next =
+        current === -1
+          ? 0
+          : Math.min(Math.max(current + (forward ? 1 : -1), 0), list.length - 1);
+      if (next === current) return;
+
+      const target = list[next].original_entry || list[next];
+      event.preventDefault();
+      navigate({
+        to: '/$author/$permlink',
+        params: { author: `@${target.author}`, permlink: target.permlink },
+        search: { raw: undefined },
+      });
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [navigate]);
+
+  // Keyboard moves must keep the selection in sight; 'nearest' leaves mouse
+  // scrolling alone when the entry is already visible.
+  const activeItemRef = useRef<HTMLAnchorElement | null>(null);
+  useEffect(() => {
+    activeItemRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [activePermlink]);
+
+  if (outcome === 'failed') {
+    return (
+      <div className="p-4">
+        <ErrorMessage onRetry={() => refetch()} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {nothingToShow(outcome) && !isFetching && (
+        <div className="text-center py-10 text-theme-muted text-sm">
+          {t('noPosts')}
+        </div>
+      )}
+
+      {entries.map((entry) => {
+        const entryData = entry.original_entry || entry;
+        const active = entry.permlink === activePermlink;
+        return (
+          <Link
+            key={`${entry.author}/${entry.permlink}`}
+            ref={active ? activeItemRef : undefined}
+            to="/$author/$permlink"
+            params={{
+              author: `@${entryData.author}`,
+              permlink: entryData.permlink,
+            }}
+            search={{ raw: undefined }}
+            aria-current={active ? 'page' : undefined}
+            className={clsx(
+              'block px-4 py-3 no-underline border-b border-theme transition-theme',
+              'border-l-2',
+              active
+                ? 'bg-theme-tertiary border-l-[var(--theme-accent)]'
+                : 'border-l-transparent hover:bg-theme-hover',
+            )}
+          >
+            <p className="text-xs text-theme-muted font-theme-ui mb-1">
+              <time dateTime={entryData.created}>
+                {formatDate(entryData.created)}
+              </time>
+              {entryData.community && entryData.community_title && (
+                <span> · {entryData.community_title}</span>
+              )}
+            </p>
+            <h3
+              className={clsx(
+                'text-[15px] leading-snug text-theme-primary',
+                active ? 'font-semibold' : 'font-medium',
+              )}
+            >
+              {entryData.title}
+            </h3>
+          </Link>
+        );
+      })}
+
+      {/* Unmounted while the last page is failing, same reasoning as the seam
+          default: leaving it mounted would refire the failed fetch in a loop. */}
+      {hasNextPage && outcome !== 'stale' && (
+        <DetectBottom onBottom={() => fetchNextPage()} />
+      )}
+
+      {isFetching && (
+        <div className="text-center py-4 text-theme-muted text-sm">
+          {t('loadingMore')}
+        </div>
+      )}
+
+      {outcome === 'pending' && !isFetching && (
+        <div className="text-center py-10 text-theme-muted text-sm">
+          {t('loading')}
+        </div>
+      )}
+
+      {outcome === 'stale' && !isFetching && (
+        <InlineError
+          className="m-3"
+          message={t('posts_load_failed')}
+          onRetry={() =>
+            chooseFeedRetry({ isFetchNextPageError, isRefetchError }) ===
+            'next-page'
+              ? fetchNextPage()
+              : refetch()
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/self-hosted/src/themes/reader/reader-shell.tsx
+++ b/apps/self-hosted/src/themes/reader/reader-shell.tsx
@@ -1,0 +1,125 @@
+import type { PropsWithChildren } from 'react';
+import { Link, useLocation } from '@tanstack/react-router';
+import clsx from 'clsx';
+import { InstanceConfigManager } from '@/core';
+import { CreatePostButton, UserMenu } from '@/features/auth';
+import { SearchInput } from '@/features/blog/components/search-input';
+import {
+  useCommunityData,
+  useInstanceConfig,
+} from '@/features/blog/hooks/use-instance-config';
+import { usePostsFilterState } from '@/features/blog/hooks/use-posts-filter-state';
+import { ReaderRail } from './reader-rail';
+
+/**
+ * The Reader page frame: the archive as a persistent rail beside whatever is
+ * open, the way a feed reader lays out. Both panes scroll independently, so
+ * moving between posts never loses the reader's place in the archive. On
+ * small screens the split collapses to one pane at a time: the feed route IS
+ * the rail, and every other route (post, search, publish) shows the content
+ * pane. The sidebar seam is not rendered at all; its config options are
+ * declared unsupported through the manifest, so the editor hides them under
+ * this theme instead of leaving them silently inert.
+ */
+export function ReaderShell(props: PropsWithChildren) {
+  const { username, isCommunityMode } = useInstanceConfig();
+  const { data: community } = useCommunityData();
+  const location = useLocation();
+
+  const blogTitle = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.instanceConfiguration.meta.title,
+  );
+  const proxyBase = InstanceConfigManager.useConfig(
+    ({ configuration }) =>
+      configuration.general.imageProxy || 'https://i.ecency.com',
+  );
+
+  const displayTitle =
+    isCommunityMode && community?.title ? community.title : blogTitle || username;
+  const avatarAccount = isCommunityMode ? community?.name : username;
+  const avatarUrl = avatarAccount
+    ? `${proxyBase}/u/${avatarAccount}/avatar/small`
+    : null;
+
+  // Shared with BlogNavigation, so the shell cannot drift from it.
+  const { availableFilters, currentFilter, filterLabel } = usePostsFilterState();
+
+  // The one route where the rail is the whole story on small screens.
+  const pathname = location.pathname.replace(/\/+$/, '') || '/';
+  const isFeedRoute = pathname === '/' || pathname === '/blog';
+
+  return (
+    <div className="h-dvh flex flex-col bg-theme-primary">
+      <header className="shrink-0 border-b border-theme">
+        {/* flex-wrap: at narrow viewports the search and menu drop to their
+            own line instead of overflowing the strip. */}
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-1 px-4 py-2">
+          <Link
+            to="/blog"
+            search={{ filter: availableFilters[0] || 'posts' }}
+            className="flex items-center gap-2 no-underline text-theme-primary hover:opacity-80 transition-theme min-w-0"
+          >
+            {avatarUrl && (
+              <img
+                src={avatarUrl}
+                alt=""
+                aria-hidden="true"
+                className="size-7 rounded-full object-cover"
+              />
+            )}
+            <span className="font-theme-ui font-semibold truncate">
+              {displayTitle}
+            </span>
+          </Link>
+          <nav className="flex items-center gap-4 overflow-x-auto min-w-0">
+            {availableFilters.map((filter) => (
+              <Link
+                key={filter}
+                to="/blog"
+                search={{ filter }}
+                className={clsx(
+                  'text-sm no-underline font-theme-ui whitespace-nowrap transition-theme',
+                  currentFilter === filter
+                    ? 'text-theme-primary font-medium'
+                    : 'text-theme-muted hover:text-theme-primary',
+                )}
+              >
+                {filterLabel(filter)}
+              </Link>
+            ))}
+          </nav>
+          <span className="ml-auto flex items-center gap-3">
+            <SearchInput />
+            <UserMenu />
+          </span>
+        </div>
+      </header>
+
+      <div className="flex-1 flex min-h-0">
+        <aside
+          className={clsx(
+            'w-full lg:w-[var(--theme-sidebar-width)] lg:shrink-0 lg:border-r border-theme overflow-y-auto bg-theme-secondary',
+            !isFeedRoute && 'hidden lg:block',
+          )}
+        >
+          <ReaderRail filter={currentFilter} />
+        </aside>
+        <main
+          id="main-content"
+          className={clsx(
+            'flex-1 min-w-0 overflow-y-auto',
+            isFeedRoute && 'hidden lg:block',
+          )}
+        >
+          <div className="mx-auto w-full max-w-[var(--theme-content-width)] container-padding-theme py-6">
+            {props.children}
+          </div>
+        </main>
+      </div>
+
+      {/* The floating composer entry point the default navigation mounts; a
+          theme shell must never cost owners and community members the way in. */}
+      <CreatePostButton />
+    </div>
+  );
+}

--- a/apps/self-hosted/src/themes/reader/reader-shell.tsx
+++ b/apps/self-hosted/src/themes/reader/reader-shell.tsx
@@ -102,7 +102,7 @@ export function ReaderShell(props: PropsWithChildren) {
             !isFeedRoute && 'hidden lg:block',
           )}
         >
-          <ReaderRail filter={currentFilter} />
+          <ReaderRail />
         </aside>
         <main
           id="main-content"

--- a/apps/self-hosted/src/themes/registry.test.ts
+++ b/apps/self-hosted/src/themes/registry.test.ts
@@ -37,6 +37,18 @@ describe('theme manifest registry', () => {
     expect(journal.unsupportedOptions).toEqual(['sidebar', 'listType']);
   });
 
+  it('reader owns its shell and archive pane, declares what it does not consume', () => {
+    const reader = getThemeManifest('reader');
+    expect(reader.components?.Shell).toBeTypeOf('function');
+    // The rail owns the archive, so the feed route's ArchiveList seam becomes
+    // the reading-pane greeting rather than a second copy of the feed.
+    expect(reader.components?.ArchiveList).toBeTypeOf('function');
+    // Cards stay the shared default: search results render them in the pane.
+    expect(reader.components?.PostCard).toBeUndefined();
+    expect(reader.components?.Navigation).toBeUndefined();
+    expect(reader.unsupportedOptions).toEqual(['sidebar', 'listType']);
+  });
+
   it('unknown and absent ids resolve to the default template', () => {
     expect(getThemeManifest(undefined).id).toBe('medium');
     expect(getThemeManifest('no-such-theme').id).toBe('medium');
@@ -55,7 +67,8 @@ const { DEFAULT_THEME_COMPONENTS, resolveThemeComponents } = await import(
 
 describe('component resolution', () => {
   it('every CSS-only template resolves to exactly the shared defaults', () => {
-    for (const id of STYLE_TEMPLATES.filter((t) => t !== 'journal')) {
+    const layoutThemes = new Set(['journal', 'reader']);
+    for (const id of STYLE_TEMPLATES.filter((t) => !layoutThemes.has(t))) {
       const resolved = resolveThemeComponents(id);
       // Identity per seam, not just deep equality: the no-op migration means
       // the very same component functions render, so nothing remounts.
@@ -78,6 +91,16 @@ describe('component resolution', () => {
     expect(resolved.Navigation).toBe(DEFAULT_THEME_COMPONENTS.Navigation);
     expect(resolved.Sidebar).toBe(DEFAULT_THEME_COMPONENTS.Sidebar);
     expect(resolved.ArchiveList).toBe(DEFAULT_THEME_COMPONENTS.ArchiveList);
+  });
+
+  it('reader resolves its own shell and archive pane, defaults for the rest', () => {
+    const reader = getThemeManifest('reader');
+    const resolved = resolveThemeComponents('reader');
+    expect(resolved.Shell).toBe(reader.components?.Shell);
+    expect(resolved.ArchiveList).toBe(reader.components?.ArchiveList);
+    expect(resolved.Navigation).toBe(DEFAULT_THEME_COMPONENTS.Navigation);
+    expect(resolved.Sidebar).toBe(DEFAULT_THEME_COMPONENTS.Sidebar);
+    expect(resolved.PostCard).toBe(DEFAULT_THEME_COMPONENTS.PostCard);
   });
 
   it('option support reads the manifest declaration', async () => {

--- a/apps/self-hosted/src/themes/registry.ts
+++ b/apps/self-hosted/src/themes/registry.ts
@@ -5,6 +5,8 @@ import {
 } from '../../hosting/api/src/style-templates';
 import { JournalPostCard } from './journal/journal-post-card';
 import { JournalShell } from './journal/journal-shell';
+import { ReaderHome } from './reader/reader-home';
+import { ReaderShell } from './reader/reader-shell';
 import type { ThemeManifest, ThemeOptionKey } from './manifest';
 
 /**
@@ -29,6 +31,16 @@ const MANIFESTS: Record<StyleTemplate, ThemeManifest> = {
     id: 'journal',
     tier: 'free',
     components: { Shell: JournalShell, PostCard: JournalPostCard },
+    unsupportedOptions: ['sidebar', 'listType'],
+  },
+  // The second layout-level design: a split frame with the archive as a
+  // persistent rail beside the open post. The home pane replaces the
+  // ArchiveList seam (the rail owns the archive), while cards stay the shared
+  // default so search results keep their look inside the reading pane.
+  reader: {
+    id: 'reader',
+    tier: 'free',
+    components: { Shell: ReaderShell, ArchiveList: ReaderHome },
     unsupportedOptions: ['sidebar', 'listType'],
   },
 };


### PR DESCRIPTION
Closes #1421

## What

The second layout-level design on the theme manifest architecture: a Reader template that keeps the post archive as a persistent rail beside the open article, so moving between posts never leaves the page.

## How

- **Shell** (`themes/reader/reader-shell.tsx`): a compact masthead strip (title, filters, search, user menu) over a two-pane split; both panes scroll independently. On small screens the split collapses to one pane at a time: the feed route shows the rail full-width and every other route (post, search, publish) shows the content pane.
- **Rail** (`reader-rail.tsx`): every entry as a compact row with the open one highlighted, infinite paging, and `j`/`k` keyboard navigation to the next and previous entry (arrow keys are left alone so they keep scrolling the article). Deep links work unchanged; the rail just marks whatever permlink the route carries.
- **Home pane** (`reader-home.tsx`): the feed route's ArchiveList seam becomes a greeting with the keyboard hint, since the rail owns the archive. Cards stay the shared default so search results keep their look.
- **Shared fetching**: the seam default's feed queries are extracted into `useArchiveFeed` and consumed by both BlogPostsList and the rail, so the two cannot drift (same queries, same DMCA filtering path, same paging).
- Registered across the roster, the `/v1/templates` display catalog, the editor label map, the CSS registry and the guard suites (roster lockstep, appearance tokens, failure states). `sidebar` and `listType` are declared unsupported so the editor hides them under this theme.

## Tests

- SPA: 916 passing (registry resolution for Reader, roster lockstep, token guards, failure-state sweep)
- Hosting API: 419 passing (catalog derives from the roster)
- Both typechecks and the SPA production build green