### PR TITLE
seo: truncate the deployment id to 8 hex

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -197,8 +197,13 @@ const config = {
   // chunk (the post-deploy "undefined (reading 'call')" / "element type is
   // invalid" 500s). Reuses the SHA already injected as SENTRY_RELEASE in CI;
   // unset in local dev, where skew protection is inactive (and unnecessary).
+  // Truncated to 8 hex: skew protection only needs the value to CHANGE between
+  // deploys, not to be globally unique. Next appends `?dpl=<id>` to all 1,235
+  // chunk references on a post page, so the full 40-char SHA cost 55,575 B
+  // (16-19% of the page); 8 chars costs 16,055 B. See #1533. SENTRY_RELEASE
+  // itself stays full above — Sentry matches sourcemaps on the whole release.
   deploymentId: process.env.SENTRY_RELEASE
-    ? process.env.SENTRY_RELEASE.replace(/^ecency-next@/, "")
+    ? process.env.SENTRY_RELEASE.replace(/^ecency-next@/, "").slice(0, 8)
     : undefined,
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },

--- a/apps/web/src/specs/config/deployment-id.spec.ts
+++ b/apps/web/src/specs/config/deployment-id.spec.ts
@@ -1,0 +1,54 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * The deployment ID is appended to every asset and RSC chunk reference as
+ * `?dpl=<id>`. A post page carries ~1,235 such references, so each byte of the
+ * id costs ~1.2 KB of page weight. The full 40-char SHA cost 55,575 B, 16-19%
+ * of the page (#1533).
+ *
+ * Skew protection only requires the value to CHANGE between deploys, so it is
+ * truncated to 8 hex. This evaluates the real expression out of next.config.js
+ * rather than grepping for `.slice`, so it fails if the logic is rewritten in a
+ * way that restores the long id.
+ */
+const CONFIG = path.resolve(__dirname, "../../../next.config.js");
+const SHA = "2e1e30395130118638606085fb594aedfcf2e694";
+const CHUNK_REFS_PER_POST_PAGE = 1235;
+
+function deploymentIdFor(sentryRelease: string | undefined): string | undefined {
+  const src = fs.readFileSync(CONFIG, "utf8");
+  const m = src.match(/deploymentId:\s*([\s\S]*?),\n\s{2}\w/);
+  if (!m) throw new Error("deploymentId expression not found in next.config.js");
+  // eslint-disable-next-line no-new-func
+  return new Function("process", `return (${m[1]});`)({ env: { SENTRY_RELEASE: sentryRelease } });
+}
+
+describe("deploymentId stays short (#1533)", () => {
+  it("truncates the CI release SHA to 8 characters", () => {
+    const id = deploymentIdFor(`ecency-next@${SHA}`);
+    expect(id).toBe("2e1e3039");
+    expect(id).toHaveLength(8);
+  });
+
+  it("is undefined in local dev, where skew protection is inactive", () => {
+    expect(deploymentIdFor(undefined)).toBeUndefined();
+  });
+
+  it("still changes between deploys, which is all skew protection needs", () => {
+    expect(deploymentIdFor("ecency-next@aaaaaaaa1111"))
+      .not.toBe(deploymentIdFor("ecency-next@bbbbbbbb2222"));
+  });
+
+  it("keeps the per-page ?dpl= cost under 20 KB", () => {
+    const perRef = `?dpl=${deploymentIdFor(`ecency-next@${SHA}`)}`.length;
+    expect(perRef * CHUNK_REFS_PER_POST_PAGE).toBeLessThan(20_000);
+  });
+
+  it("does not truncate SENTRY_RELEASE itself (sourcemaps match the full release)", () => {
+    const src = fs.readFileSync(CONFIG, "utf8");
+    const inlined = src.match(/SENTRY_RELEASE: process\.env\.SENTRY_RELEASE[^\n]*/);
+    expect(inlined).not.toBeNull();
+    expect(inlined![0]).not.toMatch(/slice|substring|substr/);
+  });
+});


### PR DESCRIPTION
Refs #1533.

Next appends `?dpl=<deploymentId>` to every asset and RSC chunk reference. A post page carries **1,235** of them (48 distinct chunks, each listed ~26 times), so the full 40-character SHA cost **55,575 B per page** — 16-19% of a 290-353 KB page, fixed, regardless of content.

```
?dpl= + 40 hex = 45 B  x 1,235 = 55,575 B
?dpl= +  8 hex = 13 B  x 1,235 = 16,055 B
                        saving   39,520 B   (~11% of page weight)
```

Skew protection only requires the value to **change** between deploys, not to be globally unique. 8 hex is 4.3 billion values, so a consecutive-deploy collision is not a practical concern, and the protection against mismatched-chunk 500s is unaffected.

`SENTRY_RELEASE` is deliberately untouched (`next.config.js:160`) — Sentry matches uploaded sourcemaps on the full release name. Only the value handed to `deploymentId` is shortened.

## Why this matters

Sampling posts that Search Console reports as "Crawled, currently not indexed", **8 of 14 were indexed on another Hive frontend** — the same on-chain post, our copy declined. For those posts we serve 290-353 KB against PeakD's 8.5 KB and hive.blog's 80 KB, and page weight is the strongest measurable difference between us and the frontends Google prefers.

**Stated plainly: weight is a correlate, not a proven cause.** PeakD serves 0% of the article body server-side and is indexed anyway, so Google is clearly not rewarding content delivery here. This is the cheapest available test of the crawl-budget theory, not a guaranteed fix.

## Verification

- `deployment-id.spec.ts` evaluates the actual expression out of `next.config.js` (via the extracted ternary), so it is not a grep for `.slice` and survives a rewrite of the logic
- Confirmed it is a real regression test: **2 of its 5 cases fail against the unpatched config**
- Covers CI (8 chars), local dev (`undefined`), change-between-deploys, the per-page byte budget, and that `SENTRY_RELEASE` is not truncated
- `tsc --noEmit` clean; 44 tests pass across `specs/config` and `specs/features/seo`

## How we will know if it worked

`/root/seo-index-tracker.py` already records the fresh-post index rate weekly (5.0% → 30.0% since June) plus the indexed footprint. If crawl budget is the constraint, both should move. If neither moves in a few weeks, the crawl-budget theory is wrong and this was still a free 11% off every page.
