### PR TITLE
Staging: pass the newsletter service settings to alpha

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -135,12 +135,18 @@ jobs:
         SEO_CRON_SECRET: ${{secrets.SEO_CRON_SECRET}}
         SEO_BLACKLIST_URL: ${{secrets.SEO_BLACKLIST_URL}}
         TURNSTILE_SECRET: ${{secrets.TURNSTILE_SECRET}}
+        # Newsletter service (ecency/news) lives on the EU production box; staging reaches
+        # it through the IP-allowlisted TLS relay on the EU origin, same as US, with its own
+        # URL secret. There is one service and one database, so subscriptions made on alpha
+        # are real: test with your own addresses. Optional here (see the script below).
+        NEWSLETTER_API_URL: ${{secrets.NEWSLETTER_API_URL_STAGING}}
+        NEWSLETTER_SERVICE_TOKEN: ${{secrets.NEWSLETTER_SERVICE_TOKEN}}
       with:
         host: ${{ secrets.SSH_STAGING_HOST }}
         username: ${{ secrets.SSH_USERNAME }}
         key: ${{ secrets.SSH_KEY }}
         port: ${{ secrets.SSH_PORT }}
-        envs: USE_PRIVATE,PRIVATE_API_ADDR,PRIVATE_API_AUTH,HIVESIGNER_SECRET,SEARCH_API_ADDR,SEARCH_API_SECRET,STRIPE_INTERNAL_SECRET,HOSTING_INTERNAL_SECRET,HIVESEARCHER_ORIGIN_IP,PLAUSIBLE_API_KEY,BLOCKSTREAM_CLIENT_ID,BLOCKSTREAM_CLIENT_SECRET,MATTERMOST_TEAM_ID,MATTERMOST_ADMIN_TOKEN,MATTERMOST_BASE_URL,MATTERMOST_WS_ALLOWED_ORIGINS,THREESPEAK_EMBED_API_KEY,SEO_CRON_SECRET,SEO_BLACKLIST_URL,TURNSTILE_SECRET
+        envs: USE_PRIVATE,PRIVATE_API_ADDR,PRIVATE_API_AUTH,HIVESIGNER_SECRET,SEARCH_API_ADDR,SEARCH_API_SECRET,STRIPE_INTERNAL_SECRET,HOSTING_INTERNAL_SECRET,HIVESEARCHER_ORIGIN_IP,PLAUSIBLE_API_KEY,BLOCKSTREAM_CLIENT_ID,BLOCKSTREAM_CLIENT_SECRET,MATTERMOST_TEAM_ID,MATTERMOST_ADMIN_TOKEN,MATTERMOST_BASE_URL,MATTERMOST_WS_ALLOWED_ORIGINS,THREESPEAK_EMBED_API_KEY,SEO_CRON_SECRET,SEO_BLACKLIST_URL,TURNSTILE_SECRET,NEWSLETTER_API_URL,NEWSLETTER_SERVICE_TOKEN
         script: |
           export USE_PRIVATE=$USE_PRIVATE
           export PRIVATE_API_ADDR=$PRIVATE_API_ADDR
@@ -158,6 +164,13 @@ jobs:
           export SEO_CRON_SECRET=$SEO_CRON_SECRET
           export SEO_BLACKLIST_URL=$SEO_BLACKLIST_URL
           export TURNSTILE_SECRET=$TURNSTILE_SECRET
+          # Unlike production this does not fail without the newsletter settings: staging may run
+          # without the feature. It says so, because the web hides the controls silently otherwise.
+          if [ -z "$NEWSLETTER_API_URL" ] || [ -z "$NEWSLETTER_SERVICE_TOKEN" ]; then
+            echo "::warning::NEWSLETTER_API_URL/NEWSLETTER_SERVICE_TOKEN unset: newsletter controls hidden on staging"
+          fi
+          export NEWSLETTER_API_URL=$NEWSLETTER_API_URL
+          export NEWSLETTER_SERVICE_TOKEN=$NEWSLETTER_SERVICE_TOKEN
           cd ~/vision-web
           git pull origin develop
           cd apps/web

--- a/apps/self-hosted/hosting/origin/README.md
+++ b/apps/self-hosted/hosting/origin/README.md
@@ -215,7 +215,7 @@ box, prefix stripped). The service is EU-only; the US web tier reaches it throug
 over TLS, so every region can render the digest controls. Same shape and same reasoning as
 above: one `allow` per line, wildcard include so a missing file degrades to `deny all` on this
 path only. What belongs in it: the co-located web origin's swarm gateway range, the US web
-origin, and loopback for on-box diagnostics. The service also checks its own bearer token on
+origin, the staging (alpha) web origin, and loopback for on-box diagnostics. The service also checks its own bearer token on
 every `/api` route, so this list is the outer gate, not the only one.
 
 ```sh

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -17,10 +17,6 @@ services:
       - SEARCH_API_ADDR
       - SEARCH_API_SECRET
       - TURNSTILE_SECRET
-      # Newsletter service (ecency/news); staging reaches the EU instance through the TLS
-      # relay. Unset = the handlers answer 503 and no newsletter control renders.
-      - NEWSLETTER_API_URL
-      - NEWSLETTER_SERVICE_TOKEN
       - BLOCKSTREAM_CLIENT_ID
       - BLOCKSTREAM_CLIENT_SECRET
       # Pinned to Warning at deploy time (the CI deploy env does not forward
@@ -69,6 +65,11 @@ services:
       - REDIS_URL=redis://redis:6379
       - HIVESIGNER_SECRET
       - HOSTING_INTERNAL_SECRET
+      # Newsletter service (ecency/news), read by the Next.js server (web), not vapi;
+      # staging reaches the EU instance through the TLS relay. Unset = the handlers
+      # answer 503 and no newsletter control renders.
+      - NEWSLETTER_API_URL
+      - NEWSLETTER_SERVICE_TOKEN
       - PLAUSIBLE_API_KEY
       - NEXT_PUBLIC_GMAPS_MAP_ID
       - NEXT_PUBLIC_GMAPS_API_KEY

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       - SEARCH_API_ADDR
       - SEARCH_API_SECRET
       - TURNSTILE_SECRET
+      # Newsletter service (ecency/news); staging reaches the EU instance through the TLS
+      # relay. Unset = the handlers answer 503 and no newsletter control renders.
+      - NEWSLETTER_API_URL
+      - NEWSLETTER_SERVICE_TOKEN
       - BLOCKSTREAM_CLIENT_ID
       - BLOCKSTREAM_CLIENT_SECRET
       # Pinned to Warning at deploy time (the CI deploy env does not forward

--- a/apps/web/src/specs/deploy/newsletter-wiring.spec.ts
+++ b/apps/web/src/specs/deploy/newsletter-wiring.spec.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The newsletter feature is decided at request time in the Next.js server
+ * (server/newsletter-internal.ts reads NEWSLETTER_API_URL + NEWSLETTER_SERVICE_TOKEN),
+ * so the deploy wiring must hand both variables to the `web` service, and the
+ * deploy jobs must forward them. #1523 first put them under `vapi`, which is
+ * silent: nothing fails, the controls simply never render. This pins the wiring.
+ */
+const root = join(__dirname, "..", "..", "..", "..", "..");
+const read = (p: string) => readFileSync(join(root, p), "utf8");
+const VARS = ["NEWSLETTER_API_URL", "NEWSLETTER_SERVICE_TOKEN"];
+
+/** The lines of one top-level service block in a compose file (2-space keys under `services:`). */
+function serviceBlock(compose: string, name: string): string {
+  const lines = compose.split("\n");
+  const start = lines.findIndex((l) => l === `  ${name}:`);
+  if (start < 0) throw new Error(`service ${name} not found`);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^  [A-Za-z_-]+:/.test(lines[i]) || /^[A-Za-z_-]+:/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+const envEntries = (block: string) => block.split("\n").filter((l) => /^      - [A-Z_]+/.test(l)).map((l) => l.trim().slice(2));
+
+describe("newsletter deploy wiring", () => {
+  it.each(["apps/web/docker-compose.yml", "apps/web/docker-compose.production.yml"])(
+    "%s passes both variables to the web service and to nothing else",
+    (file) => {
+      const compose = read(file);
+      const web = envEntries(serviceBlock(compose, "web"));
+      for (const v of VARS) expect(web, `${file}: web.environment lacks ${v}`).toContain(v);
+      const vapi = envEntries(serviceBlock(compose, "vapi"));
+      for (const v of VARS) expect(vapi, `${file}: ${v} does not belong to vapi`).not.toContain(v);
+    }
+  );
+
+  it.each([".github/workflows/master.yml", ".github/workflows/staging.yml"])("%s forwards both variables in every deploy job", (file) => {
+    const wf = read(file);
+    // Every ssh-action step that deploys the stack carries an `envs:` list; each must forward both.
+    const envsLines = wf.split("\n").filter((l) => /^\s+envs:\s/.test(l));
+    expect(envsLines.length).toBeGreaterThan(0);
+    for (const line of envsLines) for (const v of VARS) expect(line, `${file}: envs lacks ${v}`).toContain(v);
+    for (const v of VARS) {
+      expect(wf.match(new RegExp(`export ${v}=\\$${v}`, "g"))?.length ?? 0, `${file}: export ${v}`).toBe(envsLines.length);
+    }
+  });
+});


### PR DESCRIPTION
Since #1522 the web decides per request whether the newsletter service is configured (`NEWSLETTER_API_URL` + `NEWSLETTER_SERVICE_TOKEN`); the staging deploy never received them, so alpha renders no newsletter controls and cannot be used to test the feature.

- `staging.yml`: forwards both to the deploy; the URL comes from a new `NEWSLETTER_API_URL_STAGING` secret (the EU relay, `https://api.blogs.ecency.com/newsletter-relay`), the token is the shared one. Unlike production the job warns instead of failing when they are unset: staging may run without the feature, but silently hidden controls should at least be named in the log.
- `docker-compose.yml`: passes both through to the web service.
- Origin README: the relay allowlist now names the staging origin as a legitimate caller (the allowlist file itself stays out of git).

There is one service and one database, so subscriptions made on alpha are real; test with your own addresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled newsletter service configuration for web deployments, including staging and self-hosted environments.
  * Newsletter functionality now receives the required service URL and authentication token during deployment.

* **Bug Fixes**
  * Added a warning when newsletter configuration is missing instead of stopping deployment.

* **Documentation**
  * Updated deployment guidance to include the staging web origin in the newsletter relay allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->