### PR TITLE
Newsletter: compose an email digest from several posts

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { NewsletterGate, SenderStatusNotice, SentIssues } from "@/features/newsletter";
+import { ComposeDigestButton, NewsletterGate, SenderStatusNotice, SentIssues } from "@/features/newsletter";
 import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import { Button } from "@ui/button";
@@ -53,6 +53,12 @@ export function CommunityCard({ community, account }: Props) {
   const canEditTeam = useMemo(() => !!(roleInTeam && roleMap[roleInTeam]), [roleInTeam]);
   // Names compared lowercase: the stored username keeps whatever casing was typed,
   // team entries are canonical. Owner, admin and mod are the digest's senders.
+  // Sending mail is heavier than moderating: owner and admin only, lowercase names.
+  const canSendDigest = useMemo(() => {
+    const me = activeUser?.username?.toLowerCase();
+    const mine = me ? community.team.find((x: (string | undefined)[]) => x[0]?.toLowerCase() === me) : undefined;
+    return !!(mine?.[1] && [ROLES.OWNER.toString(), ROLES.ADMIN.toString()].includes(mine[1]));
+  }, [activeUser?.username, community.team]);
   const isDigestSender = useMemo(() => {
     const me = activeUser?.username?.toLowerCase();
     const mine = me ? community.team.find((x: (string | undefined)[]) => x[0]?.toLowerCase() === me) : undefined;
@@ -64,6 +70,7 @@ export function CommunityCard({ community, account }: Props) {
       {/* Policing (vision-web#1513): the team sees when this community's digest is suspended, and why. */}
       <NewsletterGate>
         <SenderStatusNotice type="community" target={community.name} isSender={isDigestSender} className="mb-4" />
+        <ComposeDigestButton target={{ type: "community", target: community.name, label: community.title || community.name }} isSender={canSendDigest} className="mb-2" />
         <SentIssues type="community" target={community.name} isSender={isDigestSender} className="mb-4" />
       </NewsletterGate>
       <div className="community-avatar inline-flex items-center justify-center md:justify-start">

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
@@ -52,18 +52,14 @@ export function CommunityCard({ community, account }: Props) {
   );
   const canEditTeam = useMemo(() => !!(roleInTeam && roleMap[roleInTeam]), [roleInTeam]);
   // Names compared lowercase: the stored username keeps whatever casing was typed,
-  // team entries are canonical. Owner, admin and mod are the digest's senders.
-  // Sending mail is heavier than moderating: owner and admin only, lowercase names.
-  const canSendDigest = useMemo(() => {
+  // team entries are canonical. Owner, admin and mod see the digest's standing and
+  // history; sending mail is heavier than moderating: owner and admin only.
+  const myDigestRole = useMemo(() => {
     const me = activeUser?.username?.toLowerCase();
-    const mine = me ? community.team.find((x: (string | undefined)[]) => x[0]?.toLowerCase() === me) : undefined;
-    return !!(mine?.[1] && [ROLES.OWNER.toString(), ROLES.ADMIN.toString()].includes(mine[1]));
+    return me ? community.team.find((x: (string | undefined)[]) => x[0]?.toLowerCase() === me)?.[1] : undefined;
   }, [activeUser?.username, community.team]);
-  const isDigestSender = useMemo(() => {
-    const me = activeUser?.username?.toLowerCase();
-    const mine = me ? community.team.find((x: (string | undefined)[]) => x[0]?.toLowerCase() === me) : undefined;
-    return !!(mine?.[1] && [ROLES.OWNER.toString(), ROLES.ADMIN.toString(), ROLES.MOD.toString()].includes(mine[1]));
-  }, [activeUser?.username, community.team]);
+  const canSendDigest = !!(myDigestRole && [ROLES.OWNER.toString(), ROLES.ADMIN.toString()].includes(myDigestRole));
+  const isDigestSender = canSendDigest || myDigestRole === ROLES.MOD.toString();
 
   return (
     <div className="community-card">

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { ComposeDigestButton, NewsletterGate, SenderStatusNotice, SentIssues } from "@/features/newsletter";
+import { communityDigestRoles, ComposeDigestButton, NewsletterGate, SenderStatusNotice, SentIssues } from "@/features/newsletter";
 import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import { Button } from "@ui/button";
@@ -51,15 +51,11 @@ export function CommunityCard({ community, account }: Props) {
     [roleInTeam]
   );
   const canEditTeam = useMemo(() => !!(roleInTeam && roleMap[roleInTeam]), [roleInTeam]);
-  // Names compared lowercase: the stored username keeps whatever casing was typed,
-  // team entries are canonical. Owner, admin and mod see the digest's standing and
-  // history; sending mail is heavier than moderating: owner and admin only.
-  const myDigestRole = useMemo(() => {
-    const me = activeUser?.username?.toLowerCase();
-    return me ? community.team.find((x: (string | undefined)[]) => x[0]?.toLowerCase() === me)?.[1] : undefined;
-  }, [activeUser?.username, community.team]);
-  const canSendDigest = !!(myDigestRole && [ROLES.OWNER.toString(), ROLES.ADMIN.toString()].includes(myDigestRole));
-  const isDigestSender = canSendDigest || myDigestRole === ROLES.MOD.toString();
+  // Owner, admin and mod see the digest's standing and history; owner and admin may send.
+  const { canView: isDigestSender, canSend: canSendDigest } = useMemo(
+    () => communityDigestRoles(community.team, activeUser?.username),
+    [activeUser?.username, community.team]
+  );
 
   return (
     <div className="community-card">

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -35,7 +35,7 @@ import { profileWebsiteHref } from "./website-href";
 import { FinalizeCommunityBanner } from "../finalize-community-banner";
 import { useActiveAccount } from "@/core/hooks";
 import { ProBadge } from "@/features/pro";
-import { DigestSubscribeButton, NewsletterGate, SenderStatusNotice, SentIssues } from "@/features/newsletter";
+import { ComposeDigestButton, DigestSubscribeButton, NewsletterGate, SenderStatusNotice, SentIssues } from "@/features/newsletter";
 
 interface Props {
   account: Account;
@@ -139,6 +139,7 @@ export function ProfileCard({ account }: Props) {
       {activeUsername?.toLowerCase() === account.name && (
         <NewsletterGate>
           <SenderStatusNotice type="creator" target={account.name} isSender className="mb-4" />
+          <ComposeDigestButton target={{ type: "creator", target: account.name, label: `@${account.name}` }} isSender className="mb-2" />
           <SentIssues type="creator" target={account.name} isSender className="mb-4" />
         </NewsletterGate>
       )}

--- a/apps/web/src/app/api/newsletter/posts/route.ts
+++ b/apps/web/src/app/api/newsletter/posts/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest } from "next/server";
+import { resolveUser, unauthorizedResponse } from "@/app/api/threespeak/resolve-user";
+import { callNewsletter, newsletterConfigured, notConfigured, relay } from "@/server/newsletter-internal";
+import { SENDER_TARGET_RE, senderGate } from "@/server/newsletter-sender-gate";
+
+/** The sender's candidate posts for the composer, filtered by the service, marked when a recent issue carried them. Send gate. */
+export async function GET(request: NextRequest): Promise<Response> {
+  if (!newsletterConfigured()) return notConfigured();
+  const auth = await resolveUser(request, {});
+  if (!auth.ok) return unauthorizedResponse(auth.reason);
+  const username = auth.username.toLowerCase();
+  const type = request.nextUrl.searchParams.get("type");
+  const target = (request.nextUrl.searchParams.get("target") ?? "").toLowerCase();
+  const limit = Number(request.nextUrl.searchParams.get("limit") ?? 20);
+  if ((type !== "creator" && type !== "community") || !SENDER_TARGET_RE.test(target)) {
+    return Response.json({ error: "type must be creator or community, target a valid name" }, { status: 400 });
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > 40) return Response.json({ error: "limit must be 1..40" }, { status: 400 });
+  const gate = await senderGate(username, type, target, "send");
+  if (!gate.ok) return Response.json({ error: gate.error }, { status: gate.status });
+  const upstream = await callNewsletter(`/api/posts?type=${type}&target=${encodeURIComponent(target)}&limit=${limit}`);
+  return relay(upstream);
+}

--- a/apps/web/src/core/react-query/index.ts
+++ b/apps/web/src/core/react-query/index.ts
@@ -11,6 +11,7 @@ export enum QueryIdentifiers {
   NEWSLETTER_SENDER_STANDING = "newsletter-sender-standing",
   NEWSLETTER_SEND_PREVIEW = "newsletter-send-preview",
   NEWSLETTER_SENT_ISSUES = "newsletter-sent-issues",
+  NEWSLETTER_CANDIDATE_POSTS = "newsletter-candidate-posts",
   NEWSLETTER_CONFIRM_INSPECT = "newsletter-confirm-inspect",
   NEWSLETTER_UNSUBSCRIBE_INSPECT = "newsletter-unsubscribe-inspect",
   COMMUNITY_THREADS = "community-threads",

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -4218,6 +4218,18 @@
     "send-taken-by-send": "was sent by you or your team",
     "send-see-history": "See sent issues",
     "sent-issues-unavailable": "Sent issues could not be loaded right now.",
-    "sent-issue-rejected": "{{rejected}} rejected by receivers"
+    "sent-issue-rejected": "{{rejected}} rejected by receivers",
+    "compose-button": "Compose email digest",
+    "compose-title": "Compose an email digest for {{list}}",
+    "compose-help": "Pick {{min}} to {{max}} recent posts, in the order they should appear, then add a subject and an intro. Readers get it as their current issue.",
+    "compose-loading": "Loading your recent posts…",
+    "compose-candidates-unavailable": "Recent posts could not be loaded right now.",
+    "compose-no-candidates": "No recent posts can be sent yet.",
+    "compose-pick": "Recent posts",
+    "compose-featured": "featured recently",
+    "compose-subject": "Subject (optional)",
+    "compose-intro": "A short intro for your readers (optional)",
+    "compose-picked": "{{n}} picked ({{min}} to {{max}})",
+    "compose-continue": "Preview"
   }
 }

--- a/apps/web/src/features/newsletter/author-send-api.ts
+++ b/apps/web/src/features/newsletter/author-send-api.ts
@@ -6,11 +6,36 @@ import { NewsletterApiError } from "./newsletter-api";
  * call carries the HiveSigner token; the route decides who may send. Errors
  * keep the service's status and code so the dialog can say exactly why.
  */
-export interface SendRef {
-  type: "creator" | "community";
-  target: string;
+export interface PostRef {
   author: string;
   permlink: string;
+}
+
+/** One post, the post being the issue. */
+export interface SendRef extends PostRef {
+  type: "creator" | "community";
+  target: string;
+}
+
+/** Several posts with a subject and an intro (news#21). */
+export interface ComposeRequest {
+  type: "creator" | "community";
+  target: string;
+  posts: PostRef[];
+  subject?: string;
+  intro?: string;
+}
+
+export type SendRequest = SendRef | ComposeRequest;
+export const COMPOSE_MIN = 2;
+export const COMPOSE_MAX = 10;
+export const SUBJECT_MAX = 120;
+export const INTRO_MAX = 500;
+
+export interface CandidatePost extends PostRef {
+  title: string;
+  created: string;
+  featured: boolean;
 }
 
 export interface SendPreview {
@@ -18,6 +43,7 @@ export interface SendPreview {
   html: string;
   text: string;
   post: { author: string; permlink: string; title: string };
+  posts: Array<{ author: string; permlink: string; title: string }>;
   subscribers: { weekly: number; monthly: number };
   alreadySent: Array<"weekly" | "monthly">;
 }
@@ -68,8 +94,17 @@ async function post<T>(path: string, body: unknown, username: string): Promise<T
 }
 
 export const authorSendApi = {
-  preview: (ref: SendRef, username: string): Promise<SendPreview> => post<SendPreview>("/api/newsletter/send/preview", ref, username),
-  send: (ref: SendRef, username: string): Promise<SendResult> => post<SendResult>("/api/newsletter/send", ref, username),
+  preview: (req: SendRequest, username: string): Promise<SendPreview> => post<SendPreview>("/api/newsletter/send/preview", req, username),
+  send: (req: SendRequest, username: string): Promise<SendResult> => post<SendResult>("/api/newsletter/send", req, username),
+  async candidates(type: "creator" | "community", target: string, username: string, limit = 20): Promise<CandidatePost[]> {
+    const token = await ensureValidToken(username);
+    const res = await fetch(`/api/newsletter/posts?type=${type}&target=${encodeURIComponent(target)}&limit=${limit}`, {
+      headers: token ? { "X-HS-Token": token } : {}
+    });
+    const data = (await res.json().catch(() => ({}))) as { posts?: CandidatePost[]; error?: string };
+    if (!res.ok) throw new NewsletterApiError(data?.error || `Request failed (${res.status})`, res.status);
+    return data.posts ?? [];
+  },
   async issues(type: "creator" | "community", target: string, username: string): Promise<SentIssue[]> {
     const token = await ensureValidToken(username);
     const res = await fetch(`/api/newsletter/issues?type=${type}&target=${encodeURIComponent(target)}`, {

--- a/apps/web/src/features/newsletter/author-send-api.ts
+++ b/apps/web/src/features/newsletter/author-send-api.ts
@@ -27,10 +27,7 @@ export interface ComposeRequest {
 }
 
 export type SendRequest = SendRef | ComposeRequest;
-export const COMPOSE_MIN = 2;
-export const COMPOSE_MAX = 10;
-export const SUBJECT_MAX = 120;
-export const INTRO_MAX = 500;
+export { COMPOSE_MAX, COMPOSE_MIN, INTRO_MAX, SUBJECT_MAX } from "./compose-limits";
 
 export interface CandidatePost extends PostRef {
   title: string;

--- a/apps/web/src/features/newsletter/author-send-dialog.tsx
+++ b/apps/web/src/features/newsletter/author-send-dialog.tsx
@@ -27,10 +27,15 @@ interface Props {
   onHide: () => void;
 }
 
-/** A stable identity for what is being sent: the post, or the composition's posts, subject and intro. */
+/**
+ * A stable identity for what is being sent: the post, or the composition's
+ * posts, subject and intro. JSON, not a delimiter join: subject and intro are
+ * the sender's text, and two different compositions must never share a key
+ * (the preview is cached by it while the send carries the current request).
+ */
 function requestKey(req: SendRequest): string {
-  if ("posts" in req) return `compose:${req.posts.map((p) => `${p.author}/${p.permlink}`).join(",")}|${req.subject ?? ""}|${req.intro ?? ""}`;
-  return `post:${req.author}/${req.permlink}`;
+  if ("posts" in req) return JSON.stringify(["compose", req.posts.map((p) => `${p.author}/${p.permlink}`), req.subject ?? "", req.intro ?? ""]);
+  return JSON.stringify(["post", `${req.author}/${req.permlink}`]);
 }
 
 export const sendPreviewKey = (req: SendRequest, viewer: string): readonly [QueryIdentifiers, string, string, string, string] =>
@@ -125,6 +130,8 @@ export function SendFlow({
       setResult(r);
       queryClient.invalidateQueries({ queryKey: [QueryIdentifiers.NEWSLETTER_SEND_PREVIEW] });
       queryClient.invalidateQueries({ queryKey: [QueryIdentifiers.NEWSLETTER_SENT_ISSUES, target.type, target.target] });
+      // The composer's candidates carry a "featured recently" mark; the posts just sent now have it.
+      queryClient.invalidateQueries({ queryKey: [QueryIdentifiers.NEWSLETTER_CANDIDATE_POSTS, target.type, target.target] });
     }
   });
 
@@ -137,7 +144,22 @@ export function SendFlow({
     <>
         {preview.isPending && <div className="text-sm opacity-70">{i18next.t("newsletter.send-loading")}</div>}
 
-        {preview.isError && <RefusalAlert refusal={describeRefusal(preview.error)} target={target} />}
+        {preview.isError && (
+          <>
+            <RefusalAlert refusal={describeRefusal(preview.error)} target={target} />
+            {onBack ? (
+              // The composer: a refused post is fixed in the picker, not by starting over.
+              <div className="mt-4 flex justify-end gap-2">
+                <Button appearance="gray-link" onClick={onBack}>
+                  {i18next.t("g.back")}
+                </Button>
+                <Button appearance="gray-link" onClick={onHide}>
+                  {i18next.t("g.cancel")}
+                </Button>
+              </div>
+            ) : null}
+          </>
+        )}
 
         {p && !result && (
           <>

--- a/apps/web/src/features/newsletter/author-send-dialog.tsx
+++ b/apps/web/src/features/newsletter/author-send-dialog.tsx
@@ -9,7 +9,7 @@ import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import i18next from "i18next";
 import Link from "next/link";
 import { type ReactElement, useMemo, useState } from "react";
-import { authorSendApi, type SendPreview, type SendRef, type SendResult, SendRefusedError } from "./author-send-api";
+import { authorSendApi, type SendPreview, type SendRequest, type SendResult, SendRefusedError } from "./author-send-api";
 import type { SendTarget } from "./author-send-eligibility";
 
 /**
@@ -27,11 +27,14 @@ interface Props {
   onHide: () => void;
 }
 
-export const sendPreviewKey = (
-  ref: SendRef,
-  viewer: string
-): readonly [QueryIdentifiers, string, string, string, string, string] =>
-  [QueryIdentifiers.NEWSLETTER_SEND_PREVIEW, ref.type, ref.target, ref.author, ref.permlink, viewer] as const;
+/** A stable identity for what is being sent: the post, or the composition's posts, subject and intro. */
+function requestKey(req: SendRequest): string {
+  if ("posts" in req) return `compose:${req.posts.map((p) => `${p.author}/${p.permlink}`).join(",")}|${req.subject ?? ""}|${req.intro ?? ""}`;
+  return `post:${req.author}/${req.permlink}`;
+}
+
+export const sendPreviewKey = (req: SendRequest, viewer: string): readonly [QueryIdentifiers, string, string, string, string] =>
+  [QueryIdentifiers.NEWSLETTER_SEND_PREVIEW, req.type, req.target, requestKey(req), viewer] as const;
 
 /** Where the sender's history lives: their own profile card, or the community card. */
 export function senderHistoryHref(target: SendTarget): string {
@@ -86,23 +89,38 @@ function RefusalAlert({ refusal, target }: { refusal: Refusal; target: SendTarge
   );
 }
 
-export function AuthorSendDialog({ target, author, permlink, show, onHide }: Props): ReactElement {
+/**
+ * The send flow proper, reused by the single-post dialog and the composer:
+ * preview, readers per cadence, the one-per-period rule, taken periods, send,
+ * outcome. `request` is what is being sent, already decided by the caller.
+ */
+export function SendFlow({
+  request,
+  target,
+  onHide,
+  onBack
+}: {
+  request: SendRequest;
+  target: SendTarget;
+  onHide: () => void;
+  /** The composer offers a way back to the picker. */
+  onBack?: () => void;
+}): ReactElement {
   const { activeUser } = useActiveAccount();
   const username = activeUser?.username ?? "";
   const queryClient = useQueryClient();
-  const ref = useMemo<SendRef>(() => ({ type: target.type, target: target.target, author, permlink }), [target, author, permlink]);
   const [result, setResult] = useState<SendResult | null>(null);
 
   const preview = useQuery<SendPreview, Error>({
-    queryKey: sendPreviewKey(ref, username),
-    enabled: show && !!username,
+    queryKey: sendPreviewKey(request, username),
+    enabled: !!username,
     staleTime: 60_000,
     retry: false,
-    queryFn: () => authorSendApi.preview(ref, username)
+    queryFn: () => authorSendApi.preview(request, username)
   });
 
   const send = useMutation({
-    mutationFn: () => authorSendApi.send(ref, username),
+    mutationFn: () => authorSendApi.send(request, username),
     onSuccess: (r) => {
       setResult(r);
       queryClient.invalidateQueries({ queryKey: [QueryIdentifiers.NEWSLETTER_SEND_PREVIEW] });
@@ -116,11 +134,7 @@ export function AuthorSendDialog({ target, author, permlink, show, onHide }: Pro
   const canSend = !!p && freeCadences.length > 0 && !send.isPending && !result;
 
   return (
-    <Modal show={show} onHide={onHide} centered={true} size="lg">
-      <ModalHeader closeButton={true}>
-        <ModalTitle>{i18next.t("newsletter.send-title", { list: target.label })}</ModalTitle>
-      </ModalHeader>
-      <ModalBody>
+    <>
         {preview.isPending && <div className="text-sm opacity-70">{i18next.t("newsletter.send-loading")}</div>}
 
         {preview.isError && <RefusalAlert refusal={describeRefusal(preview.error)} target={target} />}
@@ -154,6 +168,11 @@ export function AuthorSendDialog({ target, author, permlink, show, onHide }: Pro
             </div>
             {send.isError && <RefusalAlert refusal={describeRefusal(send.error)} target={target} />}
             <div className="mt-4 flex justify-end gap-2">
+              {onBack ? (
+                <Button appearance="gray-link" onClick={onBack}>
+                  {i18next.t("g.back")}
+                </Button>
+              ) : null}
               <Button appearance="gray-link" onClick={onHide}>
                 {i18next.t("g.cancel")}
               </Button>
@@ -183,7 +202,19 @@ export function AuthorSendDialog({ target, author, permlink, show, onHide }: Pro
             </div>
           </>
         )}
-      </ModalBody>
+    </>
+  );
+}
+
+/** One post as the issue, from the post's menu. */
+export function AuthorSendDialog({ target, author, permlink, show, onHide }: Props): ReactElement {
+  const request = useMemo<SendRequest>(() => ({ type: target.type, target: target.target, author, permlink }), [target, author, permlink]);
+  return (
+    <Modal show={show} onHide={onHide} centered={true} size="lg">
+      <ModalHeader closeButton={true}>
+        <ModalTitle>{i18next.t("newsletter.send-title", { list: target.label })}</ModalTitle>
+      </ModalHeader>
+      <ModalBody>{show ? <SendFlow request={request} target={target} onHide={onHide} /> : null}</ModalBody>
     </Modal>
   );
 }

--- a/apps/web/src/features/newsletter/author-send-eligibility.ts
+++ b/apps/web/src/features/newsletter/author-send-eligibility.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { getProMembersQueryOptions } from "@ecency/sdk";
-import type { Community, Entry } from "@/entities";
+import type { Community, CommunityTeam, Entry } from "@/entities";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { isProMember } from "@/features/pro/pro-config";
 import { useMemo } from "react";
@@ -25,6 +25,20 @@ export interface SendTarget {
 }
 
 const SEND_ROLES = new Set(["owner", "admin"]);
+const VIEW_ROLES = new Set(["owner", "admin", "mod"]);
+
+/**
+ * The viewer's standing towards a community's digest, from the team roster.
+ * Names compared lowercase: the stored username keeps whatever casing was
+ * typed, team entries are canonical. Owner, admin and mod may see the digest's
+ * standing and history (view); sending mail is heavier than moderating, so
+ * owner and admin only (send). The same roles as the server gate.
+ */
+export function communityDigestRoles(team: CommunityTeam | undefined, username: string | null | undefined): { canView: boolean; canSend: boolean } {
+  const me = username?.toLowerCase();
+  const role = me ? team?.find((m: (string | undefined)[]) => m[0]?.toLowerCase() === me)?.[1] : undefined;
+  return { canView: !!role && VIEW_ROLES.has(role), canSend: !!role && SEND_ROLES.has(role) };
+}
 
 export function useAuthorSendTarget(entry: Entry, community?: Community | null): SendTarget | null {
   const enabled = useNewsletterEnabled();
@@ -36,9 +50,8 @@ export function useAuthorSendTarget(entry: Entry, community?: Community | null):
 
   return useMemo(() => {
     if (!enabled || !me || !isTopLevel) return null;
-    if (community && community.name === entry.category) {
-      const role = community.team?.find((m: (string | undefined)[]) => m[0]?.toLowerCase() === me)?.[1];
-      if (role && SEND_ROLES.has(role)) return { type: "community", target: community.name, label: community.title || community.name };
+    if (community && community.name === entry.category && communityDigestRoles(community.team, me).canSend) {
+      return { type: "community", target: community.name, label: community.title || community.name };
     }
     if (isOwn && isProMember(pro?.members, me)) return { type: "creator", target: me, label: `@${me}` };
     return null;

--- a/apps/web/src/features/newsletter/compose-digest-dialog.tsx
+++ b/apps/web/src/features/newsletter/compose-digest-dialog.tsx
@@ -26,7 +26,7 @@ import { useNewsletterEnabled } from "./runtime";
 export const candidatesKey = (type: "creator" | "community", target: string, viewer: string | null | undefined): readonly [QueryIdentifiers, string, string, string] =>
   [QueryIdentifiers.NEWSLETTER_CANDIDATE_POSTS, type, target, viewer ?? "anon"] as const;
 
-const refKey = (p: { author: string; permlink: string }) => `${p.author}/${p.permlink}`;
+const refKey = (p: { author: string; permlink: string }): string => `${p.author}/${p.permlink}`;
 
 export function ComposeDigestDialog({ target, show, onHide }: { target: SendTarget; show: boolean; onHide: () => void }): ReactElement {
   const { activeUser } = useActiveAccount();
@@ -44,18 +44,21 @@ export function ComposeDigestDialog({ target, show, onHide }: { target: SendTarg
     queryFn: () => authorSendApi.candidates(target.type, target.target, username)
   });
 
-  const toggle = (key: string) =>
+  const toggle = (key: string): void =>
     setPicked((cur) => (cur.includes(key) ? cur.filter((k) => k !== key) : cur.length < COMPOSE_MAX ? [...cur, key] : cur));
 
   const request = useMemo<ComposeRequest | null>(() => {
-    if (picked.length < COMPOSE_MIN || !candidates.data) return null;
-    // Keep the sender's picking order: it is the order in the issue.
+    if (!candidates.data) return null;
+    // Keep the sender's picking order: it is the order in the issue. Picks are
+    // resolved against the current candidates: a pick whose post is gone (the
+    // list refreshed, the account changed) does not count towards the minimum.
     const byKey = new Map(candidates.data.map((c) => [refKey(c), c]));
     const posts = picked.map((k) => byKey.get(k)).filter((c): c is CandidatePost => !!c).map((c) => ({ author: c.author, permlink: c.permlink }));
+    if (posts.length < COMPOSE_MIN) return null;
     return { type: target.type, target: target.target, posts, subject: subject.trim() || undefined, intro: intro.trim() || undefined };
   }, [picked, candidates.data, target, subject, intro]);
 
-  const close = () => {
+  const close = (): void => {
     onHide();
     setPhase("pick");
   };

--- a/apps/web/src/features/newsletter/compose-digest-dialog.tsx
+++ b/apps/web/src/features/newsletter/compose-digest-dialog.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getProMembersQueryOptions } from "@ecency/sdk";
+import { isProMember } from "@/features/pro/pro-config";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { QueryIdentifiers } from "@/core/react-query";
+import { Alert } from "@ui/alert";
+import { Button } from "@ui/button";
+import { FormControl } from "@ui/input";
+import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
+import { UilEnvelopeEdit } from "@tooni/iconscout-unicons-react";
+import i18next from "i18next";
+import React, { type ReactElement, useMemo, useState } from "react";
+import { authorSendApi, type CandidatePost, COMPOSE_MAX, COMPOSE_MIN, type ComposeRequest, INTRO_MAX, SUBJECT_MAX } from "./author-send-api";
+import { SendFlow } from "./author-send-dialog";
+import type { SendTarget } from "./author-send-eligibility";
+import { useNewsletterEnabled } from "./runtime";
+
+/**
+ * Compose an email digest (vision-web#1536): pick 2..10 of the list's recent
+ * posts (candidates come filtered from the service, with "featured recently"
+ * marks), write a subject and an intro, then the same preview-and-send flow as
+ * a single post. Same gate, same one-issue-per-period rule.
+ */
+export const candidatesKey = (type: "creator" | "community", target: string, viewer: string | null | undefined): readonly [QueryIdentifiers, string, string, string] =>
+  [QueryIdentifiers.NEWSLETTER_CANDIDATE_POSTS, type, target, viewer ?? "anon"] as const;
+
+const refKey = (p: { author: string; permlink: string }) => `${p.author}/${p.permlink}`;
+
+export function ComposeDigestDialog({ target, show, onHide }: { target: SendTarget; show: boolean; onHide: () => void }): ReactElement {
+  const { activeUser } = useActiveAccount();
+  const username = activeUser?.username ?? "";
+  const [picked, setPicked] = useState<string[]>([]);
+  const [subject, setSubject] = useState("");
+  const [intro, setIntro] = useState("");
+  const [phase, setPhase] = useState<"pick" | "send">("pick");
+
+  const candidates = useQuery<CandidatePost[], Error>({
+    queryKey: candidatesKey(target.type, target.target, username),
+    enabled: show && !!username,
+    staleTime: 60_000,
+    retry: false,
+    queryFn: () => authorSendApi.candidates(target.type, target.target, username)
+  });
+
+  const toggle = (key: string) =>
+    setPicked((cur) => (cur.includes(key) ? cur.filter((k) => k !== key) : cur.length < COMPOSE_MAX ? [...cur, key] : cur));
+
+  const request = useMemo<ComposeRequest | null>(() => {
+    if (picked.length < COMPOSE_MIN || !candidates.data) return null;
+    // Keep the sender's picking order: it is the order in the issue.
+    const byKey = new Map(candidates.data.map((c) => [refKey(c), c]));
+    const posts = picked.map((k) => byKey.get(k)).filter((c): c is CandidatePost => !!c).map((c) => ({ author: c.author, permlink: c.permlink }));
+    return { type: target.type, target: target.target, posts, subject: subject.trim() || undefined, intro: intro.trim() || undefined };
+  }, [picked, candidates.data, target, subject, intro]);
+
+  const close = () => {
+    onHide();
+    setPhase("pick");
+  };
+
+  return (
+    <Modal show={show} onHide={close} centered={true} size="lg">
+      <ModalHeader closeButton={true}>
+        <ModalTitle>{i18next.t("newsletter.compose-title", { list: target.label })}</ModalTitle>
+      </ModalHeader>
+      <ModalBody>
+        {phase === "send" && request ? (
+          <SendFlow request={request} target={target} onHide={close} onBack={() => setPhase("pick")} />
+        ) : (
+          <>
+            <p className="text-sm opacity-80 mb-3">{i18next.t("newsletter.compose-help", { min: COMPOSE_MIN, max: COMPOSE_MAX })}</p>
+            {candidates.isPending && <div className="text-sm opacity-70">{i18next.t("newsletter.compose-loading")}</div>}
+            {candidates.isError && <Alert appearance="warning">{i18next.t("newsletter.compose-candidates-unavailable")}</Alert>}
+            {candidates.data && candidates.data.length === 0 && <Alert appearance="primary">{i18next.t("newsletter.compose-no-candidates")}</Alert>}
+            {candidates.data && candidates.data.length > 0 && (
+              <ul className="m-0 p-0 list-none flex flex-col gap-1 max-h-[300px] overflow-y-auto border border-[--border-color] rounded-lg p-2" aria-label={i18next.t("newsletter.compose-pick")}>
+                {candidates.data.map((c) => {
+                  const key = refKey(c);
+                  const on = picked.includes(key);
+                  const idx = picked.indexOf(key);
+                  return (
+                    <li key={key}>
+                      <label className="flex items-start gap-2 cursor-pointer text-sm">
+                        <input
+                          type="checkbox"
+                          className="mt-1"
+                          checked={on}
+                          disabled={!on && picked.length >= COMPOSE_MAX}
+                          onChange={() => toggle(key)}
+                          aria-label={c.title}
+                        />
+                        <span className="min-w-0">
+                          <span className="block truncate">
+                            {on ? <span className="opacity-60 tabular-nums mr-1">{idx + 1}.</span> : null}
+                            {c.title}
+                          </span>
+                          <span className="text-xs opacity-60">
+                            <time dateTime={c.created}>{new Date(c.created).toLocaleDateString(i18next.language)}</time>
+                            {c.featured ? ` · ${i18next.t("newsletter.compose-featured")}` : ""}
+                          </span>
+                        </span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            <div className="mt-3 flex flex-col gap-2">
+              <FormControl
+                type="text"
+                value={subject}
+                maxLength={SUBJECT_MAX}
+                placeholder={i18next.t("newsletter.compose-subject")}
+                aria-label={i18next.t("newsletter.compose-subject")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSubject(e.target.value)}
+              />
+              <FormControl
+                type="textarea"
+                value={intro}
+                maxLength={INTRO_MAX}
+                rows={3}
+                placeholder={i18next.t("newsletter.compose-intro")}
+                aria-label={i18next.t("newsletter.compose-intro")}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setIntro(e.target.value)}
+              />
+              <div className="text-xs opacity-60">{i18next.t("newsletter.compose-picked", { n: picked.length, min: COMPOSE_MIN, max: COMPOSE_MAX })}</div>
+            </div>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button appearance="gray-link" onClick={close}>
+                {i18next.t("g.cancel")}
+              </Button>
+              <Button disabled={!request} onClick={() => setPhase("send")}>
+                {i18next.t("newsletter.compose-continue")}
+              </Button>
+            </div>
+          </>
+        )}
+      </ModalBody>
+    </Modal>
+  );
+}
+
+/**
+ * The entry point on the sender's own surfaces. Renders nothing unless the
+ * viewer may send: `isSender` is the surface's own knowledge (own profile;
+ * community owner or admin), and a creator additionally has to be Pro, checked
+ * here against the roster the way the post menu does.
+ */
+export function ComposeDigestButton({ target, isSender, className }: { target: SendTarget; isSender: boolean; className?: string }): ReactElement | null {
+  const enabled = useNewsletterEnabled();
+  const [open, setOpen] = useState(false);
+  const { data: pro } = useQuery({ ...getProMembersQueryOptions(), enabled: enabled && isSender && target.type === "creator" });
+  const canSend = isSender && (target.type !== "creator" || isProMember(pro?.members, target.target));
+  if (!enabled || !canSend) return null;
+  return (
+    <>
+      <Button size="sm" appearance="gray-link" icon={<UilEnvelopeEdit />} iconPlacement="left" className={className} onClick={() => setOpen(true)}>
+        {i18next.t("newsletter.compose-button")}
+      </Button>
+      {open && <ComposeDigestDialog target={target} show={open} onHide={() => setOpen(false)} />}
+    </>
+  );
+}

--- a/apps/web/src/features/newsletter/compose-limits.ts
+++ b/apps/web/src/features/newsletter/compose-limits.ts
@@ -1,0 +1,13 @@
+/**
+ * The bounds of a composed digest (news#21), shared by the composer and the
+ * relay's request parser so the two cannot drift. Plain constants: this module
+ * is imported on both sides and must stay free of client or server imports.
+ *
+ * COMPOSE_MIN is the composer's floor: a one-post composition is what the
+ * service (and the relay) accept as the single-post issue, so the parser
+ * bounds posts at 1..COMPOSE_MAX and only the picker asks for two.
+ */
+export const COMPOSE_MIN = 2;
+export const COMPOSE_MAX = 10;
+export const SUBJECT_MAX = 120;
+export const INTRO_MAX = 500;

--- a/apps/web/src/features/newsletter/index.ts
+++ b/apps/web/src/features/newsletter/index.ts
@@ -11,3 +11,4 @@ export * from "./author-send-api";
 export * from "./author-send-eligibility";
 export * from "./author-send-dialog";
 export * from "./sent-issues";
+export * from "./compose-digest-dialog";

--- a/apps/web/src/server/newsletter-sender-gate.ts
+++ b/apps/web/src/server/newsletter-sender-gate.ts
@@ -54,14 +54,23 @@ export async function senderGate(
 const AUTHOR_RE = /^[a-z0-9.-]{3,16}$/;
 const PERMLINK_RE = /^[a-z0-9-]{1,256}$/;
 
-export interface SendBody {
-  type: "creator" | "community";
-  target: string;
+export interface PostRef {
   author: string;
   permlink: string;
 }
 
-/** The body of a send or preview request, validated; a Response when it is not. */
+/**
+ * A single post ({author, permlink}) or a composition ({posts: [...], subject?,
+ * intro?}), the two shapes the service accepts (news#21).
+ */
+export type SendBody =
+  | { type: "creator" | "community"; target: string; author: string; permlink: string }
+  | { type: "creator" | "community"; target: string; posts: PostRef[]; subject?: string; intro?: string };
+
+export const COMPOSE_MAX = 10;
+export const SUBJECT_MAX = 120;
+export const INTRO_MAX = 500;
+
 /** Reads the JSON body once; the same object feeds resolveUser (body.code) and the field validation. */
 export async function readJsonBody(request: NextRequest): Promise<Record<string, unknown>> {
   const body = (await request.json().catch(() => null)) as unknown;
@@ -75,16 +84,40 @@ export async function readJsonBody(request: NextRequest): Promise<Record<string,
  * request it can already see is wrong.
  */
 export function postBelongsToSender(body: SendBody, username: string): boolean {
-  return body.type !== "creator" || body.author === username;
+  if (body.type !== "creator") return true;
+  return "posts" in body ? body.posts.every((p) => p.author === username) : body.author === username;
 }
 
+function parseRef(v: unknown): PostRef | null {
+  const o = v as { author?: unknown; permlink?: unknown } | null;
+  const author = String(o?.author ?? "").toLowerCase();
+  const permlink = String(o?.permlink ?? "");
+  return AUTHOR_RE.test(author) && PERMLINK_RE.test(permlink) ? { author, permlink } : null;
+}
+
+const text = (v: unknown, max: number): string | undefined => {
+  if (typeof v !== "string") return undefined;
+  const t = v.replace(/\s+/g, " ").trim();
+  return t ? t.slice(0, max) : undefined;
+};
+
+/** The body of a send or preview request, validated; a Response when it is not. */
 export function parseSendBody(body: Record<string, unknown>): SendBody | Response {
   const type = body?.type;
   const target = String(body?.target ?? "").toLowerCase();
-  const author = String(body?.author ?? "").toLowerCase();
-  const permlink = String(body?.permlink ?? "");
-  if ((type !== "creator" && type !== "community") || !SENDER_TARGET_RE.test(target) || !AUTHOR_RE.test(author) || !PERMLINK_RE.test(permlink)) {
-    return Response.json({ error: "type, target, author and permlink are required and must be valid" }, { status: 400 });
+  const bad = (why: string) => Response.json({ error: why }, { status: 400 });
+  if ((type !== "creator" && type !== "community") || !SENDER_TARGET_RE.test(target)) return bad("type must be creator or community, target a valid name");
+  if (Array.isArray(body.posts)) {
+    if (body.posts.length < 1 || body.posts.length > COMPOSE_MAX) return bad(`posts must hold 1 to ${COMPOSE_MAX} entries`);
+    const posts: PostRef[] = [];
+    for (const v of body.posts) {
+      const ref = parseRef(v);
+      if (!ref) return bad("every post needs a valid author and permlink");
+      posts.push(ref);
+    }
+    return { type, target, posts, subject: text(body.subject, SUBJECT_MAX), intro: text(body.intro, INTRO_MAX) };
   }
-  return { type, target, author, permlink };
+  const ref = parseRef(body);
+  if (!ref) return bad("author and permlink are required and must be valid");
+  return { type, target, ...ref };
 }

--- a/apps/web/src/server/newsletter-sender-gate.ts
+++ b/apps/web/src/server/newsletter-sender-gate.ts
@@ -1,6 +1,7 @@
 import { getCommunity } from "@ecency/sdk";
 import type { NextRequest } from "next/server";
 import { isProRosterMember } from "@/server/pro-members";
+import { COMPOSE_MAX, INTRO_MAX, SUBJECT_MAX } from "@/features/newsletter/compose-limits";
 
 /**
  * Who counts as a list's SENDER, decided in the web tier because it knows Pro
@@ -67,9 +68,7 @@ export type SendBody =
   | { type: "creator" | "community"; target: string; author: string; permlink: string }
   | { type: "creator" | "community"; target: string; posts: PostRef[]; subject?: string; intro?: string };
 
-export const COMPOSE_MAX = 10;
-export const SUBJECT_MAX = 120;
-export const INTRO_MAX = 500;
+export { COMPOSE_MAX, INTRO_MAX, SUBJECT_MAX };
 
 /** Reads the JSON body once; the same object feeds resolveUser (body.code) and the field validation. */
 export async function readJsonBody(request: NextRequest): Promise<Record<string, unknown>> {

--- a/apps/web/src/specs/api/newsletter-send-routes.spec.ts
+++ b/apps/web/src/specs/api/newsletter-send-routes.spec.ts
@@ -125,6 +125,43 @@ describe("author send routes", () => {
     expect(mocks.fetch).not.toHaveBeenCalled();
   });
 
+  it("accepts a composition (posts, subject, intro), binds every post to a creator sender, bounds and cleans the text; candidates route uses the send gate", async () => {
+    mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
+    mocks.pro.mockResolvedValue(true);
+    mocks.fetch.mockResolvedValue(upstream(201, { issues: [] }));
+    const { POST } = await import("@/app/api/newsletter/send/route");
+    const compose = { type: "creator", target: "alice", posts: [{ author: "alice", permlink: "one" }, { author: "Alice", permlink: "two" }], subject: "  Two   things ", intro: "Hi\n\nall" };
+    const res = await POST(req(compose, { "x-hs-token": "tok" }));
+    expect(res.status).toBe(201);
+    expect(JSON.parse(mocks.fetch.mock.calls[0][1].body)).toEqual({
+      type: "creator",
+      target: "alice",
+      posts: [{ author: "alice", permlink: "one" }, { author: "alice", permlink: "two" }],
+      subject: "Two things",
+      intro: "Hi all",
+      requestedBy: "alice"
+    });
+    // A foreign post inside the composition is refused for a creator list.
+    expect((await POST(req({ ...compose, posts: [{ author: "alice", permlink: "one" }, { author: "bob", permlink: "x" }] }, { "x-hs-token": "tok" }))).status).toBe(403);
+    // Bounds and shape.
+    expect((await POST(req({ ...compose, posts: [] }, { "x-hs-token": "tok" }))).status).toBe(400);
+    expect((await POST(req({ ...compose, posts: Array.from({ length: 11 }, (_, i) => ({ author: "alice", permlink: `p${i}` })) }, { "x-hs-token": "tok" }))).status).toBe(400);
+    expect((await POST(req({ ...compose, posts: [{ author: "alice", permlink: "Bad!" }] }, { "x-hs-token": "tok" }))).status).toBe(400);
+    const long = await POST(req({ ...compose, subject: "s".repeat(500), intro: "i".repeat(2000) }, { "x-hs-token": "tok" }));
+    expect(long.status).toBe(201);
+    const sent = JSON.parse(mocks.fetch.mock.calls[mocks.fetch.mock.calls.length - 1][1].body);
+    expect(sent.subject).toHaveLength(120);
+    expect(sent.intro).toHaveLength(500);
+    // Candidates: same gate as sending (a mod is refused), relayed with the limit.
+    const { GET: POSTS } = await import("@/app/api/newsletter/posts/route");
+    mocks.fetch.mockResolvedValue(upstream(200, { posts: [] }));
+    expect((await POSTS(req(undefined, { "x-hs-token": "tok" }, "type=creator&target=alice&limit=5"))).status).toBe(200);
+    expect(mocks.fetch.mock.calls[mocks.fetch.mock.calls.length - 1][0]).toBe("http://news.internal:3300/api/posts?type=creator&target=alice&limit=5");
+    expect((await POSTS(req(undefined, { "x-hs-token": "tok" }, "type=creator&target=alice&limit=99"))).status).toBe(400);
+    mocks.getCommunity.mockResolvedValue({ name: "hive-125125", team: [["alice", "mod", ""]] });
+    expect((await POSTS(req(undefined, { "x-hs-token": "tok" }, "type=community&target=hive-125125"))).status).toBe(403);
+  });
+
   it("validates the body, requires identity, and answers 503 unconfigured", async () => {
     mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
     mocks.pro.mockResolvedValue(true);

--- a/apps/web/src/specs/features/newsletter/author-send.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/author-send.spec.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactElement, ReactNode } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { NewsletterRuntimeProvider } from "@/features/newsletter/runtime";
-import { AuthorSendDialog, SentIssues, useAuthorSendTarget } from "@/features/newsletter";
+import { AuthorSendDialog, ComposeDigestButton, ComposeDigestDialog, SentIssues, useAuthorSendTarget } from "@/features/newsletter";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import {
   cleanupModalContainers,
@@ -220,5 +220,101 @@ describe("SentIssues", () => {
     fetchMock.mockReturnValue(json(503, { error: "down" }));
     render(<SentIssues type="creator" target="alice" isSender />);
     await waitFor(() => expect(screen.getByText("newsletter.sent-issues-unavailable")).toBeInTheDocument());
+  });
+});
+
+describe("ComposeDigestDialog", () => {
+  const candidates = [
+    { author: "alice", permlink: "one", title: "One", created: "2026-08-17T09:00:00Z", featured: false },
+    { author: "alice", permlink: "two", title: "Two", created: "2026-08-16T09:00:00Z", featured: true },
+    { author: "alice", permlink: "three", title: "Three", created: "2026-08-15T09:00:00Z", featured: false }
+  ];
+  beforeEach(() => {
+    setupModalContainers();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    flags.newsletter = true;
+    loggedIn("alice");
+  });
+  afterEach(() => {
+    cleanupModalContainers();
+    vi.unstubAllGlobals();
+  });
+
+  it("picks 2..10 posts in the sender's order, takes subject and intro, then hands the composition to the send flow", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/newsletter/posts")) return json(200, { posts: candidates });
+      if (url.endsWith("/preview")) return json(200, preview({ subject: "Two things", posts: [{ author: "alice", permlink: "two", title: "Two" }, { author: "alice", permlink: "one", title: "One" }] }));
+      return json(201, { issues: [{ issueId: "i1", cadence: "weekly", period: "2026-08-17", send: { recipients: 12, sent: 12, pending: 0 } }] });
+    });
+    render(<ComposeDigestDialog target={target} show onHide={() => {}} />);
+    await screen.findByRole("list", { name: "newsletter.compose-pick" });
+    expect(screen.getByText(/newsletter.compose-featured/)).toBeInTheDocument();
+    const cont = () => screen.getByText("newsletter.compose-continue").closest("button")!;
+    expect(cont()).toBeDisabled();
+    fireEvent.click(screen.getByLabelText("Two"));
+    expect(cont()).toBeDisabled(); // one is not enough
+    fireEvent.click(screen.getByLabelText("One"));
+    expect(cont()).not.toBeDisabled();
+    fireEvent.change(screen.getByLabelText("newsletter.compose-subject"), { target: { value: "Two things" } });
+    fireEvent.change(screen.getByLabelText("newsletter.compose-intro"), { target: { value: "Hi all" } });
+    fireEvent.click(cont());
+    // The send flow previews the composition: picked order (Two, then One), subject and intro travel with it.
+    await waitFor(() => expect(screen.getByText("Two things")).toBeInTheDocument());
+    const previewCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith("/preview"))!;
+    expect(JSON.parse(previewCall[1].body)).toEqual({
+      type: "creator",
+      target: "alice",
+      posts: [{ author: "alice", permlink: "two" }, { author: "alice", permlink: "one" }],
+      subject: "Two things",
+      intro: "Hi all"
+    });
+    // Back returns to the picker with the choices kept.
+    fireEvent.click(screen.getByText("g.back"));
+    await screen.findByRole("list", { name: "newsletter.compose-pick" });
+    expect((screen.getByLabelText("Two") as HTMLInputElement).checked).toBe(true);
+    fireEvent.click(cont());
+    await waitFor(() => expect(screen.getByText("newsletter.send-now")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("newsletter.send-now"));
+    await waitFor(() => expect(screen.getByText("newsletter.send-done")).toBeInTheDocument());
+  });
+
+  it("says when there are no candidates or they could not be loaded", async () => {
+    fetchMock.mockImplementation(() => json(200, { posts: [] }));
+    const { unmount } = render(<ComposeDigestDialog target={target} show onHide={() => {}} />);
+    await waitFor(() => expect(screen.getByText("newsletter.compose-no-candidates")).toBeInTheDocument());
+    unmount();
+    fetchMock.mockImplementation(() => json(503, { error: "down" }));
+    render(<ComposeDigestDialog target={target} show onHide={() => {}} />);
+    await waitFor(() => expect(screen.getByText("newsletter.compose-candidates-unavailable")).toBeInTheDocument());
+  });
+});
+
+describe("ComposeDigestButton", () => {
+  beforeEach(() => {
+    flags.newsletter = true;
+    loggedIn("alice");
+  });
+
+  it("shows for a Pro creator on their own surface and for a community sender; not for a non-Pro creator, a non-sender, or with the feature off", () => {
+    const client = createTestQueryClient();
+    client.setQueryData(["accounts", "pro-members"], { members: ["alice"] });
+    const { unmount: u1 } = render(<ComposeDigestButton target={target} isSender />, client);
+    expect(screen.getByText("newsletter.compose-button")).toBeInTheDocument();
+    u1();
+    const { unmount: u2 } = render(<ComposeDigestButton target={{ type: "community", target: "hive-125125", label: "Town Square" }} isSender />, client);
+    expect(screen.getByText("newsletter.compose-button")).toBeInTheDocument();
+    u2();
+    client.setQueryData(["accounts", "pro-members"], { members: ["someone-else"] });
+    const { container: c1, unmount: u3 } = render(<ComposeDigestButton target={target} isSender />, client);
+    expect(c1.textContent).toBe("");
+    u3();
+    client.setQueryData(["accounts", "pro-members"], { members: ["alice"] });
+    const { container: c2, unmount: u4 } = render(<ComposeDigestButton target={target} isSender={false} />, client);
+    expect(c2.textContent).toBe("");
+    u4();
+    flags.newsletter = false;
+    const { container: c3 } = render(<ComposeDigestButton target={target} isSender />, client);
+    expect(c3.textContent).toBe("");
   });
 });

--- a/apps/web/src/specs/features/newsletter/author-send.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/author-send.spec.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactElement, ReactNode } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { NewsletterRuntimeProvider } from "@/features/newsletter/runtime";
-import { AuthorSendDialog, ComposeDigestButton, ComposeDigestDialog, SentIssues, useAuthorSendTarget } from "@/features/newsletter";
+import { AuthorSendDialog, candidatesKey, ComposeDigestButton, ComposeDigestDialog, sendPreviewKey, SentIssues, useAuthorSendTarget } from "@/features/newsletter";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import {
   cleanupModalContainers,
@@ -277,6 +277,77 @@ describe("ComposeDigestDialog", () => {
     await waitFor(() => expect(screen.getByText("newsletter.send-now")).toBeInTheDocument());
     fireEvent.click(screen.getByText("newsletter.send-now"));
     await waitFor(() => expect(screen.getByText("newsletter.send-done")).toBeInTheDocument());
+  });
+
+  it("a refused preview offers the way back to the picker; the picks and text survive", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/newsletter/posts")) return json(200, { posts: candidates });
+      return json(422, { error: "@alice/two: the post is tagged nsfw", code: "post_refused" });
+    });
+    render(<ComposeDigestDialog target={target} show onHide={() => {}} />);
+    await screen.findByRole("list", { name: "newsletter.compose-pick" });
+    fireEvent.click(screen.getByLabelText("Two"));
+    fireEvent.click(screen.getByLabelText("One"));
+    fireEvent.change(screen.getByLabelText("newsletter.compose-subject"), { target: { value: "Two things" } });
+    fireEvent.click(screen.getByText("newsletter.compose-continue"));
+    await waitFor(() => expect(screen.getByText("newsletter.send-post-refused")).toBeInTheDocument());
+    expect(screen.getByText("@alice/two: the post is tagged nsfw")).toBeInTheDocument();
+    expect(screen.queryByText("newsletter.send-now")).toBeNull();
+    fireEvent.click(screen.getByText("g.back"));
+    await screen.findByRole("list", { name: "newsletter.compose-pick" });
+    expect((screen.getByLabelText("Two") as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByLabelText("newsletter.compose-subject") as HTMLInputElement).value).toBe("Two things");
+    // The offending post can be swapped out.
+    fireEvent.click(screen.getByLabelText("Two"));
+    fireEvent.click(screen.getByLabelText("Three"));
+    expect(screen.getByText("newsletter.compose-continue").closest("button")).not.toBeDisabled();
+  });
+
+  it("picks that no longer resolve to a candidate do not count towards the minimum", async () => {
+    fetchMock.mockImplementation(() => json(200, { posts: candidates }));
+    const client = createTestQueryClient();
+    render(<ComposeDigestDialog target={target} show onHide={() => {}} />, client);
+    await screen.findByRole("list", { name: "newsletter.compose-pick" });
+    fireEvent.click(screen.getByLabelText("Two"));
+    fireEvent.click(screen.getByLabelText("One"));
+    const cont = () => screen.getByText("newsletter.compose-continue").closest("button")!;
+    expect(cont()).not.toBeDisabled();
+    // The list refreshes without "Two": one live pick is not enough to continue.
+    client.setQueryData(candidatesKey("creator", "alice", "alice"), candidates.filter((c) => c.permlink !== "two"));
+    await waitFor(() => expect(cont()).toBeDisabled());
+  });
+
+  it("a sent composition invalidates the candidates, so the featured marks refresh on the next open", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/newsletter/posts")) return json(200, { posts: candidates });
+      if (url.endsWith("/preview")) return json(200, preview({ subject: "Two things" }));
+      return json(201, { issues: [{ issueId: "i1", cadence: "weekly", period: "2026-08-17", send: { recipients: 12, sent: 12, pending: 0 } }] });
+    });
+    const client = createTestQueryClient();
+    render(<ComposeDigestDialog target={target} show onHide={() => {}} />, client);
+    await screen.findByRole("list", { name: "newsletter.compose-pick" });
+    fireEvent.click(screen.getByLabelText("Two"));
+    fireEvent.click(screen.getByLabelText("One"));
+    fireEvent.click(screen.getByText("newsletter.compose-continue"));
+    await waitFor(() => expect(screen.getByText("newsletter.send-now")).toBeInTheDocument());
+    const candidateFetches = () => fetchMock.mock.calls.filter((c) => String(c[0]).startsWith("/api/newsletter/posts")).length;
+    expect(candidateFetches()).toBe(1);
+    fireEvent.click(screen.getByText("newsletter.send-now"));
+    await waitFor(() => expect(screen.getByText("newsletter.send-done")).toBeInTheDocument());
+    // The candidates query is still mounted behind the send flow, so the invalidation refetches it at once.
+    await waitFor(() => expect(candidateFetches()).toBe(2));
+    expect(client.getQueryState(candidatesKey("creator", "alice", "alice"))?.status).toBe("success");
+  });
+
+  it("the preview's cache key tells compositions apart even when subject and intro share text", () => {
+    const base = { type: "creator" as const, target: "alice", posts: [{ author: "alice", permlink: "one" }, { author: "alice", permlink: "two" }] };
+    const a = sendPreviewKey({ ...base, subject: "A|B", intro: "C" }, "alice");
+    const b = sendPreviewKey({ ...base, subject: "A", intro: "B|C" }, "alice");
+    const c = sendPreviewKey({ ...base, subject: "A|B", intro: "C" }, "alice");
+    expect(a).not.toEqual(b);
+    expect(a).toEqual(c);
+    expect(sendPreviewKey({ ...base, posts: [base.posts[1], base.posts[0]] }, "alice")).not.toEqual(a);
+    expect(sendPreviewKey({ type: "creator", target: "alice", author: "alice", permlink: "one" }, "alice")).not.toEqual(sendPreviewKey({ ...base, posts: [base.posts[0]] }, "alice"));
   });
 
   it("says when there are no candidates or they could not be loaded", async () => {

--- a/apps/web/src/specs/features/newsletter/author-send.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/author-send.spec.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactElement, ReactNode } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { NewsletterRuntimeProvider } from "@/features/newsletter/runtime";
-import { AuthorSendDialog, candidatesKey, ComposeDigestButton, ComposeDigestDialog, sendPreviewKey, SentIssues, useAuthorSendTarget } from "@/features/newsletter";
+import { AuthorSendDialog, candidatesKey, communityDigestRoles, ComposeDigestButton, ComposeDigestDialog, sendPreviewKey, SentIssues, useAuthorSendTarget } from "@/features/newsletter";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import {
   cleanupModalContainers,
@@ -358,6 +358,22 @@ describe("ComposeDigestDialog", () => {
     fetchMock.mockImplementation(() => json(503, { error: "down" }));
     render(<ComposeDigestDialog target={target} show onHide={() => {}} />);
     await waitFor(() => expect(screen.getByText("newsletter.compose-candidates-unavailable")).toBeInTheDocument());
+  });
+});
+
+describe("communityDigestRoles", () => {
+  it("owner and admin may view and send, a mod may only view, anyone else neither; names match regardless of case", () => {
+    const team = [["owner1", "owner", ""], ["Alice", "admin", ""], ["mia", "mod", ""], ["bob", "member", ""]];
+    expect(communityDigestRoles(team, "owner1")).toEqual({ canView: true, canSend: true });
+    expect(communityDigestRoles(team, "alice")).toEqual({ canView: true, canSend: true });
+    expect(communityDigestRoles(team, "ALICE")).toEqual({ canView: true, canSend: true });
+    expect(communityDigestRoles(team, "MIA")).toEqual({ canView: true, canSend: false });
+    expect(communityDigestRoles(team, "bob")).toEqual({ canView: false, canSend: false });
+    expect(communityDigestRoles(team, "stranger")).toEqual({ canView: false, canSend: false });
+    expect(communityDigestRoles(team, null)).toEqual({ canView: false, canSend: false });
+    expect(communityDigestRoles(team, "")).toEqual({ canView: false, canSend: false });
+    expect(communityDigestRoles(undefined, "owner1")).toEqual({ canView: false, canSend: false });
+    expect(communityDigestRoles([["", "owner", ""]], "")).toEqual({ canView: false, canSend: false });
   });
 });
 


### PR DESCRIPTION
Closes #1536. The composer on top of #1535: a sender picks 2..10 of the list's recent posts, writes a subject and an intro, sees the reader's view, sends. Service side is ecency/news #22 (merged, deployed).

- **Server**: `parseSendBody` accepts a composition (`posts` 1..10 valid refs, `subject` ≤ 120, `intro` ≤ 500, whitespace-cleaned) beside the single `{author, permlink}`; `postBelongsToSender` binds every post of a creator list to the sender; `GET /api/newsletter/posts` relays the sender's candidates behind the send gate.
- **UI**: "Compose email digest" on the creator's own profile card (Pro) and on the community card (owner/admin). The picker lists the service's candidates (already through the refusal rules, "featured recently" marked), the order of picking is the order in the issue, then subject and intro, then the same preview-and-send flow as a single post (`SendFlow`, extracted from the dialog and reused) with a way back to the picker. Same one-issue-per-period rule and refusals.
- **Specs**: composition parsing, creator binding and bounds; candidates route with the send gate; the composer's picking, bounds, continue/back and send; the button's visibility (Pro creator / community sender / neither / feature off). Typecheck, eslint, icon audit, 2,092 specs green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added email digest composition for authorized newsletter senders.
  - Select 2–10 recent posts, customize the subject and introduction, preview the digest, and send it.
  - Added candidate-post retrieval and clear loading, empty, error, and selection-limit states.
  - Added digest composition access to eligible community and creator profile pages.
  - Distinguished sender permissions for owners, administrators, and moderators.

- **Bug Fixes**
  - Improved validation and handling of invalid, unauthorized, or outdated post selections.

- **Tests**
  - Added coverage for composition, permissions, validation, previews, navigation, and error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->