### PR TITLE
Use a real i18n key for the comment collapse toggle

### DIFF
--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1263,6 +1263,7 @@
     "reveal-muted": "Muted author - Reveal comment",
     "reveal-muted-long-description": "Show additional replies, including those that may contain offensive content",
     "reveal": "Reveal comment",
+    "hide": "Hide comment",
     "reveal-comments": "Show {{n}} comments",
     "no-conversation": "No conversation yet, be first to reply",
     "start-conversation": "Start conversation",

--- a/apps/web/src/features/shared/discussion/discussion-item.tsx
+++ b/apps/web/src/features/shared/discussion/discussion-item.tsx
@@ -309,7 +309,7 @@ export const DiscussionItem = memo(function DiscussionItem({
                   aria-expanded={!isContentCollapsed}
                   onClick={() => setIsContentCollapsed((value) => !value)}
                 >
-                  {i18next.t(isContentCollapsed ? toggleLabelKey : "chat.hide-message")}
+                  {i18next.t(isContentCollapsed ? toggleLabelKey : "discussion.hide")}
                 </Button>
               )}
             </div>

--- a/apps/web/src/specs/features/shared/discussion-item.spec.tsx
+++ b/apps/web/src/specs/features/shared/discussion-item.spec.tsx
@@ -84,6 +84,14 @@ vi.mock("@/features/shared/discussion/discussion-list", () => ({ DiscussionList:
 vi.mock("@/features/shared/comment", () => ({ Comment: () => null }));
 
 import { DiscussionItem } from "@/features/shared/discussion/discussion-item";
+import enUS from "@/features/i18n/locales/en-US.json";
+
+// Resolve a dotted i18n key against the shipped English locale.
+function getLocaleValue(key: string) {
+  return key
+    .split(".")
+    .reduce<any>((acc, part) => (acc == null ? acc : acc[part]), enUS as Record<string, unknown>);
+}
 
 function renderItem(entry: Entry, root: Entry) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -146,6 +154,33 @@ describe("DiscussionItem", () => {
     );
 
     expect(screen.queryByTestId("entry-tip-btn")).not.toBeInTheDocument();
+  });
+
+  it("labels the collapse toggle with keys that exist in en-US.json", () => {
+    // i18next is globally mocked to echo the key, so the rendered text IS the
+    // key the component asked for. The hide side used to ask for
+    // `chat.hide-message`, which no locale defines, and shipped the raw key.
+    const lowRepComment = mockEntry({
+      author: "spammer",
+      permlink: "re-the-post-spam",
+      parent_author: "bob",
+      parent_permlink: "the-post",
+      depth: 1,
+      author_reputation: -8,
+      net_rshares: 0,
+      stats: { flag_weight: 0, gray: true, hide: false, total_votes: 0 }
+    });
+
+    renderItem(lowRepComment, root);
+
+    const revealKey = screen.getByRole("button", { name: /^discussion\./ }).textContent!;
+    expect(getLocaleValue(revealKey)).toBeTypeOf("string");
+
+    fireEvent.click(screen.getByText(revealKey));
+
+    const hideKey = screen.getByRole("button", { name: /^discussion\./ }).textContent!;
+    expect(hideKey).not.toBe(revealKey);
+    expect(getLocaleValue(hideKey)).toBeTypeOf("string");
   });
 
   it("animates the reply composer entrance only after clicking Reply, never on initial render", () => {

--- a/apps/web/src/specs/features/shared/discussion-item.spec.tsx
+++ b/apps/web/src/specs/features/shared/discussion-item.spec.tsx
@@ -87,10 +87,13 @@ import { DiscussionItem } from "@/features/shared/discussion/discussion-item";
 import enUS from "@/features/i18n/locales/en-US.json";
 
 // Resolve a dotted i18n key against the shipped English locale.
-function getLocaleValue(key: string) {
-  return key
-    .split(".")
-    .reduce<any>((acc, part) => (acc == null ? acc : acc[part]), enUS as Record<string, unknown>);
+function getLocaleValue(key: string): unknown {
+  return key.split(".").reduce<unknown>((acc, part) => {
+    if (typeof acc !== "object" || acc === null) {
+      return undefined;
+    }
+    return (acc as Record<string, unknown>)[part];
+  }, enUS as Record<string, unknown>);
 }
 
 function renderItem(entry: Entry, root: Entry) {


### PR DESCRIPTION
Fixes #1502

The collapse toggle on a muted / low-reputation comment called `i18next.t("chat.hide-message")`. That key exists in no locale, so i18next echoed it and the raw `chat.hide-message` string rendered next to "Author of this content has low reputation." The expand side was fine (`discussion.reveal` / `discussion.reveal-muted`).

Adds `discussion.hide` to `en-US.json` and points the toggle at it.

Tests: `discussion-item.spec.tsx` now renders a low-reputation comment and asserts both toggle labels resolve to a string in `en-US.json`. It fails against `chat.hide-message` and passes with the fix.