### PR TITLE
fix(editor): paste markdown tables that contain blank cells

### DIFF
--- a/apps/web/src/features/tiptap-editor/functions/parse-all-extensions-to-doc.ts
+++ b/apps/web/src/features/tiptap-editor/functions/parse-all-extensions-to-doc.ts
@@ -180,8 +180,13 @@ export function parseAllExtensionsToDoc(value?: string) {
   // insert with "Invalid content for node tableCell: <>". Because insertContent
   // throws, NOTHING is pasted: the table does not appear at all, rather than
   // appearing with a gap. One blank cell anywhere is enough to lose the table.
+  // Replace rather than append: the guard also matches cells holding only
+  // whitespace or &nbsp;, which the browser already renders as one paragraph.
+  // Appending to those would leave the invisible text AND an empty paragraph
+  // behind, doubling the cell's height for no visible reason.
   (Array.from(tree.querySelectorAll("td, th")) as HTMLElement[]).forEach((cell) => {
     if (!cell.firstElementChild && !cell.textContent?.trim()) {
+      cell.textContent = "";
       cell.appendChild(document.createElement("p"));
     }
   });

--- a/apps/web/src/features/tiptap-editor/functions/parse-all-extensions-to-doc.ts
+++ b/apps/web/src/features/tiptap-editor/functions/parse-all-extensions-to-doc.ts
@@ -174,5 +174,17 @@ export function parseAllExtensionsToDoc(value?: string) {
     }
   });
 
+  // Same problem, same fix, for table cells. A markdown table may legitimately
+  // leave a cell blank, which renders as <td></td>, but the ProseMirror
+  // tableCell schema requires at least one block child and rejects the whole
+  // insert with "Invalid content for node tableCell: <>". Because insertContent
+  // throws, NOTHING is pasted: the table does not appear at all, rather than
+  // appearing with a gap. One blank cell anywhere is enough to lose the table.
+  (Array.from(tree.querySelectorAll("td, th")) as HTMLElement[]).forEach((cell) => {
+    if (!cell.firstElementChild && !cell.textContent?.trim()) {
+      cell.appendChild(document.createElement("p"));
+    }
+  });
+
   return tree.innerHTML;
 }

--- a/apps/web/src/specs/features/tiptap-editor/empty-table-cell-paste.spec.ts
+++ b/apps/web/src/specs/features/tiptap-editor/empty-table-cell-paste.spec.ts
@@ -31,7 +31,18 @@ function pasteMarkdown(markdown: string): string {
   }
 }
 
-const rowCount = (html: string) => (html.match(/<tr/g) || []).length;
+/** Pastes raw HTML through the same parse step, for cases markdown cannot express. */
+function pasteHtml(html: string): string {
+  const editor = new Editor({ extensions: TABLE_EXTENSIONS, content: "<p></p>" });
+  try {
+    editor.chain().insertContent(parseAllExtensionsToDoc(html)).run();
+    return editor.getHTML();
+  } finally {
+    editor.destroy();
+  }
+}
+
+const rowCount = (html: string): number => (html.match(/<tr/g) || []).length;
 
 describe("pasting a markdown table with blank cells", () => {
   // Regression: a blank cell renders as <td></td>, which the ProseMirror
@@ -53,7 +64,7 @@ describe("pasting a markdown table with blank cells", () => {
     ["whole row blank", "| A | B |\n| --- | --- |\n|  |  |"],
     ["blank header cell", "| A |  |\n| --- | --- |\n| 1 | 2 |"],
     ["several blank rows", "| A | B |\n| --- | --- |\n| 1 |  |\n|  | 4 |\n|  |  |"]
-  ])("survives a %s", (_label, markdown) => {
+  ])("survives a %s", (_label: string, markdown: string) => {
     const html = pasteMarkdown(markdown);
     expect(html).toContain("<table");
     expect(rowCount(html)).toBe(markdown.split("\n").length - 1);
@@ -79,5 +90,37 @@ describe("pasting a markdown table with blank cells", () => {
     const doc = parseAllExtensionsToDoc("<table><tbody><tr><td>1</td><td></td></tr></tbody></table>");
 
     expect(doc).toContain("<td><p></p></td>");
+  });
+
+  // Regression: the blank guard also matches cells holding only whitespace or
+  // &nbsp;, which the browser already renders as one paragraph. Appending to
+  // those left the invisible text plus an empty paragraph, doubling the cell
+  // height. They must be replaced, not appended to.
+  it.each([
+    ["a non-breaking space", "&nbsp;"],
+    ["plain spaces", "   "],
+    ["a tab", "\t"],
+    ["mixed invisible content", " &nbsp; "]
+  ])("normalises a cell holding only %s to a single empty paragraph", (_label: string, filler: string) => {
+    const doc = parseAllExtensionsToDoc(
+      `<table><tbody><tr><td>1</td><td>${filler}</td></tr></tbody></table>`
+    );
+
+    expect(doc).toContain("<td><p></p></td>");
+    expect(doc).not.toContain("&nbsp;<p>");
+  });
+
+  it("renders a visually blank cell as exactly one paragraph in the editor", () => {
+    const html = pasteHtml("<table><tbody><tr><td>1</td><td>&nbsp;</td></tr></tbody></table>");
+    const lastCell = html.match(/<td[^>]*>(?:(?!<\/td>).)*<\/td>\s*<\/tr>/s)?.[0] ?? "";
+
+    expect((lastCell.match(/<p>/g) || []).length).toBe(1);
+  });
+
+  it("leaves a cell with real content alone", () => {
+    const doc = parseAllExtensionsToDoc("<table><tbody><tr><td>1</td><td>kept</td></tr></tbody></table>");
+
+    expect(doc).toContain("kept");
+    expect(doc).not.toContain("<td><p></p></td>");
   });
 });

--- a/apps/web/src/specs/features/tiptap-editor/empty-table-cell-paste.spec.ts
+++ b/apps/web/src/specs/features/tiptap-editor/empty-table-cell-paste.spec.ts
@@ -1,0 +1,83 @@
+import { vi } from "vitest";
+
+vi.mock("@/features/tiptap-editor/extensions", () => ({
+  HIVE_POST_PURE_REGEX: /$a^/,
+  LOOM_REGEX: /$a^/,
+  TAG_MENTION_PURE_REGEX: /$a^/,
+  USER_MENTION_PURE_REGEX: /$a^/,
+  YOUTUBE_REGEX: /$a^/
+}));
+
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import Table from "@tiptap/extension-table";
+import TableCell from "@tiptap/extension-table-cell";
+import TableHeader from "@tiptap/extension-table-header";
+import TableRow from "@tiptap/extension-table-row";
+import { simpleMarkdownToHTML } from "@ecency/render-helper";
+
+import { parseAllExtensionsToDoc } from "@/features/tiptap-editor/functions/parse-all-extensions-to-doc";
+
+const TABLE_EXTENSIONS = [StarterKit, Table, TableRow, TableCell, TableHeader];
+
+/** Pastes markdown exactly as the clipboard text strategy does. */
+function pasteMarkdown(markdown: string): string {
+  const editor = new Editor({ extensions: TABLE_EXTENSIONS, content: "<p></p>" });
+  try {
+    editor.chain().insertContent(parseAllExtensionsToDoc(simpleMarkdownToHTML(markdown))).run();
+    return editor.getHTML();
+  } finally {
+    editor.destroy();
+  }
+}
+
+const rowCount = (html: string) => (html.match(/<tr/g) || []).length;
+
+describe("pasting a markdown table with blank cells", () => {
+  // Regression: a blank cell renders as <td></td>, which the ProseMirror
+  // tableCell schema rejects with "Invalid content for node tableCell: <>".
+  // insertContent throws, so nothing is inserted and the table never appears.
+  // One blank cell anywhere was enough to lose the whole table.
+  it("does not throw on a trailing blank cell", () => {
+    expect(() => pasteMarkdown("| A | B |\n| --- | --- |\n| 1 |  |")).not.toThrow();
+  });
+
+  it("keeps every row when a cell is blank", () => {
+    expect(rowCount(pasteMarkdown("| A | B |\n| --- | --- |\n| 1 |  |"))).toBe(2);
+  });
+
+  it.each([
+    ["trailing blank", "| A | B |\n| --- | --- |\n| 1 |  |"],
+    ["leading blank", "| A | B |\n| --- | --- |\n|  | 2 |"],
+    ["middle blank", "| A | B | C |\n| --- | --- | --- |\n| 1 |  | 3 |"],
+    ["whole row blank", "| A | B |\n| --- | --- |\n|  |  |"],
+    ["blank header cell", "| A |  |\n| --- | --- |\n| 1 | 2 |"],
+    ["several blank rows", "| A | B |\n| --- | --- |\n| 1 |  |\n|  | 4 |\n|  |  |"]
+  ])("survives a %s", (_label, markdown) => {
+    const html = pasteMarkdown(markdown);
+    expect(html).toContain("<table");
+    expect(rowCount(html)).toBe(markdown.split("\n").length - 1);
+  });
+
+  it("preserves the content of the cells that are not blank", () => {
+    const html = pasteMarkdown("| Date | Memo |\n| --- | --- |\n| 2019-02-11 |  |\n| 2023-01-06 | closed off |");
+
+    expect(html).toContain("2019-02-11");
+    expect(html).toContain("2023-01-06");
+    expect(html).toContain("closed off");
+  });
+
+  it("still pastes a table with no blank cells at all", () => {
+    const html = pasteMarkdown("| A | B |\n| --- | --- |\n| 1 | 2 |");
+
+    expect(rowCount(html)).toBe(2);
+    expect(html).toContain("1");
+    expect(html).toContain("2");
+  });
+
+  it("fills a blank cell with an empty paragraph rather than dropping it", () => {
+    const doc = parseAllExtensionsToDoc("<table><tbody><tr><td>1</td><td></td></tr></tbody></table>");
+
+    expect(doc).toContain("<td><p></p></td>");
+  });
+});


### PR DESCRIPTION
Pasting a markdown table that contains **any blank cell** inserts nothing at all. The table does not appear, and no error reaches the user.

Reported from a real case: a 29-row table with blank cells in one column simply would not paste into the publish editor.

### Cause

A blank cell renders as `<td></td>`. The ProseMirror `tableCell` schema requires at least one block child, so it rejects the document:

```
RangeError: Invalid content for node tableCell: <>
```

`insertContent` throws, and the throw aborts the entire paste. That is why one blank cell anywhere loses the whole table rather than leaving a gap in it.

Minimal reproduction, all through the real clipboard path:

| markdown | result on develop |
|---|---|
| `\| A \| B \|` / `\| 1 \| 2 \|` | pastes, 2 rows |
| `\| A \| B \|` / `\| 1 \|  \|` | **throws, nothing inserted** |

### Fix

`parse-all-extensions-to-doc` already solves exactly this for blockquotes, which fail the same schema check for the same reason:

```ts
// Ensure empty blockquotes have at least one paragraph to satisfy ProseMirror schema.
```

Table cells needed the same treatment. An empty `<td>` or `<th>` gets one empty paragraph, so the cell renders blank and the document validates.

### Verification against the reported case

A real 29-row table containing 16 blank cells, pasted through `simpleMarkdownToHTML` then `parseAllExtensionsToDoc` then `insertContent`:

```
              develop        with this change
paste         THREW          SUCCEEDED
rows          0              29
blank cells   -              16 (rendered as empty cells)
stored body   -              a table, all content intact
```

### Testing

- New `empty-table-cell-paste.spec.ts`: blank cell leading, trailing, in the middle, a fully blank row, a blank header cell, several blank rows, the unaffected all-filled case, and a direct assertion that a blank cell becomes `<td><p></p></td>` rather than being dropped.
- Full suite green: 2687 tests / 279 files. Typecheck clean, no new lint.

### Note

This supersedes #1482, which was closed. That PR diagnosed the same report as a Turndown serialization problem, which turned out not to exist: the existing custom `table` rule already preserves tables through the editor losslessly. The actual failure is upstream of serialization, at paste time, and this is a much smaller change.
