### PR TITLE
Independent deployment: compose-config endpoint and deployment docs

### DIFF
--- a/apps/self-hosted/DEPLOYMENT.md
+++ b/apps/self-hosted/DEPLOYMENT.md
@@ -71,7 +71,8 @@ single command: compose reads that file for EVERY invocation, so `logs`,
 `restart` and `down` keep working afterwards.
 
 ```bash
-# Pin the image build
+# Pin the image build. sha-abc1234 is a PLACEHOLDER: replace it with a tag
+# that exists, from https://hub.docker.com/r/ecency/self-hosted/tags
 echo "TAG=sha-abc1234" > .env
 
 # Pull and start
@@ -81,8 +82,14 @@ docker compose up -d
 docker compose logs -f
 ```
 
+The site is published on loopback by default, so reach it locally first and
+put a reverse proxy in front of it for the public address. To serve directly
+with no proxy (and therefore no HTTPS), set `BIND=0.0.0.0` in `.env`.
+
 Your blog is now running at `http://localhost:3000` (the container listens on
-port 80 and compose publishes it as `PORT`, which defaults to 3000).
+port 80 and compose publishes it as `PORT`, which defaults to 3000). If you
+changed `PORT`, `docker compose port blog 80` prints where it actually
+landed, and every proxy example below has to point at that same port.
 
 ## Configuration
 
@@ -206,10 +213,17 @@ Published tags for `ecency/self-hosted` (and its paired `ecency/hosting-api`):
 | `develop` | every merge | tracking development, never a deployment you care about |
 | `latest` | releases only | convenience; it does not move until a release is tagged |
 
-No `vX.Y.Z` tag exists yet, so pin a `sha-<7>` tag. Pick one from the
-[image tags on Docker Hub](https://hub.docker.com/r/ecency/self-hosted/tags),
-or read what the managed platform runs from
+Prefer a `vX.Y.Z` release tag when one is listed; no release has been cut
+yet, so today that means pinning a `sha-<7>` tag. Take a tag that exists
+from [Docker Hub](https://hub.docker.com/r/ecency/self-hosted/tags), which
+is the source of truth, or read what the managed platform runs from
 `https://api.blogs.ecency.com/health`, which answers `{version, sha}`.
+
+**`sha-abc1234` throughout this guide is a placeholder.** Substitute a real
+tag before running any command that mentions it. The blog and the hosting
+API are built from the same commit in the same CI run, so the same `sha-<7>`
+tag exists for `ecency/self-hosted` and `ecency/hosting-api`; if you pick one
+that is only in one repository, choose another.
 
 ### Option 1: Docker Compose (Recommended)
 
@@ -283,14 +297,15 @@ forwards to the port compose publishes (`PORT`, 3000 by default).
 
 ### With Caddy (recommended: certificates without ACME wiring)
 
-```
+```caddyfile
 blog.yourdomain.com {
     reverse_proxy 127.0.0.1:3000
 }
 ```
 
 That is the whole configuration. Caddy obtains and renews a Let's Encrypt
-certificate on its own, so there is no certbot timer to forget.
+certificate on its own, so there is no certbot timer to forget. The port must
+match your `PORT`; `docker compose port blog 80` prints it.
 
 ### With Nginx
 
@@ -312,7 +327,8 @@ server {
 }
 ```
 
-Certificates come from certbot: `certbot --nginx -d blog.yourdomain.com`.
+Certificates come from certbot: `certbot --nginx -d blog.yourdomain.com`. As
+with Caddy, `proxy_pass` must point at your `PORT`.
 
 ### Managed platform reference (not a self-hosting recipe)
 
@@ -392,7 +408,9 @@ with the generator shipped in the `ecency/hosting-api` image, run on a cron
 (hourly is plenty; the feeds carry the latest 100 posts):
 
 ```bash
-docker run --rm -v "$PWD:/work" ecency/hosting-api \
+# Pin the same tag the blog runs. Without one this pulls :latest, which
+# moves independently of what you deployed.
+docker run --rm -v "$PWD:/work" ecency/hosting-api:sha-abc1234 \
   npm run generate-seo -- \
   --config /work/config.json \
   --url https://blog.example.com \
@@ -500,8 +518,8 @@ docker compose restart
 # Check logs
 docker compose logs blog
 
-# Check if the published port is in use
-lsof -i :3000
+# Where the site is actually published (honours PORT and BIND)
+docker compose port blog 80
 ```
 
 `required variable TAG is missing a value` means exactly that: pick a tag

--- a/apps/self-hosted/DEPLOYMENT.md
+++ b/apps/self-hosted/DEPLOYMENT.md
@@ -6,6 +6,7 @@ Deploy your own blog powered by the Hive blockchain. This guide covers Docker de
 
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
+- [Choosing an image tag](#choosing-an-image-tag)
 - [Deployment Options](#deployment-options)
 - [Production Deployment](#production-deployment)
 - [SEO files (robots, sitemap, RSS)](#seo-files-robots-sitemap-rss)
@@ -61,15 +62,20 @@ Edit `config.json` with your settings:
 
 ### 3. Start the Application
 
+Pick an image tag first. `TAG` is required and has no default, so a
+deployment always states what it runs; see [Choosing an image
+tag](#choosing-an-image-tag).
+
 ```bash
-# Build and start
-docker compose up -d
+# Pull and start
+TAG=sha-abc1234 docker compose up -d
 
 # View logs
 docker compose logs -f
 ```
 
-Your blog is now running at `http://localhost:80`
+Your blog is now running at `http://localhost:3000` (the container listens on
+port 80 and compose publishes it as `PORT`, which defaults to 3000).
 
 ## Configuration
 
@@ -105,11 +111,18 @@ Display posts from a Hive community:
 
 | Style Template | Description |
 |----------------|-------------|
-| `medium` | Editorial style (default) |
-| `minimal` | Clean, minimalist |
-| `magazine` | Magazine layout |
-| `developer` | Tech-focused |
-| `modern-gradient` | Modern with gradients |
+| `medium` | Clean long-form reading with a classic serif voice (default) |
+| `minimal` | Quiet, spacious and out of the way of your words |
+| `magazine` | Warm editorial look with display headlines |
+| `developer` | Dark, code-friendly and easy on late-night eyes |
+| `modern-gradient` | Bright surfaces with a vivid accent |
+| `journal` | Ink on paper: one quiet column for long-form writing |
+| `reader` | Your archive beside the open post, the way a feed reader works |
+
+`journal` and `reader` change the page STRUCTURE, not only its colours, so
+they ignore the options a single-column layout has no place for: neither
+renders a sidebar, and both fix the archive to one column regardless of
+`layout.listType`.
 
 ### Feature Flags
 
@@ -175,83 +188,129 @@ Editor, under General Settings > Hivesigner.
 
 ## Deployment Options
 
+### Choosing an image tag
+
+Published tags for `ecency/self-hosted` (and its paired `ecency/hosting-api`):
+
+| Tag | Moves? | Use it for |
+|-----|--------|-----------|
+| `sha-<7>` | never | **what to pin today**: one immutable build, e.g. `sha-abc1234` |
+| `vX.Y.Z` | never | a tagged release, once releases are cut |
+| `develop` | every merge | tracking development, never a deployment you care about |
+| `latest` | releases only | convenience; it does not move until a release is tagged |
+
+No `vX.Y.Z` tag exists yet, so pin a `sha-<7>` tag. Pick one from the
+[image tags on Docker Hub](https://hub.docker.com/r/ecency/self-hosted/tags),
+or read what the managed platform runs from
+`https://api.blogs.ecency.com/health`, which answers `{version, sha}`.
+
 ### Option 1: Docker Compose (Recommended)
 
 ```bash
 # Start in detached mode
-docker compose up -d
+TAG=sha-abc1234 docker compose up -d
 
-# Custom port
-PORT=8080 docker compose up -d
+# Custom port (the container always listens on 80 inside)
+TAG=sha-abc1234 PORT=8080 docker compose up -d
+```
+
+Put `TAG` in a `.env` file beside `docker-compose.yml` so it applies to every
+compose command, including `docker compose logs` and `docker compose down`:
+
+```bash
+echo "TAG=sha-abc1234" > .env
+docker compose up -d
 ```
 
 ### Option 2: Docker Run
 
 ```bash
-# Build the image
-docker build -t myblog -f Dockerfile ../..
-
-# Run with config volume mount
 docker run -d \
-  -p 80:80 \
+  -p 3000:80 \
   -v $(pwd)/config.json:/usr/share/nginx/html/config.json:ro \
   --name myblog \
-  myblog
+  ecency/self-hosted:sha-abc1234
 ```
 
-### Option 3: Pre-built Image
+### Option 3: Build from Source
+
+Only needed to run modified code; the published images are built from this
+same Dockerfile.
 
 ```bash
-# Pull a specific version from Docker Hub
-docker pull ecency/self-hosted:sha-abc1234
+# From apps/self-hosted, with the monorepo as build context
+docker build -t myblog -f Dockerfile ../..
 
-# Run with your config
 docker run -d \
-  -p 80:80 \
+  -p 3000:80 \
   -v $(pwd)/config.json:/usr/share/nginx/html/config.json:ro \
-  ecency/self-hosted:sha-abc1234
+  myblog
 ```
 
 ### Option 4: Build with Config Baked In
 
-For immutable deployments (e.g., Kubernetes), use base64 encoding to safely pass the config:
+For immutable deployments (e.g. Kubernetes) where mounting a file is
+awkward. The Dockerfile already accepts the config as a build argument, so
+nothing needs editing: base64 keeps the JSON clear of shell interpolation.
 
 ```bash
 # Encode config as base64 to avoid shell interpolation issues
 CONFIG_B64=$(base64 -w0 config.json)  # Linux
 # or: CONFIG_B64=$(base64 -i config.json)  # macOS
 
-# Build with base64-encoded config
 docker build \
   --build-arg CONFIG_JSON_B64="$CONFIG_B64" \
   -t myblog:configured \
   -f Dockerfile ../..
 ```
 
-The Dockerfile should decode this during build:
-
-```dockerfile
-ARG CONFIG_JSON_B64
-RUN echo "$CONFIG_JSON_B64" | base64 -d > /usr/share/nginx/html/config.json
-```
-
-**Alternative: COPY method** (simpler, requires config.json in build context):
-
-```dockerfile
-# In Dockerfile, add:
-COPY apps/self-hosted/config.json /usr/share/nginx/html/config.json
-```
-
-Then build without build-args:
-```bash
-docker build -t myblog:configured -f Dockerfile ../..
-```
+A baked config trades the main advantage of this app away: with a mounted
+file, changing settings is an edit plus a container restart, while a baked
+one needs a rebuild for every change.
 
 ## Production Deployment
 
-The managed hosting platform runs behind nginx with SSL terminated at the reverse proxy layer. The Docker containers bind to localhost-only ports and nginx routes traffic to them.
+Put a reverse proxy in front of the container: it terminates TLS and
+forwards to the port compose publishes (`PORT`, 3000 by default).
 
-### With Nginx Reverse Proxy (Current Production Setup)
+### With Caddy (recommended: certificates without ACME wiring)
+
+```
+blog.yourdomain.com {
+    reverse_proxy 127.0.0.1:3000
+}
+```
+
+That is the whole configuration. Caddy obtains and renews a Let's Encrypt
+certificate on its own, so there is no certbot timer to forget.
+
+### With Nginx
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name blog.yourdomain.com;
+
+    ssl_certificate     /etc/letsencrypt/live/blog.yourdomain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/blog.yourdomain.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Certificates come from certbot: `certbot --nginx -d blog.yourdomain.com`.
+
+### Managed platform reference (not a self-hosting recipe)
+
+The rest of this section documents how Ecency's own multi-tenant platform is
+wired, for anyone reading the `hosting/` directory. **A single self-hosted
+blog needs none of it** — the ports below are that platform's, not yours.
 
 The blog server container exposes port 80 internally, mapped to `127.0.0.1:3100` on the host. The hosting API exposes port 3001, mapped to `127.0.0.1:3101`.
 
@@ -316,24 +375,6 @@ server {
 }
 ```
 
-### With Caddy (Simple SSL)
-
-```
-blog.yourdomain.com {
-    reverse_proxy 127.0.0.1:3100
-}
-```
-
-### Standalone (Single Blog)
-
-For a single self-hosted blog without the managed hosting platform:
-
-```bash
-docker run -d \
-  -p 80:80 \
-  -v $(pwd)/config.json:/usr/share/nginx/html/config.json:ro \
-  ecency/self-hosted:sha-abc1234
-```
 
 ## SEO files (robots, sitemap, RSS)
 
@@ -350,8 +391,10 @@ docker run --rm -v "$PWD:/work" ecency/hosting-api \
   --out /work/seo
 ```
 
-Serve the output beside the app by mounting the files over the defaults in
-your compose file:
+`--url` must be a plain https origin: no path, no query, no credentials.
+
+Serve the output beside the app by uncommenting the SEO mounts in
+`docker-compose.yml`:
 
 ```yaml
     volumes:
@@ -360,6 +403,11 @@ your compose file:
       - ./seo/sitemap.xml:/usr/share/nginx/html/sitemap.xml:ro
       - ./seo/rss.xml:/usr/share/nginx/html/rss.xml:ro
 ```
+
+Run the generator BEFORE the first `up` with those mounts uncommented.
+Docker creates a directory for any mount source that does not exist, and an
+empty directory mounted over `robots.txt` replaces the working one the image
+ships.
 
 Then point the app's RSS link at your own feed in `config.json`:
 
@@ -410,14 +458,19 @@ sudo certbot certonly --standalone -d blog.yourdomain.com
 
 ### Update with Docker Compose
 
-```bash
-# Pull new images and restart
-TAG=sha-abc1234 docker compose up -d
+Upgrading is a one-line change: point `TAG` at the newer build.
 
-# Or pull latest for your channel
-TAG=develop docker compose pull
-TAG=develop docker compose up -d
+```bash
+# Pick the new tag, pull it, restart onto it
+TAG=sha-def5678 docker compose pull
+TAG=sha-def5678 docker compose up -d
 ```
+
+Rolling back is the same move with the previous tag, which is exactly why
+the tag is pinned rather than floating. Keep the last known-good value
+somewhere (the `.env` file's previous line is enough).
+
+Your `config.json` is untouched by an upgrade: it is mounted, not baked.
 
 ### Update Configuration Only
 
@@ -437,11 +490,14 @@ docker compose restart
 
 ```bash
 # Check logs
-docker compose logs blog-server
+docker compose logs blog
 
-# Check if port is in use
-lsof -i :3100
+# Check if the published port is in use
+lsof -i :3000
 ```
+
+`required variable TAG is missing a value` means exactly that: pick a tag
+(see [Choosing an image tag](#choosing-an-image-tag)) or put one in `.env`.
 
 ### Config Changes Not Reflected
 
@@ -450,17 +506,22 @@ lsof -i :3100
 3. Check nginx is serving the right file:
 
 ```bash
-docker compose exec blog-server cat /usr/share/nginx/html/config.json
+docker compose exec blog cat /usr/share/nginx/html/config.json
 ```
 
-### Build Failures
+If that prints a directory listing error, `config.json` did not exist when
+the container first started and Docker created a directory in its place.
+Stop the stack, remove the directory, `cp config.template.json config.json`,
+and start again.
+
+### The Site Shows Someone Else's Demo Blog
+
+The app falls back to its built-in demo config when the mounted
+`config.json` is missing, is not valid JSON, or lacks a truthy `version` and
+`configuration`. Check it parses:
 
 ```bash
-# Clean Docker cache
-docker system prune -a
-
-# Rebuild from scratch
-docker compose build --no-cache
+python3 -m json.tool config.json > /dev/null && echo "config.json is valid JSON"
 ```
 
 ### Performance Issues
@@ -469,7 +530,10 @@ docker compose build --no-cache
 2. Use a CDN like Cloudflare
 3. Ensure image proxy is fast (default: i.ecency.com)
 
-## Architecture
+## Architecture (managed platform)
+
+A single self-hosted blog is just the one container from Quick Start. The
+diagram below is Ecency's multi-tenant platform, for readers of `hosting/`.
 
 ```
                         Internet
@@ -511,10 +575,15 @@ Don't want to manage your own infrastructure? Let Ecency host your blog.
 
 ### Pricing
 
-| Plan | Price | Features |
-|------|-------|----------|
-| **Standard** | 0.1 HBD/month | Custom subdomain, SSL, CDN, 99.9% uptime |
-| **Pro** | 0.5 HBD/month | Custom domain, priority support, analytics |
+Current prices are shown on the [hosting
+page](https://blogs.ecency.com/hosting) and quoted again at checkout. They
+are deliberately not repeated here: this file drifted from the real numbers
+once already.
+
+| Plan | Includes |
+|------|----------|
+| **Standard** | Subdomain on `blogs.ecency.com`, SSL, CDN, automatic upgrades |
+| **Pro** | Everything above plus a custom domain |
 
 ### How It Works
 

--- a/apps/self-hosted/DEPLOYMENT.md
+++ b/apps/self-hosted/DEPLOYMENT.md
@@ -66,9 +66,16 @@ Pick an image tag first. `TAG` is required and has no default, so a
 deployment always states what it runs; see [Choosing an image
 tag](#choosing-an-image-tag).
 
+Put it in a `.env` file beside `docker-compose.yml` rather than in front of a
+single command: compose reads that file for EVERY invocation, so `logs`,
+`restart` and `down` keep working afterwards.
+
 ```bash
+# Pin the image build
+echo "TAG=sha-abc1234" > .env
+
 # Pull and start
-TAG=sha-abc1234 docker compose up -d
+docker compose up -d
 
 # View logs
 docker compose logs -f
@@ -206,21 +213,22 @@ or read what the managed platform runs from
 
 ### Option 1: Docker Compose (Recommended)
 
-```bash
-# Start in detached mode
-TAG=sha-abc1234 docker compose up -d
-
-# Custom port (the container always listens on 80 inside)
-TAG=sha-abc1234 PORT=8080 docker compose up -d
-```
-
-Put `TAG` in a `.env` file beside `docker-compose.yml` so it applies to every
-compose command, including `docker compose logs` and `docker compose down`:
+Settings live in `.env` beside `docker-compose.yml`, which compose reads on
+every invocation:
 
 ```bash
-echo "TAG=sha-abc1234" > .env
+cat > .env <<'ENV'
+TAG=sha-abc1234
+PORT=3000
+ENV
+
 docker compose up -d
 ```
+
+`PORT` is what the site is published on; the container always listens on 80
+inside. A one-off command can still override either (`PORT=8080 docker
+compose up -d`), but a value only on the command line is gone by the next
+compose command, and `${TAG:?...}` will stop that one.
 
 ### Option 2: Docker Run
 
@@ -461,14 +469,14 @@ sudo certbot certonly --standalone -d blog.yourdomain.com
 Upgrading is a one-line change: point `TAG` at the newer build.
 
 ```bash
-# Pick the new tag, pull it, restart onto it
-TAG=sha-def5678 docker compose pull
-TAG=sha-def5678 docker compose up -d
+# Edit TAG in .env to the newer tag, then:
+docker compose pull
+docker compose up -d
 ```
 
-Rolling back is the same move with the previous tag, which is exactly why
-the tag is pinned rather than floating. Keep the last known-good value
-somewhere (the `.env` file's previous line is enough).
+Rolling back is the same two commands with the previous tag, which is
+exactly why the tag is pinned rather than floating. Keep the last known-good
+value somewhere; the line you just replaced in `.env` is enough.
 
 Your `config.json` is untouched by an upgrade: it is mounted, not baked.
 

--- a/apps/self-hosted/docker-compose.yml
+++ b/apps/self-hosted/docker-compose.yml
@@ -4,28 +4,37 @@
 # Quick start:
 #   1. Copy config.template.json to config.json
 #   2. Edit config.json with your settings
-#   3. Run: docker-compose up -d
+#   3. Pick an image tag and run: TAG=sha-abc1234 docker compose up -d
 #
-# For production with SSL, use docker-compose.production.yml
+# TAG is REQUIRED and has no default on purpose: a moving tag silently
+# changes what a deployment runs. Immutable tags are `sha-<7>` (every
+# build) and `vX.Y.Z` (releases); `develop` and `latest` move. See
+# DEPLOYMENT.md for how to choose and how to upgrade.
+#
+# For HTTPS, put a reverse proxy in front of this (Caddy gets certificates
+# on its own); DEPLOYMENT.md carries a working example.
 # =============================================================================
 
 services:
   blog:
-    build:
-      context: ../..
-      dockerfile: apps/self-hosted/Dockerfile
-      args:
-        # Inject config at build time (optional)
-        # CONFIG_JSON: ${CONFIG_JSON:-}
-    image: ecency/self-hosted:latest
+    image: ecency/self-hosted:${TAG:?TAG environment variable is required}
     container_name: ecency-blog
     restart: unless-stopped
     ports:
       - "${PORT:-3000}:80"
     volumes:
       # Mount config.json for runtime configuration updates
-      # Changes to config.json will be reflected without rebuilding
+      # Changes to config.json will be reflected without rebuilding.
+      # The file must EXIST before the first `up`: Docker silently creates a
+      # directory in its place otherwise, and the site then falls back to the
+      # built-in demo config. `cp config.template.json config.json` first.
       - ./config.json:/usr/share/nginx/html/config.json:ro
+      # SEO files, if you run the generator (see DEPLOYMENT.md). Uncomment
+      # only once the files exist, for the same reason as above: an empty
+      # directory mounted over robots.txt replaces a working one.
+      # - ./seo/robots.txt:/usr/share/nginx/html/robots.txt:ro
+      # - ./seo/sitemap.xml:/usr/share/nginx/html/sitemap.xml:ro
+      # - ./seo/rss.xml:/usr/share/nginx/html/rss.xml:ro
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80/"]
       interval: 30s
@@ -36,40 +45,8 @@ services:
       - "com.ecency.service=self-hosted-blog"
 
 # =============================================================================
-# Production configuration with Traefik (optional)
-# Uncomment the following to enable automatic HTTPS with Let's Encrypt
+# HTTPS
 # =============================================================================
-#
-#   blog:
-#     # ... same as above, but remove ports mapping
-#     labels:
-#       - "traefik.enable=true"
-#       - "traefik.http.routers.blog.rule=Host(`yourdomain.com`)"
-#       - "traefik.http.routers.blog.entrypoints=websecure"
-#       - "traefik.http.routers.blog.tls.certresolver=letsencrypt"
-#       - "traefik.http.services.blog.loadbalancer.server.port=80"
-#
-#   traefik:
-#     image: traefik:v3.0
-#     container_name: traefik
-#     restart: unless-stopped
-#     command:
-#       - "--api.insecure=false"
-#       - "--providers.docker=true"
-#       - "--providers.docker.exposedbydefault=false"
-#       - "--entrypoints.web.address=:80"
-#       - "--entrypoints.websecure.address=:443"
-#       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
-#       - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
-#       - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
-#       - "--certificatesresolvers.letsencrypt.acme.email=your-email@example.com"
-#       - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
-#     ports:
-#       - "80:80"
-#       - "443:443"
-#     volumes:
-#       - "/var/run/docker.sock:/var/run/docker.sock:ro"
-#       - "letsencrypt:/letsencrypt"
-#
-# volumes:
-#   letsencrypt:
+# Add a reverse proxy that obtains certificates for you. DEPLOYMENT.md has a
+# ready-to-copy Caddy service (two lines of Caddyfile, no ACME wiring) and an
+# nginx + certbot alternative.

--- a/apps/self-hosted/docker-compose.yml
+++ b/apps/self-hosted/docker-compose.yml
@@ -21,7 +21,11 @@ services:
     container_name: ecency-blog
     restart: unless-stopped
     ports:
-      - "${PORT:-3000}:80"
+      # Loopback by default: with a reverse proxy terminating TLS in front,
+      # a port published on every interface lets clients reach the site over
+      # plain HTTP and skip the proxy entirely. Set BIND=0.0.0.0 only to
+      # serve directly, with no proxy and no HTTPS.
+      - "${BIND:-127.0.0.1}:${PORT:-3000}:80"
     volumes:
       # Mount config.json for runtime configuration updates
       # Changes to config.json will be reflected without rebuilding.

--- a/apps/self-hosted/hosting/README.md
+++ b/apps/self-hosted/hosting/README.md
@@ -97,10 +97,22 @@ Each tenant gets their own container. Higher resource usage but better isolation
 ## Files
 
 - `docker-compose.yml` - Full hosting stack
-- `traefik/` - Traefik configuration
-- `nginx/` - Multi-tenant nginx config
+- `nginx-multi-tenant.conf` - Multi-tenant nginx config (a file, not a `nginx/` directory)
+- `default-config.json` - Config served for a subdomain with no tenant
 - `api/` - Hosting management API
+- `db/` - Schema and migrations
 - `scripts/` - Utility scripts
+- `origin/` - Host-level config (edge vhost, certificates). Applied by hand,
+  never by CI; see its README.
+- `traefik/` - **Unused.** Traefik is not in the stack and nothing loads
+  this. Note before wiring it in: `dynamic/middlewares.yml` sets
+  `X-Robots-Tag: noindex, nofollow` on every response, which would deindex
+  every tenant blog.
+
+CI copies only `docker-compose.yml`, `nginx-multi-tenant.conf`,
+`default-config.json` and `db/*` to the host, so adding a file beside them
+does not deploy it, and editing one of them on the host is reverted by the
+next deploy.
 
 ## Quick Start
 

--- a/apps/self-hosted/hosting/README.md
+++ b/apps/self-hosted/hosting/README.md
@@ -12,9 +12,9 @@ Multi-tenant hosting infrastructure for Ecency self-hosted blogs.
                                    └──────────────────┬──────────────────┘
                                                       │
                                    ┌──────────────────▼──────────────────┐
-                                   │        Load Balancer (Traefik)       │
+                                   │          Edge nginx (host)           │
                                    │  - SSL termination (Let's Encrypt)   │
-                                   │  - Dynamic routing by hostname       │
+                                   │  - Routing by hostname               │
                                    │  - Rate limiting                     │
                                    └──────────────────┬──────────────────┘
                                                       │
@@ -42,11 +42,11 @@ Multi-tenant hosting infrastructure for Ecency self-hosted blogs.
 
 ## Components
 
-### 1. Traefik (Edge Router)
+### 1. Edge nginx (host)
 - Handles all incoming traffic
-- Dynamic routing based on hostname
-- Automatic SSL via Let's Encrypt
-- Wildcard cert for `*.blogs.ecency.com`
+- Routes by hostname to the blog container or the hosting API
+- Let's Encrypt wildcard cert for `*.blogs.ecency.com`
+- Lives in `origin/`, applied by hand rather than by CI
 
 ### 2. Blog Instances
 - Shared static SPA assets

--- a/apps/self-hosted/hosting/api/src/index.ts
+++ b/apps/self-hosted/hosting/api/src/index.ts
@@ -15,6 +15,7 @@ import { domainRoutes } from './routes/domains';
 import { paymentRoutes } from './routes/payments';
 import { authRoutes } from './routes/auth';
 import { metaRoutes } from './routes/meta';
+import { toolsRoutes } from './routes/tools';
 import { internalRoutes, internalSecret, MIN_INTERNAL_SECRET_LENGTH } from './routes/internal';
 import { rateLimit } from './middleware/rate-limit';
 import { sourceAllowlist } from './middleware/source-allowlist';
@@ -76,6 +77,9 @@ app.use('/v1/templates', generalLimit);
 app.use('/v1/meta/*', generalLimit);
 app.use('/v1/auth/*', generalLimit);
 app.use('/v1/auth/*', authLimit);
+// The compose-config tool is anonymous and each call can spend a chain
+// lookup, so it sits behind the general budget as well as its own.
+app.use('/v1/tools/*', generalLimit);
 
 // Source-address allowlist for the service-to-service routes, ahead of the rate limit so a
 // refused source never spends a Redis round trip. Defence in depth behind the edge nginx,
@@ -95,6 +99,9 @@ app.route('/v1/templates', templateRoutes);
 app.route('/v1/domains', domainRoutes);
 app.route('/v1/payments', paymentRoutes);
 app.route('/v1/auth', authRoutes);
+// Composes a config document for an INDEPENDENT deployment. Creates no
+// tenant row and publishes no file: see routes/tools.ts.
+app.route('/v1/tools', toolsRoutes);
 // Head snippets for the blog nginx's SSI include (per-post unfurls). Reached
 // through the docker network by the blog container, cached by its proxy
 // cache; rate limiting matches the other public GET surfaces.

--- a/apps/self-hosted/hosting/api/src/routes/tools.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tools.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({
-  create: vi.fn(),
-  generateConfigFile: vi.fn(),
-  publishConfigFile: vi.fn(),
-  getCommunityTitle: vi.fn(async () => 'A Community'),
-}));
+interface ComposeResponse {
+  config?: {
+    version: number;
+    configuration: {
+      general: Record<string, unknown>;
+      instanceConfiguration: Record<string, unknown> & { meta?: Record<string, unknown> };
+    };
+  };
+  error?: string;
+}
 
 // The DB client is imported transitively; nothing in this route may reach it,
 // and a mock that throws proves it rather than assuming it.
@@ -39,13 +43,6 @@ vi.mock('@ecency/sdk/hive', () => ({
 }));
 
 const { toolsRoutes, withoutServedOnlyMarkers } = await import('./tools');
-const { TenantService } = await import('../services/tenant-service');
-
-// Guard the two persistence entry points on the real service too: a future
-// edit that starts creating rows from here fails loudly.
-TenantService.create = mocks.create.mockRejectedValue(
-  new Error('compose-config must not create a tenant'),
-) as typeof TenantService.create;
 
 async function compose(body: unknown) {
   const res = await toolsRoutes.request('http://localhost/compose-config', {
@@ -53,7 +50,12 @@ async function compose(body: unknown) {
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   });
-  return { res, body: (await res.json()) as any };
+  return { res, body: (await res.json()) as ComposeResponse };
+}
+
+/** The composed instance block, which every assertion below reads. */
+function instanceOf(body: ComposeResponse): Record<string, unknown> {
+  return body.config!.configuration.instanceConfiguration;
 }
 
 describe('POST /v1/tools/compose-config', () => {
@@ -64,27 +66,27 @@ describe('POST /v1/tools/compose-config', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(body.config.version).toBe(1);
-    const instance = body.config.configuration.instanceConfiguration;
+    expect(body.config!.version).toBe(1);
+    const instance = instanceOf(body);
     expect(instance.username).toBe('alice');
     // The instance reads this to decide who may open its editor.
     expect(instance.owner).toBe('alice');
-    expect(instance.meta.title).toBe('Alice writes');
-    expect(body.config.configuration.general.styleTemplate).toBe('journal');
-    expect(body.config.configuration.general.styles.accent).toBe('#112233');
-    expect(mocks.create).not.toHaveBeenCalled();
+    expect((instance.meta as Record<string, unknown>).title).toBe('Alice writes');
+    const general = body.config!.configuration.general;
+    expect(general.styleTemplate).toBe('journal');
+    expect((general.styles as Record<string, unknown>).accent).toBe('#112233');
   });
 
   it('strips every marker that only makes sense on a managed instance', async () => {
     const { body } = await compose({ username: 'alice' });
-    const instance = body.config.configuration.instanceConfiguration;
+    const instance = instanceOf(body);
     // managed would point the editor's Save at a hosting API that is not
     // theirs; template would replace the site with the claim landing page.
     expect(instance).not.toHaveProperty('managed');
     expect(instance).not.toHaveProperty('template');
     expect(instance).not.toHaveProperty('claimPreview');
     // An Ecency-owned Hivesigner app only answers to Ecency's redirect URIs.
-    expect(body.config.configuration.general).not.toHaveProperty('hivesigner');
+    expect(body.config!.configuration.general).not.toHaveProperty('hivesigner');
   });
 
   it('requires a separate owner for a community, which cannot administer itself', async () => {
@@ -102,13 +104,22 @@ describe('POST /v1/tools/compose-config', () => {
     });
     expect(self.res.status).toBe(400);
 
+    // Another community as owner is the same lockout: that account holds no
+    // keys either, so nobody could ever open the editor.
+    const otherCommunity = await compose({
+      username: 'hive-125125',
+      owner: 'hive-99999',
+      config: { type: 'community', communityId: 'hive-125125' },
+    });
+    expect(otherCommunity.res.status).toBe(400);
+
     const ok = await compose({
       username: 'hive-125125',
       owner: 'alice',
       config: { type: 'community', communityId: 'hive-125125' },
     });
     expect(ok.res.status).toBe(200);
-    const instance = ok.body.config.configuration.instanceConfiguration;
+    const instance = instanceOf(ok.body);
     expect(instance.type).toBe('community');
     // The named owner, not the community itself, is what the editor gates on.
     expect(instance.owner).toBe('alice');
@@ -133,7 +144,7 @@ describe('POST /v1/tools/compose-config', () => {
     for (const config of [undefined, { type: 'blog' as const }]) {
       const { res, body } = await compose({ username: 'hive-125125', owner: 'alice', config });
       expect(res.status, JSON.stringify(config)).toBe(200);
-      const instance = body.config.configuration.instanceConfiguration;
+      const instance = instanceOf(body);
       expect(instance.owner).toBe('alice');
       expect(instance.type).toBe('community');
       expect(instance.communityId).toBe('hive-125125');

--- a/apps/self-hosted/hosting/api/src/routes/tools.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tools.test.ts
@@ -126,6 +126,24 @@ describe('POST /v1/tools/compose-config', () => {
     expect(res.status).toBe(400);
   });
 
+  it('treats a hive-NNNN name as a community even when the body does not say so', async () => {
+    // Reading only config.type let this compose a BLOG owned by the keyless
+    // community account: the real administrator could never open the editor,
+    // and the feed would read an account that never posts.
+    for (const config of [undefined, { type: 'blog' as const }]) {
+      const { res, body } = await compose({ username: 'hive-125125', owner: 'alice', config });
+      expect(res.status, JSON.stringify(config)).toBe(200);
+      const instance = body.config.configuration.instanceConfiguration;
+      expect(instance.owner).toBe('alice');
+      expect(instance.type).toBe('community');
+      expect(instance.communityId).toBe('hive-125125');
+    }
+
+    // And it still refuses without a separate owner, by the same rule.
+    const noOwner = await compose({ username: 'hive-125125' });
+    expect(noOwner.res.status).toBe(400);
+  });
+
   it('rejects a community id that is not shaped like one', async () => {
     const { res } = await compose({
       username: 'notacommunity',

--- a/apps/self-hosted/hosting/api/src/routes/tools.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tools.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  generateConfigFile: vi.fn(),
+  publishConfigFile: vi.fn(),
+  getCommunityTitle: vi.fn(async () => 'A Community'),
+}));
+
+// The DB client is imported transitively; nothing in this route may reach it,
+// and a mock that throws proves it rather than assuming it.
+vi.mock('../db/client', () => ({
+  db: new Proxy(
+    {},
+    {
+      get() {
+        throw new Error('compose-config must not touch the database');
+      },
+    },
+  ),
+}));
+
+// ConfigService writes into the SERVED volume: publishing a file there puts a
+// blog live, which an anonymous caller must never be able to do.
+vi.mock('../services/config-service', () => ({
+  ConfigService: new Proxy(
+    {},
+    {
+      get() {
+        throw new Error('compose-config must not publish a config file');
+      },
+    },
+  ),
+}));
+
+vi.mock('@ecency/sdk/hive', () => ({
+  callRPC: vi.fn(async () => ({ title: 'A Community' })),
+  config: { set: vi.fn() },
+}));
+
+const { toolsRoutes, withoutServedOnlyMarkers } = await import('./tools');
+const { TenantService } = await import('../services/tenant-service');
+
+// Guard the two persistence entry points on the real service too: a future
+// edit that starts creating rows from here fails loudly.
+TenantService.create = mocks.create.mockRejectedValue(
+  new Error('compose-config must not create a tenant'),
+) as typeof TenantService.create;
+
+async function compose(body: unknown) {
+  const res = await toolsRoutes.request('http://localhost/compose-config', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { res, body: (await res.json()) as any };
+}
+
+describe('POST /v1/tools/compose-config', () => {
+  it('composes a blog config owned by its own account, creating nothing', async () => {
+    const { res, body } = await compose({
+      username: 'alice',
+      config: { title: 'Alice writes', styleTemplate: 'journal', accent: '#112233' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(body.config.version).toBe(1);
+    const instance = body.config.configuration.instanceConfiguration;
+    expect(instance.username).toBe('alice');
+    // The instance reads this to decide who may open its editor.
+    expect(instance.owner).toBe('alice');
+    expect(instance.meta.title).toBe('Alice writes');
+    expect(body.config.configuration.general.styleTemplate).toBe('journal');
+    expect(body.config.configuration.general.styles.accent).toBe('#112233');
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('strips every marker that only makes sense on a managed instance', async () => {
+    const { body } = await compose({ username: 'alice' });
+    const instance = body.config.configuration.instanceConfiguration;
+    // managed would point the editor's Save at a hosting API that is not
+    // theirs; template would replace the site with the claim landing page.
+    expect(instance).not.toHaveProperty('managed');
+    expect(instance).not.toHaveProperty('template');
+    expect(instance).not.toHaveProperty('claimPreview');
+    // An Ecency-owned Hivesigner app only answers to Ecency's redirect URIs.
+    expect(body.config.configuration.general).not.toHaveProperty('hivesigner');
+  });
+
+  it('requires a separate owner for a community, which cannot administer itself', async () => {
+    const missing = await compose({
+      username: 'hive-125125',
+      config: { type: 'community', communityId: 'hive-125125' },
+    });
+    expect(missing.res.status).toBe(400);
+    expect(missing.body.error).toMatch(/separate owner/);
+
+    const self = await compose({
+      username: 'hive-125125',
+      owner: 'hive-125125',
+      config: { type: 'community', communityId: 'hive-125125' },
+    });
+    expect(self.res.status).toBe(400);
+
+    const ok = await compose({
+      username: 'hive-125125',
+      owner: 'alice',
+      config: { type: 'community', communityId: 'hive-125125' },
+    });
+    expect(ok.res.status).toBe(200);
+    const instance = ok.body.config.configuration.instanceConfiguration;
+    expect(instance.type).toBe('community');
+    // The named owner, not the community itself, is what the editor gates on.
+    expect(instance.owner).toBe('alice');
+    expect(instance.communityId).toBe('hive-125125');
+  });
+
+  it('rejects a name the chain could never carry, like createTenant does', async () => {
+    // Same regex as createTenantSchema: Hive account names are lowercase, so
+    // an uppercase owner is a client bug, not something to normalize away.
+    const { res } = await compose({
+      username: 'hive-125125',
+      owner: 'Alice',
+      config: { type: 'community', communityId: 'hive-125125' },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a community id that is not shaped like one', async () => {
+    const { res } = await compose({
+      username: 'notacommunity',
+      owner: 'alice',
+      config: { type: 'community', communityId: 'notacommunity' },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects values outside the shared rosters instead of composing junk', async () => {
+    for (const config of [
+      { styleTemplate: 'not-a-template' },
+      { accent: 'red' },
+      { fontPreset: 'comic-sans' },
+    ]) {
+      const { res } = await compose({ username: 'alice', config });
+      expect(res.status, JSON.stringify(config)).toBe(400);
+    }
+    const badName = await compose({ username: 'A' });
+    expect(badName.res.status).toBe(400);
+  });
+});
+
+describe('withoutServedOnlyMarkers', () => {
+  it('leaves everything else untouched and does not mutate its input', () => {
+    const document = {
+      version: 1,
+      configuration: {
+        general: {
+          theme: 'system',
+          hivesigner: { clientId: 'ecency.app', extra: 'kept' },
+        },
+        instanceConfiguration: { username: 'alice', managed: true, meta: { title: 'T' } },
+      },
+    };
+    const stripped = withoutServedOnlyMarkers(document);
+
+    expect(stripped.configuration).toMatchObject({
+      general: { theme: 'system', hivesigner: { extra: 'kept' } },
+      instanceConfiguration: { username: 'alice', meta: { title: 'T' } },
+    });
+    // The caller's document is untouched: this is a copy, not a mutation.
+    expect(document.configuration.instanceConfiguration.managed).toBe(true);
+    expect(document.configuration.general.hivesigner.clientId).toBe('ecency.app');
+  });
+
+  it('removes a hivesigner block the strip leaves empty', () => {
+    const stripped = withoutServedOnlyMarkers({
+      configuration: { general: { hivesigner: { clientId: 'ecency.app' } } },
+    });
+    // An empty hivesigner block reads as a deliberately blank app id.
+    expect(stripped.configuration).toEqual({ general: {} });
+  });
+});

--- a/apps/self-hosted/hosting/api/src/routes/tools.test.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tools.test.ts
@@ -155,6 +155,19 @@ describe('POST /v1/tools/compose-config', () => {
     expect(noOwner.res.status).toBe(400);
   });
 
+  it('refuses a subdomain and community id that disagree', async () => {
+    // The document pins BOTH names. Letting them differ would compose a
+    // site called hive-125125 that serves hive-99999's feed, which the
+    // managed create path rejects for the same reason.
+    const { res, body } = await compose({
+      username: 'hive-125125',
+      owner: 'alice',
+      config: { type: 'community', communityId: 'hive-99999' },
+    });
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/must equal/);
+  });
+
   it('rejects a community id that is not shaped like one', async () => {
     const { res } = await compose({
       username: 'notacommunity',

--- a/apps/self-hosted/hosting/api/src/routes/tools.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tools.ts
@@ -122,6 +122,12 @@ toolsRoutes.post('/compose-config', composeLimit, zValidator('json', composeConf
     if (!COMMUNITY_NAME.test(communityId)) {
       return c.json({ error: 'Community id must look like hive-NNNN' }, 400);
     }
+    // Same rule as the managed create path. The document pins BOTH names,
+    // and letting them disagree would compose a site called hive-125125
+    // that serves hive-99999's feed. There is one identity or none.
+    if (username !== communityId) {
+      return c.json({ error: 'Subdomain must equal the community id' }, 400);
+    }
     // A community account holds nobody's keys, so it can never administer
     // an instance: without a separate owner, or with ANOTHER community named
     // as owner, the deployment would be permanently locked out of its own

--- a/apps/self-hosted/hosting/api/src/routes/tools.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tools.ts
@@ -104,13 +104,19 @@ const composeLimit = rateLimit({ name: 'tools-compose', limit: 20, windowMs: 60_
 toolsRoutes.post('/compose-config', composeLimit, zValidator('json', composeConfigSchema), async (c) => {
   const body = c.req.valid('json');
   const username = body.username.toLowerCase();
-  const isCommunity = body.config?.type === 'community';
+  // Derived exactly as the managed create path derives it: a hive-NNNN name
+  // IS a community whatever the body claims. Reading only config.type let a
+  // request for a community name with no type compose a blog owned by the
+  // community account itself, which holds nobody's keys, so the real
+  // administrator would be locked out of the editor for good.
+  const isCommunity = COMMUNITY_NAME.test(username) || body.config?.type === 'community';
 
   // The owner rule, and the ONLY validation this route needs. Nothing here
   // is registered anywhere, so account existence and community control are
   // the deployer's business; but the owner value IS load-bearing, because
   // the instance reads it to decide who may open its editor.
   let owner: string;
+  let overrides = body.config;
   if (isCommunity) {
     const communityId = (body.config?.communityId || username).toLowerCase();
     if (!COMMUNITY_NAME.test(communityId)) {
@@ -123,11 +129,15 @@ toolsRoutes.post('/compose-config', composeLimit, zValidator('json', composeConf
       return c.json({ error: 'A community instance requires a separate owner account' }, 400);
     }
     owner = body.owner.toLowerCase();
+    // Say so in the document too, or a community name sent without a type
+    // composes a BLOG whose feed reads a keyless account and is always
+    // empty. The ownership rule and the composed mode have to agree.
+    overrides = { ...body.config, type: 'community', communityId };
   } else {
     // A personal blog is always controlled by its own account.
     owner = username;
   }
 
-  const document = await TenantService.buildConfig(username, body.config, owner);
+  const document = await TenantService.buildConfig(username, overrides, owner);
   return c.json({ config: withoutServedOnlyMarkers(document) });
 });

--- a/apps/self-hosted/hosting/api/src/routes/tools.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tools.ts
@@ -123,12 +123,14 @@ toolsRoutes.post('/compose-config', composeLimit, zValidator('json', composeConf
       return c.json({ error: 'Community id must look like hive-NNNN' }, 400);
     }
     // A community account holds nobody's keys, so it can never administer
-    // its own instance: without a separate owner the deployment would be
-    // permanently locked out of its own Configuration Editor.
-    if (!body.owner || body.owner.toLowerCase() === communityId) {
+    // an instance: without a separate owner, or with ANOTHER community named
+    // as owner, the deployment would be permanently locked out of its own
+    // Configuration Editor. The name shape decides this with no lookup.
+    const requested = body.owner?.toLowerCase();
+    if (!requested || requested === communityId || COMMUNITY_NAME.test(requested)) {
       return c.json({ error: 'A community instance requires a separate owner account' }, 400);
     }
-    owner = body.owner.toLowerCase();
+    owner = requested;
     // Say so in the document too, or a community name sent without a type
     // composes a BLOG whose feed reads a keyless account and is always
     // empty. The ownership rule and the composed mode have to agree.

--- a/apps/self-hosted/hosting/api/src/routes/tools.ts
+++ b/apps/self-hosted/hosting/api/src/routes/tools.ts
@@ -1,0 +1,133 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { STYLE_TEMPLATES } from '../style-templates';
+import { ACCENT_HEX_PATTERN, FONT_PRESET_KEYS } from '../appearance';
+import { rateLimit } from '../middleware/rate-limit';
+import { COMMUNITY_NAME, TenantService } from '../services/tenant-service';
+
+/**
+ * Tools for INDEPENDENT deployments: compose the config document a
+ * self-hoster's instance will serve, from the same builder the managed
+ * signup uses, so a blog someone runs themselves starts from exactly the
+ * look they customized on ecency.com.
+ *
+ * This route creates NOTHING. No tenant row, no reservation, no published
+ * config file, no payment lock: it is a pure function of the request body
+ * plus (for a community) one chain lookup for the title. Everything that
+ * makes a blog live is deliberately absent, because the caller is
+ * anonymous.
+ */
+export const toolsRoutes = new Hono();
+
+/**
+ * The same vocabulary the signup's create call speaks, so one customize
+ * payload composes identically down either path. Kept in step with
+ * createTenantSchema by sharing the rosters rather than by copying lists.
+ */
+const composeConfigSchema = z.object({
+  username: z.string().min(3).max(16).regex(/^[a-z][a-z0-9.-]*$/),
+  owner: z.string().min(3).max(16).regex(/^[a-z][a-z0-9.-]*$/).optional(),
+  config: z
+    .object({
+      theme: z.enum(['light', 'dark', 'system']).optional(),
+      styleTemplate: z.enum(STYLE_TEMPLATES).optional(),
+      accent: z.string().regex(ACCENT_HEX_PATTERN, 'accent must be #rgb or #rrggbb').optional(),
+      fontPreset: z.enum(FONT_PRESET_KEYS).optional(),
+      type: z.enum(['blog', 'community']).optional(),
+      communityId: z.string().optional(),
+      title: z.string().max(100).optional(),
+      description: z.string().max(500).optional(),
+    })
+    .optional(),
+});
+
+/**
+ * Paths that describe a MANAGED instance and must never reach a config
+ * someone else runs:
+ *
+ * - `managed` is the only signal an instance has that it is hosted here. On
+ *   a self-hoster's domain it flips the Configuration Editor from Download
+ *   to Save, and the Save calls a hosting API that is not theirs.
+ * - `template` replaces the whole site with the claim landing page.
+ * - `claimPreview` marks the read-only preview of an unclaimed subdomain.
+ * - `hivesigner.clientId` may be Ecency's own app, which only answers to
+ *   redirect URIs registered for Ecency's domains: an owner's login would
+ *   fail on their own site. They register their own app (or ask us to add
+ *   their address) and set it themselves.
+ */
+const SERVED_ONLY_PATHS: readonly (readonly string[])[] = [
+  ['configuration', 'instanceConfiguration', 'managed'],
+  ['configuration', 'instanceConfiguration', 'template'],
+  ['configuration', 'instanceConfiguration', 'claimPreview'],
+  ['configuration', 'general', 'hivesigner', 'clientId'],
+];
+
+/**
+ * Drop one path. If removing the leaf empties the block that held it, that
+ * block goes too: `general.hivesigner` with no clientId reads as a
+ * deliberately blank app id rather than as "no Hivesigner app here". The
+ * prune stops at that one level on purpose, since emptying cascades all the
+ * way up would delete `general` and then `configuration` itself.
+ */
+function deletePath(document: Record<string, unknown>, path: readonly string[]): void {
+  let parent = document;
+  for (const segment of path.slice(0, -1)) {
+    const next = parent[segment];
+    if (typeof next !== 'object' || next === null || Array.isArray(next)) return;
+    parent = next as Record<string, unknown>;
+  }
+  delete parent[path[path.length - 1]];
+  if (path.length < 2 || Object.keys(parent).length > 0) return;
+
+  // The leaf's own block is now empty: remove it from ITS parent.
+  let grandparent = document;
+  for (const segment of path.slice(0, -2)) {
+    grandparent = grandparent[segment] as Record<string, unknown>;
+  }
+  delete grandparent[path[path.length - 2]];
+}
+
+/** The document with every managed-only marker removed. */
+export function withoutServedOnlyMarkers(document: unknown): Record<string, unknown> {
+  const copy = JSON.parse(JSON.stringify(document)) as Record<string, unknown>;
+  for (const path of SERVED_ONLY_PATHS) {
+    deletePath(copy, path);
+  }
+  return copy;
+}
+
+// Anonymous and unauthenticated, and each call can spend a chain lookup, so
+// it carries its own budget rather than sharing the create route's.
+const composeLimit = rateLimit({ name: 'tools-compose', limit: 20, windowMs: 60_000 });
+
+toolsRoutes.post('/compose-config', composeLimit, zValidator('json', composeConfigSchema), async (c) => {
+  const body = c.req.valid('json');
+  const username = body.username.toLowerCase();
+  const isCommunity = body.config?.type === 'community';
+
+  // The owner rule, and the ONLY validation this route needs. Nothing here
+  // is registered anywhere, so account existence and community control are
+  // the deployer's business; but the owner value IS load-bearing, because
+  // the instance reads it to decide who may open its editor.
+  let owner: string;
+  if (isCommunity) {
+    const communityId = (body.config?.communityId || username).toLowerCase();
+    if (!COMMUNITY_NAME.test(communityId)) {
+      return c.json({ error: 'Community id must look like hive-NNNN' }, 400);
+    }
+    // A community account holds nobody's keys, so it can never administer
+    // its own instance: without a separate owner the deployment would be
+    // permanently locked out of its own Configuration Editor.
+    if (!body.owner || body.owner.toLowerCase() === communityId) {
+      return c.json({ error: 'A community instance requires a separate owner account' }, 400);
+    }
+    owner = body.owner.toLowerCase();
+  } else {
+    // A personal blog is always controlled by its own account.
+    owner = username;
+  }
+
+  const document = await TenantService.buildConfig(username, body.config, owner);
+  return c.json({ config: withoutServedOnlyMarkers(document) });
+});


### PR DESCRIPTION
First half of #1453 (the server and documentation side). The web fork that consumes this endpoint follows in a separate PR, since it cannot ship before this is deployed.

## POST /v1/tools/compose-config

Runs `TenantService.buildConfig` on a customize payload and returns the composed document. It creates nothing: no tenant row, no reservation, no published config file, no payment lock. The route speaks the same vocabulary as `createTenantSchema` and shares the same rosters, so one payload composes identically down either path.

Managed-only markers are stripped before the document is returned, because each one misdirects an instance somebody else runs:

- `managed` is the only signal an instance has that it is hosted here; on another domain it flips the Configuration Editor from Download to Save, and that Save calls a hosting API that is not theirs.
- `template` replaces the whole site with the claim landing page.
- `claimPreview` marks the read-only preview of an unclaimed subdomain.
- `hivesigner.clientId` may be Ecency's own app, which only answers to redirect URIs registered for Ecency's domains, so an owner's login would fail on their own site.

Owner rule: a personal blog is owned by its own account; a community requires a separate owner, because a community account holds nobody's keys and an instance owned by itself would be permanently locked out of its own editor. The rest of `resolveAndValidateTenant` (account existence, community control) is deliberately not run, as nothing here is registered anywhere.

Rate limited on its own budget as well as the general one, since it is anonymous and each call can spend a chain lookup.

Tests assert on the response body and prove the absences: the DB client and ConfigService are mocked as throwing proxies, so a future edit that starts creating rows or publishing files fails loudly rather than silently putting a blog live.

## Deployment drift

`docker-compose.yml` documented `TAG` while hardcoding `image: ecency/self-hosted:latest`, so every deployment following the guide silently ran `latest` (last published 2026-08-12 08:21, before the release-tag change) rather than the pinned build. It now requires `TAG` the way the managed stack does, and no longer carries a `build:` section that would ignore the pin and try to build from a monorepo the recipient does not have.

DEPLOYMENT.md corrections: a new tag-choosing section stating which tags move and which do not (no `vX.Y.Z` tag exists yet, so `sha-<7>` is what to pin today); `journal` and `reader` added to the template table with their real taglines and their structural limitations; the port corrected from 80 to 3000 throughout; Caddy promoted to the recommended HTTPS path with a working two-line example; the managed platform's topology labelled as reference rather than instruction, since its `:3100` ports are not a self-hoster's; Option 4 no longer tells readers to add a Dockerfile ARG that already exists; upgrade and rollback described as the one-line tag change they are; the stale pricing table replaced by a pointer to the hosting page, which is what it should have been.

`hosting/README.md` listed a `nginx/` directory that does not exist and omitted four that do. It now also notes that the unused `traefik/` config sets `X-Robots-Tag: noindex, nofollow`, which would deindex every tenant blog if it were ever wired in.

Verified: 463 hosting API tests and `npm run build` (tsc), which CI does not run on PRs for this package. `docker compose config` validates with a TAG and fails loudly without one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a self-hosted configuration endpoint for generating customized deployment settings.
  - Added validation for ownership, community setup, account names, and configuration options.
  - Added rate limiting to configuration tools.
  - Added support for immutable image tags and `.env`-based Compose configuration.

- **Documentation**
  - Updated deployment, upgrade, troubleshooting, proxy, SEO, theme, hosting, pricing, and CI guidance.
  - Documented current reverse-proxy and HTTPS deployment workflows.

- **Bug Fixes**
  - Removed managed-only settings from generated self-hosted configurations.
  - Improved handling of missing SEO files and empty configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->