### PR TITLE
Newsletter: author sends from a post (gated cohort, preview, one issue per period)

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { NewsletterGate, SenderStatusNotice } from "@/features/newsletter";
+import { NewsletterGate, SenderStatusNotice, SentIssues } from "@/features/newsletter";
 import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import { Button } from "@ui/button";
@@ -64,6 +64,7 @@ export function CommunityCard({ community, account }: Props) {
       {/* Policing (vision-web#1513): the team sees when this community's digest is suspended, and why. */}
       <NewsletterGate>
         <SenderStatusNotice type="community" target={community.name} isSender={isDigestSender} className="mb-4" />
+        <SentIssues type="community" target={community.name} isSender={isDigestSender} className="mb-4" />
       </NewsletterGate>
       <div className="community-avatar inline-flex items-center justify-center md:justify-start">
         {canUpdatePic && (

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -35,7 +35,7 @@ import { profileWebsiteHref } from "./website-href";
 import { FinalizeCommunityBanner } from "../finalize-community-banner";
 import { useActiveAccount } from "@/core/hooks";
 import { ProBadge } from "@/features/pro";
-import { DigestSubscribeButton, NewsletterGate, SenderStatusNotice } from "@/features/newsletter";
+import { DigestSubscribeButton, NewsletterGate, SenderStatusNotice, SentIssues } from "@/features/newsletter";
 
 interface Props {
   account: Account;
@@ -139,6 +139,7 @@ export function ProfileCard({ account }: Props) {
       {activeUsername?.toLowerCase() === account.name && (
         <NewsletterGate>
           <SenderStatusNotice type="creator" target={account.name} isSender className="mb-4" />
+          <SentIssues type="creator" target={account.name} isSender className="mb-4" />
         </NewsletterGate>
       )}
 

--- a/apps/web/src/app/api/newsletter/issues/route.ts
+++ b/apps/web/src/app/api/newsletter/issues/route.ts
@@ -4,7 +4,7 @@ import { callNewsletter, newsletterConfigured, notConfigured, relay } from "@/se
 import { SENDER_TARGET_RE, senderGate } from "@/server/newsletter-sender-gate";
 
 /** The list's issues, newest first, with what became of them. Sender's view (owner, admin, mod; the creator). */
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest): Promise<Response> {
   if (!newsletterConfigured()) return notConfigured();
   const auth = await resolveUser(request, {});
   if (!auth.ok) return unauthorizedResponse(auth.reason);

--- a/apps/web/src/app/api/newsletter/issues/route.ts
+++ b/apps/web/src/app/api/newsletter/issues/route.ts
@@ -3,17 +3,12 @@ import { resolveUser, unauthorizedResponse } from "@/app/api/threespeak/resolve-
 import { callNewsletter, newsletterConfigured, notConfigured, relay } from "@/server/newsletter-internal";
 import { SENDER_TARGET_RE, senderGate } from "@/server/newsletter-sender-gate";
 
-/**
- * A sender's standing with the newsletter service (vision-web#1513): status,
- * reason, since when, the rolling numbers, and the subscriber counts. Shown to
- * the SENDER only (see senderGate, mode view).
- */
+/** The list's issues, newest first, with what became of them. Sender's view (owner, admin, mod; the creator). */
 export async function GET(request: NextRequest) {
   if (!newsletterConfigured()) return notConfigured();
   const auth = await resolveUser(request, {});
   if (!auth.ok) return unauthorizedResponse(auth.reason);
   const username = auth.username.toLowerCase();
-
   const type = request.nextUrl.searchParams.get("type");
   const target = (request.nextUrl.searchParams.get("target") ?? "").toLowerCase();
   if ((type !== "creator" && type !== "community") || !SENDER_TARGET_RE.test(target)) {
@@ -21,7 +16,6 @@ export async function GET(request: NextRequest) {
   }
   const gate = await senderGate(username, type, target, "view");
   if (!gate.ok) return Response.json({ error: gate.error }, { status: gate.status });
-
-  const upstream = await callNewsletter(`/api/senders/${type}/${encodeURIComponent(target)}`);
+  const upstream = await callNewsletter(`/api/issues?type=${type}&target=${encodeURIComponent(target)}`);
   return relay(upstream);
 }

--- a/apps/web/src/app/api/newsletter/send/preview/route.ts
+++ b/apps/web/src/app/api/newsletter/send/preview/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from "next/server";
+import { resolveUser, unauthorizedResponse } from "@/app/api/threespeak/resolve-user";
+import { callNewsletter, newsletterConfigured, notConfigured, relay } from "@/server/newsletter-internal";
+import { parseSendBody, senderGate } from "@/server/newsletter-sender-gate";
+
+/** What the reader would get, subscriber counts, and which cadences already have this period's issue. Same gate as sending. */
+export async function POST(request: NextRequest) {
+  if (!newsletterConfigured()) return notConfigured();
+  const auth = await resolveUser(request, {});
+  if (!auth.ok) return unauthorizedResponse(auth.reason);
+  const username = auth.username.toLowerCase();
+  const parsed = await parseSendBody(request);
+  if (parsed instanceof Response) return parsed;
+  const gate = await senderGate(username, parsed.type, parsed.target, "send");
+  if (!gate.ok) return Response.json({ error: gate.error }, { status: gate.status });
+  const upstream = await callNewsletter("/api/issues/preview", { method: "POST", body: parsed });
+  return relay(upstream);
+}

--- a/apps/web/src/app/api/newsletter/send/preview/route.ts
+++ b/apps/web/src/app/api/newsletter/send/preview/route.ts
@@ -1,15 +1,17 @@
 import { NextRequest } from "next/server";
 import { resolveUser, unauthorizedResponse } from "@/app/api/threespeak/resolve-user";
 import { callNewsletter, newsletterConfigured, notConfigured, relay } from "@/server/newsletter-internal";
-import { parseSendBody, senderGate } from "@/server/newsletter-sender-gate";
+import { parseSendBody, readJsonBody, senderGate } from "@/server/newsletter-sender-gate";
 
 /** What the reader would get, subscriber counts, and which cadences already have this period's issue. Same gate as sending. */
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest): Promise<Response> {
   if (!newsletterConfigured()) return notConfigured();
-  const auth = await resolveUser(request, {});
+  // One read of the body: it may carry the HiveSigner code as well as the fields.
+  const body = await readJsonBody(request);
+  const auth = await resolveUser(request, body);
   if (!auth.ok) return unauthorizedResponse(auth.reason);
   const username = auth.username.toLowerCase();
-  const parsed = await parseSendBody(request);
+  const parsed = parseSendBody(body);
   if (parsed instanceof Response) return parsed;
   const gate = await senderGate(username, parsed.type, parsed.target, "send");
   if (!gate.ok) return Response.json({ error: gate.error }, { status: gate.status });

--- a/apps/web/src/app/api/newsletter/send/preview/route.ts
+++ b/apps/web/src/app/api/newsletter/send/preview/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { resolveUser, unauthorizedResponse } from "@/app/api/threespeak/resolve-user";
 import { callNewsletter, newsletterConfigured, notConfigured, relay } from "@/server/newsletter-internal";
-import { parseSendBody, readJsonBody, senderGate } from "@/server/newsletter-sender-gate";
+import { parseSendBody, postBelongsToSender, readJsonBody, senderGate } from "@/server/newsletter-sender-gate";
 
 /** What the reader would get, subscriber counts, and which cadences already have this period's issue. Same gate as sending. */
 export async function POST(request: NextRequest): Promise<Response> {
@@ -13,6 +13,7 @@ export async function POST(request: NextRequest): Promise<Response> {
   const username = auth.username.toLowerCase();
   const parsed = parseSendBody(body);
   if (parsed instanceof Response) return parsed;
+  if (!postBelongsToSender(parsed, username)) return Response.json({ error: "a creator digest carries only the creator's own posts" }, { status: 403 });
   const gate = await senderGate(username, parsed.type, parsed.target, "send");
   if (!gate.ok) return Response.json({ error: gate.error }, { status: gate.status });
   const upstream = await callNewsletter("/api/issues/preview", { method: "POST", body: parsed });

--- a/apps/web/src/app/api/newsletter/send/route.ts
+++ b/apps/web/src/app/api/newsletter/send/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { resolveUser, unauthorizedResponse } from "@/app/api/threespeak/resolve-user";
 import { callNewsletter, newsletterConfigured, notConfigured, relay } from "@/server/newsletter-internal";
-import { parseSendBody, readJsonBody, senderGate } from "@/server/newsletter-sender-gate";
+import { parseSendBody, postBelongsToSender, readJsonBody, senderGate } from "@/server/newsletter-sender-gate";
 
 /**
  * Author send (vision-web#1532): the sender's own post as the list's issue for
@@ -19,6 +19,7 @@ export async function POST(request: NextRequest): Promise<Response> {
   const username = auth.username.toLowerCase();
   const parsed = parseSendBody(body);
   if (parsed instanceof Response) return parsed;
+  if (!postBelongsToSender(parsed, username)) return Response.json({ error: "a creator digest carries only the creator's own posts" }, { status: 403 });
   const gate = await senderGate(username, parsed.type, parsed.target, "send");
   if (!gate.ok) return Response.json({ error: gate.error }, { status: gate.status });
   const upstream = await callNewsletter("/api/issues", { method: "POST", body: { ...parsed, requestedBy: username } });

--- a/apps/web/src/app/api/newsletter/send/route.ts
+++ b/apps/web/src/app/api/newsletter/send/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { resolveUser, unauthorizedResponse } from "@/app/api/threespeak/resolve-user";
 import { callNewsletter, newsletterConfigured, notConfigured, relay } from "@/server/newsletter-internal";
-import { parseSendBody, senderGate } from "@/server/newsletter-sender-gate";
+import { parseSendBody, readJsonBody, senderGate } from "@/server/newsletter-sender-gate";
 
 /**
  * Author send (vision-web#1532): the sender's own post as the list's issue for
@@ -10,12 +10,14 @@ import { parseSendBody, senderGate } from "@/server/newsletter-sender-gate";
  * whether the period is free, and its answers (403 suspended, 404, 409 taken,
  * 422 refused) are relayed as they are.
  */
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest): Promise<Response> {
   if (!newsletterConfigured()) return notConfigured();
-  const auth = await resolveUser(request, {});
+  // One read of the body: it may carry the HiveSigner code as well as the fields.
+  const body = await readJsonBody(request);
+  const auth = await resolveUser(request, body);
   if (!auth.ok) return unauthorizedResponse(auth.reason);
   const username = auth.username.toLowerCase();
-  const parsed = await parseSendBody(request);
+  const parsed = parseSendBody(body);
   if (parsed instanceof Response) return parsed;
   const gate = await senderGate(username, parsed.type, parsed.target, "send");
   if (!gate.ok) return Response.json({ error: gate.error }, { status: gate.status });

--- a/apps/web/src/app/api/newsletter/send/route.ts
+++ b/apps/web/src/app/api/newsletter/send/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest } from "next/server";
+import { resolveUser, unauthorizedResponse } from "@/app/api/threespeak/resolve-user";
+import { callNewsletter, newsletterConfigured, notConfigured, relay } from "@/server/newsletter-internal";
+import { parseSendBody, senderGate } from "@/server/newsletter-sender-gate";
+
+/**
+ * Author send (vision-web#1532): the sender's own post as the list's issue for
+ * the current period. The gate here decides WHO may send (Pro creator for their
+ * own list; community owner or admin); the service decides what may be sent and
+ * whether the period is free, and its answers (403 suspended, 404, 409 taken,
+ * 422 refused) are relayed as they are.
+ */
+export async function POST(request: NextRequest) {
+  if (!newsletterConfigured()) return notConfigured();
+  const auth = await resolveUser(request, {});
+  if (!auth.ok) return unauthorizedResponse(auth.reason);
+  const username = auth.username.toLowerCase();
+  const parsed = await parseSendBody(request);
+  if (parsed instanceof Response) return parsed;
+  const gate = await senderGate(username, parsed.type, parsed.target, "send");
+  if (!gate.ok) return Response.json({ error: gate.error }, { status: gate.status });
+  const upstream = await callNewsletter("/api/issues", { method: "POST", body: { ...parsed, requestedBy: username } });
+  return relay(upstream);
+}

--- a/apps/web/src/app/api/newsletter/sender/route.ts
+++ b/apps/web/src/app/api/newsletter/sender/route.ts
@@ -8,7 +8,7 @@ import { SENDER_TARGET_RE, senderGate } from "@/server/newsletter-sender-gate";
  * reason, since when, the rolling numbers, and the subscriber counts. Shown to
  * the SENDER only (see senderGate, mode view).
  */
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest): Promise<Response> {
   if (!newsletterConfigured()) return notConfigured();
   const auth = await resolveUser(request, {});
   if (!auth.ok) return unauthorizedResponse(auth.reason);

--- a/apps/web/src/core/react-query/index.ts
+++ b/apps/web/src/core/react-query/index.ts
@@ -9,6 +9,8 @@ import { cache } from "react";
 export enum QueryIdentifiers {
   NEWSLETTER_SUBSCRIPTIONS = "newsletter-subscriptions",
   NEWSLETTER_SENDER_STANDING = "newsletter-sender-standing",
+  NEWSLETTER_SEND_PREVIEW = "newsletter-send-preview",
+  NEWSLETTER_SENT_ISSUES = "newsletter-sent-issues",
   NEWSLETTER_CONFIRM_INSPECT = "newsletter-confirm-inspect",
   NEWSLETTER_UNSUBSCRIBE_INSPECT = "newsletter-unsubscribe-inspect",
   COMMUNITY_THREADS = "community-threads",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -4212,6 +4212,12 @@
     "cadence-weekly": "weekly",
     "cadence-monthly": "monthly",
     "sent-issues": "Sent issues",
-    "sent-issue-stats": "{{delivered}} delivered, {{bounced}} bounced"
+    "sent-issue-stats": "{{delivered}} delivered, {{bounced}} bounced",
+    "send-taken-line": "{{cadence}} readers: the issue for the period starting {{period}} {{what}}",
+    "send-taken-by-digest": "was the automatic digest",
+    "send-taken-by-send": "was sent by you or your team",
+    "send-see-history": "See sent issues",
+    "sent-issues-unavailable": "Sent issues could not be loaded right now.",
+    "sent-issue-rejected": "{{rejected}} rejected by receivers"
   }
 }

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -4191,6 +4191,27 @@
     "suspended-reason-complaints": "Too many recipients marked recent issues as spam. Sending is paused to protect every Ecency sender's deliverability.",
     "suspended-reason-bounces": "Too many recent recipients could not be delivered to. Sending is paused to protect every Ecency sender's deliverability.",
     "suspended-reason-manual": "Sending is paused by Ecency. No new issues go out until it is lifted.",
-    "suspended-help": "Existing subscribers are kept. Contact Ecency support to have the suspension reviewed."
+    "suspended-help": "Existing subscribers are kept. Contact Ecency support to have the suspension reviewed.",
+    "send-to-subscribers": "Send to email subscribers",
+    "send-title": "Send to {{list}} email subscribers",
+    "send-loading": "Preparing the preview…",
+    "send-readers": "{{weekly}} weekly and {{monthly}} monthly readers will get this as their current issue.",
+    "send-no-readers": "Nobody is subscribed to this list yet.",
+    "send-period-taken-some": "The {{cadences}} readers already received this period's issue; they will not get this one.",
+    "send-period-taken-all": "This period's issue has already gone out to every reader. The next one can be sent in the next period.",
+    "send-one-per-period": "Readers get at most one issue per period they chose (weekly or monthly). Sending this replaces the automatic digest for the period.",
+    "send-preview": "Email preview",
+    "send-now": "Send now",
+    "send-done": "Sent to {{count}} readers. Delivery is spread over the next hours.",
+    "send-done-line": "{{cadence}} readers: {{recipients}}",
+    "send-already-sent": "This period's issue has already gone out. Try again in the next period.",
+    "send-suspended": "Sending is suspended for this list. See the notice on your profile or community page.",
+    "send-post-refused": "This post cannot be sent to the list.",
+    "send-post-not-found": "The post could not be found.",
+    "send-not-allowed": "You cannot send to this list.",
+    "cadence-weekly": "weekly",
+    "cadence-monthly": "monthly",
+    "sent-issues": "Sent issues",
+    "sent-issue-stats": "{{delivered}} delivered, {{bounced}} bounced"
   }
 }

--- a/apps/web/src/features/newsletter/author-send-api.ts
+++ b/apps/web/src/features/newsletter/author-send-api.ts
@@ -1,0 +1,80 @@
+import { ensureValidToken } from "@/utils";
+import { NewsletterApiError } from "./newsletter-api";
+
+/**
+ * Author sends (vision-web#1532), browser side of /api/newsletter/send*. Every
+ * call carries the HiveSigner token; the route decides who may send. Errors
+ * keep the service's status and code so the dialog can say exactly why.
+ */
+export interface SendRef {
+  type: "creator" | "community";
+  target: string;
+  author: string;
+  permlink: string;
+}
+
+export interface SendPreview {
+  subject: string;
+  html: string;
+  text: string;
+  post: { author: string; permlink: string; title: string };
+  subscribers: { weekly: number; monthly: number };
+  alreadySent: Array<"weekly" | "monthly">;
+}
+
+export interface SendResult {
+  issues: Array<{ issueId: string; cadence: "weekly" | "monthly"; period: string; send: { recipients: number; sent: number; pending: number } }>;
+}
+
+export interface SentIssue {
+  id: string;
+  cadence: "weekly" | "monthly";
+  kind: "digest" | "post";
+  period_start: string;
+  subject: string;
+  status: string;
+  post_author: string | null;
+  post_permlink: string | null;
+  requested_by: string | null;
+  created_at: string;
+  delivered: number;
+  bounced: number;
+  rejected: number;
+}
+
+export class SendRefusedError extends NewsletterApiError {
+  constructor(
+    message: string,
+    status: number,
+    public readonly code?: string,
+    public readonly taken?: Array<{ cadence: string; period: string; kind: string }>
+  ) {
+    super(message, status);
+  }
+}
+
+async function post<T>(path: string, body: unknown, username: string): Promise<T> {
+  const token = await ensureValidToken(username);
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...(token ? { "X-HS-Token": token } : {}) },
+    body: JSON.stringify(body)
+  });
+  const data = (await res.json().catch(() => ({}))) as T & { error?: string; code?: string; taken?: SendRefusedError["taken"] };
+  if (!res.ok) throw new SendRefusedError(data?.error || `Request failed (${res.status})`, res.status, data?.code, data?.taken);
+  return data;
+}
+
+export const authorSendApi = {
+  preview: (ref: SendRef, username: string) => post<SendPreview>("/api/newsletter/send/preview", ref, username),
+  send: (ref: SendRef, username: string) => post<SendResult>("/api/newsletter/send", ref, username),
+  async issues(type: "creator" | "community", target: string, username: string): Promise<SentIssue[]> {
+    const token = await ensureValidToken(username);
+    const res = await fetch(`/api/newsletter/issues?type=${type}&target=${encodeURIComponent(target)}`, {
+      headers: token ? { "X-HS-Token": token } : {}
+    });
+    const data = (await res.json().catch(() => ({}))) as { issues?: SentIssue[]; error?: string };
+    if (!res.ok) throw new NewsletterApiError(data?.error || `Request failed (${res.status})`, res.status);
+    return data.issues ?? [];
+  }
+};

--- a/apps/web/src/features/newsletter/author-send-api.ts
+++ b/apps/web/src/features/newsletter/author-send-api.ts
@@ -60,9 +60,11 @@ async function post<T>(path: string, body: unknown, username: string): Promise<T
     headers: { "Content-Type": "application/json", ...(token ? { "X-HS-Token": token } : {}) },
     body: JSON.stringify(body)
   });
-  const data = (await res.json().catch(() => ({}))) as T & { error?: string; code?: string; taken?: SendRefusedError["taken"] };
-  if (!res.ok) throw new SendRefusedError(data?.error || `Request failed (${res.status})`, res.status, data?.code, data?.taken);
-  return data;
+  const parsed = (await res.json().catch(() => null)) as (T & { error?: string; code?: string; taken?: SendRefusedError["taken"] }) | null;
+  if (!res.ok) throw new SendRefusedError(parsed?.error || `Request failed (${res.status})`, res.status, parsed?.code, parsed?.taken);
+  // A 2xx without a JSON body is not a result; saying so beats rendering blanks.
+  if (!parsed || typeof parsed !== "object") throw new SendRefusedError(`Unexpected response (${res.status})`, res.status);
+  return parsed;
 }
 
 export const authorSendApi = {

--- a/apps/web/src/features/newsletter/author-send-api.ts
+++ b/apps/web/src/features/newsletter/author-send-api.ts
@@ -66,8 +66,8 @@ async function post<T>(path: string, body: unknown, username: string): Promise<T
 }
 
 export const authorSendApi = {
-  preview: (ref: SendRef, username: string) => post<SendPreview>("/api/newsletter/send/preview", ref, username),
-  send: (ref: SendRef, username: string) => post<SendResult>("/api/newsletter/send", ref, username),
+  preview: (ref: SendRef, username: string): Promise<SendPreview> => post<SendPreview>("/api/newsletter/send/preview", ref, username),
+  send: (ref: SendRef, username: string): Promise<SendResult> => post<SendResult>("/api/newsletter/send", ref, username),
   async issues(type: "creator" | "community", target: string, username: string): Promise<SentIssue[]> {
     const token = await ensureValidToken(username);
     const res = await fetch(`/api/newsletter/issues?type=${type}&target=${encodeURIComponent(target)}`, {

--- a/apps/web/src/features/newsletter/author-send-dialog.tsx
+++ b/apps/web/src/features/newsletter/author-send-dialog.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { QueryIdentifiers } from "@/core/react-query";
+import { Alert } from "@ui/alert";
+import { Button } from "@ui/button";
+import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
+import i18next from "i18next";
+import { useMemo, useState } from "react";
+import { authorSendApi, type SendPreview, type SendRef, type SendResult, SendRefusedError } from "./author-send-api";
+import type { SendTarget } from "./author-send-eligibility";
+
+/**
+ * "Send to email subscribers" (vision-web#1532). Shows the reader's view of the
+ * post as an issue, how many readers get it and as which period's issue, the
+ * one-issue-per-period reminder, then sends. Every refusal the service can give
+ * is shown for what it is: this period already has an issue (409, with what
+ * took it), the list is suspended (403), the post is not sendable (422).
+ */
+interface Props {
+  target: SendTarget;
+  author: string;
+  permlink: string;
+  show: boolean;
+  onHide: () => void;
+}
+
+export const sendPreviewKey = (ref: SendRef, viewer: string) =>
+  [QueryIdentifiers.NEWSLETTER_SEND_PREVIEW, ref.type, ref.target, ref.author, ref.permlink, viewer] as const;
+
+function describeRefusal(err: unknown): { key: string; detail?: string } {
+  if (err instanceof SendRefusedError) {
+    if (err.code === "already_sent") return { key: "newsletter.send-already-sent" };
+    if (err.code === "suspended") return { key: "newsletter.send-suspended" };
+    if (err.code === "post_refused") return { key: "newsletter.send-post-refused", detail: err.message };
+    if (err.code === "post_not_found") return { key: "newsletter.send-post-not-found" };
+    if (err.status === 403) return { key: "newsletter.send-not-allowed", detail: err.message };
+    if (err.status === 503 || err.status === 502 || err.status === 504) return { key: "newsletter.error-unavailable" };
+  }
+  return { key: "newsletter.error-generic" };
+}
+
+export function AuthorSendDialog({ target, author, permlink, show, onHide }: Props) {
+  const { activeUser } = useActiveAccount();
+  const username = activeUser?.username ?? "";
+  const queryClient = useQueryClient();
+  const ref = useMemo<SendRef>(() => ({ type: target.type, target: target.target, author, permlink }), [target, author, permlink]);
+  const [result, setResult] = useState<SendResult | null>(null);
+
+  const preview = useQuery<SendPreview, Error>({
+    queryKey: sendPreviewKey(ref, username),
+    enabled: show && !!username,
+    staleTime: 60_000,
+    retry: false,
+    queryFn: () => authorSendApi.preview(ref, username)
+  });
+
+  const send = useMutation({
+    mutationFn: () => authorSendApi.send(ref, username),
+    onSuccess: (r) => {
+      setResult(r);
+      queryClient.invalidateQueries({ queryKey: [QueryIdentifiers.NEWSLETTER_SEND_PREVIEW] });
+      queryClient.invalidateQueries({ queryKey: [QueryIdentifiers.NEWSLETTER_SENT_ISSUES, target.type, target.target] });
+    }
+  });
+
+  const p = preview.data;
+  const total = p ? p.subscribers.weekly + p.subscribers.monthly : 0;
+  const freeCadences = p ? (["weekly", "monthly"] as const).filter((c) => p.subscribers[c] > 0 && !p.alreadySent.includes(c)) : [];
+  const canSend = !!p && freeCadences.length > 0 && !send.isPending && !result;
+
+  return (
+    <Modal show={show} onHide={onHide} centered={true} size="lg">
+      <ModalHeader closeButton={true}>
+        <ModalTitle>{i18next.t("newsletter.send-title", { list: target.label })}</ModalTitle>
+      </ModalHeader>
+      <ModalBody>
+        {preview.isPending && <div className="text-sm opacity-70">{i18next.t("newsletter.send-loading")}</div>}
+
+        {preview.isError && (
+          <Alert appearance="warning">
+            {i18next.t(describeRefusal(preview.error).key)}
+            {describeRefusal(preview.error).detail ? <div className="mt-1 text-xs opacity-80">{describeRefusal(preview.error).detail}</div> : null}
+          </Alert>
+        )}
+
+        {p && !result && (
+          <>
+            <div className="mb-3 text-sm">
+              <div className="font-semibold">{p.subject}</div>
+              <div className="opacity-80">
+                {total === 0
+                  ? i18next.t("newsletter.send-no-readers")
+                  : i18next.t("newsletter.send-readers", { weekly: p.subscribers.weekly, monthly: p.subscribers.monthly })}
+              </div>
+              {p.alreadySent.length > 0 && (
+                <div className="mt-1 text-red">
+                  {i18next.t(p.alreadySent.length === 2 ? "newsletter.send-period-taken-all" : "newsletter.send-period-taken-some", {
+                    cadences: p.alreadySent.map((c) => i18next.t(`newsletter.cadence-${c}`)).join(", ")
+                  })}
+                </div>
+              )}
+              <div className="mt-1 text-xs opacity-70">{i18next.t("newsletter.send-one-per-period")}</div>
+            </div>
+            <div className="rounded-lg border border-[--border-color] overflow-hidden bg-white">
+              <iframe
+                title={i18next.t("newsletter.send-preview")}
+                sandbox=""
+                srcDoc={p.html}
+                className="w-full h-[420px] border-0"
+                referrerPolicy="no-referrer"
+              />
+            </div>
+            {send.isError && (
+              <Alert appearance="warning" className="mt-3">
+                {i18next.t(describeRefusal(send.error).key)}
+                {describeRefusal(send.error).detail ? <div className="mt-1 text-xs opacity-80">{describeRefusal(send.error).detail}</div> : null}
+              </Alert>
+            )}
+            <div className="mt-4 flex justify-end gap-2">
+              <Button appearance="gray-link" onClick={onHide}>
+                {i18next.t("g.cancel")}
+              </Button>
+              <Button disabled={!canSend} isLoading={send.isPending} onClick={() => send.mutate()}>
+                {i18next.t("newsletter.send-now")}
+              </Button>
+            </div>
+          </>
+        )}
+
+        {result && (
+          <>
+            <Alert appearance="success">
+              {i18next.t("newsletter.send-done", {
+                count: result.issues.reduce((n, i) => n + i.send.recipients, 0)
+              })}
+            </Alert>
+            <ul className="mt-2 text-sm list-disc pl-5">
+              {result.issues.map((i) => (
+                <li key={i.issueId}>
+                  {i18next.t("newsletter.send-done-line", { cadence: i18next.t(`newsletter.cadence-${i.cadence}`), recipients: i.send.recipients })}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-4 flex justify-end">
+              <Button onClick={onHide}>{i18next.t("g.close")}</Button>
+            </div>
+          </>
+        )}
+      </ModalBody>
+    </Modal>
+  );
+}

--- a/apps/web/src/features/newsletter/author-send-dialog.tsx
+++ b/apps/web/src/features/newsletter/author-send-dialog.tsx
@@ -7,7 +7,8 @@ import { Alert } from "@ui/alert";
 import { Button } from "@ui/button";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import i18next from "i18next";
-import { useMemo, useState } from "react";
+import Link from "next/link";
+import { type ReactElement, useMemo, useState } from "react";
 import { authorSendApi, type SendPreview, type SendRef, type SendResult, SendRefusedError } from "./author-send-api";
 import type { SendTarget } from "./author-send-eligibility";
 
@@ -26,12 +27,27 @@ interface Props {
   onHide: () => void;
 }
 
-export const sendPreviewKey = (ref: SendRef, viewer: string) =>
+export const sendPreviewKey = (
+  ref: SendRef,
+  viewer: string
+): readonly [QueryIdentifiers, string, string, string, string, string] =>
   [QueryIdentifiers.NEWSLETTER_SEND_PREVIEW, ref.type, ref.target, ref.author, ref.permlink, viewer] as const;
 
-function describeRefusal(err: unknown): { key: string; detail?: string } {
+/** Where the sender's history lives: their own profile card, or the community card. */
+export function senderHistoryHref(target: SendTarget): string {
+  return target.type === "creator" ? `/@${target.target}` : `/created/${target.target}`;
+}
+
+interface Refusal {
+  key: string;
+  detail?: string;
+  /** For 409: which cadence's period is taken, and by what. */
+  taken?: Array<{ cadence: string; period: string; kind: string }>;
+}
+
+function describeRefusal(err: unknown): Refusal {
   if (err instanceof SendRefusedError) {
-    if (err.code === "already_sent") return { key: "newsletter.send-already-sent" };
+    if (err.code === "already_sent") return { key: "newsletter.send-already-sent", taken: err.taken };
     if (err.code === "suspended") return { key: "newsletter.send-suspended" };
     if (err.code === "post_refused") return { key: "newsletter.send-post-refused", detail: err.message };
     if (err.code === "post_not_found") return { key: "newsletter.send-post-not-found" };
@@ -41,7 +57,36 @@ function describeRefusal(err: unknown): { key: string; detail?: string } {
   return { key: "newsletter.error-generic" };
 }
 
-export function AuthorSendDialog({ target, author, permlink, show, onHide }: Props) {
+function RefusalAlert({ refusal, target }: { refusal: Refusal; target: SendTarget }): ReactElement {
+  return (
+    <Alert appearance="warning" className="mt-3">
+      {i18next.t(refusal.key)}
+      {refusal.detail ? <div className="mt-1 text-xs opacity-80">{refusal.detail}</div> : null}
+      {refusal.taken && refusal.taken.length > 0 ? (
+        <ul className="mt-1 text-xs opacity-90 list-disc pl-4">
+          {refusal.taken.map((t) => (
+            <li key={`${t.cadence}-${t.period}`}>
+              {i18next.t("newsletter.send-taken-line", {
+                cadence: i18next.t(`newsletter.cadence-${t.cadence}`),
+                period: t.period,
+                what: i18next.t(t.kind === "digest" ? "newsletter.send-taken-by-digest" : "newsletter.send-taken-by-send")
+              })}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {refusal.key === "newsletter.send-already-sent" ? (
+        <div className="mt-1 text-xs">
+          <Link href={senderHistoryHref(target)} className="underline">
+            {i18next.t("newsletter.send-see-history")}
+          </Link>
+        </div>
+      ) : null}
+    </Alert>
+  );
+}
+
+export function AuthorSendDialog({ target, author, permlink, show, onHide }: Props): ReactElement {
   const { activeUser } = useActiveAccount();
   const username = activeUser?.username ?? "";
   const queryClient = useQueryClient();
@@ -78,12 +123,7 @@ export function AuthorSendDialog({ target, author, permlink, show, onHide }: Pro
       <ModalBody>
         {preview.isPending && <div className="text-sm opacity-70">{i18next.t("newsletter.send-loading")}</div>}
 
-        {preview.isError && (
-          <Alert appearance="warning">
-            {i18next.t(describeRefusal(preview.error).key)}
-            {describeRefusal(preview.error).detail ? <div className="mt-1 text-xs opacity-80">{describeRefusal(preview.error).detail}</div> : null}
-          </Alert>
-        )}
+        {preview.isError && <RefusalAlert refusal={describeRefusal(preview.error)} target={target} />}
 
         {p && !result && (
           <>
@@ -112,12 +152,7 @@ export function AuthorSendDialog({ target, author, permlink, show, onHide }: Pro
                 referrerPolicy="no-referrer"
               />
             </div>
-            {send.isError && (
-              <Alert appearance="warning" className="mt-3">
-                {i18next.t(describeRefusal(send.error).key)}
-                {describeRefusal(send.error).detail ? <div className="mt-1 text-xs opacity-80">{describeRefusal(send.error).detail}</div> : null}
-              </Alert>
-            )}
+            {send.isError && <RefusalAlert refusal={describeRefusal(send.error)} target={target} />}
             <div className="mt-4 flex justify-end gap-2">
               <Button appearance="gray-link" onClick={onHide}>
                 {i18next.t("g.cancel")}

--- a/apps/web/src/features/newsletter/author-send-eligibility.ts
+++ b/apps/web/src/features/newsletter/author-send-eligibility.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getProMembersQueryOptions } from "@ecency/sdk";
+import type { Community, Entry } from "@/entities";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { isProMember } from "@/features/pro/pro-config";
+import { useMemo } from "react";
+import { useNewsletterEnabled } from "./runtime";
+
+/**
+ * Whether the viewer may send THIS post to a list, and which list (vision-web#1532).
+ * Mirrors the server gate (server/newsletter-sender-gate.ts) so the action is
+ * only offered where the request would succeed; the server decides for real.
+ *
+ *   creator: the viewer's own top-level post, and the viewer is an Ecency Pro member.
+ *   community: a top-level post made in a community whose owner or admin the viewer is.
+ * A post that is both is offered to the community list when the viewer runs it,
+ * else to their own list.
+ */
+export interface SendTarget {
+  type: "creator" | "community";
+  target: string;
+  label: string;
+}
+
+const SEND_ROLES = new Set(["owner", "admin"]);
+
+export function useAuthorSendTarget(entry: Entry, community?: Community | null): SendTarget | null {
+  const enabled = useNewsletterEnabled();
+  const { activeUser } = useActiveAccount();
+  const me = activeUser?.username?.toLowerCase();
+  const isTopLevel = !entry.parent_author && (entry.depth ?? 0) === 0;
+  const isOwn = !!me && me === entry.author;
+  const { data: pro } = useQuery({ ...getProMembersQueryOptions(), enabled: enabled && isOwn && isTopLevel });
+
+  return useMemo(() => {
+    if (!enabled || !me || !isTopLevel) return null;
+    if (community && community.name === entry.category) {
+      const role = community.team?.find((m: (string | undefined)[]) => m[0]?.toLowerCase() === me)?.[1];
+      if (role && SEND_ROLES.has(role)) return { type: "community", target: community.name, label: community.title || community.name };
+    }
+    if (isOwn && isProMember(pro?.members, me)) return { type: "creator", target: me, label: `@${me}` };
+    return null;
+  }, [enabled, me, isTopLevel, community, entry.category, isOwn, pro?.members]);
+}

--- a/apps/web/src/features/newsletter/index.ts
+++ b/apps/web/src/features/newsletter/index.ts
@@ -7,3 +7,7 @@ export * from "./digest-subscribe-dialog";
 export * from "./describe";
 export * from "./first-publish-digest-prompt";
 export * from "./sender-status";
+export * from "./author-send-api";
+export * from "./author-send-eligibility";
+export * from "./author-send-dialog";
+export * from "./sent-issues";

--- a/apps/web/src/features/newsletter/sent-issues.tsx
+++ b/apps/web/src/features/newsletter/sent-issues.tsx
@@ -55,7 +55,9 @@ export function SentIssues({
       <ul className="m-0 p-0 list-none flex flex-col gap-1" aria-labelledby="newsletter-sent-issues-heading">
         {items.map((i: SentIssue) => (
           <li key={i.id} className="flex flex-wrap items-baseline gap-x-2 opacity-90">
-            <span className="text-xs opacity-70 tabular-nums">{i.period_start}</span>
+            <time dateTime={i.period_start} className="text-xs opacity-70 tabular-nums">
+              {new Date(`${i.period_start}T00:00:00Z`).toLocaleDateString(i18next.language, { timeZone: "UTC" })}
+            </time>
             {i.post_author && i.post_permlink ? (
               <Link href={`/@${i.post_author}/${i.post_permlink}`} className="truncate max-w-[16rem]">
                 {i.subject}

--- a/apps/web/src/features/newsletter/sent-issues.tsx
+++ b/apps/web/src/features/newsletter/sent-issues.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { QueryIdentifiers } from "@/core/react-query";
+import i18next from "i18next";
+import Link from "next/link";
+import { authorSendApi, type SentIssue } from "./author-send-api";
+import { useNewsletterEnabled } from "./runtime";
+
+/**
+ * The sender's own history (vision-web#1532): the list's last issues, digest or
+ * author-sent, with what became of them. Sender-only, like the standing notice:
+ * asked for only when the viewer is the sender, and rendered from nothing else.
+ */
+export const sentIssuesKey = (type: "creator" | "community", target: string, viewer: string | null | undefined) =>
+  [QueryIdentifiers.NEWSLETTER_SENT_ISSUES, type, target, viewer ?? "anon"] as const;
+
+export function SentIssues({ type, target, isSender, limit = 5, className }: { type: "creator" | "community"; target: string; isSender: boolean; limit?: number; className?: string }) {
+  const enabled = useNewsletterEnabled();
+  const { activeUser } = useActiveAccount();
+  const username = activeUser?.username;
+  const { data } = useQuery({
+    queryKey: sentIssuesKey(type, target, username),
+    enabled: enabled && isSender && !!username,
+    staleTime: 60_000,
+    queryFn: () => authorSendApi.issues(type, target, username!)
+  });
+  if (!isSender || !data || data.length === 0) return null;
+  const items = data.slice(0, limit);
+  return (
+    <div className={`text-sm ${className ?? ""}`} data-testid="newsletter-sent-issues">
+      <div className="font-semibold mb-1">{i18next.t("newsletter.sent-issues")}</div>
+      <ul className="m-0 p-0 list-none flex flex-col gap-1">
+        {items.map((i: SentIssue) => (
+          <li key={i.id} className="flex flex-wrap items-baseline gap-x-2 opacity-90">
+            <span className="text-xs opacity-70 tabular-nums">{i.period_start}</span>
+            {i.post_author && i.post_permlink ? (
+              <Link href={`/@${i.post_author}/${i.post_permlink}`} className="truncate max-w-[16rem]">
+                {i.subject}
+              </Link>
+            ) : (
+              <span className="truncate max-w-[16rem]">{i.subject}</span>
+            )}
+            <span className="text-xs opacity-70">
+              {i18next.t("newsletter.sent-issue-stats", { delivered: i.delivered, bounced: i.bounced + i.rejected })}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/features/newsletter/sent-issues.tsx
+++ b/apps/web/src/features/newsletter/sent-issues.tsx
@@ -5,6 +5,7 @@ import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { QueryIdentifiers } from "@/core/react-query";
 import i18next from "i18next";
 import Link from "next/link";
+import type { ReactElement } from "react";
 import { authorSendApi, type SentIssue } from "./author-send-api";
 import { useNewsletterEnabled } from "./runtime";
 
@@ -13,25 +14,45 @@ import { useNewsletterEnabled } from "./runtime";
  * author-sent, with what became of them. Sender-only, like the standing notice:
  * asked for only when the viewer is the sender, and rendered from nothing else.
  */
-export const sentIssuesKey = (type: "creator" | "community", target: string, viewer: string | null | undefined) =>
-  [QueryIdentifiers.NEWSLETTER_SENT_ISSUES, type, target, viewer ?? "anon"] as const;
+export const sentIssuesKey = (
+  type: "creator" | "community",
+  target: string,
+  viewer: string | null | undefined
+): readonly [QueryIdentifiers, string, string, string] => [QueryIdentifiers.NEWSLETTER_SENT_ISSUES, type, target, viewer ?? "anon"] as const;
 
-export function SentIssues({ type, target, isSender, limit = 5, className }: { type: "creator" | "community"; target: string; isSender: boolean; limit?: number; className?: string }) {
+export function SentIssues({
+  type,
+  target,
+  isSender,
+  limit = 5,
+  className
+}: {
+  type: "creator" | "community";
+  target: string;
+  isSender: boolean;
+  limit?: number;
+  className?: string;
+}): ReactElement | null {
   const enabled = useNewsletterEnabled();
   const { activeUser } = useActiveAccount();
   const username = activeUser?.username;
-  const { data } = useQuery({
+  const { data, isError } = useQuery({
     queryKey: sentIssuesKey(type, target, username),
     enabled: enabled && isSender && !!username,
     staleTime: 60_000,
     queryFn: () => authorSendApi.issues(type, target, username!)
   });
-  if (!isSender || !data || data.length === 0) return null;
+  if (!isSender) return null;
+  // A failed load is said, quietly: it is not the same as "nothing sent yet".
+  if (isError) return <div className={`text-xs opacity-60 ${className ?? ""}`}>{i18next.t("newsletter.sent-issues-unavailable")}</div>;
+  if (!data || data.length === 0) return null;
   const items = data.slice(0, limit);
   return (
-    <div className={`text-sm ${className ?? ""}`} data-testid="newsletter-sent-issues">
-      <div className="font-semibold mb-1">{i18next.t("newsletter.sent-issues")}</div>
-      <ul className="m-0 p-0 list-none flex flex-col gap-1">
+    <div className={`text-sm ${className ?? ""}`}>
+      <div className="font-semibold mb-1" id="newsletter-sent-issues-heading">
+        {i18next.t("newsletter.sent-issues")}
+      </div>
+      <ul className="m-0 p-0 list-none flex flex-col gap-1" aria-labelledby="newsletter-sent-issues-heading">
         {items.map((i: SentIssue) => (
           <li key={i.id} className="flex flex-wrap items-baseline gap-x-2 opacity-90">
             <span className="text-xs opacity-70 tabular-nums">{i.period_start}</span>
@@ -43,7 +64,8 @@ export function SentIssues({ type, target, isSender, limit = 5, className }: { t
               <span className="truncate max-w-[16rem]">{i.subject}</span>
             )}
             <span className="text-xs opacity-70">
-              {i18next.t("newsletter.sent-issue-stats", { delivered: i.delivered, bounced: i.bounced + i.rejected })}
+              {i18next.t("newsletter.sent-issue-stats", { delivered: i.delivered, bounced: i.bounced })}
+              {i.rejected > 0 ? ` · ${i18next.t("newsletter.sent-issue-rejected", { rejected: i.rejected })}` : ""}
             </span>
           </li>
         ))}

--- a/apps/web/src/features/shared/entry-menu/index.tsx
+++ b/apps/web/src/features/shared/entry-menu/index.tsx
@@ -47,6 +47,13 @@ const EntryTranslate = dynamic(
   () => import("@/features/shared/entry-translate").then((m) => ({ default: m.EntryTranslate })),
   { ssr: false }
 );
+// Loaded on demand and by file, not through the newsletter barrel: that barrel
+// imports @/features/shared for its toasts, and a static import here would
+// close a cycle through this very module.
+const AuthorSendDialog = dynamic(
+  () => import("@/features/newsletter/author-send-dialog").then((m) => ({ default: m.AuthorSendDialog })),
+  { ssr: false }
+);
 
 interface Props {
   entry: Entry;
@@ -125,7 +132,10 @@ export const EntryMenu = ({
     promote,
     setPromote,
     translate,
-    setTranslate
+    setTranslate,
+    sendNewsletter,
+    setSendNewsletter,
+    newsletterTarget
   } = useMenuItemsGenerator(entry, community, separatedSharing, extraMenuItems);
 
   return (
@@ -176,6 +186,15 @@ export const EntryMenu = ({
         />
       )}
       {share && <EntryShare entry={entry} onHide={() => setShare(false)} />}
+      {sendNewsletter && newsletterTarget && (
+        <AuthorSendDialog
+          target={newsletterTarget}
+          author={entry.author}
+          permlink={entry.permlink}
+          show={sendNewsletter}
+          onHide={() => setSendNewsletter(false)}
+        />
+      )}
       {editHistory && showEditHistoryInMenu && (
         <EditHistory entry={entry} onHide={toggleEditHistory} />
       )}

--- a/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
+++ b/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
@@ -199,7 +199,7 @@ export function useMenuItemsGenerator(
         () => ({
           label: i18next.t("newsletter.send-to-subscribers"),
           onClick: () => setSendNewsletter(true),
-          icon: <UilEnvelopeSend />
+          icon: <UilEnvelopeSend className="size-4" />
         })
       ),
       ...(extraMenuItems ?? []),

--- a/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
+++ b/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useContext, useEffect, useState } from "react";
+import { useAuthorSendTarget } from "@/features/newsletter/author-send-eligibility";
+import { UilEnvelopeSend } from "@tooni/iconscout-unicons-react";
 import { success } from "../feedback";
 import { Community, Entry, FullAccount, ROLES } from "@/entities";
 import { useCommunityPinCache } from "@/core/caches";
@@ -48,6 +50,9 @@ export function useMenuItemsGenerator(
   const [mute, setMute] = useState(false);
   const [promote, setPromote] = useState(false);
   const [translate, setTranslate] = useState(false);
+  const [sendNewsletter, setSendNewsletter] = useState(false);
+  // vision-web#1532: the list this post may be sent to by this viewer, or null.
+  const newsletterTarget = useAuthorSendTarget(entry, community);
   const [canMute, setCanMute] = useState(false);
   const [menuItems, setMenuItems] = useState<MenuItem[]>([]);
 
@@ -189,6 +194,14 @@ export function useMenuItemsGenerator(
           icon: <UilLanguage className="size-4" />
         })
       ),
+      ...safeSpread(
+        () => !!newsletterTarget,
+        () => ({
+          label: i18next.t("newsletter.send-to-subscribers"),
+          onClick: () => setSendNewsletter(true),
+          icon: <UilEnvelopeSend className="size-4" />
+        })
+      ),
       ...(extraMenuItems ?? []),
       ...EcencyConfigManager.composeConditionals(
         EcencyConfigManager.withConditional(
@@ -284,6 +297,7 @@ export function useMenuItemsGenerator(
     isPinned,
     isTeamManager,
     mute,
+    newsletterTarget,
     promote,
     router,
     separatedSharing,
@@ -296,7 +310,7 @@ export function useMenuItemsGenerator(
 
   useEffect(() => {
     generate();
-  }, [isPinned, activeUser, community, canMute, separatedSharing, extraMenuItems, generate]);
+  }, [isPinned, activeUser, community, canMute, separatedSharing, extraMenuItems, generate, newsletterTarget]);
 
   return {
     menuItems,
@@ -320,6 +334,9 @@ export function useMenuItemsGenerator(
     promote,
     setPromote,
     translate,
-    setTranslate
+    setTranslate,
+    sendNewsletter,
+    setSendNewsletter,
+    newsletterTarget
   };
 }

--- a/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
+++ b/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
@@ -199,7 +199,7 @@ export function useMenuItemsGenerator(
         () => ({
           label: i18next.t("newsletter.send-to-subscribers"),
           onClick: () => setSendNewsletter(true),
-          icon: <UilEnvelopeSend className="size-4" />
+          icon: <UilEnvelopeSend />
         })
       ),
       ...(extraMenuItems ?? []),

--- a/apps/web/src/server/newsletter-sender-gate.ts
+++ b/apps/web/src/server/newsletter-sender-gate.ts
@@ -68,6 +68,16 @@ export async function readJsonBody(request: NextRequest): Promise<Record<string,
   return body && typeof body === "object" && !Array.isArray(body) ? (body as Record<string, unknown>) : {};
 }
 
+/**
+ * A creator's list carries the creator's own posts, and only they may send to
+ * it: so for a creator list the post's author IS the sender. The service checks
+ * the same (422 for a foreign post), this keeps the relay from forwarding a
+ * request it can already see is wrong.
+ */
+export function postBelongsToSender(body: SendBody, username: string): boolean {
+  return body.type !== "creator" || body.author === username;
+}
+
 export function parseSendBody(body: Record<string, unknown>): SendBody | Response {
   const type = body?.type;
   const target = String(body?.target ?? "").toLowerCase();

--- a/apps/web/src/server/newsletter-sender-gate.ts
+++ b/apps/web/src/server/newsletter-sender-gate.ts
@@ -35,7 +35,14 @@ export async function senderGate(
     }
     return { ok: true };
   }
-  const community = await getCommunity(target, username);
+  let community: Awaited<ReturnType<typeof getCommunity>>;
+  try {
+    community = await getCommunity(target, username);
+  } catch {
+    // The bridge is the authority on the team; without it there is no verdict.
+    // A retryable answer, not a framework 500.
+    return { ok: false, status: 503, error: "community lookup unavailable" };
+  }
   const role = community?.team?.find(([account]) => account === username)?.[1];
   const roles = mode === "send" ? SEND_ROLES : VIEW_ROLES;
   if (!role || !roles.has(role)) {
@@ -55,8 +62,13 @@ export interface SendBody {
 }
 
 /** The body of a send or preview request, validated; a Response when it is not. */
-export async function parseSendBody(request: NextRequest): Promise<SendBody | Response> {
-  const body = (await request.json().catch(() => null)) as Partial<SendBody> | null;
+/** Reads the JSON body once; the same object feeds resolveUser (body.code) and the field validation. */
+export async function readJsonBody(request: NextRequest): Promise<Record<string, unknown>> {
+  const body = (await request.json().catch(() => null)) as unknown;
+  return body && typeof body === "object" && !Array.isArray(body) ? (body as Record<string, unknown>) : {};
+}
+
+export function parseSendBody(body: Record<string, unknown>): SendBody | Response {
   const type = body?.type;
   const target = String(body?.target ?? "").toLowerCase();
   const author = String(body?.author ?? "").toLowerCase();

--- a/apps/web/src/server/newsletter-sender-gate.ts
+++ b/apps/web/src/server/newsletter-sender-gate.ts
@@ -1,0 +1,68 @@
+import { getCommunity } from "@ecency/sdk";
+import type { NextRequest } from "next/server";
+import { isProRosterMember } from "@/server/pro-members";
+
+/**
+ * Who counts as a list's SENDER, decided in the web tier because it knows Pro
+ * membership and community teams; the service trusts what the relay asserts.
+ *
+ *   view: may see the list's standing and history. The account itself for a
+ *         creator list; owner, admin or mod for a community list.
+ *   send: may send an issue. A creator only while an Ecency Pro member (the
+ *         same gate that offers a creator digest at all); a community's owner
+ *         or admin (mods moderate content, mail is heavier).
+ */
+export type SenderListType = "creator" | "community";
+export const SENDER_TARGET_RE = /^[a-z0-9.-]{1,32}$/;
+
+const VIEW_ROLES = new Set(["owner", "admin", "mod"]);
+const SEND_ROLES = new Set(["owner", "admin"]);
+
+export type GateResult = { ok: true } | { ok: false; status: 403 | 503; error: string };
+
+export async function senderGate(
+  username: string,
+  type: SenderListType,
+  target: string,
+  mode: "view" | "send"
+): Promise<GateResult> {
+  if (type === "creator") {
+    if (target !== username) return { ok: false, status: 403, error: "not your digest" };
+    if (mode === "send") {
+      const pro = await isProRosterMember(username);
+      if (pro === null) return { ok: false, status: 503, error: "membership check unavailable" };
+      if (!pro) return { ok: false, status: 403, error: "sending to a creator digest is an Ecency Pro capability" };
+    }
+    return { ok: true };
+  }
+  const community = await getCommunity(target, username);
+  const role = community?.team?.find(([account]) => account === username)?.[1];
+  const roles = mode === "send" ? SEND_ROLES : VIEW_ROLES;
+  if (!role || !roles.has(role)) {
+    return { ok: false, status: 403, error: mode === "send" ? "only the community's owner or admin may send" : "not on this community's team" };
+  }
+  return { ok: true };
+}
+
+const AUTHOR_RE = /^[a-z0-9.-]{3,16}$/;
+const PERMLINK_RE = /^[a-z0-9-]{1,256}$/;
+
+export interface SendBody {
+  type: "creator" | "community";
+  target: string;
+  author: string;
+  permlink: string;
+}
+
+/** The body of a send or preview request, validated; a Response when it is not. */
+export async function parseSendBody(request: NextRequest): Promise<SendBody | Response> {
+  const body = (await request.json().catch(() => null)) as Partial<SendBody> | null;
+  const type = body?.type;
+  const target = String(body?.target ?? "").toLowerCase();
+  const author = String(body?.author ?? "").toLowerCase();
+  const permlink = String(body?.permlink ?? "");
+  if ((type !== "creator" && type !== "community") || !SENDER_TARGET_RE.test(target) || !AUTHOR_RE.test(author) || !PERMLINK_RE.test(permlink)) {
+    return Response.json({ error: "type, target, author and permlink are required and must be valid" }, { status: 400 });
+  }
+  return { type, target, author, permlink };
+}

--- a/apps/web/src/specs/api/newsletter-send-routes.spec.ts
+++ b/apps/web/src/specs/api/newsletter-send-routes.spec.ts
@@ -90,6 +90,36 @@ describe("author send routes", () => {
     expect(mocks.fetch).toHaveBeenCalledTimes(2);
   });
 
+  it("accepts the HiveSigner code in the body as well as the header, and reads the body once", async () => {
+    mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
+    mocks.pro.mockResolvedValue(true);
+    mocks.fetch.mockResolvedValue(upstream(201, { issues: [] }));
+    const { POST } = await import("@/app/api/newsletter/send/route");
+    const res = await POST(req({ ...SEND, code: "body-token" }));
+    expect(res.status).toBe(201);
+    expect(mocks.verify).toHaveBeenCalledWith("body-token");
+    // The code is not forwarded to the service.
+    expect(JSON.parse(mocks.fetch.mock.calls[0][1].body)).toEqual({ ...SEND, requestedBy: "alice" });
+    const { POST: PREVIEW } = await import("@/app/api/newsletter/send/preview/route");
+    mocks.fetch.mockResolvedValue(upstream(200, { subject: "x" }));
+    expect((await PREVIEW(req({ ...SEND, code: "body-token" }))).status).toBe(200);
+  });
+
+  it("a failing community lookup is a retryable 503 on every community route, never a 500", async () => {
+    mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
+    mocks.getCommunity.mockRejectedValue(new Error("rpc timeout"));
+    const body = { type: "community", target: "hive-125125", author: "bob", permlink: "post" };
+    const { POST } = await import("@/app/api/newsletter/send/route");
+    const { POST: PREVIEW } = await import("@/app/api/newsletter/send/preview/route");
+    const { GET: ISSUES } = await import("@/app/api/newsletter/issues/route");
+    const { GET: SENDER } = await import("@/app/api/newsletter/sender/route");
+    expect((await POST(req(body, { "x-hs-token": "tok" }))).status).toBe(503);
+    expect((await PREVIEW(req(body, { "x-hs-token": "tok" }))).status).toBe(503);
+    expect((await ISSUES(req(undefined, { "x-hs-token": "tok" }, "type=community&target=hive-125125"))).status).toBe(503);
+    expect((await SENDER(req(undefined, { "x-hs-token": "tok" }, "type=community&target=hive-125125"))).status).toBe(503);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
   it("validates the body, requires identity, and answers 503 unconfigured", async () => {
     mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
     mocks.pro.mockResolvedValue(true);

--- a/apps/web/src/specs/api/newsletter-send-routes.spec.ts
+++ b/apps/web/src/specs/api/newsletter-send-routes.spec.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ verify: vi.fn(), fetch: vi.fn(), getCommunity: vi.fn(), pro: vi.fn() }));
+vi.mock("@/server/hivesigner-verify", () => ({ verifyHsAccessToken: mocks.verify }));
+vi.mock("@ecency/sdk", () => ({ getCommunity: mocks.getCommunity }));
+vi.mock("@/server/pro-members", () => ({ isProRosterMember: mocks.pro }));
+
+function req(body: unknown, headers: Record<string, string> = {}, query = "") {
+  const url = new URL(`http://localhost/api/newsletter/x?${query}`);
+  return { json: async () => body, headers: new Headers(headers), nextUrl: url } as never;
+}
+function upstream(status: number, body: unknown) {
+  return { status, ok: status < 400, json: async () => body } as never;
+}
+const SEND = { type: "creator", target: "alice", author: "alice", permlink: "hello" };
+
+/**
+ * vision-web#1532: who may send is decided here (Pro creator for their own
+ * list; community owner or admin); the service's answers are relayed as they
+ * are, with the requester asserted.
+ */
+describe("author send routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("fetch", mocks.fetch);
+    vi.stubEnv("NEWSLETTER_API_URL", "http://news.internal:3300");
+    vi.stubEnv("NEWSLETTER_SERVICE_TOKEN", "service-token-0123456789abcdefghijklmnop");
+    mocks.fetch.mockReset();
+    mocks.verify.mockReset();
+    mocks.getCommunity.mockReset();
+    mocks.pro.mockReset();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("a Pro creator sends their own post; the requester is asserted and the service's answer relayed", async () => {
+    mocks.verify.mockResolvedValue({ ok: true, username: "Alice" });
+    mocks.pro.mockResolvedValue(true);
+    mocks.fetch.mockResolvedValue(upstream(201, { issues: [{ issueId: "i1", cadence: "weekly", period: "2026-08-17", send: { recipients: 3, sent: 3 } }] }));
+    const { POST } = await import("@/app/api/newsletter/send/route");
+    const res = await POST(req(SEND, { "x-hs-token": "tok" }));
+    expect(res.status).toBe(201);
+    expect(mocks.fetch.mock.calls[0][0]).toBe("http://news.internal:3300/api/issues");
+    expect(JSON.parse(mocks.fetch.mock.calls[0][1].body)).toEqual({ ...SEND, requestedBy: "alice" });
+    // 409 / 422 / 403 from the service pass through with their bodies.
+    mocks.fetch.mockResolvedValue(upstream(409, { error: "taken", code: "already_sent", taken: [{ cadence: "weekly" }] }));
+    const taken = await POST(req(SEND, { "x-hs-token": "tok" }));
+    expect(taken.status).toBe(409);
+    expect(await taken.json()).toMatchObject({ code: "already_sent" });
+  });
+
+  it("a creator who is not Pro, or someone else's list, is refused before the service is asked; an unknown roster is a 503", async () => {
+    mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
+    const { POST } = await import("@/app/api/newsletter/send/route");
+    mocks.pro.mockResolvedValue(false);
+    expect((await POST(req(SEND, { "x-hs-token": "tok" }))).status).toBe(403);
+    mocks.pro.mockResolvedValue(true);
+    expect((await POST(req({ ...SEND, target: "bob" }, { "x-hs-token": "tok" }))).status).toBe(403);
+    mocks.pro.mockResolvedValue(null);
+    expect((await POST(req(SEND, { "x-hs-token": "tok" }))).status).toBe(503);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it("a community's owner or admin may send; a mod may look but not send; a member neither", async () => {
+    mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
+    mocks.getCommunity.mockResolvedValue({ name: "hive-125125", team: [["owner1", "owner", ""], ["alice", "mod", ""], ["dora", "admin", ""], ["carol", "member", ""]] });
+    mocks.fetch.mockResolvedValue(upstream(201, { issues: [] }));
+    const body = { type: "community", target: "hive-125125", author: "bob", permlink: "post" };
+    const { POST } = await import("@/app/api/newsletter/send/route");
+    const { POST: PREVIEW } = await import("@/app/api/newsletter/send/preview/route");
+    const { GET: ISSUES } = await import("@/app/api/newsletter/issues/route");
+    // alice is a mod: may view issues, may not send or preview a send.
+    expect((await POST(req(body, { "x-hs-token": "tok" }))).status).toBe(403);
+    expect((await PREVIEW(req(body, { "x-hs-token": "tok" }))).status).toBe(403);
+    mocks.fetch.mockResolvedValue(upstream(200, { issues: [] }));
+    expect((await ISSUES(req(undefined, { "x-hs-token": "tok" }, "type=community&target=hive-125125"))).status).toBe(200);
+    expect(mocks.fetch.mock.calls[0][0]).toBe("http://news.internal:3300/api/issues?type=community&target=hive-125125");
+    // dora is an admin: sends.
+    mocks.verify.mockResolvedValue({ ok: true, username: "dora" });
+    mocks.fetch.mockResolvedValue(upstream(200, { subject: "x", subscribers: { weekly: 1, monthly: 0 }, alreadySent: [] }));
+    expect((await PREVIEW(req(body, { "x-hs-token": "tok" }))).status).toBe(200);
+    expect(mocks.fetch.mock.calls[1][0]).toBe("http://news.internal:3300/api/issues/preview");
+    expect(JSON.parse(mocks.fetch.mock.calls[1][1].body)).toEqual(body);
+    // carol is a member: nothing.
+    mocks.verify.mockResolvedValue({ ok: true, username: "carol" });
+    expect((await ISSUES(req(undefined, { "x-hs-token": "tok" }, "type=community&target=hive-125125"))).status).toBe(403);
+    expect((await POST(req(body, { "x-hs-token": "tok" }))).status).toBe(403);
+    expect(mocks.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("validates the body, requires identity, and answers 503 unconfigured", async () => {
+    mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
+    mocks.pro.mockResolvedValue(true);
+    const { POST } = await import("@/app/api/newsletter/send/route");
+    expect((await POST(req({ ...SEND, permlink: "Bad Permlink!" }, { "x-hs-token": "tok" }))).status).toBe(400);
+    expect((await POST(req({ ...SEND, type: "site" }, { "x-hs-token": "tok" }))).status).toBe(400);
+    expect((await POST(req(null, { "x-hs-token": "tok" }))).status).toBe(400);
+    mocks.verify.mockResolvedValue({ ok: false, reason: "missing" });
+    expect((await POST(req(SEND))).status).toBe(401);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    vi.stubEnv("NEWSLETTER_SERVICE_TOKEN", "");
+    vi.resetModules();
+    const { POST: POST2 } = await import("@/app/api/newsletter/send/route");
+    expect((await POST2(req(SEND, { "x-hs-token": "tok" }))).status).toBe(503);
+  });
+});

--- a/apps/web/src/specs/api/newsletter-send-routes.spec.ts
+++ b/apps/web/src/specs/api/newsletter-send-routes.spec.ts
@@ -51,9 +51,14 @@ describe("author send routes", () => {
     expect(await taken.json()).toMatchObject({ code: "already_sent" });
   });
 
-  it("a creator who is not Pro, or someone else's list, is refused before the service is asked; an unknown roster is a 503", async () => {
+  it("a creator who is not Pro, or someone else's list, or someone else's post, is refused before the service is asked; an unknown roster is a 503", async () => {
     mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
     const { POST } = await import("@/app/api/newsletter/send/route");
+    const { POST: PREVIEW } = await import("@/app/api/newsletter/send/preview/route");
+    mocks.pro.mockResolvedValue(true);
+    // A creator's list carries only their own posts: bob's post to alice's list is refused here, preview included.
+    expect((await POST(req({ ...SEND, author: "bob" }, { "x-hs-token": "tok" }))).status).toBe(403);
+    expect((await PREVIEW(req({ ...SEND, author: "bob" }, { "x-hs-token": "tok" }))).status).toBe(403);
     mocks.pro.mockResolvedValue(false);
     expect((await POST(req(SEND, { "x-hs-token": "tok" }))).status).toBe(403);
     mocks.pro.mockResolvedValue(true);

--- a/apps/web/src/specs/features/newsletter/author-send-api.spec.ts
+++ b/apps/web/src/specs/features/newsletter/author-send-api.spec.ts
@@ -38,4 +38,9 @@ describe("authorSendApi", () => {
     expect(err).toBeInstanceOf(SendRefusedError);
     expect(err).toMatchObject({ status: 409, code: "already_sent", taken: [{ cadence: "weekly" }] });
   });
+
+  it("a 2xx without a JSON body is an error, not an empty result", async () => {
+    fetchMock.mockReturnValueOnce(Promise.resolve({ ok: true, status: 200, json: async () => { throw new Error("no body"); } } as unknown as Response));
+    await expect(authorSendApi.preview({ type: "creator", target: "alice", author: "alice", permlink: "hello" }, "alice")).rejects.toThrow(/Unexpected response/);
+  });
 });

--- a/apps/web/src/specs/features/newsletter/author-send-api.spec.ts
+++ b/apps/web/src/specs/features/newsletter/author-send-api.spec.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { authorSendApi, SendRefusedError } from "@/features/newsletter/author-send-api";
+
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<object>("@/utils")),
+  ensureValidToken: vi.fn(async () => "mock-token")
+}));
+
+const fetchMock = vi.fn();
+const json = (status: number, body: unknown) => Promise.resolve({ ok: status < 400, status, json: async () => body } as Response);
+
+/** The browser client's contract with the relay routes: paths, bodies, the token header, error shape. */
+describe("authorSendApi", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("previews and sends with the token header and the exact body; lists issues by list", async () => {
+    const ref = { type: "creator" as const, target: "alice", author: "alice", permlink: "hello" };
+    fetchMock.mockReturnValueOnce(json(200, { subject: "x" }));
+    await authorSendApi.preview(ref, "alice");
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/newsletter/send/preview");
+    expect(fetchMock.mock.calls[0][1].headers).toMatchObject({ "X-HS-Token": "mock-token" });
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual(ref);
+    fetchMock.mockReturnValueOnce(json(201, { issues: [] }));
+    await authorSendApi.send(ref, "alice");
+    expect(fetchMock.mock.calls[1][0]).toBe("/api/newsletter/send");
+    fetchMock.mockReturnValueOnce(json(200, { issues: [{ id: "1" }] }));
+    expect(await authorSendApi.issues("community", "hive-125125", "alice")).toEqual([{ id: "1" }]);
+    expect(fetchMock.mock.calls[2][0]).toBe("/api/newsletter/issues?type=community&target=hive-125125");
+  });
+
+  it("keeps the service's status, code and taken details on refusal", async () => {
+    fetchMock.mockReturnValueOnce(json(409, { error: "taken", code: "already_sent", taken: [{ cadence: "weekly", period: "2026-08-17", kind: "post" }] }));
+    const err = await authorSendApi.send({ type: "creator", target: "alice", author: "alice", permlink: "hello" }, "alice").catch((e) => e);
+    expect(err).toBeInstanceOf(SendRefusedError);
+    expect(err).toMatchObject({ status: 409, code: "already_sent", taken: [{ cadence: "weekly" }] });
+  });
+});

--- a/apps/web/src/specs/features/newsletter/author-send.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/author-send.spec.tsx
@@ -6,11 +6,11 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { NewsletterRuntimeProvider } from "@/features/newsletter/runtime";
 import { AuthorSendDialog, SentIssues, useAuthorSendTarget } from "@/features/newsletter";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
-import type { Community } from "@/entities";
 import {
   cleanupModalContainers,
   createTestQueryClient,
   mockActiveUser,
+  mockCommunity,
   mockEntry,
   renderWithQueryClient,
   setupModalContainers
@@ -46,7 +46,7 @@ function loggedIn(username: string | null) {
   } as never);
 }
 
-const community = { name: "hive-125125", title: "Town Square", team: [["owner1", "owner", ""], ["alice", "admin", ""], ["mia", "mod", ""]] } as unknown as Community;
+const community = mockCommunity({ name: "hive-125125", title: "Town Square", team: [["owner1", "owner", ""], ["alice", "admin", ""], ["mia", "mod", ""]] });
 const target = { type: "creator" as const, target: "alice", label: "@alice" };
 const preview = (over: Record<string, unknown> = {}) => ({
   subject: "Hello world",
@@ -129,14 +129,11 @@ describe("AuthorSendDialog", () => {
     await waitFor(() => expect(screen.getByText("Hello world")).toBeInTheDocument());
     expect(screen.getByText("newsletter.send-readers")).toBeInTheDocument();
     expect(screen.getByText("newsletter.send-one-per-period")).toBeInTheDocument();
-    expect(fetchMock.mock.calls[0][0]).toBe("/api/newsletter/send/preview");
-    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ type: "creator", target: "alice", author: "alice", permlink: "hello" });
     const iframe = document.querySelector("iframe") as HTMLIFrameElement;
     expect(iframe.getAttribute("sandbox")).toBe("");
     expect(iframe.getAttribute("srcdoc")).toContain("Hello");
     fireEvent.click(screen.getByText("newsletter.send-now"));
     await waitFor(() => expect(screen.getByText("newsletter.send-done")).toBeInTheDocument());
-    expect(fetchMock.mock.calls[1][0]).toBe("/api/newsletter/send");
     expect(screen.getAllByText("newsletter.send-done-line")).toHaveLength(2);
   });
 
@@ -154,7 +151,8 @@ describe("AuthorSendDialog", () => {
 
   it("shows the service's refusals for what they are: taken, suspended, post refused, not allowed, unavailable", async () => {
     const cases: Array<[number, Record<string, unknown>, string]> = [
-      [409, { error: "taken", code: "already_sent" }, "newsletter.send-already-sent"],
+      [409, { error: "taken", code: "already_sent", taken: [{ cadence: "weekly", period: "2026-08-17", kind: "digest" }] }, "newsletter.send-already-sent"],
+      [404, { error: "post not found", code: "post_not_found" }, "newsletter.send-post-not-found"],
       [403, { error: "suspended", code: "suspended" }, "newsletter.send-suspended"],
       [422, { error: "the post is tagged nsfw", code: "post_refused" }, "newsletter.send-post-refused"],
       [403, { error: "sending to a creator digest is an Ecency Pro capability" }, "newsletter.send-not-allowed"],
@@ -167,6 +165,11 @@ describe("AuthorSendDialog", () => {
       fireEvent.click(screen.getByText("newsletter.send-now"));
       await waitFor(() => expect(screen.getByText(key)).toBeInTheDocument());
       if (status === 422) expect(screen.getByText("the post is tagged nsfw")).toBeInTheDocument();
+      if (status === 409) {
+        // The conflict says which period is taken and by what, and points at the history.
+        expect(screen.getByText("newsletter.send-taken-line")).toBeInTheDocument();
+        expect(screen.getByText("newsletter.send-see-history").closest("a")).toHaveAttribute("href", "/@alice");
+      }
       unmount();
     }
     // A refused preview shows the reason too, and no send button.
@@ -196,19 +199,26 @@ describe("SentIssues", () => {
       })
     );
     render(<SentIssues type="creator" target="alice" isSender />);
-    const list = await screen.findByTestId("newsletter-sent-issues");
+    const list = await screen.findByRole("list", { name: "newsletter.sent-issues" });
     expect(list).toHaveTextContent("Hello world");
     expect(list.querySelector('a[href="/@alice/hello"]')).not.toBeNull();
     expect(list).toHaveTextContent("@alice's weekly digest: 3 new posts");
-    expect(fetchMock.mock.calls[0][0]).toBe("/api/newsletter/issues?type=creator&target=alice");
+    // Bounced and rejected are different outcomes and are shown as such.
+    expect(list).toHaveTextContent("newsletter.sent-issue-stats");
+    expect(screen.getAllByText(/newsletter.sent-issue-rejected/)).toHaveLength(1);
     fetchMock.mockReset();
     const { container } = render(<SentIssues type="creator" target="alice" isSender={false} />);
     await new Promise((r) => setTimeout(r, 30));
     expect(fetchMock).not.toHaveBeenCalled();
     expect(container.textContent).toBe("");
     fetchMock.mockReturnValue(json(200, { issues: [] }));
-    const { container: c2 } = render(<SentIssues type="community" target="hive-125125" isSender />);
+    const { container: c2, unmount } = render(<SentIssues type="community" target="hive-125125" isSender />);
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(c2.textContent).toBe("");
+    unmount();
+    // A failed load is not "nothing sent yet".
+    fetchMock.mockReturnValue(json(503, { error: "down" }));
+    render(<SentIssues type="creator" target="alice" isSender />);
+    await waitFor(() => expect(screen.getByText("newsletter.sent-issues-unavailable")).toBeInTheDocument());
   });
 });

--- a/apps/web/src/specs/features/newsletter/author-send.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/author-send.spec.tsx
@@ -1,0 +1,214 @@
+import "@testing-library/jest-dom";
+import { fireEvent, renderHook, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactElement, ReactNode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { NewsletterRuntimeProvider } from "@/features/newsletter/runtime";
+import { AuthorSendDialog, SentIssues, useAuthorSendTarget } from "@/features/newsletter";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import type { Community } from "@/entities";
+import {
+  cleanupModalContainers,
+  createTestQueryClient,
+  mockActiveUser,
+  mockEntry,
+  renderWithQueryClient,
+  setupModalContainers
+} from "@/specs/test-utils";
+
+const flags = vi.hoisted(() => ({ newsletter: true }));
+vi.mock("@/config", () => ({
+  EcencyConfigManager: {
+    getConfigValue: (fn: (c: unknown) => unknown) => fn({ visionFeatures: { newsletter: { enabled: flags.newsletter } } })
+  }
+}));
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<object>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token"),
+  ensureValidToken: vi.fn(async () => "mock-token")
+}));
+
+const fetchMock = vi.fn();
+const json = (status: number, body: unknown) => Promise.resolve({ ok: status < 400, status, json: async () => body } as Response);
+
+function loggedIn(username: string | null) {
+  vi.mocked(useActiveAccount).mockReturnValue({
+    activeUser: username ? mockActiveUser({ username }) : null,
+    username,
+    account: null,
+    isLoading: false,
+    isPending: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isSuccess: true
+  } as never);
+}
+
+const community = { name: "hive-125125", title: "Town Square", team: [["owner1", "owner", ""], ["alice", "admin", ""], ["mia", "mod", ""]] } as unknown as Community;
+const target = { type: "creator" as const, target: "alice", label: "@alice" };
+const preview = (over: Record<string, unknown> = {}) => ({
+  subject: "Hello world",
+  html: "<html><body><p>Hello</p></body></html>",
+  text: "Hello",
+  post: { author: "alice", permlink: "hello", title: "Hello world" },
+  subscribers: { weekly: 12, monthly: 3 },
+  alreadySent: [],
+  ...over
+});
+
+const wrap = (client: ReturnType<typeof createTestQueryClient>) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <NewsletterRuntimeProvider configured>{children}</NewsletterRuntimeProvider>
+      </QueryClientProvider>
+    );
+  };
+const render = (ui: ReactElement, client = createTestQueryClient()) =>
+  renderWithQueryClient(<NewsletterRuntimeProvider configured>{ui}</NewsletterRuntimeProvider>, { queryClient: client });
+
+describe("useAuthorSendTarget", () => {
+  beforeEach(() => {
+    flags.newsletter = true;
+    loggedIn("alice");
+  });
+
+  it("offers a Pro creator their own top-level post, and a community's owner/admin a post made there; nobody else", () => {
+    const client = createTestQueryClient();
+    client.setQueryData(["accounts", "pro-members"], { members: ["alice"] });
+    const own = mockEntry({ author: "alice", permlink: "hello", category: "photography", parent_author: "", depth: 0 });
+    expect(renderHook(() => useAuthorSendTarget(own, null), { wrapper: wrap(client) }).result.current).toEqual(target);
+    // In a community she administers, the community list wins for that post.
+    const inCommunity = mockEntry({ author: "bob", permlink: "p", category: "hive-125125", parent_author: "", depth: 0 });
+    expect(renderHook(() => useAuthorSendTarget(inCommunity, community), { wrapper: wrap(client) }).result.current).toEqual({
+      type: "community",
+      target: "hive-125125",
+      label: "Town Square"
+    });
+    // A comment, never.
+    const comment = mockEntry({ author: "alice", permlink: "re", category: "photography", parent_author: "bob", depth: 1 });
+    expect(renderHook(() => useAuthorSendTarget(comment, null), { wrapper: wrap(client) }).result.current).toBeNull();
+    // Not Pro: own post not offered; still may send as community admin.
+    client.setQueryData(["accounts", "pro-members"], { members: ["someone-else"] });
+    expect(renderHook(() => useAuthorSendTarget(own, null), { wrapper: wrap(client) }).result.current).toBeNull();
+    expect(renderHook(() => useAuthorSendTarget(inCommunity, community), { wrapper: wrap(client) }).result.current?.type).toBe("community");
+    // A mod: no. Someone else's post outside a community she runs: no. Logged out: no. Feature off: no.
+    loggedIn("mia");
+    expect(renderHook(() => useAuthorSendTarget(inCommunity, community), { wrapper: wrap(client) }).result.current).toBeNull();
+    loggedIn("alice");
+    expect(renderHook(() => useAuthorSendTarget(mockEntry({ author: "bob", permlink: "q", category: "photography", parent_author: "", depth: 0 }), null), { wrapper: wrap(client) }).result.current).toBeNull();
+    loggedIn(null);
+    expect(renderHook(() => useAuthorSendTarget(own, null), { wrapper: wrap(client) }).result.current).toBeNull();
+    loggedIn("alice");
+    flags.newsletter = false;
+    client.setQueryData(["accounts", "pro-members"], { members: ["alice"] });
+    expect(renderHook(() => useAuthorSendTarget(own, null), { wrapper: wrap(client) }).result.current).toBeNull();
+  });
+});
+
+describe("AuthorSendDialog", () => {
+  beforeEach(() => {
+    setupModalContainers();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    flags.newsletter = true;
+    loggedIn("alice");
+  });
+  afterEach(() => {
+    cleanupModalContainers();
+    vi.unstubAllGlobals();
+  });
+
+  it("previews, states the readers and the one-per-period rule, sends, and reports what went out", async () => {
+    fetchMock.mockImplementation((url: string) =>
+      url.endsWith("/preview") ? json(200, preview()) : json(201, { issues: [{ issueId: "i1", cadence: "weekly", period: "2026-08-17", send: { recipients: 12, sent: 12, pending: 0 } }, { issueId: "i2", cadence: "monthly", period: "2026-08-01", send: { recipients: 3, sent: 3, pending: 0 } }] })
+    );
+    render(<AuthorSendDialog target={target} author="alice" permlink="hello" show onHide={() => {}} />);
+    await waitFor(() => expect(screen.getByText("Hello world")).toBeInTheDocument());
+    expect(screen.getByText("newsletter.send-readers")).toBeInTheDocument();
+    expect(screen.getByText("newsletter.send-one-per-period")).toBeInTheDocument();
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/newsletter/send/preview");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ type: "creator", target: "alice", author: "alice", permlink: "hello" });
+    const iframe = document.querySelector("iframe") as HTMLIFrameElement;
+    expect(iframe.getAttribute("sandbox")).toBe("");
+    expect(iframe.getAttribute("srcdoc")).toContain("Hello");
+    fireEvent.click(screen.getByText("newsletter.send-now"));
+    await waitFor(() => expect(screen.getByText("newsletter.send-done")).toBeInTheDocument());
+    expect(fetchMock.mock.calls[1][0]).toBe("/api/newsletter/send");
+    expect(screen.getAllByText("newsletter.send-done-line")).toHaveLength(2);
+  });
+
+  it("when this period's issue already went out for every cadence, says so and offers no send; a partial take-over is stated and still sends", async () => {
+    fetchMock.mockImplementation(() => json(200, preview({ alreadySent: ["weekly", "monthly"] })));
+    const { unmount } = render(<AuthorSendDialog target={target} author="alice" permlink="hello" show onHide={() => {}} />);
+    await waitFor(() => expect(screen.getByText("newsletter.send-period-taken-all")).toBeInTheDocument());
+    expect(screen.getByText("newsletter.send-now").closest("button")).toBeDisabled();
+    unmount();
+    fetchMock.mockImplementation((url: string) => (url.endsWith("/preview") ? json(200, preview({ alreadySent: ["weekly"] })) : json(201, { issues: [{ issueId: "i2", cadence: "monthly", period: "2026-08-01", send: { recipients: 3, sent: 3, pending: 0 } }] })));
+    render(<AuthorSendDialog target={target} author="alice" permlink="hello" show onHide={() => {}} />);
+    await waitFor(() => expect(screen.getByText("newsletter.send-period-taken-some")).toBeInTheDocument());
+    expect(screen.getByText("newsletter.send-now").closest("button")).not.toBeDisabled();
+  });
+
+  it("shows the service's refusals for what they are: taken, suspended, post refused, not allowed, unavailable", async () => {
+    const cases: Array<[number, Record<string, unknown>, string]> = [
+      [409, { error: "taken", code: "already_sent" }, "newsletter.send-already-sent"],
+      [403, { error: "suspended", code: "suspended" }, "newsletter.send-suspended"],
+      [422, { error: "the post is tagged nsfw", code: "post_refused" }, "newsletter.send-post-refused"],
+      [403, { error: "sending to a creator digest is an Ecency Pro capability" }, "newsletter.send-not-allowed"],
+      [503, { error: "not configured" }, "newsletter.error-unavailable"]
+    ];
+    for (const [status, body, key] of cases) {
+      fetchMock.mockImplementation((url: string) => (url.endsWith("/preview") ? json(200, preview()) : json(status, body)));
+      const { unmount } = render(<AuthorSendDialog target={target} author="alice" permlink="hello" show onHide={() => {}} />);
+      await waitFor(() => expect(screen.getByText("newsletter.send-now")).toBeInTheDocument());
+      fireEvent.click(screen.getByText("newsletter.send-now"));
+      await waitFor(() => expect(screen.getByText(key)).toBeInTheDocument());
+      if (status === 422) expect(screen.getByText("the post is tagged nsfw")).toBeInTheDocument();
+      unmount();
+    }
+    // A refused preview shows the reason too, and no send button.
+    fetchMock.mockImplementation(() => json(422, { error: "the post is not by this creator", code: "post_refused" }));
+    render(<AuthorSendDialog target={target} author="alice" permlink="hello" show onHide={() => {}} />);
+    await waitFor(() => expect(screen.getByText("newsletter.send-post-refused")).toBeInTheDocument());
+    expect(screen.queryByText("newsletter.send-now")).toBeNull();
+  });
+});
+
+describe("SentIssues", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    flags.newsletter = true;
+    loggedIn("alice");
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("lists the sender's issues with what became of them; nothing for a non-sender, nothing when empty", async () => {
+    fetchMock.mockReturnValue(
+      json(200, {
+        issues: [
+          { id: "1", cadence: "weekly", kind: "post", period_start: "2026-08-17", subject: "Hello world", status: "sent", post_author: "alice", post_permlink: "hello", requested_by: "alice", created_at: "2026-08-19T10:00:00Z", delivered: 12, bounced: 1, rejected: 0 },
+          { id: "2", cadence: "weekly", kind: "digest", period_start: "2026-08-10", subject: "@alice's weekly digest: 3 new posts", status: "sent", post_author: null, post_permlink: null, requested_by: null, created_at: "2026-08-17T09:00:00Z", delivered: 11, bounced: 0, rejected: 1 }
+        ]
+      })
+    );
+    render(<SentIssues type="creator" target="alice" isSender />);
+    const list = await screen.findByTestId("newsletter-sent-issues");
+    expect(list).toHaveTextContent("Hello world");
+    expect(list.querySelector('a[href="/@alice/hello"]')).not.toBeNull();
+    expect(list).toHaveTextContent("@alice's weekly digest: 3 new posts");
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/newsletter/issues?type=creator&target=alice");
+    fetchMock.mockReset();
+    const { container } = render(<SentIssues type="creator" target="alice" isSender={false} />);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(container.textContent).toBe("");
+    fetchMock.mockReturnValue(json(200, { issues: [] }));
+    const { container: c2 } = render(<SentIssues type="community" target="hive-125125" isSender />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(c2.textContent).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #1532. Phase 2 of #1507, app side; the service half is ecency/news #20 (merged, deployed).

**Rule carried over from the service:** a subscriber never receives more than one issue per period they chose. An author send *is* the list's issue for the current week (and month, for monthly readers): it replaces that period's automatic digest, and a second send in the same period is refused per cadence. The app states this in the dialog and shows the service's answers as they are.

**Who may send (`server/newsletter-sender-gate.ts`, enforced in the routes):** a creator only for their own list and only while an Ecency Pro member (the gate that offers a creator digest at all); a community's owner or admin. Viewing standing and history: the creator; owner, admin, mod. `/api/newsletter/sender` now goes through the same gate.

**Routes:** `POST /api/newsletter/send` (asserts `requestedBy` = the verified account), `POST /api/newsletter/send/preview`, `GET /api/newsletter/issues`. Body validated (type, target, author, permlink); 401 without identity, 403 outside the gate, 503 when the Pro roster cannot be read or the service is unconfigured; 409/422/404 from the service pass through with their bodies.

**UI (feature-gated):** "Send to email subscribers" in the post menu for the viewer's sendable posts (`useAuthorSendTarget` mirrors the gate; a post in a community the viewer runs goes to the community list, otherwise to their own). The dialog shows the reader's view of the issue in a sandboxed iframe, "N weekly and M monthly readers will get this as their current issue", the one-per-period reminder, which cadences already have this period's issue (send disabled when all do), then Send; success lists what went out per cadence; refusals are named (already sent, suspended, post refused with the reason, not allowed, unavailable). `SentIssues` on the creator's own profile card and the community card for its team: the last issues with delivered/bounced counts, linked to the post.

**Specs:** route gate matrix (Pro/non-Pro creator, own vs other list, unknown roster → 503; community owner/admin send, mod views only, member nothing), body validation, relay bodies; the hook's eligibility table; dialog flow, taken periods, every refusal; sent issues. Typecheck, eslint, 740 specs green.

Note: the dialog is loaded on demand by file path from the entry menu, not through the newsletter barrel, because that barrel imports `@/features/shared` for its toasts and a static import would close a cycle through the entry menu itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authors can preview and manually send eligible posts to creator or community newsletter subscribers.
  * Send dialogs show subscriber counts, delivery cadence, preview content, and delivery results.
  * Creator and community profiles now display newsletter issue history and delivery statistics.
  * Entry menus include newsletter sending when available.
  * Added clear messaging for eligibility, duplicate sends, suspensions, and delivery errors.

* **Tests**
  * Added coverage for newsletter sending, previews, authorization, validation, and issue history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->