### PR TITLE
Fix comment list emptying when a post has a hidden comment

### DIFF
--- a/apps/web/src/features/shared/discussion/discussion-list.tsx
+++ b/apps/web/src/features/shared/discussion/discussion-list.tsx
@@ -62,12 +62,21 @@ export function DiscussionList({
         [activeUser, filtered, mutedUsers, parent.author]
     );
 
+    // Identify a comment by author/permlink. `bridge.get_discussion` returns no
+    // `post_id`, so the previous `fd.post_id === md.post_id` check compared
+    // `undefined` with `undefined` and matched every comment: a single hidden
+    // reply emptied the whole list.
+    const hiddenKeys = useMemo(
+        () => new Set(hiddenContent.map((item) => `${item.author}/${item.permlink}`)),
+        [hiddenContent]
+    );
+
     const data = useMemo(() => {
         const visibleContent = filtered.filter(
-            (md) => !hiddenContent.some((fd) => fd.post_id === md.post_id)
+            (md) => !hiddenKeys.has(`${md.author}/${md.permlink}`)
         );
         return isHiddenPermitted ? [...visibleContent, ...hiddenContent] : visibleContent;
-    }, [filtered, hiddenContent, isHiddenPermitted]);
+    }, [filtered, hiddenContent, hiddenKeys, isHiddenPermitted]);
 
     const botsFreeData = useMemo(
         () =>

--- a/apps/web/src/specs/features/shared/discussion-list.spec.tsx
+++ b/apps/web/src/specs/features/shared/discussion-list.spec.tsx
@@ -1,29 +1,39 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { describe, expect, it, vi } from "vitest";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Entry } from "@/entities";
-import { mockEntry } from "@/specs/test-utils";
+import { mockEntry, renderWithQueryClient } from "@/specs/test-utils";
 
 // DiscussionList only touches these two SDK queries; keep them local so the
-// spec doesn't depend on the global SDK mock exporting them.
-vi.mock("@ecency/sdk", () => ({
-  getMutedUsersQueryOptions: (username?: string) => ({
-    queryKey: ["muted-users", username],
-    queryFn: async () => []
-  }),
-  getBotsQueryOptions: () => ({ queryKey: ["bots"], queryFn: async () => [] })
-}));
+// spec doesn't depend on the global SDK mock exporting them. Keys come from the
+// SDK's own builders (the module is dependency-free) so the mocked queries land
+// on the same cache keys production uses.
+vi.mock("@ecency/sdk", async () => {
+  const { QueryKeys } = await vi.importActual<typeof import("@ecency/sdk")>(
+    "../../../../../../packages/sdk/src/modules/core/query-keys"
+  );
+  return {
+    QueryKeys,
+    getMutedUsersQueryOptions: vi.fn((username: string) => ({
+      queryKey: QueryKeys.accounts.mutedUsers(username),
+      queryFn: async () => []
+    })),
+    getBotsQueryOptions: vi.fn(() => ({
+      queryKey: QueryKeys.accounts.bots(),
+      queryFn: async () => []
+    }))
+  };
+});
 
 // The item itself renders the whole comment chrome (votes, payout, composer).
-// Stub it down to its author so the assertions are about which comments the
-// list decides to render.
+// Stub it down to a labelled landmark carrying its author, so the assertions
+// read the rendered comments by role instead of the stub's markup.
 vi.mock("@/features/shared/discussion/discussion-item", async () => {
   const Real = await import("react");
   return {
     DiscussionItem: ({ entry }: { entry: Entry }) =>
-      Real.createElement("div", { "data-testid": "discussion-item" }, entry.author)
+      Real.createElement("article", { "aria-label": entry.author }, entry.author)
   };
 });
 
@@ -48,28 +58,29 @@ function comment(author: string, reputation: number): Entry {
 }
 
 function renderList(discussionList: Entry[]) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <DiscussionList
-        root={root}
-        parent={root}
-        discussionList={discussionList}
-        community={null}
-        hideControls={false}
-        isRawContent={false}
-      />
-    </QueryClientProvider>
+  return renderWithQueryClient(
+    <DiscussionList
+      root={root}
+      parent={root}
+      discussionList={discussionList}
+      community={null}
+      hideControls={false}
+      isRawContent={false}
+    />
   );
+}
+
+// The rendered comments, in the order the list decided to show them.
+function renderedAuthors() {
+  return screen.getAllByRole("article").map((el) => el.getAttribute("aria-label"));
 }
 
 describe("DiscussionList", () => {
   it("keeps the normal comments visible when one commenter has negative reputation", () => {
     renderList([comment("alice", 60), comment("carol", 55), comment("spammer", -8)]);
 
-    const authors = screen.getAllByTestId("discussion-item").map((el) => el.textContent);
-    expect(authors).toEqual(["alice", "carol"]);
-    expect(authors).not.toContain("spammer");
+    expect(renderedAuthors()).toEqual(["alice", "carol"]);
+    expect(screen.queryByText("spammer")).not.toBeInTheDocument();
 
     // The low-reputation reply is offered behind the reveal prompt.
     expect(screen.getByText("discussion.reveal-muted-long-description")).toBeInTheDocument();
@@ -80,17 +91,13 @@ describe("DiscussionList", () => {
 
     fireEvent.click(screen.getByText("g.show"));
 
-    expect(screen.getAllByTestId("discussion-item").map((el) => el.textContent)).toEqual([
-      "alice",
-      "carol",
-      "spammer"
-    ]);
+    expect(renderedAuthors()).toEqual(["alice", "carol", "spammer"]);
   });
 
   it("renders every comment when none of them are hidden", () => {
     renderList([comment("alice", 60), comment("carol", 55)]);
 
-    expect(screen.getAllByTestId("discussion-item")).toHaveLength(2);
+    expect(renderedAuthors()).toEqual(["alice", "carol"]);
     expect(screen.queryByText("discussion.reveal-muted-long-description")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/specs/features/shared/discussion-list.spec.tsx
+++ b/apps/web/src/specs/features/shared/discussion-list.spec.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Entry } from "@/entities";
+import { mockEntry } from "@/specs/test-utils";
+
+// DiscussionList only touches these two SDK queries; keep them local so the
+// spec doesn't depend on the global SDK mock exporting them.
+vi.mock("@ecency/sdk", () => ({
+  getMutedUsersQueryOptions: (username?: string) => ({
+    queryKey: ["muted-users", username],
+    queryFn: async () => []
+  }),
+  getBotsQueryOptions: () => ({ queryKey: ["bots"], queryFn: async () => [] })
+}));
+
+// The item itself renders the whole comment chrome (votes, payout, composer).
+// Stub it down to its author so the assertions are about which comments the
+// list decides to render.
+vi.mock("@/features/shared/discussion/discussion-item", async () => {
+  const Real = await import("react");
+  return {
+    DiscussionItem: ({ entry }: { entry: Entry }) =>
+      Real.createElement("div", { "data-testid": "discussion-item" }, entry.author)
+  };
+});
+
+import { DiscussionList } from "@/features/shared/discussion/discussion-list";
+
+const root = mockEntry({ author: "bob", permlink: "the-post" });
+
+// `bridge.get_discussion` returns no `post_id` — mockEntry's default would hide
+// the regression, so drop it the way the real API does.
+function comment(author: string, reputation: number): Entry {
+  return {
+    ...mockEntry({
+      author,
+      permlink: `re-the-post-${author}`,
+      parent_author: "bob",
+      parent_permlink: "the-post",
+      depth: 1,
+      author_reputation: reputation
+    }),
+    post_id: undefined as unknown as number
+  };
+}
+
+function renderList(discussionList: Entry[]) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DiscussionList
+        root={root}
+        parent={root}
+        discussionList={discussionList}
+        community={null}
+        hideControls={false}
+        isRawContent={false}
+      />
+    </QueryClientProvider>
+  );
+}
+
+describe("DiscussionList", () => {
+  it("keeps the normal comments visible when one commenter has negative reputation", () => {
+    renderList([comment("alice", 60), comment("carol", 55), comment("spammer", -8)]);
+
+    const authors = screen.getAllByTestId("discussion-item").map((el) => el.textContent);
+    expect(authors).toEqual(["alice", "carol"]);
+    expect(authors).not.toContain("spammer");
+
+    // The low-reputation reply is offered behind the reveal prompt.
+    expect(screen.getByText("discussion.reveal-muted-long-description")).toBeInTheDocument();
+  });
+
+  it("appends the hidden comment on reveal instead of replacing the list", () => {
+    renderList([comment("alice", 60), comment("carol", 55), comment("spammer", -8)]);
+
+    fireEvent.click(screen.getByText("g.show"));
+
+    expect(screen.getAllByTestId("discussion-item").map((el) => el.textContent)).toEqual([
+      "alice",
+      "carol",
+      "spammer"
+    ]);
+  });
+
+  it("renders every comment when none of them are hidden", () => {
+    renderList([comment("alice", 60), comment("carol", 55)]);
+
+    expect(screen.getAllByTestId("discussion-item")).toHaveLength(2);
+    expect(screen.queryByText("discussion.reveal-muted-long-description")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1501

`bridge.get_discussion` returns entries with no `post_id`, so the visible-content filter in `discussion-list.tsx` compared `undefined === undefined` and matched every comment against the first hidden one. A single low-reputation or muted reply emptied the whole list: the header still counted every top-level comment while nothing rendered, and the reveal prompt then showed only the hidden reply.

Comments are now keyed by `author/permlink`.

Reproduced on `/@acidyo/this-is-really-unfair` (36 top-level comments, one low-rep replier): 0 items rendered, reveal showed 1.

Tests: new `discussion-list.spec.tsx` covers the mixed list, the reveal path and the no-hidden-comment case. All three fail against the old filter (`expected [ 'spammer' ] to deeply equal [ 'alice', 'carol', 'spammer' ]`) and pass with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed hidden discussion replies so concealing one reply no longer unintentionally hides other comments.
  - Improved handling of discussions where comment identifiers are unavailable.
  - Revealed comments now appear correctly alongside existing discussion content.
  - Reveal prompts are omitted when all discussion content is already visible.

- **Tests**
  - Added coverage for hidden comments, revealing additional replies, and fully visible discussions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->