### PR TITLE
entry: mount the NSFW click-to-reveal gate only for NSFW posts (tree hygiene, no byte claim)

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-ssr.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-ssr.tsx
@@ -11,6 +11,7 @@ import { EntryPageStaticBody } from "./entry-page-static-body";
 import { EntryPageWarnings } from "./entry-page-warnings";
 import { EntryTags } from "./entry-tags";
 import { EntryPageNsfwBodyWrapper } from "./entry-page-nsfw-body-wrapper";
+import { needsNsfwGate } from "./entry-page-nsfw-gate";
 import { EntryTranslateInline } from "@/features/shared/entry-translate/entry-translate-inline";
 
 interface Props {
@@ -21,6 +22,25 @@ interface Props {
 export function EntryPageContentSSR({ entry, isRawContent }: Props) {
   const location = useEntryLocation(entry);
   const postPoll = useEntryPollExtractor(entry);
+  const body = (
+    <>
+      {!isRawContent && (
+        <div className="bg-white/80 dark:bg-dark-200/90 rounded-xl p-2 md:p-4">
+          <EntryTranslateInline entry={entry} />
+          <EntryPageStaticBody entry={entry} />
+          {postPoll && <PollWidget entry={entry} poll={postPoll} isReadOnly={false} />}
+        </div>
+      )}
+      {isRawContent && (
+        <pre
+          id="post-body"
+          className="entry-body markdown-view user-selectable font-mono bg-gray-100 rounded text-sm !p-4 dark:bg-gray-900 whitespace-pre-wrap break-words"
+        >
+          {entry.body}
+        </pre>
+      )}
+    </>
+  );
   return (
     <>
       <div className="entry-header">
@@ -28,24 +48,19 @@ export function EntryPageContentSSR({ entry, isRawContent }: Props) {
         <EntryPageIsCommentHeader entry={entry} />
         <EntryPageMainInfo entry={entry} />
       </div>
-      {/* SSR static body - wrapped with NSFW check */}
-      <EntryPageNsfwBodyWrapper entry={entry}>
-        {!isRawContent && (
-          <div className="bg-white/80 dark:bg-dark-200/90 rounded-xl p-2 md:p-4">
-            <EntryTranslateInline entry={entry} />
-            <EntryPageStaticBody entry={entry} />
-            {postPoll && <PollWidget entry={entry} poll={postPoll} isReadOnly={false} />}
-          </div>
-        )}
-        {isRawContent && (
-          <pre
-            id="post-body"
-            className="entry-body markdown-view user-selectable font-mono bg-gray-100 rounded text-sm !p-4 dark:bg-gray-900 whitespace-pre-wrap break-words"
-          >
-            {entry.body}
-          </pre>
-        )}
-      </EntryPageNsfwBodyWrapper>
+      {/* SSR static body. The NSFW click-to-reveal gate is a client component,
+          and any server subtree passed through it as children has its element
+          props serialized into the RSC payload — including the rendered
+          article in EntryPageStaticBody's dangerouslySetInnerHTML (~11 KB that
+          nothing on the client reads; the viewer only enhances the SSR-painted
+          #post-body). So the gate is mounted ONLY when the post actually needs
+          it. Non-NSFW posts (the vast majority) render the body directly in the
+          server tree. NSFW posts keep exactly the previous behaviour. See #1538. */}
+      {needsNsfwGate(entry) ? (
+        <EntryPageNsfwBodyWrapper entry={entry}>{body}</EntryPageNsfwBodyWrapper>
+      ) : (
+        body
+      )}
       <div className="entry-footer bg-white/80 dark:bg-dark-200/90 rounded-xl flex-wrap my-4 lg:mb-8">
         {location?.coordinates && (
           <Link

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-nsfw-gate.ts
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-nsfw-gate.ts
@@ -1,0 +1,17 @@
+import { Entry } from "@/entities";
+
+/**
+ * Should the post body be hidden behind the NSFW click-to-reveal gate?
+ *
+ * Deliberately the literal-tag check the gate has always used, NOT the broader
+ * `isNsfwEntry()` (which also matches NSFW communities and title stems). Using
+ * that here would start gating posts that carry no nsfw tag today — a behaviour
+ * change worth its own decision, not one to fold into a rendering optimisation.
+ *
+ * Shared by the server (which decides whether to mount the client gate at all,
+ * see #1538) and by the client gate itself, so the two can never disagree.
+ */
+export function needsNsfwGate(entry: Pick<Entry, "json_metadata">): boolean {
+  const tags = entry.json_metadata?.tags;
+  return Array.isArray(tags) && tags.includes("nsfw");
+}

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-nsfw-revealing.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-nsfw-revealing.tsx
@@ -3,6 +3,7 @@
 import { useGlobalStore } from "@/core/global-store";
 import { Entry } from "@/entities";
 import { EntryPageNsfwWarning } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-nsfw-warning";
+import { needsNsfwGate } from "./entry-page-nsfw-gate";
 import React from "react";
 
 interface Props {
@@ -14,11 +15,7 @@ interface Props {
 export function EntryPageNsfwRevealing({ entry, showIfNsfw, children }: Props) {
   const globalNsfw = useGlobalStore((s) => s.nsfw);
 
-  const showNsfwWarning =
-      Array.isArray(entry.json_metadata?.tags) &&
-      entry.json_metadata?.tags.includes("nsfw") &&
-      !showIfNsfw &&
-      !globalNsfw;
+  const showNsfwWarning = needsNsfwGate(entry) && !showIfNsfw && !globalNsfw;
 
   return showNsfwWarning ? <EntryPageNsfwWarning /> : children;
 }

--- a/apps/web/src/specs/app/entry/nsfw-gate.spec.tsx
+++ b/apps/web/src/specs/app/entry/nsfw-gate.spec.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { needsNsfwGate } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-nsfw-gate";
+import { Entry } from "@/entities";
+
+/**
+ * #1538: the NSFW click-to-reveal gate is a client component. Any server subtree
+ * passed through it as children has its element props serialized into the RSC
+ * payload, which shipped the rendered article (dangerouslySetInnerHTML, ~11 KB)
+ * to the client on EVERY post — though nothing client-side reads it.
+ *
+ * The fix is to decide on the server whether the gate is needed and mount it
+ * only for NSFW posts. These tests pin (a) the predicate, unchanged from the
+ * gate's own literal-tag check, and (b) that the server tree really does skip
+ * the client wrapper for a non-NSFW post and keep it for an NSFW one.
+ */
+
+// The gate is the ONLY thing being observed. Everything else in the SSR tree
+// is stubbed to a marker so the assertion is about tree shape, not content.
+vi.mock("@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-nsfw-body-wrapper", () => ({
+  EntryPageNsfwBodyWrapper: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="nsfw-gate">{children}</div>
+  )
+}));
+vi.mock("@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-static-body", () => ({
+  EntryPageStaticBody: () => <div id="post-body">STATIC_BODY</div>
+}));
+for (const stub of [
+  "entry-footer-controls|EntryFooterControls",
+  "entry-footer-info|EntryFooterInfo",
+  "entry-page-is-comment-header|EntryPageIsCommentHeader",
+  "entry-page-main-info|EntryPageMainInfo",
+  "entry-page-warnings|EntryPageWarnings",
+  "entry-tags|EntryTags"
+]) {
+  const [file, name] = stub.split("|");
+  vi.doMock(`@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/${file}`, () => ({
+    [name]: () => null
+  }));
+}
+vi.mock("@/features/shared/entry-translate/entry-translate-inline", () => ({
+  EntryTranslateInline: () => null
+}));
+vi.mock("@/features/polls", () => ({
+  PollWidget: () => null,
+  useEntryPollExtractor: () => null
+}));
+vi.mock("@/utils", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  useEntryLocation: () => null
+}));
+
+const entry = (tags: string[]): Entry =>
+  ({
+    author: "alice",
+    permlink: "p",
+    body: "hello",
+    json_metadata: { tags },
+    category: "test"
+  }) as unknown as Entry;
+
+describe("needsNsfwGate — the literal-tag predicate the gate always used", () => {
+  it("true only for the literal nsfw tag", () => {
+    expect(needsNsfwGate(entry(["nsfw"]))).toBe(true);
+    expect(needsNsfwGate(entry(["photography", "nsfw", "art"]))).toBe(true);
+  });
+
+  it("false for no tags, other tags, or missing metadata", () => {
+    expect(needsNsfwGate(entry([]))).toBe(false);
+    expect(needsNsfwGate(entry(["photography"]))).toBe(false);
+    expect(needsNsfwGate({ json_metadata: undefined } as unknown as Entry)).toBe(false);
+    expect(needsNsfwGate({ json_metadata: { tags: undefined } } as unknown as Entry)).toBe(false);
+  });
+
+  it("does NOT widen to community/title heuristics (that is isNsfwEntry, a separate decision)", () => {
+    // A DPorn-community post with no nsfw tag is NOT gated by this predicate —
+    // exactly as before. Widening it is #1538's explicitly deferred question.
+    const dporn = { ...entry(["photo"]), category: "hive-109634" } as Entry;
+    expect(needsNsfwGate(dporn)).toBe(false);
+  });
+});
+
+describe("EntryPageContentSSR mounts the client gate only when needed (#1538)", () => {
+  async function render(tags: string[]) {
+    const { EntryPageContentSSR } = await import(
+      "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-ssr"
+    );
+    return renderToStaticMarkup(<EntryPageContentSSR entry={entry(tags)} />);
+  }
+
+  it("non-NSFW post: static body is rendered with NO client gate around it", async () => {
+    const html = await render(["photography"]);
+    expect(html).toContain("STATIC_BODY");
+    expect(html).not.toContain('data-testid="nsfw-gate"');
+  });
+
+  it("NSFW post: static body is still wrapped in the client gate (behaviour preserved)", async () => {
+    const html = await render(["nsfw"]);
+    expect(html).toContain('data-testid="nsfw-gate"');
+    expect(html).toContain("STATIC_BODY");
+    // and the body sits INSIDE the gate, not beside it
+    expect(html.indexOf('data-testid="nsfw-gate"')).toBeLessThan(html.indexOf("STATIC_BODY"));
+  });
+});


### PR DESCRIPTION
Refs #1538.

The NSFW click-to-reveal gate (`EntryPageNsfwBodyWrapper`) is a client component and wrapped the static body on **every** post. Any server subtree passed through a client boundary as `children` has its element props serialized into the RSC payload — and `EntryPageStaticBody`'s `dangerouslySetInnerHTML` is an element prop. So the whole rendered article shipped to the client on every page, though nothing client-side reads it: `EntryPageBodyViewer` only enhances the SSR-painted `#post-body`.

Confirmed in the live payload before this change:

```
3f:["$","$L4d",null,{"entry":"$1e:...","children":[... {"id":"post-body","dangerouslySetInnerHTML":{"__html":"$4f"}} ...
4f:T2b24,<p dir="auto">The concept of giving kids allowances ...      ← 11,044 B hoisted text row
```

## Change

Decide on the server. `needsNsfwGate()` is the gate's own literal-tag predicate, extracted to a shared helper so server and client can never disagree, and the client wrapper is mounted **only when it returns true**. Non-NSFW posts (the vast majority) render the body directly in the server tree; NSFW posts keep exactly the previous behaviour, reveal click included.

**Deliberately not switched to `isNsfwEntry()`.** That helper is broader — it also matches NSFW communities and title stems — so using it here would start gating DPorn-community posts that carry no `nsfw` tag today. That may well be desirable, but it is a behaviour change worth its own decision, not one to fold into a byte optimisation. The spec pins that the predicate is unchanged.

## Verification

- `nsfw-gate.spec.tsx` renders `EntryPageContentSSR` to static markup with everything except the gate stubbed and asserts **tree shape**: non-NSFW → body with no gate around it; NSFW → body inside the gate.
- Confirmed it is a real regression test, not a tautology: **reverting only the call site fails the non-NSFW case** (gate mounted when it should not be) while the NSFW case still passes.
- `tsc --noEmit` clean; 79 tests pass across `specs/app/entry` and `entry-indexability`.

## Measurement

Baseline captured on alpha **before** this change, same post: `$4f` = **11,044 B** rendered-article row in flight, 4 `dangerouslySetInnerHTML` props serialized. `/root/creator-reports/verify_nsfw_gate.sh` re-measures the deployed build; the expected after-state for a non-NSFW post is **zero** rendered-HTML rows and zero `dangerouslySetInnerHTML` in flight. I will post the after-numbers here once staging rebuilds rather than assert them.

Second of the page-weight items from #1533. The crawl-budget theory there is a correlate, not a proven cause — but this is a free ~11 KB per post with no feature cost either way.

## Not in this PR

The raw-markdown copy in the dehydrated entry (`$32`, 4.3 KB) has six real client consumers, including the reply/edit editor (`comment/index.tsx` does `setText(entry.body)`), so it needs an on-demand fetch and its own PR.
