### PR TITLE
Self-hosted: add a Gallery layout for image-led blogs

### DIFF
--- a/apps/self-hosted/hosting/api/src/style-template-display.ts
+++ b/apps/self-hosted/hosting/api/src/style-template-display.ts
@@ -103,6 +103,17 @@ export const STYLE_TEMPLATE_DISPLAY = {
     },
     headingStyle: 'sans',
   },
+  gallery: {
+    name: 'Gallery',
+    tagline: 'A wall of pictures: the image leads, the words step back',
+    colors: {
+      background: '#f6f6f4',
+      surface: '#ffffff',
+      accent: '#37596b',
+      text: '#1b1b1a',
+    },
+    headingStyle: 'sans',
+  },
 } satisfies Record<StyleTemplate, StyleTemplateDisplay>;
 
 export function templateCatalog() {

--- a/apps/self-hosted/hosting/api/src/style-templates.ts
+++ b/apps/self-hosted/hosting/api/src/style-templates.ts
@@ -25,6 +25,7 @@ export const STYLE_TEMPLATES = Object.freeze([
   'modern-gradient',
   'journal',
   'reader',
+  'gallery',
 ] as const);
 
 export type StyleTemplate = (typeof STYLE_TEMPLATES)[number];

--- a/apps/self-hosted/src/core/i18n-strings.ts
+++ b/apps/self-hosted/src/core/i18n-strings.ts
@@ -262,6 +262,7 @@ export type TranslationKey =
   | 'panel_configuration_general_style_template_modern_gradient_option'
   | 'panel_configuration_general_style_template_journal_option'
   | 'panel_configuration_general_style_template_reader_option'
+  | 'panel_configuration_general_style_template_gallery_option'
   | 'reader_home_hint'
   | 'reader_home_keys'
   | 'panel_configuration_general_language_label'
@@ -602,6 +603,8 @@ export const translations: { en: Translations } & Record<
       'Journal (single column, serif, no sidebar)',
     panel_configuration_general_style_template_reader_option:
       'Reader (split view, archive rail beside the post)',
+    panel_configuration_general_style_template_gallery_option:
+      'Gallery (image grid, for picture-led blogs)',
     reader_home_hint: 'Pick a post from the list to start reading.',
     reader_home_keys: 'Tip: j and k move between posts.',
     panel_configuration_general_language_label: 'Language',

--- a/apps/self-hosted/src/features/blog/layout/blog-page.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-page.tsx
@@ -1,5 +1,15 @@
 import type { PropsWithChildren } from 'react';
 
+/**
+ * The reading measure inside the shared shell. `max-w-3xl` stays the width
+ * every template has always had; `blog-page-measure` is a styling hook so a
+ * theme whose archive is not a column of text (Gallery's grid of covers) can
+ * widen it from its own stylesheet without changing anyone else's measure.
+ */
 export function BlogPage(props: PropsWithChildren) {
-  return <div className="max-w-3xl mx-auto w-full">{props.children}</div>;
+  return (
+    <div className="blog-page-measure max-w-3xl mx-auto w-full">
+      {props.children}
+    </div>
+  );
 }

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -47,6 +47,7 @@ const STYLE_TEMPLATE_LABEL_KEYS = {
     'panel_configuration_general_style_template_modern_gradient_option',
   journal: 'panel_configuration_general_style_template_journal_option',
   reader: 'panel_configuration_general_style_template_reader_option',
+  gallery: 'panel_configuration_general_style_template_gallery_option',
 } satisfies Record<StyleTemplate, TranslationKey>;
 
 export type ConfigFieldType =

--- a/apps/self-hosted/src/styles/gallery-layout.test.ts
+++ b/apps/self-hosted/src/styles/gallery-layout.test.ts
@@ -4,61 +4,88 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 /**
- * Gallery is the first layout-level theme that keeps the shared shell: its
- * structure is three CSS rules rather than a Shell component. That makes the
- * rules load-bearing and silent when broken, which is what this pins.
+ * Gallery is the first layout-level theme that keeps the shared shell, so its
+ * structure is CSS rather than a Shell component. That makes these rules
+ * load-bearing and silent when broken, and it makes their SCOPE the thing
+ * most likely to go wrong: the classes they hang off are rendered by more
+ * than the blog shell.
  *
- * Delete the grid rule and Gallery renders a single column of covers, which
- * looks like a styling choice rather than a bug. Delete the measure rule and
- * the wall is capped at the reading width the text templates use. Weaken the
- * selectors and components.css wins, because it is imported AFTER the themes.
+ * Two real bugs are pinned here, both found in review:
+ *
+ * 1. The measure widening applied to every route in the shell, so an article
+ *    and the About page lost the reading width that makes prose readable.
+ *    It now only applies to a page that actually contains a grid.
+ * 2. The sidebar rules applied to /publish and /edit, which render
+ *    `.blog-sidebar-container` and `.blog-layout-grid` themselves, outside
+ *    the theme seam. They took the editor's sidebar away on a Gallery
+ *    instance. They are now qualified by the wrapper only the blog shell
+ *    renders.
  */
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const CSS = readFileSync(join(HERE, 'themes', 'gallery.css'), 'utf8');
 
-/** The declarations of the first rule whose selector matches exactly. */
-function rule(selector: string): string | null {
-  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(CSS);
-  return match ? match[1] : null;
+/** Every rule as { selector, declarations }, comments and newlines removed. */
+function rules(): { selector: string; body: string }[] {
+  const withoutComments = CSS.replace(/\/\*[\s\S]*?\*\//g, '');
+  return [...withoutComments.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => ({
+    selector: m[1].replace(/\s+/g, ' ').trim(),
+    body: m[2],
+  }));
+}
+
+/** The rules whose subject is one of the shared layout classes. */
+function layoutRules() {
+  return rules().filter((r) => r.selector.includes('.blog-'));
+}
+
+function ruleFor(match: RegExp) {
+  return layoutRules().find((r) => match.test(r.selector)) ?? null;
 }
 
 describe('gallery layout rules', () => {
   it('turns the archive into a grid whatever list type the config carries', () => {
-    // listType is hidden by the manifest, but a config written before that
-    // (or by hand) can still say 'list', and the grid has to hold anyway.
-    const archive = rule(':root[data-style-template="gallery"] .blog-posts-list');
+    const archive = ruleFor(/\.blog-posts-list$/);
     expect(archive).not.toBeNull();
-    expect(archive).toMatch(/display:\s*grid/);
-    expect(archive).toMatch(/grid-template-columns:\s*repeat\(auto-fill/);
+    expect(archive!.body).toMatch(/display:\s*grid/);
+    expect(archive!.body).toMatch(/grid-template-columns:\s*repeat\(auto-fill/);
   });
 
-  it('widens the shared reading measure to the theme content width', () => {
-    const measure = rule(':root[data-style-template="gallery"] .blog-page-measure');
+  it('widens the measure only on a page that has a grid on it', () => {
+    // Without the :has, an article and the About page render prose at the
+    // gallery's 1200px content width instead of a reading measure.
+    const measure = ruleFor(/\.blog-page-measure/);
     expect(measure).not.toBeNull();
-    expect(measure).toMatch(/max-width:\s*var\(--theme-content-width\)/);
+    expect(measure!.selector).toContain(':has(.blog-posts-list)');
+    expect(measure!.body).toMatch(/max-width:\s*var\(--theme-content-width\)/);
   });
 
-  it('collapses the sidebar column the shell reserves', () => {
+  it('touches the sidebar only inside the blog shell', () => {
+    // /publish and /edit render .blog-sidebar-container and
+    // .blog-layout-grid directly. Only the blog shell renders
+    // .blog-page-measure, which is what separates them.
+    const sidebarRules = layoutRules().filter((r) =>
+      /\.blog-sidebar-container|\.blog-layout-grid/.test(r.selector),
+    );
+    expect(sidebarRules.length).toBeGreaterThanOrEqual(2);
+    for (const rule of sidebarRules) {
+      expect(rule.selector, rule.selector).toContain(':has(.blog-page-measure)');
+    }
     expect(
-      rule(':root[data-style-template="gallery"] .blog-sidebar-container'),
+      sidebarRules.find((r) => /\.blog-sidebar-container/.test(r.selector))!.body,
     ).toMatch(/display:\s*none/);
-    expect(
-      rule(':root[data-style-template="gallery"] .blog-layout-grid'),
-    ).toMatch(/grid-template-columns:\s*1fr/);
   });
 
   it('keeps every layout selector rooted, so it outranks components.css', () => {
     // components.css is imported after the themes, so an equal-specificity
     // selector there would win. `:root` is the step that prevents it, and a
     // "tidy up" that drops it would break the layout with nothing else failing.
-    const layoutSelectors = [...CSS.matchAll(/^(\S.*)\{/gm)]
-      .map((m) => m[1].trim())
-      .filter((s) => s.includes('.blog-'));
-    expect(layoutSelectors.length).toBeGreaterThanOrEqual(4);
-    for (const selector of layoutSelectors) {
-      expect(selector, selector).toMatch(/^:root\[data-style-template="gallery"\]/);
+    const selectors = layoutRules().map((r) => r.selector);
+    expect(selectors.length).toBeGreaterThanOrEqual(4);
+    for (const selector of selectors) {
+      expect(selector, selector).toMatch(
+        /^:root\[data-style-template="gallery"\]/,
+      );
     }
   });
 });

--- a/apps/self-hosted/src/styles/gallery-layout.test.ts
+++ b/apps/self-hosted/src/styles/gallery-layout.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Gallery is the first layout-level theme that keeps the shared shell: its
+ * structure is three CSS rules rather than a Shell component. That makes the
+ * rules load-bearing and silent when broken, which is what this pins.
+ *
+ * Delete the grid rule and Gallery renders a single column of covers, which
+ * looks like a styling choice rather than a bug. Delete the measure rule and
+ * the wall is capped at the reading width the text templates use. Weaken the
+ * selectors and components.css wins, because it is imported AFTER the themes.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CSS = readFileSync(join(HERE, 'themes', 'gallery.css'), 'utf8');
+
+/** The declarations of the first rule whose selector matches exactly. */
+function rule(selector: string): string | null {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(CSS);
+  return match ? match[1] : null;
+}
+
+describe('gallery layout rules', () => {
+  it('turns the archive into a grid whatever list type the config carries', () => {
+    // listType is hidden by the manifest, but a config written before that
+    // (or by hand) can still say 'list', and the grid has to hold anyway.
+    const archive = rule(':root[data-style-template="gallery"] .blog-posts-list');
+    expect(archive).not.toBeNull();
+    expect(archive).toMatch(/display:\s*grid/);
+    expect(archive).toMatch(/grid-template-columns:\s*repeat\(auto-fill/);
+  });
+
+  it('widens the shared reading measure to the theme content width', () => {
+    const measure = rule(':root[data-style-template="gallery"] .blog-page-measure');
+    expect(measure).not.toBeNull();
+    expect(measure).toMatch(/max-width:\s*var\(--theme-content-width\)/);
+  });
+
+  it('collapses the sidebar column the shell reserves', () => {
+    expect(
+      rule(':root[data-style-template="gallery"] .blog-sidebar-container'),
+    ).toMatch(/display:\s*none/);
+    expect(
+      rule(':root[data-style-template="gallery"] .blog-layout-grid'),
+    ).toMatch(/grid-template-columns:\s*1fr/);
+  });
+
+  it('keeps every layout selector rooted, so it outranks components.css', () => {
+    // components.css is imported after the themes, so an equal-specificity
+    // selector there would win. `:root` is the step that prevents it, and a
+    // "tidy up" that drops it would break the layout with nothing else failing.
+    const layoutSelectors = [...CSS.matchAll(/^(\S.*)\{/gm)]
+      .map((m) => m[1].trim())
+      .filter((s) => s.includes('.blog-'));
+    expect(layoutSelectors.length).toBeGreaterThanOrEqual(4);
+    for (const selector of layoutSelectors) {
+      expect(selector, selector).toMatch(/^:root\[data-style-template="gallery"\]/);
+    }
+  });
+});

--- a/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
+++ b/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
@@ -174,10 +174,10 @@ const accentBlocks = ALL_BLOCKS.filter((block) =>
 
 describe('accent blocks', () => {
   it('are every light and dark palette the templates declare', () => {
-    // Seven templates in two modes, plus the two base blocks in variables.css.
+    // Eight templates in two modes, plus the two base blocks in variables.css.
     // A parser that stopped seeing them would make every check below vacuous.
-    expect(accentBlocks.length).toBe(16);
-    expect(new Set(accentBlocks.map((block) => block.file)).size).toBe(8);
+    expect(accentBlocks.length).toBe(18);
+    expect(new Set(accentBlocks.map((block) => block.file)).size).toBe(9);
   });
 
   it('declare the chip text next to the accent that fills the chip', () => {
@@ -326,7 +326,7 @@ describe('card treatment', () => {
   );
 
   it('is stated by every template rather than inherited by accident', () => {
-    expect(templates.length).toBe(7);
+    expect(templates.length).toBe(8);
     const missing: string[] = [];
     for (const block of templates) {
       for (const token of CARD_TOKENS) {

--- a/apps/self-hosted/src/styles/themes/gallery.css
+++ b/apps/self-hosted/src/styles/themes/gallery.css
@@ -1,0 +1,166 @@
+/* Gallery Theme - A wall of pictures
+ *
+ * The third layout-level design, for blogs whose posts ARE the images: the
+ * archive is a grid of covers rather than a list of headlines, and the
+ * chrome recedes so nothing competes with the pictures. The structural half
+ * lives in src/themes/gallery/ (PostCard and a Sidebar that renders nothing);
+ * these tokens carry the full --theme-* contract so the accent correction
+ * sweep and every token utility keep working.
+ *
+ * The palette is a gallery wall on purpose: near-neutral grounds and a
+ * desaturated slate accent, because a saturated accent beside a photograph
+ * fights it. The two rules at the bottom are the layout itself.
+ */
+
+[data-style-template="gallery"] {
+  /* Typography: the UI face throughout. Captions, not headlines. */
+  --theme-font-body:
+    -apple-system, "BlinkMacSystemFont", "Segoe UI", "Helvetica Neue", "Arial",
+    sans-serif;
+  --theme-font-heading:
+    -apple-system, "BlinkMacSystemFont", "Segoe UI", "Helvetica Neue", "Arial",
+    sans-serif;
+  --theme-font-ui:
+    -apple-system, "BlinkMacSystemFont", "Segoe UI", "Helvetica Neue", "Arial",
+    sans-serif;
+
+  --theme-text-base: 16px;
+  --theme-leading-normal: 1.55;
+  --theme-tracking-normal: 0;
+  --theme-tracking-tight: -0.011em;
+
+  /* Colors - Light: gallery wall, near-black label text, slate accent */
+  --theme-bg-primary: #f6f6f4;
+  --theme-bg-secondary: #ffffff;
+  --theme-bg-tertiary: rgba(27, 27, 26, 0.05);
+  --theme-bg-card: #ffffff;
+
+  --theme-text-primary: #1b1b1a;
+  --theme-text-secondary: rgba(27, 27, 26, 0.72);
+  /* 0.6 composites to ~4.6:1 over the wall: captions stay quiet but AA. */
+  --theme-text-muted: rgba(27, 27, 26, 0.6);
+
+  --theme-accent: #37596b;
+  --theme-accent-hover: #2b4655;
+  /* Ink on the accent fill: white on #37596b is 7.5:1, and it is what the
+   * correction module picks for this fill, so CSS and runtime preview agree. */
+  --theme-accent-contrast: #ffffff;
+
+  --theme-border: rgba(27, 27, 26, 0.1);
+  --theme-border-strong: rgba(27, 27, 26, 0.18);
+
+  /* Effects: a picture needs no frame, so the radius is small and the
+   * elevation is a hairline rather than a drop shadow. */
+  --theme-radius-sm: 3px;
+  --theme-radius: 4px;
+  --theme-radius-lg: 6px;
+  --theme-radius-full: 9999px;
+
+  --theme-shadow-sm: none;
+  --theme-shadow: none;
+  --theme-shadow-lg: 0 8px 30px rgba(27, 27, 26, 0.1);
+
+  /* Link underline style, derived from the accent; see variables.css */
+  --theme-link-decoration: underline;
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
+
+  /* Tag style: small and quiet, the way a wall label is set */
+  --theme-tag-text: var(--theme-accent-text-light, rgba(27, 27, 26, 0.72));
+  --theme-tag-radius: 3px;
+
+  /* Card treatment: the image is the card. No fill, no border, no backdrop,
+   * so a cover sits directly on the wall. */
+  --theme-card-bg: transparent;
+  --theme-card-border: none;
+  --theme-card-backdrop: none;
+
+  /* Layout: wide, because a grid of pictures wants the room. The sidebar
+   * tokens keep the contract satisfied; Gallery renders no sidebar. */
+  --theme-content-width: 1200px;
+  --theme-sidebar-width: 280px;
+  --theme-layout-gap: 2rem;
+  --theme-layout-container-padding: 1.25rem;
+  --theme-layout-section-gap: 2rem;
+  --theme-card-padding: 0px;
+  --theme-grid-gap: 1.25rem;
+  --theme-grid-columns-tablet: 2;
+  --theme-grid-columns-desktop: 3;
+  --theme-post-card-image-height: 240px;
+  --theme-post-card-image-radius: 4px;
+}
+
+/* Gallery Dark Mode: the room with the lights down, the way a photo viewer
+ * goes dark so the picture carries the brightness. */
+[data-style-template="gallery"][data-theme="dark"] {
+  --theme-bg-primary: #121212;
+  --theme-bg-secondary: #1a1a1a;
+  --theme-bg-tertiary: rgba(246, 246, 244, 0.07);
+  --theme-bg-card: #1a1a1a;
+
+  --theme-text-primary: rgba(246, 246, 244, 0.93);
+  --theme-text-secondary: rgba(246, 246, 244, 0.74);
+  --theme-text-muted: rgba(246, 246, 244, 0.58);
+
+  --theme-accent: #8fb8cc;
+  --theme-accent-hover: #a5c8d9;
+  /* The correction module's pick for this fill: 8.4:1. */
+  --theme-accent-contrast: #111827;
+
+  --theme-border: rgba(246, 246, 244, 0.12);
+  --theme-border-strong: rgba(246, 246, 244, 0.2);
+
+  --theme-shadow-lg: 0 8px 30px rgba(0, 0, 0, 0.5);
+
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
+
+  --theme-tag-text: var(--theme-accent-text-dark, rgba(246, 246, 244, 0.62));
+}
+
+/*
+ * The layout. Two rules, both needing to beat components.css, which is
+ * imported AFTER this file: `:root[data-style-template="gallery"]` is one
+ * specificity step above the `[data-list-type="grid"] .blog-posts-list`
+ * rules there, so the grid holds whichever list type the config carries.
+ *
+ * auto-fill with a minimum rather than a fixed column count: a gallery
+ * should reflow to the window, and it keeps the single-column phone case
+ * working without another breakpoint.
+ */
+/*
+ * The shared shell holds the archive at a reading measure (max-w-3xl, the
+ * width every template has always used). A wall of pictures wants the room
+ * instead, so Gallery widens that one wrapper to its own content-width
+ * token. Unlayered, so it beats the Tailwind utility whatever the
+ * specificity; every other template keeps the measure untouched.
+ */
+:root[data-style-template="gallery"] .blog-page-measure {
+  max-width: var(--theme-content-width);
+}
+
+:root[data-style-template="gallery"] .blog-posts-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(260px, 100%), 1fr));
+  gap: var(--theme-grid-gap);
+  align-items: start;
+}
+
+/* No sidebar: the grid is the page. The Sidebar seam already renders
+ * nothing, so this only collapses the column the shell's grid reserves for
+ * it at desktop widths. */
+:root[data-style-template="gallery"] .blog-layout-grid {
+  grid-template-columns: 1fr;
+}
+
+:root[data-style-template="gallery"] .blog-sidebar-container {
+  display: none;
+}

--- a/apps/self-hosted/src/styles/themes/gallery.css
+++ b/apps/self-hosted/src/styles/themes/gallery.css
@@ -137,16 +137,36 @@
  * working without another breakpoint.
  */
 /*
- * The shared shell holds the archive at a reading measure (max-w-3xl, the
- * width every template has always used). A wall of pictures wants the room
- * instead, so Gallery widens that one wrapper to its own content-width
- * token. Unlayered, so it beats the Tailwind utility whatever the
- * specificity; every other template keeps the measure untouched.
+ * The layout, all of it scoped to the blog shell.
+ *
+ * `.blog-layout-grid` and `.blog-sidebar-container` are ALSO rendered by
+ * /publish and /edit, which mount the sidebar directly rather than through
+ * the theme seam. An unscoped rule here reached those routes and took the
+ * editor's sidebar away on a Gallery instance, so every rule below is
+ * qualified by `:has(.blog-page-measure)`, the wrapper only the blog shell
+ * renders.
+ *
+ * The `:root` prefix is the other half: components.css is imported AFTER the
+ * themes, so an equal-specificity selector there would win.
  */
-:root[data-style-template="gallery"] .blog-page-measure {
+
+/*
+ * The shell holds pages at a reading measure (max-w-3xl). A wall of pictures
+ * wants the room instead, but ONLY where there is a wall: an article and the
+ * About page keep the measure that makes prose readable. `:has` scopes this
+ * to pages that actually contain a grid, which is the archive and the search
+ * results, both of which render `.blog-posts-list`.
+ */
+:root[data-style-template="gallery"] .blog-page-measure:has(.blog-posts-list) {
   max-width: var(--theme-content-width);
 }
 
+/*
+ * auto-fill with a minimum rather than a fixed column count: a gallery
+ * should reflow to the window, and it keeps the single-column phone case
+ * working without another breakpoint. Applies whatever list type the config
+ * carries, since a stored 'list' predates this theme.
+ */
 :root[data-style-template="gallery"] .blog-posts-list {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(min(260px, 100%), 1fr));
@@ -154,13 +174,15 @@
   align-items: start;
 }
 
-/* No sidebar: the grid is the page. The Sidebar seam already renders
- * nothing, so this only collapses the column the shell's grid reserves for
- * it at desktop widths. */
-:root[data-style-template="gallery"] .blog-layout-grid {
+/* No sidebar on the blog shell: the seam already renders nothing, so this
+ * only collapses the column the grid reserves for it. */
+:root[data-style-template="gallery"]
+  .blog-layout-grid:has(.blog-page-measure) {
   grid-template-columns: 1fr;
 }
 
-:root[data-style-template="gallery"] .blog-sidebar-container {
+:root[data-style-template="gallery"]
+  .blog-layout-grid:has(.blog-page-measure)
+  > .blog-sidebar-container {
   display: none;
 }

--- a/apps/self-hosted/src/styles/themes/index.css
+++ b/apps/self-hosted/src/styles/themes/index.css
@@ -11,3 +11,4 @@
 @import "./modern-gradient.css";
 @import "./journal.css";
 @import "./reader.css";
+@import "./gallery.css";

--- a/apps/self-hosted/src/themes/gallery/gallery-post-card.tsx
+++ b/apps/self-hosted/src/themes/gallery/gallery-post-card.tsx
@@ -73,12 +73,18 @@ export function GalleryPostCard({ entry }: Props) {
                * `vw` fraction cannot express. Measured at 1x:
                *
                *   <580  1 col, container 100vw-40   tile up to 535
-               *   <768  2 col, container 100vw-40   tile 260 to 354
-               *   <1024 2 col, container 728        tile 354
-               *   <1280 3 col, container 984        tile 315
+               *   <640  2 col, container 100vw-40   tile 260 to 290
+               *   <768  2 col, container 600 (sm)   tile 290
+               *   <1024 2 col, container 728 (md)   tile 354
+               *   <1280 3 col, container 984 (lg)   tile 315
                *   else  4 col, container 1200 (cap) tile 285
+               *
+               * The 640 step is the one that is easy to miss: the container
+               * caps at 640 there, so the tile stops growing while the
+               * viewport keeps going, and a formula that tracks the viewport
+               * overstates by a fifth by the time it reaches 767.
                */
-              sizes="(max-width: 579px) calc(100vw - 40px), (max-width: 767px) calc((100vw - 60px) / 2), (max-width: 1023px) 354px, (max-width: 1279px) 315px, 285px"
+              sizes="(max-width: 579px) calc(100vw - 40px), (max-width: 639px) calc((100vw - 60px) / 2), (max-width: 767px) 290px, (max-width: 1023px) 354px, (max-width: 1279px) 315px, 285px"
               alt={entryData.title}
               loading="lazy"
               className="w-full h-[var(--theme-post-card-image-height)] object-cover transition-theme group-hover:opacity-90"

--- a/apps/self-hosted/src/themes/gallery/gallery-post-card.tsx
+++ b/apps/self-hosted/src/themes/gallery/gallery-post-card.tsx
@@ -1,0 +1,109 @@
+import { Link } from '@tanstack/react-router';
+import type { Entry } from '@ecency/sdk';
+import { buildSrcSet, catchPostImage, postBodySummary } from '@ecency/render-helper';
+import { useMemo } from 'react';
+import { formatDate } from '@/core';
+
+interface Props {
+  entry: Entry;
+  index?: number;
+}
+
+/**
+ * A Gallery tile: the cover at full card width with the title and date as a
+ * quiet label underneath, the way a picture is captioned rather than
+ * headlined. No excerpt, no counters, no card chrome; the wall is the page
+ * and the image is the content.
+ *
+ * A post with no usable image is NOT dropped and NOT given an empty box.
+ * Some posts in an image-led blog are text (a note, an update), and a hole
+ * in a grid reads as a bug. Those tiles fall back to a typeset panel: the
+ * title set larger over the theme's own surface, with the first line of the
+ * post as the picture's stand-in. It keeps the grid rhythm and stays
+ * legible next to real covers.
+ */
+export function GalleryPostCard({ entry }: Props) {
+  const entryData = entry.original_entry || entry;
+
+  // Resolved and proxied by render-helper exactly like the default card:
+  // json_metadata is authored on-chain, so the raw value is untrusted and
+  // only a proxy URL (or null) ever reaches the src.
+  const imageUrl = useMemo(
+    () => catchPostImage(entryData, 600, 600) || null,
+    [entryData],
+  );
+
+  // Only ever rendered in the no-image fallback, so it is computed for the
+  // handful of text posts rather than for every tile on the wall.
+  const summary = useMemo(
+    () =>
+      imageUrl
+        ? null
+        : entryData.json_metadata?.description ||
+          postBodySummary(entryData.body, 160),
+    [imageUrl, entryData],
+  );
+
+  // Same canonical link shape the default card uses: the '@' is part of the
+  // post URL and the router leaves it unencoded.
+  const postParams = useMemo(
+    () => ({ author: `@${entryData.author}`, permlink: entryData.permlink }),
+    [entryData.author, entryData.permlink],
+  );
+  const postSearch = { raw: undefined };
+
+  return (
+    <article className="group">
+      <Link
+        to="/$author/$permlink"
+        params={postParams}
+        search={postSearch}
+        className="block no-underline text-theme-primary"
+      >
+        {imageUrl ? (
+          <div className="overflow-hidden rounded-[var(--theme-post-card-image-radius)] bg-theme-secondary">
+            <img
+              src={imageUrl}
+              srcSet={buildSrcSet(imageUrl) || undefined}
+              /* One tile wide: the grid packs at a 260px minimum and grows,
+                 so a third of a wide window is the realistic upper bound. */
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              alt={entryData.title}
+              loading="lazy"
+              className="w-full h-[var(--theme-post-card-image-height)] object-cover transition-theme group-hover:opacity-90"
+            />
+          </div>
+        ) : (
+          <div className="flex h-[var(--theme-post-card-image-height)] flex-col justify-center gap-2 rounded-[var(--theme-post-card-image-radius)] bg-theme-secondary p-5 border border-theme">
+            <h2 className="heading-theme text-xl leading-snug line-clamp-3">
+              {entryData.title}
+            </h2>
+            {summary && (
+              <p className="text-sm text-theme-secondary line-clamp-3">
+                {summary}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* The wall label. When the tile already carries the title (the
+            no-image case) this is date only, so it is never repeated. */}
+        <div className="mt-2.5">
+          {imageUrl && (
+            <h2 className="heading-theme text-base leading-snug line-clamp-2">
+              {entryData.title}
+            </h2>
+          )}
+          <p className="text-xs text-theme-muted font-theme-ui mt-1">
+            <time dateTime={entryData.created}>
+              {formatDate(entryData.created)}
+            </time>
+            {entryData.community && entryData.community_title && (
+              <span> · {entryData.community_title}</span>
+            )}
+          </p>
+        </div>
+      </Link>
+    </article>
+  );
+}

--- a/apps/self-hosted/src/themes/gallery/gallery-post-card.tsx
+++ b/apps/self-hosted/src/themes/gallery/gallery-post-card.tsx
@@ -65,9 +65,15 @@ export function GalleryPostCard({ entry }: Props) {
             <img
               src={imageUrl}
               srcSet={buildSrcSet(imageUrl) || undefined}
-              /* One tile wide: the grid packs at a 260px minimum and grows,
-                 so a third of a wide window is the realistic upper bound. */
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              /*
+               * Measured from the layout rather than guessed as a viewport
+               * fraction. The grid is auto-fill at a 260px minimum inside a
+               * content width capped at 1200px, so a tile is about 285px on
+               * a wide screen however wide the window gets: a `33vw` hint
+               * told the browser 475px at 1440 and had it fetch a candidate
+               * nobody displays. Values are the measured widths rounded up.
+               */
+              sizes="(max-width: 639px) 100vw, (max-width: 1023px) 360px, 300px"
               alt={entryData.title}
               loading="lazy"
               className="w-full h-[var(--theme-post-card-image-height)] object-cover transition-theme group-hover:opacity-90"

--- a/apps/self-hosted/src/themes/gallery/gallery-post-card.tsx
+++ b/apps/self-hosted/src/themes/gallery/gallery-post-card.tsx
@@ -66,14 +66,19 @@ export function GalleryPostCard({ entry }: Props) {
               src={imageUrl}
               srcSet={buildSrcSet(imageUrl) || undefined}
               /*
-               * Measured from the layout rather than guessed as a viewport
-               * fraction. The grid is auto-fill at a 260px minimum inside a
-               * content width capped at 1200px, so a tile is about 285px on
-               * a wide screen however wide the window gets: a `33vw` hint
-               * told the browser 475px at 1440 and had it fetch a candidate
-               * nobody displays. Values are the measured widths rounded up.
+               * Measured from the rendered grid, not modelled from the
+               * viewport. The container does not grow smoothly: Tailwind's
+               * `container` snaps to breakpoint max-widths, so the tile
+               * width steps rather than sliding, and the steps are what a
+               * `vw` fraction cannot express. Measured at 1x:
+               *
+               *   <580  1 col, container 100vw-40   tile up to 535
+               *   <768  2 col, container 100vw-40   tile 260 to 354
+               *   <1024 2 col, container 728        tile 354
+               *   <1280 3 col, container 984        tile 315
+               *   else  4 col, container 1200 (cap) tile 285
                */
-              sizes="(max-width: 639px) 100vw, (max-width: 1023px) 360px, 300px"
+              sizes="(max-width: 579px) calc(100vw - 40px), (max-width: 767px) calc((100vw - 60px) / 2), (max-width: 1023px) 354px, (max-width: 1279px) 315px, 285px"
               alt={entryData.title}
               loading="lazy"
               className="w-full h-[var(--theme-post-card-image-height)] object-cover transition-theme group-hover:opacity-90"

--- a/apps/self-hosted/src/themes/gallery/gallery-sidebar.tsx
+++ b/apps/self-hosted/src/themes/gallery/gallery-sidebar.tsx
@@ -1,0 +1,13 @@
+/**
+ * Gallery renders no sidebar: the grid is the page, and a rail beside it
+ * would take the width the pictures want.
+ *
+ * This is a seam override rather than a CSS hide on purpose. The default
+ * sidebar fetches followers, following and chain information; hiding it in
+ * CSS would still run all of that for a column nobody sees. Returning null
+ * here means the queries are never made. gallery.css collapses the grid
+ * column the shell reserves.
+ */
+export function GallerySidebar() {
+  return null;
+}

--- a/apps/self-hosted/src/themes/registry.test.ts
+++ b/apps/self-hosted/src/themes/registry.test.ts
@@ -67,7 +67,7 @@ const { DEFAULT_THEME_COMPONENTS, resolveThemeComponents } = await import(
 
 describe('component resolution', () => {
   it('every CSS-only template resolves to exactly the shared defaults', () => {
-    const layoutThemes = new Set(['journal', 'reader']);
+    const layoutThemes = new Set(['journal', 'reader', 'gallery']);
     for (const id of STYLE_TEMPLATES.filter((t) => !layoutThemes.has(t))) {
       const resolved = resolveThemeComponents(id);
       // Identity per seam, not just deep equality: the no-op migration means
@@ -91,6 +91,22 @@ describe('component resolution', () => {
     expect(resolved.Navigation).toBe(DEFAULT_THEME_COMPONENTS.Navigation);
     expect(resolved.Sidebar).toBe(DEFAULT_THEME_COMPONENTS.Sidebar);
     expect(resolved.ArchiveList).toBe(DEFAULT_THEME_COMPONENTS.ArchiveList);
+  });
+
+  it('gallery resolves its own tile and drops the sidebar, defaults for the rest', () => {
+    const gallery = getThemeManifest('gallery');
+    const resolved = resolveThemeComponents('gallery');
+    expect(resolved.PostCard).toBe(gallery.components?.PostCard);
+    // The sidebar seam is overridden rather than hidden in CSS, so the
+    // default sidebar's follower and chain queries never run for a theme
+    // that shows no sidebar at all.
+    expect(resolved.Sidebar).toBe(gallery.components?.Sidebar);
+    expect(resolved.Sidebar).not.toBe(DEFAULT_THEME_COMPONENTS.Sidebar);
+    // Gallery keeps the shared frame: its archive becomes a grid through
+    // CSS the theme owns, not through a shell of its own.
+    expect(resolved.Shell).toBe(DEFAULT_THEME_COMPONENTS.Shell);
+    expect(resolved.ArchiveList).toBe(DEFAULT_THEME_COMPONENTS.ArchiveList);
+    expect(resolved.Navigation).toBe(DEFAULT_THEME_COMPONENTS.Navigation);
   });
 
   it('reader resolves its own shell and archive pane, defaults for the rest', () => {

--- a/apps/self-hosted/src/themes/registry.ts
+++ b/apps/self-hosted/src/themes/registry.ts
@@ -6,6 +6,8 @@ import {
 import { JournalPostCard } from './journal/journal-post-card';
 import { JournalShell } from './journal/journal-shell';
 import { ReaderHome } from './reader/reader-home';
+import { GalleryPostCard } from './gallery/gallery-post-card';
+import { GallerySidebar } from './gallery/gallery-sidebar';
 import { ReaderShell } from './reader/reader-shell';
 import type { ThemeManifest, ThemeOptionKey } from './manifest';
 
@@ -43,6 +45,17 @@ const MANIFESTS: Record<StyleTemplate, ThemeManifest> = {
     tier: 'free',
     showsReadTime: true,
     components: { Shell: ReaderShell, ArchiveList: ReaderHome },
+    unsupportedOptions: ['sidebar', 'listType'],
+  },
+  // The third layout-level design, and the first that keeps the shared
+  // shell: the archive becomes a grid of covers through CSS the theme owns,
+  // so only the tile and the (absent) sidebar are components. listType is
+  // hidden because the grid is not optional here, and sidebar because the
+  // seam renders nothing whatever the config says.
+  gallery: {
+    id: 'gallery',
+    tier: 'free',
+    components: { PostCard: GalleryPostCard, Sidebar: GallerySidebar },
     unsupportedOptions: ['sidebar', 'listType'],
   },
 };


### PR DESCRIPTION
Closes #1467.

The roster had seven templates but three layouts. Five of them (medium, minimal, magazine, developer, modern-gradient) carry no component overrides at all: they render the identical tree and differ in tokens. Nothing served a blog whose posts are pictures, which got a text list with a thumbnail beside it.

## The layout

The archive becomes a grid of covers, with the title and date as a quiet caption underneath and no sidebar. The palette is a gallery wall on purpose: near-neutral grounds and a desaturated slate accent, because a saturated accent beside a photograph fights it. In dark mode the wall drops to #121212 so the pictures carry the brightness.

Gallery is the first layout-level theme that keeps the **shared shell**. Its structure is three CSS rules the theme owns, so only two things are components: the tile, and a Sidebar that renders nothing. That last one is a seam override rather than a CSS hide on purpose, because the default sidebar fetches followers, following and chain data, and hiding it in CSS would still run all of that for a column nobody sees.

A post with no usable image is not dropped and not given an empty box. Some posts in an image-led blog are text, and a hole in a grid reads as a bug, so those tiles fall back to a typeset panel carrying the title and first lines.

## One shared-component change

`BlogPage` gains a `blog-page-measure` class beside its existing `max-w-3xl`. Nothing changes for any other template; it is a styling hook so Gallery can widen that one wrapper from its own stylesheet. Making `BlogPage` read `--theme-content-width` instead was the tempting fix and would have been wrong: every other template declares 640px to 760px there, so it would have narrowed every existing blog's archive as a side effect of adding a theme.

## Verified by rendering it

Built the SPA and served the real `dist` through the published image's nginx with a config for an image-heavy account:

- four columns at 1440px, one on a 390px phone, no horizontal scroll at either;
- the sidebar column collapsed rather than left empty;
- 21 tiles, images loading, no console errors;
- dark config confirmed: ground #121212 and the caption tokens from the dark block.

The three layout rules are pinned by a new guard test, because they are silent when broken: delete the grid rule and Gallery becomes a single column that looks like a design choice, and the guard also asserts every layout selector keeps its `:root` prefix, since components.css is imported after the themes and would otherwise win at equal specificity.

939 SPA tests, 465 hosting API tests, typecheck and a production build all pass. Roster, editor label, token and card-treatment guards updated for the eighth template.

Screenshots (desktop light, desktop dark, phone) attached in the next comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Gallery style template for picture-led blogs.
  * Introduced a responsive image-grid layout with light and dark theme support.
  * Added gallery post cards with cover images, titles, summaries, dates, and links.
  * Added the Gallery option to the style-template configuration menu.
  * Gallery layouts use a single-column page and hide the sidebar for a focused presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->