### PR TITLE
fix(web): show a translated message when extension signing is cancelled

### DIFF
--- a/apps/self-hosted/src/core/i18n-strings.ts
+++ b/apps/self-hosted/src/core/i18n-strings.ts
@@ -114,6 +114,7 @@ export type TranslationKey =
   | 'tip_login_to_send'
   | 'tip_asset_not_supported'
   | 'tip_transaction_failed'
+  | 'transaction_cancelled_by_user'
   | 'tip_qr_no_address'
   | 'tip_qr_failed'
   | 'cancel'
@@ -425,6 +426,7 @@ export const translations: { en: Translations } & Record<
     tip_login_to_send: 'Login to send a tip',
     tip_asset_not_supported: 'This asset is not supported for tipping yet',
     tip_transaction_failed: 'Transaction failed',
+    transaction_cancelled_by_user: 'Transaction cancelled by user.',
     tip_qr_no_address: 'No address',
     tip_qr_failed: 'Failed to generate QR',
     cancel: 'Cancel',
@@ -725,6 +727,7 @@ export const translations: { en: Translations } & Record<
     tip_login_to_send: 'Inicia sesión para enviar una propina',
     tip_asset_not_supported: 'Este activo aún no es compatible con las propinas',
     tip_transaction_failed: 'Transacción fallida',
+    transaction_cancelled_by_user: 'Transacción cancelada por el usuario.',
     tip_qr_no_address: 'Sin dirección',
     tip_qr_failed: 'Error al generar el QR',
     cancel: 'Cancelar',
@@ -869,6 +872,7 @@ export const translations: { en: Translations } & Record<
     tip_login_to_send: 'Melde dich an, um ein Trinkgeld zu senden',
     tip_asset_not_supported: 'Dieses Asset wird für Trinkgelder noch nicht unterstützt',
     tip_transaction_failed: 'Transaktion fehlgeschlagen',
+    transaction_cancelled_by_user: 'Transaktion vom Benutzer abgebrochen.',
     tip_qr_no_address: 'Keine Adresse',
     tip_qr_failed: 'QR-Generierung fehlgeschlagen',
     cancel: 'Abbrechen',
@@ -1014,6 +1018,7 @@ export const translations: { en: Translations } & Record<
     tip_login_to_send: 'Connectez-vous pour envoyer un pourboire',
     tip_asset_not_supported: "Cet actif n'est pas encore pris en charge pour les pourboires",
     tip_transaction_failed: 'Échec de la transaction',
+    transaction_cancelled_by_user: "Transaction annulée par l'utilisateur.",
     tip_qr_no_address: 'Aucune adresse',
     tip_qr_failed: 'Échec de la génération du QR',
     cancel: 'Annuler',
@@ -1159,6 +1164,7 @@ export const translations: { en: Translations } & Record<
     tip_login_to_send: '팁을 보내려면 로그인하세요',
     tip_asset_not_supported: '이 자산은 아직 팁으로 지원되지 않습니다',
     tip_transaction_failed: '거래 실패',
+    transaction_cancelled_by_user: '사용자가 거래를 취소했습니다.',
     tip_qr_no_address: '주소 없음',
     tip_qr_failed: 'QR 생성 실패',
     cancel: '취소',
@@ -1299,6 +1305,7 @@ export const translations: { en: Translations } & Record<
     tip_login_to_send: 'Войдите, чтобы отправить чаевые',
     tip_asset_not_supported: 'Этот актив пока не поддерживается для чаевых',
     tip_transaction_failed: 'Транзакция не удалась',
+    transaction_cancelled_by_user: 'Транзакция отменена пользователем.',
     tip_qr_no_address: 'Нет адреса',
     tip_qr_failed: 'Не удалось создать QR-код',
     cancel: 'Отмена',

--- a/apps/self-hosted/src/features/auth/utils/extension-error.test.ts
+++ b/apps/self-hosted/src/features/auth/utils/extension-error.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  extensionErrorMessage,
+  isExplicitUserCancellation,
+} from './extension-error';
+
+/**
+ * A cancelled signing request used to throw `resp.error` verbatim, so the user
+ * saw the bare code `user_cancel`. It now resolves to the translated sentence,
+ * while every other failure keeps the detail that says what went wrong.
+ */
+describe('extensionErrorMessage', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('lang');
+  });
+
+  it.each([
+    [{ error: 'user_cancel', message: 'Request was canceled by the user.' }],
+    [{ error: 'user_cancel' }],
+    [{ error: 'cancelled' }],
+    [{ message: 'Request was canceled by the user.' }],
+    [{ error: { code: 4001, message: 'User rejected request' } }],
+  ])('translates the cancellation for %o', (resp) => {
+    const result = extensionErrorMessage(resp, 'Operation cancelled');
+    expect(result).toBe('Transaction cancelled by user.');
+    expect(result).not.toContain('user_cancel');
+  });
+
+  it('follows the language on the document', () => {
+    document.documentElement.lang = 'es';
+    expect(extensionErrorMessage({ error: 'user_cancel' }, 'fallback')).toBe(
+      'Transacción cancelada por el usuario.',
+    );
+  });
+
+  it('falls back to English for a language with no translation', () => {
+    document.documentElement.lang = 'xx';
+    expect(extensionErrorMessage({ error: 'user_cancel' }, 'fallback')).toBe(
+      'Transaction cancelled by user.',
+    );
+  });
+
+  it.each([
+    [{ message: 'transaction rejected: missing required active authority' }],
+    [{ error: { message: 'Assert Exception:limit_order_cancel: no order' } }],
+    [{ message: 'Broadcast rejected by the node' }],
+    [
+      {
+        error: 'rejected',
+        message: 'Invalid transaction: duplicate transaction',
+      },
+    ],
+  ])('keeps the real failure detail for %o', (resp) => {
+    expect(extensionErrorMessage(resp, 'Extension broadcast failed')).not.toBe(
+      'Transaction cancelled by user.',
+    );
+  });
+
+  it('joins the readable reason and the underlying error', () => {
+    const result = extensionErrorMessage(
+      {
+        message: 'There was an error broadcasting.',
+        error: { message: 'missing required active authority' },
+      },
+      'fallback',
+    );
+    expect(result).toContain('There was an error broadcasting.');
+    expect(result).toContain('missing required active authority');
+  });
+
+  it('uses the fallback when the response says nothing', () => {
+    expect(extensionErrorMessage({}, 'Extension broadcast failed')).toBe(
+      'Extension broadcast failed',
+    );
+  });
+});
+
+describe('isExplicitUserCancellation', () => {
+  it.each([
+    [{ error: 'user_cancel' }],
+    [{ error: 'USER_CANCEL' }],
+    [{ error: 'rejected' }],
+    [{ message: 'User declined the transaction' }],
+    [{ error: { code: 4001, message: 'User rejected request' } }],
+  ])('treats %o as an explicit cancellation', (resp) => {
+    expect(isExplicitUserCancellation(resp)).toBe(true);
+  });
+
+  it.each([
+    [{}],
+    [{ message: 'transaction rejected: missing required active authority' }],
+    [{ message: 'Request declined: insufficient resource credits' }],
+    [{ error: 'unauthorized' }],
+    [{ error: 'cancel_transfer_from_savings failed' }],
+    [
+      {
+        error: 'rejected',
+        message: 'Invalid transaction: duplicate transaction',
+      },
+    ],
+  ])('treats %o as NOT an explicit cancellation', (resp) => {
+    expect(isExplicitUserCancellation(resp)).toBe(false);
+  });
+});

--- a/apps/self-hosted/src/features/auth/utils/extension-error.ts
+++ b/apps/self-hosted/src/features/auth/utils/extension-error.ts
@@ -1,0 +1,152 @@
+import { type TranslationKey, translations } from '@/core/i18n-strings';
+
+/**
+ * Turning an extension failure into something worth showing a user.
+ *
+ * Ported from the web client (apps/web/src/utils/extension-error.ts), where a
+ * cancelled signing request rendered as "Request was canceled by the user. --
+ * user_cancel": Keychain's internal code, straight on screen. Here it was worse,
+ * the throw sites used `resp.error` alone, so a cancel showed the bare
+ * `user_cancel` with no readable half at all.
+ */
+
+interface ExtensionFailure {
+  message?: string;
+  error?: unknown;
+}
+
+/**
+ * `core/i18n`'s `t()` reaches `configuration-loader`, which statically imports the
+ * gitignored build-time `config.json`. Importing it here would make this module,
+ * and every test that touches the signing path, unloadable in CI. The language is
+ * already on the document (`applyConfigDom` writes `configuration.general.language`
+ * to `<html lang>`), so read it from there and look the string up directly.
+ */
+function translate(key: TranslationKey): string {
+  const language =
+    typeof document !== 'undefined' ? document.documentElement.lang : '';
+  return translations[language]?.[key] ?? translations.en[key];
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Normalizes an extension `error` field to a lowercased string for matching.
+ * Extensions return it either as a string code or as an object (e.g.
+ * `{ code: 4001, message: "User rejected request" }`).
+ */
+function normalizeErrorText(error: unknown): string {
+  if (error == null) return '';
+  if (typeof error === 'string') return error.toLowerCase();
+  if (typeof error === 'object') {
+    const e = error as Record<string, unknown>;
+    const fields = [e.message, e.error, e.reason, e.type]
+      .filter((v): v is string => typeof v === 'string')
+      .join(' ');
+    return (fields || safeStringify(error)).toLowerCase();
+  }
+  return String(error).toLowerCase();
+}
+
+/**
+ * A failure signal that rules a cancellation out however cancel-ish the rest of
+ * the text reads. A node answering "transaction rejected: missing required active
+ * authority" is reporting a cause the user has to keep seeing.
+ */
+const CHAIN_FAILURE_SIGNAL =
+  /missing (required )?(active|owner|posting) authority|resource credit|insufficient|unauthorized|token expired/;
+
+/** An `error` field that is nothing but a user-named cancellation code. */
+const EXPLICIT_CANCELLATION_CODE =
+  /^user[_-]?(cancel(l?ed)?|reject(ed)?|denied|declined)$/;
+
+/**
+ * A status that names no actor: "rejected" alone reads as a user cancellation,
+ * but the same word is what a node says when it refuses a transaction, so it only
+ * counts while the response carries no other detail.
+ */
+const BARE_CANCELLATION_STATUS =
+  /^(cancel(l?ed)?|reject(ed)?|denied|declined)$/;
+
+/** Phrases only a user-driven cancellation produces, anchored on the actor. */
+const CANCELLATION_PHRASES = [
+  /\buser[_ ]?cancel(l?ed)?\b/,
+  /\buser (rejected|denied|declined)\b/,
+  /\b(cancell?ed|rejected|denied|declined) by (the )?user\b/,
+];
+
+/** EIP-1193 / wallet standard code for "user rejected the request". */
+const USER_REJECTED_CODE = 4001;
+
+/**
+ * True when a failure is explicitly a user cancellation.
+ *
+ * Narrow on purpose: it decides whether the real failure text is discarded, so a
+ * false positive would hide the cause. A bare "cancel"/"reject" substring is not
+ * enough, which keeps `limit_order_cancel` inside an assert message and a node's
+ * "transaction rejected" intact.
+ */
+export function isExplicitUserCancellation(resp: ExtensionFailure): boolean {
+  const haystack = `${normalizeErrorText(resp.error)} ${(resp.message ?? '').toLowerCase()}`;
+  if (CHAIN_FAILURE_SIGNAL.test(haystack)) {
+    return false;
+  }
+
+  if (
+    typeof resp.error === 'object' &&
+    resp.error !== null &&
+    (resp.error as { code?: unknown }).code === USER_REJECTED_CODE
+  ) {
+    return true;
+  }
+
+  const code =
+    typeof resp.error === 'string' ? resp.error.trim().toLowerCase() : '';
+  if (EXPLICIT_CANCELLATION_CODE.test(code)) {
+    return true;
+  }
+
+  if (CANCELLATION_PHRASES.some((phrase) => phrase.test(haystack))) {
+    return true;
+  }
+
+  return (
+    BARE_CANCELLATION_STATUS.test(code) &&
+    (resp.message ?? '').trim().length === 0
+  );
+}
+
+/**
+ * Builds a message worth showing from an extension failure.
+ *
+ * A cancellation resolves to one translated sentence, since there is no
+ * underlying cause worth surfacing. Everything else keeps both halves the
+ * extension gave us: the readable reason and the underlying node/RPC error.
+ */
+export function extensionErrorMessage(
+  resp: ExtensionFailure,
+  fallback: string,
+): string {
+  if (isExplicitUserCancellation(resp)) {
+    return translate('transaction_cancelled_by_user');
+  }
+
+  const parts: string[] = [];
+  if (resp.message) {
+    parts.push(String(resp.message));
+  }
+  if (resp.error != null) {
+    const detail =
+      typeof resp.error === 'string' ? resp.error : safeStringify(resp.error);
+    if (detail && detail !== '{}' && !parts.includes(detail)) {
+      parts.push(detail);
+    }
+  }
+  return parts.join(' - ') || fallback;
+}

--- a/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
+++ b/apps/self-hosted/src/features/auth/utils/hive-extensions.ts
@@ -19,6 +19,7 @@
 
 import type { Operation } from '@ecency/sdk';
 import type { HiveExtensionId, KeychainResponse } from '../types';
+import { extensionErrorMessage } from './extension-error';
 import {
   broadcast as broadcastViaKeychain,
   signBuffer as signBufferViaKeychain,
@@ -453,7 +454,7 @@ async function signBufferViaPeakVault(
     message,
   );
   if (!resp.success) {
-    throw new Error(resp.error || 'Operation cancelled');
+    throw new Error(extensionErrorMessage(resp, 'Operation cancelled'));
   }
   return { success: true, result: resp.result };
 }
@@ -474,7 +475,7 @@ async function broadcastViaPeakVault(
     keyRole as 'posting' | 'active' | 'memo',
   );
   if (!resp.success) {
-    throw new Error(resp.error || 'Extension broadcast failed');
+    throw new Error(extensionErrorMessage(resp, 'Extension broadcast failed'));
   }
   return { success: true, result: resp.result };
 }

--- a/apps/self-hosted/src/features/auth/utils/keychain.ts
+++ b/apps/self-hosted/src/features/auth/utils/keychain.ts
@@ -1,5 +1,6 @@
 import type { Operation } from '@ecency/sdk';
 import type { KeychainResponse, KeychainSignTxResponse } from '../types';
+import { extensionErrorMessage } from './extension-error';
 
 export type AuthorityType = 'Owner' | 'Active' | 'Posting' | 'Memo';
 
@@ -102,7 +103,7 @@ export function signBuffer(
       finished = true;
       clearTimeout(timeout);
       if (!resp.success) {
-        reject(new Error(resp.error || 'Operation cancelled'));
+        reject(new Error(extensionErrorMessage(resp, 'Operation cancelled')));
         return;
       }
       resolve(resp);
@@ -138,7 +139,7 @@ export function broadcast(
       finished = true;
       clearTimeout(timeout);
       if (!resp.success) {
-        reject(new Error(resp.error || 'Operation cancelled'));
+        reject(new Error(extensionErrorMessage(resp, 'Operation cancelled')));
         return;
       }
       resolve(resp);
@@ -184,7 +185,11 @@ export function signTx(
       finished = true;
       clearTimeout(timeout);
       if (!resp.success) {
-        reject(new Error(resp.error || 'Transaction signing cancelled'));
+        reject(
+          new Error(
+            extensionErrorMessage(resp, 'Transaction signing cancelled'),
+          ),
+        );
         return;
       }
       resolve(resp);

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1807,8 +1807,7 @@
     "sign-title": "Sign transaction",
     "sign-sub-title": "Sign your transaction",
     "success-title": "Success",
-    "success-sub-title": "Transaction successful",
-    "cancelled": "You cancelled the request."
+    "success-sub-title": "Transaction successful"
   },
   "transactions": {
     "title": "History",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1807,7 +1807,8 @@
     "sign-title": "Sign transaction",
     "sign-sub-title": "Sign your transaction",
     "success-title": "Success",
-    "success-sub-title": "Transaction successful"
+    "success-sub-title": "Transaction successful",
+    "cancelled": "You cancelled the request."
   },
   "transactions": {
     "title": "History",

--- a/apps/web/src/specs/utils/extension-error.spec.ts
+++ b/apps/web/src/specs/utils/extension-error.spec.ts
@@ -13,12 +13,25 @@ describe("extensionErrorMessage", () => {
 
   it("surfaces the human-readable message", () => {
     expect(
-      extensionErrorMessage({ message: "Request was canceled by the user." }, "fallback")
-    ).toBe("Request was canceled by the user.");
+      extensionErrorMessage({ message: "There was an error broadcasting." }, "fallback")
+    ).toBe("There was an error broadcasting.");
   });
 
   it("surfaces a string error code", () => {
-    expect(extensionErrorMessage({ error: "user_cancel" }, "fallback")).toBe("user_cancel");
+    expect(extensionErrorMessage({ error: "invalid_params" }, "fallback")).toBe("invalid_params");
+  });
+
+  // Regression: a cancel used to render as "Request was canceled by the user. -- user_cancel",
+  // leaking Keychain's internal code into the UI. It now resolves to one translated line.
+  it.each([
+    [{ error: "user_cancel", message: "Request was canceled by the user." }],
+    [{ error: "user_cancel" }],
+    [{ message: "Request was canceled by the user." }],
+    [{ error: { code: 4001, message: "User rejected request" } }],
+  ])("returns the translated cancellation for %o", (resp) => {
+    const result = extensionErrorMessage(resp, "Operation cancelled");
+    expect(result).toBe("trx-common.cancelled");
+    expect(result).not.toContain("user_cancel");
   });
 
   it("combines message and underlying error detail", () => {

--- a/apps/web/src/specs/utils/extension-error.spec.ts
+++ b/apps/web/src/specs/utils/extension-error.spec.ts
@@ -1,5 +1,8 @@
+import fs from "fs";
+import path from "path";
 import {
   extensionErrorMessage,
+  isExplicitUserCancellation,
   isUserCancellation,
   isRetryableNodeError
 } from "../../utils/extension-error";
@@ -30,8 +33,21 @@ describe("extensionErrorMessage", () => {
     [{ error: { code: 4001, message: "User rejected request" } }],
   ])("returns the translated cancellation for %o", (resp) => {
     const result = extensionErrorMessage(resp, "Operation cancelled");
-    expect(result).toBe("trx-common.cancelled");
+    expect(result).toBe("external-transfer.cancelled");
     expect(result).not.toContain("user_cancel");
+  });
+
+  // The replacement must not swallow a real failure that happens to read
+  // cancel-ish. Hiding "missing required active authority" here would leave the
+  // SDK's auth-upgrade classifier with nothing to match on.
+  it.each([
+    [{ message: "transaction rejected: missing required active authority" }],
+    [{ error: { message: "Assert Exception:limit_order_cancel: order not found" } }],
+    [{ message: "Broadcast rejected by the node" }],
+    [{ error: "unauthorized", message: "Request rejected" }],
+  ])("keeps the real failure detail for %o", (resp) => {
+    const result = extensionErrorMessage(resp, "Extension broadcast failed");
+    expect(result).not.toBe("external-transfer.cancelled");
   });
 
   it("combines message and underlying error detail", () => {
@@ -71,6 +87,59 @@ describe("isUserCancellation", () => {
   ])("treats %o as NOT a cancellation", (resp) => {
     expect(isUserCancellation(resp)).toBe(false);
   });
+});
+
+/**
+ * The strict variant gates whether the real failure text is discarded, so it
+ * matches only explicit signals: a whole-string cancellation code, the wallet
+ * 4001 code, or a phrase naming the user as the actor.
+ */
+describe("isExplicitUserCancellation", () => {
+  it.each([
+    [{ error: "user_cancel" }],
+    [{ error: "USER_CANCEL" }],
+    [{ error: "cancelled" }],
+    [{ error: "rejected" }],
+    [{ message: "Request was canceled by the user." }],
+    [{ message: "User declined the transaction" }],
+    [{ error: { code: 4001, message: "User rejected request" } }],
+    [{ error: { message: "user_cancelled" } }],
+  ])("treats %o as an explicit cancellation", (resp) => {
+    expect(isExplicitUserCancellation(resp)).toBe(true);
+  });
+
+  it.each([
+    [{}],
+    // Unanchored substrings that the loose matcher accepts and this one must not
+    [{ message: "transaction rejected: missing required active authority" }],
+    [{ error: { message: "Assert Exception:limit_order_cancel: order not found" } }],
+    [{ message: "Broadcast rejected by the node" }],
+    [{ message: "Request declined: insufficient resource credits" }],
+    [{ error: "unauthorized" }],
+    // A cancellation code is only a code when it is the whole field
+    [{ error: "cancel_transfer_from_savings failed" }],
+  ])("treats %o as NOT an explicit cancellation", (resp) => {
+    expect(isExplicitUserCancellation(resp)).toBe(false);
+  });
+});
+
+/**
+ * The cancellation sentence is reused rather than newly minted: `external-transfer.cancelled`
+ * ("Transaction cancelled by user.") is already translated in every locale, while a new
+ * en-US key would read English everywhere until Crowdin round-trips it. That only holds
+ * while the key exists in all of them.
+ */
+describe("cancellation string coverage", () => {
+  const LOCALES_DIR = path.join(__dirname, "../../features/i18n/locales");
+
+  it.each(fs.readdirSync(LOCALES_DIR).filter((f) => f.endsWith(".json")))(
+    "%s defines external-transfer.cancelled",
+    (file) => {
+      const locale = JSON.parse(fs.readFileSync(path.join(LOCALES_DIR, file), "utf-8"));
+      expect(typeof locale["external-transfer"]?.cancelled).toBe("string");
+      expect(locale["external-transfer"].cancelled.length).toBeGreaterThan(0);
+    }
+  );
 });
 
 describe("isRetryableNodeError", () => {

--- a/apps/web/src/specs/utils/extension-error.spec.ts
+++ b/apps/web/src/specs/utils/extension-error.spec.ts
@@ -45,9 +45,21 @@ describe("extensionErrorMessage", () => {
     [{ error: { message: "Assert Exception:limit_order_cancel: order not found" } }],
     [{ message: "Broadcast rejected by the node" }],
     [{ error: "unauthorized", message: "Request rejected" }],
+    // A bare status code alongside a detailed message: the message is the only
+    // thing saying what actually happened, so it has to survive.
+    [{ error: "rejected", message: "Invalid transaction: duplicate transaction" }],
   ])("keeps the real failure detail for %o", (resp) => {
     const result = extensionErrorMessage(resp, "Extension broadcast failed");
     expect(result).not.toBe("external-transfer.cancelled");
+  });
+
+  it("keeps both halves when a bare status carries a detailed message", () => {
+    const result = extensionErrorMessage(
+      { error: "rejected", message: "Invalid transaction: duplicate transaction" },
+      "Extension broadcast failed"
+    );
+    expect(result).toContain("Invalid transaction: duplicate transaction");
+    expect(result).toContain("rejected");
   });
 
   it("combines message and underlying error detail", () => {
@@ -118,6 +130,9 @@ describe("isExplicitUserCancellation", () => {
     [{ error: "unauthorized" }],
     // A cancellation code is only a code when it is the whole field
     [{ error: "cancel_transfer_from_savings failed" }],
+    // A bare status names no actor, so a message alongside it is real detail
+    [{ error: "rejected", message: "Invalid transaction: duplicate transaction" }],
+    [{ error: "cancelled", message: "The node closed the connection mid-broadcast" }],
   ])("treats %o as NOT an explicit cancellation", (resp) => {
     expect(isExplicitUserCancellation(resp)).toBe(false);
   });

--- a/apps/web/src/specs/utils/hive-extensions.spec.ts
+++ b/apps/web/src/specs/utils/hive-extensions.spec.ts
@@ -75,7 +75,11 @@ describe("signBufferWithExtension (Keychain liveness ping)", () => {
         cb({ success: false, error: "user_cancel" })
     };
 
-    await expect(signBufferWithExtension("alice", "message", "Posting")).rejects.toThrow();
+    // i18next is mocked to echo the key, so this asserts the translated string is
+    // used and that Keychain's internal code never reaches the message.
+    await expect(signBufferWithExtension("alice", "message", "Posting")).rejects.toThrow(
+      "trx-common.cancelled"
+    );
   });
 });
 
@@ -130,6 +134,24 @@ describe("broadcastWithExtension (Keychain liveness ping)", () => {
     await assertion;
 
     expect(requestBroadcast).not.toHaveBeenCalled();
+  });
+
+  // The reported case: cancelling a power up in the extension surfaced
+  // "Request was canceled by the user. -- user_cancel" in the operation error box.
+  it("surfaces a cancelled broadcast as the translated message, without the raw code", async () => {
+    (window as any).hive_keychain = {
+      requestHandshake: (cb: () => void) => cb(),
+      requestBroadcast: (_a: string, _o: any[], _t: string, cb: (r: any) => void) =>
+        cb({
+          success: false,
+          error: "user_cancel",
+          message: "Request was canceled by the user."
+        })
+    };
+
+    await expect(
+      broadcastWithExtension("alice", [["transfer_to_vesting", {}]], "active")
+    ).rejects.toThrow("trx-common.cancelled");
   });
 });
 

--- a/apps/web/src/specs/utils/hive-extensions.spec.ts
+++ b/apps/web/src/specs/utils/hive-extensions.spec.ts
@@ -76,10 +76,12 @@ describe("signBufferWithExtension (Keychain liveness ping)", () => {
     };
 
     // i18next is mocked to echo the key, so this asserts the translated string is
-    // used and that Keychain's internal code never reaches the message.
-    await expect(signBufferWithExtension("alice", "message", "Posting")).rejects.toThrow(
-      "external-transfer.cancelled"
+    // used. Exact equality, not a substring: "<key> — user_cancel" would satisfy
+    // toThrow() while leaking exactly the code this fix removes.
+    const error = await signBufferWithExtension("alice", "message", "Posting").catch(
+      (e: Error) => e
     );
+    expect(error.message).toBe("external-transfer.cancelled");
   });
 });
 
@@ -149,9 +151,12 @@ describe("broadcastWithExtension (Keychain liveness ping)", () => {
         })
     };
 
-    await expect(
-      broadcastWithExtension("alice", [["transfer_to_vesting", {}]], "active")
-    ).rejects.toThrow("external-transfer.cancelled");
+    const error = await broadcastWithExtension(
+      "alice",
+      [["transfer_to_vesting", {}]],
+      "active"
+    ).catch((e: Error) => e);
+    expect(error.message).toBe("external-transfer.cancelled");
   });
 });
 

--- a/apps/web/src/specs/utils/hive-extensions.spec.ts
+++ b/apps/web/src/specs/utils/hive-extensions.spec.ts
@@ -78,7 +78,7 @@ describe("signBufferWithExtension (Keychain liveness ping)", () => {
     // i18next is mocked to echo the key, so this asserts the translated string is
     // used and that Keychain's internal code never reaches the message.
     await expect(signBufferWithExtension("alice", "message", "Posting")).rejects.toThrow(
-      "trx-common.cancelled"
+      "external-transfer.cancelled"
     );
   });
 });
@@ -151,7 +151,7 @@ describe("broadcastWithExtension (Keychain liveness ping)", () => {
 
     await expect(
       broadcastWithExtension("alice", [["transfer_to_vesting", {}]], "active")
-    ).rejects.toThrow("trx-common.cancelled");
+    ).rejects.toThrow("external-transfer.cancelled");
   });
 });
 

--- a/apps/web/src/utils/extension-error.ts
+++ b/apps/web/src/utils/extension-error.ts
@@ -41,18 +41,21 @@ function normalizeErrorText(error: unknown): string {
  * A user cancellation is the exception: there is no underlying cause worth
  * surfacing, so joining the parts only leaked an internal code to the user
  * ("Request was canceled by the user. -- user_cancel"). Those resolve to a single
- * translated sentence instead. Nothing classifies on the cancellation text:
- * `parseChainError` has no cancellation branch, `shouldTriggerAuthFallback` fires
- * only on missing-authority/token-expired, so this cannot re-trigger an auth
- * upgrade. The retry gates read `isUserCancellation(resp)` off the response
- * itself, never off the message.
+ * translated sentence instead. Replacing the text discards the real cause, so the
+ * test is `isExplicitUserCancellation` (wallet cancellation codes and user-driven
+ * phrases only), NOT the deliberately loose `isUserCancellation` used by the retry
+ * gate: "transaction rejected: missing required active authority" has to keep its
+ * authority detail or the SDK's auth-upgrade classifier never sees it.
+ *
+ * The retry gates read the response object, never this message, so a translated
+ * cancellation cannot change retry or auth-fallback behaviour.
  */
 export function extensionErrorMessage(
   resp: Pick<TxResponse, "message" | "error">,
   fallback: string
 ): string {
-  if (isUserCancellation(resp)) {
-    return i18next.t("trx-common.cancelled");
+  if (isExplicitUserCancellation(resp)) {
+    return i18next.t("external-transfer.cancelled");
   }
 
   const parts: string[] = [];
@@ -70,11 +73,70 @@ export function extensionErrorMessage(
 }
 
 /**
- * True when a Keychain-style failure represents the user declining/cancelling
+ * A failure signal that rules a cancellation out however cancel-ish the rest of
+ * the text reads. A node that answers "transaction rejected: missing required
+ * active authority" is reporting a cause the user (and the SDK's auth-upgrade
+ * classifier) must keep seeing.
+ */
+const CHAIN_FAILURE_SIGNAL =
+  /missing (required )?(active|owner|posting) authority|resource credit|insufficient|unauthorized|token expired/;
+
+/** An `error` field that is nothing but a cancellation code, e.g. "user_cancel". */
+const CANCELLATION_CODE = /^(user[_-]?)?(cancel(l?ed)?|reject(ed)?|denied|declined)$/;
+
+/** Phrases only a user-driven cancellation produces, anchored on the actor. */
+const CANCELLATION_PHRASES = [
+  /\buser[_ ]?cancel(l?ed)?\b/, // "user_cancel", "the user cancelled the request"
+  /\buser (rejected|denied|declined)\b/, // "User rejected request" (code 4001)
+  /\b(cancell?ed|rejected|denied|declined) by (the )?user\b/ // Keychain's own wording
+];
+
+/** EIP-1193 / wallet standard code for "user rejected the request". */
+const USER_REJECTED_CODE = 4001;
+
+/**
+ * True when a failure is explicitly a user cancellation.
+ *
+ * Deliberately narrower than `isUserCancellation`: this one decides whether to
+ * REPLACE the error text, where a false positive hides a real cause. It matches
+ * only a whole-string cancellation code, the wallet `4001` code, or a phrase that
+ * names the user as the actor. A bare "reject"/"cancel" substring is not enough,
+ * so `limit_order_cancel` in an assert message or a node's "transaction rejected"
+ * keeps its detail.
+ */
+export function isExplicitUserCancellation(
+  resp: Pick<TxResponse, "message" | "error">
+): boolean {
+  const haystack = `${normalizeErrorText(resp.error)} ${(resp.message ?? "").toLowerCase()}`;
+  if (CHAIN_FAILURE_SIGNAL.test(haystack)) {
+    return false;
+  }
+
+  if (
+    typeof resp.error === "object" &&
+    resp.error !== null &&
+    (resp.error as { code?: unknown }).code === USER_REJECTED_CODE
+  ) {
+    return true;
+  }
+
+  if (typeof resp.error === "string" && CANCELLATION_CODE.test(resp.error.trim().toLowerCase())) {
+    return true;
+  }
+
+  return CANCELLATION_PHRASES.some((phrase) => phrase.test(haystack));
+}
+
+/**
+ * True when a Keychain-style failure looks like the user declining/cancelling
  * the request (rather than a node, network, or validation error). Used to avoid
  * pointless broadcast retries that would re-open the extension popup. Handles
  * both string and object-shaped `error` fields (e.g. `{ code: 4001, message:
  * "User rejected request" }`).
+ *
+ * Loose on purpose, and only safe because of what it gates: over-matching here
+ * costs one skipped retry, never a hidden error. Use `isExplicitUserCancellation`
+ * for anything that replaces or suppresses the underlying failure.
  */
 export function isUserCancellation(
   resp: Pick<TxResponse, "message" | "error">

--- a/apps/web/src/utils/extension-error.ts
+++ b/apps/web/src/utils/extension-error.ts
@@ -1,4 +1,5 @@
 import type { TxResponse } from "@/types";
+import i18next from "i18next";
 
 function safeStringify(value: unknown): string {
   try {
@@ -36,11 +37,24 @@ function normalizeErrorText(error: unknown): string {
  * classifier (`parseChainError` / `shouldTriggerAuthFallback`) can detect cases
  * like a missing active authority and trigger the auth-upgrade flow instead of
  * hard-failing on a generic, unmatchable string.
+ *
+ * A user cancellation is the exception: there is no underlying cause worth
+ * surfacing, so joining the parts only leaked an internal code to the user
+ * ("Request was canceled by the user. -- user_cancel"). Those resolve to a single
+ * translated sentence instead. Nothing classifies on the cancellation text:
+ * `parseChainError` has no cancellation branch, `shouldTriggerAuthFallback` fires
+ * only on missing-authority/token-expired, so this cannot re-trigger an auth
+ * upgrade. The retry gates read `isUserCancellation(resp)` off the response
+ * itself, never off the message.
  */
 export function extensionErrorMessage(
   resp: Pick<TxResponse, "message" | "error">,
   fallback: string
 ): string {
+  if (isUserCancellation(resp)) {
+    return i18next.t("trx-common.cancelled");
+  }
+
   const parts: string[] = [];
   if (resp.message) {
     parts.push(String(resp.message));

--- a/apps/web/src/utils/extension-error.ts
+++ b/apps/web/src/utils/extension-error.ts
@@ -81,8 +81,15 @@ export function extensionErrorMessage(
 const CHAIN_FAILURE_SIGNAL =
   /missing (required )?(active|owner|posting) authority|resource credit|insufficient|unauthorized|token expired/;
 
-/** An `error` field that is nothing but a cancellation code, e.g. "user_cancel". */
-const CANCELLATION_CODE = /^(user[_-]?)?(cancel(l?ed)?|reject(ed)?|denied|declined)$/;
+/** An `error` field that is nothing but a user-named cancellation code, e.g. "user_cancel". */
+const EXPLICIT_CANCELLATION_CODE = /^user[_-]?(cancel(l?ed)?|reject(ed)?|denied|declined)$/;
+
+/**
+ * A status that names no actor: "rejected" alone reads as a user cancellation,
+ * but the same word is what a node says when it refuses a transaction, so it
+ * only counts while the response carries no other detail.
+ */
+const BARE_CANCELLATION_STATUS = /^(cancel(l?ed)?|reject(ed)?|denied|declined)$/;
 
 /** Phrases only a user-driven cancellation produces, anchored on the actor. */
 const CANCELLATION_PHRASES = [
@@ -99,10 +106,15 @@ const USER_REJECTED_CODE = 4001;
  *
  * Deliberately narrower than `isUserCancellation`: this one decides whether to
  * REPLACE the error text, where a false positive hides a real cause. It matches
- * only a whole-string cancellation code, the wallet `4001` code, or a phrase that
+ * only a user-named cancellation code, the wallet `4001` code, or a phrase that
  * names the user as the actor. A bare "reject"/"cancel" substring is not enough,
  * so `limit_order_cancel` in an assert message or a node's "transaction rejected"
  * keeps its detail.
+ *
+ * A bare status code ("rejected", "cancelled") names no actor, so it only counts
+ * while the response carries nothing else: `{ error: "rejected", message: "Invalid
+ * transaction: duplicate transaction" }` is a node refusal whose message is the
+ * only thing telling the user what went wrong.
  */
 export function isExplicitUserCancellation(
   resp: Pick<TxResponse, "message" | "error">
@@ -120,11 +132,16 @@ export function isExplicitUserCancellation(
     return true;
   }
 
-  if (typeof resp.error === "string" && CANCELLATION_CODE.test(resp.error.trim().toLowerCase())) {
+  const code = typeof resp.error === "string" ? resp.error.trim().toLowerCase() : "";
+  if (EXPLICIT_CANCELLATION_CODE.test(code)) {
     return true;
   }
 
-  return CANCELLATION_PHRASES.some((phrase) => phrase.test(haystack));
+  if (CANCELLATION_PHRASES.some((phrase) => phrase.test(haystack))) {
+    return true;
+  }
+
+  return BARE_CANCELLATION_STATUS.test(code) && (resp.message ?? "").trim().length === 0;
 }
 
 /**

--- a/apps/web/src/utils/hive-extensions.ts
+++ b/apps/web/src/utils/hive-extensions.ts
@@ -556,7 +556,7 @@ async function signBufferViaPeakVault(
   }
   const resp = await peakvault.requestSignBuffer(account, keyRole as "posting" | "active" | "memo", message);
   if (!resp.success) {
-    throw new Error(resp.error || "Operation cancelled");
+    throw new Error(extensionErrorMessage(resp, "Operation cancelled"));
   }
   return { success: true, result: resp.result } as TxResponse;
 }
@@ -569,7 +569,7 @@ async function broadcastViaPeakVault(
 ): Promise<any> {
   const resp = await peakvault.requestBroadcast(account, operations, keyRole);
   if (!resp.success) {
-    throw new Error(resp.error || "Extension broadcast failed");
+    throw new Error(extensionErrorMessage(resp, "Extension broadcast failed"));
   }
   return resp.result;
 }


### PR DESCRIPTION
Closes #1514

Cancelling a signing request in the extension showed Keychain's internal code in the wallet operation error box:

> **Error**
> Request was canceled by the user. — user_cancel

`extensionErrorMessage()` joins the extension's `message` with its raw `error` field on purpose, so a genuine failure keeps the underlying node/RPC cause visible and the SDK classifier can still spot things like a missing active authority. A cancellation has no underlying cause worth surfacing, so it now short-circuits to the already-translated `external-transfer.cancelled` ("Transaction cancelled by user."), which also replaces the extension's own English wording with the language the user picked on Ecency.

The Peak Vault sign/broadcast paths threw `resp.error` directly, leaking a bare code the same way, so they now go through the same helper.

### Detecting the cancellation

Replacing the text discards the real cause, so the replacement is gated on `isExplicitUserCancellation()`, not on the loose `isUserCancellation()` used by the retry gate. Explicit means one of:

- an `error` field that is entirely a user-named cancellation code (`user_cancel`, `user_rejected`, ...),
- the wallet `4001` code on an object-shaped error,
- a phrase naming the user as the actor (`user rejected request`, `canceled by the user`).

A bare status code (`rejected`, `cancelled`) names no actor, so it counts only while the response carries nothing else: `{ error: "rejected", message: "Invalid transaction: duplicate transaction" }` is a node refusal whose message is the only thing telling the user what went wrong. On top of that, a chain-failure signal (missing active/owner/posting authority, resource credits, insufficient, unauthorized, token expired) rules a cancellation out regardless, so `transaction rejected: missing required active authority` keeps its detail and still reaches `shouldTriggerAuthFallback`.

### Self-hosted app

Same defect, worse: `apps/self-hosted`'s Keychain and Peak Vault throw sites used `resp.error` alone, so a cancel showed a bare `user_cancel` with no readable half at all. They now share the same detection through a local port of the helper.

The port resolves the string itself rather than calling `core/i18n`'s `t()`: that reaches `configuration-loader`, which statically imports the gitignored build-time `config.json`, and would make every test touching the signing path unloadable in CI. `applyConfigDom` already writes the configured language to `<html lang>`, so the helper reads it there and looks the string up directly. The sentence is added to all six SPA languages.

### Localization

No new source string in the web app. `external-transfer.cancelled` is already translated in all 19 locales, so every language gets the translated sentence immediately, where a new en-US key would read English everywhere until the Crowdin upload/download round trip lands. A spec asserts every locale file still defines the key.

### Not affected

- Retry gating is unchanged: `broadcastViaKeychain` reads `isUserCancellation(response)` off the response object, never off the message.
- Real failures are untouched, message and underlying error are still joined.

### Tests

`extension-error.spec.ts` covers the cancellation shapes (string code, code plus message, message only, EIP-1193 `4001`), the near-miss failures that must keep their detail, and locale coverage for the reused key. `hive-extensions.spec.ts` asserts it through the real path: a cancelled `broadcastWithExtension` rejects with exactly the translated string. The SPA gets `extension-error.test.ts`, including the language-from-document behaviour. Web suite green (2793), self-hosted suite green (982), typecheck clean, self-hosted build clean.
