### PR TITLE
self-hosted: render the following count, so its toggle finally does something

### DIFF
--- a/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
@@ -81,12 +81,24 @@ function BlogSidebarContent({ username }: { username: string }) {
           {data.profile.about}
         </div>
       )}
+      {/*
+       * Both counts come off the same follow_stats payload this component
+       * already fetches, so the second one costs no request. The row collapses
+       * in CSS when an owner turns both off, or its bottom margin would leave
+       * a gap where the counts used to be.
+       */}
       {data?.follow_stats && (
-        <div className="flex gap-6 mb-4">
+        <div className="flex gap-6 mb-4 sidebar-follow-stats">
           <div className="flex flex-col sidebar-followers-section">
             <div className="text-xs text-theme-muted">{t("subscribers")}</div>
             <div className="text-sm font-medium text-theme-primary">
               {data.follow_stats.follower_count}
+            </div>
+          </div>
+          <div className="flex flex-col sidebar-following-section">
+            <div className="text-xs text-theme-muted">{t("following")}</div>
+            <div className="text-sm font-medium text-theme-primary">
+              {data.follow_stats.following_count}
             </div>
           </div>
         </div>

--- a/apps/self-hosted/src/styles/components.css
+++ b/apps/self-hosted/src/styles/components.css
@@ -291,6 +291,16 @@
   display: none;
 }
 
+/*
+ * The row that holds both counts carries a bottom margin, so with both
+ * sections hidden it would leave a gap where the counts used to be. Collapsing
+ * it is the one rule here that needs BOTH attributes, which is also why the
+ * pairing guard skips it: it matches on a single attribute per rule.
+ */
+[data-show-followers="false"][data-show-following="false"] .sidebar-follow-stats {
+  display: none;
+}
+
 [data-show-hive-info="false"] .sidebar-hive-info-section {
   display: none;
 }

--- a/apps/self-hosted/src/styles/sidebar-visibility.test.ts
+++ b/apps/self-hosted/src/styles/sidebar-visibility.test.ts
@@ -31,11 +31,12 @@ const SIDEBAR = readFileSync(
 );
 
 /**
- * Known-dead, tracked in #1477: the editor offers a Following toggle and the
- * whole chain exists except the component. Resolving that issue empties this
- * list, at which point the last case below starts enforcing on it too.
+ * This list is empty and should stay that way. It briefly held
+ * `data-show-following`, whose toggle had a field, a seed, an attribute and a
+ * rule but no component rendering the class it hid, so it had never done
+ * anything (#1477). An entry here means a toggle that lies to the owner.
  */
-const RENDERS_NOTHING_YET = new Set(['data-show-following']);
+const RENDERS_NOTHING_YET = new Set<string>();
 
 /** Every data-show-* attribute apply-config-dom actually emits. */
 function emittedAttributes(): string[] {
@@ -80,6 +81,18 @@ describe('sidebar section visibility', () => {
         `components.css hides on ${attribute}, but apply-config-dom never writes it`,
       ).toBe(true);
     }
+  });
+
+  it('collapses the counts row when both of its sections are hidden', () => {
+    // Needs both attributes, so it is not in hidingRules(). Without it the
+    // row's bottom margin survives its contents as a gap.
+    const withoutComments = CSS.replace(/\/\*[\s\S]*?\*\//g, '');
+    const collapse = withoutComments.match(
+      /\[data-show-followers="false"\]\[data-show-following="false"\]\s*\.([a-z-]+)\s*\{([^{}]*)\}/,
+    );
+    expect(collapse, 'no rule collapses the follow-stats row').not.toBeNull();
+    expect(collapse![2]).toMatch(/display:\s*none/);
+    expect(SIDEBAR).toContain(collapse![1]);
   });
 
   it('hides a class the sidebar actually renders', () => {


### PR DESCRIPTION
Closes #1477.

The sidebar's **Following** toggle has never done anything. Everything around it exists: a labelled control with the description "Show following section", a value seeded into every tenant's config, `data-show-following` written to `<html>`, and a CSS rule keyed to that attribute. The one missing piece is a component rendering `.sidebar-following-section`, so the rule matched nothing and an owner switching it off saw no change. It went unnoticed precisely because every grep for "is this wired up" answers yes.

### Why render it rather than retire it

I filed the issue with both options open and called it a product decision. Looking at the code settled it, so I want the evidence on the record rather than just the choice:

- `following_count` arrives in the **same `follow_stats` payload** this component already fetches. Rendering it costs no additional request.
- **ecency.com's own profile card shows both counts** (`profile-card/index.tsx`, `waves-profile-card.tsx`). Showing only followers is the odd one out.
- The markup was `flex gap-6` wrapped around a **single child**. That is a row built for two, with the second never added.
- **No tenant has ever turned it off.** I checked the live configs; every one carries the seeded `true`, so there is no owner relying on it to hide something.
- The editor already promises it in writing.

Retiring would have meant deleting a promised control whose data was already on hand. This is blog mode only: `BlogSidebar` returns early for communities and renders its own sidebar, where "following" would be meaningless for a community account.

### The row has to collapse

With two toggles, both-off became reachable, and the row carries `mb-4`. Hidden children leave the margin behind as a gap where the counts used to be, so a rule collapses the row when both are off. It is the only rule here needing **two** attributes at once, which is why the pairing guard cannot match it (that guard reads one attribute per rule) and it gets its own test case.

### The guard loses its exception

`sidebar-visibility.test.ts` had `data-show-following` on a `RENDERS_NOTHING_YET` list pointing at this issue. That list is now empty and typed so, with a comment saying an entry in it means a toggle that lies to the owner. The "hides a class the sidebar actually renders" case now enforces on all three toggles with no exemption.

### Verified

All four combinations, in a browser against a real build of this branch serving a real account:

| followers | following | followers section | following section | row |
|---|---|---|---|---|
| on | on | visible, "Subscribers 40178" | visible, "Following 173" | 36px |
| on | off | visible | `display: none` | 36px |
| off | on | `display: none` | visible | 36px |
| off | off | `display: none` | `display: none` | **collapsed, 0px** |

Hive info stayed visible throughout as a control, and there were no console errors in any run. 952 SPA tests pass.

One note for review: `biome format` on this file rewrites every quote in it, since the committed file uses double quotes and the config wants single. I reverted that and matched the file's existing style, so the diff is the change and nothing else. `apps/self-hosted` has no lint or format script wired into CI, which is why the drift exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Blog sidebars now display both follower/subscriber and following counts.

- **Bug Fixes**
  - Follow statistics are now hidden when both follower and following sections are disabled.
  - Improved sidebar visibility behavior to prevent empty statistics rows from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->