### PR TITLE
Build packages before testing them, and report PR build on every PR

### DIFF
--- a/.github/workflows/PR-branch.yml
+++ b/.github/workflows/PR-branch.yml
@@ -1,20 +1,12 @@
 name: PR build
+# Mirrors lint.yml and typecheck.yml: pull_request rather than a branch-filtered push,
+# so this check reports on EVERY pull request. It used to opt in by branch prefix, which
+# left two holes. A branch named anything outside the list was never built at all, and
+# once this becomes a required check, such a PR could never satisfy it: Dependabot,
+# Renovate, forks and hotfix/* would be blocked forever with no way to produce the check.
+# Both holes close by keying on the pull request itself instead of the branch name.
 on:
-  push:
-    branches:
-      # Every prefix in real use, not just the two most common. This list is an
-      # opt-IN, so a branch named anything else silently gets no build at all --
-      # which is how a change to next.config.js (a build-time file that neither
-      # tsc nor eslint evaluates) reached review with nothing having compiled it.
-      # Add new prefixes here, or they inherit that same silent gap.
-      - 'bugfix/*'
-      - 'feature/*'
-      - 'fix/*'
-      - 'chore/*'
-      - 'refactor/*'
-      - 'docs/*'
-      # Bot-authored PRs were previously merged without ever being built.
-      - 'seer/*'
+  pull_request:
 # Build/test only — no writes back to GitHub.
 # Superseded runs are cancelled: only the newest commit on the branch is worth building.
 concurrency:
@@ -48,6 +40,15 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Validate DMCA patterns
         run: pnpm validate:dmca
+      # Ahead of the tests, not after them. apps/web resolves `@ecency/sdk` to the
+      # COMMITTED packages/sdk/dist, so a PR changing SDK source was tested against a
+      # stale build until some later commit happened to rebuild the dist. #1493 spent
+      # six runs red on 36 tests whose source and mocks were both correct, purely
+      # because `isAuthorMuted` existed in src but not yet in the committed dist. A
+      # required check that goes red for reasons the author cannot act on is what
+      # teaches everyone to merge past it, so the consumers test what this PR builds.
+      - name: Build packages
+        run: pnpm build:packages
       - name: Run Tests
         run: pnpm -r test
       - name: Build

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,10 +43,12 @@ jobs:
       run: pnpm install --frozen-lockfile
       env:
         CI: true
-    - name: Run Tests
-      run: pnpm -r test
+    # Packages first: apps/web resolves `@ecency/sdk` to the COMMITTED
+    # packages/sdk/dist, so testing before this builds against a stale dist.
     - name: Build packages
       run: pnpm build:packages
+    - name: Run Tests
+      run: pnpm -r test
     - name: Build web app
       run: pnpm --filter @ecency/web build
       env:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -46,10 +46,12 @@ jobs:
       run: pnpm install --frozen-lockfile
       env:
         CI: true
-    - name: Run Tests
-      run: pnpm -r test
+    # Packages first: apps/web resolves `@ecency/sdk` to the COMMITTED
+    # packages/sdk/dist, so testing before this builds against a stale dist.
     - name: Build packages
       run: pnpm build:packages
+    - name: Run Tests
+      run: pnpm -r test
     - name: Build web app
       run: pnpm --filter @ecency/web build
       env:


### PR DESCRIPTION
Groundwork for making `build (24.x)` a required check on `develop`. It is not required today, which is how #1493 merged with six consecutive red builds and 36 failing tests behind it: `lint (24.x)` and `typecheck (24.x)` are the only required contexts, neither runs tests, and both were green.

Two things have to change before that setting can be flipped safely.

## Build packages before running them

`apps/web` resolves `@ecency/sdk` to the **committed** `packages/sdk/dist`, so running tests first tests a stale build whenever a PR changes SDK source.

That is precisely what reddened #1493. `isAuthorMuted` was added to src at 07:18 but only reached the committed dist at 08:34, when the label-triggered changeset commit rebuilt it. Every run in between failed with `No "isAuthorMuted" export is defined on the "@ecency/sdk" mock`, while the source and the mocks were both correct throughout. Re-running that suite on current develop gives 2742 passing.

A required check that fails for a reason its author cannot act on is what teaches everyone to merge past CI, so consumers now test what the PR actually builds. `staging.yml` and `master.yml` carried the same ordering and get the same move.

## Report on every pull request

`PR build` opted in by branch prefix. Two holes: a branch named anything outside the list got no build at all, and once this check is required, such a PR could never satisfy it. Dependabot, Renovate, forks and `hotfix/*` would be blocked with no way to produce the check.

Keying on the pull request closes both. This is what `lint.yml` and `typecheck.yml` already do, and their comments cite this same trap.

## Remaining manual step

Adding `build (24.x)` to the required contexts on `develop` is a repo setting and cannot ride along in a PR. Worth doing once this merges, so the check reports on every PR first.

This PR exercises its own change: the `PR build` run below is the new trigger and the new ordering.
