### PR TITLE
Newsletter: show a suspended digest to its sender

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
+import { NewsletterGate, SenderStatusNotice } from "@/features/newsletter";
 import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import { Button } from "@ui/button";
@@ -50,9 +51,17 @@ export function CommunityCard({ community, account }: Props) {
     [roleInTeam]
   );
   const canEditTeam = useMemo(() => !!(roleInTeam && roleMap[roleInTeam]), [roleInTeam]);
+  const isDigestSender = useMemo(
+    () => !!(roleInTeam && [ROLES.OWNER.toString(), ROLES.ADMIN.toString(), ROLES.MOD.toString()].includes(roleInTeam)),
+    [roleInTeam]
+  );
 
   return (
     <div className="community-card">
+      {/* Policing (vision-web#1513): the team sees when this community's digest is suspended, and why. */}
+      <NewsletterGate>
+        <SenderStatusNotice type="community" target={community.name} isSender={isDigestSender} className="mb-4" />
+      </NewsletterGate>
       <div className="community-avatar inline-flex items-center justify-center md:justify-start">
         {canUpdatePic && (
           <CommunityCardEditPic

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
@@ -51,10 +51,13 @@ export function CommunityCard({ community, account }: Props) {
     [roleInTeam]
   );
   const canEditTeam = useMemo(() => !!(roleInTeam && roleMap[roleInTeam]), [roleInTeam]);
-  const isDigestSender = useMemo(
-    () => !!(roleInTeam && [ROLES.OWNER.toString(), ROLES.ADMIN.toString(), ROLES.MOD.toString()].includes(roleInTeam)),
-    [roleInTeam]
-  );
+  // Names compared lowercase: the stored username keeps whatever casing was typed,
+  // team entries are canonical. Owner, admin and mod are the digest's senders.
+  const isDigestSender = useMemo(() => {
+    const me = activeUser?.username?.toLowerCase();
+    const mine = me ? community.team.find((x: (string | undefined)[]) => x[0]?.toLowerCase() === me) : undefined;
+    return !!(mine?.[1] && [ROLES.OWNER.toString(), ROLES.ADMIN.toString(), ROLES.MOD.toString()].includes(mine[1]));
+  }, [activeUser?.username, community.team]);
 
   return (
     <div className="community-card">

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -133,8 +133,10 @@ export function ProfileCard({ account }: Props) {
       </div>
       <HivePosh username={account.name} className="mb-4" />
 
-      {/* Policing (vision-web#1513): the creator sees when their own digest is suspended, and why. */}
-      {isMyProfile && (
+      {/* Policing (vision-web#1513): the creator sees when their own digest is suspended, and why.
+          Gated on the account itself, not on isMyProfile, which also wants profile metadata that
+          not every account has; names compared lowercase, the stored username keeps its casing. */}
+      {activeUsername?.toLowerCase() === account.name && (
         <NewsletterGate>
           <SenderStatusNotice type="creator" target={account.name} isSender className="mb-4" />
         </NewsletterGate>

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -35,7 +35,7 @@ import { profileWebsiteHref } from "./website-href";
 import { FinalizeCommunityBanner } from "../finalize-community-banner";
 import { useActiveAccount } from "@/core/hooks";
 import { ProBadge } from "@/features/pro";
-import { DigestSubscribeButton, NewsletterGate } from "@/features/newsletter";
+import { DigestSubscribeButton, NewsletterGate, SenderStatusNotice } from "@/features/newsletter";
 
 interface Props {
   account: Account;
@@ -132,6 +132,13 @@ export function ProfileCard({ account }: Props) {
         </div>
       </div>
       <HivePosh username={account.name} className="mb-4" />
+
+      {/* Policing (vision-web#1513): the creator sees when their own digest is suspended, and why. */}
+      {isMyProfile && (
+        <NewsletterGate>
+          <SenderStatusNotice type="creator" target={account.name} isSender className="mb-4" />
+        </NewsletterGate>
+      )}
 
       {!isMyProfile && (
         <div className="mb-4 flex flex-wrap gap-2">

--- a/apps/web/src/app/api/newsletter/sender/route.ts
+++ b/apps/web/src/app/api/newsletter/sender/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest } from "next/server";
+import { getCommunity } from "@ecency/sdk";
+import { resolveUser, unauthorizedResponse } from "@/app/api/threespeak/resolve-user";
+import { callNewsletter, newsletterConfigured, notConfigured, relay } from "@/server/newsletter-internal";
+
+/**
+ * A sender's standing with the newsletter service (vision-web#1513): status,
+ * reason, since when, and the rolling numbers. Shown to the SENDER only: the
+ * account itself for a creator digest, the community's team (owner, admin,
+ * mod) for a community digest. Nobody else has a reason to see another
+ * sender's complaint rate.
+ */
+const TARGET_RE = /^[a-z0-9.-]{1,32}$/;
+const TEAM_ROLES = new Set(["owner", "admin", "mod"]);
+
+export async function GET(request: NextRequest) {
+  if (!newsletterConfigured()) return notConfigured();
+  const auth = await resolveUser(request, {});
+  if (!auth.ok) return unauthorizedResponse(auth.reason);
+  const username = auth.username.toLowerCase();
+
+  const type = request.nextUrl.searchParams.get("type");
+  const target = (request.nextUrl.searchParams.get("target") ?? "").toLowerCase();
+  if ((type !== "creator" && type !== "community") || !TARGET_RE.test(target)) {
+    return Response.json({ error: "type must be creator or community, target a valid name" }, { status: 400 });
+  }
+
+  if (type === "creator") {
+    if (target !== username) return Response.json({ error: "not your digest" }, { status: 403 });
+  } else {
+    const community = await getCommunity(target, username);
+    const role = community?.team?.find(([account]) => account === username)?.[1];
+    if (!role || !TEAM_ROLES.has(role)) return Response.json({ error: "not on this community's team" }, { status: 403 });
+  }
+
+  const upstream = await callNewsletter(`/api/senders/${type}/${encodeURIComponent(target)}`);
+  return relay(upstream);
+}

--- a/apps/web/src/core/react-query/index.ts
+++ b/apps/web/src/core/react-query/index.ts
@@ -8,6 +8,7 @@ import { cache } from "react";
  */
 export enum QueryIdentifiers {
   NEWSLETTER_SUBSCRIPTIONS = "newsletter-subscriptions",
+  NEWSLETTER_SENDER_STANDING = "newsletter-sender-standing",
   NEWSLETTER_CONFIRM_INSPECT = "newsletter-confirm-inspect",
   NEWSLETTER_UNSUBSCRIBE_INSPECT = "newsletter-unsubscribe-inspect",
   COMMUNITY_THREADS = "community-threads",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -4185,6 +4185,12 @@
     "prompt-title": "Want a digest of your Ecency activity by email?",
     "prompt-body": "Replies, mentions and new followers, once a week or once a month. Nothing is sent until you confirm your address, and you can leave from any email.",
     "prompt-accept": "Yes, set it up",
-    "prompt-dismiss": "No thanks"
+    "prompt-dismiss": "No thanks",
+    "suspended-title-creator": "Your email digest is suspended (since {{since}})",
+    "suspended-title-community": "This community's email digest is suspended (since {{since}})",
+    "suspended-reason-complaints": "Too many recipients marked recent issues as spam. Sending is paused to protect every Ecency sender's deliverability.",
+    "suspended-reason-bounces": "Too many recent recipients could not be delivered to. Sending is paused to protect every Ecency sender's deliverability.",
+    "suspended-reason-manual": "Sending is paused by Ecency. No new issues go out until it is lifted.",
+    "suspended-help": "Existing subscribers are kept. Contact Ecency support to have the suspension reviewed."
   }
 }

--- a/apps/web/src/features/newsletter/index.ts
+++ b/apps/web/src/features/newsletter/index.ts
@@ -6,3 +6,4 @@ export * from "./digest-subscribe-button";
 export * from "./digest-subscribe-dialog";
 export * from "./describe";
 export * from "./first-publish-digest-prompt";
+export * from "./sender-status";

--- a/apps/web/src/features/newsletter/sender-status.tsx
+++ b/apps/web/src/features/newsletter/sender-status.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { QueryIdentifiers } from "@/core/react-query";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { ensureValidToken } from "@/utils";
@@ -41,7 +41,11 @@ export interface SenderStanding {
 export const senderStandingKey = (type: DigestType, target: string, viewer: string | null | undefined) =>
   [QueryIdentifiers.NEWSLETTER_SENDER_STANDING, type, target, viewer ?? "anon"] as const;
 
-export function useSenderStanding(type: "creator" | "community", target: string, isSender: boolean) {
+export function useSenderStanding(
+  type: "creator" | "community",
+  target: string,
+  isSender: boolean
+): UseQueryResult<SenderStanding, Error> {
   const enabled = useNewsletterEnabled();
   const { activeUser } = useActiveAccount();
   return useQuery({
@@ -85,7 +89,6 @@ export function SenderStatusNotice({
     <div
       role="status"
       className={`rounded-xl border border-red bg-red/10 px-4 py-3 text-sm text-red ${className ?? ""}`}
-      data-testid="newsletter-sender-suspended"
     >
       <div className="font-semibold">
         {i18next.t(type === "creator" ? "newsletter.suspended-title-creator" : "newsletter.suspended-title-community", { since })}

--- a/apps/web/src/features/newsletter/sender-status.tsx
+++ b/apps/web/src/features/newsletter/sender-status.tsx
@@ -32,14 +32,20 @@ export interface SenderStanding {
   };
 }
 
-export const senderStandingKey = (type: DigestType, target: string) =>
-  [QueryIdentifiers.NEWSLETTER_SENDER_STANDING, type, target] as const;
+/**
+ * Scoped to the VIEWER as well as the list: the standing is the sender's private
+ * view, and one browser can hold several accounts in turn. A key without the
+ * viewer would let a plain member render what a team member fetched minutes
+ * before under the same key.
+ */
+export const senderStandingKey = (type: DigestType, target: string, viewer: string | null | undefined) =>
+  [QueryIdentifiers.NEWSLETTER_SENDER_STANDING, type, target, viewer ?? "anon"] as const;
 
 export function useSenderStanding(type: "creator" | "community", target: string, isSender: boolean) {
   const enabled = useNewsletterEnabled();
   const { activeUser } = useActiveAccount();
   return useQuery({
-    queryKey: senderStandingKey(type, target),
+    queryKey: senderStandingKey(type, target, activeUser?.username),
     enabled: enabled && isSender && !!activeUser?.username && !!target,
     staleTime: 5 * 60_000,
     queryFn: async (): Promise<SenderStanding> => {
@@ -71,7 +77,8 @@ export function SenderStatusNotice({
   className?: string;
 }) {
   const { data } = useSenderStanding(type, target, isSender);
-  if (!data || data.status !== "suspended") return null;
+  // Belt to the key's brace: whatever the cache holds, a non-sender sees nothing.
+  if (!isSender || !data || data.status !== "suspended") return null;
   const since = data.since ? new Date(data.since).toLocaleDateString() : "";
   const reason = i18next.t(REASONS[data.reason ?? ""] ?? "newsletter.suspended-reason-manual");
   return (

--- a/apps/web/src/features/newsletter/sender-status.tsx
+++ b/apps/web/src/features/newsletter/sender-status.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { QueryIdentifiers } from "@/core/react-query";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { ensureValidToken } from "@/utils";
+import i18next from "i18next";
+import { useNewsletterEnabled } from "./runtime";
+import type { DigestType } from "./types";
+
+/**
+ * The sender's own view of policing (vision-web#1513): a creator on their own
+ * profile, a community's team on the community page. Renders NOTHING unless
+ * the digest is suspended; the numbers stay in the API for the operator and
+ * for a fuller surface later. Only the sender is ever asked for it (the route
+ * refuses everyone else), and only when the feature is on.
+ */
+export interface SenderStanding {
+  type: DigestType;
+  target: string;
+  status: "active" | "suspended";
+  reason: string | null;
+  since: string | null;
+  stats: {
+    delivered: number;
+    bounced: number;
+    rejected: number;
+    complaints: number;
+    unsubscribed: number;
+    complaintRate: number;
+    bounceRate: number;
+  };
+}
+
+export const senderStandingKey = (type: DigestType, target: string) =>
+  [QueryIdentifiers.NEWSLETTER_SENDER_STANDING, type, target] as const;
+
+export function useSenderStanding(type: "creator" | "community", target: string, isSender: boolean) {
+  const enabled = useNewsletterEnabled();
+  const { activeUser } = useActiveAccount();
+  return useQuery({
+    queryKey: senderStandingKey(type, target),
+    enabled: enabled && isSender && !!activeUser?.username && !!target,
+    staleTime: 5 * 60_000,
+    queryFn: async (): Promise<SenderStanding> => {
+      const token = activeUser?.username ? await ensureValidToken(activeUser.username) : null;
+      const res = await fetch(`/api/newsletter/sender?type=${type}&target=${encodeURIComponent(target)}`, {
+        headers: token ? { "X-HS-Token": token } : {}
+      });
+      if (!res.ok) throw new Error(`sender standing: ${res.status}`);
+      return (await res.json()) as SenderStanding;
+    }
+  });
+}
+
+const REASONS: Record<string, string> = {
+  complaint_rate: "newsletter.suspended-reason-complaints",
+  bounce_rate: "newsletter.suspended-reason-bounces",
+  manual: "newsletter.suspended-reason-manual"
+};
+
+export function SenderStatusNotice({
+  type,
+  target,
+  isSender,
+  className
+}: {
+  type: "creator" | "community";
+  target: string;
+  isSender: boolean;
+  className?: string;
+}) {
+  const { data } = useSenderStanding(type, target, isSender);
+  if (!data || data.status !== "suspended") return null;
+  const since = data.since ? new Date(data.since).toLocaleDateString() : "";
+  const reason = i18next.t(REASONS[data.reason ?? ""] ?? "newsletter.suspended-reason-manual");
+  return (
+    <div
+      role="status"
+      className={`rounded-xl border border-red bg-red/10 px-4 py-3 text-sm text-red ${className ?? ""}`}
+      data-testid="newsletter-sender-suspended"
+    >
+      <div className="font-semibold">
+        {i18next.t(type === "creator" ? "newsletter.suspended-title-creator" : "newsletter.suspended-title-community", { since })}
+      </div>
+      <div className="mt-1 opacity-90">{reason}</div>
+      <div className="mt-1 opacity-75">{i18next.t("newsletter.suspended-help")}</div>
+    </div>
+  );
+}

--- a/apps/web/src/specs/api/newsletter-sender-route.spec.ts
+++ b/apps/web/src/specs/api/newsletter-sender-route.spec.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ verify: vi.fn(), fetch: vi.fn(), getCommunity: vi.fn() }));
+vi.mock("@/server/hivesigner-verify", () => ({ verifyHsAccessToken: mocks.verify }));
+vi.mock("@ecency/sdk", () => ({ getCommunity: mocks.getCommunity }));
+
+function req(query: string, headers: Record<string, string> = {}) {
+  const url = new URL(`http://localhost/api/newsletter/sender?${query}`);
+  return { nextUrl: url, headers: new Headers(headers), json: async () => ({}) } as never;
+}
+function upstream(status: number, body: unknown) {
+  return { status, ok: status < 400, json: async () => body } as never;
+}
+
+/**
+ * vision-web#1513: a sender's standing is shown to the SENDER. The route is the
+ * gate: the account itself for a creator digest, the community's team for a
+ * community digest, nobody else.
+ */
+describe("GET /api/newsletter/sender", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("fetch", mocks.fetch);
+    vi.stubEnv("NEWSLETTER_API_URL", "http://news.internal:3300");
+    vi.stubEnv("NEWSLETTER_SERVICE_TOKEN", "service-token-0123456789abcdefghijklmnop");
+    mocks.fetch.mockReset();
+    mocks.verify.mockReset();
+    mocks.getCommunity.mockReset();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("a creator sees their own standing and nobody else's", async () => {
+    mocks.verify.mockResolvedValue({ ok: true, username: "Alice" });
+    mocks.fetch.mockResolvedValue(upstream(200, { status: "suspended", reason: "complaint_rate" }));
+    const { GET } = await import("@/app/api/newsletter/sender/route");
+    const mine = await GET(req("type=creator&target=alice", { "x-hs-token": "tok" }));
+    expect(mine.status).toBe(200);
+    expect(mocks.fetch.mock.calls[0][0]).toBe("http://news.internal:3300/api/senders/creator/alice");
+    const other = await GET(req("type=creator&target=bob", { "x-hs-token": "tok" }));
+    expect(other.status).toBe(403);
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("a community's owner, admin or mod sees the community's standing; a member or stranger does not", async () => {
+    mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
+    mocks.fetch.mockResolvedValue(upstream(200, { status: "active" }));
+    mocks.getCommunity.mockResolvedValue({ name: "hive-125125", team: [["owner1", "owner", ""], ["alice", "mod", ""], ["carol", "member", ""]] });
+    const { GET } = await import("@/app/api/newsletter/sender/route");
+    expect((await GET(req("type=community&target=hive-125125", { "x-hs-token": "tok" }))).status).toBe(200);
+    expect(mocks.getCommunity).toHaveBeenCalledWith("hive-125125", "alice");
+    expect(mocks.fetch.mock.calls[0][0]).toBe("http://news.internal:3300/api/senders/community/hive-125125");
+    mocks.verify.mockResolvedValue({ ok: true, username: "carol" });
+    expect((await GET(req("type=community&target=hive-125125", { "x-hs-token": "tok" }))).status).toBe(403);
+    mocks.verify.mockResolvedValue({ ok: true, username: "dave" });
+    expect((await GET(req("type=community&target=hive-125125", { "x-hs-token": "tok" }))).status).toBe(403);
+    mocks.getCommunity.mockResolvedValue(null);
+    expect((await GET(req("type=community&target=hive-000000", { "x-hs-token": "tok" }))).status).toBe(403);
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses bad input, missing identity, and an unconfigured service", async () => {
+    mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
+    const { GET } = await import("@/app/api/newsletter/sender/route");
+    expect((await GET(req("type=site&target=ecency", { "x-hs-token": "tok" }))).status).toBe(400);
+    expect((await GET(req("type=creator&target=Bad%20Name", { "x-hs-token": "tok" }))).status).toBe(400);
+    mocks.verify.mockResolvedValue({ ok: false, reason: "missing" });
+    expect((await GET(req("type=creator&target=alice"))).status).toBe(401);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    vi.stubEnv("NEWSLETTER_SERVICE_TOKEN", "");
+    vi.resetModules();
+    const { GET: GET2 } = await import("@/app/api/newsletter/sender/route");
+    expect((await GET2(req("type=creator&target=alice", { "x-hs-token": "tok" }))).status).toBe(503);
+  });
+});

--- a/apps/web/src/specs/features/newsletter/sender-status.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/sender-status.spec.tsx
@@ -1,0 +1,103 @@
+import "@testing-library/jest-dom";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactElement } from "react";
+import { NewsletterRuntimeProvider } from "@/features/newsletter/runtime";
+import { SenderStatusNotice } from "@/features/newsletter";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { mockActiveUser, renderWithQueryClient } from "@/specs/test-utils";
+
+const flags = vi.hoisted(() => ({ newsletter: true }));
+vi.mock("@/config", () => ({
+  EcencyConfigManager: {
+    getConfigValue: (fn: (c: unknown) => unknown) => fn({ visionFeatures: { newsletter: { enabled: flags.newsletter } } })
+  }
+}));
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<object>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token"),
+  ensureValidToken: vi.fn(async () => "mock-token")
+}));
+
+const fetchMock = vi.fn();
+const json = (status: number, body: unknown) => Promise.resolve({ ok: status < 400, status, json: async () => body } as Response);
+const standing = (over: Record<string, unknown>) => ({
+  type: "creator",
+  target: "alice",
+  status: "active",
+  reason: null,
+  since: null,
+  stats: { delivered: 500, bounced: 3, rejected: 1, complaints: 0, unsubscribed: 2, complaintRate: 0, bounceRate: 0.006 },
+  ...over
+});
+
+function loggedIn(username: string | null) {
+  vi.mocked(useActiveAccount).mockReturnValue({
+    activeUser: username ? mockActiveUser({ username }) : null,
+    username,
+    account: null,
+    isLoading: false,
+    isPending: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isSuccess: true
+  } as never);
+}
+
+const render = (ui: ReactElement) => renderWithQueryClient(<NewsletterRuntimeProvider configured>{ui}</NewsletterRuntimeProvider>);
+
+/** vision-web#1513: the suspension is visible to the sender, and only when there is one to see. */
+describe("SenderStatusNotice", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    flags.newsletter = true;
+    loggedIn("alice");
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("shows the suspension, its reason and since when, to the sender", async () => {
+    fetchMock.mockReturnValue(json(200, standing({ status: "suspended", reason: "complaint_rate", since: "2026-08-18T13:00:00Z" })));
+    render(<SenderStatusNotice type="creator" target="alice" isSender />);
+    const notice = await screen.findByTestId("newsletter-sender-suspended");
+    expect(notice).toHaveTextContent("newsletter.suspended-title-creator");
+    expect(notice).toHaveTextContent("newsletter.suspended-reason-complaints");
+    expect(notice).toHaveTextContent("newsletter.suspended-help");
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/newsletter/sender?type=creator&target=alice");
+    expect(fetchMock.mock.calls[0][1].headers).toEqual({ "X-HS-Token": "mock-token" });
+  });
+
+  it("renders nothing while the sender is in good standing, and says why for a bounce suspension of a community", async () => {
+    fetchMock.mockReturnValue(json(200, standing({ status: "active" })));
+    const { container, unmount } = render(<SenderStatusNotice type="creator" target="alice" isSender />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(container.querySelector("[data-testid=newsletter-sender-suspended]")).toBeNull();
+    unmount();
+    fetchMock.mockReturnValue(json(200, standing({ type: "community", target: "hive-125125", status: "suspended", reason: "bounce_rate", since: "2026-08-18T13:00:00Z" })));
+    render(<SenderStatusNotice type="community" target="hive-125125" isSender />);
+    const notice = await screen.findByTestId("newsletter-sender-suspended");
+    expect(notice).toHaveTextContent("newsletter.suspended-title-community");
+    expect(notice).toHaveTextContent("newsletter.suspended-reason-bounces");
+  });
+
+  it("never asks when the viewer is not the sender, is logged out, or the feature is off", async () => {
+    fetchMock.mockReturnValue(json(200, standing({ status: "suspended", reason: "manual" })));
+    const { container: c1, unmount: u1 } = render(<SenderStatusNotice type="creator" target="alice" isSender={false} />);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(c1.textContent).toBe("");
+    u1();
+    loggedIn(null);
+    const { unmount: u2 } = render(<SenderStatusNotice type="creator" target="alice" isSender />);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchMock).not.toHaveBeenCalled();
+    u2();
+    loggedIn("alice");
+    flags.newsletter = false;
+    render(<SenderStatusNotice type="creator" target="alice" isSender />);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/specs/features/newsletter/sender-status.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/sender-status.spec.tsx
@@ -3,9 +3,9 @@ import { screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactElement } from "react";
 import { NewsletterRuntimeProvider } from "@/features/newsletter/runtime";
-import { SenderStatusNotice } from "@/features/newsletter";
+import { SenderStatusNotice, senderStandingKey } from "@/features/newsletter";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
-import { mockActiveUser, renderWithQueryClient } from "@/specs/test-utils";
+import { createTestQueryClient, mockActiveUser, renderWithQueryClient } from "@/specs/test-utils";
 
 const flags = vi.hoisted(() => ({ newsletter: true }));
 vi.mock("@/config", () => ({
@@ -46,7 +46,8 @@ function loggedIn(username: string | null) {
   } as never);
 }
 
-const render = (ui: ReactElement) => renderWithQueryClient(<NewsletterRuntimeProvider configured>{ui}</NewsletterRuntimeProvider>);
+const render = (ui: ReactElement, queryClient?: ReturnType<typeof createTestQueryClient>) =>
+  renderWithQueryClient(<NewsletterRuntimeProvider configured>{ui}</NewsletterRuntimeProvider>, queryClient ? { queryClient } : undefined);
 
 /** vision-web#1513: the suspension is visible to the sender, and only when there is one to see. */
 describe("SenderStatusNotice", () => {
@@ -80,6 +81,28 @@ describe("SenderStatusNotice", () => {
     const notice = await screen.findByTestId("newsletter-sender-suspended");
     expect(notice).toHaveTextContent("newsletter.suspended-title-community");
     expect(notice).toHaveTextContent("newsletter.suspended-reason-bounces");
+  });
+
+  it("a standing cached by one viewer is never shown to another: the key is scoped to the viewer and a non-sender renders nothing regardless", async () => {
+    // A team member (alice) fetched and saw the suspension...
+    fetchMock.mockReturnValue(json(200, standing({ type: "community", target: "hive-125125", status: "suspended", reason: "complaint_rate", since: "2026-08-18T13:00:00Z" })));
+    const client = createTestQueryClient();
+    const { unmount } = render(<SenderStatusNotice type="community" target="hive-125125" isSender />, client);
+    await screen.findByTestId("newsletter-sender-suspended");
+    expect(client.getQueryData(senderStandingKey("community", "hive-125125", "alice"))).toMatchObject({ status: "suspended" });
+    unmount();
+    // ...then a plain member (carol) opens the same page in the same browser, same cache.
+    loggedIn("carol");
+    fetchMock.mockReset();
+    const { container } = render(<SenderStatusNotice type="community" target="hive-125125" isSender={false} />, client);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(container.querySelector("[data-testid=newsletter-sender-suspended]")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    // Even a stale entry under carol's own key (say, from a role she since lost) is not shown once she is no longer a sender.
+    client.setQueryData(senderStandingKey("community", "hive-125125", "carol"), standing({ status: "suspended", reason: "manual" }));
+    const { container: c2 } = render(<SenderStatusNotice type="community" target="hive-125125" isSender={false} />, client);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(c2.querySelector("[data-testid=newsletter-sender-suspended]")).toBeNull();
   });
 
   it("never asks when the viewer is not the sender, is logged out, or the feature is off", async () => {

--- a/apps/web/src/specs/features/newsletter/sender-status.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/sender-status.spec.tsx
@@ -62,7 +62,7 @@ describe("SenderStatusNotice", () => {
   it("shows the suspension, its reason and since when, to the sender", async () => {
     fetchMock.mockReturnValue(json(200, standing({ status: "suspended", reason: "complaint_rate", since: "2026-08-18T13:00:00Z" })));
     render(<SenderStatusNotice type="creator" target="alice" isSender />);
-    const notice = await screen.findByTestId("newsletter-sender-suspended");
+    const notice = await screen.findByRole("status");
     expect(notice).toHaveTextContent("newsletter.suspended-title-creator");
     expect(notice).toHaveTextContent("newsletter.suspended-reason-complaints");
     expect(notice).toHaveTextContent("newsletter.suspended-help");
@@ -74,13 +74,23 @@ describe("SenderStatusNotice", () => {
     fetchMock.mockReturnValue(json(200, standing({ status: "active" })));
     const { container, unmount } = render(<SenderStatusNotice type="creator" target="alice" isSender />);
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    expect(container.querySelector("[data-testid=newsletter-sender-suspended]")).toBeNull();
+    expect(container.querySelector("[role=status]")).toBeNull();
     unmount();
     fetchMock.mockReturnValue(json(200, standing({ type: "community", target: "hive-125125", status: "suspended", reason: "bounce_rate", since: "2026-08-18T13:00:00Z" })));
     render(<SenderStatusNotice type="community" target="hive-125125" isSender />);
-    const notice = await screen.findByTestId("newsletter-sender-suspended");
+    const notice = await screen.findByRole("status");
     expect(notice).toHaveTextContent("newsletter.suspended-title-community");
     expect(notice).toHaveTextContent("newsletter.suspended-reason-bounces");
+  });
+
+  it("a manual suspension says so, and an unknown reason falls back to the manual wording", async () => {
+    fetchMock.mockReturnValue(json(200, standing({ status: "suspended", reason: "manual", since: "2026-08-18T13:00:00Z" })));
+    const { unmount } = render(<SenderStatusNotice type="creator" target="alice" isSender />);
+    expect(await screen.findByRole("status")).toHaveTextContent("newsletter.suspended-reason-manual");
+    unmount();
+    fetchMock.mockReturnValue(json(200, standing({ status: "suspended", reason: "something_new", since: null })));
+    render(<SenderStatusNotice type="creator" target="alice" isSender />);
+    expect(await screen.findByRole("status")).toHaveTextContent("newsletter.suspended-reason-manual");
   });
 
   it("a standing cached by one viewer is never shown to another: the key is scoped to the viewer and a non-sender renders nothing regardless", async () => {
@@ -88,7 +98,7 @@ describe("SenderStatusNotice", () => {
     fetchMock.mockReturnValue(json(200, standing({ type: "community", target: "hive-125125", status: "suspended", reason: "complaint_rate", since: "2026-08-18T13:00:00Z" })));
     const client = createTestQueryClient();
     const { unmount } = render(<SenderStatusNotice type="community" target="hive-125125" isSender />, client);
-    await screen.findByTestId("newsletter-sender-suspended");
+    await screen.findByRole("status");
     expect(client.getQueryData(senderStandingKey("community", "hive-125125", "alice"))).toMatchObject({ status: "suspended" });
     unmount();
     // ...then a plain member (carol) opens the same page in the same browser, same cache.
@@ -96,13 +106,13 @@ describe("SenderStatusNotice", () => {
     fetchMock.mockReset();
     const { container } = render(<SenderStatusNotice type="community" target="hive-125125" isSender={false} />, client);
     await new Promise((r) => setTimeout(r, 30));
-    expect(container.querySelector("[data-testid=newsletter-sender-suspended]")).toBeNull();
+    expect(container.querySelector("[role=status]")).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
     // Even a stale entry under carol's own key (say, from a role she since lost) is not shown once she is no longer a sender.
     client.setQueryData(senderStandingKey("community", "hive-125125", "carol"), standing({ status: "suspended", reason: "manual" }));
     const { container: c2 } = render(<SenderStatusNotice type="community" target="hive-125125" isSender={false} />, client);
     await new Promise((r) => setTimeout(r, 30));
-    expect(c2.querySelector("[data-testid=newsletter-sender-suspended]")).toBeNull();
+    expect(c2.querySelector("[role=status]")).toBeNull();
   });
 
   it("never asks when the viewer is not the sender, is logged out, or the feature is off", async () => {


### PR DESCRIPTION
Closes #1513. The service half landed in ecency/news #16 (rolling-window accounting, automatic suspension at the complaint and bounce thresholds, alerts to the operator, `GET /api/senders/:type/:target`); this is the half the acceptance criterion names: the suspension is visible **to the sender**.

- `GET /api/newsletter/sender?type=creator|community&target=` relays the standing to the sender only: the account itself for a creator digest, the community's owner/admin/mod (checked against the bridge `get_community` team with the viewer as observer) for a community digest; anyone else gets 403.
- `SenderStatusNotice`: on the creator's own profile card and on the community card for its team. Renders nothing while the sender is in good standing; when suspended, the reason (complaints, bounces, manual), since when, and what to do. The query runs only when the viewer is the sender, is logged in, and the feature is on.
- Specs: route gates (own account vs someone else's, team roles vs member/stranger/unknown community, bad input, missing identity, unconfigured service → 503) and the notice's states.

The numbers themselves stay in the API for the operator (`sender:status`) and for a fuller "digest health" surface when author sends arrive.