### PR TITLE
Self-hosted: static SEO files, canonical policy and responsive media

### DIFF
--- a/apps/self-hosted/DEPLOYMENT.md
+++ b/apps/self-hosted/DEPLOYMENT.md
@@ -8,6 +8,7 @@ Deploy your own blog powered by the Hive blockchain. This guide covers Docker de
 - [Configuration](#configuration)
 - [Deployment Options](#deployment-options)
 - [Production Deployment](#production-deployment)
+- [SEO files (robots, sitemap, RSS)](#seo-files-robots-sitemap-rss)
 - [Custom Domain & SSL](#custom-domain--ssl)
 - [Updating](#updating)
 - [Troubleshooting](#troubleshooting)
@@ -333,6 +334,47 @@ docker run -d \
   -v $(pwd)/config.json:/usr/share/nginx/html/config.json:ro \
   ecency/self-hosted:sha-abc1234
 ```
+
+## SEO files (robots, sitemap, RSS)
+
+Managed instances get per-tenant `robots.txt`, `sitemap.xml` and `rss.xml`
+generated automatically. An independent deployment produces the same files
+with the generator shipped in the `ecency/hosting-api` image, run on a cron
+(hourly is plenty; the feeds carry the latest 100 posts):
+
+```bash
+docker run --rm -v "$PWD:/work" ecency/hosting-api \
+  npm run generate-seo -- \
+  --config /work/config.json \
+  --url https://blog.example.com \
+  --out /work/seo
+```
+
+Serve the output beside the app by mounting the files over the defaults in
+your compose file:
+
+```yaml
+    volumes:
+      - ./config.json:/usr/share/nginx/html/config.json:ro
+      - ./seo/robots.txt:/usr/share/nginx/html/robots.txt:ro
+      - ./seo/sitemap.xml:/usr/share/nginx/html/sitemap.xml:ro
+      - ./seo/rss.xml:/usr/share/nginx/html/rss.xml:ro
+```
+
+Then point the app's RSS link at your own feed in `config.json`:
+
+```json
+{
+  "configuration": {
+    "general": {
+      "rssFeedUrl": "https://blog.example.com/rss.xml"
+    }
+  }
+}
+```
+
+Without the generator the app links the ecency.com feed for your account, so
+the RSS link never points at a file that does not exist.
 
 ## Custom Domain & SSL
 

--- a/apps/self-hosted/hosting/api/Dockerfile
+++ b/apps/self-hosted/hosting/api/Dockerfile
@@ -35,8 +35,10 @@ ENV RELEASE_VERSION=$RELEASE_VERSION
 
 WORKDIR /app
 
-# Copy source and dependencies (tsx runs TypeScript directly)
+# Copy source and dependencies (tsx runs TypeScript directly). scripts/ ships
+# too: independent deployments run `npm run generate-seo` through this image.
 COPY --from=builder /app/src ./src
+COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/tsconfig.json ./
 COPY --from=builder /app/node_modules ./node_modules

--- a/apps/self-hosted/hosting/api/package-lock.json
+++ b/apps/self-hosted/hosting/api/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@ecency/hosting-api",
       "version": "1.0.0",
       "dependencies": {
+        "@ecency/render-helper": "^2.5.26",
         "@ecency/sdk": "^2.2.0",
         "@hiveio/x402": "^0.1.2",
         "@hono/node-server": "^2.0.11",
@@ -38,6 +39,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@ecency/render-helper": {
+      "version": "2.5.26",
+      "resolved": "https://registry.npmjs.org/@ecency/render-helper/-/render-helper-2.5.26.tgz",
+      "integrity": "sha512-n6nOXQYkX8VaS1bxE5fKbBX7B5Ro7xzZrbfqGLHZc8gNgVm0w8wTIHQUd9ObfXOzpzDZhnK2F9OwOVKHPy8bYA==",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "dom-serializer": "^2.0.0",
+        "he": "^1.2.0",
+        "htmlparser2": "^10.0.0",
+        "lolight": "^1.4.0",
+        "lru-cache": "^11.0.2",
+        "path": "^0.12.7",
+        "querystring": "^0.2.0",
+        "react-native-crypto-js": "^1.0.0",
+        "remarkable": "^2.0.1",
+        "url": "^0.11.0",
+        "xss": "^1.0.9"
       }
     },
     "node_modules/@ecency/sdk": {
@@ -1183,6 +1203,14 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1193,6 +1221,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/array-flatten": {
@@ -1215,6 +1251,14 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/autolinker": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.16.2.tgz",
+      "integrity": "sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -1509,6 +1553,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1591,6 +1640,11 @@
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
+    },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "node_modules/date-fns": {
       "version": "3.6.0",
@@ -1690,6 +1744,57 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/drbg.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
@@ -1766,6 +1871,17 @@
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -2168,6 +2284,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hive-uri": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/hive-uri/-/hive-uri-0.2.8.tgz",
@@ -2205,6 +2329,35 @@
       "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-errors": {
@@ -2445,6 +2598,11 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
+    "node_modules/lolight": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lolight/-/lolight-1.4.1.tgz",
+      "integrity": "sha512-AALiVBZpkryshtHbhE3KnRMGSnNtj7yfC2JgnMvXZ2sQQues4omu3pp04S+7X4P2QQhcXanPEXOGQgd77qMvJg=="
+    },
     "node_modules/long": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
@@ -2458,6 +2616,14 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2680,6 +2846,15 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2916,6 +3091,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2942,6 +3125,11 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+    },
     "node_modules/qs": {
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -2955,6 +3143,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/querystringify": {
@@ -2998,6 +3195,11 @@
       "bin": {
         "rc": "cli.js"
       }
+    },
+    "node_modules/react-native-crypto-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-crypto-js/-/react-native-crypto-js-1.0.0.tgz",
+      "integrity": "sha512-FNbLuG/HAdapQoybeZSoes1PWdOj0w242gb+e1R0hicf3Gyj/Mf8M9NaED2AnXVOX01b2FXomwUiw1xP1K+8sA=="
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
@@ -3050,6 +3252,21 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/remarkable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-2.0.1.tgz",
+      "integrity": "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==",
+      "dependencies": {
+        "argparse": "^1.0.10",
+        "autolinker": "^3.11.0"
+      },
+      "bin": {
+        "remarkable": "bin/remarkable.js"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/requires-port": {
@@ -3385,6 +3602,11 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3569,6 +3791,11 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
     "node_modules/tsx": {
       "version": "4.23.12",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
@@ -3650,6 +3877,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -3660,10 +3899,23 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -3972,6 +4224,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/apps/self-hosted/hosting/api/package.json
+++ b/apps/self-hosted/hosting/api/package.json
@@ -8,7 +8,8 @@
     "start": "tsx src/index.ts",
     "start:listener": "tsx src/payment-listener.ts",
     "db:migrate": "tsx src/db/migrate.ts",
-    "test": "vitest run"
+    "test": "vitest run",
+    "generate-seo": "tsx scripts/generate-seo.ts"
   },
   "dependencies": {
     "@ecency/render-helper": "^2.5.26",

--- a/apps/self-hosted/hosting/api/package.json
+++ b/apps/self-hosted/hosting/api/package.json
@@ -11,17 +11,18 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@ecency/render-helper": "^2.5.26",
     "@ecency/sdk": "^2.2.0",
     "@hiveio/x402": "^0.1.2",
     "@hono/node-server": "^2.0.11",
     "@hono/zod-validator": "^0.4.0",
+    "date-fns": "^3.6.0",
     "hono": "^4.4.0",
     "jsonwebtoken": "^9.0.0",
+    "nanoid": "^5.0.0",
     "pg": "^8.12.0",
     "redis": "^4.6.0",
-    "zod": "^3.23.0",
-    "date-fns": "^3.6.0",
-    "nanoid": "^5.0.0"
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.0",

--- a/apps/self-hosted/hosting/api/scripts/generate-seo.ts
+++ b/apps/self-hosted/hosting/api/scripts/generate-seo.ts
@@ -30,6 +30,17 @@ function arg(name: string): string | undefined {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
+/**
+ * The output dir is typically served by a web server while the cron rewrites
+ * it, so each file is written beside its target and renamed into place:
+ * readers see the old file or the new one, never a truncated one.
+ */
+async function writeAtomic(filePath: string, content: string): Promise<void> {
+  const tmp = `${filePath}.tmp-${process.pid}`;
+  await fs.writeFile(tmp, content);
+  await fs.rename(tmp, filePath);
+}
+
 async function main(): Promise<void> {
   const configPath = arg('config');
   const url = arg('url');
@@ -63,12 +74,12 @@ async function main(): Promise<void> {
 
   const posts = await fetchTenantPosts(tenant);
   await fs.mkdir(outDir, { recursive: true });
-  await fs.writeFile(path.join(outDir, 'robots.txt'), buildRobotsTxt(tenant));
-  await fs.writeFile(
+  await writeAtomic(path.join(outDir, 'robots.txt'), buildRobotsTxt(tenant));
+  await writeAtomic(
     path.join(outDir, 'sitemap.xml'),
     buildSitemapXml(tenant, posts),
   );
-  await fs.writeFile(path.join(outDir, 'rss.xml'), buildRssXml(tenant, posts));
+  await writeAtomic(path.join(outDir, 'rss.xml'), buildRssXml(tenant, posts));
   console.log(
     `Wrote robots.txt, sitemap.xml, rss.xml (${posts.length} posts) to ${outDir}`,
   );

--- a/apps/self-hosted/hosting/api/scripts/generate-seo.ts
+++ b/apps/self-hosted/hosting/api/scripts/generate-seo.ts
@@ -1,0 +1,80 @@
+/**
+ * Owner-run SEO generator for INDEPENDENT deployments: the same builders the
+ * managed sync pass uses, producing robots.txt, sitemap.xml and rss.xml for
+ * one instance from its config.json. Run it on a cron and mount the output
+ * beside the app (see apps/self-hosted/DEPLOYMENT.md):
+ *
+ *   npm run generate-seo -- \
+ *     --config /path/to/config.json \
+ *     --url https://blog.example.com \
+ *     --out /path/to/seo
+ *
+ * Or through the published image, with no local Node at all:
+ *
+ *   docker run --rm -v "$PWD:/work" ecency/hosting-api \
+ *     npm run generate-seo -- --config /work/config.json \
+ *     --url https://blog.example.com --out /work/seo
+ */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import {
+  buildRobotsTxt,
+  buildRssXml,
+  buildSitemapXml,
+  fetchTenantPosts,
+} from '../src/services/seo-files';
+import type { Tenant } from '../src/types';
+
+function arg(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+async function main(): Promise<void> {
+  const configPath = arg('config');
+  const url = arg('url');
+  const outDir = arg('out') || '.';
+  if (!configPath || !url || !/^https:\/\/[^/]+$/i.test(url)) {
+    console.error(
+      'Usage: npm run generate-seo -- --config <config.json> --url https://your.domain --out <dir>',
+    );
+    process.exit(1);
+  }
+
+  const config = JSON.parse(await fs.readFile(configPath, 'utf8'));
+  const instance = config?.configuration?.instanceConfiguration ?? {};
+  const username: unknown = instance.username || instance.communityId;
+  if (typeof username !== 'string' || !username) {
+    console.error('config.json carries no instanceConfiguration.username');
+    process.exit(1);
+  }
+
+  // A synthetic tenant whose "custom domain" is the owner's own URL: the
+  // builders then emit that domain everywhere, and the canonical policy
+  // (own domain = canonicalize to self) applies exactly as it does for a
+  // managed custom-domain tenant.
+  const host = new URL(url).host;
+  const tenant = {
+    username,
+    customDomain: host,
+    customDomainVerified: true,
+    config,
+  } as unknown as Tenant;
+
+  const posts = await fetchTenantPosts(tenant);
+  await fs.mkdir(outDir, { recursive: true });
+  await fs.writeFile(path.join(outDir, 'robots.txt'), buildRobotsTxt(tenant));
+  await fs.writeFile(
+    path.join(outDir, 'sitemap.xml'),
+    buildSitemapXml(tenant, posts),
+  );
+  await fs.writeFile(path.join(outDir, 'rss.xml'), buildRssXml(tenant, posts));
+  console.log(
+    `Wrote robots.txt, sitemap.xml, rss.xml (${posts.length} posts) to ${outDir}`,
+  );
+}
+
+main().catch((e) => {
+  console.error('generate-seo failed:', (e as Error).message);
+  process.exit(1);
+});

--- a/apps/self-hosted/hosting/api/scripts/generate-seo.ts
+++ b/apps/self-hosted/hosting/api/scripts/generate-seo.ts
@@ -45,10 +45,31 @@ async function main(): Promise<void> {
   const configPath = arg('config');
   const url = arg('url');
   const outDir = arg('out') || '.';
-  if (!configPath || !url || !/^https:\/\/[^/]+$/i.test(url)) {
+  if (!configPath || !url) {
     console.error(
       'Usage: npm run generate-seo -- --config <config.json> --url https://your.domain --out <dir>',
     );
+    process.exit(1);
+  }
+  // A parsed origin, not a prefix match: a trailing slash is accepted, and
+  // user-info, a path, a query or a fragment (all silently discarded by the
+  // host extraction below) are rejected instead.
+  let siteUrl: URL;
+  try {
+    siteUrl = new URL(url);
+  } catch {
+    console.error('--url must be a plain https origin, e.g. https://blog.example.com');
+    process.exit(1);
+  }
+  if (
+    siteUrl.protocol !== 'https:' ||
+    siteUrl.username ||
+    siteUrl.password ||
+    siteUrl.search ||
+    siteUrl.hash ||
+    siteUrl.pathname !== '/'
+  ) {
+    console.error('--url must be a plain https origin, e.g. https://blog.example.com');
     process.exit(1);
   }
 
@@ -64,7 +85,7 @@ async function main(): Promise<void> {
   // builders then emit that domain everywhere, and the canonical policy
   // (own domain = canonicalize to self) applies exactly as it does for a
   // managed custom-domain tenant.
-  const host = new URL(url).host;
+  const host = siteUrl.host;
   const tenant = {
     username,
     customDomain: host,

--- a/apps/self-hosted/hosting/api/src/index.ts
+++ b/apps/self-hosted/hosting/api/src/index.ts
@@ -135,6 +135,24 @@ async function syncTenantConfigs(): Promise<void> {
   }
 }
 
+// Static SEO files (robots/sitemap/rss) refresh on their own loop with their
+// own single-flight: they spend chain calls, and sharing the config sync's
+// serial pass let a slow RPC delay config publication for every tenant
+// behind it.
+let seoSyncRunning = false;
+async function syncSeoFiles(): Promise<void> {
+  if (seoSyncRunning) return;
+  seoSyncRunning = true;
+  try {
+    const tenants = await TenantService.getActiveTenants();
+    await ConfigService.syncAllSeoFiles(tenants);
+  } catch (e) {
+    console.error('[Startup] SEO sync failed:', (e as Error).message);
+  } finally {
+    seoSyncRunning = false;
+  }
+}
+
 // Say once, at boot, what state the internal shared secret is in. Without this the two
 // misconfigurations are indistinguishable in production: both simply reject every call,
 // one because the operator meant to disable card activation and one because the value
@@ -178,3 +196,10 @@ startVerifiedDomainRefresh();
 // startup deadline) converges within a few minutes; identical files are not rewritten.
 const configSyncTimer = setInterval(() => void syncTenantConfigs(), 5 * 60 * 1000);
 configSyncTimer.unref?.();
+
+// The SEO pass first runs shortly after boot (never blocking startup) and
+// then every five minutes; the freshness window makes most passes free.
+const seoSyncKickoff = setTimeout(() => void syncSeoFiles(), 30 * 1000);
+seoSyncKickoff.unref?.();
+const seoSyncTimer = setInterval(() => void syncSeoFiles(), 5 * 60 * 1000);
+seoSyncTimer.unref?.();

--- a/apps/self-hosted/hosting/api/src/services/config-publish-lock.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-publish-lock.test.ts
@@ -16,7 +16,10 @@ vi.mock('../db/client', () => ({
 }));
 
 vi.mock('./tenant-service', () => ({
-  TenantService: { getByUsername: mocks.getByUsername },
+  TenantService: {
+    getByUsername: mocks.getByUsername,
+    getBlogUrl: (t: any) => `https://${t.username}.blogs.ecency.com`,
+  },
 }));
 
 const { ConfigService } = await import('./config-service');

--- a/apps/self-hosted/hosting/api/src/services/config-service.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-service.test.ts
@@ -59,6 +59,14 @@ describe('ConfigService.generateConfigFile', () => {
     expect(repaired.configuration.instanceConfiguration.meta.title).toBe('One');
   });
 
+  it('publishes by rename and leaves no staging residue behind', async () => {
+    const configPath = await ConfigService.generateConfigFile(tenant('trent', 'Atomic'));
+    const siblings = await fs.readdir(path.dirname(configPath));
+    expect(siblings.filter((f) => f.includes('.tmp-'))).toEqual([]);
+    const written = JSON.parse(await fs.readFile(configPath, 'utf-8'));
+    expect(written.configuration.instanceConfiguration.meta.title).toBe('Atomic');
+  });
+
   it('a newer write is not clobbered by an older concurrent write', async () => {
     // Simulates the sync-vs-update race: an older (slow) generation submitted first and a
     // newer one submitted second must finish with the newer content on disk.

--- a/apps/self-hosted/hosting/api/src/services/config-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-service.ts
@@ -141,7 +141,21 @@ export const ConfigService = {
     } catch {
       // Missing or unreadable: write it.
     }
-    await fs.writeFile(path, content, 'utf-8');
+    // nginx serves these files while the sync rewrites them, and writeFile
+    // truncates before it fills: a concurrent reader could answer half a
+    // sitemap. Write beside the target and rename over it, which is atomic
+    // on the same filesystem, so a reader always sees whole old bytes or
+    // whole new bytes. The suffix matches no extension listConfigFiles
+    // knows, so a tmp file orphaned by a crash cannot masquerade as a
+    // tenant's config.
+    const tmpPath = `${path}.tmp-${process.pid}`;
+    try {
+      await fs.writeFile(tmpPath, content, 'utf-8');
+      await fs.rename(tmpPath, path);
+    } catch (err) {
+      await fs.unlink(tmpPath).catch(() => {});
+      throw err;
+    }
     return true;
   },
 

--- a/apps/self-hosted/hosting/api/src/services/config-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-service.ts
@@ -231,7 +231,19 @@ export const ConfigService = {
         break;
       }
     }
-    if (fresh) return;
+    // mtime alone misses a DOMAIN change: verifying or removing a custom
+    // domain rewrites every embedded URL, and files can advertise the old
+    // address for the whole window. robots costs no RPC to rebuild, so its
+    // content doubles as the domain fingerprint.
+    if (fresh) {
+      try {
+        const currentRobots = await fs.readFile(paths.robots, 'utf-8');
+        if (currentRobots === buildRobotsTxt(tenant)) return;
+      } catch {
+        // Unreadable robots: regenerate.
+      }
+      fresh = false;
+    }
 
     // One bounded chain page; a failure here is caught by the sync pass's
     // per-tenant isolation and yesterday's files keep serving.
@@ -308,6 +320,44 @@ export const ConfigService = {
   },
 
   /**
+   * Refresh every active tenant's static SEO files, decoupled from the
+   * config sync: each stale tenant costs one bounded chain call, and running
+   * them inside the serial config pass let an RPC outage delay config
+   * publication and cleanup by tenant-count times the timeout while the
+   * single-flight guard skipped the next passes. A small worker pool keeps
+   * the wall clock flat; the freshness window keeps quiet passes free.
+   */
+  async syncAllSeoFiles(activeTenants: Tenant[], concurrency = 4): Promise<void> {
+    const queue = [...activeTenants];
+    let failed = 0;
+    const worker = async () => {
+      for (;;) {
+        const tenant = queue.shift();
+        if (!tenant) return;
+        try {
+          await withTenantWriteLock(tenant.username, async () => {
+            const fresh = await TenantService.getByUsername(tenant.username);
+            if (!fresh || !isPublishableTenant(fresh)) return;
+            await this.writeSeoFilesIfStale(fresh);
+          });
+        } catch (err) {
+          failed++;
+          console.error(
+            `[ConfigService] SEO sync failed for ${tenant.username}:`,
+            (err as Error).message
+          );
+        }
+      }
+    };
+    await Promise.all(
+      Array.from({ length: Math.max(1, concurrency) }, () => worker())
+    );
+    if (failed > 0) {
+      console.error(`[ConfigService] SEO sync finished with ${failed} failure(s)`);
+    }
+  },
+
+  /**
    * List every tenant username that has ANY served file on disk (config .json OR .meta.html).
    * The reconcile sweep keys off this, so a tenant whose .json was removed but whose
    * .meta.html lingered (partial delete failure) is still revisited and cleaned up.
@@ -367,7 +417,6 @@ export const ConfigService = {
           const fresh = await TenantService.getByUsername(tenant.username);
           if (!fresh || !isPublishableTenant(fresh)) return;
           await this.writeConfigFile(fresh);
-          await this.writeSeoFilesIfStale(fresh);
         });
       } catch (err) {
         failed++;

--- a/apps/self-hosted/hosting/api/src/services/config-service.ts
+++ b/apps/self-hosted/hosting/api/src/services/config-service.ts
@@ -7,19 +7,23 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { withAdvisoryLock } from '../db/client';
+import { escapeHtml } from '../utils/escape-html';
 import { TenantService, type Tenant } from './tenant-service';
+import {
+  buildRobotsTxt,
+  buildRssXml,
+  buildSitemapXml,
+  canonicalHomeUrl,
+  fetchTenantPosts,
+  SEO_FRESH_MS,
+} from './seo-files';
 
 const CONFIG_DIR = process.env.CONFIG_DIR || '/app/configs';
 
-/** Escape a string for safe interpolation into HTML text and attribute values. */
-export function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
+// Re-exported for existing consumers; the implementation lives in its own
+// util so seo-files can use it without importing this module back
+// (config-service consumes seo-files below).
+export { escapeHtml } from '../utils/escape-html';
 
 // Per-tenant write chains: every config-file write for a tenant runs strictly after the
 // previous one, so the periodic sync and a concurrent tenant update can never interleave.
@@ -178,6 +182,11 @@ export const ConfigService = {
           ]
         : []),
       `<meta name="twitter:card" content="${ogImage ? 'summary_large_image' : 'summary'}" />`,
+      // Custom-domain tenants canonicalize to themselves, subdomain tenants
+      // to the ecency.com SSR page (see canonicalHomeUrl); the feed link is
+      // in the SSI snippet so crawlers see it, not only JS runtimes.
+      `<link rel="canonical" href="${escapeHtml(canonicalHomeUrl(tenant))}" />`,
+      `<link rel="alternate" type="application/rss+xml" title="${title}" href="${escapeHtml(TenantService.getBlogUrl(tenant) + '/rss.xml')}" />`,
       `<link rel="icon" href="${favicon}" />`,
       '',
     ].join('\n');
@@ -186,6 +195,56 @@ export const ConfigService = {
   /** Path of a tenant's SSI head-metadata snippet. */
   getMetaPath(username: string): string {
     return path.join(CONFIG_DIR, username.toLowerCase() + '.meta.html');
+  },
+
+  /** Paths of a tenant's static SEO files (robots, sitemap, rss). */
+  getSeoPaths(username: string): { robots: string; sitemap: string; rss: string } {
+    const base = path.join(CONFIG_DIR, username.toLowerCase());
+    return {
+      robots: `${base}.robots.txt`,
+      sitemap: `${base}.sitemap.xml`,
+      rss: `${base}.rss.xml`,
+    };
+  },
+
+  /**
+   * Regenerate a tenant's static SEO files when they are stale. Called from
+   * the sync pass inside the per-tenant lock. Freshness is mtime-based, so
+   * after an unchanged regeneration the files are touched: writeIfChanged
+   * deliberately skips identical writes, and without the touch every later
+   * pass would refetch the feed for a blog that has not posted.
+   */
+  async writeSeoFilesIfStale(tenant: Tenant): Promise<void> {
+    const paths = this.getSeoPaths(tenant.username);
+    const all = [paths.robots, paths.sitemap, paths.rss];
+
+    let fresh = true;
+    for (const p of all) {
+      try {
+        const stat = await fs.stat(p);
+        if (Date.now() - stat.mtimeMs > SEO_FRESH_MS) {
+          fresh = false;
+          break;
+        }
+      } catch {
+        fresh = false;
+        break;
+      }
+    }
+    if (fresh) return;
+
+    // One bounded chain page; a failure here is caught by the sync pass's
+    // per-tenant isolation and yesterday's files keep serving.
+    const posts = await fetchTenantPosts(tenant);
+    await fs.mkdir(CONFIG_DIR, { recursive: true });
+    await this.writeIfChanged(paths.robots, buildRobotsTxt(tenant));
+    await this.writeIfChanged(paths.sitemap, buildSitemapXml(tenant, posts));
+    await this.writeIfChanged(paths.rss, buildRssXml(tenant, posts));
+
+    const now = new Date();
+    for (const p of all) {
+      await fs.utimes(p, now, now).catch(() => {});
+    }
   },
 
   /**
@@ -198,7 +257,14 @@ export const ConfigService = {
 
   /** The actual unlink; only ever invoked under the per-tenant lock. */
   async removeConfigFileUnlocked(username: string): Promise<void> {
-    for (const filePath of [this.getConfigPath(username), this.getMetaPath(username)]) {
+    const seo = this.getSeoPaths(username);
+    for (const filePath of [
+      this.getConfigPath(username),
+      this.getMetaPath(username),
+      seo.robots,
+      seo.sitemap,
+      seo.rss,
+    ]) {
       try {
         await fs.unlink(filePath);
         console.log('[ConfigService] Deleted config:', filePath);
@@ -253,6 +319,9 @@ export const ConfigService = {
       for (const f of files) {
         if (f === 'default.json') continue;
         if (f.endsWith('.meta.html')) names.add(f.slice(0, -'.meta.html'.length));
+        else if (f.endsWith('.robots.txt')) names.add(f.slice(0, -'.robots.txt'.length));
+        else if (f.endsWith('.sitemap.xml')) names.add(f.slice(0, -'.sitemap.xml'.length));
+        else if (f.endsWith('.rss.xml')) names.add(f.slice(0, -'.rss.xml'.length));
         else if (f.endsWith('.json')) names.add(f.slice(0, -'.json'.length));
       }
       return [...names];
@@ -298,6 +367,7 @@ export const ConfigService = {
           const fresh = await TenantService.getByUsername(tenant.username);
           if (!fresh || !isPublishableTenant(fresh)) return;
           await this.writeConfigFile(fresh);
+          await this.writeSeoFilesIfStale(fresh);
         });
       } catch (err) {
         failed++;

--- a/apps/self-hosted/hosting/api/src/services/hivesigner-registry.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/hivesigner-registry.test.ts
@@ -36,6 +36,7 @@ vi.mock('../db/client', () => ({
 
 vi.mock('./tenant-service', () => ({
   TenantService: {
+    getBlogUrl: (t: any) => `https://${t.username}.blogs.ecency.com`,
     getActiveTenants: mocks.getActiveTenants,
     applyConfigDocument: mocks.applyConfigDocument,
     getByUsername: mocks.getByUsername,

--- a/apps/self-hosted/hosting/api/src/services/hivesigner-registry.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/hivesigner-registry.test.ts
@@ -47,18 +47,30 @@ vi.mock('./tenant-service', () => ({
 // thing under test here, and a stand-in for the publisher would be a copy of the
 // rule it is supposed to be checked against. The filesystem is mocked instead,
 // so the assertions are about the bytes that reach disk.
-vi.mock('fs', () => ({
-  promises: {
-    mkdir: async () => undefined,
-    readFile: async () => {
-      const missing = new Error('ENOENT') as NodeJS.ErrnoException;
-      missing.code = 'ENOENT';
-      throw missing;
+// The publisher writes beside the target and renames over it (atomic
+// publish), so `written` observes the rename: what becomes visible at the
+// final path is what these assertions are about, not the staging write.
+vi.mock('fs', () => {
+  const staged = new Map<string, string>();
+  return {
+    promises: {
+      mkdir: async () => undefined,
+      readFile: async () => {
+        const missing = new Error('ENOENT') as NodeJS.ErrnoException;
+        missing.code = 'ENOENT';
+        throw missing;
+      },
+      writeFile: async (file: string, contents: string) => {
+        staged.set(file, contents);
+      },
+      rename: async (from: string, to: string) => {
+        mocks.written(to, staged.get(from));
+        staged.delete(from);
+      },
+      unlink: async () => undefined,
     },
-    writeFile: async (file: string, contents: string) => mocks.written(file, contents),
-    unlink: async () => undefined,
-  },
-}));
+  };
+});
 
 const {
   decideClientId,

--- a/apps/self-hosted/hosting/api/src/services/post-meta.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/post-meta.test.ts
@@ -86,6 +86,51 @@ describe('buildMetaForUri', () => {
     expect(html).toContain('twitter:card" content="summary_large_image"');
   });
 
+  it("emits the cover on the tenant's configured image proxy", async () => {
+    mocks.callRPC.mockResolvedValue({
+      title: 'Proxied',
+      body: 'Some words to read here.',
+      json_metadata: { image: ['https://img.example/meta.png'] },
+    });
+    const tenant = {
+      ...TENANT,
+      config: {
+        configuration: {
+          general: { imageProxy: 'https://images.example.com/' },
+          instanceConfiguration: { meta: { title: 'Alice writes' } },
+        },
+      },
+    } as any;
+
+    const html = await buildMetaForUri(tenant, '/@alice/custom-proxy');
+    // Same hash and params render-helper emitted, rebased onto the
+    // tenant's proxy (trailing slash stripped), never the default host.
+    expect(html).toMatch(
+      /og:image" content="https:\/\/images\.example\.com\/p\/[A-Za-z0-9]+\?format=match/,
+    );
+    expect(html).not.toContain('i.ecency.com/p/');
+  });
+
+  it('a junk imageProxy value stays on the default proxy', async () => {
+    mocks.callRPC.mockResolvedValue({
+      title: 'Junk proxy',
+      body: 'Some words to read here.',
+      json_metadata: { image: ['https://img.example/meta.png'] },
+    });
+    const tenant = {
+      ...TENANT,
+      config: {
+        configuration: {
+          general: { imageProxy: 'javascript:alert(1)' },
+          instanceConfiguration: { meta: { title: 'Alice writes' } },
+        },
+      },
+    } as any;
+
+    const html = await buildMetaForUri(tenant, '/@alice/junk-proxy');
+    expect(html).toMatch(/og:image" content="https:\/\/i\.ecency\.com\/p\//);
+  });
+
   it('caches the chain lookup: one RPC serves repeat unfurls', async () => {
     mocks.callRPC.mockResolvedValue({ title: 'T', body: 'words here' });
     await buildMetaForUri(TENANT, '/@alice/my-post');

--- a/apps/self-hosted/hosting/api/src/services/post-meta.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/post-meta.test.ts
@@ -111,24 +111,29 @@ describe('buildMetaForUri', () => {
     expect(html).not.toContain('i.ecency.com/p/');
   });
 
-  it('a junk imageProxy value stays on the default proxy', async () => {
+  it('junk imageProxy values stay on the default proxy', async () => {
     mocks.callRPC.mockResolvedValue({
       title: 'Junk proxy',
       body: 'Some words to read here.',
       json_metadata: { image: ['https://img.example/meta.png'] },
     });
-    const tenant = {
-      ...TENANT,
-      config: {
-        configuration: {
-          general: { imageProxy: 'javascript:alert(1)' },
-          instanceConfiguration: { meta: { title: 'Alice writes' } },
+    // A protocol prefix alone must not pass: "https://" and "https://?x"
+    // would rebase onto a hostless base and emit malformed URLs.
+    const junkValues = ['javascript:alert(1)', 'https://', 'https://?invalid', 'not a url'];
+    for (const [i, imageProxy] of junkValues.entries()) {
+      const tenant = {
+        ...TENANT,
+        config: {
+          configuration: {
+            general: { imageProxy },
+            instanceConfiguration: { meta: { title: 'Alice writes' } },
+          },
         },
-      },
-    } as any;
+      } as any;
 
-    const html = await buildMetaForUri(tenant, '/@alice/junk-proxy');
-    expect(html).toMatch(/og:image" content="https:\/\/i\.ecency\.com\/p\//);
+      const html = await buildMetaForUri(tenant, `/@alice/junk-proxy-${i}`);
+      expect(html).toMatch(/og:image" content="https:\/\/i\.ecency\.com\/p\//);
+    }
   });
 
   it('caches the chain lookup: one RPC serves repeat unfurls', async () => {

--- a/apps/self-hosted/hosting/api/src/services/post-meta.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/post-meta.test.ts
@@ -74,8 +74,10 @@ describe('buildMetaForUri', () => {
     });
     expect(html).not.toContain('<script>');
     expect(html).toContain('og:type" content="article"');
-    expect(html).toContain(
-      'og:image" content="https://i.ecency.com/1200x630/https://img.example/meta.png"',
+    // render-helper's modern proxy path: a hashed /p/ URL with explicit
+    // dimensions, not the legacy redirecting /WxH/ route.
+    expect(html).toMatch(
+      /og:image" content="https:\/\/i\.ecency\.com\/p\/[A-Za-z0-9]+\?format=match&amp;mode=fit&amp;width=1200&amp;height=630"/,
     );
     expect(html).toContain('Some words to read here');
     expect(html).toContain(

--- a/apps/self-hosted/hosting/api/src/services/post-meta.ts
+++ b/apps/self-hosted/hosting/api/src/services/post-meta.ts
@@ -65,6 +65,32 @@ export function resetPostMetaCache(): void {
 // the second layer.
 const RPC_TIMEOUT_MS = 2500;
 
+/** A tenant's own image proxy, when the config carries a valid one. */
+function proxyBaseOf(tenant: Tenant): string | null {
+  const configured = (tenant.config as any)?.configuration?.general?.imageProxy;
+  return typeof configured === 'string' && /^https?:\/\//i.test(configured)
+    ? configured.replace(/\/+$/, '')
+    : null;
+}
+
+/**
+ * render-helper emits proxy URLs on its module-global base, and a
+ * multi-tenant server must not flip that global per request. A tenant's
+ * configured proxy is honored by rebasing the emitted URL instead: the /p/
+ * route is content-addressed by the hash, so the same path answers on any
+ * imagehoster deployment.
+ */
+function rebaseProxyUrl(url: string, customBase: string | null): string {
+  if (!customBase) return url;
+  try {
+    const parsed = new URL(url);
+    if (!parsed.pathname.startsWith('/p/')) return url;
+    return `${customBase}${parsed.pathname}${parsed.search}`;
+  } catch {
+    return url;
+  }
+}
+
 async function getPostCached(author: string, permlink: string): Promise<any | null> {
   const key = `${author}/${permlink}`;
   const hit = postCache.get(key);
@@ -134,7 +160,10 @@ export async function buildMetaForUri(tenant: Tenant, uri: unknown): Promise<str
   // fences, and emits the modern proxy path instead of the legacy sized
   // route that answers with a redirect. Chain-authored, so escaped.
   const coverProxied = catchPostImage(post, 1200, 630, 'match');
-  const ogImage = coverProxied ? escapeHtml(coverProxied) : null;
+  const cover = coverProxied
+    ? rebaseProxyUrl(coverProxied, proxyBaseOf(tenant))
+    : null;
+  const ogImage = cover ? escapeHtml(cover) : null;
 
   const canonical = escapeHtml(
     `${TenantService.getBlogUrl(tenant)}/@${parsed.author}/${parsed.permlink}`,

--- a/apps/self-hosted/hosting/api/src/services/post-meta.ts
+++ b/apps/self-hosted/hosting/api/src/services/post-meta.ts
@@ -65,12 +65,22 @@ export function resetPostMetaCache(): void {
 // the second layer.
 const RPC_TIMEOUT_MS = 2500;
 
-/** A tenant's own image proxy, when the config carries a valid one. */
+/**
+ * A tenant's own image proxy, when the config carries a valid one. Parsed,
+ * not prefix-matched: "https://" or "https://?x" would pass a protocol
+ * regex and produce malformed social-image URLs instead of the default
+ * proxy. Query and fragment are dropped; a path prefix is kept.
+ */
 function proxyBaseOf(tenant: Tenant): string | null {
   const configured = (tenant.config as any)?.configuration?.general?.imageProxy;
-  return typeof configured === 'string' && /^https?:\/\//i.test(configured)
-    ? configured.replace(/\/+$/, '')
-    : null;
+  if (typeof configured !== 'string') return null;
+  try {
+    const parsed = new URL(configured);
+    if (!/^https?:$/.test(parsed.protocol) || !parsed.hostname) return null;
+    return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, '');
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/apps/self-hosted/hosting/api/src/services/post-meta.ts
+++ b/apps/self-hosted/hosting/api/src/services/post-meta.ts
@@ -1,7 +1,24 @@
+import { createRequire } from 'node:module';
 import { callRPC } from '@ecency/sdk/hive';
+
+// render-helper through its CJS build: the package's node ESM entry carries
+// a directory import ('remarkable/linkify') that Node refuses, so the ESM
+// path crashes at module load. Tracked as a render-helper packaging fix;
+// until it ships, CJS resolution handles the directory import fine.
+const requireCjs = createRequire(import.meta.url);
+const { catchPostImage } = requireCjs('@ecency/render-helper') as {
+  catchPostImage: (
+    entry: unknown,
+    width?: number,
+    height?: number,
+    format?: string,
+  ) => string | null;
+};
 import type { Tenant } from '../types';
 import { ConfigService, escapeHtml } from './config-service';
 import { TenantService } from './tenant-service';
+import { canonicalPostUrl } from './seo-files';
+import { excerptOf } from '../utils/excerpt';
 
 /**
  * Per-post head metadata for link unfurls. The SPA sets OG tags client-side,
@@ -85,43 +102,6 @@ async function getPostCached(author: string, permlink: string): Promise<any | nu
   return post;
 }
 
-/** Strip markdown/html noise the way an excerpt should read. */
-function excerptOf(body: unknown, max = 200): string {
-  if (typeof body !== 'string') return '';
-  const text = body
-    .replace(/```[\s\S]*?```/g, ' ')
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-    .replace(/<[^>]*>/g, ' ')
-    .replace(/^#{1,6}\s+/gm, '')
-    .replace(/[`*_>~|]/g, ' ')
-    .replace(/https?:\/\/\S+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-  return text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text;
-}
-
-/** The post's cover: json_metadata image first, then the first body image. */
-function coverOf(post: any): string | null {
-  const metaImage = post?.json_metadata?.image?.[0];
-  if (typeof metaImage === 'string' && /^https?:\/\//i.test(metaImage)) {
-    return metaImage;
-  }
-  const body = typeof post?.body === 'string' ? post.body : '';
-  const md = /!\[[^\]]*\]\((https?:\/\/[^\s)]+)\)/.exec(body);
-  if (md) return md[1];
-  const html = /<img[^>]+src=["'](https?:\/\/[^\s"']+)["']/.exec(body);
-  if (html) return html[1];
-  return null;
-}
-
-function proxyBaseOf(tenant: Tenant): string {
-  const configured = (tenant.config as any)?.configuration?.general?.imageProxy;
-  return typeof configured === 'string' && /^https?:\/\//i.test(configured)
-    ? configured.replace(/\/+$/, '')
-    : 'https://i.ecency.com';
-}
-
 /**
  * The head snippet for one post. Falls back to the tenant snippet whenever
  * the URI is not a post or the post cannot be resolved, so this endpoint
@@ -149,12 +129,12 @@ export async function buildMetaForUri(tenant: Tenant, uri: unknown): Promise<str
     excerptOf(post.body) || `A post by @${parsed.author}`,
   );
 
-  const coverRaw = coverOf(post);
-  // Unfurl targets get a crawler-friendly size through the image proxy; the
-  // raw URL is chain-authored and untrusted, so it is escaped like the rest.
-  const ogImage = coverRaw
-    ? escapeHtml(`${proxyBaseOf(tenant)}/1200x630/${coverRaw}`)
-    : null;
+  // render-helper's own cover extraction and proxying, the same pipeline the
+  // apps render with: it understands string-form metadata, entities and code
+  // fences, and emits the modern proxy path instead of the legacy sized
+  // route that answers with a redirect. Chain-authored, so escaped.
+  const coverProxied = catchPostImage(post, 1200, 630, 'match');
+  const ogImage = coverProxied ? escapeHtml(coverProxied) : null;
 
   const canonical = escapeHtml(
     `${TenantService.getBlogUrl(tenant)}/@${parsed.author}/${parsed.permlink}`,
@@ -175,6 +155,9 @@ export async function buildMetaForUri(tenant: Tenant, uri: unknown): Promise<str
         ]
       : []),
     `<meta name="twitter:card" content="${ogImage ? 'summary_large_image' : 'summary'}" />`,
+    // Same canonical policy as the tenant snippet: the owner's own domain
+    // when one is verified, the ecency.com SSR post otherwise.
+    `<link rel="canonical" href="${escapeHtml(canonicalPostUrl(tenant, parsed.author, parsed.permlink))}" />`,
     '',
   ].join('\n');
 }

--- a/apps/self-hosted/hosting/api/src/services/seo-files.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/seo-files.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  callRPC: vi.fn(),
+}));
+
+vi.mock('@ecency/sdk/hive', () => ({ callRPC: mocks.callRPC }));
+vi.mock('./tenant-service', () => ({
+  TenantService: {
+    getBlogUrl: (t: any) =>
+      t.customDomain && t.customDomainVerified
+        ? `https://${t.customDomain}`
+        : `https://${t.username}.blogs.ecency.com`,
+  },
+}));
+
+const {
+  buildRobotsTxt,
+  buildRssXml,
+  buildSitemapXml,
+  canonicalHomeUrl,
+  canonicalPostUrl,
+  fetchTenantPosts,
+} = await import('./seo-files');
+
+const TENANT = {
+  username: 'alice',
+  customDomain: null,
+  customDomainVerified: false,
+  config: {
+    configuration: {
+      instanceConfiguration: { meta: { title: 'Alice writes', description: 'Notes' } },
+    },
+  },
+} as any;
+
+const CUSTOM_TENANT = {
+  ...TENANT,
+  customDomain: 'blog.alice.example',
+  customDomainVerified: true,
+} as any;
+
+const POSTS = [
+  {
+    author: 'alice',
+    permlink: 'first-post',
+    title: 'First <post>',
+    created: '2026-08-01T10:00:00',
+    updated: '2026-08-02T11:00:00',
+    body: 'Some **words** and ![img](https://a.b/c.png)',
+  },
+];
+
+describe('seo file builders', () => {
+  it('robots carries the sitemap line for the served domain', () => {
+    expect(buildRobotsTxt(TENANT)).toBe(
+      'User-agent: *\nAllow: /\nSitemap: https://alice.blogs.ecency.com/sitemap.xml\n',
+    );
+  });
+
+  it('sitemap lists home, about and posts with W3C lastmod', () => {
+    const xml = buildSitemapXml(TENANT, POSTS as any);
+    expect(xml).toContain('<loc>https://alice.blogs.ecency.com/</loc>');
+    expect(xml).toContain('<loc>https://alice.blogs.ecency.com/about</loc>');
+    expect(xml).toContain(
+      '<loc>https://alice.blogs.ecency.com/@alice/first-post</loc>',
+    );
+    expect(xml).toContain('<lastmod>2026-08-02T11:00:00.000Z</lastmod>');
+  });
+
+  it('rss escapes chain text and stamps RFC822 dates with a self link', () => {
+    const xml = buildRssXml(TENANT, POSTS as any);
+    expect(xml).toContain('<title>Alice writes</title>');
+    expect(xml).toContain('<title>First &lt;post&gt;</title>');
+    expect(xml).not.toContain('<post>');
+    expect(xml).toContain('<pubDate>Sat, 01 Aug 2026 10:00:00 GMT</pubDate>');
+    expect(xml).toContain(
+      'href="https://alice.blogs.ecency.com/rss.xml" rel="self"',
+    );
+    expect(xml).toContain('Some words and');
+  });
+});
+
+describe('canonical policy', () => {
+  it('a verified custom domain canonicalizes to itself', () => {
+    expect(canonicalHomeUrl(CUSTOM_TENANT)).toBe('https://blog.alice.example');
+    expect(canonicalPostUrl(CUSTOM_TENANT, 'alice', 'p')).toBe(
+      'https://blog.alice.example/@alice/p',
+    );
+  });
+
+  it('a subdomain tenant canonicalizes to the ecency.com SSR pages', () => {
+    expect(canonicalHomeUrl(TENANT)).toBe('https://ecency.com/@alice');
+    expect(canonicalPostUrl(TENANT, 'alice', 'p')).toBe(
+      'https://ecency.com/@alice/p',
+    );
+    const community = {
+      ...TENANT,
+      username: 'hive-125125',
+      config: {
+        configuration: {
+          instanceConfiguration: { type: 'community', communityId: 'hive-125125' },
+        },
+      },
+    } as any;
+    expect(canonicalHomeUrl(community)).toBe(
+      'https://ecency.com/created/hive-125125',
+    );
+  });
+});
+
+describe('fetchTenantPosts', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('pages the account feed for a blog and the ranked feed for a community', async () => {
+    mocks.callRPC.mockResolvedValue(POSTS);
+    await fetchTenantPosts(TENANT);
+    expect(mocks.callRPC).toHaveBeenCalledWith(
+      'bridge.get_account_posts',
+      expect.objectContaining({ account: 'alice', sort: 'posts' }),
+    );
+
+    const community = {
+      ...TENANT,
+      config: {
+        configuration: {
+          instanceConfiguration: { type: 'community', communityId: 'hive-1' },
+        },
+      },
+    } as any;
+    await fetchTenantPosts(community);
+    expect(mocks.callRPC).toHaveBeenCalledWith(
+      'bridge.get_ranked_posts',
+      expect.objectContaining({ tag: 'hive-1', sort: 'created' }),
+    );
+  });
+
+  it('answers an empty list for a malformed response', async () => {
+    mocks.callRPC.mockResolvedValue({ nope: true });
+    expect(await fetchTenantPosts(TENANT)).toEqual([]);
+  });
+});

--- a/apps/self-hosted/hosting/api/src/services/seo-files.test.ts
+++ b/apps/self-hosted/hosting/api/src/services/seo-files.test.ts
@@ -118,6 +118,9 @@ describe('fetchTenantPosts', () => {
     expect(mocks.callRPC).toHaveBeenCalledWith(
       'bridge.get_account_posts',
       expect.objectContaining({ account: 'alice', sort: 'posts' }),
+      expect.any(Number),
+      undefined,
+      expect.any(AbortSignal),
     );
 
     const community = {
@@ -132,11 +135,32 @@ describe('fetchTenantPosts', () => {
     expect(mocks.callRPC).toHaveBeenCalledWith(
       'bridge.get_ranked_posts',
       expect.objectContaining({ tag: 'hive-1', sort: 'created' }),
+      expect.any(Number),
+      undefined,
+      expect.any(AbortSignal),
     );
   });
 
-  it('answers an empty list for a malformed response', async () => {
+  it('throws on a malformed response so stale files are kept, never blanked', async () => {
     mocks.callRPC.mockResolvedValue({ nope: true });
-    expect(await fetchTenantPosts(TENANT)).toEqual([]);
+    await expect(fetchTenantPosts(TENANT)).rejects.toThrow('malformed');
+  });
+
+  it('drops or normalizes malformed records instead of failing the pass', async () => {
+    mocks.callRPC.mockResolvedValue([
+      { author: 'a', permlink: 'p', created: 1 },
+      { author: 'a', permlink: 'q', created: '2026-08-01T00:00:00', updated: 7, title: 9 },
+    ]);
+    const posts = await fetchTenantPosts(TENANT);
+    expect(posts).toEqual([
+      {
+        author: 'a',
+        permlink: 'q',
+        title: '',
+        created: '2026-08-01T00:00:00',
+        updated: undefined,
+        body: undefined,
+      },
+    ]);
   });
 });

--- a/apps/self-hosted/hosting/api/src/services/seo-files.ts
+++ b/apps/self-hosted/hosting/api/src/services/seo-files.ts
@@ -74,18 +74,16 @@ function isCommunityTenant(tenant: Tenant): {
   };
 }
 
-async function bounded<T>(work: Promise<T>): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
+/**
+ * A bounded AND aborted chain call: the per-attempt timeout goes to the SDK
+ * and the controller cancels the request outright at the same deadline, so a
+ * timed-out fetch stops consuming a socket instead of racing on unobserved.
+ */
+async function boundedCall<T>(method: string, params: object): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), RPC_TIMEOUT_MS);
   try {
-    return await Promise.race([
-      work,
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error('seo rpc timeout')),
-          RPC_TIMEOUT_MS,
-        );
-      }),
-    ]);
+    return await callRPC<T>(method, params, RPC_TIMEOUT_MS, undefined, controller.signal);
   } finally {
     clearTimeout(timer);
   }
@@ -95,27 +93,46 @@ async function bounded<T>(work: Promise<T>): Promise<T> {
 export async function fetchTenantPosts(tenant: Tenant): Promise<TenantPost[]> {
   const { community, communityId } = isCommunityTenant(tenant);
   const raw = community
-    ? await bounded(
-        callRPC('bridge.get_ranked_posts', {
-          sort: 'created',
-          tag: communityId,
-          limit: POST_LIMIT,
-          observer: '',
-        }),
-      )
-    : await bounded(
-        callRPC('bridge.get_account_posts', {
-          sort: 'posts',
-          account: tenant.username,
-          limit: POST_LIMIT,
-          observer: '',
-        }),
-      );
-  if (!Array.isArray(raw)) return [];
-  return raw.filter(
-    (p: any): p is TenantPost =>
-      typeof p?.author === 'string' && typeof p?.permlink === 'string',
-  );
+    ? await boundedCall<unknown>('bridge.get_ranked_posts', {
+        sort: 'created',
+        tag: communityId,
+        limit: POST_LIMIT,
+        observer: '',
+      })
+    : await boundedCall<unknown>('bridge.get_account_posts', {
+        sort: 'posts',
+        account: tenant.username,
+        limit: POST_LIMIT,
+        observer: '',
+      });
+  // A malformed answer is an ERROR, never an empty blog: returning [] here
+  // would overwrite a good sitemap and feed with empty ones and mark them
+  // fresh, while throwing lets the sync pass keep yesterday's files.
+  if (!Array.isArray(raw)) {
+    throw new Error('malformed bridge feed response');
+  }
+  // Every field the builders touch is type-checked here: a malformed record
+  // (a numeric date, a missing permlink) is dropped or normalized instead of
+  // failing the tenant's whole SEO pass on an .endsWith of a number.
+  const posts: TenantPost[] = [];
+  for (const p of raw as any[]) {
+    if (
+      typeof p?.author !== 'string' ||
+      typeof p?.permlink !== 'string' ||
+      typeof p?.created !== 'string'
+    ) {
+      continue;
+    }
+    posts.push({
+      author: p.author,
+      permlink: p.permlink,
+      title: typeof p.title === 'string' ? p.title : '',
+      created: p.created,
+      updated: typeof p.updated === 'string' ? p.updated : undefined,
+      body: typeof p.body === 'string' ? p.body : undefined,
+    });
+  }
+  return posts;
 }
 
 export function buildRobotsTxt(tenant: Tenant): string {

--- a/apps/self-hosted/hosting/api/src/services/seo-files.ts
+++ b/apps/self-hosted/hosting/api/src/services/seo-files.ts
@@ -1,0 +1,213 @@
+import { callRPC } from '@ecency/sdk/hive';
+import type { Tenant } from '../types';
+import { escapeHtml } from '../utils/escape-html';
+import { excerptOf } from '../utils/excerpt';
+import { TenantService } from './tenant-service';
+
+/**
+ * Per-tenant static SEO files: robots.txt (with its Sitemap line),
+ * sitemap.xml and rss.xml, written into the served configs volume by the
+ * periodic sync pass. Static by design: crawlers and feed readers read
+ * files nginx serves from disk, and no request ever waits on the chain.
+ *
+ * Everything in these files is chain- or owner-authored and lands in
+ * documents other parsers read, so URLs and text are escaped for the
+ * containing format.
+ */
+
+/**
+ * Canonical policy (decided 2026-08): a tenant with a VERIFIED custom domain
+ * has invested in its own address and canonicalizes to itself; a subdomain
+ * tenant canonicalizes to the ecency.com SSR page, whose rendered HTML
+ * indexes better than an empty-before-JS SPA body. og:url stays the served
+ * URL either way; only rel=canonical follows the policy.
+ */
+export function canonicalHomeUrl(tenant: Tenant): string {
+  if (tenant.customDomain && tenant.customDomainVerified) {
+    return TenantService.getBlogUrl(tenant);
+  }
+  const { community, communityId } = isCommunityTenant(tenant);
+  return community
+    ? `https://ecency.com/created/${communityId}`
+    : `https://ecency.com/@${tenant.username}`;
+}
+
+export function canonicalPostUrl(
+  tenant: Tenant,
+  author: string,
+  permlink: string,
+): string {
+  if (tenant.customDomain && tenant.customDomainVerified) {
+    return `${TenantService.getBlogUrl(tenant)}/@${author}/${permlink}`;
+  }
+  return `https://ecency.com/@${author}/${permlink}`;
+}
+
+/** How many posts feeds and sitemaps carry; one bridge page. */
+const POST_LIMIT = 100;
+/** A pass regenerates a tenant's files only when they are older than this. */
+export const SEO_FRESH_MS = 30 * 60 * 1000;
+/** The background pass is patient but never unbounded. */
+const RPC_TIMEOUT_MS = 10_000;
+
+interface TenantPost {
+  author: string;
+  permlink: string;
+  title: string;
+  created: string;
+  updated?: string;
+  body?: string;
+}
+
+function isCommunityTenant(tenant: Tenant): {
+  community: boolean;
+  communityId: string;
+} {
+  const instance = (tenant.config as any)?.configuration?.instanceConfiguration;
+  const community = instance?.type === 'community';
+  return {
+    community,
+    communityId:
+      typeof instance?.communityId === 'string' && instance.communityId
+        ? instance.communityId
+        : tenant.username,
+  };
+}
+
+async function bounded<T>(work: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error('seo rpc timeout')),
+          RPC_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** The tenant's latest posts, the same feeds the archive itself pages. */
+export async function fetchTenantPosts(tenant: Tenant): Promise<TenantPost[]> {
+  const { community, communityId } = isCommunityTenant(tenant);
+  const raw = community
+    ? await bounded(
+        callRPC('bridge.get_ranked_posts', {
+          sort: 'created',
+          tag: communityId,
+          limit: POST_LIMIT,
+          observer: '',
+        }),
+      )
+    : await bounded(
+        callRPC('bridge.get_account_posts', {
+          sort: 'posts',
+          account: tenant.username,
+          limit: POST_LIMIT,
+          observer: '',
+        }),
+      );
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (p: any): p is TenantPost =>
+      typeof p?.author === 'string' && typeof p?.permlink === 'string',
+  );
+}
+
+export function buildRobotsTxt(tenant: Tenant): string {
+  const blogUrl = TenantService.getBlogUrl(tenant);
+  return ['User-agent: *', 'Allow: /', `Sitemap: ${blogUrl}/sitemap.xml`, ''].join(
+    '\n',
+  );
+}
+
+/** W3C datetime for <lastmod>; bridge dates carry no zone and mean UTC. */
+function lastmodOf(post: TenantPost): string | null {
+  const raw = post.updated || post.created;
+  if (!raw) return null;
+  const parsed = Date.parse(raw.endsWith('Z') ? raw : `${raw}Z`);
+  if (Number.isNaN(parsed)) return null;
+  return new Date(parsed).toISOString();
+}
+
+export function buildSitemapXml(tenant: Tenant, posts: TenantPost[]): string {
+  const blogUrl = TenantService.getBlogUrl(tenant);
+  const urls: string[] = [
+    `  <url><loc>${escapeHtml(blogUrl + '/')}</loc></url>`,
+    `  <url><loc>${escapeHtml(blogUrl + '/about')}</loc></url>`,
+  ];
+  for (const post of posts) {
+    const loc = escapeHtml(`${blogUrl}/@${post.author}/${post.permlink}`);
+    const lastmod = lastmodOf(post);
+    urls.push(
+      lastmod
+        ? `  <url><loc>${loc}</loc><lastmod>${lastmod}</lastmod></url>`
+        : `  <url><loc>${loc}</loc></url>`,
+    );
+  }
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...urls,
+    '</urlset>',
+    '',
+  ].join('\n');
+}
+
+/** RFC 822 for <pubDate>, the format RSS 2.0 readers expect. */
+function pubDateOf(post: TenantPost): string | null {
+  const raw = post.created;
+  if (!raw) return null;
+  const parsed = Date.parse(raw.endsWith('Z') ? raw : `${raw}Z`);
+  if (Number.isNaN(parsed)) return null;
+  return new Date(parsed).toUTCString();
+}
+
+export function buildRssXml(tenant: Tenant, posts: TenantPost[]): string {
+  const blogUrl = TenantService.getBlogUrl(tenant);
+  const meta = (tenant.config as any)?.configuration?.instanceConfiguration?.meta ?? {};
+  const title = escapeHtml(
+    (typeof meta.title === 'string' && meta.title.trim()) ||
+      `${tenant.username} blog`,
+  );
+  const description = escapeHtml(
+    (typeof meta.description === 'string' && meta.description.trim()) ||
+      'A blog powered by Hive blockchain and Ecency.',
+  );
+
+  const items = posts.map((post) => {
+    const link = escapeHtml(`${blogUrl}/@${post.author}/${post.permlink}`);
+    const itemTitle = escapeHtml(
+      (typeof post.title === 'string' && post.title.trim()) ||
+        `@${post.author}/${post.permlink}`,
+    );
+    const pubDate = pubDateOf(post);
+    return [
+      '    <item>',
+      `      <title>${itemTitle}</title>`,
+      `      <link>${link}</link>`,
+      `      <guid isPermaLink="true">${link}</guid>`,
+      ...(pubDate ? [`      <pubDate>${pubDate}</pubDate>`] : []),
+      `      <description>${escapeHtml(excerptOf(post.body))}</description>`,
+      '    </item>',
+    ].join('\n');
+  });
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    '  <channel>',
+    `    <title>${title}</title>`,
+    `    <link>${escapeHtml(blogUrl)}</link>`,
+    `    <description>${description}</description>`,
+    `    <atom:link href="${escapeHtml(blogUrl + '/rss.xml')}" rel="self" type="application/rss+xml" />`,
+    ...items,
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n');
+}

--- a/apps/self-hosted/hosting/api/src/utils/escape-html.test.ts
+++ b/apps/self-hosted/hosting/api/src/utils/escape-html.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { escapeHtml } from './escape-html';
+
+describe('escapeHtml', () => {
+  it('escapes markup metacharacters', () => {
+    expect(escapeHtml(`<a href="x">&'</a>`)).toBe(
+      '&lt;a href=&quot;x&quot;&gt;&amp;&#39;&lt;/a&gt;',
+    );
+  });
+
+  it('removes XML-invalid control characters and non-characters', () => {
+    // One chain-authored control char must not unparse a whole feed.
+    expect(escapeHtml('a\u0000b\u000Bc\u001Fd\uFFFEe')).toBe('abcde');
+    // Tab and newlines are VALID XML and survive.
+    expect(escapeHtml('a\tb\nc')).toBe('a\tb\nc');
+  });
+
+  it('removes lone surrogate halves but keeps real astral pairs', () => {
+    expect(escapeHtml('a\uD800b')).toBe('ab');
+    expect(escapeHtml('a\uDC00b')).toBe('ab');
+    expect(escapeHtml('a😀b')).toBe('a😀b');
+  });
+});

--- a/apps/self-hosted/hosting/api/src/utils/escape-html.ts
+++ b/apps/self-hosted/hosting/api/src/utils/escape-html.ts
@@ -1,6 +1,9 @@
 /**
- * XML 1.0 forbids most control characters and non-characters outright, and
- * lone surrogate halves are invalid in any well-formed document. One
+ * XML 1.0 forbids C0 control characters (beyond tab, LF, CR), U+FFFE/FFFF
+ * and lone surrogate halves outright. The C1 controls (U+007F-9F ranges)
+ * and the U+FDD0-FDEF non-characters are Char-valid but sit on the spec's
+ * own discouraged list (XML 1.0 5e, section 2.2) and are flagged by the
+ * W3C feed validator; neither kind carries content, so both sets go. One
  * chain-authored post carrying a stray \u000B must not make a tenant's
  * entire feed or sitemap unparsable, so invalid code points are REMOVED
  * before entity escaping. HTML meta snippets go through the same path;

--- a/apps/self-hosted/hosting/api/src/utils/escape-html.ts
+++ b/apps/self-hosted/hosting/api/src/utils/escape-html.ts
@@ -1,6 +1,22 @@
+/**
+ * XML 1.0 forbids most control characters and non-characters outright, and
+ * lone surrogate halves are invalid in any well-formed document. One
+ * chain-authored post carrying a stray \u000B must not make a tenant's
+ * entire feed or sitemap unparsable, so invalid code points are REMOVED
+ * before entity escaping. HTML meta snippets go through the same path;
+ * control characters are junk there too.
+ */
+const INVALID_XML_CHARS =
+  // eslint-disable-next-line no-control-regex
+  /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u0084\u0086-\u009F\uFDD0-\uFDEF\uFFFE\uFFFF]/g;
+const LONE_SURROGATES =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
 /** Escape a string for safe interpolation into HTML/XML text and attributes. */
 export function escapeHtml(value: string): string {
   return value
+    .replace(LONE_SURROGATES, '')
+    .replace(INVALID_XML_CHARS, '')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')

--- a/apps/self-hosted/hosting/api/src/utils/escape-html.ts
+++ b/apps/self-hosted/hosting/api/src/utils/escape-html.ts
@@ -1,0 +1,9 @@
+/** Escape a string for safe interpolation into HTML/XML text and attributes. */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/apps/self-hosted/hosting/api/src/utils/excerpt.ts
+++ b/apps/self-hosted/hosting/api/src/utils/excerpt.ts
@@ -1,0 +1,15 @@
+/** Strip markdown/html noise the way an excerpt should read. */
+export function excerptOf(body: unknown, max = 200): string {
+  if (typeof body !== 'string') return '';
+  const text = body
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/[`*_>~|]/g, ' ')
+    .replace(/https?:\/\/\S+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text;
+}

--- a/apps/self-hosted/hosting/nginx-multi-tenant.conf
+++ b/apps/self-hosted/hosting/nginx-multi-tenant.conf
@@ -120,6 +120,19 @@ server {
         try_files /configs/$tenant_id.meta.html /meta.html =404;
     }
 
+    # Per-tenant static SEO files, written by the hosting API's sync pass.
+    # robots falls back to the generic file baked in the image; sitemap and
+    # rss simply 404 until the first pass writes them.
+    location = /robots.txt {
+        try_files /configs/$tenant_id.robots.txt /robots.txt =404;
+    }
+    location = /sitemap.xml {
+        try_files /configs/$tenant_id.sitemap.xml =404;
+    }
+    location = /rss.xml {
+        try_files /configs/$tenant_id.rss.xml =404;
+    }
+
     # Static assets - shared across all tenants
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
@@ -194,6 +207,17 @@ server {
         ssi off;
         default_type text/html;
         try_files /configs/$custom_tenant_id.meta.html /meta.html =404;
+    }
+
+    # Same static SEO files, keyed by custom tenant.
+    location = /robots.txt {
+        try_files /configs/$custom_tenant_id.robots.txt /robots.txt =404;
+    }
+    location = /sitemap.xml {
+        try_files /configs/$custom_tenant_id.sitemap.xml =404;
+    }
+    location = /rss.xml {
+        try_files /configs/$custom_tenant_id.rss.xml =404;
     }
 
     # Same static asset handling

--- a/apps/self-hosted/src/core/configuration-loader.ts
+++ b/apps/self-hosted/src/core/configuration-loader.ts
@@ -59,6 +59,13 @@ export interface InstanceConfig {
       timeFormat: string;
       dateTimeFormat: string;
       imageProxy: string;
+      /**
+       * An explicit feed URL for the RSS link. Independent deployments that
+       * run the SEO generator point this at their own /rss.xml; absent,
+       * managed instances use their served feed and everything else the
+       * ecency.com one.
+       */
+      rssFeedUrl?: string;
       profileBaseUrl: string;
       createPostUrl: string;
     /**

--- a/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
@@ -17,7 +17,10 @@ import { formatDate, InstanceConfigManager, t } from '@/core';
 import { UserAvatar } from '@/features/shared/user-avatar';
 import { useHiveLayer } from '../hooks/use-hive-layer';
 import { estimateReadMinutes } from '../utils/read-time';
-import { useThemeShowsReadTime } from '@/themes/use-theme-components';
+import {
+  useThemeGridSizes,
+  useThemeShowsReadTime,
+} from '@/themes/use-theme-components';
 import { PostPayout } from './post-payout';
 
 interface Props {
@@ -99,13 +102,14 @@ export function BlogPostItem({ entry }: Props) {
   }, [entryData]);
 
   // Width variants of the same proxied image, so a phone never downloads the
-  // 800px cut a desktop grid cell needs. Sizes below mirror each layout's
-  // actual box; the CSS height token already pins the box, so no CLS either
-  // way.
+  // 800px cut a desktop grid cell needs. The grid sizes come from the
+  // theme's own column variables; the CSS height token already pins the
+  // box, so no CLS either way.
   const imageSrcSet = useMemo(
     () => (imageUrl ? buildSrcSet(imageUrl) || undefined : undefined),
     [imageUrl],
   );
+  const gridSizes = useThemeGridSizes();
 
   // Router navigation, not a document load: an <a href> here tore down the SPA
   // on every feed-to-post click, refetching the instance config and throwing
@@ -151,7 +155,7 @@ export function BlogPostItem({ entry }: Props) {
             <img
               src={imageUrl}
               srcSet={imageSrcSet}
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              sizes={gridSizes}
               alt={entryData.title}
               className="w-full object-cover post-card-image-theme"
               loading="lazy"

--- a/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
+++ b/apps/self-hosted/src/features/blog/components/blog-post-item.tsx
@@ -1,4 +1,5 @@
 import {
+  buildSrcSet,
   catchPostImage,
   postBodySummary,
   renderPostBody,
@@ -97,6 +98,15 @@ export function BlogPostItem({ entry }: Props) {
     return catchPostImage(entryData, 800, 600) || null;
   }, [entryData]);
 
+  // Width variants of the same proxied image, so a phone never downloads the
+  // 800px cut a desktop grid cell needs. Sizes below mirror each layout's
+  // actual box; the CSS height token already pins the box, so no CLS either
+  // way.
+  const imageSrcSet = useMemo(
+    () => (imageUrl ? buildSrcSet(imageUrl) || undefined : undefined),
+    [imageUrl],
+  );
+
   // Router navigation, not a document load: an <a href> here tore down the SPA
   // on every feed-to-post click, refetching the instance config and throwing
   // away the query cache the feed had just filled. The route param carries the
@@ -140,6 +150,8 @@ export function BlogPostItem({ entry }: Props) {
           <Link to="/$author/$permlink" params={postParams} search={postSearch}>
             <img
               src={imageUrl}
+              srcSet={imageSrcSet}
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
               alt={entryData.title}
               className="w-full object-cover post-card-image-theme"
               loading="lazy"
@@ -259,6 +271,8 @@ export function BlogPostItem({ entry }: Props) {
             >
               <img
                 src={imageUrl}
+                srcSet={imageSrcSet}
+                sizes="(max-width: 640px) 100vw, 200px"
                 alt={entryData.title}
                 className="w-full h-48 sm:h-32 object-cover rounded-theme"
                 loading="lazy"

--- a/apps/self-hosted/src/features/blog/layout/blog-navigation.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-navigation.tsx
@@ -129,7 +129,10 @@ function RssFeedLink() {
     ({ configuration }) =>
       configuration.instanceConfiguration.managed === true,
   );
-  const rssUrl = getRssFeedUrl(type, username, communityId, managed);
+  const rssOverride = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.general.rssFeedUrl,
+  );
+  const rssUrl = getRssFeedUrl(type, username, communityId, managed, rssOverride);
 
   if (!rssUrl) return null;
 

--- a/apps/self-hosted/src/features/blog/layout/blog-navigation.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-navigation.tsx
@@ -125,7 +125,11 @@ export function BlogNavigation() {
 
 function RssFeedLink() {
   const { username, communityId, type } = useInstanceConfig();
-  const rssUrl = getRssFeedUrl(type, username, communityId);
+  const managed = InstanceConfigManager.useConfig(
+    ({ configuration }) =>
+      configuration.instanceConfiguration.managed === true,
+  );
+  const rssUrl = getRssFeedUrl(type, username, communityId, managed);
 
   if (!rssUrl) return null;
 

--- a/apps/self-hosted/src/index.tsx
+++ b/apps/self-hosted/src/index.tsx
@@ -99,7 +99,12 @@ function applyConfig() {
   }
 
   // Add RSS feed auto-discovery link
-  const rssUrl = getRssFeedUrl(instanceType, instanceConfiguration.username, instanceConfiguration.communityId);
+  const rssUrl = getRssFeedUrl(
+    instanceType,
+    instanceConfiguration.username,
+    instanceConfiguration.communityId,
+    instanceConfiguration.managed === true,
+  );
   const existingRssLink = document.querySelector('link[rel="alternate"][type="application/rss+xml"]') as HTMLLinkElement | null;
   if (rssUrl) {
     const rssLink = existingRssLink ?? document.createElement('link');

--- a/apps/self-hosted/src/index.tsx
+++ b/apps/self-hosted/src/index.tsx
@@ -104,6 +104,7 @@ function applyConfig() {
     instanceConfiguration.username,
     instanceConfiguration.communityId,
     instanceConfiguration.managed === true,
+    config.configuration.general.rssFeedUrl,
   );
   const existingRssLink = document.querySelector('link[rel="alternate"][type="application/rss+xml"]') as HTMLLinkElement | null;
   if (rssUrl) {

--- a/apps/self-hosted/src/themes/grid-sizes.test.ts
+++ b/apps/self-hosted/src/themes/grid-sizes.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { computeThemeGridSizes } from './grid-sizes';
+
+const VARS = ['--theme-grid-columns-tablet', '--theme-grid-columns-desktop'];
+
+describe('computeThemeGridSizes', () => {
+  afterEach(() => {
+    for (const name of VARS) {
+      document.documentElement.style.removeProperty(name);
+    }
+  });
+
+  it('derives the sizes hint from the theme column variables', () => {
+    // One column everywhere, the Reader and Journal shape.
+    document.documentElement.style.setProperty('--theme-grid-columns-tablet', '1');
+    document.documentElement.style.setProperty('--theme-grid-columns-desktop', '1');
+    expect(computeThemeGridSizes('reader')).toBe(
+      '(max-width: 767px) 100vw, (max-width: 1023px) 100vw, 100vw',
+    );
+
+    // Two columns everywhere, the Minimal and Developer shape.
+    document.documentElement.style.setProperty('--theme-grid-columns-tablet', '2');
+    document.documentElement.style.setProperty('--theme-grid-columns-desktop', '2');
+    expect(computeThemeGridSizes('minimal')).toBe(
+      '(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 50vw',
+    );
+  });
+
+  it('falls back to the default two-then-three grid when variables are absent or junk', () => {
+    expect(computeThemeGridSizes('medium')).toBe(
+      '(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 33vw',
+    );
+
+    document.documentElement.style.setProperty('--theme-grid-columns-tablet', 'banana');
+    document.documentElement.style.setProperty('--theme-grid-columns-desktop', '-2');
+    expect(computeThemeGridSizes('medium')).toBe(
+      '(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 33vw',
+    );
+  });
+});

--- a/apps/self-hosted/src/themes/grid-sizes.ts
+++ b/apps/self-hosted/src/themes/grid-sizes.ts
@@ -1,0 +1,31 @@
+/**
+ * A `sizes` attribute matching the theme's OWN grid. The column counts live
+ * in the --theme-grid-columns-* custom properties that components.css
+ * consumes behind 768px and 1024px media queries, so the image hint reads
+ * that same source: a hard-coded three-column assumption had browsers
+ * fetching undersized images on the one-column Reader and Journal grids and
+ * the two-column Minimal and Developer grids.
+ *
+ * The parameter only keys memoization; the values come from computed style
+ * on the document root, where apply-config-dom stamps data-style-template.
+ * By the time a render reads this the attribute reflects the template being
+ * rendered: boot applies the DOM declaration before mounting, and preview
+ * applies it before React flushes the store update.
+ */
+export function computeThemeGridSizes(_styleTemplate: unknown): string {
+  const columnsOf = (name: string, fallback: number): number => {
+    if (typeof document === 'undefined') return fallback;
+    const raw = getComputedStyle(document.documentElement)
+      .getPropertyValue(name)
+      .trim();
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  };
+  const tablet = columnsOf('--theme-grid-columns-tablet', 2);
+  const desktop = columnsOf('--theme-grid-columns-desktop', 3);
+  return [
+    '(max-width: 767px) 100vw',
+    `(max-width: 1023px) ${Math.round(100 / tablet)}vw`,
+    `${Math.round(100 / desktop)}vw`,
+  ].join(', ');
+}

--- a/apps/self-hosted/src/themes/journal/journal-post-card.tsx
+++ b/apps/self-hosted/src/themes/journal/journal-post-card.tsx
@@ -3,6 +3,7 @@ import type { Entry } from '@ecency/sdk';
 import { catchPostImage, postBodySummary } from '@ecency/render-helper';
 import { useMemo } from 'react';
 import { estimateReadMinutes } from '@/features/blog/utils/read-time';
+import { buildSrcSet } from '@ecency/render-helper';
 import { useThemeShowsReadTime } from '@/themes/use-theme-components';
 import { formatDate, t } from '@/core';
 
@@ -100,6 +101,8 @@ export function JournalPostCard({ entry }: Props) {
           >
             <img
               src={imageUrl}
+              srcSet={imageUrl ? buildSrcSet(imageUrl) || undefined : undefined}
+              sizes="112px"
               alt=""
               loading="lazy"
               className="size-28 object-cover rounded-[var(--theme-post-card-image-radius)]"

--- a/apps/self-hosted/src/themes/use-theme-components.ts
+++ b/apps/self-hosted/src/themes/use-theme-components.ts
@@ -7,6 +7,7 @@ import { BlogNavigation } from '@/features/blog/layout/blog-navigation';
 import { BlogSidebar } from '@/features/blog/layout/blog-sidebar';
 import type { ThemeComponents } from './manifest';
 import { getThemeManifest } from './registry';
+import { computeThemeGridSizes } from './grid-sizes';
 
 /**
  * The shared defaults behind every seam: exactly the components every
@@ -41,6 +42,18 @@ export function useThemeComponents(): ThemeComponents {
     ({ configuration }) => configuration.general.styleTemplate,
   );
   return useMemo(() => resolveThemeComponents(styleTemplate), [styleTemplate]);
+}
+
+/**
+ * The image `sizes` hint for the active theme's post grid (see
+ * computeThemeGridSizes). Keyed on the template like the resolvers above,
+ * so the Configuration Editor's template preview re-derives it live.
+ */
+export function useThemeGridSizes(): string {
+  const styleTemplate = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.general.styleTemplate,
+  );
+  return useMemo(() => computeThemeGridSizes(styleTemplate), [styleTemplate]);
 }
 
 /**

--- a/apps/self-hosted/src/utils/rss-feed-url.test.ts
+++ b/apps/self-hosted/src/utils/rss-feed-url.test.ts
@@ -54,10 +54,13 @@ describe('getRssFeedUrl', () => {
     expect(
       getRssFeedUrl('blog', 'alice', undefined, true, 'https://blog.example/rss.xml'),
     ).toBe('https://blog.example/rss.xml');
-    // Not a web URL: fall through to the normal resolution.
-    expect(
-      getRssFeedUrl('blog', 'alice', undefined, false, 'javascript:alert(1)'),
-    ).toBe('https://ecency.com/@alice/rss');
+    // Not a web URL: fall through to the normal resolution. A protocol
+    // prefix alone is not enough; hostless values must not become the link.
+    for (const junk of ['javascript:alert(1)', 'https://', 'https://?invalid', 'not a url']) {
+      expect(getRssFeedUrl('blog', 'alice', undefined, false, junk)).toBe(
+        'https://ecency.com/@alice/rss',
+      );
+    }
   });
 
 });

--- a/apps/self-hosted/src/utils/rss-feed-url.test.ts
+++ b/apps/self-hosted/src/utils/rss-feed-url.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
 import { getRssFeedUrl } from './rss-feed-url';
 
@@ -33,4 +34,19 @@ describe('getRssFeedUrl', () => {
   it('returns null for community type with whitespace communityId', () => {
     expect(getRssFeedUrl('community', '', '   ')).toBeNull();
   });
+
+  it('a managed instance serves its own feed instead of the ecency.com one', () => {
+    // jsdom's origin stands in for the tenant's; the point is the SELF feed.
+    expect(getRssFeedUrl('blog', 'alice', undefined, true)).toBe(
+      `${window.location.origin}/rss.xml`,
+    );
+    expect(getRssFeedUrl('community', undefined, 'hive-1', true)).toBe(
+      `${window.location.origin}/rss.xml`,
+    );
+    // Unmanaged keeps the ecency.com stand-in, never a 404 on itself.
+    expect(getRssFeedUrl('blog', 'alice', undefined, false)).toBe(
+      'https://ecency.com/@alice/rss',
+    );
+  });
+
 });

--- a/apps/self-hosted/src/utils/rss-feed-url.test.ts
+++ b/apps/self-hosted/src/utils/rss-feed-url.test.ts
@@ -49,4 +49,15 @@ describe('getRssFeedUrl', () => {
     );
   });
 
+
+  it('an explicit override outranks everything and junk overrides are ignored', () => {
+    expect(
+      getRssFeedUrl('blog', 'alice', undefined, true, 'https://blog.example/rss.xml'),
+    ).toBe('https://blog.example/rss.xml');
+    // Not a web URL: fall through to the normal resolution.
+    expect(
+      getRssFeedUrl('blog', 'alice', undefined, false, 'javascript:alert(1)'),
+    ).toBe('https://ecency.com/@alice/rss');
+  });
+
 });

--- a/apps/self-hosted/src/utils/rss-feed-url.ts
+++ b/apps/self-hosted/src/utils/rss-feed-url.ts
@@ -13,8 +13,17 @@ export function getRssFeedUrl(
   managed?: boolean,
   override?: string,
 ): string | null {
-  if (typeof override === 'string' && /^https?:\/\//i.test(override.trim())) {
-    return override.trim();
+  // Parsed, not prefix-matched: "https://" or "https://?x" would pass a
+  // protocol regex and render a dead feed link instead of the fallback.
+  if (typeof override === 'string') {
+    try {
+      const parsed = new URL(override.trim());
+      if (/^https?:$/.test(parsed.protocol) && parsed.hostname) {
+        return override.trim();
+      }
+    } catch {
+      // Malformed override: fall through to the derived URLs.
+    }
   }
   if (managed && typeof window !== 'undefined') {
     return `${window.location.origin}/rss.xml`;

--- a/apps/self-hosted/src/utils/rss-feed-url.ts
+++ b/apps/self-hosted/src/utils/rss-feed-url.ts
@@ -1,12 +1,19 @@
 /**
- * Builds the ecency.com RSS feed URL for a blog or community instance.
- * Returns null if the required identifier is missing.
+ * The RSS feed URL for this instance. A managed instance serves its own
+ * /rss.xml (written per tenant by the hosting API's sync pass and served
+ * statically by nginx); everywhere else the ecency.com feed for the same
+ * account or community stands in, so the link never points at a file that
+ * does not exist.
  */
 export function getRssFeedUrl(
   instanceType: string,
   username: string | undefined,
-  communityId: string | undefined
+  communityId: string | undefined,
+  managed?: boolean,
 ): string | null {
+  if (managed && typeof window !== 'undefined') {
+    return `${window.location.origin}/rss.xml`;
+  }
   if (instanceType === "community") {
     if (!communityId?.trim()) return null;
     return `https://ecency.com/created/${communityId.trim()}/rss`;

--- a/apps/self-hosted/src/utils/rss-feed-url.ts
+++ b/apps/self-hosted/src/utils/rss-feed-url.ts
@@ -1,16 +1,21 @@
 /**
- * The RSS feed URL for this instance. A managed instance serves its own
- * /rss.xml (written per tenant by the hosting API's sync pass and served
- * statically by nginx); everywhere else the ecency.com feed for the same
- * account or community stands in, so the link never points at a file that
- * does not exist.
+ * The RSS feed URL for this instance, in priority order: an explicit
+ * config override (an independent deployment that runs the SEO generator
+ * and serves its own files), the managed instance's own /rss.xml (written
+ * per tenant by the hosting API's sync pass), and finally the ecency.com
+ * feed for the same account or community, so the link never points at a
+ * file that does not exist.
  */
 export function getRssFeedUrl(
   instanceType: string,
   username: string | undefined,
   communityId: string | undefined,
   managed?: boolean,
+  override?: string,
 ): string | null {
+  if (typeof override === 'string' && /^https?:\/\//i.test(override.trim())) {
+    return override.trim();
+  }
   if (managed && typeof window !== 'undefined') {
     return `${window.location.origin}/rss.xml`;
   }


### PR DESCRIPTION
Closes #1451
Closes #1452

Implements the approved proposals from both research issues; static-only, no new request-time compute.

## Static SEO files (#1451)

Per-tenant `robots.txt` (with its Sitemap line), `sitemap.xml` (home, about and the latest posts with lastmod) and `rss.xml` (RSS 2.0 with atom self-link, escaped chain text, RFC822 dates) are written by the existing sync pass into the served configs volume: one bounded bridge page per tenant, a thirty-minute freshness window (files are touched after unchanged writes so write-if-changed cannot defeat the mtime check), the same per-tenant locks, delete path and reconcile sweep as every other served file. nginx serves them per tenant in both server blocks, generic robots as fallback. Managed instances now advertise their OWN feed — crawler-visible from the SSI head snippet — instead of pointing at ecency.com from client-injected markup crawlers never ran.

## Canonical policy (#1451, as decided)

A tenant with a verified custom domain canonicalizes to itself; a subdomain tenant canonicalizes to the ecency.com SSR page, home and per-post alike. Derived from the tenant row, no config option. og:url stays the served URL.

## Responsive media (#1452)

Both card layouts and the Journal thumbnail emit srcset/sizes from render-helper's builders, so phones stop downloading desktop cuts (the CSS height token already pins the boxes, so CLS was bounded). The per-post og:image goes through render-helper's own cover extraction and the modern hashed proxy path instead of a local regex duplicate and the legacy redirecting sized route.

render-helper loads through its CJS build in the hosting API: the package's Node ESM entry crashes at module load on a directory import — that packaging fix plus a body-image dimensions option are filed as #1461, and the missing editor image upload as #1462.

## Tests

- 7 new SEO suites (builders, escaping, dates, canonical policy both ways, feed routing per instance kind, malformed responses)
- Updated post-meta cover assertion to the modern proxy path; TenantService mocks extended where the builders now reach getBlogUrl
- Full suites green: 930 SPA, 443 hosting API; both typechecks; SPA production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-specific `robots.txt`, `sitemap.xml`, and RSS feeds.
  * Improved canonical URLs and metadata for custom domains and community sites.
  * Added responsive image loading for blog and Journal post cards.
  * Managed instances now support local or configured RSS feed URLs.
  * Added scheduled SEO file generation for self-hosted deployments.

* **Bug Fixes**
  * Improved post excerpts, image previews, HTML/XML escaping, and RSS metadata.
  * Updated image proxy URLs for more reliable social previews.
  * Improved atomic configuration and SEO file updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->