### PR TITLE
Self-hosted: add a Terminal layout, the Developer aesthetic as a console

### DIFF
--- a/apps/self-hosted/hosting/api/src/style-template-display.ts
+++ b/apps/self-hosted/hosting/api/src/style-template-display.ts
@@ -114,6 +114,17 @@ export const STYLE_TEMPLATE_DISPLAY = {
     },
     headingStyle: 'sans',
   },
+  terminal: {
+    name: 'Terminal',
+    tagline: 'A console listing: monospace, dense, no card in sight',
+    colors: {
+      background: '#0d1117',
+      surface: '#161b22',
+      accent: '#7ee787',
+      text: '#c9d1d9',
+    },
+    headingStyle: 'mono',
+  },
 } satisfies Record<StyleTemplate, StyleTemplateDisplay>;
 
 export function templateCatalog() {

--- a/apps/self-hosted/hosting/api/src/style-templates.ts
+++ b/apps/self-hosted/hosting/api/src/style-templates.ts
@@ -26,6 +26,7 @@ export const STYLE_TEMPLATES = Object.freeze([
   'journal',
   'reader',
   'gallery',
+  'terminal',
 ] as const);
 
 export type StyleTemplate = (typeof STYLE_TEMPLATES)[number];

--- a/apps/self-hosted/src/core/i18n-strings.ts
+++ b/apps/self-hosted/src/core/i18n-strings.ts
@@ -263,6 +263,7 @@ export type TranslationKey =
   | 'panel_configuration_general_style_template_journal_option'
   | 'panel_configuration_general_style_template_reader_option'
   | 'panel_configuration_general_style_template_gallery_option'
+  | 'panel_configuration_general_style_template_terminal_option'
   | 'reader_home_hint'
   | 'reader_home_keys'
   | 'panel_configuration_general_language_label'
@@ -605,6 +606,8 @@ export const translations: { en: Translations } & Record<
       'Reader (split view, archive rail beside the post)',
     panel_configuration_general_style_template_gallery_option:
       'Gallery (image grid, for picture-led blogs)',
+    panel_configuration_general_style_template_terminal_option:
+      'Terminal (console listing, monospace)',
     reader_home_hint: 'Pick a post from the list to start reading.',
     reader_home_keys: 'Tip: j and k move between posts.',
     panel_configuration_general_language_label: 'Language',

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -48,6 +48,7 @@ const STYLE_TEMPLATE_LABEL_KEYS = {
   journal: 'panel_configuration_general_style_template_journal_option',
   reader: 'panel_configuration_general_style_template_reader_option',
   gallery: 'panel_configuration_general_style_template_gallery_option',
+  terminal: 'panel_configuration_general_style_template_terminal_option',
 } satisfies Record<StyleTemplate, TranslationKey>;
 
 export type ConfigFieldType =

--- a/apps/self-hosted/src/styles/terminal-layout.test.ts
+++ b/apps/self-hosted/src/styles/terminal-layout.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Terminal's structure is a Shell and an ArchiveList, so unlike Gallery most
+ * of it is components rather than CSS. Two rules still carry weight and both
+ * are silent when broken, which is what this pins.
+ *
+ * The listing rule also has to survive a config that says `grid`: the feed
+ * setting predates the theme, and `apply-config-dom` falls back to `grid`
+ * when the key is absent, so a stored document can put a console listing
+ * into a grid unless this rule wins.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CSS = readFileSync(join(HERE, 'themes', 'terminal.css'), 'utf8');
+
+function rules() {
+  const withoutComments = CSS.replace(/\/\*[\s\S]*?\*\//g, '');
+  return [...withoutComments.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => ({
+    selector: m[1].replace(/\s+/g, ' ').trim(),
+    body: m[2],
+  }));
+}
+
+const layoutRules = () => rules().filter((r) => r.selector.includes('.blog-'));
+
+describe('terminal layout rules', () => {
+  it('keeps the archive a listing whatever the feed setting says', () => {
+    const listing = layoutRules().find((r) => /\.blog-posts-list$/.test(r.selector));
+    expect(listing).toBeDefined();
+    expect(listing!.body).toMatch(/display:\s*flex/);
+    expect(listing!.body).toMatch(/flex-direction:\s*column/);
+  });
+
+  it('widens the measure only on a page that has the listing on it', () => {
+    // Without the :has, an article and the About page would render prose at
+    // the listing's 900px instead of a reading measure.
+    const measure = layoutRules().find((r) => /\.blog-page-measure/.test(r.selector));
+    expect(measure).toBeDefined();
+    expect(measure!.selector).toContain(':has(.blog-posts-list)');
+    expect(measure!.body).toMatch(/max-width:\s*var\(--theme-content-width\)/);
+  });
+
+  it('carries no sidebar rules, because its shell renders no sidebar', () => {
+    // Gallery needs them: it keeps the shared shell and has to collapse the
+    // column that shell reserves. TerminalShell renders its own frame, so a
+    // rule hiding a sidebar here would match nothing and mislead the reader.
+    expect(CSS).not.toContain('.blog-sidebar-container');
+    expect(CSS).not.toContain('.blog-layout-grid');
+  });
+
+  it('keeps every layout selector rooted, so it outranks components.css', () => {
+    const selectors = layoutRules().map((r) => r.selector);
+    expect(selectors.length).toBeGreaterThanOrEqual(2);
+    for (const selector of selectors) {
+      expect(selector, selector).toMatch(
+        /^:root\[data-style-template="terminal"\]/,
+      );
+    }
+  });
+});

--- a/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
+++ b/apps/self-hosted/src/styles/theme-appearance-tokens.test.ts
@@ -174,10 +174,10 @@ const accentBlocks = ALL_BLOCKS.filter((block) =>
 
 describe('accent blocks', () => {
   it('are every light and dark palette the templates declare', () => {
-    // Eight templates in two modes, plus the two base blocks in variables.css.
+    // Nine templates in two modes, plus the two base blocks in variables.css.
     // A parser that stopped seeing them would make every check below vacuous.
-    expect(accentBlocks.length).toBe(18);
-    expect(new Set(accentBlocks.map((block) => block.file)).size).toBe(9);
+    expect(accentBlocks.length).toBe(20);
+    expect(new Set(accentBlocks.map((block) => block.file)).size).toBe(10);
   });
 
   it('declare the chip text next to the accent that fills the chip', () => {
@@ -326,7 +326,7 @@ describe('card treatment', () => {
   );
 
   it('is stated by every template rather than inherited by accident', () => {
-    expect(templates.length).toBe(8);
+    expect(templates.length).toBe(9);
     const missing: string[] = [];
     for (const block of templates) {
       for (const token of CARD_TOKENS) {

--- a/apps/self-hosted/src/styles/themes/index.css
+++ b/apps/self-hosted/src/styles/themes/index.css
@@ -12,3 +12,4 @@
 @import "./journal.css";
 @import "./reader.css";
 @import "./gallery.css";
+@import "./terminal.css";

--- a/apps/self-hosted/src/styles/themes/terminal.css
+++ b/apps/self-hosted/src/styles/themes/terminal.css
@@ -1,0 +1,157 @@
+/* Terminal Theme - A console listing
+ *
+ * The fourth layout-level design. Developer was the template whose look
+ * implied a structure it did not have: dark and code-friendly, rendering the
+ * same cards as everything else. Terminal is that aesthetic as an actual
+ * layout, and it ships BESIDE Developer rather than replacing it, because
+ * independent deployments cannot be surveyed and an unknown template id
+ * clamps to the roster default: removing 'developer' would silently reset
+ * someone's blog to Medium.
+ *
+ * The structural half lives in src/themes/terminal/ (Shell and ArchiveList
+ * manifest overrides); these tokens carry the full --theme-* contract so the
+ * accent correction sweep and every token utility keep working.
+ *
+ * Monospace throughout on purpose, including headings: the idiom is a
+ * console, where everything is one face at one width.
+ */
+
+[data-style-template="terminal"] {
+  /* Typography: one face, everywhere. */
+  --theme-font-body:
+    ui-monospace, "SFMono-Regular", "SF Mono", "Menlo", "Consolas",
+    "Liberation Mono", monospace;
+  --theme-font-heading:
+    ui-monospace, "SFMono-Regular", "SF Mono", "Menlo", "Consolas",
+    "Liberation Mono", monospace;
+  --theme-font-ui:
+    ui-monospace, "SFMono-Regular", "SF Mono", "Menlo", "Consolas",
+    "Liberation Mono", monospace;
+
+  --theme-text-base: 15px;
+  --theme-leading-normal: 1.6;
+  --theme-tracking-normal: 0;
+  --theme-tracking-tight: 0;
+
+  /* Colors - Light: a pale terminal, for the owner who wants one. The
+   * accent is a deep green so it stays legible on paper as well as glass. */
+  --theme-bg-primary: #f6f8fa;
+  --theme-bg-secondary: #eaeef2;
+  --theme-bg-tertiary: rgba(31, 35, 40, 0.06);
+  --theme-bg-card: #ffffff;
+
+  --theme-text-primary: #1f2328;
+  --theme-text-secondary: rgba(31, 35, 40, 0.75);
+  /* 0.62 composites to ~4.6:1 over the ground. */
+  --theme-text-muted: rgba(31, 35, 40, 0.62);
+
+  --theme-accent: #116329;
+  --theme-accent-hover: #0d4f20;
+  /* Ink on the accent fill: white on #116329 is 7.4:1, and it is what the
+   * correction module picks, so static CSS and runtime preview agree. */
+  --theme-accent-contrast: #ffffff;
+
+  --theme-border: rgba(31, 35, 40, 0.15);
+  --theme-border-strong: rgba(31, 35, 40, 0.25);
+
+  /* Effects: a terminal has corners, not curves, and no elevation. */
+  --theme-radius-sm: 0px;
+  --theme-radius: 0px;
+  --theme-radius-lg: 2px;
+  --theme-radius-full: 0px;
+
+  --theme-shadow-sm: none;
+  --theme-shadow: none;
+  --theme-shadow-lg: none;
+
+  /* Link underline style, derived from the accent; see variables.css */
+  --theme-link-decoration: underline;
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
+
+  /* Tags read as shell tokens: square, quiet, the UI face like everything. */
+  --theme-tag-text: var(--theme-accent-text-light, rgba(31, 35, 40, 0.72));
+  --theme-tag-radius: 0px;
+
+  /* Card treatment: a listing row is not a card. */
+  --theme-card-bg: transparent;
+  --theme-card-border: none;
+  --theme-card-backdrop: none;
+
+  /* Layout: a wide column, because a listing is columns of text. The sidebar
+   * tokens keep the contract satisfied; the Terminal shell renders none. */
+  --theme-content-width: 900px;
+  --theme-sidebar-width: 280px;
+  --theme-layout-gap: 1.5rem;
+  --theme-layout-container-padding: 1rem;
+  --theme-layout-section-gap: 1.5rem;
+  --theme-card-padding: 0px;
+  --theme-grid-gap: 1rem;
+  --theme-grid-columns-tablet: 1;
+  --theme-grid-columns-desktop: 1;
+  --theme-post-card-image-height: 180px;
+  --theme-post-card-image-radius: 0px;
+}
+
+/* Terminal Dark Mode: the home state. Deep slate ground, phosphor green. */
+[data-style-template="terminal"][data-theme="dark"] {
+  --theme-bg-primary: #0d1117;
+  --theme-bg-secondary: #161b22;
+  --theme-bg-tertiary: rgba(201, 209, 217, 0.08);
+  --theme-bg-card: #161b22;
+
+  --theme-text-primary: #c9d1d9;
+  --theme-text-secondary: rgba(201, 209, 217, 0.78);
+  --theme-text-muted: rgba(201, 209, 217, 0.6);
+
+  --theme-accent: #7ee787;
+  --theme-accent-hover: #a2f2a9;
+  /* The correction module's pick for this fill: 11.6:1. */
+  --theme-accent-contrast: #111827;
+
+  --theme-border: rgba(201, 209, 217, 0.15);
+  --theme-border-strong: rgba(201, 209, 217, 0.25);
+
+  --theme-link-decoration-color: color-mix(
+    in srgb,
+    var(--theme-accent-text, var(--theme-accent)) 40%,
+    transparent
+  );
+  --theme-link-decoration-hover: var(--theme-accent-text, var(--theme-accent));
+
+  --theme-tag-text: var(--theme-accent-text-dark, rgba(201, 209, 217, 0.7));
+}
+
+/*
+ * The listing rules. Rooted like every theme's layout CSS: this file is
+ * imported BEFORE components.css, so an equal-specificity selector there
+ * would win.
+ *
+ * There are no sidebar rules here, unlike Gallery's. Gallery keeps the
+ * shared shell, so it has to collapse the column that shell reserves.
+ * TerminalShell renders its own frame with no sidebar in it at all, so a
+ * rule hiding one would never match anything.
+ */
+
+/*
+ * The shell holds pages at a reading measure (max-w-3xl), which left the
+ * listing inset from the prompt line above it: a console whose header and
+ * body do not share a left edge does not read as one. Widened only where
+ * there IS a listing, so an article and the About page keep the measure
+ * that makes prose readable.
+ */
+:root[data-style-template="terminal"] .blog-page-measure:has(.blog-posts-list) {
+  max-width: var(--theme-content-width);
+}
+
+/* A listing is rows, whatever the config's feed setting says: the layout is
+ * the point of the theme, and a stored 'grid' predates it. */
+:root[data-style-template="terminal"] .blog-posts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}

--- a/apps/self-hosted/src/themes/registry.test.ts
+++ b/apps/self-hosted/src/themes/registry.test.ts
@@ -67,7 +67,7 @@ const { DEFAULT_THEME_COMPONENTS, resolveThemeComponents } = await import(
 
 describe('component resolution', () => {
   it('every CSS-only template resolves to exactly the shared defaults', () => {
-    const layoutThemes = new Set(['journal', 'reader', 'gallery', 'magazine']);
+    const layoutThemes = new Set(['journal', 'reader', 'gallery', 'magazine', 'terminal']);
     for (const id of STYLE_TEMPLATES.filter((t) => !layoutThemes.has(t))) {
       const resolved = resolveThemeComponents(id);
       // Identity per seam, not just deep equality: the no-op migration means
@@ -118,6 +118,16 @@ describe('component resolution', () => {
     expect(resolved.Shell).toBe(DEFAULT_THEME_COMPONENTS.Shell);
     expect(resolved.ArchiveList).toBe(DEFAULT_THEME_COMPONENTS.ArchiveList);
     expect(resolved.Navigation).toBe(DEFAULT_THEME_COMPONENTS.Navigation);
+  });
+
+  it('terminal owns its shell and listing, and mounts the composer entry', () => {
+    const terminal = getThemeManifest('terminal');
+    const resolved = resolveThemeComponents('terminal');
+    expect(resolved.Shell).toBe(terminal.components?.Shell);
+    expect(resolved.ArchiveList).toBe(terminal.components?.ArchiveList);
+    // The card stays shared: search results render through that seam, and a
+    // listing row has no meaning outside the archive.
+    expect(resolved.PostCard).toBe(DEFAULT_THEME_COMPONENTS.PostCard);
   });
 
   it('reader resolves its own shell and archive pane, defaults for the rest', () => {

--- a/apps/self-hosted/src/themes/registry.ts
+++ b/apps/self-hosted/src/themes/registry.ts
@@ -9,6 +9,8 @@ import { ReaderHome } from './reader/reader-home';
 import { MagazineArchive } from './magazine/magazine-archive';
 import { GalleryPostCard } from './gallery/gallery-post-card';
 import { GallerySidebar } from './gallery/gallery-sidebar';
+import { TerminalShell } from './terminal/terminal-shell';
+import { TerminalArchive } from './terminal/terminal-archive';
 import { ReaderShell } from './reader/reader-shell';
 import type { ThemeManifest, ThemeOptionKey } from './manifest';
 
@@ -66,6 +68,19 @@ const MANIFESTS: Record<StyleTemplate, ThemeManifest> = {
     id: 'gallery',
     tier: 'free',
     components: { PostCard: GalleryPostCard, Sidebar: GallerySidebar },
+    unsupportedOptions: ['sidebar', 'listType'],
+  },
+  // The fourth layout-level design: the Developer aesthetic as an actual
+  // console. Its own shell (prompt line, filters as flags, no sidebar) and
+  // its own archive (a dense listing, no cards). Ships beside Developer
+  // rather than replacing it: an unknown template id clamps to the roster
+  // default, so removing that id would silently reset an independent
+  // deployment's blog to Medium, and those cannot be surveyed.
+  terminal: {
+    id: 'terminal',
+    tier: 'free',
+    showsReadTime: true,
+    components: { Shell: TerminalShell, ArchiveList: TerminalArchive },
     unsupportedOptions: ['sidebar', 'listType'],
   },
 };

--- a/apps/self-hosted/src/themes/terminal/terminal-archive.tsx
+++ b/apps/self-hosted/src/themes/terminal/terminal-archive.tsx
@@ -17,12 +17,45 @@ import { ArchiveFrame } from '@/features/blog/components/archive-frame';
 export function TerminalArchive({ filter, limit }: { filter?: string; limit?: number }) {
   return (
     <ArchiveFrame filter={filter} limit={limit}>
-      {({ posts }) => posts.map((post) => <TerminalRow key={`${post.author}/${post.permlink}`} entry={post} />)}
+      {({ posts }) => {
+        /*
+         * The date column is measured, not assumed. `general.dateFormat` is
+         * free-form, so a site can be running `MMMM d, yyyy` ("August 13,
+         * 2026") where the default renders `2026-08-13`. A fixed width made
+         * the long one wrap into the title column and destroy the alignment
+         * that is the whole point of a listing.
+         *
+         * `ch` is exact here because the theme is monospace throughout: one
+         * character is one advance width, so the widest formatted date in
+         * the batch gives a column that fits every row in it.
+         */
+        const dated = posts.map((post) => ({
+          post,
+          dateText: formatDate((post.original_entry || post).created),
+        }));
+        const dateColumn = dated.reduce((w, d) => Math.max(w, d.dateText.length), 0);
+
+        return dated.map(({ post, dateText }) => (
+          <TerminalRow
+            key={`${post.author}/${post.permlink}`}
+            entry={post}
+            dateText={dateText}
+            dateColumn={dateColumn}
+          />
+        ));
+      }}
     </ArchiveFrame>
   );
 }
 
-function TerminalRow({ entry }: { entry: Entry }) {
+interface RowProps {
+  entry: Entry;
+  dateText: string;
+  /** Width of the date column in characters, the widest in the batch. */
+  dateColumn: number;
+}
+
+function TerminalRow({ entry, dateText, dateColumn }: RowProps) {
   const entryData = entry.original_entry || entry;
 
   const showsReadTime = useThemeShowsReadTime();
@@ -48,20 +81,24 @@ function TerminalRow({ entry }: { entry: Entry }) {
         className="group flex items-baseline gap-3 py-2 no-underline text-theme-primary hover:bg-theme-tertiary transition-theme"
       >
         {/*
-          tabular-nums so the dates form a real column: proportional digits
-          make a monospace listing ragged, which is the one thing a listing
-          cannot be. Fixed width for the same reason.
+          tabular-nums so digits share an advance width even if a font
+          substitutes, and nowrap so an unusually long format pushes the
+          column rather than folding onto a second line.
         */}
         <time
           dateTime={entryData.created}
-          className="shrink-0 w-[6.5rem] text-xs text-theme-muted tabular-nums"
+          style={{ width: `${dateColumn}ch` }}
+          className="shrink-0 whitespace-nowrap text-xs text-theme-muted tabular-nums"
         >
-          {formatDate(entryData.created)}
+          {dateText}
         </time>
 
         {/* The prompt mark, purely decorative: a listing reads as a listing
             because every line starts the same way. */}
-        <span aria-hidden="true" className="shrink-0 text-theme-muted group-hover:text-theme-accent transition-theme">
+        <span
+          aria-hidden="true"
+          className="shrink-0 text-theme-muted group-hover:text-theme-accent transition-theme"
+        >
           &gt;
         </span>
 

--- a/apps/self-hosted/src/themes/terminal/terminal-archive.tsx
+++ b/apps/self-hosted/src/themes/terminal/terminal-archive.tsx
@@ -1,0 +1,80 @@
+import { Link } from '@tanstack/react-router';
+import type { Entry } from '@ecency/sdk';
+import { useMemo } from 'react';
+import { formatDate, t } from '@/core';
+import { estimateReadMinutes } from '@/features/blog/utils/read-time';
+import { useThemeShowsReadTime } from '@/themes/use-theme-components';
+import { ArchiveFrame } from '@/features/blog/components/archive-frame';
+
+/**
+ * The Terminal archive: a listing, not a feed. One row per post, aligned in
+ * columns the way `ls -l` aligns, with the date first because that is the
+ * column a listing sorts by.
+ *
+ * No images, no excerpts, no counters. The whole point of the idiom is
+ * density: a reader sees thirty titles at once instead of five cards.
+ */
+export function TerminalArchive({ filter, limit }: { filter?: string; limit?: number }) {
+  return (
+    <ArchiveFrame filter={filter} limit={limit}>
+      {({ posts }) => posts.map((post) => <TerminalRow key={`${post.author}/${post.permlink}`} entry={post} />)}
+    </ArchiveFrame>
+  );
+}
+
+function TerminalRow({ entry }: { entry: Entry }) {
+  const entryData = entry.original_entry || entry;
+
+  const showsReadTime = useThemeShowsReadTime();
+  const readTime = useMemo(
+    () => (showsReadTime ? estimateReadMinutes(entryData.body) : null),
+    [showsReadTime, entryData.body],
+  );
+
+  // Same canonical link shape every other card uses: the '@' is part of the
+  // post URL and the router leaves it unencoded.
+  const postParams = useMemo(
+    () => ({ author: `@${entryData.author}`, permlink: entryData.permlink }),
+    [entryData.author, entryData.permlink],
+  );
+  const postSearch = { raw: undefined };
+
+  return (
+    <article className="border-b border-theme last:border-b-0">
+      <Link
+        to="/$author/$permlink"
+        params={postParams}
+        search={postSearch}
+        className="group flex items-baseline gap-3 py-2 no-underline text-theme-primary hover:bg-theme-tertiary transition-theme"
+      >
+        {/*
+          tabular-nums so the dates form a real column: proportional digits
+          make a monospace listing ragged, which is the one thing a listing
+          cannot be. Fixed width for the same reason.
+        */}
+        <time
+          dateTime={entryData.created}
+          className="shrink-0 w-[6.5rem] text-xs text-theme-muted tabular-nums"
+        >
+          {formatDate(entryData.created)}
+        </time>
+
+        {/* The prompt mark, purely decorative: a listing reads as a listing
+            because every line starts the same way. */}
+        <span aria-hidden="true" className="shrink-0 text-theme-muted group-hover:text-theme-accent transition-theme">
+          &gt;
+        </span>
+
+        <span className="min-w-0 flex-1 truncate group-hover:underline">
+          {entryData.title}
+        </span>
+
+        {readTime !== null && (
+          <span className="shrink-0 text-xs text-theme-muted tabular-nums hidden sm:inline">
+            {readTime} {t('minRead')}
+          </span>
+        )}
+      </Link>
+    </article>
+  );
+}

--- a/apps/self-hosted/src/themes/terminal/terminal-shell.tsx
+++ b/apps/self-hosted/src/themes/terminal/terminal-shell.tsx
@@ -4,7 +4,10 @@ import clsx from 'clsx';
 import { InstanceConfigManager, t } from '@/core';
 import { CreatePostButton, UserMenu } from '@/features/auth';
 import { SearchInput } from '@/features/blog/components/search-input';
-import { useInstanceConfig } from '@/features/blog/hooks/use-instance-config';
+import {
+  useCommunityData,
+  useInstanceConfig,
+} from '@/features/blog/hooks/use-instance-config';
 import { usePostsFilterState } from '@/features/blog/hooks/use-posts-filter-state';
 import { BlogPage } from '@/features/blog/layout/blog-page';
 
@@ -19,7 +22,8 @@ import { BlogPage } from '@/features/blog/layout/blog-page';
  * removes the only way an owner writes a post.
  */
 export function TerminalShell(props: PropsWithChildren) {
-  const { username, isCommunityMode } = useInstanceConfig();
+  const { username, communityId, isCommunityMode } = useInstanceConfig();
+  const { data: community } = useCommunityData();
 
   const blogTitle = InstanceConfigManager.useConfig(
     ({ configuration }) => configuration.instanceConfiguration.meta.title,
@@ -32,9 +36,18 @@ export function TerminalShell(props: PropsWithChildren) {
   const { availableFilters, currentFilter, filterLabel, isAboutActive } =
     usePostsFilterState();
 
-  // The prompt reads as a path: a community is a directory of many authors,
-  // a blog is one person's home.
-  const prompt = isCommunityMode ? `~/${username}` : `~/${username}`;
+  // The prompt reads as a path. A community instance is keyed by its
+  // community id, not by `username`: a hand-written self-hosted config can
+  // leave username empty or set it to something unrelated, and the prompt
+  // would then name an account that has nothing to do with the site.
+  const identity = isCommunityMode ? communityId || username : username;
+  const prompt = `~/${identity}`;
+
+  // Same preference the other shells use: the community's current on-chain
+  // title beats a title stored in the config, which goes stale the moment
+  // the community is renamed.
+  const displayTitle =
+    (isCommunityMode && community?.title) || blogTitle || identity;
 
   return (
     <div className="min-h-screen bg-theme-primary">
@@ -50,7 +63,7 @@ export function TerminalShell(props: PropsWithChildren) {
                 <span aria-hidden="true" className="text-theme-muted">
                   {prompt}
                 </span>{' '}
-                {blogTitle || username}
+                {displayTitle}
               </Link>
             </h1>
             <span className="ml-auto flex items-center gap-3">

--- a/apps/self-hosted/src/themes/terminal/terminal-shell.tsx
+++ b/apps/self-hosted/src/themes/terminal/terminal-shell.tsx
@@ -1,0 +1,110 @@
+import type { PropsWithChildren } from 'react';
+import { Link } from '@tanstack/react-router';
+import clsx from 'clsx';
+import { InstanceConfigManager, t } from '@/core';
+import { CreatePostButton, UserMenu } from '@/features/auth';
+import { SearchInput } from '@/features/blog/components/search-input';
+import { useInstanceConfig } from '@/features/blog/hooks/use-instance-config';
+import { usePostsFilterState } from '@/features/blog/hooks/use-posts-filter-state';
+import { BlogPage } from '@/features/blog/layout/blog-page';
+
+/**
+ * The Terminal page frame: a prompt line instead of a masthead, filters as
+ * flags after it, and no sidebar. Wide-ish column because a listing is
+ * columns of text rather than a measure of prose.
+ *
+ * It mounts CreatePostButton itself. That is the standing contract for every
+ * theme shell here: the default navigation is what mounts the composer
+ * entry, so a shell that replaces the navigation and forgets it silently
+ * removes the only way an owner writes a post.
+ */
+export function TerminalShell(props: PropsWithChildren) {
+  const { username, isCommunityMode } = useInstanceConfig();
+
+  const blogTitle = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.instanceConfiguration.meta.title,
+  );
+  const blogDescription = InstanceConfigManager.useConfig(
+    ({ configuration }) => configuration.instanceConfiguration.meta.description,
+  );
+
+  // Shared with BlogNavigation, so the shell cannot drift from it.
+  const { availableFilters, currentFilter, filterLabel, isAboutActive } =
+    usePostsFilterState();
+
+  // The prompt reads as a path: a community is a directory of many authors,
+  // a blog is one person's home.
+  const prompt = isCommunityMode ? `~/${username}` : `~/${username}`;
+
+  return (
+    <div className="min-h-screen bg-theme-primary">
+      <div className="mx-auto w-full max-w-[900px] container-padding-theme">
+        <header className="pt-8 pb-4">
+          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-2">
+            <h1 className="heading-theme text-lg sm:text-xl">
+              <Link
+                to="/blog"
+                search={{ filter: availableFilters[0] || 'posts' }}
+                className="no-underline text-theme-primary hover:opacity-80 transition-theme"
+              >
+                <span aria-hidden="true" className="text-theme-muted">
+                  {prompt}
+                </span>{' '}
+                {blogTitle || username}
+              </Link>
+            </h1>
+            <span className="ml-auto flex items-center gap-3">
+              <SearchInput />
+              <CreatePostButton />
+              <UserMenu />
+            </span>
+          </div>
+
+          {blogDescription && (
+            <p className="mt-2 text-sm text-theme-muted">
+              <span aria-hidden="true"># </span>
+              {blogDescription}
+            </p>
+          )}
+
+          {/* Filters as flags on the prompt line. Wrapping rather than
+              scrolling: a listing that scrolls sideways is not a listing. */}
+          <nav className="mt-5 flex flex-wrap items-center gap-x-4 gap-y-1 border-y border-theme py-2 text-sm">
+            {availableFilters.map((filter) => (
+              <Link
+                key={filter}
+                to="/blog"
+                search={{ filter }}
+                className={clsx(
+                  'no-underline transition-theme',
+                  !isAboutActive && currentFilter === filter
+                    ? 'text-theme-accent'
+                    : 'text-theme-muted hover:text-theme-primary',
+                )}
+              >
+                <span aria-hidden="true">--</span>
+                {filterLabel(filter)}
+              </Link>
+            ))}
+            <Link
+              to="/about"
+              className={clsx(
+                'no-underline transition-theme',
+                isAboutActive
+                  ? 'text-theme-accent'
+                  : 'text-theme-muted hover:text-theme-primary',
+              )}
+            >
+              <span aria-hidden="true">--</span>
+              {t('about_nav')}
+            </Link>
+          </nav>
+        </header>
+
+        <main id="main-content" className="pb-16">
+          <BlogPage>{props.children}</BlogPage>
+        </main>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #1469. Takes the roster to nine templates and **five layouts**.

Developer was the template whose look implied a structure it did not have: dark and code-friendly, rendering the same cards as everything else. Terminal is that aesthetic as an actual layout.

- **Its own shell**: a prompt line (`~/username`) instead of a masthead, the description as a `#` comment, filters rendered as `--flags` with the active one in the accent, and no sidebar.
- **Its own archive**: one row per post, dates in a `tabular-nums` column so they line up (proportional digits make a monospace listing ragged, which is the one thing a listing cannot be), a `>` prompt mark, the title truncating, read time on the right. No images, no excerpts, no cards. A reader sees thirty titles where a feed shows five.
- Monospace throughout including headings, since the idiom is a console where everything is one face.

## Two decisions worth stating

**It ships beside Developer rather than replacing it.** Replacing would keep the roster honest and no managed tenant uses Developer today, so the temptation was real. But an unknown template id clamps to the roster default, and independent deployments cannot be surveyed: retiring the id would silently reset someone's self-hosted blog to Medium. The cost of keeping a redundant skin is lower than that.

**It carries no sidebar CSS.** Gallery needs those rules because it keeps the shared shell and has to collapse the column that shell reserves. `TerminalShell` renders its own frame with no sidebar in it, so a rule hiding one would match nothing. I wrote them first, then removed them on reading the file back, and the guard test now asserts their absence so nobody adds them back for symmetry.

The shell mounts `CreatePostButton` itself, which is the standing contract here: the default navigation is what mounts the composer entry, so a shell replacing it and forgetting silently removes the only way an owner writes a post.

## Verified by rendering it

Built the app and served the real `dist` through the published image's nginx, against a real account, with the **hostile config**: `listType: grid` (which is also what `apply-config-dom` falls back to when the key is absent) and dark mode.

| viewport | archive | rows | dates aligned | sidebar | horizontal scroll | console |
|---|---|---|---|---|---|---|
| 1440px | flex listing | 20 | yes | none | none | clean |
| 390px | flex listing | 20 | yes | none | none | clean |

The listing stays a listing under `grid`, monospace resolves, and the ground is the dark token rather than an inherited one. Rendering also caught a misalignment worth fixing: the shared `BlogPage` measure left the listing inset from the prompt line above it, so the header and body did not share a left edge. Both now sit at the same 868px.

946 SPA tests and typecheck pass. Roster, editor label, token and card-treatment guards updated for the ninth template, plus a layout guard for the two CSS rules that carry weight.