### PR TITLE
fix(publish): offer both RC top-up routes, and fix href button alignment

### DIFF
--- a/apps/web/src/app/publish/_components/publish-validate-post.tsx
+++ b/apps/web/src/app/publish/_components/publish-validate-post.tsx
@@ -4,12 +4,9 @@ import { SUBMIT_TAG_MAX_LENGTH } from "@/app/submit/_consts";
 import { TagSelector, sanitizeTagInput } from "@/app/submit/_components";
 import { Alert, Button, FormControl } from "@/features/ui";
 import { formatError } from "@/api/format-error";
-import {
-  buildRcTopUpUrl,
-  isShortfallStillRelevant,
-  resolveRcShortfall,
-  type RcShortfall
-} from "../_utils/rc-shortfall";
+import { isShortfallStillRelevant, resolveRcShortfall, type RcShortfall } from "../_utils/rc-shortfall";
+import { useRcTopupAction } from "@/features/shared/rc-topup/use-rc-topup-action";
+import { PointsTopupCta } from "@/features/shared/points-topup-cta";
 import { handleAndReportError, error as feedbackError } from "@/features/shared";
 import { UilMultiply } from "@tooni/iconscout-unicons-react";
 import i18next from "i18next";
@@ -61,6 +58,7 @@ export function PublishValidatePost({ onClose, onSuccess }: Props) {
 
   const { activeUser } = useActiveAccount();
   const [rcShortfall, setRcShortfall] = useState<RcShortfall | null>(null);
+  const { openTopup, dialog: rcTopupDialog } = useRcTopupAction(rcShortfall?.username);
   const isMounted = useRef(true);
   const { data: supportSettings } = useSupportEcencySettingsQuery();
 
@@ -296,19 +294,22 @@ export function PublishValidatePost({ onClose, onSuccess }: Props) {
           )}
 
           {rcShortfall && (
-            <Alert className="w-full flex flex-col gap-2 items-start" appearance="danger">
+            <Alert className="w-full flex flex-col gap-3 items-start" appearance="danger">
               <span>{rcShortfall.message}</span>
-              <Button
-                size="sm"
-                appearance="primary"
-                href={buildRcTopUpUrl(rcShortfall.username)}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {i18next.t("feedback-modal.insufficient-resource-buy")}
-              </Button>
+              {/*
+                Both routes out of this state, rather than only the Boost page:
+                spend Points on an RC-only delegation to your own account, or
+                buy Points with a card when the balance is short.
+              */}
+              <div className="flex flex-wrap items-center gap-2">
+                <Button size="sm" appearance="primary" onClick={openTopup}>
+                  {i18next.t("rc-precheck.top-up")}
+                </Button>
+                <PointsTopupCta />
+              </div>
             </Alert>
           )}
+          {rcTopupDialog}
 
           {activeUser?.username && (
             <div className="w-full flex flex-col gap-2">

--- a/apps/web/src/app/publish/_utils/rc-shortfall.ts
+++ b/apps/web/src/app/publish/_utils/rc-shortfall.ts
@@ -34,11 +34,6 @@ export function resolveRcShortfall(err: unknown, username: string | undefined): 
   return { message, username };
 }
 
-/** Top-up destination for a specific account. */
-export function buildRcTopUpUrl(username: string): string {
-  return `/purchase?username=${encodeURIComponent(username)}&type=boost&product_id=999points`;
-}
-
 /**
  * Whether a shortfall raised for one account should still be shown while
  * another is active. It should not: the failure belongs to the account that

--- a/apps/web/src/features/shared/rc-precheck/rc-precheck-banner.tsx
+++ b/apps/web/src/features/shared/rc-precheck/rc-precheck-banner.tsx
@@ -1,22 +1,13 @@
 "use client";
 
-import { useState } from "react";
 import i18next from "i18next";
 import { Button } from "@ui/button";
 
 import { useActiveAccount } from "@/core/hooks/use-active-account";
-import dynamic from "next/dynamic";
-import { EcencyConfigManager } from "@/config";
 import { useRcPrecheck } from "./use-rc-precheck";
+import { useRcTopupAction } from "@/features/shared/rc-topup/use-rc-topup-action";
 import type { RcPrecheckOperation } from "@ecency/sdk";
 import { alertCircleSvg } from "@ui/svg";
-
-// Lazy-load the purchase dialog so its mutation/SDK import chain is not pulled
-// into every comment/editor/vote render until a user actually opens it.
-const RcTopupDialog = dynamic(
-  () => import("@/features/shared/rc-topup").then((m) => m.RcTopupDialog),
-  { ssr: false }
-);
 
 interface Props {
   operation?: RcPrecheckOperation;
@@ -42,24 +33,11 @@ export function RcPrecheckBanner({
   const { activeUser } = useActiveAccount();
   const username = activeUser?.username;
   const { ready, willLikelyFail } = useRcPrecheck(username, operation);
-  const [showTopup, setShowTopup] = useState(false);
+  const { openTopup: onTopUp, dialog } = useRcTopupAction(username);
 
   if (!username || !ready || !willLikelyFail) {
     return null;
   }
-
-  const rcTopupEnabled = EcencyConfigManager.getConfigValue(
-    ({ visionFeatures }) => visionFeatures.rcTopup.enabled
-  );
-  const onTopUp = () => {
-    if (rcTopupEnabled) {
-      setShowTopup(true);
-    } else {
-      window.open(`/purchase?username=${username}&type=boost`, "_blank", "noopener");
-    }
-  };
-
-  const dialog = showTopup ? <RcTopupDialog onHide={() => setShowTopup(false)} /> : null;
 
   if (compact) {
     return (

--- a/apps/web/src/features/shared/rc-topup/index.ts
+++ b/apps/web/src/features/shared/rc-topup/index.ts
@@ -1,1 +1,2 @@
 export * from "./rc-topup-dialog";
+export * from "./use-rc-topup-action";

--- a/apps/web/src/features/shared/rc-topup/use-rc-topup-action.tsx
+++ b/apps/web/src/features/shared/rc-topup/use-rc-topup-action.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { EcencyConfigManager } from "@/config";
 
@@ -24,6 +24,14 @@ const RcTopupDialog = dynamic(
 export function useRcTopupAction(username: string | undefined) {
   const [showTopup, setShowTopup] = useState(false);
 
+  // RcTopupDialog resolves its account from useActiveAccount and its mutation
+  // spends that account's Points. Left mounted across an account switch it
+  // would quietly retarget, spending B's Points for a shortfall that belongs
+  // to A, so switching accounts closes it.
+  useEffect(() => {
+    setShowTopup(false);
+  }, [username]);
+
   const rcTopupEnabled = EcencyConfigManager.getConfigValue(
     ({ visionFeatures }) => visionFeatures.rcTopup.enabled
   );
@@ -32,7 +40,13 @@ export function useRcTopupAction(username: string | undefined) {
     if (rcTopupEnabled) {
       setShowTopup(true);
     } else if (username) {
-      window.open(`/purchase?username=${encodeURIComponent(username)}&type=boost`, "_blank", "noopener");
+      // noreferrer as well as noopener: without it the purchase page receives
+      // the editor URL, which can carry draft identifiers in the path.
+      window.open(
+        `/purchase?username=${encodeURIComponent(username)}&type=boost`,
+        "_blank",
+        "noopener,noreferrer"
+      );
     }
   }, [rcTopupEnabled, username]);
 

--- a/apps/web/src/features/shared/rc-topup/use-rc-topup-action.tsx
+++ b/apps/web/src/features/shared/rc-topup/use-rc-topup-action.tsx
@@ -1,15 +1,35 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import i18next from "i18next";
 import { useCallback, useEffect, useState } from "react";
+import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 
 import { EcencyConfigManager } from "@/config";
 
 // Lazy-loaded so its mutation/SDK import chain is not pulled into every
-// comment, editor and vote render until someone actually opens it.
+// comment, editor and vote render until someone actually opens it. The
+// fallback is the dialog's own shell rather than nothing: without it a click
+// on a cold cache looks ignored, and these buttons sit on surfaces someone
+// reaches only after an action already failed.
 const RcTopupDialog = dynamic(
   () => import("@/features/shared/rc-topup").then((m) => m.RcTopupDialog),
-  { ssr: false }
+  {
+    ssr: false,
+    // No close button on the fallback: it cannot reach the hook's state, so a
+    // close control here would be dead. The real dialog, which does close,
+    // replaces it as soon as the chunk lands.
+    loading: () => (
+      <Modal show={true} centered={true} onHide={() => {}}>
+        <ModalHeader closeButton={false}>{i18next.t("rc-topup.title")}</ModalHeader>
+        <ModalBody>
+          <div className="flex items-center justify-center min-h-32 opacity-60">
+            {i18next.t("g.loading")}
+          </div>
+        </ModalBody>
+      </Modal>
+    )
+  }
 );
 
 /**

--- a/apps/web/src/features/shared/rc-topup/use-rc-topup-action.tsx
+++ b/apps/web/src/features/shared/rc-topup/use-rc-topup-action.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useCallback, useState } from "react";
+
+import { EcencyConfigManager } from "@/config";
+
+// Lazy-loaded so its mutation/SDK import chain is not pulled into every
+// comment, editor and vote render until someone actually opens it.
+const RcTopupDialog = dynamic(
+  () => import("@/features/shared/rc-topup").then((m) => m.RcTopupDialog),
+  { ssr: false }
+);
+
+/**
+ * The one way to offer an RC top-up, shared by the pre-publish warning and the
+ * post-failure alert so the two cannot drift apart.
+ *
+ * When the RC top-up product is live the user spends Ecency Points on a
+ * short-term RC-only delegation to their own account, which is the direct fix
+ * for being out of RC. Until then it falls back to the Boost+ purchase page,
+ * an HP delegation that raises RC as a side effect.
+ */
+export function useRcTopupAction(username: string | undefined) {
+  const [showTopup, setShowTopup] = useState(false);
+
+  const rcTopupEnabled = EcencyConfigManager.getConfigValue(
+    ({ visionFeatures }) => visionFeatures.rcTopup.enabled
+  );
+
+  const openTopup = useCallback(() => {
+    if (rcTopupEnabled) {
+      setShowTopup(true);
+    } else if (username) {
+      window.open(`/purchase?username=${encodeURIComponent(username)}&type=boost`, "_blank", "noopener");
+    }
+  }, [rcTopupEnabled, username]);
+
+  return {
+    rcTopupEnabled,
+    openTopup,
+    dialog: showTopup ? <RcTopupDialog onHide={() => setShowTopup(false)} /> : null
+  };
+}

--- a/apps/web/src/features/ui/button/index.tsx
+++ b/apps/web/src/features/ui/button/index.tsx
@@ -51,6 +51,10 @@ const ForwardedButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Button
       "border-[1.25px] border-solid": props.outline ?? false,
       // With icon
       "flex items-center justify-center gap-2": !!props.icon || props.isLoading,
+      // A <button> centres its content natively; an <a> does not. Without this
+      // an href Button with no icon renders as an inline anchor, so the label
+      // sits on the text baseline and overflows the padded box.
+      "inline-flex items-center justify-center": "href" in props && !props.icon && !props.isLoading,
       "flex-row-reverse": props.iconPlacement === "left",
 
       // Styles

--- a/apps/web/src/specs/app/publish/rc-shortfall.spec.ts
+++ b/apps/web/src/specs/app/publish/rc-shortfall.spec.ts
@@ -1,8 +1,4 @@
-import {
-  buildRcTopUpUrl,
-  isShortfallStillRelevant,
-  resolveRcShortfall
-} from "@/app/publish/_utils/rc-shortfall";
+import { isShortfallStillRelevant, resolveRcShortfall } from "@/app/publish/_utils/rc-shortfall";
 
 /**
  * The verbatim rejection a 10 HP account received when publishing an oversized
@@ -46,27 +42,6 @@ describe("resolveRcShortfall", () => {
   it("returns null when there is no signed-in account to bind to", () => {
     expect(resolveRcShortfall(RC_REJECTION, undefined)).toBeNull();
     expect(resolveRcShortfall(RC_REJECTION, "")).toBeNull();
-  });
-});
-
-describe("buildRcTopUpUrl", () => {
-  // Regression: the URL was built from the active user at render time, so
-  // switching accounts while the alert was up offered to boost the wrong one.
-  it("targets the account passed to it", () => {
-    expect(buildRcTopUpUrl("spacecop")).toContain("username=spacecop");
-  });
-
-  it("points at the boost product", () => {
-    const url = buildRcTopUpUrl("spacecop");
-
-    expect(url).toContain("type=boost");
-    expect(url).toContain("product_id=999points");
-  });
-
-  it("encodes names that need it rather than breaking the query string", () => {
-    expect(buildRcTopUpUrl("a b&c=d")).toBe(
-      "/purchase?username=a%20b%26c%3Dd&type=boost&product_id=999points"
-    );
   });
 });
 

--- a/apps/web/src/specs/features/shared/use-rc-topup-action.spec.tsx
+++ b/apps/web/src/specs/features/shared/use-rc-topup-action.spec.tsx
@@ -1,0 +1,122 @@
+import { act, renderHook } from "@testing-library/react";
+import { vi } from "vitest";
+
+const getConfigValue = vi.fn();
+vi.mock("@/config", () => ({
+  EcencyConfigManager: {
+    getConfigValue: (...args: unknown[]) => getConfigValue(...args)
+  }
+}));
+
+// The dialog is lazy-loaded and pulls the whole mutation/SDK chain; the hook's
+// contract is only whether it is mounted, so stand it in with a marker.
+vi.mock("next/dynamic", () => ({
+  default: () => () => null
+}));
+
+import { useRcTopupAction } from "@/features/shared/rc-topup/use-rc-topup-action";
+
+describe("useRcTopupAction", () => {
+  const openSpy = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, "open", { value: openSpy, writable: true });
+  });
+
+  describe("when the RC top-up product is live", () => {
+    beforeEach(() => getConfigValue.mockReturnValue(true));
+
+    it("mounts the dialog rather than navigating away", () => {
+      const { result } = renderHook(() => useRcTopupAction("alice"));
+
+      expect(result.current.dialog).toBeNull();
+      act(() => result.current.openTopup());
+
+      expect(result.current.dialog).not.toBeNull();
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Regression: the dialog resolves its account from useActiveAccount and
+     * its mutation spends that account's Points. Left mounted across a switch
+     * it would spend account B's Points for a shortfall belonging to A.
+     */
+    it("closes the dialog when the active account changes", () => {
+      const { result, rerender } = renderHook(({ user }) => useRcTopupAction(user), {
+        initialProps: { user: "alice" }
+      });
+
+      act(() => result.current.openTopup());
+      expect(result.current.dialog).not.toBeNull();
+
+      rerender({ user: "bob" });
+
+      expect(result.current.dialog).toBeNull();
+    });
+
+    it("closes the dialog on sign-out", () => {
+      const { result, rerender } = renderHook(({ user }) => useRcTopupAction(user), {
+        initialProps: { user: "alice" as string | undefined }
+      });
+
+      act(() => result.current.openTopup());
+      rerender({ user: undefined });
+
+      expect(result.current.dialog).toBeNull();
+    });
+
+    it("stays open across an unrelated re-render", () => {
+      const { result, rerender } = renderHook(({ user }) => useRcTopupAction(user), {
+        initialProps: { user: "alice" }
+      });
+
+      act(() => result.current.openTopup());
+      rerender({ user: "alice" });
+
+      expect(result.current.dialog).not.toBeNull();
+    });
+  });
+
+  describe("when the RC top-up product is off", () => {
+    beforeEach(() => getConfigValue.mockReturnValue(false));
+
+    it("falls back to the boost purchase page for that account", () => {
+      const { result } = renderHook(() => useRcTopupAction("alice"));
+
+      act(() => result.current.openTopup());
+
+      expect(result.current.dialog).toBeNull();
+      const [url] = openSpy.mock.calls[0];
+      expect(url).toContain("username=alice");
+      expect(url).toContain("type=boost");
+    });
+
+    it("opens the fallback without leaking the opener or the referrer", () => {
+      const { result } = renderHook(() => useRcTopupAction("alice"));
+
+      act(() => result.current.openTopup());
+
+      const [, target, features] = openSpy.mock.calls[0];
+      expect(target).toBe("_blank");
+      expect(features).toContain("noopener");
+      expect(features).toContain("noreferrer");
+    });
+
+    it("encodes account names that would otherwise break the query string", () => {
+      const { result } = renderHook(() => useRcTopupAction("a b&c"));
+
+      act(() => result.current.openTopup());
+
+      expect(openSpy.mock.calls[0][0]).toContain("username=a%20b%26c");
+    });
+
+    it("does nothing without a signed-in account", () => {
+      const { result } = renderHook(() => useRcTopupAction(undefined));
+
+      act(() => result.current.openTopup());
+
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Two problems with the out-of-RC alert from #1485, both visible in the reported screenshot.

### The label overflowed its button

`Button` only applies flex centering when an icon is present. A `<button>` centres its content natively, but an `<a>` does not, so **any href Button without an icon** rendered as an inline anchor with the label sitting on the text baseline, outside the padded box.

Fixed in the component rather than at my call site, because it is not specific to this alert: `PointsTopupCta` has the same shape and the same bug.

### The alert offered the wrong route

It linked to a hardcoded `/purchase?type=boost&product_id=999points`, bypassing the top-up product entirely. Ecency already supports:

- spending **Points** on a short-term RC-only delegation to your own account (`RcTopupDialog`), which is the direct fix for being out of RC
- buying **Points by card** when the balance is short (`PointsTopupCta`)
- **Boost+** as the fallback, an HP delegation that raises RC as a side effect

The alert now offers the first two, and falls back to Boost when `visionFeatures.rcTopup` is off.

### One implementation, not two

That fallback logic already existed in `RcPrecheckBanner`. Rather than copy it, the decision moved into a shared `useRcTopupAction` hook that both the pre-publish warning and the post-failure alert use, so the two surfaces cannot drift apart. The banner's behaviour is unchanged; it just no longer owns the only copy.

`buildRcTopUpUrl` is removed along with its specs: it hardcoded the boost product and nothing calls it now.

Full suite green: 2706 tests / 281 files. Typecheck clean, no new lint.

Screenshots of the corrected alert are worth taking on staging before merge, since tests cannot see the alignment this fixes.
