### PR TITLE
fix(editor): bind Ctrl/Cmd+B and anchor the emoji picker

### DIFF
--- a/apps/web/src/app/submit/_functions/handle-shortcuts.ts
+++ b/apps/web/src/app/submit/_functions/handle-shortcuts.ts
@@ -1,34 +1,6 @@
 import { KeyboardEvent } from "react";
-import { detectEvent } from "@/features/shared/editor-toolbar";
+import { handleEditorShortcut } from "@/features/shared/editor-toolbar/shortcuts";
 
 export function handleShortcuts(e: KeyboardEvent<HTMLDivElement>) {
-  if (!e.altKey) {
-    return;
-  }
-
-  switch (e.key) {
-    case "b":
-      detectEvent("bold");
-      break;
-    case "i":
-      detectEvent("italic");
-      break;
-    case "t":
-      detectEvent("table");
-      break;
-    case "k":
-      detectEvent("link");
-      break;
-    case "c":
-      detectEvent("codeBlock");
-      break;
-    case "d":
-      detectEvent("image");
-      break;
-    case "m":
-      detectEvent("blockquote");
-      break;
-    default:
-      return;
-  }
+  handleEditorShortcut(e);
 }

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -1948,8 +1948,8 @@
     "deleted": "Removed from favorites"
   },
   "editor-toolbar": {
-    "bold": "Bold (Alt + B)",
-    "italic": "Italic (Alt + I)",
+    "bold": "Bold (Ctrl + B)",
+    "italic": "Italic (Ctrl + I)",
     "header": "Heading",
     "code": "Code (Alt + C)",
     "quote": "Quote (Alt + M)",

--- a/apps/web/src/features/shared/comment/index.tsx
+++ b/apps/web/src/features/shared/comment/index.tsx
@@ -4,7 +4,8 @@ import defaults from "@/defaults";
 import { Entry } from "@/entities";
 import { AvailableCredits, handleAndReportError, LoginRequired } from "@/features/shared";
 import { CommentPreview } from "@/features/shared/comment/comment-preview";
-import { detectEvent, EditorToolbar, toolbarEventListener } from "@/features/shared/editor-toolbar";
+import { EditorToolbar, toolbarEventListener } from "@/features/shared/editor-toolbar";
+import { handleEditorShortcut } from "@/features/shared/editor-toolbar/shortcuts";
 import { TextareaAutocomplete } from "@/features/shared/textarea-autocomplete";
 import { PREFIX } from "@/utils/local-storage";
 import { createReplyPermlink, makeJsonMetaDataReply } from "@/utils";
@@ -254,27 +255,7 @@ export function Comment({
       }
       return;
     }
-    if (e.altKey && e.key === "b") {
-      detectEvent("bold");
-    }
-    if (e.altKey && e.key === "i") {
-      detectEvent("italic");
-    }
-    if (e.altKey && e.key === "t") {
-      detectEvent("table");
-    }
-    if (e.altKey && e.key === "k") {
-      detectEvent("link");
-    }
-    if (e.altKey && e.key === "c") {
-      detectEvent("codeBlock");
-    }
-    if (e.altKey && e.key === "d") {
-      detectEvent("image");
-    }
-    if (e.altKey && e.key === "m") {
-      detectEvent("blockquote");
-    }
+    handleEditorShortcut(e);
   };
   const isCommunityPost = isCommunity(entry.category);
   const canComment = isCommunityPost

--- a/apps/web/src/features/shared/editor-toolbar/events.ts
+++ b/apps/web/src/features/shared/editor-toolbar/events.ts
@@ -1,0 +1,16 @@
+/**
+ * The toolbar's action bus. Editors broadcast an action name on `window` and
+ * the toolbar whose editor holds focus applies it (see `EditorToolbar`).
+ *
+ * Kept apart from the toolbar component so shortcut handling can be imported,
+ * and tested, without dragging the whole toolbar along.
+ */
+export const detectEvent = (eventType: string) => {
+  const ev = new Event(eventType);
+  window.dispatchEvent(ev);
+};
+
+export const toolbarEventListener = (event: Event, eventType: string) => {
+  const ev = new CustomEvent("customToolbarEvent", { detail: { event, eventType } });
+  window.dispatchEvent(ev);
+};

--- a/apps/web/src/features/shared/editor-toolbar/index.tsx
+++ b/apps/web/src/features/shared/editor-toolbar/index.tsx
@@ -93,14 +93,43 @@ export function EditorToolbar({
     activeUserRef.current = activeUser;
   }, [activeUser]);
 
+  // Keyboard shortcuts are broadcast on `window`, so every mounted toolbar
+  // hears every one of them. An entry page runs several at once (the reply box
+  // plus an inline reply form under each comment). Acting on a shortcut
+  // that was typed in someone else's editor inserted the markdown into all of
+  // them and, because insertOrReplace focuses its target, moved the caret out
+  // of the box being typed in. Only the toolbar whose own editor holds focus
+  // may act.
+  //
+  // Toolbar buttons call these same handlers directly and are unaffected: a
+  // click moves focus to the button, so they must not go through this gate.
+  useEffect(() => {
+    const forFocusedEditor =
+      (handler: (e: Event) => void): EventListener =>
+      (e) => {
+        const el = getTargetEl();
+        if (el && document.activeElement === el) {
+          handler(e);
+        }
+      };
+
+    const listeners: [string, EventListener][] = [
+      ["bold", forFocusedEditor(bold)],
+      ["italic", forFocusedEditor(italic)],
+      ["table", forFocusedEditor(table)],
+      ["link", forFocusedEditor(() => setLink(true))],
+      ["codeBlock", forFocusedEditor(code)],
+      ["blockquote", forFocusedEditor(quote)],
+      ["image", forFocusedEditor(() => setImage(true))]
+    ];
+
+    listeners.forEach(([type, listener]) => window.addEventListener(type, listener));
+
+    return () => listeners.forEach(([type, listener]) => window.removeEventListener(type, listener));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useMount(() => {
-    window.addEventListener("bold", bold);
-    window.addEventListener("italic", italic);
-    window.addEventListener("table", table);
-    window.addEventListener("link", () => setLink(true));
-    window.addEventListener("codeBlock", code);
-    window.addEventListener("blockquote", quote);
-    window.addEventListener("image", () => setImage(true));
     // 🆕 Native drag-drop listeners on the editor
     const editor = rootRef.current?.parentElement?.querySelector(".the-editor");
 
@@ -109,22 +138,6 @@ export function EditorToolbar({
       editor.addEventListener("drop", (e) => drop(e as DragEvent));
       editor.addEventListener("paste", (e) => onPaste(e as ClipboardEvent));
     }
-
-    return () => {
-      window.removeEventListener("bold", bold);
-      window.removeEventListener("italic", italic);
-      window.removeEventListener("table", table);
-      window.removeEventListener("link", () => setLink(true));
-      window.removeEventListener("codeBlock", code);
-      window.removeEventListener("blockquote", quote);
-      window.removeEventListener("image", () => setImage(true));
-
-      if (editor) {
-        editor.removeEventListener("dragover", (e) => onDragOver(e as DragEvent));
-        editor.removeEventListener("drop", (e) => drop(e as DragEvent));
-        editor.removeEventListener("paste", (e) => onPaste(e as ClipboardEvent));
-      }
-    };
   });
 
   const getTargetEl = () => {

--- a/apps/web/src/features/shared/editor-toolbar/index.tsx
+++ b/apps/web/src/features/shared/editor-toolbar/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useRef, useState, useEffect } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMountedState } from "react-use";
 import { v4 } from "uuid";
 import { codeTagsSvg, emoticonHappyOutlineSvg, formatBoldSvg, formatItalicSvg, formatListBulletedSvg, formatListNumberedSvg, formatQuoteCloseSvg, formatTitleSvg, gifIcon, gridSvg, imageSvg, textShortSvg, videoSvg } from "@/assets/img/svg";
@@ -24,7 +24,6 @@ import { VideoUpload } from "@/features/shared/video-upload-threespeak";
 import { AddImage } from "@/features/shared/editor-toolbar/add-image";
 import { AddLink } from "@/features/shared/editor-toolbar/add-link";
 import { AddImageMobile } from "@/features/shared/editor-toolbar/add-image-mobile";
-import useMount from "react-use/lib/useMount";
 import { EcencyConfigManager } from "@/config";
 // Import directly from the file, NOT the "@/app/publish/_hooks" barrel:
 // the barrel re-exports use-publish-editor (the full TipTap/ProseMirror graph,
@@ -44,15 +43,7 @@ interface Props {
   readonlyPoll?: boolean;
 }
 
-export const detectEvent = (eventType: string) => {
-  const ev = new Event(eventType);
-  window.dispatchEvent(ev);
-};
-
-export const toolbarEventListener = (event: Event, eventType: string) => {
-  const ev = new CustomEvent("customToolbarEvent", { detail: { event, eventType } });
-  window.dispatchEvent(ev);
-};
+export { detectEvent, toolbarEventListener } from "./events";
 
 export function EditorToolbar({
   sm,
@@ -93,6 +84,32 @@ export function EditorToolbar({
     activeUserRef.current = activeUser;
   }, [activeUser]);
 
+  const getTargetEl = useCallback(() => {
+    const root = rootRef.current;
+    if (!root || !root.parentElement) {
+      return null;
+    }
+
+    return root.parentElement.querySelector(".the-editor") as HTMLInputElement | null;
+  }, []);
+
+  // The action handlers below are plain closures re-created on every render.
+  // The listener effects read them through this ref, so they are subscribed
+  // once yet always run the current render's version.
+  const handlersRef = useRef<Record<string, (e: Event) => void>>({});
+  handlersRef.current = {
+    bold: () => bold(),
+    italic: () => italic(),
+    table: (e) => table(e),
+    link: () => setLink(true),
+    codeBlock: () => code(),
+    blockquote: () => quote(),
+    image: () => setImage(true),
+    dragover: (e) => onDragOver(e as DragEvent),
+    drop: (e) => drop(e as DragEvent),
+    paste: (e) => onPaste(e as ClipboardEvent)
+  };
+
   // Keyboard shortcuts are broadcast on `window`, so every mounted toolbar
   // hears every one of them. An entry page runs several at once (the reply box
   // plus an inline reply form under each comment). Acting on a shortcut
@@ -105,49 +122,45 @@ export function EditorToolbar({
   // click moves focus to the button, so they must not go through this gate.
   useEffect(() => {
     const forFocusedEditor =
-      (handler: (e: Event) => void): EventListener =>
+      (action: string): EventListener =>
       (e) => {
         const el = getTargetEl();
         if (el && document.activeElement === el) {
-          handler(e);
+          handlersRef.current[action]?.(e);
         }
       };
 
     const listeners: [string, EventListener][] = [
-      ["bold", forFocusedEditor(bold)],
-      ["italic", forFocusedEditor(italic)],
-      ["table", forFocusedEditor(table)],
-      ["link", forFocusedEditor(() => setLink(true))],
-      ["codeBlock", forFocusedEditor(code)],
-      ["blockquote", forFocusedEditor(quote)],
-      ["image", forFocusedEditor(() => setImage(true))]
-    ];
+      "bold",
+      "italic",
+      "table",
+      "link",
+      "codeBlock",
+      "blockquote",
+      "image"
+    ].map((action) => [action, forFocusedEditor(action)]);
 
     listeners.forEach(([type, listener]) => window.addEventListener(type, listener));
 
     return () => listeners.forEach(([type, listener]) => window.removeEventListener(type, listener));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [getTargetEl]);
 
-  useMount(() => {
-    // 🆕 Native drag-drop listeners on the editor
-    const editor = rootRef.current?.parentElement?.querySelector(".the-editor");
-
-    if (editor) {
-      editor.addEventListener("dragover", (e) => onDragOver(e as DragEvent));
-      editor.addEventListener("drop", (e) => drop(e as DragEvent));
-      editor.addEventListener("paste", (e) => onPaste(e as ClipboardEvent));
-    }
-  });
-
-  const getTargetEl = () => {
-    const root = rootRef.current;
-    if (!root || !root.parentElement) {
-      return null;
+  // Native drag-drop and paste listeners on the editor.
+  useEffect(() => {
+    const editor = getTargetEl();
+    if (!editor) {
+      return;
     }
 
-    return root.parentElement.querySelector(".the-editor") as HTMLInputElement;
-  };
+    const listeners: [string, EventListener][] = ["dragover", "drop", "paste"].map((type) => [
+      type,
+      (e) => handlersRef.current[type]?.(e)
+    ]);
+
+    listeners.forEach(([type, listener]) => editor.addEventListener(type, listener));
+
+    return () => listeners.forEach(([type, listener]) => editor.removeEventListener(type, listener));
+  }, [getTargetEl]);
 
   const insertText = (before: string, after: string = "") => {
     const el = getTargetEl();

--- a/apps/web/src/features/shared/editor-toolbar/shortcuts.ts
+++ b/apps/web/src/features/shared/editor-toolbar/shortcuts.ts
@@ -1,5 +1,5 @@
 import { KeyboardEvent } from "react";
-import { detectEvent } from "./index";
+import { detectEvent } from "./events";
 
 /**
  * Ctrl/Cmd formatting shortcuts. These are the ones every editor on the web
@@ -27,22 +27,28 @@ const ALT_SHORTCUTS: Record<string, string> = {
 /**
  * The letter a shortcut is aimed at.
  *
- * `e.key` is the right source for Ctrl/Cmd combos (it follows the keyboard
- * layout), but Alt combos on macOS report a typographic character there:
- * Alt+B arrives as "∫", which is why the Alt shortcuts never worked on a Mac.
- * `e.code` names the physical key and covers that case, so either match counts.
+ * `e.key` follows the keyboard layout and is the only safe source for Ctrl/Cmd
+ * combos: on Dvorak, Cmd+C arrives as `key: "c", code: "KeyI"`, so reading the
+ * physical key there would fire italic and swallow the copy.
+ *
+ * Alt combos on macOS report a typographic character in `e.key` instead
+ * (Alt+B arrives as "∫"), which is why every Alt shortcut was dead on a Mac.
+ * The physical key is the only thing left to go on, so it is used as a fallback
+ * for those and only when `e.key` carries no letter at all.
  */
-function shortcutLetters(e: Pick<KeyboardEvent, "key" | "code">): string[] {
-  const letters: string[] = [];
-
+function shortcutLetter(
+  e: Pick<KeyboardEvent, "key" | "code">,
+  allowPhysicalKey: boolean
+): string | null {
   if (typeof e.key === "string" && /^[a-z]$/i.test(e.key)) {
-    letters.push(e.key.toLowerCase());
-  }
-  if (typeof e.code === "string" && /^Key[A-Z]$/.test(e.code)) {
-    letters.push(e.code.charAt(3).toLowerCase());
+    return e.key.toLowerCase();
   }
 
-  return letters;
+  if (allowPhysicalKey && typeof e.code === "string" && /^Key[A-Z]$/.test(e.code)) {
+    return e.code.charAt(3).toLowerCase();
+  }
+
+  return null;
 }
 
 /**
@@ -61,10 +67,8 @@ export function handleEditorShortcut(e: KeyboardEvent<HTMLElement>): boolean {
     return false;
   }
 
-  const table = hasCtrl ? CTRL_SHORTCUTS : ALT_SHORTCUTS;
-  const action = shortcutLetters(e)
-    .map((letter) => table[letter])
-    .find(Boolean);
+  const letter = shortcutLetter(e, !hasCtrl);
+  const action = letter ? (hasCtrl ? CTRL_SHORTCUTS : ALT_SHORTCUTS)[letter] : undefined;
 
   if (!action) {
     return false;

--- a/apps/web/src/features/shared/editor-toolbar/shortcuts.ts
+++ b/apps/web/src/features/shared/editor-toolbar/shortcuts.ts
@@ -1,0 +1,77 @@
+import { KeyboardEvent } from "react";
+import { detectEvent } from "./index";
+
+/**
+ * Ctrl/Cmd formatting shortcuts. These are the ones every editor on the web
+ * binds, so people press them here too and expect the same result.
+ *
+ * Firefox binds Ctrl+B to the bookmarks sidebar and Ctrl+I to page info, so the
+ * keystroke has to be claimed with preventDefault or the browser takes it.
+ */
+const CTRL_SHORTCUTS: Record<string, string> = {
+  b: "bold",
+  i: "italic"
+};
+
+/** Legacy Alt shortcuts, advertised in the toolbar tooltips. */
+const ALT_SHORTCUTS: Record<string, string> = {
+  b: "bold",
+  i: "italic",
+  t: "table",
+  k: "link",
+  c: "codeBlock",
+  d: "image",
+  m: "blockquote"
+};
+
+/**
+ * The letter a shortcut is aimed at.
+ *
+ * `e.key` is the right source for Ctrl/Cmd combos (it follows the keyboard
+ * layout), but Alt combos on macOS report a typographic character there:
+ * Alt+B arrives as "∫", which is why the Alt shortcuts never worked on a Mac.
+ * `e.code` names the physical key and covers that case, so either match counts.
+ */
+function shortcutLetters(e: Pick<KeyboardEvent, "key" | "code">): string[] {
+  const letters: string[] = [];
+
+  if (typeof e.key === "string" && /^[a-z]$/i.test(e.key)) {
+    letters.push(e.key.toLowerCase());
+  }
+  if (typeof e.code === "string" && /^Key[A-Z]$/.test(e.code)) {
+    letters.push(e.code.charAt(3).toLowerCase());
+  }
+
+  return letters;
+}
+
+/**
+ * Maps a keydown on a markdown editor to a toolbar action and dispatches it.
+ * Returns true when the keystroke was consumed.
+ *
+ * The action is broadcast on `window` and picked up by the toolbar that owns
+ * the focused editor (see `EditorToolbar`), which is what keeps the insertion
+ * in the composer the person is actually typing in.
+ */
+export function handleEditorShortcut(e: KeyboardEvent<HTMLElement>): boolean {
+  const hasCtrl = e.ctrlKey || e.metaKey;
+
+  // Alt+Ctrl and Shift combinations belong to the browser / OS, not to us.
+  if (hasCtrl === e.altKey || e.shiftKey) {
+    return false;
+  }
+
+  const table = hasCtrl ? CTRL_SHORTCUTS : ALT_SHORTCUTS;
+  const action = shortcutLetters(e)
+    .map((letter) => table[letter])
+    .find(Boolean);
+
+  if (!action) {
+    return false;
+  }
+
+  e.preventDefault();
+  detectEvent(action);
+
+  return true;
+}

--- a/apps/web/src/features/ui/emoji-picker/_index.scss
+++ b/apps/web/src/features/ui/emoji-picker/_index.scss
@@ -1,11 +1,17 @@
 @import "src/styles/vars_mixins";
 
 .emoji-picker-dialog {
-  position: absolute;
   z-index: 201;
 
   em-emoji-picker {
     width: 300px;
+    // Set by the `size` middleware from the room actually left in the viewport,
+    // so a short window (or a phone held sideways) gets a shorter panel instead
+    // of one running off the edge of the screen. emoji-mart defaults to a fixed
+    // 435px with a 230px floor on its own :host. Outside CSS is what beats
+    // :host, so without clearing the floor the panel cannot shrink to fit.
+    min-height: 0;
+    height: var(--emoji-picker-height, 435px);
   }
 
   @include media-breakpoint-down(sm) {
@@ -21,6 +27,9 @@
 
     em-emoji-picker {
       width: 100%;
+      // Full height as a bottom sheet: the anchored measurement above is for
+      // the popover layout, which this breakpoint replaces.
+      height: 435px;
     }
 
     > div {

--- a/apps/web/src/features/ui/emoji-picker/_index.scss
+++ b/apps/web/src/features/ui/emoji-picker/_index.scss
@@ -5,6 +5,7 @@
 
   em-emoji-picker {
     width: 300px;
+
     // Set by the `size` middleware from the room actually left in the viewport,
     // so a short window (or a phone held sideways) gets a shorter panel instead
     // of one running off the edge of the screen. emoji-mart defaults to a fixed
@@ -27,9 +28,13 @@
 
     em-emoji-picker {
       width: 100%;
+
       // Full height as a bottom sheet: the anchored measurement above is for
-      // the popover layout, which this breakpoint replaces.
+      // the popover layout, which this breakpoint replaces. Capped to the
+      // dynamic viewport so a phone held sideways still shows the whole sheet;
+      // the plain value stays first for browsers without dvh.
       height: 435px;
+      height: min(435px, calc(100dvh - 16px));
     }
 
     > div {

--- a/apps/web/src/features/ui/emoji-picker/index.tsx
+++ b/apps/web/src/features/ui/emoji-picker/index.tsx
@@ -27,12 +27,10 @@ interface Props {
   position?: "top" | "bottom";
 }
 
-// emoji-mart sizes the picker from its own `:host` rule. Outside CSS beats
-// `:host`, so these are the numbers the panel is actually laid out with and the
-// range we may squeeze it into when the viewport is short - the floor is ours,
-// low enough that a phone held sideways still gets a panel that fits.
+// emoji-mart sizes the picker from its own `:host` rule (435px tall). Outside
+// CSS beats `:host`, so this is the height the panel is actually laid out with
+// and the most it may take; when the viewport leaves less room it gets less.
 const PICKER_HEIGHT = 435;
-const PICKER_MIN_HEIGHT = 180;
 const VIEWPORT_PADDING = 8;
 
 export function EmojiPicker({
@@ -71,9 +69,12 @@ export function EmojiPicker({
       size({
         padding: VIEWPORT_PADDING,
         apply({ availableHeight, elements }) {
+          // Never taller than the room left on the chosen side: a floor here
+          // would push the panel back off-screen on a very short viewport, and
+          // the panel scrolls internally, so a shorter one is still usable.
           elements.floating.style.setProperty(
             "--emoji-picker-height",
-            `${Math.max(PICKER_MIN_HEIGHT, Math.min(PICKER_HEIGHT, Math.floor(availableHeight)))}px`
+            `${Math.min(PICKER_HEIGHT, Math.max(0, Math.floor(availableHeight)))}px`
           );
         }
       })

--- a/apps/web/src/features/ui/emoji-picker/index.tsx
+++ b/apps/web/src/features/ui/emoji-picker/index.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { useEffect, useRef, useState, type CSSProperties, type MutableRefObject } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MutableRefObject
+} from "react";
+import { createPortal } from "react-dom";
+import { flip, offset, shift, size, useFloating } from "@floating-ui/react-dom";
 import "./_index.scss";
 import Picker from "@emoji-mart/react";
 import emojiData from "@emoji-mart/data";
 import { useGlobalStore } from "@/core/global-store";
-import { classNameObject } from "@ui/util";
+import { classNameObject, safeAutoUpdate } from "@ui/util";
 
 interface Props {
   show: boolean;
@@ -18,8 +27,13 @@ interface Props {
   position?: "top" | "bottom";
 }
 
-const PICKER_ESTIMATED_HEIGHT = 380;
-const PICKER_ESTIMATED_WIDTH = 340;
+// emoji-mart sizes the picker from its own `:host` rule. Outside CSS beats
+// `:host`, so these are the numbers the panel is actually laid out with and the
+// range we may squeeze it into when the viewport is short - the floor is ours,
+// low enough that a phone held sideways still gets a panel that fits.
+const PICKER_HEIGHT = 435;
+const PICKER_MIN_HEIGHT = 180;
+const VIEWPORT_PADDING = 8;
 
 export function EmojiPicker({
   show,
@@ -34,39 +48,55 @@ export function EmojiPicker({
   const internalRootRef = useRef<HTMLDivElement | null>(null);
   const ref = rootRef ?? internalRootRef;
   const theme = useGlobalStore((state) => state.theme);
-  const [pickerPosition, setPickerPosition] = useState<{ top: number; left: number } | null>(null);
+  const [portalContainer, setPortalContainer] = useState<Element | null>(null);
 
-  // Calculate position when picker is shown
+  // Anchored to the trigger and measured from the panel's real size. The
+  // previous version guessed the size and wrote the coordinates from an effect
+  // that ran after the first paint, without ever recalculating. It flashed at
+  // its static position (a whole viewport away on a scrolled page), jumped to
+  // the estimate, hung 47px off the bottom of the screen because the estimate
+  // was 55px short of the real height then stayed put while the page scrolled.
+  const { refs, floatingStyles, isPositioned } = useFloating({
+    strategy: "fixed",
+    // `-end` keeps the panel's trailing edge on the trigger's trailing edge.
+    placement: position === "top" ? "top-end" : "bottom-end",
+    // Write top/left rather than a transform, so the small-screen stylesheet
+    // can still pin the panel as a bottom sheet.
+    transform: false,
+    whileElementsMounted: safeAutoUpdate,
+    middleware: [
+      offset(8),
+      flip({ padding: VIEWPORT_PADDING }),
+      shift({ padding: VIEWPORT_PADDING }),
+      size({
+        padding: VIEWPORT_PADDING,
+        apply({ availableHeight, elements }) {
+          elements.floating.style.setProperty(
+            "--emoji-picker-height",
+            `${Math.max(PICKER_MIN_HEIGHT, Math.min(PICKER_HEIGHT, Math.floor(availableHeight)))}px`
+          );
+        }
+      })
+    ]
+  });
+
+  const { setReference, setFloating } = refs;
+
   useEffect(() => {
-    if (!show || !buttonRef?.current) {
-      return;
-    }
+    setReference(buttonRef?.current ?? null);
+  }, [buttonRef, setReference]);
 
-    const rect = buttonRef.current.getBoundingClientRect();
-    let top: number;
-    let left: number;
+  useEffect(() => {
+    setPortalContainer(document.getElementById("popper-container") ?? document.body);
+  }, []);
 
-    // Align the picker to the right edge of the trigger button
-    const desiredLeft = rect.right - PICKER_ESTIMATED_WIDTH;
-
-    if (position === "top") {
-      top = rect.top - PICKER_ESTIMATED_HEIGHT - 8;
-    } else {
-      top = rect.bottom + 8;
-    }
-
-    // Clamp top so it stays on screen
-    const minTop = 8;
-    const maxTop = window.innerHeight - PICKER_ESTIMATED_HEIGHT - 8;
-    top = Math.max(minTop, Math.min(top, maxTop));
-
-    // Clamp left so it stays on screen
-    const minLeft = 8;
-    const maxLeft = window.innerWidth - PICKER_ESTIMATED_WIDTH - 8;
-    left = Math.max(minLeft, Math.min(desiredLeft, maxLeft));
-
-    setPickerPosition({ top, left });
-  }, [show, buttonRef, position]);
+  const setDialogRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      ref.current = node;
+      setFloating(node);
+    },
+    [ref, setFloating]
+  );
 
   // Handle click outside to close picker (same pattern as GIF picker)
   useEffect(() => {
@@ -100,19 +130,24 @@ export function EmojiPicker({
     return () => {
       document.removeEventListener("pointerdown", handlePointerDown);
     };
-  }, [show, changeState, buttonRef]);
+  }, [show, changeState, buttonRef, ref]);
+
+  if (!show || !portalContainer) {
+    return null;
+  }
 
   const mergedStyle: CSSProperties = {
-    position: "fixed",
-    top: pickerPosition?.top,
-    left: pickerPosition?.left,
+    ...floatingStyles,
     zIndex: 9999,
+    // Nothing is drawn until the panel has been measured against the viewport,
+    // otherwise the first paint lands at the top-left corner.
+    visibility: isPositioned ? "visible" : "hidden",
     ...style
   };
 
-  return (
+  return createPortal(
     <div
-      ref={ref}
+      ref={setDialogRef}
       className={classNameObject({
         "emoji-picker-dialog": true
       })}
@@ -133,6 +168,7 @@ export function EmojiPicker({
         set="native"
         theme={theme === "day" ? "light" : "dark"}
       />
-    </div>
+    </div>,
+    portalContainer
   );
 }

--- a/apps/web/src/specs/features/shared/comment.spec.tsx
+++ b/apps/web/src/specs/features/shared/comment.spec.tsx
@@ -88,6 +88,7 @@ vi.mock("@/utils", () => ({
 }));
 
 import { Comment } from "@/features/shared/comment";
+import { detectEvent } from "@/features/shared/editor-toolbar";
 
 const entry = {
   author: "alice",
@@ -184,6 +185,45 @@ describe("Comment composer", () => {
     const { queryByRole } = renderComment();
 
     expect(queryByRole("status")).toBeNull();
+  });
+
+  test("Ctrl+B emphasises from the composer", () => {
+    const { getByTestId, container } = renderComment();
+
+    type(getByTestId, "hello world");
+    fireEvent.keyDown(container.querySelector(".comment-body")!, {
+      key: "b",
+      code: "KeyB",
+      ctrlKey: true
+    });
+
+    expect(detectEvent).toHaveBeenCalledWith("bold");
+  });
+
+  test("Cmd+I emphasises from the composer", () => {
+    const { getByTestId, container } = renderComment();
+
+    type(getByTestId, "hello world");
+    fireEvent.keyDown(container.querySelector(".comment-body")!, {
+      key: "i",
+      code: "KeyI",
+      metaKey: true
+    });
+
+    expect(detectEvent).toHaveBeenCalledWith("italic");
+  });
+
+  test("Ctrl+B does not submit the reply", () => {
+    const { onSubmit, getByTestId, container } = renderComment();
+
+    type(getByTestId, "hello world");
+    fireEvent.keyDown(container.querySelector(".comment-body")!, {
+      key: "b",
+      code: "KeyB",
+      ctrlKey: true
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   test("Cmd/Ctrl+Enter is suppressed while the mention dropdown is open", () => {

--- a/apps/web/src/specs/features/shared/comment.spec.tsx
+++ b/apps/web/src/specs/features/shared/comment.spec.tsx
@@ -8,7 +8,6 @@ import type { Entry } from "@/entities";
 // --- Mock the heavy children so we can exercise the composer logic in isolation ---
 vi.mock("@/features/shared/editor-toolbar", () => ({
   EditorToolbar: () => null,
-  detectEvent: vi.fn(),
   toolbarEventListener: vi.fn()
 }));
 
@@ -88,7 +87,6 @@ vi.mock("@/utils", () => ({
 }));
 
 import { Comment } from "@/features/shared/comment";
-import { detectEvent } from "@/features/shared/editor-toolbar";
 
 const entry = {
   author: "alice",
@@ -108,8 +106,16 @@ function renderComment(onSubmit = vi.fn().mockResolvedValue(undefined)) {
   return { onSubmit, ...utils };
 }
 
-function type(getByTestId: (testId: string) => HTMLElement, value: string) {
-  fireEvent.change(getByTestId("comment-textarea"), { target: { value } });
+function type(getByRole: (role: string) => HTMLElement, value: string) {
+  fireEvent.change(getByRole("textbox"), { target: { value } });
+}
+
+// The composer hands formatting to the toolbar as a DOM event on `window`
+// (the toolbar itself is mocked out above); this is that boundary.
+function listenFor(action: string) {
+  const heard = vi.fn();
+  window.addEventListener(action, heard, { once: true });
+  return heard;
 }
 
 describe("Comment composer", () => {
@@ -119,9 +125,9 @@ describe("Comment composer", () => {
   });
 
   test("Cmd/Ctrl+Enter submits the typed comment", async () => {
-    const { onSubmit, getByTestId, container } = renderComment();
+    const { onSubmit, getByRole, container } = renderComment();
 
-    type(getByTestId, "hello world");
+    type(getByRole, "hello world");
     const body = container.querySelector(".comment-body")!;
     fireEvent.keyDown(body, { key: "Enter", ctrlKey: true });
 
@@ -129,9 +135,9 @@ describe("Comment composer", () => {
   });
 
   test("plain Enter does NOT submit (newline behavior preserved)", () => {
-    const { onSubmit, getByTestId, container } = renderComment();
+    const { onSubmit, getByRole, container } = renderComment();
 
-    type(getByTestId, "hello");
+    type(getByRole, "hello");
     fireEvent.keyDown(container.querySelector(".comment-body")!, { key: "Enter" });
 
     expect(onSubmit).not.toHaveBeenCalled();
@@ -146,38 +152,38 @@ describe("Comment composer", () => {
   });
 
   test("warns that a reply too short to earn points will not count", () => {
-    const { getByTestId, getByRole } = renderComment();
+    const { getByRole } = renderComment();
 
-    type(getByTestId, "Thank you");
+    type(getByRole, "Thank you");
 
     expect(getByRole("status")).toBeTruthy();
   });
 
   test("counts a link-only reply as too short, matching the backend rule", () => {
-    const { getByTestId, getByRole } = renderComment();
+    const { getByRole } = renderComment();
 
-    type(getByTestId, "https://i.example.com/a-very-long-image-url-here.gif");
+    type(getByRole, "https://i.example.com/a-very-long-image-url-here.gif");
 
     expect(getByRole("status")).toBeTruthy();
   });
 
   test("counts emoji as the backend does, not as UTF-16 code units", () => {
-    const { getByTestId, getByRole } = renderComment();
+    const { getByRole } = renderComment();
 
     // 13 astral emoji measure as 13 code points, under the minimum. Counting UTF-16
     // units would score them as 26 and wrongly promise points.
-    type(getByTestId, "😂".repeat(13));
+    type(getByRole, "😂".repeat(13));
 
     expect(getByRole("status")).toBeTruthy();
   });
 
   test("drops the warning once the reply is long enough to earn", () => {
-    const { getByTestId, getByRole, queryByRole } = renderComment();
+    const { getByRole, queryByRole } = renderComment();
 
-    type(getByTestId, "Thank you");
+    type(getByRole, "Thank you");
     expect(getByRole("status")).toBeTruthy();
 
-    type(getByTestId, "Thank you, this is a genuinely useful reply with something to say");
+    type(getByRole, "Thank you, this is a genuinely useful reply with something to say");
     expect(queryByRole("status")).toBeNull();
   });
 
@@ -187,36 +193,38 @@ describe("Comment composer", () => {
     expect(queryByRole("status")).toBeNull();
   });
 
-  test("Ctrl+B emphasises from the composer", () => {
-    const { getByTestId, container } = renderComment();
+  test("Ctrl+B asks the toolbar for bold", () => {
+    const { getByRole, container } = renderComment();
+    const bold = listenFor("bold");
 
-    type(getByTestId, "hello world");
+    type(getByRole, "hello world");
     fireEvent.keyDown(container.querySelector(".comment-body")!, {
       key: "b",
       code: "KeyB",
       ctrlKey: true
     });
 
-    expect(detectEvent).toHaveBeenCalledWith("bold");
+    expect(bold).toHaveBeenCalledTimes(1);
   });
 
-  test("Cmd+I emphasises from the composer", () => {
-    const { getByTestId, container } = renderComment();
+  test("Cmd+I asks the toolbar for italic", () => {
+    const { getByRole, container } = renderComment();
+    const italic = listenFor("italic");
 
-    type(getByTestId, "hello world");
+    type(getByRole, "hello world");
     fireEvent.keyDown(container.querySelector(".comment-body")!, {
       key: "i",
       code: "KeyI",
       metaKey: true
     });
 
-    expect(detectEvent).toHaveBeenCalledWith("italic");
+    expect(italic).toHaveBeenCalledTimes(1);
   });
 
   test("Ctrl+B does not submit the reply", () => {
-    const { onSubmit, getByTestId, container } = renderComment();
+    const { onSubmit, getByRole, container } = renderComment();
 
-    type(getByTestId, "hello world");
+    type(getByRole, "hello world");
     fireEvent.keyDown(container.querySelector(".comment-body")!, {
       key: "b",
       code: "KeyB",
@@ -227,9 +235,9 @@ describe("Comment composer", () => {
   });
 
   test("Cmd/Ctrl+Enter is suppressed while the mention dropdown is open", () => {
-    const { onSubmit, getByTestId, container } = renderComment();
+    const { onSubmit, getByRole, container } = renderComment();
 
-    type(getByTestId, "hey @al");
+    type(getByRole, "hey @al");
     // Simulate the react-textarea-autocomplete dropdown being open.
     const body = container.querySelector(".comment-body")!;
     body.insertAdjacentHTML("beforeend", '<div class="rta__autocomplete"></div>');

--- a/apps/web/src/specs/features/shared/editor-shortcuts.spec.ts
+++ b/apps/web/src/specs/features/shared/editor-shortcuts.spec.ts
@@ -1,12 +1,16 @@
 import { vi } from "vitest";
 import type { KeyboardEvent } from "react";
-
-vi.mock("@/features/shared/editor-toolbar", () => ({
-  detectEvent: vi.fn()
-}));
-
-import { detectEvent } from "@/features/shared/editor-toolbar";
 import { handleEditorShortcut } from "@/features/shared/editor-toolbar/shortcuts";
+
+// A matched shortcut is broadcast as a DOM event on `window`, which the toolbar
+// owning the focused editor picks up. Every action name is watched, so a test
+// can assert both what fired and that nothing else did.
+const ACTIONS = ["bold", "italic", "table", "link", "codeBlock", "blockquote", "image"];
+const fired: string[] = [];
+const record = (e: Event) => fired.push(e.type);
+
+beforeAll(() => ACTIONS.forEach((a) => window.addEventListener(a, record)));
+afterAll(() => ACTIONS.forEach((a) => window.removeEventListener(a, record)));
 
 interface KeyInit {
   key?: string;
@@ -17,7 +21,7 @@ interface KeyInit {
   shiftKey?: boolean;
 }
 
-function press(init: KeyInit) {
+function press(init: KeyInit): { handled: boolean; preventDefault: ReturnType<typeof vi.fn> } {
   const preventDefault = vi.fn();
   const event = {
     key: "",
@@ -34,7 +38,9 @@ function press(init: KeyInit) {
 }
 
 describe("editor keyboard shortcuts", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    fired.length = 0;
+  });
 
   test("Ctrl+B asks for bold and keeps the keystroke from the browser", () => {
     // Firefox binds Ctrl+B to the bookmarks sidebar, so not preventing the
@@ -43,26 +49,26 @@ describe("editor keyboard shortcuts", () => {
 
     expect(handled).toBe(true);
     expect(preventDefault).toHaveBeenCalled();
-    expect(detectEvent).toHaveBeenCalledWith("bold");
+    expect(fired).toEqual(["bold"]);
   });
 
   test("Cmd+B asks for bold", () => {
     press({ key: "b", code: "KeyB", metaKey: true });
 
-    expect(detectEvent).toHaveBeenCalledWith("bold");
+    expect(fired).toEqual(["bold"]);
   });
 
   test("Ctrl+I asks for italic", () => {
     press({ key: "i", code: "KeyI", ctrlKey: true });
 
-    expect(detectEvent).toHaveBeenCalledWith("italic");
+    expect(fired).toEqual(["italic"]);
   });
 
   test("Alt+B still asks for bold", () => {
     const { handled } = press({ key: "b", code: "KeyB", altKey: true });
 
     expect(handled).toBe(true);
-    expect(detectEvent).toHaveBeenCalledWith("bold");
+    expect(fired).toEqual(["bold"]);
   });
 
   test("Alt+B on macOS asks for bold", () => {
@@ -71,7 +77,7 @@ describe("editor keyboard shortcuts", () => {
     const { handled } = press({ key: "∫", code: "KeyB", altKey: true });
 
     expect(handled).toBe(true);
-    expect(detectEvent).toHaveBeenCalledWith("bold");
+    expect(fired).toEqual(["bold"]);
   });
 
   test.each([
@@ -83,7 +89,21 @@ describe("editor keyboard shortcuts", () => {
   ])("Alt+%s asks for %s", (letter, action) => {
     press({ key: letter, code: `Key${letter.toUpperCase()}`, altKey: true });
 
-    expect(detectEvent).toHaveBeenCalledWith(action);
+    expect(fired).toEqual([action]);
+  });
+
+  test.each([
+    ["Cmd+C", { key: "c", code: "KeyI", metaKey: true }],
+    ["Cmd+X", { key: "x", code: "KeyB", metaKey: true }]
+  ])("%s on a Dvorak layout is left to the browser", (_label, init) => {
+    // Dvorak sends the letter in `key` and a different physical key in `code`,
+    // so reading `code` for Ctrl/Cmd combos would fire italic/bold here and
+    // swallow the copy and the cut.
+    const { handled, preventDefault } = press(init);
+
+    expect(handled).toBe(false);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(fired).toEqual([]);
   });
 
   test("Ctrl is only bound to bold and italic", () => {
@@ -93,7 +113,7 @@ describe("editor keyboard shortcuts", () => {
 
     expect(handled).toBe(false);
     expect(preventDefault).not.toHaveBeenCalled();
-    expect(detectEvent).not.toHaveBeenCalled();
+    expect(fired).toEqual([]);
   });
 
   test.each([
@@ -106,6 +126,6 @@ describe("editor keyboard shortcuts", () => {
 
     expect(handled).toBe(false);
     expect(preventDefault).not.toHaveBeenCalled();
-    expect(detectEvent).not.toHaveBeenCalled();
+    expect(fired).toEqual([]);
   });
 });

--- a/apps/web/src/specs/features/shared/editor-shortcuts.spec.ts
+++ b/apps/web/src/specs/features/shared/editor-shortcuts.spec.ts
@@ -1,0 +1,111 @@
+import { vi } from "vitest";
+import type { KeyboardEvent } from "react";
+
+vi.mock("@/features/shared/editor-toolbar", () => ({
+  detectEvent: vi.fn()
+}));
+
+import { detectEvent } from "@/features/shared/editor-toolbar";
+import { handleEditorShortcut } from "@/features/shared/editor-toolbar/shortcuts";
+
+interface KeyInit {
+  key?: string;
+  code?: string;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+}
+
+function press(init: KeyInit) {
+  const preventDefault = vi.fn();
+  const event = {
+    key: "",
+    code: "",
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...init,
+    preventDefault
+  } as unknown as KeyboardEvent<HTMLElement>;
+
+  return { handled: handleEditorShortcut(event), preventDefault };
+}
+
+describe("editor keyboard shortcuts", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("Ctrl+B asks for bold and keeps the keystroke from the browser", () => {
+    // Firefox binds Ctrl+B to the bookmarks sidebar, so not preventing the
+    // default means the browser eats it and nothing is emphasised.
+    const { handled, preventDefault } = press({ key: "b", code: "KeyB", ctrlKey: true });
+
+    expect(handled).toBe(true);
+    expect(preventDefault).toHaveBeenCalled();
+    expect(detectEvent).toHaveBeenCalledWith("bold");
+  });
+
+  test("Cmd+B asks for bold", () => {
+    press({ key: "b", code: "KeyB", metaKey: true });
+
+    expect(detectEvent).toHaveBeenCalledWith("bold");
+  });
+
+  test("Ctrl+I asks for italic", () => {
+    press({ key: "i", code: "KeyI", ctrlKey: true });
+
+    expect(detectEvent).toHaveBeenCalledWith("italic");
+  });
+
+  test("Alt+B still asks for bold", () => {
+    const { handled } = press({ key: "b", code: "KeyB", altKey: true });
+
+    expect(handled).toBe(true);
+    expect(detectEvent).toHaveBeenCalledWith("bold");
+  });
+
+  test("Alt+B on macOS asks for bold", () => {
+    // Option+B produces "∫" in `key` there, which is why matching on `key`
+    // alone left every Alt shortcut dead on a Mac.
+    const { handled } = press({ key: "∫", code: "KeyB", altKey: true });
+
+    expect(handled).toBe(true);
+    expect(detectEvent).toHaveBeenCalledWith("bold");
+  });
+
+  test.each([
+    ["t", "table"],
+    ["k", "link"],
+    ["c", "codeBlock"],
+    ["d", "image"],
+    ["m", "blockquote"]
+  ])("Alt+%s asks for %s", (letter, action) => {
+    press({ key: letter, code: `Key${letter.toUpperCase()}`, altKey: true });
+
+    expect(detectEvent).toHaveBeenCalledWith(action);
+  });
+
+  test("Ctrl is only bound to bold and italic", () => {
+    // The other toolbar actions stay on Alt: claiming Ctrl+K would take the
+    // browser's address bar shortcut away from people.
+    const { handled, preventDefault } = press({ key: "k", code: "KeyK", ctrlKey: true });
+
+    expect(handled).toBe(false);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(detectEvent).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["a bare letter", { key: "b", code: "KeyB" }],
+    ["Ctrl+Shift+B", { key: "B", code: "KeyB", ctrlKey: true, shiftKey: true }],
+    ["Ctrl+Alt+B", { key: "b", code: "KeyB", ctrlKey: true, altKey: true }],
+    ["a non-letter key", { key: "Enter", code: "Enter", ctrlKey: true }]
+  ])("%s is left alone", (_label, init) => {
+    const { handled, preventDefault } = press(init);
+
+    expect(handled).toBe(false);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(detectEvent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/specs/features/shared/editor-toolbar.spec.tsx
+++ b/apps/web/src/specs/features/shared/editor-toolbar.spec.tsx
@@ -1,0 +1,116 @@
+import { vi } from "vitest";
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// The toolbar's own text insertion (input-util) is the behaviour under test,
+// so it stays real; only the token/session plumbing that rides along in the
+// same barrel is stubbed.
+vi.mock("@/utils", async () => {
+  const inputUtil = await vi.importActual<Record<string, unknown>>("@/utils/input-util");
+  return {
+    ...inputUtil,
+    random: vi.fn(() => "rnd"),
+    getAccessToken: vi.fn(() => "mock-token"),
+    ensureValidToken: vi.fn(async () => "mock-token")
+  };
+});
+vi.mock("@/api/sdk-mutations", () => ({
+  useUploadImageMutation: () => ({ mutateAsync: vi.fn(), isPending: false })
+}));
+vi.mock("@/core/global-store", () => ({
+  useGlobalStore: (selector: (s: { theme: string }) => unknown) => selector({ theme: "day" })
+}));
+
+import { EditorToolbar } from "@/features/shared/editor-toolbar";
+import { handleEditorShortcut } from "@/features/shared/editor-toolbar/shortcuts";
+
+// One markdown composer as the comment box and the /submit page assemble it:
+// the toolbar next to a `.the-editor` textarea, with the shortcut handler on
+// the wrapper the way `Comment` and `/submit` attach it.
+function Composer({ name, value }: { name: string; value: string }) {
+  return (
+    <div role="presentation" onKeyDown={handleEditorShortcut}>
+      <EditorToolbar comment={true} sm={true} />
+      <textarea className="the-editor" aria-label={name} defaultValue={value} />
+    </div>
+  );
+}
+
+function renderComposers(): void {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <Composer name="first" value="alpha" />
+      <Composer name="second" value="beta" />
+    </QueryClientProvider>
+  );
+}
+
+function focusAndSelect(name: string, start: number, end: number): HTMLTextAreaElement {
+  const box = screen.getByRole("textbox", { name }) as HTMLTextAreaElement;
+  box.focus();
+  box.setSelectionRange(start, end);
+  return box;
+}
+
+describe("EditorToolbar", () => {
+  test("Ctrl+B wraps the selection of the composer being typed in", () => {
+    renderComposers();
+    const first = focusAndSelect("first", 0, 5);
+
+    fireEvent.keyDown(first, { key: "b", code: "KeyB", ctrlKey: true });
+
+    expect(first).toHaveValue("**alpha**");
+  });
+
+  test("Ctrl+I wraps the selection with single stars", () => {
+    renderComposers();
+    const first = focusAndSelect("first", 0, 5);
+
+    fireEvent.keyDown(first, { key: "i", code: "KeyI", ctrlKey: true });
+
+    expect(first).toHaveValue("*alpha*");
+  });
+
+  test("a shortcut leaves every other composer on the page alone", () => {
+    // Every mounted toolbar hears the same window event. Before the focus
+    // gate, this keystroke produced `beta****` in the second box and moved the
+    // caret there.
+    renderComposers();
+    const first = focusAndSelect("first", 0, 5);
+    const second = screen.getByRole("textbox", { name: "second" });
+
+    fireEvent.keyDown(first, { key: "b", code: "KeyB", ctrlKey: true });
+
+    expect(first).toHaveValue("**alpha**");
+    expect(second).toHaveValue("beta");
+    expect(document.activeElement).toBe(first);
+  });
+
+  test("a shortcut with no editor focused does nothing", () => {
+    // Nothing to aim at: acting anyway would format whichever box happened to
+    // be mounted first, exactly the bug the gate is for.
+    renderComposers();
+    (document.activeElement as HTMLElement | null)?.blur();
+
+    window.dispatchEvent(new Event("bold"));
+
+    expect(screen.getByRole("textbox", { name: "first" })).toHaveValue("alpha");
+    expect(screen.getByRole("textbox", { name: "second" })).toHaveValue("beta");
+  });
+
+  test("the toolbar button formats its own composer without needing focus", () => {
+    // Clicking a button moves focus onto the button, so the button path must
+    // not go through the focus gate.
+    renderComposers();
+    focusAndSelect("second", 0, 4);
+
+    const [, secondBold] = screen.getAllByRole("button", { name: "editor-toolbar.bold" });
+    fireEvent.click(secondBold);
+
+    expect(screen.getByRole("textbox", { name: "second" })).toHaveValue("**beta**");
+    expect(screen.getByRole("textbox", { name: "first" })).toHaveValue("alpha");
+  });
+});

--- a/apps/web/src/specs/features/ui/emoji-picker.spec.tsx
+++ b/apps/web/src/specs/features/ui/emoji-picker.spec.tsx
@@ -1,0 +1,149 @@
+import { vi } from "vitest";
+import React, { useRef } from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// jsdom has neither ResizeObserver nor layout, so floating-ui's auto-update
+// needs a stub. Coordinates are therefore meaningless here; what this spec
+// pins down is the behaviour around them, which is where the bugs were.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(globalThis, "ResizeObserver", {
+  value: ResizeObserverStub,
+  writable: true,
+  configurable: true
+});
+
+vi.mock("@emoji-mart/data", () => ({ default: {} }));
+vi.mock("@emoji-mart/react", () => ({
+  // eslint-disable-next-line react/display-name
+  default: ({ onEmojiSelect }: { onEmojiSelect: (e: { native: string }) => void }) => (
+    <button data-testid="emoji-grid" onClick={() => onEmojiSelect({ native: "👍" })}>
+      grid
+    </button>
+  )
+}));
+vi.mock("@/core/global-store", () => ({
+  useGlobalStore: (selector: (s: { theme: string }) => unknown) => selector({ theme: "day" })
+}));
+
+import { EmojiPicker } from "@/features/ui/emoji-picker";
+
+function Harness({
+  show,
+  changeState,
+  onSelect,
+  withTrigger = true
+}: {
+  show: boolean;
+  changeState: (v: boolean) => void;
+  onSelect?: (v: string) => void;
+  withTrigger?: boolean;
+}) {
+  const buttonRef = useRef<HTMLElement | null>(null);
+
+  return (
+    <div>
+      <button ref={buttonRef as React.RefObject<HTMLButtonElement>} data-testid="trigger">
+        emoji
+      </button>
+      <div data-testid="elsewhere">elsewhere</div>
+      <EmojiPicker
+        show={show}
+        changeState={changeState}
+        onSelect={onSelect ?? (() => {})}
+        buttonRef={withTrigger ? buttonRef : undefined}
+      />
+    </div>
+  );
+}
+
+function renderPicker(props: Partial<React.ComponentProps<typeof Harness>> = {}) {
+  const changeState = vi.fn();
+  const onSelect = vi.fn();
+  const container = document.createElement("div");
+  container.id = "popper-container";
+  document.body.appendChild(container);
+
+  const utils = render(
+    <Harness show={true} changeState={changeState} onSelect={onSelect} {...props} />
+  );
+
+  return { changeState, onSelect, popper: container, ...utils };
+}
+
+const dialog = () => document.querySelector(".emoji-picker-dialog") as HTMLElement | null;
+
+describe("EmojiPicker", () => {
+  afterEach(() => {
+    document.getElementById("popper-container")?.remove();
+  });
+
+  test("renders nothing while closed", () => {
+    renderPicker({ show: false });
+
+    expect(dialog()).toBeNull();
+  });
+
+  test("renders into the popper container, not next to its trigger", () => {
+    // Escaping the toolbar's subtree is what keeps an ancestor with a
+    // backdrop-filter (the decks post viewer) from capturing fixed positioning.
+    const { popper } = renderPicker();
+
+    expect(dialog()).not.toBeNull();
+    expect(popper.contains(dialog())).toBe(true);
+  });
+
+  test("stays invisible while it has nothing to be positioned against", () => {
+    // The panel used to paint at its static position for a frame before the
+    // coordinates were written, which put it a whole viewport away on a
+    // scrolled page. Without a trigger to anchor to there is no position to
+    // compute, so it must never become visible.
+    renderPicker({ withTrigger: false });
+
+    expect(dialog()).toHaveStyle({ visibility: "hidden" });
+  });
+
+  test("becomes visible once positioned against its trigger", async () => {
+    renderPicker();
+
+    await waitFor(() => expect(dialog()).toHaveStyle({ visibility: "visible" }));
+  });
+
+  test("closes on a pointer down outside", () => {
+    const { changeState, getByTestId } = renderPicker();
+
+    fireEvent.pointerDown(getByTestId("elsewhere"));
+
+    expect(changeState).toHaveBeenCalledWith(false);
+  });
+
+  test("stays open on a pointer down inside the panel", () => {
+    const { changeState, getByTestId } = renderPicker();
+
+    fireEvent.pointerDown(getByTestId("emoji-grid"));
+
+    expect(changeState).not.toHaveBeenCalled();
+  });
+
+  test("leaves the trigger to toggle itself", () => {
+    // Closing here would fight the trigger's own click handler and reopen it.
+    const { changeState, getByTestId } = renderPicker();
+
+    fireEvent.pointerDown(getByTestId("trigger"));
+
+    expect(changeState).not.toHaveBeenCalled();
+  });
+
+  test("hands the picked emoji up and closes", () => {
+    const { changeState, onSelect, getByTestId } = renderPicker();
+
+    fireEvent.click(getByTestId("emoji-grid"));
+
+    expect(onSelect).toHaveBeenCalledWith("👍");
+    expect(changeState).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
Closes #1529
Closes #1530

### Ctrl/Cmd+B

`Comment`'s shortcut handler only matched `e.altKey`, so no Ctrl/Cmd combination was bound. It also matched on `e.key`, which Option+B does not produce on macOS (it sends `∫`), so the Alt shortcuts were dead there too. Matching now accepts `e.code` as well, and Ctrl/Cmd+B / Ctrl/Cmd+I call `preventDefault` because Firefox binds them to the bookmarks sidebar and page info.

The mapping moved into `editor-toolbar/shortcuts.ts`, which `/submit` now shares instead of keeping its own copy.

### Shortcuts leaking between composers

`detectEvent` dispatches on `window` and every mounted `EditorToolbar` listened, so on an entry page with the reply box plus an inline reply form, one keystroke inserted the markdown into both and `insertOrReplace` dragged focus into the other box. Measured before the change: Alt+B typed in box 1 gave box 1 `**alpha**`, box 2 `beta****`, focus in box 2. After: box 2 untouched, focus unmoved. A toolbar now acts only when its own editor holds focus; toolbar buttons call the handlers directly and are unaffected.

While there, the `useMount` cleanup that removed those listeners was dead code twice over: `react-use`'s `useMount` discards the returned cleanup, and the `removeEventListener` calls passed freshly built arrow functions. The window listeners moved to a `useEffect` that actually unregisters them.

### Emoji picker

Replaced the hand-rolled positioning with `@floating-ui/react-dom` (already used by `StyledTooltip`). What was wrong, measured frame by frame in a browser:

| | before | after |
|---|---|---|
| first paint | one frame at `top: 1044` in a 900px viewport, then jumps | painted only once positioned |
| size | estimated 340x380, real 435x300 | measured |
| bottom overflow | up to 47px below the fold | none across 8 viewport/scroll combinations |
| alignment | 40px left of the trigger | trailing edges match |
| on scroll | button at `top: 298`, panel left behind at `top: 512` | follows |
| short viewport | overlays the toolbar | flips, shifts, shrinks to fit |

The panel also renders into `#popper-container` now, so an ancestor with `backdrop-filter` cannot capture its fixed positioning. The decks post viewer has one, which broke the picker there for the same reason.

The small-screen bottom sheet is unchanged: floating-ui is configured with `transform: false` so the existing `!important` rules still win.

### Verification

Driven in Chromium against the real composer on a dev build (both bugs reproduced first, then re-measured):

- Ctrl+B with "world" selected: `hello world` -> `hello **world**`; preview renders `<strong>`.
- Emoji pick inserts into the composer, closes the panel and updates the controlled value.
- Open/close by button toggle and by outside click both still work.
- Fully visible at 1280x900 (top/middle/bottom of viewport), 1280x720, 1280x420, 740x900, 390x780 and 780x390.

`vitest run`: 304 files, 2868 tests passing, including 15 new ones covering the shortcut matrix (Ctrl, Cmd, Alt, macOS `∫`, ignored combinations) and the composer-level bindings. `tsc --noEmit` and `next lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standard Ctrl/Cmd+B and Ctrl/Cmd+I shortcuts for bold and italic formatting.
  * Improved emoji picker positioning, automatically adapting to available screen space and staying anchored to its trigger.

* **Bug Fixes**
  * Formatting shortcuts now apply only to the active editor.
  * Prevented formatting shortcuts from unintentionally submitting comments or triggering browser defaults.

* **Tests**
  * Added coverage for editor and comment formatting shortcuts across supported keyboard layouts and modifier combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->