### PR TITLE
fix(publish): surface resource credits in the editor and stop overstating them

### DIFF
--- a/apps/web/src/app/publish/_components/publish-validate-post.tsx
+++ b/apps/web/src/app/publish/_components/publish-validate-post.tsx
@@ -19,6 +19,8 @@ import { isCommunity } from "@/utils";
 import { wordOverlapSimilarity } from "@/utils/text-similarity";
 import { hasPublishContent } from "../_utils/content";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { AvailableCredits } from "@/features/shared";
+import { RcPrecheckBanner } from "@/features/shared/rc-precheck";
 import {
   canFitBeneficiary,
   isSupportEcencyRow,
@@ -254,6 +256,13 @@ export function PublishValidatePost({ onClose, onSuccess }: Props) {
             >
               {i18next.t("support-ecency.add-chip")}
             </Button>
+          )}
+
+          {activeUser?.username && (
+            <div className="w-full flex flex-col gap-2">
+              <RcPrecheckBanner operation="comment_operation" />
+              <AvailableCredits username={activeUser.username} operation="comment_operation" />
+            </div>
           )}
 
           <div className="flex items-center gap-2">

--- a/apps/web/src/features/shared/available-credits/index.tsx
+++ b/apps/web/src/features/shared/available-credits/index.tsx
@@ -3,6 +3,7 @@
 import { calculateRCMana, powerRechargeTime, rcPower } from "@ecency/sdk";
 import { RcOperation } from "@/entities";
 import { rcFormatter } from "@/utils";
+import { rcAffordableOperations } from "@/utils/rc-affordable-operations";
 import { useMounted } from "@/utils/use-mounted";
 import { getAccountRcQueryOptions, getRcStatsQueryOptions } from "@ecency/sdk";
 import { flip, shift, useFloating } from "@floating-ui/react-dom";
@@ -73,9 +74,10 @@ export const AvailableCredits = ({ username, className }: Props) => {
     const voteCost = operationCosts.vote_operation.avg_cost;
 
     const availableResourceCredit: any = rcValues.map((a: any) => a.rc_manabar.current_mana);
-    setCommentAmount(Math.ceil(Number(availableResourceCredit[0]) / commentCost));
-    setVoteAmount(Math.ceil(Number(availableResourceCredit[0]) / voteCost));
-    setTransferAmount(Math.ceil(Number(availableResourceCredit[0]) / transferCost));
+    const mana = Number(availableResourceCredit[0]);
+    setCommentAmount(rcAffordableOperations(mana, commentCost));
+    setVoteAmount(rcAffordableOperations(mana, voteCost));
+    setTransferAmount(rcAffordableOperations(mana, transferCost));
   }, [rcStats, rcValues]);
 
   const show = () => setIsShow(true);

--- a/apps/web/src/specs/utils/rc-affordable-operations.spec.ts
+++ b/apps/web/src/specs/utils/rc-affordable-operations.spec.ts
@@ -1,0 +1,37 @@
+import { rcAffordableOperations } from "@/utils/rc-affordable-operations";
+
+// Real numbers from rc_api.get_rc_stats, 2026-08-13.
+const COMMENT_COST = 1_224_266_459;
+
+describe("rcAffordableOperations", () => {
+  it("rounds down rather than up", () => {
+    // Regression: this used Math.ceil, so a user holding 1.2x the cost of one
+    // comment was told they had 2, then hit "not enough RC" on the first post.
+    expect(rcAffordableOperations(COMMENT_COST * 1.2, COMMENT_COST)).toBe(1);
+    expect(rcAffordableOperations(COMMENT_COST * 2.4, COMMENT_COST)).toBe(2);
+    expect(rcAffordableOperations(COMMENT_COST * 2.99, COMMENT_COST)).toBe(2);
+  });
+
+  it("reports 0 when the user cannot afford a single operation", () => {
+    // Math.ceil could never return 0 for any positive mana, so the widget
+    // always promised at least one operation.
+    expect(rcAffordableOperations(COMMENT_COST * 0.1, COMMENT_COST)).toBe(0);
+    expect(rcAffordableOperations(1, COMMENT_COST)).toBe(0);
+    expect(rcAffordableOperations(COMMENT_COST - 1, COMMENT_COST)).toBe(0);
+  });
+
+  it("is exact on whole multiples", () => {
+    expect(rcAffordableOperations(COMMENT_COST, COMMENT_COST)).toBe(1);
+    expect(rcAffordableOperations(COMMENT_COST * 5, COMMENT_COST)).toBe(5);
+  });
+
+  it("returns 0 for empty, negative or unusable input", () => {
+    expect(rcAffordableOperations(0, COMMENT_COST)).toBe(0);
+    expect(rcAffordableOperations(-1, COMMENT_COST)).toBe(0);
+    expect(rcAffordableOperations(COMMENT_COST, 0)).toBe(0);
+    expect(rcAffordableOperations(COMMENT_COST, -5)).toBe(0);
+    expect(rcAffordableOperations(NaN, COMMENT_COST)).toBe(0);
+    expect(rcAffordableOperations(COMMENT_COST, NaN)).toBe(0);
+    expect(rcAffordableOperations(Infinity, COMMENT_COST)).toBe(0);
+  });
+});

--- a/apps/web/src/utils/rc-affordable-operations.ts
+++ b/apps/web/src/utils/rc-affordable-operations.ts
@@ -1,0 +1,23 @@
+/**
+ * How many more operations of a given kind an account can still afford.
+ *
+ * This answers "how many can I still do", so it rounds DOWN. Rounding up
+ * reported 1 to a user holding less than a single operation's worth of RC, and
+ * 2 to a user who could afford exactly one. That is how the credits tooltip
+ * came to promise posts that the chain then rejected for insufficient RC.
+ *
+ * Note that the cost passed in is the network-wide average for the operation.
+ * A full post is a comment_operation like any reply, but it carries a much
+ * larger payload, so it costs meaningfully more RC than that average. Treat the
+ * result as an optimistic ceiling rather than a guarantee.
+ */
+export function rcAffordableOperations(currentMana: number, avgCost: number): number {
+  if (!Number.isFinite(currentMana) || !Number.isFinite(avgCost)) {
+    return 0;
+  }
+  if (avgCost <= 0 || currentMana <= 0) {
+    return 0;
+  }
+
+  return Math.floor(currentMana / avgCost);
+}


### PR DESCRIPTION
Reported together: the publish editor gives no warning and no way to top up when RC runs out, and the credits tooltip promises posts that then fail to broadcast. Both are fixed here.

### 1. Neither RC widget was mounted on the publish page

`AvailableCredits` and `RcPrecheckBanner` are wired into the comment box, the legacy `app/submit` editor and deck threads, but `app/publish` got neither:

| surface | AvailableCredits | RcPrecheckBanner |
|---|---|---|
| `features/shared/comment` | yes | yes |
| `app/submit` (legacy editor) | yes | yes |
| `app/decks/deck-threads-form` | yes | no |
| `app/publish` (current editor) | **no** | **no** |

So a user out of RC saw no bar, no warning and no route to `PurchaseQrDialog`. They found out by pressing publish. Both now render in the publish confirmation step, directly above the publish button, gated on there being an active user.

### 2. The credits tooltip rounded up

```js
setCommentAmount(Math.ceil(Number(availableResourceCredit[0]) / commentCost));
```

`Math.ceil` can never return 0 for any positive mana, so the widget always claimed at least one operation was affordable. Against the live `comment_operation` average cost:

| holding | displayed (before) | truthful |
|---|---:|---:|
| 0.1x one comment | 1 | 0 |
| 1.2x one comment | 2 | 1 |
| 2.4x one comment | 3 | 2 |

That is the "it said 2 posts, then said not enough RC" report. The same bug applied to the vote and transfer figures.

The arithmetic moves to `rcAffordableOperations`, which floors and returns 0 for empty, negative or unusable input. The SDK's own `estimateRcPrecheck` already floors, so this only ever affected the tooltip.

### A caveat left in place, deliberately

The figure is derived from `comment_operation.avg_cost`, a network-wide average dominated by short replies. A post is the same operation but carries a much larger payload, so it costs meaningfully more RC than that average. Flooring removes the overstatement but the number remains an optimistic ceiling, which the helper's doc comment records. Sizing the estimate off the actual draft body would need changes in the SDK estimator and is out of scope here.

### Testing

- New `rc-affordable-operations.spec.ts`: rounding direction, the zero case that `Math.ceil` could never produce, exact multiples, plus empty/negative/NaN/Infinity input.
- Full suite green: 2680 tests / 279 files. Typecheck clean, no new lint.

### Related

Sentry `ECENCY-NEXT-1GH5` ("You don't have enough RC to broadcast this operation") is live: 27 events across 9 users, last seen today, on `/waves`, `/witnesses` and community feeds. Worth noting that `beforeSend` drops RC rejections matching the older `has_mana:` patterns, so the publish-path failures behind this report likely never reached Sentry at all.
