### PR TITLE
Restore the profile entries list, and fix text-to-speech on older Safari

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-content.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-content.tsx
@@ -1,7 +1,8 @@
 import { CommunitySubscribers } from "@/app/(dynamicPages)/community/[community]/_components/community-subscribers";
 import { CommunityActivities } from "@/app/(dynamicPages)/community/[community]/_components/community-activities";
 import { CommunityRoles } from "@/app/(dynamicPages)/community/[community]/_components/community-roles";
-import { EntryListContent, LinearProgress } from "@/features/shared";
+import { EntryListContent } from "@/features/shared/entry-list-content";
+import { LinearProgress } from "@/features/shared";
 import { Fragment } from "react";
 import { Community, Entry } from "@/entities";
 import { getPostsFeedQueryData } from "@/api/queries/get-account-posts-feed-query";

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-archive.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-archive.tsx
@@ -1,5 +1,5 @@
 import { Entry, FullAccount } from "@/entities";
-import { EntryListContent } from "@/features/shared";
+import { EntryListContent } from "@/features/shared/entry-list-content";
 import { EntryArchivePager } from "@/features/shared/entry-archive-pager";
 import { ProfileEntriesLayout } from "@/app/(dynamicPages)/profile/[username]/_components/profile-entries-layout";
 import { stripActiveVotesFromValue } from "@/core/react-query/strip-active-votes";

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-entries-list.tsx
@@ -1,5 +1,12 @@
 import { Entry, FullAccount } from "@/entities";
-import { EntryListContent } from "@/features/shared";
+// Imported from its own module, NOT the `@/features/shared` barrel. This is a
+// server component, and the barrel reaches `entry-list-content` through an
+// `export *`. Once that module became "use client", the star re-export started
+// handing server components `undefined` in place of the component: it rendered
+// as "Element type is invalid ... but got: undefined" and took the entries
+// section off every profile page. Any server component pulling a "use client"
+// module needs to reach it directly, the way the feed list already does.
+import { EntryListContent } from "@/features/shared/entry-list-content";
 import React from "react";
 import { getPostsFeedQueryData } from "@/api/queries";
 import { getQueryData } from "@/core/react-query";

--- a/apps/web/src/specs/app/server-components-avoid-client-barrel.spec.ts
+++ b/apps/web/src/specs/app/server-components-avoid-client-barrel.spec.ts
@@ -1,0 +1,206 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * A server component may not reach a "use client" module through the
+ * `@/features/shared` barrel.
+ *
+ * The barrel re-exports its modules with `export *`. When one of those modules
+ * is a client boundary, that star re-export hands server components `undefined`
+ * instead of the component: React reports "Element type is invalid ... but got:
+ * undefined" while server-rendering, and "Received a promise that resolves to:
+ * undefined" in the browser. The subtree renders as nothing at all, at HTTP 200,
+ * so it fails silently. That is how every profile page shipped with no posts
+ * when `entry-list-content` gained its "use client" directive.
+ *
+ * Nothing else in the suite can see this: vitest renders components in jsdom and
+ * never crosses the server/client boundary, so the barrel resolves normally
+ * there, and `next build` compiles it happily. It only breaks when a real server
+ * renders the route. So the check is on the import graph rather than on output.
+ *
+ * Deliberately conservative: a module imported ANYWHERE by a client component is
+ * treated as client-side and skipped, because it cannot be told apart from a
+ * genuine server component by source alone. That trades some coverage for never
+ * failing a PR that is actually fine.
+ */
+
+const SRC = path.resolve(__dirname, "../..");
+const BARREL = path.join(SRC, "features/shared/index.ts");
+const BARREL_SPECIFIER = "@/features/shared";
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "specs") continue;
+      walk(full, out);
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function read(file: string): string {
+  return fs.readFileSync(file, "utf8");
+}
+
+function isClientBoundary(file: string): boolean {
+  // The directive has to be the first statement, so a match in the opening
+  // lines is the directive rather than a mention in prose.
+  return /^\s*(?:\/\/[^\n]*\n|\/\*[\s\S]*?\*\/\s*)*["']use client["']/.test(read(file));
+}
+
+/** Resolve an import specifier to a file inside src, or null if it leaves src. */
+function resolveSpecifier(fromFile: string, specifier: string): string | null {
+  let base: string;
+  if (specifier.startsWith("@/")) {
+    base = path.join(SRC, specifier.slice(2));
+  } else if (specifier.startsWith(".")) {
+    base = path.resolve(path.dirname(fromFile), specifier);
+  } else {
+    return null;
+  }
+
+  for (const candidate of [
+    `${base}.ts`,
+    `${base}.tsx`,
+    path.join(base, "index.ts"),
+    path.join(base, "index.tsx")
+  ]) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+  }
+  return null;
+}
+
+// Static `from "x"`, bare `import "x"`, and lazy `import("x")` / `require("x")`
+// alike. The lazy forms matter most: `dynamic(() => import("..."))` is how much
+// of this codebase reaches its client components, and missing those edges would
+// report client modules as server ones.
+const IMPORT_SOURCE =
+  /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s+|\brequire\s*\(\s*)["']([^"']+)["']/g;
+
+function importedSpecifiers(file: string): string[] {
+  return [...read(file).matchAll(IMPORT_SOURCE)].map((m) => m[1]);
+}
+
+/** Every name a module exports, following its own `export *` re-exports. */
+function exportedNames(file: string, seen = new Set<string>()): Set<string> {
+  const names = new Set<string>();
+  if (seen.has(file)) return names;
+  seen.add(file);
+
+  const source = read(file);
+
+  for (const m of source.matchAll(
+    /export\s+(?:async\s+)?(?:function|const|let|var|class|enum|interface|type)\s+([A-Za-z0-9_$]+)/g
+  )) {
+    names.add(m[1]);
+  }
+
+  for (const m of source.matchAll(/export\s*\{([^}]*)\}(?!\s*from\s*["']\.)/g)) {
+    for (const part of m[1].split(",")) {
+      const alias = part.split(/\s+as\s+/).pop()?.trim();
+      if (alias) names.add(alias);
+    }
+  }
+
+  for (const m of source.matchAll(/export\s*\*\s*from\s*["']([^"']+)["']/g)) {
+    const target = resolveSpecifier(file, m[1]);
+    if (target) for (const name of exportedNames(target, seen)) names.add(name);
+  }
+
+  return names;
+}
+
+describe("server components and the shared barrel", () => {
+  const files = walk(SRC);
+
+  // Anything a client component pulls in is client-side too, however deep.
+  const clientTainted = new Set<string>();
+  const queue = files.filter(isClientBoundary);
+  queue.forEach((f) => clientTainted.add(f));
+
+  while (queue.length) {
+    const current = queue.shift()!;
+    for (const specifier of importedSpecifiers(current)) {
+      const target = resolveSpecifier(current, specifier);
+      if (target && !clientTainted.has(target)) {
+        clientTainted.add(target);
+        queue.push(target);
+      }
+    }
+  }
+
+  /** Does this module, or anything it re-exports, import the barrel back? */
+  function closesCycleWithBarrel(file: string, seen = new Set<string>()): boolean {
+    if (seen.has(file)) return false;
+    seen.add(file);
+
+    const source = read(file);
+    if (new RegExp(`from\\s*["']${BARREL_SPECIFIER}["']`).test(source)) return true;
+
+    for (const m of source.matchAll(/export\s*\*\s*from\s*["']([^"']+)["']/g)) {
+      const target = resolveSpecifier(file, m[1]);
+      if (target && closesCycleWithBarrel(target, seen)) return true;
+    }
+    return false;
+  }
+
+  // The dangerous barrel entries, and the names they contribute.
+  //
+  // Two conditions have to meet. The module must be a client boundary, and it
+  // must import the barrel back, so the barrel and the module form a cycle
+  // across that boundary. Entering the cycle at the barrel then reads the
+  // module's exports before they exist. Entering at the module instead lets the
+  // barrel finish first, which is why the feed list, importing the very same
+  // component by its own path, kept working throughout.
+  //
+  // Client boundaries with no cycle are fine: `/discover` server-renders 146
+  // UserAvatars through this barrel. The cycle is what breaks it, not the
+  // directive on its own.
+  const clientExports = new Map<string, string>();
+  for (const m of read(BARREL).matchAll(/export\s*\*\s*from\s*["']([^"']+)["']/g)) {
+    const target = resolveSpecifier(BARREL, m[1]);
+    if (!target || !isClientBoundary(target) || !closesCycleWithBarrel(target)) continue;
+    for (const name of exportedNames(target)) {
+      clientExports.set(name, path.relative(SRC, target));
+    }
+  }
+
+  it("knows which barrel exports are client boundaries", () => {
+    // Guard the guard: if this ever empties out, every assertion below passes
+    // for the wrong reason.
+    expect(clientExports.size).toBeGreaterThan(0);
+  });
+
+  it("never imports a client-boundary component through the barrel", () => {
+    const violations: string[] = [];
+
+    for (const file of files) {
+      if (clientTainted.has(file)) continue;
+
+      const source = read(file);
+      for (const m of source.matchAll(
+        new RegExp(`import\\s*\\{([^}]*)\\}\\s*from\\s*["']${BARREL_SPECIFIER}["']`, "g")
+      )) {
+        for (const part of m[1].split(",")) {
+          const name = part.split(/\s+as\s+/)[0].trim();
+          const owner = clientExports.get(name);
+          if (!owner) continue;
+
+          violations.push(
+            `${path.relative(SRC, file)} imports "${name}" from "${BARREL_SPECIFIER}". ` +
+              `That name comes from ${owner}, which is a "use client" module AND imports ` +
+              `the barrel back, so the two form a cycle across the client boundary. ` +
+              `Reaching it through the barrel resolves to undefined at server render ` +
+              `time and the subtree silently renders as nothing. Import it from its own ` +
+              `module instead: "${BARREL_SPECIFIER}/..." .`
+          );
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/web/src/specs/app/server-components-avoid-client-barrel.spec.ts
+++ b/apps/web/src/specs/app/server-components-avoid-client-barrel.spec.ts
@@ -46,9 +46,39 @@ function read(file: string): string {
 }
 
 function isClientBoundary(file: string): boolean {
-  // The directive has to be the first statement, so a match in the opening
-  // lines is the directive rather than a mention in prose.
-  return /^\s*(?:\/\/[^\n]*\n|\/\*[\s\S]*?\*\/\s*)*["']use client["']/.test(read(file));
+  // The directive has to be the first statement, so walk past leading blanks
+  // and comments and look at what comes first. Deliberately a scan rather than
+  // a regex: matching optional repeated comments before the directive needs
+  // nested quantifiers, which backtrack exponentially on input like `/*` then
+  // many `*//*` (CodeQL js/redos), and this runs over every file under src.
+  let inBlockComment = false;
+
+  for (const rawLine of read(file).split("\n")) {
+    let line = rawLine.trim();
+
+    if (inBlockComment) {
+      const end = line.indexOf("*/");
+      if (end === -1) continue;
+      line = line.slice(end + 2).trim();
+      inBlockComment = false;
+    }
+
+    while (line.startsWith("/*")) {
+      const end = line.indexOf("*/", 2);
+      if (end === -1) {
+        inBlockComment = true;
+        line = "";
+        break;
+      }
+      line = line.slice(end + 2).trim();
+    }
+
+    if (!line || line.startsWith("//")) continue;
+
+    return line.startsWith('"use client"') || line.startsWith("'use client'");
+  }
+
+  return false;
 }
 
 /** Resolve an import specifier to a file inside src, or null if it leaves src. */
@@ -73,15 +103,19 @@ function resolveSpecifier(fromFile: string, specifier: string): string | null {
   return null;
 }
 
-// Static `from "x"`, bare `import "x"`, and lazy `import("x")` / `require("x")`
-// alike. The lazy forms matter most: `dynamic(() => import("..."))` is how much
-// of this codebase reaches its client components, and missing those edges would
-// report client modules as server ones.
-const IMPORT_SOURCE =
+// Every edge, lazy ones included. `dynamic(() => import("..."))` is how much of
+// this codebase reaches its client components, and missing those would report
+// client modules as server ones.
+const ANY_IMPORT =
   /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s+|\brequire\s*\(\s*)["']([^"']+)["']/g;
 
-function importedSpecifiers(file: string): string[] {
-  return [...read(file).matchAll(IMPORT_SOURCE)].map((m) => m[1]);
+// Only the edges that run while the module is being evaluated. A lazy
+// `import()` resolves long after, so it cannot take part in an initialisation
+// cycle, and counting it as one would condemn imports that are perfectly safe.
+const STATIC_IMPORT = /(?:\bfrom\s*|\bimport\s+)["']([^"']+)["']/g;
+
+function importedSpecifiers(file: string, pattern: RegExp = ANY_IMPORT): string[] {
+  return [...read(file).matchAll(pattern)].map((m) => m[1]);
 }
 
 /** Every name a module exports, following its own `export *` re-exports. */
@@ -132,18 +166,36 @@ describe("server components and the shared barrel", () => {
     }
   }
 
-  /** Does this module, or anything it re-exports, import the barrel back? */
+  /**
+   * Does this module import the barrel back, closing a cycle with it?
+   *
+   * Counts a direct static import by the module itself, plus one in anything it
+   * re-exports with `export *`, since those form a single export surface with
+   * it. Lazy `import()` does not count: it resolves long after evaluation, so it
+   * cannot take part in an initialisation cycle.
+   *
+   * NOT transitive through ordinary imports, and that is a measured choice
+   * rather than an oversight. Following every static edge marks `time-label`,
+   * `tag`, `entry-stats` and `bookmark-btn` as cyclic, because somewhere down
+   * their helpers something reaches the barrel. The entry page imports all four
+   * from the barrel and server-renders them correctly today: 12 `<time>`
+   * elements, its stats, its tag links, its bookmark button, no error. A guard
+   * that fails CI on pages that demonstrably work gets bypassed, so this keeps
+   * to the shape that actually broke and stays quiet otherwise. A deeper cycle
+   * would slip through; the reproduction in the PR body is how that one gets
+   * caught.
+   */
   function closesCycleWithBarrel(file: string, seen = new Set<string>()): boolean {
     if (seen.has(file)) return false;
     seen.add(file);
 
-    const source = read(file);
-    if (new RegExp(`from\\s*["']${BARREL_SPECIFIER}["']`).test(source)) return true;
+    if (importedSpecifiers(file, STATIC_IMPORT).includes(BARREL_SPECIFIER)) return true;
 
-    for (const m of source.matchAll(/export\s*\*\s*from\s*["']([^"']+)["']/g)) {
+    for (const m of read(file).matchAll(/export\s*\*\s*from\s*["']([^"']+)["']/g)) {
       const target = resolveSpecifier(file, m[1]);
       if (target && closesCycleWithBarrel(target, seen)) return true;
     }
+
     return false;
   }
 

--- a/apps/web/src/specs/utils/speech.spec.ts
+++ b/apps/web/src/specs/utils/speech.spec.ts
@@ -44,6 +44,29 @@ function installSpeechSynthesis(
   };
 }
 
+/**
+ * Safari <= 15: `SpeechSynthesis` is not an `EventTarget` there, so the object
+ * carries no `addEventListener` at all.
+ */
+function installSpeechSynthesisWithoutEventTarget(
+  initial: Array<SpeechSynthesisVoice | undefined> = []
+) {
+  let current = initial;
+  const getVoices = vi.fn(() => current as SpeechSynthesisVoice[]);
+
+  Object.defineProperty(window, "speechSynthesis", {
+    configurable: true,
+    value: { getVoices }
+  });
+
+  return {
+    getVoices,
+    setVoices: (next: Array<SpeechSynthesisVoice | undefined>) => {
+      current = next;
+    }
+  };
+}
+
 afterEach(() => {
   if (originalSpeechSynthesisDescriptor) {
     Object.defineProperty(
@@ -86,5 +109,49 @@ describe("getVoicesAsync", () => {
       "voiceschanged",
       handler
     );
+  });
+
+  describe("when SpeechSynthesis is not an EventTarget (Safari <= 15)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("polls for voices instead of throwing on the missing addEventListener", async () => {
+      const speechSynthesis = installSpeechSynthesisWithoutEventTarget();
+
+      const voicesPromise = getVoicesAsync();
+      speechSynthesis.setVoices([undefined, voice]);
+      await vi.advanceTimersByTimeAsync(250);
+
+      await expect(voicesPromise).resolves.toEqual([voice]);
+    });
+
+    it("resolves empty once the budget runs out rather than hanging forever", async () => {
+      installSpeechSynthesisWithoutEventTarget();
+
+      const voicesPromise = getVoicesAsync();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      await expect(voicesPromise).resolves.toEqual([]);
+    });
+
+    // Regression guard: `onvoiceschanged` holds a single handler, so registering
+    // through it would let a second caller overwrite the first and strand it.
+    // Both callers here must be served.
+    it("settles every concurrent caller, not just the most recent one", async () => {
+      const speechSynthesis = installSpeechSynthesisWithoutEventTarget();
+
+      const firstPromise = getVoicesAsync();
+      const secondPromise = getVoicesAsync();
+      speechSynthesis.setVoices([voice]);
+      await vi.advanceTimersByTimeAsync(250);
+
+      await expect(firstPromise).resolves.toEqual([voice]);
+      await expect(secondPromise).resolves.toEqual([voice]);
+    });
   });
 });

--- a/apps/web/src/utils/speech.ts
+++ b/apps/web/src/utils/speech.ts
@@ -1,15 +1,48 @@
+// Safari <= 15 does not make SpeechSynthesis an EventTarget, so
+// `addEventListener` is undefined there. Calling it threw inside the Promise
+// executor below, which REJECTED the promise, and neither caller attaches a
+// `.catch` -- so the failure surfaced as an unhandled rejection and text-to-speech
+// silently lost its voice list.
+//
+// The fallback polls instead of assigning `onvoiceschanged`. That property holds
+// exactly ONE handler, and both callers (`useTts` and the settings dialog) can be
+// waiting at the same time, so the second assignment would strand the first
+// caller's promise forever. Polling gives every caller an independent waiter and
+// always settles, on a browser where we cannot rely on the event firing at all.
+const FALLBACK_POLL_INTERVAL_MS = 250;
+const FALLBACK_TIMEOUT_MS = 5000;
+
 export function getVoicesAsync(): Promise<SpeechSynthesisVoice[]> {
     return new Promise((resolve) => {
-        const voices = window.speechSynthesis.getVoices().filter(Boolean) as SpeechSynthesisVoice[];
+        const readVoices = () =>
+            window.speechSynthesis.getVoices().filter(Boolean) as SpeechSynthesisVoice[];
+
+        const voices = readVoices();
         if (voices.length) {
             resolve(voices);
-        } else {
+            return;
+        }
+
+        if (typeof window.speechSynthesis.addEventListener === "function") {
             const handler = () => {
-                resolve(window.speechSynthesis.getVoices().filter(Boolean) as SpeechSynthesisVoice[]);
+                resolve(readVoices());
                 window.speechSynthesis.removeEventListener("voiceschanged", handler);
             };
             window.speechSynthesis.addEventListener("voiceschanged", handler);
+            return;
         }
+
+        const startedAt = Date.now();
+        const poll = window.setInterval(() => {
+            const polledVoices = readVoices();
+            // Resolve with whatever is there once the budget runs out: an empty
+            // list is a state both callers already handle, and leaving the promise
+            // pending forever would hang them instead.
+            if (polledVoices.length || Date.now() - startedAt >= FALLBACK_TIMEOUT_MS) {
+                window.clearInterval(poll);
+                resolve(polledVoices);
+            }
+        }, FALLBACK_POLL_INTERVAL_MS);
     });
 }
 export function createUtterance(text: string): SpeechSynthesisUtterance | null {


### PR DESCRIPTION
Two fixes and a guard.

## Profile pages render with no posts

`ECENCY-NEXT-1GMM` (server) and `ECENCY-NEXT-1GMN` (browser, from the in-app report).

#1493 added `"use client"` to `features/shared/entry-list-content/index.tsx`. That module also imports the `@/features/shared` barrel back, so the two now form a cycle across a client boundary. A server component entering that cycle at the barrel reads the module's exports before they exist and gets `undefined`.

The directive alone is not the problem: `/discover` server-renders 146 `UserAvatar`s through this same barrel. It takes the cycle as well. And entering at the module rather than the barrel is fine, which is why the feed list kept working with the very same component.

Reproduced on alpha against the origin, bypassing the edge:

| | prod (`89af6214`) | alpha (`9f65d9a5`) |
|---|---|---|
| `/@good-karma/blog` entries in SSR HTML | 20 | 0 |
| errors logged in 30m | 0 | 98 |

Not just the items: the whole `entry-list` wrapper is absent, so no empty state either. It fires on every profile request, both `/@user` and `/@user/[section]`, matching the two digests. Fixed by importing `@/features/shared/entry-list-content` in the three server components that read it through the barrel. `community-content.tsx` is unrendered today but has the same import and would break the moment it is used.

## Text-to-speech throws on Safari <= 15

`ECENCY-NEXT-1GMK`, superseding #1498.

Safari <= 15 does not make `SpeechSynthesis` an `EventTarget`, so `addEventListener` is undefined. The call threw inside the promise executor, which rejected the promise; neither caller attaches a `.catch`, hence the unhandled rejection and no voice list.

This polls `getVoices` rather than assigning `onvoiceschanged`. That property holds one handler, and `useTts` and the settings dialog can both be waiting, so the second registration would strand the first caller. The poll also settles on a timeout rather than hanging if voices never load. Three specs cover it, each reproducing the reported `TypeError` against the previous implementation.

## Guard

`server-components-avoid-client-barrel.spec.ts` asserts on the import graph, since no rendering test can see this class of bug: vitest never crosses the server/client boundary and `next build` compiles it happily. It flags a server component importing, through the barrel, a name owned by a client module that imports the barrel back. Anything a client component imports is treated as client-side, following dynamic `import()` edges, so it stays quiet on the many barrel imports that are fine. Reverting the profile import fails it with the offending file named.

## Verification

`pnpm -r --if-present typecheck`, `pnpm -r lint` and the full web suite (288 files, 2742 tests) pass locally. The profile fix itself is not reachable by the unit suite, so it needs a check against a rendered profile page on alpha once this deploys.
