### PR TITLE
self-hosted: make the sidebar toggles work on community instances

### DIFF
--- a/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
@@ -341,8 +341,15 @@ function CommunitySidebar() {
         )}
       </div>
 
+      {/*
+       * The team is chain information too, and it is a sibling block rather
+       * than part of the one above, so it needs the class in its own right.
+       * Without it, an owner who turned Hive Information off kept the
+       * moderator list: a toggle that half works, which is the same defect as
+       * one that does nothing.
+       */}
       {community.team && community.team.length > 0 && (
-        <div className="border-t border-theme pt-4 mt-4">
+        <div className="border-t border-theme pt-4 mt-4 sidebar-hive-info-section">
           <div className="text-xs font-medium mb-2 text-theme-muted">
             {t("team")}
           </div>

--- a/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
@@ -288,8 +288,18 @@ function CommunitySidebar() {
         </div>
       )}
 
+      {/*
+       * The same two visibility classes the blog sidebar carries, on this
+       * tree's counterparts: the Followers toggle governs the subscriber
+       * count here exactly as it governs the follower count there, which the
+       * blog side also labels "Subscribers". Without them the toggles were
+       * inert on every community instance (#1480).
+       *
+       * The row needs no collapse rule: the author count has no toggle, so it
+       * can never empty the way the blog side's two-toggle row can.
+       */}
       <div className="flex gap-6 mb-4">
-        <div className="flex flex-col">
+        <div className="flex flex-col sidebar-followers-section">
           <div className="text-xs text-theme-muted">{t("subscribers")}</div>
           <div className="text-sm font-medium text-theme-primary">
             {community.subscribers?.toLocaleString() || 0}
@@ -307,7 +317,7 @@ function CommunitySidebar() {
         <CommunityJoinButton communityId={communityId} />
       </div>
 
-      <div className="border-t border-theme pt-4 mt-4">
+      <div className="border-t border-theme pt-4 mt-4 sidebar-hive-info-section">
         <div className="text-xs font-medium mb-2 text-theme-muted">
           {t("community_info")}
         </div>

--- a/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.test.ts
@@ -843,6 +843,60 @@ describe('isFieldVisible (the visibleWhen capability)', () => {
     expect(isFieldVisible(field, doc)).toBe(true);
   });
 
+  /**
+   * The real field, not a stand-in. A community sidebar shows subscribers and
+   * authors and never a following count, so the toggle has nothing to govern
+   * there and must hide rather than sit inert (#1480). The other two sidebar
+   * toggles DO have counterparts in that tree and stay visible, which is the
+   * half that proves the gate is scoped rather than blanket.
+   */
+  describe('the sidebar Following toggle, per instance type', () => {
+    const SIDEBAR = [
+      'configuration',
+      'instanceConfiguration',
+      'layout',
+      'sidebar',
+    ] as const;
+
+    function documentFor(
+      type: string,
+      communityId: string,
+    ): Record<string, import('./types').ConfigValue> {
+      return {
+        configuration: {
+          general: { styleTemplate: 'medium' },
+          instanceConfiguration: { type, communityId },
+        },
+      } as unknown as Record<string, import('./types').ConfigValue>;
+    }
+
+    const blog = documentFor('blog', '');
+    const community = documentFor('community', 'hive-125125');
+
+    it('hides on a community instance and shows on a blog', () => {
+      const following = fieldAt([...SIDEBAR, 'following']);
+      expect(following).toBeDefined();
+      expect(isFieldVisible(following!, community)).toBe(false);
+      expect(isFieldVisible(following!, blog)).toBe(true);
+    });
+
+    it('leaves the toggles a community CAN serve visible', () => {
+      for (const key of ['followers', 'hiveInformation']) {
+        const field = fieldAt([...SIDEBAR, key]);
+        expect(field, key).toBeDefined();
+        expect(isFieldVisible(field!, community), key).toBe(true);
+      }
+    });
+
+    it('treats a community type with no id as a blog, like every other caller', () => {
+      // isCommunityInstance requires BOTH, so a half-configured document keeps
+      // the toggle rather than hiding a control the instance still honours.
+      const halfConfigured = documentFor('community', '');
+      const following = fieldAt([...SIDEBAR, 'following']);
+      expect(isFieldVisible(following!, halfConfigured)).toBe(true);
+    });
+  });
+
   it('the predicate decides against the WHOLE document', () => {
     const onlyMagazine: ConfigField = {
       label: 'X',

--- a/apps/self-hosted/src/features/floating-menu/config-fields.ts
+++ b/apps/self-hosted/src/features/floating-menu/config-fields.ts
@@ -294,6 +294,13 @@ export function buildConfigFields(
                   following: {
                     label: t('panel_configuration_instance_configuration_layout_sidebar_following_label'),
                     type: 'section',
+                    // A community sidebar shows subscribers and authors, never
+                    // a following count: what accounts the community account
+                    // follows is not something its page advertises. The other
+                    // two toggles have counterparts there and work; this one
+                    // has nothing to govern, so it hides rather than sitting
+                    // inert. Same rule the theme gate above applies.
+                    visibleWhen: (document) => !isCommunityConfig(document),
                     fields: {
                       enabled: {
                         label: t('panel_configuration_instance_configuration_layout_sidebar_following_enabled_label'),

--- a/apps/self-hosted/src/styles/sidebar-visibility.test.ts
+++ b/apps/self-hosted/src/styles/sidebar-visibility.test.ts
@@ -29,6 +29,10 @@ const SIDEBAR = readFileSync(
   join(HERE, '..', 'features', 'blog', 'layout', 'blog-sidebar.tsx'),
   'utf8',
 );
+const CONFIG_FIELDS = readFileSync(
+  join(HERE, '..', 'features', 'floating-menu', 'config-fields.ts'),
+  'utf8',
+);
 
 /**
  * This list is empty and should stay that way. It briefly held
@@ -37,6 +41,33 @@ const SIDEBAR = readFileSync(
  * anything (#1477). An entry here means a toggle that lies to the owner.
  */
 const RENDERS_NOTHING_YET = new Set<string>();
+
+/**
+ * The sidebar is TWO components in one module, and an instance renders exactly
+ * one of them. Checking the module as a whole is what let #1480 through: the
+ * blog half rendered all three classes, which satisfied the assertion on
+ * behalf of a community half that rendered none of them, so every toggle was
+ * inert on a community instance while this file stayed green.
+ *
+ * An attribute a mode does NOT serve must be hidden from that mode's editor,
+ * asserted below, so the two halves of the rule cannot drift apart either.
+ */
+const MODE_SECTIONS = {
+  BlogSidebarContent: [
+    'data-show-followers',
+    'data-show-following',
+    'data-show-hive-info',
+  ],
+  CommunitySidebar: ['data-show-followers', 'data-show-hive-info'],
+} as const;
+
+/** The body of one top-level `function Name(` declaration in the sidebar. */
+function componentSource(name: string): string {
+  const start = SIDEBAR.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`${name} not found in blog-sidebar.tsx`);
+  const next = SIDEBAR.slice(start + 1).search(/\n(?:export )?function \w+\(/);
+  return next < 0 ? SIDEBAR.slice(start) : SIDEBAR.slice(start, start + 1 + next);
+}
 
 /** Every data-show-* attribute apply-config-dom actually emits. */
 function emittedAttributes(): string[] {
@@ -103,5 +134,37 @@ describe('sidebar section visibility', () => {
         `${attribute} hides .${rule.className}, which blog-sidebar.tsx never renders`,
       ).toBe(true);
     }
+  });
+
+  it('renders the class in EACH mode that serves the toggle', () => {
+    const rules = hidingRules();
+    for (const [component, attributes] of Object.entries(MODE_SECTIONS)) {
+      const source = componentSource(component);
+      for (const attribute of attributes) {
+        const rule = rules.get(attribute);
+        expect(rule, `no rule for ${attribute}`).toBeDefined();
+        expect(
+          source.includes(rule!.className),
+          `${component} never renders .${rule!.className}, so ${attribute} does nothing on that instance mode`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('hides from the editor any toggle a mode cannot serve', () => {
+    const served = new Set(MODE_SECTIONS.CommunitySidebar);
+    const unserved = MODE_SECTIONS.BlogSidebarContent.filter(
+      (a) => !served.has(a as (typeof MODE_SECTIONS.CommunitySidebar)[number]),
+    );
+    // Today that is exactly `following`: a community page does not advertise
+    // what its own account follows. Showing the control anyway is the #1480
+    // bug, so the field must carry an instance-type gate.
+    expect(unserved).toEqual(['data-show-following']);
+    const field = CONFIG_FIELDS.slice(
+      CONFIG_FIELDS.indexOf('following: {'),
+      CONFIG_FIELDS.indexOf('hiveInformation: {'),
+    );
+    expect(field).toContain('visibleWhen');
+    expect(field).toContain('isCommunityConfig');
   });
 });

--- a/apps/self-hosted/src/styles/sidebar-visibility.test.ts
+++ b/apps/self-hosted/src/styles/sidebar-visibility.test.ts
@@ -151,6 +151,23 @@ describe('sidebar section visibility', () => {
     }
   });
 
+  it('governs EVERY chain-info block a community renders, not just the first', () => {
+    // The community tree presents chain information as two sibling blocks,
+    // Community Info and Team, so one class on the first left the moderator
+    // list visible with the toggle off. A toggle that half works is the same
+    // defect as one that does nothing.
+    const source = componentSource('CommunitySidebar');
+    const occurrences = source.split('sidebar-hive-info-section').length - 1;
+    expect(
+      occurrences,
+      'each sibling chain-info block in CommunitySidebar needs the class in its own right',
+    ).toBeGreaterThanOrEqual(2);
+    // Named so the count above cannot be satisfied by two classes on one block.
+    expect(source, 'the team block is what the second occurrence is for').toMatch(
+      /sidebar-hive-info-section[\s\S]*?t\(["']team["']\)/,
+    );
+  });
+
   it('hides from the editor any toggle a mode cannot serve', () => {
     const served = new Set(MODE_SECTIONS.CommunitySidebar);
     const unserved = MODE_SECTIONS.BlogSidebarContent.filter(

--- a/apps/self-hosted/src/styles/sidebar-visibility.test.ts
+++ b/apps/self-hosted/src/styles/sidebar-visibility.test.ts
@@ -162,10 +162,20 @@ describe('sidebar section visibility', () => {
       occurrences,
       'each sibling chain-info block in CommunitySidebar needs the class in its own right',
     ).toBeGreaterThanOrEqual(2);
-    // Named so the count above cannot be satisfied by two classes on one block.
-    expect(source, 'the team block is what the second occurrence is for').toMatch(
-      /sidebar-hive-info-section[\s\S]*?t\(["']team["']\)/,
-    );
+
+    // Anchored to the team block itself, not merely to the class appearing
+    // somewhere before the word "team": this region runs from the block's
+    // guard to its heading, so it holds that block's opening element and
+    // nothing else. A looser `class ... [\s\S]*? t("team")` was satisfied by
+    // the Community Info block above and proved nothing.
+    const guard = source.indexOf('community.team');
+    const heading = source.search(/t\(["']team["']\)/);
+    expect(guard, 'team block not found').toBeGreaterThan(-1);
+    expect(heading).toBeGreaterThan(guard);
+    expect(
+      source.slice(guard, heading),
+      'the team block must carry the class on its own element',
+    ).toContain('sidebar-hive-info-section');
   });
 
   it('hides from the editor any toggle a mode cannot serve', () => {


### PR DESCRIPTION
Closes #1480.

All three sidebar visibility toggles were inert on community instances. Unlike #1477, where nobody had ever touched the control, **an owner had already tried to use one**: `hive-125125` carries `data-show-hive-info="false"` in its live config and still renders its Community Info block.

`BlogSidebar` branches on mode. `BlogSidebarContent` renders the classes the CSS rules target; `CommunitySidebar` renders its own tree and carried none of them, so no `[data-show-*]` rule could match. The editor offered all three anyway, because that section is gated only on whether the active **theme** supports a sidebar, with no instance-type condition.

### What each toggle maps to

The three do not map equally onto a community, so this is not a blanket fix:

- **Hive Information** → the Community Info block (created, language, team). Direct counterpart.
- **Followers** → the subscriber count. Consistent with blog mode, which also labels its follower count "Subscribers".
- **Following** → nothing. What accounts a community account follows is not something its page advertises, which is why the tree never showed it. It now **hides** on community instances rather than sitting inert, using the same `visibleWhen` mechanism themes already use to hide the whole sidebar section.

The gate reads the shared `isCommunityConfig`, so "community" keeps meaning type **and** id everywhere rather than growing a third definition; that module's own comment notes it was created because the editor was about to hand-roll one. A document typed community with no id keeps the toggle, since such an instance behaves as a blog throughout the app.

The community counts row needs no collapse rule, unlike blog mode's: the author count has no toggle, so it can never empty.

### The guard was mode-blind, which is why #1477 missed this

`sidebar-visibility.test.ts` asserted the hidden class is rendered, but read `blog-sidebar.tsx` as one file with both components in it. The blog half satisfied the assertion **on behalf of** a community half that rendered nothing, so the file stayed green while every toggle was dead on a community instance. That is a real weakness in the test I added last PR, and fixing it belongs here.

It now slices each component and checks only the classes that mode serves, plus asserts that a toggle a mode cannot serve is gated in the editor. Both new checks fail against the pre-fix code:

```
CommunitySidebar never renders .sidebar-hive-info-section,
  so data-show-hive-info does nothing on that instance mode
```

The editor gate is also tested by behaviour rather than by matching source text, walking the real field tree and calling `isFieldVisible`: hidden for a community document, visible for a blog, visible for a community type with no id. Removing the `visibleWhen` line fails both that test and the guard.

### Verified in a browser

Against a real build serving a community config:

| followers | hiveInfo | subscribers | Community Info |
|---|---|---|---|
| on | on | visible | visible |
| on | **off** | visible | **hidden** |
| **off** | on | **hidden** | visible |

`.sidebar-following-section` is absent in every community run, as it should be. No console errors. 957 SPA tests pass.
