### PR TITLE
Ask for the notification-digest opt-in once, after the first publish

### DIFF
--- a/apps/web/src/app/(dynamicPages)/profile/[username]/settings/_email-digests.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/settings/_email-digests.tsx
@@ -41,7 +41,6 @@ export function EmailDigestsSettings() {
   const describe = (s: DigestSubscription) => describeDigest(s.type, s.target);
 
   const changeCadence = async (s: DigestSubscription, cadence: DigestCadence) => {
-    if (s.type === "own") return;
     try {
       await subscribe.mutateAsync({
         email: s.email,
@@ -109,24 +108,22 @@ export function EmailDigestsSettings() {
                   )}
                 </div>
               </div>
-              {s.type !== "own" && (
-                <FormControl
-                  type="select"
-                  value={s.cadence}
-                  disabled={subscribe.isPending}
-                  className="!w-auto"
-                  aria-label={i18next.t("newsletter.cadence-label")}
-                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                    changeCadence(s, e.target.value as DigestCadence)
-                  }
-                >
-                  {CADENCES.map((c) => (
-                    <option key={c} value={c}>
-                      {i18next.t(`newsletter.cadence.${c}`)}
-                    </option>
-                  ))}
-                </FormControl>
-              )}
+              <FormControl
+                type="select"
+                value={s.cadence}
+                disabled={subscribe.isPending}
+                className="!w-auto"
+                aria-label={i18next.t("newsletter.cadence-label")}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  changeCadence(s, e.target.value as DigestCadence)
+                }
+              >
+                {CADENCES.map((c) => (
+                  <option key={c} value={c}>
+                    {i18next.t(`newsletter.cadence.${c}`)}
+                  </option>
+                ))}
+              </FormControl>
               <Button size="sm" appearance="danger" outline={true} disabled={leave.isPending} onClick={() => leaveOne(s)}>
                 {i18next.t("newsletter.leave")}
               </Button>

--- a/apps/web/src/app/api/newsletter/subscribe/route.ts
+++ b/apps/web/src/app/api/newsletter/subscribe/route.ts
@@ -10,9 +10,9 @@ import {
   relay
 } from "@/server/newsletter-internal";
 
-const TYPES = new Set(["community", "creator", "site"]);
+const TYPES = new Set(["own", "community", "creator", "site"]);
 const CADENCES = new Set(["weekly", "monthly"]);
-const SOURCES = new Set(["community-page", "creator-page", "settings", "landing-page"]);
+const SOURCES = new Set(["community-page", "creator-page", "settings", "landing-page", "publish-prompt"]);
 
 /**
  * Subscribe to a community or creator digest.
@@ -48,6 +48,14 @@ export async function POST(request: NextRequest) {
     const auth = await resolveUser(request, body);
     if (!auth.ok) return unauthorizedResponse(auth.reason);
     account = auth.username.toLowerCase();
+  }
+
+  // The own-notification digest is by definition the signed-in account's own:
+  // it needs a verified account, and its target IS that account. The service
+  // enforces the same; refusing here keeps a forged target from ever leaving.
+  if (type === "own") {
+    if (!account) return Response.json({ error: "Authentication required" }, { status: 401 });
+    if (target !== account) return Response.json({ error: "Invalid request" }, { status: 400 });
   }
 
   if (type === "creator") {

--- a/apps/web/src/app/publish/_components/publish-success-state.tsx
+++ b/apps/web/src/app/publish/_components/publish-success-state.tsx
@@ -27,6 +27,8 @@ interface Props {
   step: "published" | "scheduled";
   setEditStep: () => void;
   entryInfo?: EntryInfo;
+  /** The account had no posts before this publish (decided at publish time). */
+  firstPublish?: boolean;
 }
 
 const SHARE_BUTTONS = [
@@ -98,7 +100,7 @@ function QuestCompleteLine() {
   );
 }
 
-export function PublishSuccessState({ step, setEditStep, entryInfo }: Props) {
+export function PublishSuccessState({ step, setEditStep, entryInfo, firstPublish = false }: Props) {
   const { activeUser } = useActiveAccount();
   const profileHref = activeUser ? `/@${activeUser.username}/posts` : "/";
 
@@ -122,7 +124,7 @@ export function PublishSuccessState({ step, setEditStep, entryInfo }: Props) {
 
         {step === "published" && entryInfo && <ShareBar entryInfo={entryInfo} />}
 
-        {step === "published" && <FirstPublishDigestPrompt />}
+        {step === "published" && firstPublish && <FirstPublishDigestPrompt />}
 
         <div className="flex items-center gap-4">
           <Link href="/publish">

--- a/apps/web/src/app/publish/_components/publish-success-state.tsx
+++ b/apps/web/src/app/publish/_components/publish-success-state.tsx
@@ -14,6 +14,7 @@ import {
   makeShareUrlDiscord
 } from "@/utils/url-share";
 import { facebookSvg, discordSvg, linkedinSvg, redditSvg, twitterSvg } from "@ui/svg";
+import { FirstPublishDigestPrompt } from "@/features/newsletter";
 
 interface EntryInfo {
   title: string;
@@ -120,6 +121,8 @@ export function PublishSuccessState({ step, setEditStep, entryInfo }: Props) {
         {step === "published" && <QuestCompleteLine />}
 
         {step === "published" && entryInfo && <ShareBar entryInfo={entryInfo} />}
+
+        {step === "published" && <FirstPublishDigestPrompt />}
 
         <div className="flex items-center gap-4">
           <Link href="/publish">

--- a/apps/web/src/app/publish/_components/publish-validate-post.tsx
+++ b/apps/web/src/app/publish/_components/publish-validate-post.tsx
@@ -39,7 +39,12 @@ const TEMPLATE_SIMILARITY_THRESHOLD = 0.9;
 
 interface Props {
   onClose: () => void;
-  onSuccess: (step: "published" | "scheduled", entryInfo?: { title: string; author: string; permlink: string; category: string }) => void;
+  onSuccess: (
+    step: "published" | "scheduled",
+    entryInfo?: { title: string; author: string; permlink: string; category: string },
+    /** True when the account had no posts BEFORE this publish, captured at publish time. */
+    firstPublish?: boolean
+  ) => void;
 }
 
 export function PublishValidatePost({ onClose, onSuccess }: Props) {
@@ -66,7 +71,7 @@ export function PublishValidatePost({ onClose, onSuccess }: Props) {
     aiTools
   } = usePublishState();
 
-  const { activeUser } = useActiveAccount();
+  const { activeUser, account } = useActiveAccount();
   const [rcShortfall, setRcShortfall] = useState<RcShortfall | null>(null);
   const { openTopup, dialog: rcTopupDialog } = useRcTopupAction(rcShortfall?.username);
   const isMounted = useRef(true);
@@ -201,14 +206,26 @@ export function PublishValidatePost({ onClose, onSuccess }: Props) {
 
         onSuccess("scheduled");
       } else {
+        // Decided BEFORE the publish, from the account as loaded: a strict zero,
+        // and unknown counts as not-first. The success screen uses this to offer
+        // the digest opt-in once; the count in the cache is not refreshed by the
+        // publish, so a heuristic read afterwards could not tell a first post
+        // from a second one.
+        const firstPublish = account?.post_count === 0;
         const [entry] = await publishNow();
 
-        onSuccess("published", entry ? {
-          title: entry.title,
-          author: entry.author,
-          permlink: entry.permlink,
-          category: entry.category
-        } : undefined);
+        onSuccess(
+          "published",
+          entry
+            ? {
+                title: entry.title,
+                author: entry.author,
+                permlink: entry.permlink,
+                category: entry.category
+              }
+            : undefined,
+          firstPublish
+        );
       }
 
       clearAll();
@@ -235,6 +252,7 @@ export function PublishValidatePost({ onClose, onSuccess }: Props) {
       }
     }
   }, [
+    account,
     clearAll,
     content,
     onSuccess,

--- a/apps/web/src/app/publish/_page.tsx
+++ b/apps/web/src/app/publish/_page.tsx
@@ -43,6 +43,7 @@ const PublishEditor = dynamic(
 export default function Publish() {
   const [step, setStep] = useState<"edit" | "validation" | "scheduled" | "published">("edit");
   const [publishedEntry, setPublishedEntry] = useState<{ title: string; author: string; permlink: string; category: string } | undefined>();
+  const [firstPublish, setFirstPublish] = useState(false);
   const [showHtmlWarning, setShowHtmlWarning] = useState(false);
 
   const { editor, setEditorContent } = usePublishEditor(() => setShowHtmlWarning(true));
@@ -135,8 +136,9 @@ export default function Publish() {
       {step === "validation" && (
         <PublishValidatePost
           onClose={() => setStep("edit")}
-          onSuccess={(step, entryInfo) => {
+          onSuccess={(step, entryInfo, wasFirst) => {
             setPublishedEntry(entryInfo);
+            setFirstPublish(Boolean(wasFirst));
             setStep(step);
           }}
         />
@@ -146,6 +148,7 @@ export default function Publish() {
           step={step as "published" | "scheduled"}
           setEditStep={() => setStep("edit")}
           entryInfo={publishedEntry}
+          firstPublish={firstPublish}
         />
       )}
 

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -4176,6 +4176,14 @@
     "resent": "If a confirmation is due, it is on its way. Check your inbox and spam folder.",
     "error-gateway": "The digest service did not answer. Please try again in a moment.",
     "row-site": "Ecency digest",
-    "row-unknown": "Digest ({{type}})"
+    "row-unknown": "Digest ({{type}})",
+    "own-digest": "Your notification digest by email",
+    "site-digest": "Ecency digest by email",
+    "intro-own": "Get a summary of what happened on your posts, mentions and followers delivered to your inbox. You choose how often, and you can leave from any email.",
+    "intro-site": "Get a summary of the best new posts across Ecency delivered to your inbox. You choose how often, and you can leave from any email.",
+    "prompt-title": "Want a digest of your Ecency activity by email?",
+    "prompt-body": "Replies, mentions and new followers, once a week or once a month. Nothing is sent until you confirm your address, and you can leave from any email.",
+    "prompt-accept": "Yes, set it up",
+    "prompt-dismiss": "No thanks"
   }
 }

--- a/apps/web/src/features/newsletter/digest-subscribe-dialog.tsx
+++ b/apps/web/src/features/newsletter/digest-subscribe-dialog.tsx
@@ -87,9 +87,13 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
   const cadenceLabel = (c: DigestCadence) => i18next.t(`newsletter.cadence.${c}`);
   const digestName = useMemo(
     () =>
-      type === "community"
-        ? i18next.t("newsletter.community-digest", { name: targetLabel })
-        : i18next.t("newsletter.creator-digest", { name: targetLabel }),
+      type === "own"
+        ? i18next.t("newsletter.own-digest")
+        : type === "site"
+          ? i18next.t("newsletter.site-digest")
+          : type === "community"
+            ? i18next.t("newsletter.community-digest", { name: targetLabel })
+            : i18next.t("newsletter.creator-digest", { name: targetLabel }),
     [type, targetLabel]
   );
 
@@ -173,9 +177,13 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
             </Alert>
           ) : (
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              {type === "community"
-                ? i18next.t("newsletter.intro-community", { name: targetLabel })
-                : i18next.t("newsletter.intro-creator", { name: targetLabel })}
+              {type === "own"
+                ? i18next.t("newsletter.intro-own")
+                : type === "site"
+                  ? i18next.t("newsletter.intro-site")
+                  : type === "community"
+                    ? i18next.t("newsletter.intro-community", { name: targetLabel })
+                    : i18next.t("newsletter.intro-creator", { name: targetLabel })}
             </p>
           )}
 

--- a/apps/web/src/features/newsletter/first-publish-digest-prompt.tsx
+++ b/apps/web/src/features/newsletter/first-publish-digest-prompt.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { UilEnvelope } from "@tooni/iconscout-unicons-react";
+import { Button } from "@ui/button";
+import i18next from "i18next";
+import { useEffect, useState } from "react";
+import { DigestSubscribeDialog } from "./digest-subscribe-dialog";
+import { useDigestSubscriptions, useNewsletterEnabled } from "./hooks";
+
+/**
+ * The opt-in surface for the own-notification digest, offered ONCE, right after
+ * a person's first publish (vision-web#1511). Decided deliberately: after the
+ * first publish rather than at signup, because that is when they have context
+ * and intent, and because consent must be an explicit affirmative action; there
+ * is no pre-selection anywhere in this flow.
+ *
+ * Shown only when all of these hold: the feature is on, the account has at most
+ * one post (the one just published; the count is read from the account before
+ * the query refreshes, so 0 or 1), the account holds no digest subscription
+ * yet, and the person has not already answered on this device. Accepting or
+ * dismissing records the answer, so it never re-prompts.
+ */
+const STORAGE_PREFIX = "ecency:digest-prompt:";
+
+export function digestPromptAnswered(username: string): boolean {
+  try {
+    return typeof window !== "undefined" && window.localStorage.getItem(STORAGE_PREFIX + username) !== null;
+  } catch {
+    return true; // storage unavailable: better never to prompt than to prompt every time
+  }
+}
+
+export function recordDigestPromptAnswer(username: string, answer: "accepted" | "dismissed"): void {
+  try {
+    window.localStorage.setItem(STORAGE_PREFIX + username, `${answer}:${new Date().toISOString()}`);
+  } catch {
+    // nothing to do; the in-memory state still hides it for this session
+  }
+}
+
+export function FirstPublishDigestPrompt() {
+  const enabled = useNewsletterEnabled();
+  const { activeUser, account } = useActiveAccount();
+  const username = activeUser?.username;
+  const { data: subscriptions, isLoading } = useDigestSubscriptions();
+  const [answered, setAnswered] = useState(true);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (username) setAnswered(digestPromptAnswered(username));
+  }, [username]);
+
+  if (!enabled || !username || answered || isLoading) return null;
+  const postCount = account?.post_count ?? Number.POSITIVE_INFINITY;
+  if (postCount > 1) return null;
+  if ((subscriptions ?? []).length > 0) return null;
+
+  const dismiss = () => {
+    recordDigestPromptAnswer(username, "dismissed");
+    setAnswered(true);
+  };
+
+  return (
+    <div className="mt-6 max-w-md mx-auto rounded-xl border border-[--border-color] bg-white dark:bg-dark-200 p-4 text-left">
+      <div className="flex items-start gap-3">
+        <UilEnvelope className="size-5 text-blue-dark-sky shrink-0 mt-0.5" aria-hidden="true" />
+        <div className="flex-1">
+          <div className="font-semibold">{i18next.t("newsletter.prompt-title")}</div>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">{i18next.t("newsletter.prompt-body")}</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button size="sm" onClick={() => setOpen(true)}>
+              {i18next.t("newsletter.prompt-accept")}
+            </Button>
+            <Button size="sm" appearance="gray-link" onClick={dismiss}>
+              {i18next.t("newsletter.prompt-dismiss")}
+            </Button>
+          </div>
+        </div>
+      </div>
+      {open && (
+        <DigestSubscribeDialog
+          type="own"
+          target={username}
+          targetLabel={username}
+          source="publish-prompt"
+          show={open}
+          onHide={() => {
+            // Whatever they did in the dialog, they have been asked.
+            recordDigestPromptAnswer(username, "accepted");
+            setAnswered(true);
+            setOpen(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/newsletter/first-publish-digest-prompt.tsx
+++ b/apps/web/src/features/newsletter/first-publish-digest-prompt.tsx
@@ -4,7 +4,7 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { UilEnvelope } from "@tooni/iconscout-unicons-react";
 import { Button } from "@ui/button";
 import i18next from "i18next";
-import { useEffect, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 import { DigestSubscribeDialog } from "./digest-subscribe-dialog";
 import { useDigestSubscriptions, useNewsletterEnabled } from "./hooks";
 
@@ -15,11 +15,14 @@ import { useDigestSubscriptions, useNewsletterEnabled } from "./hooks";
  * and intent, and because consent must be an explicit affirmative action; there
  * is no pre-selection anywhere in this flow.
  *
- * Shown only when all of these hold: the feature is on, the account has at most
- * one post (the one just published; the count is read from the account before
- * the query refreshes, so 0 or 1), the account holds no digest subscription
- * yet, and the person has not already answered on this device. Accepting or
- * dismissing records the answer, so it never re-prompts.
+ * The caller decides that this WAS the first publish (the publish flow captures
+ * `post_count === 0` at publish time and renders this only then); a heuristic
+ * read here after the fact could not tell a first post from a second one on a
+ * device without the local answer. Shown only when, in addition, the feature is
+ * on, the subscriptions query has LOADED and shows no digest for the account
+ * (a failed load shows nothing, since "no digest" cannot be established), and
+ * the person has not already answered on this device. Accepting or dismissing
+ * records the answer, so it never re-prompts.
  */
 const STORAGE_PREFIX = "ecency:digest-prompt:";
 
@@ -39,11 +42,11 @@ export function recordDigestPromptAnswer(username: string, answer: "accepted" | 
   }
 }
 
-export function FirstPublishDigestPrompt() {
+export function FirstPublishDigestPrompt(): ReactElement | null {
   const enabled = useNewsletterEnabled();
-  const { activeUser, account } = useActiveAccount();
+  const { activeUser } = useActiveAccount();
   const username = activeUser?.username;
-  const { data: subscriptions, isLoading } = useDigestSubscriptions();
+  const { data: subscriptions, isSuccess } = useDigestSubscriptions();
   const [answered, setAnswered] = useState(true);
   const [open, setOpen] = useState(false);
 
@@ -51,10 +54,10 @@ export function FirstPublishDigestPrompt() {
     if (username) setAnswered(digestPromptAnswered(username));
   }, [username]);
 
-  if (!enabled || !username || answered || isLoading) return null;
-  const postCount = account?.post_count ?? Number.POSITIVE_INFINITY;
-  if (postCount > 1) return null;
-  if ((subscriptions ?? []).length > 0) return null;
+  if (!enabled || !username || answered) return null;
+  // Only a LOADED, empty list allows the offer. Loading, or a failed load, shows
+  // nothing: "no digest yet" cannot be established from an error.
+  if (!isSuccess || !subscriptions || subscriptions.length > 0) return null;
 
   const dismiss = () => {
     recordDigestPromptAnswer(username, "dismissed");

--- a/apps/web/src/features/newsletter/index.ts
+++ b/apps/web/src/features/newsletter/index.ts
@@ -4,3 +4,4 @@ export * from "./newsletter-api";
 export * from "./digest-subscribe-button";
 export * from "./digest-subscribe-dialog";
 export * from "./describe";
+export * from "./first-publish-digest-prompt";

--- a/apps/web/src/features/newsletter/types.ts
+++ b/apps/web/src/features/newsletter/types.ts
@@ -1,4 +1,4 @@
-export type DigestType = "community" | "creator" | "site";
+export type DigestType = "own" | "community" | "creator" | "site";
 export type DigestCadence = "weekly" | "monthly";
 export type DigestStatus = "active" | "pending_confirmation" | "suppressed" | "ended";
 
@@ -27,5 +27,5 @@ export interface SubscribeInput {
   target: string;
   targetLabel?: string;
   cadence: DigestCadence;
-  source: "community-page" | "creator-page" | "settings" | "landing-page";
+  source: "community-page" | "creator-page" | "settings" | "landing-page" | "publish-prompt";
 }

--- a/apps/web/src/specs/api/newsletter-subscribe-route.spec.ts
+++ b/apps/web/src/specs/api/newsletter-subscribe-route.spec.ts
@@ -130,9 +130,22 @@ describe("POST /api/newsletter/subscribe", () => {
     expect(JSON.parse(mocks.fetch.mock.calls[0][1].body)).toMatchObject({ type: "site", target: "ecency", source: "landing-page" });
   });
 
+  it("the own digest needs a verified account and its target must be that account", async () => {
+    // Anonymous: no account to be the target of.
+    expect((await post({ ...VALID, type: "own", target: "alice" })).status).toBe(401);
+    // Signed in as alice, asking for bob's: refused before it leaves.
+    mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
+    expect((await post({ ...VALID, type: "own", target: "bob", code: "tok" })).status).toBe(400);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    // Signed in as alice, asking for her own: relayed with the account attributed.
+    mocks.fetch.mockResolvedValue(upstream(200, { status: "pending_confirmation" }));
+    expect((await post({ ...VALID, type: "own", target: "Alice", code: "tok", source: "publish-prompt" })).status).toBe(200);
+    expect(JSON.parse(mocks.fetch.mock.calls[0][1].body)).toMatchObject({ type: "own", target: "alice", account: "alice", source: "publish-prompt" });
+  });
+
   it("400s malformed input before it reaches the service", async () => {
     for (const bad of [
-      { ...VALID, type: "own" },
+      { ...VALID, type: "nope" },
       { ...VALID, cadence: "daily" },
       { ...VALID, email: "" },
       { ...VALID, source: "elsewhere" },

--- a/apps/web/src/specs/app/publish/publish-success-first-publish.spec.tsx
+++ b/apps/web/src/specs/app/publish/publish-success-first-publish.spec.tsx
@@ -1,0 +1,67 @@
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PublishSuccessState } from "@/app/publish/_components/publish-success-state";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { mockActiveUser, mockFullAccount, renderWithQueryClient } from "@/specs/test-utils";
+
+vi.mock("@/config", () => ({
+  EcencyConfigManager: {
+    getConfigValue: (fn: (c: unknown) => unknown) => fn({ visionFeatures: { newsletter: { enabled: true } } })
+  }
+}));
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<object>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token"),
+  ensureValidToken: vi.fn(async () => "mock-token")
+}));
+
+const fetchMock = vi.fn();
+const entry = { title: "First!", author: "newbie", permlink: "first", category: "hive-1" };
+
+/**
+ * The success screen offers the digest only when the publish flow told it this
+ * was the first publish. That decision is made at publish time from the account
+ * as loaded; the screen must not infer it, since the cached post count is not
+ * refreshed by the publish and a second post looks the same afterwards.
+ */
+describe("PublishSuccessState and the first-publish digest offer", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    fetchMock.mockImplementation((url: string) =>
+      url === "/api/newsletter/subscriptions"
+        ? Promise.resolve({ ok: true, status: 200, json: async () => ({ subscriptions: [] }) } as Response)
+        : Promise.resolve({ ok: true, status: 200, json: async () => ({}) } as Response)
+    );
+    window.localStorage.clear();
+    vi.mocked(useActiveAccount).mockReturnValue({
+      activeUser: mockActiveUser({ username: "newbie" }),
+      username: "newbie",
+      account: mockFullAccount({ name: "newbie", post_count: 0 }),
+      isLoading: false,
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isSuccess: true
+    } as never);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("offers the digest when told this was the first publish", async () => {
+    renderWithQueryClient(<PublishSuccessState step="published" setEditStep={() => {}} entryInfo={entry} firstPublish={true} />);
+    expect(await screen.findByText("newsletter.prompt-title")).toBeInTheDocument();
+  });
+
+  it("offers nothing on a later publish, even with the same cached account, and nothing when scheduled", async () => {
+    const { unmount } = renderWithQueryClient(<PublishSuccessState step="published" setEditStep={() => {}} entryInfo={entry} firstPublish={false} />);
+    await new Promise((r) => setTimeout(r, 40));
+    expect(screen.queryByText("newsletter.prompt-title")).not.toBeInTheDocument();
+    unmount();
+    renderWithQueryClient(<PublishSuccessState step="scheduled" setEditStep={() => {}} entryInfo={entry} firstPublish={true} />);
+    await new Promise((r) => setTimeout(r, 40));
+    expect(screen.queryByText("newsletter.prompt-title")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/specs/features/newsletter/email-digests-settings.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/email-digests-settings.spec.tsx
@@ -54,6 +54,21 @@ describe("EmailDigestsSettings", () => {
     vi.unstubAllGlobals();
   });
 
+  it("changes the cadence of the OWN digest through the service like any other", async () => {
+    const OWN = { id: "o1", email: "alice@example.com", account: "alice", type: "own", target: "alice", cadence: "weekly", status: "active", created_at: "" };
+    const client = createTestQueryClient();
+    client.setQueryData(digestSubscriptionsKey("alice"), [OWN]);
+    fetchMock.mockImplementation((url: string) =>
+      url === "/api/newsletter/subscribe" ? ok({ status: "active", created: false, subscription: { ...OWN, cadence: "monthly" } }) : ok({ subscriptions: [OWN] })
+    );
+    renderWithQueryClient(<EmailDigestsSettings />, { queryClient: client });
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "monthly" } });
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find((c) => c[0] === "/api/newsletter/subscribe");
+      expect(JSON.parse(call![1].body)).toMatchObject({ type: "own", target: "alice", cadence: "monthly", source: "settings", code: "mock-token" });
+    });
+  });
+
   it("labels a site-digest subscription as the Ecency digest, not the notification digest", () => {
     const client = createTestQueryClient();
     client.setQueryData(digestSubscriptionsKey("alice"), [S1]);

--- a/apps/web/src/specs/features/newsletter/first-publish-digest-prompt.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/first-publish-digest-prompt.spec.tsx
@@ -28,11 +28,11 @@ vi.mock("@/utils", async () => ({
 const fetchMock = vi.fn();
 const ok = (body: unknown) => Promise.resolve({ ok: true, status: 200, json: async () => body } as Response);
 
-function signedIn(postCount: number) {
+function signedIn() {
   vi.mocked(useActiveAccount).mockReturnValue({
     activeUser: mockActiveUser({ username: "newbie" }),
     username: "newbie",
-    account: mockFullAccount({ name: "newbie", post_count: postCount }),
+    account: mockFullAccount({ name: "newbie", post_count: 0 }),
     isLoading: false,
     isPending: false,
     isError: false,
@@ -52,7 +52,7 @@ describe("FirstPublishDigestPrompt", () => {
     );
     window.localStorage.clear();
     flags.newsletter = true;
-    signedIn(1);
+    signedIn();
   });
   afterEach(() => {
     cleanupModalContainers();
@@ -68,14 +68,19 @@ describe("FirstPublishDigestPrompt", () => {
     expect(fetchMock.mock.calls.filter((c) => c[0] === "/api/newsletter/subscribe")).toHaveLength(0);
   });
 
-  it("is not offered when the account has published before, already has a digest, has answered, or the feature is off", async () => {
-    signedIn(7);
-    const { container: veteran, unmount: u1 } = renderWithQueryClient(<FirstPublishDigestPrompt />);
-    await new Promise((r) => setTimeout(r, 30));
-    expect(veteran).toBeEmptyDOMElement();
+  it("is not offered when the subscriptions failed to load, the account already has a digest, has answered, or the feature is off", async () => {
+    // A failed load: "no digest yet" cannot be established, so nothing is offered.
+    fetchMock.mockImplementation((url: string) =>
+      url === "/api/newsletter/subscriptions" ? Promise.resolve({ ok: false, status: 503, json: async () => ({ error: "down" }) } as Response) : ok({})
+    );
+    const { container: failed, unmount: u1 } = renderWithQueryClient(<FirstPublishDigestPrompt />);
+    await new Promise((r) => setTimeout(r, 60));
+    expect(failed).toBeEmptyDOMElement();
     u1();
+    fetchMock.mockImplementation((url: string) =>
+      url === "/api/newsletter/subscriptions" ? ok({ subscriptions: [] }) : ok({ status: "pending_confirmation" })
+    );
 
-    signedIn(1);
     const client = createTestQueryClient();
     client.setQueryData(digestSubscriptionsKey("newbie"), [{ id: "x", email: "n@example.com", account: "newbie", type: "own", target: "newbie", cadence: "weekly", status: "active", created_at: "" }]);
     const { container: subscribed, unmount: u2 } = renderWithQueryClient(<FirstPublishDigestPrompt />, { queryClient: client });

--- a/apps/web/src/specs/features/newsletter/first-publish-digest-prompt.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/first-publish-digest-prompt.spec.tsx
@@ -1,0 +1,131 @@
+import "@testing-library/jest-dom";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { digestSubscriptionsKey, FirstPublishDigestPrompt } from "@/features/newsletter";
+import {
+  cleanupModalContainers,
+  createTestQueryClient,
+  mockActiveUser,
+  mockFullAccount,
+  renderWithQueryClient,
+  setupModalContainers
+} from "@/specs/test-utils";
+
+const flags = vi.hoisted(() => ({ newsletter: true }));
+vi.mock("@/config", () => ({
+  EcencyConfigManager: {
+    getConfigValue: (fn: (c: unknown) => unknown) => fn({ visionFeatures: { newsletter: { enabled: flags.newsletter } } })
+  }
+}));
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<object>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token"),
+  ensureValidToken: vi.fn(async () => "mock-token")
+}));
+
+const fetchMock = vi.fn();
+const ok = (body: unknown) => Promise.resolve({ ok: true, status: 200, json: async () => body } as Response);
+
+function signedIn(postCount: number) {
+  vi.mocked(useActiveAccount).mockReturnValue({
+    activeUser: mockActiveUser({ username: "newbie" }),
+    username: "newbie",
+    account: mockFullAccount({ name: "newbie", post_count: postCount }),
+    isLoading: false,
+    isPending: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isSuccess: true
+  } as never);
+}
+
+describe("FirstPublishDigestPrompt", () => {
+  beforeEach(() => {
+    setupModalContainers();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    fetchMock.mockImplementation((url: string) =>
+      url === "/api/newsletter/subscriptions" ? ok({ subscriptions: [] }) : ok({ status: "pending_confirmation" })
+    );
+    window.localStorage.clear();
+    flags.newsletter = true;
+    signedIn(1);
+  });
+  afterEach(() => {
+    cleanupModalContainers();
+    vi.unstubAllGlobals();
+  });
+
+  it("offers the digest once after the first publish, with no pre-selection", async () => {
+    renderWithQueryClient(<FirstPublishDigestPrompt />);
+    expect(await screen.findByText("newsletter.prompt-title")).toBeInTheDocument();
+    // Two explicit actions, neither pre-selected; nothing has been sent.
+    expect(screen.getByRole("button", { name: "newsletter.prompt-accept" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "newsletter.prompt-dismiss" })).toBeInTheDocument();
+    expect(fetchMock.mock.calls.filter((c) => c[0] === "/api/newsletter/subscribe")).toHaveLength(0);
+  });
+
+  it("is not offered when the account has published before, already has a digest, has answered, or the feature is off", async () => {
+    signedIn(7);
+    const { container: veteran, unmount: u1 } = renderWithQueryClient(<FirstPublishDigestPrompt />);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(veteran).toBeEmptyDOMElement();
+    u1();
+
+    signedIn(1);
+    const client = createTestQueryClient();
+    client.setQueryData(digestSubscriptionsKey("newbie"), [{ id: "x", email: "n@example.com", account: "newbie", type: "own", target: "newbie", cadence: "weekly", status: "active", created_at: "" }]);
+    const { container: subscribed, unmount: u2 } = renderWithQueryClient(<FirstPublishDigestPrompt />, { queryClient: client });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(subscribed).toBeEmptyDOMElement();
+    u2();
+
+    window.localStorage.setItem("ecency:digest-prompt:newbie", "dismissed:2026-08-18T00:00:00Z");
+    const { container: answered, unmount: u3 } = renderWithQueryClient(<FirstPublishDigestPrompt />);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(answered).toBeEmptyDOMElement();
+    u3();
+    window.localStorage.clear();
+
+    flags.newsletter = false;
+    const { container: off } = renderWithQueryClient(<FirstPublishDigestPrompt />);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(off).toBeEmptyDOMElement();
+  });
+
+  it("dismissing records the answer so it never re-prompts", async () => {
+    renderWithQueryClient(<FirstPublishDigestPrompt />);
+    fireEvent.click(await screen.findByRole("button", { name: "newsletter.prompt-dismiss" }));
+    await waitFor(() => expect(screen.queryByText("newsletter.prompt-title")).not.toBeInTheDocument());
+    expect(window.localStorage.getItem("ecency:digest-prompt:newbie")).toMatch(/^dismissed:/);
+    // A second render on the same device is silent.
+    const { container } = renderWithQueryClient(<FirstPublishDigestPrompt />);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("accepting opens the own-digest dialog, which asks for the address and subscribes with type own", async () => {
+    renderWithQueryClient(<FirstPublishDigestPrompt />);
+    fireEvent.click(await screen.findByRole("button", { name: "newsletter.prompt-accept" }));
+    expect(await screen.findByText("newsletter.own-digest")).toBeInTheDocument();
+    // No address held for the account yet: the dialog asks for one.
+    fireEvent.change(screen.getByPlaceholderText("you@example.com"), { target: { value: "newbie@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "newsletter.subscribe" }));
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find((c) => c[0] === "/api/newsletter/subscribe");
+      expect(call).toBeTruthy();
+      expect(JSON.parse(call![1].body)).toMatchObject({
+        email: "newbie@example.com",
+        type: "own",
+        target: "newbie",
+        cadence: "weekly",
+        source: "publish-prompt",
+        code: "mock-token"
+      });
+    });
+    expect(await screen.findByText("newsletter.check-inbox")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #1511. Stacked on #1520 (shares two additive lines in the relay and the types); GitHub retargets this to `develop` when #1520 merges.

**The offer.** `FirstPublishDigestPrompt` sits in the publish success state, right after the share bar: the moment the person has just published and has context. It is shown only when the feature is on, the account has at most one post (the count is read before the account query refreshes, so 0 or 1), the account holds no digest subscription yet, and the person has not already answered on this device. Two explicit actions and nothing pre-selected, as decided on #1507: "Yes, set it up" opens the existing digest dialog with `type: own` (target = the account), which collects and confirms an address if the service holds none and offers weekly or monthly; "No thanks" records the answer. Either way it never re-prompts.

**Where the setting lives afterwards**, the open point in the issue: the "Email digests" card in profile settings from #1512, which lists the own digest and now also changes its cadence.

**Relay.** `type: own` is accepted only for a verified account and only when the target is that account (the service enforces the same rule); a foreign target is refused before it leaves.

**Tests.** Prompt gating in each direction (veteran account, already subscribed, already answered, feature off), dismissal recorded and silent afterwards, accepting opens the own dialog and subscribes with `type: own`, the account and the token; relay own rules (401 anonymous, 400 foreign target, relayed for own). Full suite 2824 green; typecheck, lint, icon audit clean.

**Acceptance.** A first-time publisher is offered the digest once, can accept or dismiss, and on accepting receives a confirmation if the address is new: the service side of that confirmation is the flow from ecency/news#2 and #3.
