### PR TITLE
Landing page: subscribe through the newsletter service with double opt-in

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/settings/_email-digests.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/settings/_email-digests.tsx
@@ -4,6 +4,7 @@ import {
   CADENCES,
   DigestCadence,
   DigestSubscription,
+  describeDigest,
   useDigestSubscriptions,
   useLeaveDigest,
   useNewsletterEnabled,
@@ -37,12 +38,7 @@ export function EmailDigestsSettings() {
   const subscriptions = data ?? [];
   const addresses = Array.from(new Set(subscriptions.map((s) => s.email)));
 
-  const describe = (s: DigestSubscription) =>
-    s.type === "community"
-      ? i18next.t("newsletter.row-community", { name: s.target })
-      : s.type === "creator"
-        ? i18next.t("newsletter.row-creator", { name: s.target })
-        : i18next.t("newsletter.row-own");
+  const describe = (s: DigestSubscription) => describeDigest(s.type, s.target);
 
   const changeCadence = async (s: DigestSubscription, cadence: DigestCadence) => {
     if (s.type === "own") return;

--- a/apps/web/src/app/_components/landing-page/index.tsx
+++ b/apps/web/src/app/_components/landing-page/index.tsx
@@ -4,6 +4,7 @@ import { initI18next } from "@/features/i18n";
 import defaults from "@/defaults.json";
 import { LandingHeroActions } from "./landing-hero-actions";
 import { LandingSubscribeForm } from "./landing-subscribe-form";
+import { EcencyConfigManager } from "@/config";
 import { LandingSignInLink } from "./landing-sign-in-link";
 import { LandingDownloadLinks } from "./landing-download-links";
 import { Suspense } from "react";
@@ -277,11 +278,16 @@ export async function LandingPage() {
             </nav>
 
             <div className="col-span-2">
-              <h2 className="text-lg font-semibold">{t("landing-page.subscribe-us")}</h2>
-              <div className="mt-3 [&_form]:flex [&_form]:gap-2 [&_input]:flex-1 [&_input]:h-11 [&_input]:px-3 [&_input]:rounded-lg [&_input]:border [&_input]:border-[--border-color] [&_input]:bg-white [&_input]:dark:bg-dark-200 [&_button]:h-11 [&_button]:px-5 [&_button]:rounded-lg [&_button]:bg-blue-dark-sky [&_button]:text-white [&_button]:font-medium">
-                <LandingSubscribeForm />
-              </div>
-              <p className="mt-2 text-sm opacity-60">{t("landing-page.subscribe-paragraph")}</p>
+              {EcencyConfigManager.getConfigValue(({ visionFeatures }) => visionFeatures.newsletter.enabled) && (
+                <>
+                <h2 className="text-lg font-semibold">{t("landing-page.subscribe-us")}</h2>
+                <div className="mt-3 [&_form]:flex [&_form]:flex-wrap [&_form]:gap-2 [&_input]:flex-1 [&_input]:min-w-[12rem] [&_input]:h-11 [&_input]:px-3 [&_input]:rounded-lg [&_input]:border [&_input]:border-[--border-color] [&_input]:bg-white [&_input]:dark:bg-dark-200 [&_select]:h-11 [&_select]:px-3 [&_select]:rounded-lg [&_select]:border [&_select]:border-[--border-color] [&_select]:bg-white [&_select]:dark:bg-dark-200 [&_button]:h-11 [&_button]:px-5 [&_button]:rounded-lg [&_button]:bg-blue-dark-sky [&_button]:text-white [&_button]:font-medium">
+                  <LandingSubscribeForm />
+                </div>
+                <p className="mt-2 text-sm opacity-60">{t("landing-page.subscribe-paragraph")}</p>
+                <p className="mt-1 text-xs opacity-60">{t("landing-page.subscribe-disclosure")}</p>
+                </>
+              )}
               <ul className="mt-4 flex gap-4 p-0 m-0 list-none">
                 {SOCIALS.map((s) => (
                   <li key={s.key}>

--- a/apps/web/src/app/_components/landing-page/index.tsx
+++ b/apps/web/src/app/_components/landing-page/index.tsx
@@ -278,16 +278,16 @@ export async function LandingPage() {
             </nav>
 
             <div className="col-span-2">
-              {EcencyConfigManager.getConfigValue(({ visionFeatures }) => visionFeatures.newsletter.enabled) && (
-                <>
+              <EcencyConfigManager.Conditional
+                condition={({ visionFeatures }) => visionFeatures.newsletter.enabled}
+              >
                 <h2 className="text-lg font-semibold">{t("landing-page.subscribe-us")}</h2>
                 <div className="mt-3 [&_form]:flex [&_form]:flex-wrap [&_form]:gap-2 [&_input]:flex-1 [&_input]:min-w-[12rem] [&_input]:h-11 [&_input]:px-3 [&_input]:rounded-lg [&_input]:border [&_input]:border-[--border-color] [&_input]:bg-white [&_input]:dark:bg-dark-200 [&_select]:h-11 [&_select]:px-3 [&_select]:rounded-lg [&_select]:border [&_select]:border-[--border-color] [&_select]:bg-white [&_select]:dark:bg-dark-200 [&_button]:h-11 [&_button]:px-5 [&_button]:rounded-lg [&_button]:bg-blue-dark-sky [&_button]:text-white [&_button]:font-medium">
                   <LandingSubscribeForm />
                 </div>
                 <p className="mt-2 text-sm opacity-60">{t("landing-page.subscribe-paragraph")}</p>
                 <p className="mt-1 text-xs opacity-60">{t("landing-page.subscribe-disclosure")}</p>
-                </>
-              )}
+              </EcencyConfigManager.Conditional>
               <ul className="mt-4 flex gap-4 p-0 m-0 list-none">
                 {SOCIALS.map((s) => (
                   <li key={s.key}>

--- a/apps/web/src/app/_components/landing-page/landing-subscribe-form.tsx
+++ b/apps/web/src/app/_components/landing-page/landing-subscribe-form.tsx
@@ -1,31 +1,68 @@
 "use client";
 
 import { FormEvent, useState } from "react";
-import { subscribeEmail } from "@ecency/sdk";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { newsletterApi, NewsletterApiError } from "@/features/newsletter";
+import type { DigestCadence } from "@/features/newsletter";
 import { error, success } from "@/features/shared/feedback";
 import { LinearProgress } from "@/features/shared/linear-progress";
 import i18next from "i18next";
 import { handleInvalid, handleOnInput } from "@/utils";
 
+/**
+ * The homepage newsletter form. It subscribes the address to the site-wide Ecency
+ * digest through the newsletter service (via /api/newsletter/subscribe), which double
+ * opts it in: the reply to an unproven caller is a bare "pending", and the person's
+ * next step is their inbox. A signed-in account is attributed so the service can treat
+ * a proven account's request as one action.
+ *
+ * It replaced a form that wrote to a legacy table nothing ever read.
+ */
 export function LandingSubscribeForm() {
+  const { activeUser } = useActiveAccount();
   const [email, setEmail] = useState("");
+  const [cadence, setCadence] = useState<DigestCadence>("weekly");
   const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState<"pending" | "active" | null>(null);
 
   const handleSubscribe = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLoading(true);
     try {
-      const response = await subscribeEmail(email);
-      if (response && response.status >= 200 && response.status < 300) {
+      const result = await newsletterApi.subscribe(
+        { email: email.trim(), type: "site", target: "ecency", cadence, source: "landing-page" },
+        activeUser?.username
+      );
+      if (result.status === "active") {
+        setDone("active");
         success(i18next.t("landing-page.success-message-subscribe"));
+      } else if (result.status === "pending_confirmation") {
+        setDone("pending");
+        success(i18next.t("landing-page.check-inbox"));
+      } else {
+        // Only a proven, signed-in caller ever sees "refused"; it means a bounce or
+        // complaint is on record for that address.
+        error(i18next.t("newsletter.refused"));
       }
-    } catch (err) {
-      error(i18next.t("landing-page.error-occured"));
-    } finally {
       setEmail("");
+    } catch (err) {
+      const unavailable =
+        err instanceof NewsletterApiError && (err.status === 502 || err.status === 503 || err.status === 504);
+      error(i18next.t(unavailable ? "newsletter.error-unavailable" : "landing-page.error-occured"));
+    } finally {
       setLoading(false);
     }
   };
+
+  if (done) {
+    return (
+      <p className="text-sm">
+        {done === "pending"
+          ? i18next.t("landing-page.check-inbox")
+          : i18next.t("landing-page.success-message-subscribe")}
+      </p>
+    );
+  }
 
   return (
     <form onSubmit={handleSubscribe}>
@@ -35,9 +72,19 @@ export function LandingSubscribeForm() {
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         required={true}
+        autoComplete="email"
+        aria-label={i18next.t("landing-page.enter-your-email-adress")}
         onInvalid={(e: any) => handleInvalid(e, "landing-page.", "validation-email")}
         onInput={handleOnInput}
       />
+      <select
+        value={cadence}
+        onChange={(e) => setCadence(e.target.value as DigestCadence)}
+        aria-label={i18next.t("newsletter.cadence-label")}
+      >
+        <option value="weekly">{i18next.t("newsletter.cadence.weekly")}</option>
+        <option value="monthly">{i18next.t("newsletter.cadence.monthly")}</option>
+      </select>
       <button disabled={loading}>
         {loading ? (
           <span>

--- a/apps/web/src/app/api/newsletter/subscribe/route.ts
+++ b/apps/web/src/app/api/newsletter/subscribe/route.ts
@@ -10,9 +10,9 @@ import {
   relay
 } from "@/server/newsletter-internal";
 
-const TYPES = new Set(["community", "creator"]);
+const TYPES = new Set(["community", "creator", "site"]);
 const CADENCES = new Set(["weekly", "monthly"]);
-const SOURCES = new Set(["community-page", "creator-page", "settings"]);
+const SOURCES = new Set(["community-page", "creator-page", "settings", "landing-page"]);
 
 /**
  * Subscribe to a community or creator digest.
@@ -25,6 +25,8 @@ const SOURCES = new Set(["community-page", "creator-page", "settings"]);
  *
  * Creator digests are offered only for Ecency Pro creators, checked here against the
  * roster on the server: the button on the profile is a convenience, this is the gate.
+ * The site digest (`type: "site"`, the homepage form) has one target, `ecency`, which the
+ * service enforces.
  */
 export async function POST(request: NextRequest) {
   if (!newsletterConfigured()) return notConfigured();

--- a/apps/web/src/app/newsletter/confirm/[token]/_page.tsx
+++ b/apps/web/src/app/newsletter/confirm/[token]/_page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { newsletterApi, NewsletterApiError, newsletterKeys } from "@/features/newsletter";
+import { describeDigest, newsletterApi, NewsletterApiError, newsletterKeys } from "@/features/newsletter";
 import { Alert } from "@ui/alert";
 import { Button } from "@ui/button";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -22,13 +22,7 @@ export function ConfirmPage({ token }: { token: string }) {
   const confirm = useMutation({ mutationFn: () => newsletterApi.confirm(token) });
 
   const describe = (s: { type: string; target: string; cadence: string }) =>
-    `${i18next.t(`newsletter.cadence.${s.cadence}`)} · ${
-      s.type === "community"
-        ? i18next.t("newsletter.row-community", { name: s.target })
-        : s.type === "creator"
-          ? i18next.t("newsletter.row-creator", { name: s.target })
-          : i18next.t("newsletter.row-own")
-    }`;
+    `${i18next.t(`newsletter.cadence.${s.cadence}`)} · ${describeDigest(s.type, s.target)}`;
 
   return (
     <div className="max-w-xl mx-auto py-10">

--- a/apps/web/src/app/newsletter/unsubscribe/[token]/_page.tsx
+++ b/apps/web/src/app/newsletter/unsubscribe/[token]/_page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { newsletterApi, NewsletterApiError, newsletterKeys } from "@/features/newsletter";
+import { describeDigest, newsletterApi, NewsletterApiError, newsletterKeys } from "@/features/newsletter";
 import { Alert } from "@ui/alert";
 import { Button } from "@ui/button";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -23,13 +23,7 @@ export function UnsubscribePage({ token }: { token: string }) {
   const stopAll = useMutation({ mutationFn: () => newsletterApi.unsubscribeEverything(token) });
 
   const s = inspect.data?.subscription;
-  const name = s
-    ? s.type === "community"
-      ? i18next.t("newsletter.row-community", { name: s.target })
-      : s.type === "creator"
-        ? i18next.t("newsletter.row-creator", { name: s.target })
-        : i18next.t("newsletter.row-own")
-    : "";
+  const name = s ? describeDigest(s.type, s.target) : "";
 
   return (
     <div className="max-w-xl mx-auto py-10">

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -3060,7 +3060,9 @@
     "copy-rights": "©{{year}} Ecency. All rights reserved.",
     "success-message-subscribe": "You are subscribed to our newsletters!",
     "validation-email": "A valid email is required",
-    "error-occured": "A server error has been occurred."
+    "error-occured": "A server error has been occurred.",
+    "check-inbox": "Almost there. We sent you an email; open it and press the button to start receiving the digest.",
+    "subscribe-disclosure": "By subscribing you agree to receive the Ecency digest by email. Every email has a link to leave it, or to stop all Ecency email at once."
   },
   "layouts": {
     "grid": "Grid",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -3060,7 +3060,7 @@
     "copy-rights": "©{{year}} Ecency. All rights reserved.",
     "success-message-subscribe": "You are subscribed to our newsletters!",
     "validation-email": "A valid email is required",
-    "error-occured": "A server error has been occurred.",
+    "error-occured": "A server error occurred.",
     "check-inbox": "Almost there. We sent you an email; open it and press the button to start receiving the digest.",
     "subscribe-disclosure": "By subscribing you agree to receive the Ecency digest by email. Every email has a link to leave it, or to stop all Ecency email at once."
   },

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -4174,6 +4174,8 @@
     "try-again": "Try a different address",
     "resend": "Resend confirmation email",
     "resent": "If a confirmation is due, it is on its way. Check your inbox and spam folder.",
-    "error-gateway": "The digest service did not answer. Please try again in a moment."
+    "error-gateway": "The digest service did not answer. Please try again in a moment.",
+    "row-site": "Ecency digest",
+    "row-unknown": "Digest ({{type}})"
   }
 }

--- a/apps/web/src/features/newsletter/describe.ts
+++ b/apps/web/src/features/newsletter/describe.ts
@@ -1,0 +1,24 @@
+import i18next from "i18next";
+import type { DigestType } from "./types";
+
+/**
+ * The one human label for a digest subscription, used everywhere a subscription
+ * is listed: settings, the confirm page, the unsubscribe page. One function so
+ * a new type gets its label in one place; a fallback that silently relabels a
+ * type as another (site shown as "your notification digest") is exactly what
+ * this replaces.
+ */
+export function describeDigest(type: DigestType | string, target: string): string {
+  switch (type) {
+    case "community":
+      return i18next.t("newsletter.row-community", { name: target });
+    case "creator":
+      return i18next.t("newsletter.row-creator", { name: target });
+    case "site":
+      return i18next.t("newsletter.row-site");
+    case "own":
+      return i18next.t("newsletter.row-own");
+    default:
+      return i18next.t("newsletter.row-unknown", { type });
+  }
+}

--- a/apps/web/src/features/newsletter/index.ts
+++ b/apps/web/src/features/newsletter/index.ts
@@ -3,3 +3,4 @@ export * from "./hooks";
 export * from "./newsletter-api";
 export * from "./digest-subscribe-button";
 export * from "./digest-subscribe-dialog";
+export * from "./describe";

--- a/apps/web/src/features/newsletter/types.ts
+++ b/apps/web/src/features/newsletter/types.ts
@@ -1,4 +1,4 @@
-export type DigestType = "community" | "creator";
+export type DigestType = "community" | "creator" | "site";
 export type DigestCadence = "weekly" | "monthly";
 export type DigestStatus = "active" | "pending_confirmation" | "suppressed" | "ended";
 
@@ -27,5 +27,5 @@ export interface SubscribeInput {
   target: string;
   targetLabel?: string;
   cadence: DigestCadence;
-  source: "community-page" | "creator-page" | "settings";
+  source: "community-page" | "creator-page" | "settings" | "landing-page";
 }

--- a/apps/web/src/specs/api/newsletter-subscribe-route.spec.ts
+++ b/apps/web/src/specs/api/newsletter-subscribe-route.spec.ts
@@ -122,6 +122,14 @@ describe("POST /api/newsletter/subscribe", () => {
     expect(mocks.isPro).toHaveBeenLastCalledWith("good-karma");
   });
 
+  it("accepts the site digest from the landing page and relays it without a Pro check", async () => {
+    mocks.fetch.mockResolvedValue(upstream(200, { status: "pending_confirmation" }));
+    const r = await post({ email: "alice@example.com", type: "site", target: "ecency", cadence: "weekly", source: "landing-page" });
+    expect(r.status).toBe(200);
+    expect(mocks.isPro).not.toHaveBeenCalled();
+    expect(JSON.parse(mocks.fetch.mock.calls[0][1].body)).toMatchObject({ type: "site", target: "ecency", source: "landing-page" });
+  });
+
   it("400s malformed input before it reaches the service", async () => {
     for (const bad of [
       { ...VALID, type: "own" },

--- a/apps/web/src/specs/features/landing-page.spec.tsx
+++ b/apps/web/src/specs/features/landing-page.spec.tsx
@@ -18,15 +18,20 @@ vi.mock("@/core/global-store", () => ({
 // The rest of this file relies on the real SDK (the global setup mock is narrower),
 // so keep the passthrough that the old subscribeEmail override provided as a side effect.
 vi.mock("@ecency/sdk", async (importOriginal) => {
-  const actual = await importOriginal<any>();
+  const actual = await importOriginal<typeof import("@ecency/sdk")>();
   return { ...actual };
 });
 
 // The form subscribes through the newsletter service; mock its browser client.
-const mockSubscribe = vi.fn();
+type NewsletterModule = typeof import("@/features/newsletter");
+type SubscribeFn = NewsletterModule["newsletterApi"]["subscribe"];
+const mockSubscribe = vi.fn<SubscribeFn>();
 vi.mock("@/features/newsletter", async (importOriginal) => {
-  const actual = await importOriginal<any>();
-  return { ...actual, newsletterApi: { ...actual.newsletterApi, subscribe: (...args: any[]) => mockSubscribe(...args) } };
+  const actual = await importOriginal<NewsletterModule>();
+  return {
+    ...actual,
+    newsletterApi: { ...actual.newsletterApi, subscribe: (...args: Parameters<SubscribeFn>) => mockSubscribe(...args) }
+  };
 });
 
 vi.mock("@/features/shared/feedback", () => ({
@@ -187,13 +192,16 @@ describe("LandingSubscribeForm", () => {
     expect(screen.queryByPlaceholderText("landing-page.enter-your-email-adress")).not.toBeInTheDocument();
   });
 
-  it("shows the subscribed message when a proven caller is active at once", async () => {
+  it("shows the subscribed state in the page when a proven caller is active at once", async () => {
     mockSubscribe.mockResolvedValue({ status: "active", created: true });
     render(<LandingSubscribeForm />);
     const input = screen.getByPlaceholderText("landing-page.enter-your-email-adress");
     fireEvent.change(input, { target: { value: "test@example.com" } });
     fireEvent.submit(input.closest("form")!);
-    await waitFor(() => expect(success).toHaveBeenCalledWith("landing-page.success-message-subscribe"));
+    // The visible outcome, not only the toast: the message replaces the form.
+    expect(await screen.findByText("landing-page.success-message-subscribe")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("landing-page.enter-your-email-adress")).not.toBeInTheDocument();
+    expect(success).toHaveBeenCalledWith("landing-page.success-message-subscribe");
   });
 
   it("shows an error on API failure and keeps the form", async () => {
@@ -207,6 +215,20 @@ describe("LandingSubscribeForm", () => {
     await waitFor(() => expect(errorFn).toHaveBeenCalledWith("landing-page.error-occured"));
     expect(screen.getByPlaceholderText("landing-page.enter-your-email-adress")).toBeInTheDocument();
     expect(screen.getByText("landing-page.send")).toBeInTheDocument();
+  });
+
+  it("says the service is unavailable, not 'server error', on 502/503/504", async () => {
+    const { NewsletterApiError } = await import("@/features/newsletter");
+    for (const status of [502, 503, 504]) {
+      vi.mocked(errorFn).mockClear();
+      mockSubscribe.mockRejectedValueOnce(new NewsletterApiError("down", status));
+      const { unmount } = render(<LandingSubscribeForm />);
+      const input = screen.getByPlaceholderText("landing-page.enter-your-email-adress");
+      fireEvent.change(input, { target: { value: "test@example.com" } });
+      fireEvent.submit(input.closest("form")!);
+      await waitFor(() => expect(errorFn).toHaveBeenCalledWith("newsletter.error-unavailable"));
+      unmount();
+    }
   });
 });
 

--- a/apps/web/src/specs/features/landing-page.spec.tsx
+++ b/apps/web/src/specs/features/landing-page.spec.tsx
@@ -15,11 +15,18 @@ vi.mock("@/core/global-store", () => ({
   })
 }));
 
-// Mock subscribeEmail - extend the global @ecency/sdk mock
-const mockSubscribeEmail = vi.fn();
+// The rest of this file relies on the real SDK (the global setup mock is narrower),
+// so keep the passthrough that the old subscribeEmail override provided as a side effect.
 vi.mock("@ecency/sdk", async (importOriginal) => {
   const actual = await importOriginal<any>();
-  return { ...actual, subscribeEmail: (...args: any[]) => mockSubscribeEmail(...args) };
+  return { ...actual };
+});
+
+// The form subscribes through the newsletter service; mock its browser client.
+const mockSubscribe = vi.fn();
+vi.mock("@/features/newsletter", async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return { ...actual, newsletterApi: { ...actual.newsletterApi, subscribe: (...args: any[]) => mockSubscribe(...args) } };
 });
 
 vi.mock("@/features/shared/feedback", () => ({
@@ -39,9 +46,10 @@ vi.mock("@ui/svg", async (importOriginal) => {
 // LandingTrending is an async server component that fetches ranked posts via
 // prefetchQuery; stub it so the test drives the rendered output deterministically.
 const mockPrefetchQuery = vi.fn();
-vi.mock("@/core/react-query", () => ({
-  prefetchQuery: (...args: any[]) => mockPrefetchQuery(...args)
-}));
+vi.mock("@/core/react-query", async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return { ...actual, prefetchQuery: (...args: any[]) => mockPrefetchQuery(...args) };
+});
 
 // Extend the global @/utils mock with landing-page-specific exports
 vi.mock("@/utils", async (importOriginal) => {
@@ -150,57 +158,55 @@ describe("LandingSubscribeForm", () => {
     vi.clearAllMocks();
   });
 
-  it("renders email input and submit button", () => {
+  it("renders email input, cadence choice and submit button", () => {
     render(<LandingSubscribeForm />);
     expect(screen.getByPlaceholderText("landing-page.enter-your-email-adress")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveValue("weekly");
     expect(screen.getByText("landing-page.send")).toBeInTheDocument();
   });
 
-  it("calls subscribeEmail on submit and shows success for 2xx", async () => {
-    mockSubscribeEmail.mockResolvedValue({ status: 200 });
+  it("subscribes the address to the site digest through the service and shows check-your-inbox on pending", async () => {
+    // What the service returns to an unproven caller: this and nothing more.
+    mockSubscribe.mockResolvedValue({ status: "pending_confirmation" });
+
+    render(<LandingSubscribeForm />);
+    const input = screen.getByPlaceholderText("landing-page.enter-your-email-adress");
+    fireEvent.change(input, { target: { value: "  test@example.com " } });
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "monthly" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() => {
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        { email: "test@example.com", type: "site", target: "ecency", cadence: "monthly", source: "landing-page" },
+        undefined // anonymous: no account attributed
+      );
+      expect(success).toHaveBeenCalledWith("landing-page.check-inbox");
+    });
+    // The form is replaced by the instruction; nothing else to do here.
+    expect(screen.getByText("landing-page.check-inbox")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("landing-page.enter-your-email-adress")).not.toBeInTheDocument();
+  });
+
+  it("shows the subscribed message when a proven caller is active at once", async () => {
+    mockSubscribe.mockResolvedValue({ status: "active", created: true });
+    render(<LandingSubscribeForm />);
+    const input = screen.getByPlaceholderText("landing-page.enter-your-email-adress");
+    fireEvent.change(input, { target: { value: "test@example.com" } });
+    fireEvent.submit(input.closest("form")!);
+    await waitFor(() => expect(success).toHaveBeenCalledWith("landing-page.success-message-subscribe"));
+  });
+
+  it("shows an error on API failure and keeps the form", async () => {
+    mockSubscribe.mockRejectedValue(new Error("Network error"));
 
     render(<LandingSubscribeForm />);
     const input = screen.getByPlaceholderText("landing-page.enter-your-email-adress");
     fireEvent.change(input, { target: { value: "test@example.com" } });
-    const form = input.closest("form");
-    expect(form).not.toBeNull();
-    fireEvent.submit(form!);
+    fireEvent.submit(input.closest("form")!);
 
-    await waitFor(() => {
-      expect(mockSubscribeEmail).toHaveBeenCalledWith("test@example.com");
-      expect(success).toHaveBeenCalledWith("landing-page.success-message-subscribe");
-    });
-  });
-
-  it("shows error on API failure", async () => {
-    mockSubscribeEmail.mockRejectedValue(new Error("Network error"));
-
-    render(<LandingSubscribeForm />);
-    const input = screen.getByPlaceholderText("landing-page.enter-your-email-adress");
-    fireEvent.change(input, { target: { value: "test@example.com" } });
-    const form = input.closest("form");
-    expect(form).not.toBeNull();
-    fireEvent.submit(form!);
-
-    await waitFor(() => {
-      expect(errorFn).toHaveBeenCalledWith("landing-page.error-occured");
-    });
-  });
-
-  it("resets email and loading state in finally block", async () => {
-    mockSubscribeEmail.mockResolvedValue({ status: 200 });
-
-    render(<LandingSubscribeForm />);
-    const input = screen.getByPlaceholderText("landing-page.enter-your-email-adress") as HTMLInputElement;
-    fireEvent.change(input, { target: { value: "test@example.com" } });
-    const form = input.closest("form");
-    expect(form).not.toBeNull();
-    fireEvent.submit(form!);
-
-    await waitFor(() => {
-      expect(input.value).toBe("");
-      expect(screen.getByText("landing-page.send")).toBeInTheDocument();
-    });
+    await waitFor(() => expect(errorFn).toHaveBeenCalledWith("landing-page.error-occured"));
+    expect(screen.getByPlaceholderText("landing-page.enter-your-email-adress")).toBeInTheDocument();
+    expect(screen.getByText("landing-page.send")).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/specs/features/newsletter/describe-digest.spec.ts
+++ b/apps/web/src/specs/features/newsletter/describe-digest.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { describeDigest } from "@/features/newsletter";
+
+// i18next is globally mocked to return keys, so the assertion is on which key
+// each type resolves to: the site digest must never fall through to "own".
+describe("describeDigest", () => {
+  it("labels every type explicitly and never relabels one as another", () => {
+    expect(describeDigest("community", "hive-1")).toBe("newsletter.row-community");
+    expect(describeDigest("creator", "alice")).toBe("newsletter.row-creator");
+    expect(describeDigest("site", "ecency")).toBe("newsletter.row-site");
+    expect(describeDigest("own", "alice")).toBe("newsletter.row-own");
+    expect(describeDigest("something-new", "x")).toBe("newsletter.row-unknown");
+  });
+});

--- a/apps/web/src/specs/features/newsletter/email-digests-settings.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/email-digests-settings.spec.tsx
@@ -30,6 +30,7 @@ const ok = (body: unknown) => Promise.resolve({ ok: true, status: 200, json: asy
 const A1 = { id: "a1", email: "alice@example.com", account: "alice", type: "community", target: "hive-1", cadence: "weekly", status: "active", created_at: "" };
 const A2 = { id: "a2", email: "alice@example.com", account: "alice", type: "creator", target: "good-karma", cadence: "weekly", status: "active", created_at: "" };
 const B1 = { id: "b1", email: "alice-work@example.com", account: "alice", type: "community", target: "hive-2", cadence: "monthly", status: "active", created_at: "" };
+const S1 = { id: "s1", email: "alice@example.com", account: "alice", type: "site", target: "ecency", cadence: "weekly", status: "active", created_at: "" };
 
 describe("EmailDigestsSettings", () => {
   beforeEach(() => {
@@ -51,6 +52,14 @@ describe("EmailDigestsSettings", () => {
   afterEach(() => {
     cleanupModalContainers();
     vi.unstubAllGlobals();
+  });
+
+  it("labels a site-digest subscription as the Ecency digest, not the notification digest", () => {
+    const client = createTestQueryClient();
+    client.setQueryData(digestSubscriptionsKey("alice"), [S1]);
+    renderWithQueryClient(<EmailDigestsSettings />, { queryClient: client });
+    expect(screen.getByText("newsletter.row-site")).toBeInTheDocument();
+    expect(screen.queryByText("newsletter.row-own")).not.toBeInTheDocument();
   });
 
   it("stopping all mail to ONE address keeps the account's subscriptions on other addresses visible", async () => {

--- a/apps/web/src/specs/features/newsletter/link-pages.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/link-pages.spec.tsx
@@ -1,0 +1,51 @@
+import "@testing-library/jest-dom";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConfirmPage } from "@/app/newsletter/confirm/[token]/_page";
+import { UnsubscribePage } from "@/app/newsletter/unsubscribe/[token]/_page";
+import { renderWithQueryClient } from "@/specs/test-utils";
+
+const fetchMock = vi.fn();
+const json = (status: number, body: unknown) => Promise.resolve({ ok: status < 400, status, json: async () => body } as Response);
+const TOKEN = "abcdefghijklmnopqrstuvwx";
+
+describe("confirm and unsubscribe pages", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("confirm page inspects on load, labels a site digest as the Ecency digest, and confirms on click", async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === `/api/newsletter/confirm/${TOKEN}` && (init?.method ?? "GET") === "GET") {
+        return json(200, { email: "al***@example.com", subscriptions: [{ type: "site", target: "ecency", cadence: "weekly", status: "pending_confirmation" }] });
+      }
+      if (url === `/api/newsletter/confirm/${TOKEN}` && init?.method === "POST") {
+        return json(200, { confirmed: true, email: "al***@example.com", subscriptions: [{ type: "site", target: "ecency", cadence: "weekly", status: "active" }] });
+      }
+      return json(404, {});
+    });
+    renderWithQueryClient(<ConfirmPage token={TOKEN} />);
+    expect(await screen.findByText(/newsletter\.row-site/)).toBeInTheDocument();
+    expect(screen.queryByText(/newsletter\.row-own/)).not.toBeInTheDocument();
+    // Loading the page confirmed nothing.
+    expect(fetchMock.mock.calls.filter((c) => c[1]?.method === "POST")).toHaveLength(0);
+    fireEvent.click(screen.getByRole("button", { name: "newsletter.confirm-button" }));
+    await waitFor(() => expect(screen.getByText("newsletter.confirm-done")).toBeInTheDocument());
+    expect(fetchMock.mock.calls.filter((c) => c[1]?.method === "POST")).toHaveLength(1);
+  });
+
+  it("unsubscribe page inspects on load and labels the site digest correctly", async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === `/api/newsletter/unsubscribe/${TOKEN}` && (init?.method ?? "GET") === "GET") {
+        return json(200, { email: "al***@example.com", subscription: { type: "site", target: "ecency", cadence: "weekly", ended: false }, otherSubscriptions: 0 });
+      }
+      return json(404, {});
+    });
+    renderWithQueryClient(<UnsubscribePage token={TOKEN} />);
+    // The intro interpolates the label; the button carries it too.
+    expect(await screen.findByRole("button", { name: "newsletter.unsubscribe-one" })).toBeInTheDocument();
+    expect(fetchMock.mock.calls.filter((c) => c[1]?.method === "POST")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #1518. Depends on ecency/news#5 (merged), which added the `site` digest target.

The homepage newsletter form posted to `/private-api/subscribe`, a plain insert into a legacy onboarding table that nothing read; that path was retired on 2026-08-18. The form now subscribes the address to the site-wide Ecency digest through `/api/newsletter/subscribe` (`type: site`, `target: ecency`, weekly by default with a monthly option, `source: landing-page`), attributed to the signed-in account when there is one. The service double opts it in and answers an unproven caller with a bare `pending_confirmation`, which the form shows as "check your inbox"; a proven signed-in account is active at once and sees the existing success copy. Errors keep the form; 502/503/504 get the "not available right now" message.

The whole subscribe block on the landing page (heading, form, blurb, new disclosure line) renders only when `visionFeatures.newsletter.enabled` is on, so a deployment without the service shows nothing rather than a form that cannot work.

Relay: `/api/newsletter/subscribe` accepts `type: site` (no Pro check; the service enforces the single `ecency` target) and `source: landing-page`.

`subscribeEmail()` remains in `@ecency/sdk` untouched: removing a published export is a package release; it is simply no longer called from the web app.

Tests: landing form (site digest call with trimmed address, monthly cadence, anonymous attribution, check-your-inbox replaces the form, active state, error keeps the form) and the relay accepting `site` without touching the Pro roster. Full web suite 2819 green; typecheck, lint, icon audit clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional landing-page newsletter subscription form.
  * Supports weekly or monthly digest preferences and signed-in user attribution.
  * Displays confirmation, activation, refusal, and service-unavailable messages.
  * Added accessible email input behavior and improved responsive form layout.

* **Bug Fixes**
  * Email fields now clear only after successful subscription.
  * Added validation and localization for subscription-related responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->