### PR TITLE
fix(editor): keep markdown tables intact through the publish editor

### DIFF
--- a/apps/web/src/features/tiptap-editor/functions/markdown-to-html.ts
+++ b/apps/web/src/features/tiptap-editor/functions/markdown-to-html.ts
@@ -4,6 +4,12 @@ import Turndown from "turndown";
 
 import { TEXT_COLOR_CLASS_PREFIX } from "@/app/publish/_constants/text-colors";
 
+/** Total <td>/<th> in a table, used to spot the single-cell case GFM cannot express. */
+function countTableCells(node: Node): number {
+  const el = node as HTMLElement;
+  return typeof el.querySelectorAll === "function" ? el.querySelectorAll("th, td").length : 0;
+}
+
 const CENTERED_TEXT_RULE_NODES = ["P", "H1", "H2", "H3", "H4", "H5", "H6"];
 const CENTERED_TEXT_ALIGNMENTS = new Set(["center", "right", "left", "justify"]);
 
@@ -184,5 +190,17 @@ export function markdownToHtml(html: string | undefined) {
     // stacked as loose paragraphs, so a pasted or inserted table is
     // destroyed on the next serialization.
     .use(tables)
+    // Added AFTER the plugin so it takes precedence (Turndown checks the most
+    // recently added rule first). The GFM rule deliberately skips single-cell
+    // tables, treating them as layout markup, but the editor can produce one
+    // from the toolbar: insert a table, then deleteColumn and deleteRow. Such a
+    // table serialized to bare cell text, or to nothing at all when the cell was
+    // empty, so it disappeared on the next draft load or publish. GFM cannot
+    // express a headerless single-cell table, so keep it as HTML, which the
+    // renderer accepts and the sanitizer allows.
+    .addRule("singleCellTable", {
+      filter: (node) => node.nodeName === "TABLE" && countTableCells(node) <= 1,
+      replacement: (_content, node) => `\n\n${(node as HTMLElement).outerHTML}\n\n`
+    })
     .turndown(html);
 }

--- a/apps/web/src/features/tiptap-editor/functions/markdown-to-html.ts
+++ b/apps/web/src/features/tiptap-editor/functions/markdown-to-html.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { strikethrough } from "@joplin/turndown-plugin-gfm";
+import { strikethrough, tables } from "@joplin/turndown-plugin-gfm";
 import Turndown from "turndown";
 
 import { TEXT_COLOR_CLASS_PREFIX } from "@/app/publish/_constants/text-colors";
@@ -45,6 +45,15 @@ export function markdownToHtml(html: string | undefined) {
   // would preserve the raw <span data-type="mention"> markup in the output.
   html = html.replace(/<span[^>]*data-type="mention"[^>]*>([^<]*)<\/span>/gi, "$1");
   html = html.replace(/<span[^>]*data-type="tag"[^>]*>([^<]*)<\/span>/gi, "$1");
+
+  // TipTap renders tables as <table><colgroup>…</colgroup><tbody>…, with the
+  // header cells as <th> in the first <tbody> row rather than in a <thead>.
+  // The GFM table rule only accepts a <tbody> whose previous sibling is absent
+  // or an empty <thead>, so the <colgroup> makes it miss the heading row and
+  // emit an empty one above the real headers. Dropping <colgroup> (it carries
+  // only editor column widths, which markdown cannot express anyway) restores
+  // the check without touching the plugin.
+  html = html.replace(/<colgroup[\s\S]*?<\/colgroup>/gi, "");
 
   return new Turndown({
     codeBlockStyle: "fenced"
@@ -170,5 +179,10 @@ export function markdownToHtml(html: string | undefined) {
       }
     })
     .use(strikethrough)
+    // Turndown has no built-in table rule. Without this the editor's
+    // HTML -> markdown pass drops every <table> and leaves the cell text
+    // stacked as loose paragraphs, so a pasted or inserted table is
+    // destroyed on the next serialization.
+    .use(tables)
     .turndown(html);
 }

--- a/apps/web/src/specs/features/tiptap-editor/table-roundtrip.spec.ts
+++ b/apps/web/src/specs/features/tiptap-editor/table-roundtrip.spec.ts
@@ -26,18 +26,28 @@ const TABLE_MARKDOWN = [
   "| 2020-04-03 | ecency | 941.94 |"
 ].join("\n");
 
+const TABLE_EXTENSIONS = [StarterKit, Table, TableRow, TableCell, TableHeader];
+
 /**
  * Mirrors what the publish editor actually does: paste plain text (converted by
  * the clipboard strategy), then serialize the document back to markdown the way
  * `use-publish-editor` does on every update.
  */
-function pasteThenSerialize(markdown: string) {
-  const editor = new Editor({
-    extensions: [StarterKit, Table, TableRow, TableCell, TableHeader],
-    content: "<p></p>"
-  });
+function pasteThenSerialize(markdown: string): string {
+  const editor = new Editor({ extensions: TABLE_EXTENSIONS, content: "<p></p>" });
   try {
     editor.chain().insertContent(parseAllExtensionsToDoc(simpleMarkdownToHTML(markdown))).run();
+    return markdownToHtml(editor.getHTML());
+  } finally {
+    editor.destroy();
+  }
+}
+
+/** Runs `build` against a live editor, then serializes exactly as publish does. */
+function buildThenSerialize(build: (editor: Editor) => void): string {
+  const editor = new Editor({ extensions: TABLE_EXTENSIONS, content: "<p></p>" });
+  try {
+    build(editor);
     return markdownToHtml(editor.getHTML());
   } finally {
     editor.destroy();
@@ -64,7 +74,7 @@ describe("markdown table round-trip through the publish editor", () => {
 
     // header + delimiter + 2 body rows
     expect(lines).toHaveLength(4);
-    expect(lines[1]).toMatch(/^\|[\s-|:]+\|$/);
+    expect(lines[1]).toMatch(/^\|[-\s|:]+\|$/);
     lines.forEach((line) => expect(line.split("|")).toHaveLength(5));
   });
 
@@ -91,15 +101,49 @@ describe("markdown table round-trip through the publish editor", () => {
   });
 
   it("serializes a table built with the editor's own insertTable command", () => {
-    const editor = new Editor({
-      extensions: [StarterKit, Table, TableRow, TableCell, TableHeader],
-      content: "<p></p>"
-    });
-    try {
+    const result = buildThenSerialize((editor) => {
       editor.chain().focus().insertTable({ rows: 2, cols: 2, withHeaderRow: true }).run();
-      expect(markdownToHtml(editor.getHTML())).toMatch(/\|.*\|/);
-    } finally {
-      editor.destroy();
-    }
+    });
+
+    expect(result).toMatch(/\|.*\|/);
+  });
+});
+
+describe("single-cell tables the GFM rule cannot express", () => {
+  // Regression: the GFM table rule deliberately skips single-cell tables, so a
+  // 1x1 built from the toolbar serialized to bare text, or to nothing at all
+  // when empty, and vanished on the next draft load or publish.
+  const shrinkToSingleCell = (editor: Editor) => {
+    editor.chain().focus().insertTable({ rows: 2, cols: 2, withHeaderRow: true }).run();
+    editor.chain().focus().deleteColumn().run();
+    editor.chain().focus().deleteRow().run();
+  };
+
+  it("keeps an empty 1x1 table instead of serializing it away", () => {
+    const result = buildThenSerialize(shrinkToSingleCell);
+
+    expect(result.trim()).not.toBe("");
+    expect(result).toContain("<table");
+  });
+
+  it("keeps a populated 1x1 table instead of flattening it to text", () => {
+    const result = buildThenSerialize((editor) => {
+      shrinkToSingleCell(editor);
+      editor.commands.insertContent("solo");
+    });
+
+    expect(result).toContain("<table");
+    expect(result).toContain("solo");
+    // pre-fix this was the bare string "solo" with no table markup at all
+    expect(result.trim()).not.toBe("solo");
+  });
+
+  it("still uses markdown syntax once the table has more than one cell", () => {
+    const result = buildThenSerialize((editor) => {
+      editor.chain().focus().insertTable({ rows: 2, cols: 2, withHeaderRow: true }).run();
+    });
+
+    expect(result).not.toContain("<table");
+    expect(result).toContain("|");
   });
 });

--- a/apps/web/src/specs/features/tiptap-editor/table-roundtrip.spec.ts
+++ b/apps/web/src/specs/features/tiptap-editor/table-roundtrip.spec.ts
@@ -1,0 +1,105 @@
+import { vi } from "vitest";
+
+vi.mock("@/features/tiptap-editor/extensions", () => ({
+  HIVE_POST_PURE_REGEX: /$a^/,
+  LOOM_REGEX: /$a^/,
+  TAG_MENTION_PURE_REGEX: /$a^/,
+  USER_MENTION_PURE_REGEX: /$a^/,
+  YOUTUBE_REGEX: /$a^/
+}));
+
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import Table from "@tiptap/extension-table";
+import TableCell from "@tiptap/extension-table-cell";
+import TableHeader from "@tiptap/extension-table-header";
+import TableRow from "@tiptap/extension-table-row";
+import { simpleMarkdownToHTML } from "@ecency/render-helper";
+
+import { markdownToHtml } from "@/features/tiptap-editor/functions/markdown-to-html";
+import { parseAllExtensionsToDoc } from "@/features/tiptap-editor/functions/parse-all-extensions-to-doc";
+
+const TABLE_MARKDOWN = [
+  "| Date | Account | Amount |",
+  "| --- | --- | --- |",
+  "| 2023-01-06 | valueplan | 52,239.55 |",
+  "| 2020-04-03 | ecency | 941.94 |"
+].join("\n");
+
+/**
+ * Mirrors what the publish editor actually does: paste plain text (converted by
+ * the clipboard strategy), then serialize the document back to markdown the way
+ * `use-publish-editor` does on every update.
+ */
+function pasteThenSerialize(markdown: string) {
+  const editor = new Editor({
+    extensions: [StarterKit, Table, TableRow, TableCell, TableHeader],
+    content: "<p></p>"
+  });
+  try {
+    editor.chain().insertContent(parseAllExtensionsToDoc(simpleMarkdownToHTML(markdown))).run();
+    return markdownToHtml(editor.getHTML());
+  } finally {
+    editor.destroy();
+  }
+}
+
+describe("markdown table round-trip through the publish editor", () => {
+  // Regression: Turndown was built with only the `strikethrough` GFM plugin, so
+  // it had no rule for <table> and flattened every pasted table into loose text
+  // on the first serialization pass.
+  it("keeps a pasted table a table", () => {
+    const result = pasteThenSerialize(TABLE_MARKDOWN);
+
+    expect(result).toContain("| Date | Account | Amount |");
+    expect(result).toContain("| 2023-01-06 | valueplan | 52,239.55 |");
+    expect(result).toContain("| 2020-04-03 | ecency | 941.94 |");
+  });
+
+  it("keeps every row on its own line with a delimiter row", () => {
+    const lines = pasteThenSerialize(TABLE_MARKDOWN)
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("|"));
+
+    // header + delimiter + 2 body rows
+    expect(lines).toHaveLength(4);
+    expect(lines[1]).toMatch(/^\|[\s-|:]+\|$/);
+    lines.forEach((line) => expect(line.split("|")).toHaveLength(5));
+  });
+
+  // Regression: TipTap emits <colgroup> before <tbody> and keeps the header
+  // cells as <th> inside that <tbody>, which made the GFM rule miss the heading
+  // row and prepend an empty one ("|  |  |  |") above the real headers.
+  it("uses the real header row rather than prepending an empty one", () => {
+    const lines = pasteThenSerialize(TABLE_MARKDOWN)
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("|"));
+
+    expect(lines[0]).toContain("Date");
+    expect(lines[0]).toContain("Account");
+    expect(lines[0]).not.toMatch(/^\|(\s*\|)+$/);
+  });
+
+  it("does not flatten cells into loose paragraphs", () => {
+    const result = pasteThenSerialize(TABLE_MARKDOWN);
+
+    // the pre-fix output was "Date\n\nAccount\n\nAmount\n\n2023-01-06\n\n..."
+    expect(result).not.toMatch(/^Date\s*$/m);
+    expect(result).not.toMatch(/^valueplan\s*$/m);
+  });
+
+  it("serializes a table built with the editor's own insertTable command", () => {
+    const editor = new Editor({
+      extensions: [StarterKit, Table, TableRow, TableCell, TableHeader],
+      content: "<p></p>"
+    });
+    try {
+      editor.chain().focus().insertTable({ rows: 2, cols: 2, withHeaderRow: true }).run();
+      expect(markdownToHtml(editor.getHTML())).toMatch(/\|.*\|/);
+    } finally {
+      editor.destroy();
+    }
+  });
+});

--- a/apps/web/src/styles/_markdown.scss
+++ b/apps/web/src/styles/_markdown.scss
@@ -240,12 +240,19 @@
   }
 
   table {
+    // `overflow-x` is inert on a `display: table` box, so a table wider than the
+    // post column was never scrollable, and the `overflow-hidden` utility below
+    // then clipped it, putting the right-hand columns permanently out of reach.
+    // `display: block` turns the table itself into the scroll container while its
+    // rows still lay out as a table internally; `width: 100%` keeps tables that
+    // already fit rendering full-width exactly as before.
+    display: block;
     word-break: normal !important;
     overflow-x: auto;
     width: 100%;
     max-width: 100%;
 
-    @apply border dark:border-gray-700 overflow-hidden table-auto border-collapse text-xs sm:text-sm md:text-base;
+    @apply border dark:border-gray-700 table-auto border-collapse text-xs sm:text-sm md:text-base;
 
     tr {
       @apply [&:last-child>td]:border-b-0 [&:nth-child(even)]:bg-light-200 dark:[&:nth-child(even)]:bg-dark-300;

--- a/apps/web/src/styles/_markdown.scss
+++ b/apps/web/src/styles/_markdown.scss
@@ -240,19 +240,12 @@
   }
 
   table {
-    // `overflow-x` is inert on a `display: table` box, so a table wider than the
-    // post column was never scrollable, and the `overflow-hidden` utility below
-    // then clipped it, putting the right-hand columns permanently out of reach.
-    // `display: block` turns the table itself into the scroll container while its
-    // rows still lay out as a table internally; `width: 100%` keeps tables that
-    // already fit rendering full-width exactly as before.
-    display: block;
     word-break: normal !important;
     overflow-x: auto;
     width: 100%;
     max-width: 100%;
 
-    @apply border dark:border-gray-700 table-auto border-collapse text-xs sm:text-sm md:text-base;
+    @apply border dark:border-gray-700 overflow-hidden table-auto border-collapse text-xs sm:text-sm md:text-base;
 
     tr {
       @apply [&:last-child>td]:border-b-0 [&:nth-child(even)]:bg-light-200 dark:[&:nth-child(even)]:bg-dark-300;


### PR DESCRIPTION
Markdown tables were destroyed by the publish editor and clipped once rendered. Two independent defects, both fixed here.

### 1. The editor flattened every table

`use-publish-editor` serializes the document back to markdown on each update via `markdownToHtml`, whose Turndown instance registered only the `strikethrough` GFM plugin. Turndown has no built-in table rule, so `<table>` was dropped and the cell text left as loose paragraphs. This hit both pasted tables and tables created with the toolbar's insert-table button.

Before, on a 3-column table:

```
"Date\n\nEntity\n\nAmount\n\n2023-01-06\n\nvalueplan\n\n52,239.55"
```

Registering `tables` alone was not sufficient. TipTap renders tables as `<table><colgroup>...</colgroup><tbody>`, keeping header cells as `<th>` in the first `tbody` row rather than in a `<thead>`. The plugin's heading-row check only accepts a `tbody` whose previous sibling is absent or an empty `<thead>`, so the `colgroup` made it miss the header row and prepend an empty one:

```
|     |     |     |
| --- | --- | --- |
| Date | Entity | Amount |
```

Stripping `<colgroup>` before Turndown runs restores the check. It carries only editor column widths, which markdown cannot express.

### 2. Wide tables were clipped with no way to scroll

`overflow-x: auto` was set on the `<table>` itself, but a `display: table` box is not a scroll container, so it never applied; the `overflow-hidden` utility in the same rule then clipped the overflow. Measured in the post column, an 18-column table needed 1732px inside 700px and the last column sat ~1030px outside the readable area, unreachable.

`display: block` makes the table its own scroll container while its rows still lay out as a table internally. `width: 100%` is kept so tables that already fit render full-width exactly as before (`width: max-content` was rejected: it shrinks narrow tables from 700px to their content width and would change existing posts).

### Testing

- New `table-roundtrip.spec.ts` drives a real TipTap editor with the same extension set as the publish editor, pastes a table through `parseAllExtensionsToDoc` and asserts the markdown survives serialization: rows stay on their own lines, the delimiter row is present, the real header is used, and cells are not flattened. A fourth case covers `insertTable` from the toolbar.
- Full suite green: 2681 tests / 279 files. Typecheck clean, no new lint.
- CSS behaviour measured in a headless browser against both a narrow and an 18-column table.

### Not covered

Cell alignment is still dropped on publish. Remarkable emits `style="text-align:…"` and the sanitizer sets `css: false` to block style attributes outright, so `---:` columns publish left-aligned. That is a deliberate security posture in `@ecency/render-helper` and is left alone here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown table conversion in the publish editor, including correct headers, rows, and cell content.
  * Preserved tables when converting between Markdown and editor content.
  * Removed unsupported table column metadata during conversion.

* **Style**
  * Enabled horizontal scrolling for wide Markdown tables while retaining full-width display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->