### PR TITLE
Newsletter: list building for creators (count, subscribe link, end-of-post prompt)

### DIFF
--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { communityDigestRoles, ComposeDigestButton, NewsletterGate, SenderStatusNotice, SentIssues } from "@/features/newsletter";
+import { communityDigestRoles, ComposeDigestButton, NewsletterGate, SenderStatusNotice, SentIssues, SubscriberCount } from "@/features/newsletter";
 import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import { Button } from "@ui/button";
@@ -62,6 +62,7 @@ export function CommunityCard({ community, account }: Props) {
       {/* Policing (vision-web#1513): the team sees when this community's digest is suspended, and why. */}
       <NewsletterGate>
         <SenderStatusNotice type="community" target={community.name} isSender={isDigestSender} className="mb-4" />
+        <SubscriberCount type="community" target={community.name} isSender={isDigestSender} className="mb-2" />
         <ComposeDigestButton target={{ type: "community", target: community.name, label: community.title || community.name }} isSender={canSendDigest} className="mb-2" />
         <SentIssues type="community" target={community.name} isSender={isDigestSender} className="mb-4" />
       </NewsletterGate>

--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-ssr.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-page-content-ssr.tsx
@@ -3,6 +3,8 @@ import { PollWidget, useEntryPollExtractor } from "@/features/polls";
 import { useEntryLocation } from "@/utils";
 import { UilMapPinAlt } from "@tooni/iconscout-unicons-react";
 import Link from "next/link";
+import { NewsletterGate } from "@/features/newsletter/runtime";
+import { PostSubscribePrompt } from "@/features/newsletter/post-subscribe-prompt";
 import { EntryFooterControls } from "./entry-footer-controls";
 import { EntryFooterInfo } from "./entry-footer-info";
 import { EntryPageIsCommentHeader } from "./entry-page-is-comment-header";
@@ -63,6 +65,9 @@ export function EntryPageContentSSR({ entry, isRawContent }: Props) {
           <EntryFooterInfo entry={entry} />
         </div>
         <EntryFooterControls entry={entry} />
+        <NewsletterGate>
+          <PostSubscribePrompt entry={entry} className="m-2 md:m-3" />
+        </NewsletterGate>
       </div>
     </>
   );

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_components/profile-card/index.tsx
@@ -35,7 +35,7 @@ import { profileWebsiteHref } from "./website-href";
 import { FinalizeCommunityBanner } from "../finalize-community-banner";
 import { useActiveAccount } from "@/core/hooks";
 import { ProBadge } from "@/features/pro";
-import { ComposeDigestButton, DigestSubscribeButton, NewsletterGate, SenderStatusNotice, SentIssues } from "@/features/newsletter";
+import { ComposeDigestButton, DigestSubscribeButton, NewsletterGate, SenderStatusNotice, SentIssues, SubscriberCount } from "@/features/newsletter";
 
 interface Props {
   account: Account;
@@ -139,6 +139,7 @@ export function ProfileCard({ account }: Props) {
       {activeUsername?.toLowerCase() === account.name && (
         <NewsletterGate>
           <SenderStatusNotice type="creator" target={account.name} isSender className="mb-4" />
+          <SubscriberCount type="creator" target={account.name} isSender className="mb-2" />
           <ComposeDigestButton target={{ type: "creator", target: account.name, label: `@${account.name}` }} isSender className="mb-2" />
           <SentIssues type="creator" target={account.name} isSender className="mb-4" />
         </NewsletterGate>

--- a/apps/web/src/app/api/newsletter/subscribe/route.ts
+++ b/apps/web/src/app/api/newsletter/subscribe/route.ts
@@ -12,7 +12,7 @@ import {
 
 const TYPES = new Set(["own", "community", "creator", "site"]);
 const CADENCES = new Set(["weekly", "monthly"]);
-const SOURCES = new Set(["community-page", "creator-page", "settings", "landing-page", "publish-prompt"]);
+const SOURCES = new Set(["community-page", "creator-page", "settings", "landing-page", "publish-prompt", "post-page"]);
 
 /**
  * Subscribe to a community or creator digest.

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -4230,6 +4230,17 @@
     "compose-subject": "Subject (optional)",
     "compose-intro": "A short intro for your readers (optional)",
     "compose-picked": "{{n}} picked ({{min}} to {{max}})",
-    "compose-continue": "Preview"
+    "compose-continue": "Preview",
+    "subscriber-count": "{{count}} email subscribers",
+    "subscriber-count_one": "{{count}} email subscriber",
+    "subscriber-count-split": "{{weekly}} weekly, {{monthly}} monthly",
+    "subscriber-count-none": "Share your subscribe link to grow the list.",
+    "copy-subscribe-link": "Copy subscribe link",
+    "subscribe-link-copied": "Subscribe link copied",
+    "post-prompt-title": "Get {{list}} by email",
+    "post-prompt-body-creator": "New posts by this author, as a weekly or monthly digest. Unsubscribe any time.",
+    "post-prompt-body-community": "The best of this community, as a weekly or monthly digest. Unsubscribe any time.",
+    "post-prompt-dismiss": "Not now",
+    "post-prompt-subscribe": "Subscribe"
   }
 }

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -4241,6 +4241,7 @@
     "post-prompt-body-creator": "New posts by this author, as a weekly or monthly digest. Unsubscribe any time.",
     "post-prompt-body-community": "The best of this community, as a weekly or monthly digest. Unsubscribe any time.",
     "post-prompt-dismiss": "Not now",
-    "post-prompt-subscribe": "Subscribe"
+    "post-prompt-subscribe": "Subscribe",
+    "subscribe-link": "Subscribe link"
   }
 }

--- a/apps/web/src/features/newsletter/digest-subscribe-button.tsx
+++ b/apps/web/src/features/newsletter/digest-subscribe-button.tsx
@@ -8,8 +8,6 @@ import { Button, ButtonProps } from "@ui/button";
 import i18next from "i18next";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { SUBSCRIBE_PARAM, SUBSCRIBE_PARAM_VALUE } from "./list-building";
-
-const noop = () => {};
 import { DigestSubscribeDialog } from "./digest-subscribe-dialog";
 import { useDigestSubscription } from "./hooks";
 import { useNewsletterEnabled } from "./runtime";
@@ -40,10 +38,14 @@ interface Props {
  * in sync with the router), so it needs neither the app router nor a Suspense
  * boundary; a button rendered outside a Next page still works.
  */
-function useSubscribeLinkOpener(onOpen: () => void): void {
+function useSubscribeLinkOpener(onOpen: (() => void) | null | undefined): void {
   const opened = useRef(false);
   useEffect(() => {
-    if (opened.current || typeof window === "undefined") return;
+    // undefined: not known yet whether this list is offered here (the Pro
+    // roster is still loading) — do nothing, touch nothing, try again on the
+    // next render. null: known not offered — leave the link alone. A function:
+    // open once and clean the URL.
+    if (!onOpen || opened.current || typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
     if (params.get(SUBSCRIBE_PARAM) !== SUBSCRIBE_PARAM_VALUE) return;
     opened.current = true;
@@ -58,10 +60,13 @@ export function DigestSubscribeButton({ type, target, targetLabel, source, size,
   const enabled = useNewsletterEnabled();
   const [open, setOpen] = useState(false);
   const { subscription } = useDigestSubscription(type, target);
-  const { data: pro } = useQuery({ ...getProMembersQueryOptions(), enabled: enabled && type === "creator" });
+  const proQuery = useQuery({ ...getProMembersQueryOptions(), enabled: enabled && type === "creator" });
+  const pro = proQuery.data;
   const offered = enabled && (type !== "creator" || isProMember(pro?.members, target));
+  // For a creator list, "offered" is unknown until the roster has answered.
+  const eligibilityKnown = type !== "creator" || !enabled || proQuery.isSuccess || proQuery.isError;
   const openFromLink = useCallback(() => setOpen(true), []);
-  useSubscribeLinkOpener(offered ? openFromLink : noop);
+  useSubscribeLinkOpener(!eligibilityKnown ? undefined : offered ? openFromLink : null);
 
   if (!offered) return null;
 

--- a/apps/web/src/features/newsletter/digest-subscribe-button.tsx
+++ b/apps/web/src/features/newsletter/digest-subscribe-button.tsx
@@ -6,7 +6,10 @@ import { useQuery } from "@tanstack/react-query";
 import { UilEnvelope, UilEnvelopeCheck } from "@tooni/iconscout-unicons-react";
 import { Button, ButtonProps } from "@ui/button";
 import i18next from "i18next";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { SUBSCRIBE_PARAM, SUBSCRIBE_PARAM_VALUE } from "./list-building";
+
+const noop = () => {};
 import { DigestSubscribeDialog } from "./digest-subscribe-dialog";
 import { useDigestSubscription } from "./hooks";
 import { useNewsletterEnabled } from "./runtime";
@@ -30,14 +33,37 @@ interface Props {
  * Pro capability, and the server enforces the same rule, this only avoids offering
  * something the request would refuse.
  */
+/**
+ * A shared subscribe link (?subscribe=digest, vision-web#1537) opens the dialog
+ * once, on the page that carries the list's button, then leaves the URL clean.
+ * Reads the location and cleans it with history.replaceState (which Next keeps
+ * in sync with the router), so it needs neither the app router nor a Suspense
+ * boundary; a button rendered outside a Next page still works.
+ */
+function useSubscribeLinkOpener(onOpen: () => void): void {
+  const opened = useRef(false);
+  useEffect(() => {
+    if (opened.current || typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get(SUBSCRIBE_PARAM) !== SUBSCRIBE_PARAM_VALUE) return;
+    opened.current = true;
+    onOpen();
+    params.delete(SUBSCRIBE_PARAM);
+    const rest = params.toString();
+    window.history.replaceState(window.history.state, "", `${window.location.pathname}${rest ? `?${rest}` : ""}${window.location.hash}`);
+  }, [onOpen]);
+}
+
 export function DigestSubscribeButton({ type, target, targetLabel, source, size, className }: Props) {
   const enabled = useNewsletterEnabled();
   const [open, setOpen] = useState(false);
   const { subscription } = useDigestSubscription(type, target);
   const { data: pro } = useQuery({ ...getProMembersQueryOptions(), enabled: enabled && type === "creator" });
+  const offered = enabled && (type !== "creator" || isProMember(pro?.members, target));
+  const openFromLink = useCallback(() => setOpen(true), []);
+  useSubscribeLinkOpener(offered ? openFromLink : noop);
 
-  if (!enabled) return null;
-  if (type === "creator" && !isProMember(pro?.members, target)) return null;
+  if (!offered) return null;
 
   const active = subscription?.status === "active";
   const label = subscription

--- a/apps/web/src/features/newsletter/index.ts
+++ b/apps/web/src/features/newsletter/index.ts
@@ -12,3 +12,5 @@ export * from "./author-send-eligibility";
 export * from "./author-send-dialog";
 export * from "./sent-issues";
 export * from "./compose-digest-dialog";
+export * from "./list-building";
+export * from "./post-subscribe-prompt";

--- a/apps/web/src/features/newsletter/list-building.tsx
+++ b/apps/web/src/features/newsletter/list-building.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@ui/button";
 import { UilLink } from "@tooni/iconscout-unicons-react";
 import i18next from "i18next";
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useEffect, useRef, useState } from "react";
 import { success } from "@/features/shared/feedback";
 import { useSenderStanding } from "./sender-status";
 
@@ -16,7 +16,7 @@ export const SUBSCRIBE_PARAM = "subscribe";
 export const SUBSCRIBE_PARAM_VALUE = "digest";
 
 /** The page that carries the list's subscribe button, with the parameter that opens the dialog. */
-export function subscribeLinkFor(type: "creator" | "community", target: string, base = ""): string {
+export function subscribeLinkFor(type: "creator" | "community", target: string, base: string = ""): string {
   const path = type === "creator" ? `/@${target}` : `/created/${target}`;
   return `${base}${path}?${SUBSCRIBE_PARAM}=${SUBSCRIBE_PARAM_VALUE}`;
 }
@@ -34,19 +34,29 @@ export function SubscriberCount({
 }): ReactElement | null {
   const { data } = useSenderStanding(type, target, isSender);
   const [copied, setCopied] = useState(false);
+  // When the clipboard is unavailable (denied, insecure context, no API), the
+  // link is shown as selectable text instead, so the click never does nothing.
+  const [shown, setShown] = useState<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
   if (!isSender || !data?.subscribers) return null;
   const { weekly, monthly } = data.subscribers;
   const total = weekly + monthly;
   const copy = async () => {
     const url = subscribeLinkFor(type, target, typeof window !== "undefined" ? window.location.origin : "");
     try {
+      if (!navigator.clipboard?.writeText) throw new Error("clipboard unavailable");
       await navigator.clipboard.writeText(url);
       setCopied(true);
+      setShown(null);
       success(i18next.t("newsletter.subscribe-link-copied"));
-      setTimeout(() => setCopied(false), 2000);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Clipboard refused (permissions, insecure context): the link is still shown as text below.
       setCopied(false);
+      setShown(url);
     }
   };
   return (
@@ -62,6 +72,15 @@ export function SubscriberCount({
       <Button size="sm" appearance="gray-link" icon={<UilLink />} iconPlacement="left" onClick={copy} className="mt-1 -ml-2">
         {copied ? i18next.t("newsletter.subscribe-link-copied") : i18next.t("newsletter.copy-subscribe-link")}
       </Button>
+      {shown ? (
+        <input
+          readOnly
+          value={shown}
+          aria-label={i18next.t("newsletter.subscribe-link")}
+          onFocus={(e) => e.currentTarget.select()}
+          className="mt-1 w-full text-xs px-2 py-1 rounded border border-[--border-color] bg-transparent"
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/newsletter/list-building.tsx
+++ b/apps/web/src/features/newsletter/list-building.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Button } from "@ui/button";
+import { UilLink } from "@tooni/iconscout-unicons-react";
+import i18next from "i18next";
+import { type ReactElement, useState } from "react";
+import { success } from "@/features/shared/feedback";
+import { useSenderStanding } from "./sender-status";
+
+/**
+ * List building for senders (vision-web#1537): how many readers there are and
+ * a link that opens the subscribe dialog on the list's own page, to share
+ * anywhere. Sender-only, like everything on the sender's card.
+ */
+export const SUBSCRIBE_PARAM = "subscribe";
+export const SUBSCRIBE_PARAM_VALUE = "digest";
+
+/** The page that carries the list's subscribe button, with the parameter that opens the dialog. */
+export function subscribeLinkFor(type: "creator" | "community", target: string, base = ""): string {
+  const path = type === "creator" ? `/@${target}` : `/created/${target}`;
+  return `${base}${path}?${SUBSCRIBE_PARAM}=${SUBSCRIBE_PARAM_VALUE}`;
+}
+
+export function SubscriberCount({
+  type,
+  target,
+  isSender,
+  className
+}: {
+  type: "creator" | "community";
+  target: string;
+  isSender: boolean;
+  className?: string;
+}): ReactElement | null {
+  const { data } = useSenderStanding(type, target, isSender);
+  const [copied, setCopied] = useState(false);
+  if (!isSender || !data?.subscribers) return null;
+  const { weekly, monthly } = data.subscribers;
+  const total = weekly + monthly;
+  const copy = async () => {
+    const url = subscribeLinkFor(type, target, typeof window !== "undefined" ? window.location.origin : "");
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      success(i18next.t("newsletter.subscribe-link-copied"));
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard refused (permissions, insecure context): the link is still shown as text below.
+      setCopied(false);
+    }
+  };
+  return (
+    <div className={`text-sm ${className ?? ""}`}>
+      <div className="flex flex-wrap items-baseline gap-x-2">
+        <span className="font-semibold">{i18next.t("newsletter.subscriber-count", { count: total })}</span>
+        {total > 0 ? (
+          <span className="text-xs opacity-70">{i18next.t("newsletter.subscriber-count-split", { weekly, monthly })}</span>
+        ) : (
+          <span className="text-xs opacity-70">{i18next.t("newsletter.subscriber-count-none")}</span>
+        )}
+      </div>
+      <Button size="sm" appearance="gray-link" icon={<UilLink />} iconPlacement="left" onClick={copy} className="mt-1 -ml-2">
+        {copied ? i18next.t("newsletter.subscribe-link-copied") : i18next.t("newsletter.copy-subscribe-link")}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/features/newsletter/post-subscribe-prompt.tsx
+++ b/apps/web/src/features/newsletter/post-subscribe-prompt.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getProMembersQueryOptions } from "@ecency/sdk";
+import type { Entry } from "@/entities";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { isProMember } from "@/features/pro/pro-config";
+import { Button } from "@ui/button";
+import { UilEnvelope } from "@tooni/iconscout-unicons-react";
+import i18next from "i18next";
+import { type ReactElement, useEffect, useState } from "react";
+import { DigestSubscribeDialog } from "./digest-subscribe-dialog";
+import { useDigestSubscription } from "./hooks";
+import { useNewsletterEnabled } from "./runtime";
+import type { DigestType } from "./types";
+
+/**
+ * At the end of a post (vision-web#1537): a reader who is signed in and not yet
+ * subscribed is offered the author's digest (when the author is Pro), or the
+ * community's digest when the post was made in one. Dismissible per list; the
+ * dismissal is remembered on this device. Never shown to the author for their
+ * own list, never twice for the same list, never while a subscription exists.
+ */
+const dismissKey = (viewer: string, type: DigestType, target: string) => `ecency:digest-post-prompt:${viewer}:${type}:${target}`;
+
+export function PostSubscribePrompt({ entry, communityTitle, className }: { entry: Entry; communityTitle?: string | null; className?: string }): ReactElement | null {
+  const enabled = useNewsletterEnabled();
+  const { activeUser } = useActiveAccount();
+  const me = activeUser?.username?.toLowerCase();
+  const isTopLevel = !entry.parent_author && (entry.depth ?? 0) === 0;
+  const inCommunity = /^hive-\d+$/.test(entry.category);
+  const { data: pro } = useQuery({ ...getProMembersQueryOptions(), enabled: enabled && !!me && isTopLevel });
+
+  // Which list to offer: the author's own when they are Pro, else the community's.
+  const authorIsPro = isProMember(pro?.members, entry.author);
+  const list: { type: "creator" | "community"; target: string; label: string } | null =
+    !enabled || !me || !isTopLevel
+      ? null
+      : authorIsPro && me !== entry.author
+        ? { type: "creator", target: entry.author, label: `@${entry.author}` }
+        : inCommunity
+          ? { type: "community", target: entry.category, label: communityTitle || entry.category }
+          : null;
+
+  const { subscription, isSuccess } = useDigestSubscription(list?.type ?? "creator", list?.target ?? "");
+  const [dismissed, setDismissed] = useState(true);
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    if (!list || !me) return;
+    try {
+      setDismissed(window.localStorage.getItem(dismissKey(me, list.type, list.target)) === "1");
+    } catch {
+      setDismissed(false);
+    }
+  }, [list?.type, list?.target, me]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!list || !me || dismissed || !isSuccess || subscription) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    try {
+      window.localStorage.setItem(dismissKey(me, list.type, list.target), "1");
+    } catch {
+      /* private mode: dismissed for this page only */
+    }
+  };
+
+  return (
+    <div className={`rounded-xl border border-[--border-color] bg-light-200 dark:bg-dark-200 p-3 md:p-4 flex flex-wrap items-center gap-3 ${className ?? ""}`} role="region" aria-label={i18next.t("newsletter.post-prompt-title", { list: list.label })}>
+      <UilEnvelope className="size-5 opacity-70" aria-hidden="true" />
+      <div className="flex-1 min-w-[12rem]">
+        <div className="font-semibold text-sm">{i18next.t("newsletter.post-prompt-title", { list: list.label })}</div>
+        <div className="text-xs opacity-70">
+          {i18next.t(list.type === "creator" ? "newsletter.post-prompt-body-creator" : "newsletter.post-prompt-body-community")}
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <Button size="sm" appearance="gray-link" onClick={dismiss}>
+          {i18next.t("newsletter.post-prompt-dismiss")}
+        </Button>
+        <Button size="sm" onClick={() => setOpen(true)}>
+          {i18next.t("newsletter.post-prompt-subscribe")}
+        </Button>
+      </div>
+      {open && <DigestSubscribeDialog type={list.type} target={list.target} targetLabel={list.label} source="post-page" show={open} onHide={() => setOpen(false)} />}
+    </div>
+  );
+}

--- a/apps/web/src/features/newsletter/post-subscribe-prompt.tsx
+++ b/apps/web/src/features/newsletter/post-subscribe-prompt.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { getProMembersQueryOptions } from "@ecency/sdk";
+import { getCommunityQueryOptions, getProMembersQueryOptions } from "@ecency/sdk";
 import type { Entry } from "@/entities";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { isProMember } from "@/features/pro/pro-config";
@@ -29,18 +29,28 @@ export function PostSubscribePrompt({ entry, communityTitle, className }: { entr
   const me = activeUser?.username?.toLowerCase();
   const isTopLevel = !entry.parent_author && (entry.depth ?? 0) === 0;
   const inCommunity = /^hive-\d+$/.test(entry.category);
-  const { data: pro } = useQuery({ ...getProMembersQueryOptions(), enabled: enabled && !!me && isTopLevel });
+  const proQuery = useQuery({ ...getProMembersQueryOptions(), enabled: enabled && !!me && isTopLevel });
+  // Until the roster has answered, no list is offered: deciding "not Pro" from
+  // a still-loading roster would offer the community's list to a reader who
+  // should get the author's. A failed roster falls back to the community's.
+  const rosterKnown = proQuery.isSuccess || proQuery.isError;
+  const authorIsPro = isProMember(proQuery.data?.members, entry.author);
 
   // Which list to offer: the author's own when they are Pro, else the community's.
-  const authorIsPro = isProMember(pro?.members, entry.author);
-  const list: { type: "creator" | "community"; target: string; label: string } | null =
-    !enabled || !me || !isTopLevel
+  const list: { type: "creator" | "community"; target: string } | null =
+    !enabled || !me || !isTopLevel || !rosterKnown
       ? null
       : authorIsPro && me !== entry.author
-        ? { type: "creator", target: entry.author, label: `@${entry.author}` }
+        ? { type: "creator", target: entry.author }
         : inCommunity
-          ? { type: "community", target: entry.category, label: communityTitle || entry.category }
+          ? { type: "community", target: entry.category }
           : null;
+  // The community's title, unless the page passed it; same cache entry the community pages use.
+  const { data: community } = useQuery({
+    ...getCommunityQueryOptions(entry.category),
+    enabled: !!list && list.type === "community" && !communityTitle
+  });
+  const label = !list ? "" : list.type === "creator" ? `@${list.target}` : communityTitle || community?.title || list.target;
 
   const { subscription, isSuccess } = useDigestSubscription(list?.type ?? "creator", list?.target ?? "");
   const [dismissed, setDismissed] = useState(true);
@@ -54,7 +64,12 @@ export function PostSubscribePrompt({ entry, communityTitle, className }: { entr
     }
   }, [list?.type, list?.target, me]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (!list || !me || dismissed || !isSuccess || subscription) return null;
+  if (!list || !me) return null;
+  // The card goes once dismissed or once a subscription exists; the dialog,
+  // if open, stays: a pending-confirmation outcome ("check your inbox") is
+  // shown by the dialog after the refetch, and unmounting it would lose it.
+  const showCard = !dismissed && isSuccess && !subscription;
+  if (!showCard && !open) return null;
 
   const dismiss = () => {
     setDismissed(true);
@@ -66,23 +81,27 @@ export function PostSubscribePrompt({ entry, communityTitle, className }: { entr
   };
 
   return (
-    <div className={`rounded-xl border border-[--border-color] bg-light-200 dark:bg-dark-200 p-3 md:p-4 flex flex-wrap items-center gap-3 ${className ?? ""}`} role="region" aria-label={i18next.t("newsletter.post-prompt-title", { list: list.label })}>
-      <UilEnvelope className="size-5 opacity-70" aria-hidden="true" />
-      <div className="flex-1 min-w-[12rem]">
-        <div className="font-semibold text-sm">{i18next.t("newsletter.post-prompt-title", { list: list.label })}</div>
-        <div className="text-xs opacity-70">
-          {i18next.t(list.type === "creator" ? "newsletter.post-prompt-body-creator" : "newsletter.post-prompt-body-community")}
+    <>
+      {showCard && (
+        <div className={`rounded-xl border border-[--border-color] bg-light-200 dark:bg-dark-200 p-3 md:p-4 flex flex-wrap items-center gap-3 ${className ?? ""}`} role="region" aria-label={i18next.t("newsletter.post-prompt-title", { list: label })}>
+          <UilEnvelope className="size-5 opacity-70" aria-hidden="true" />
+          <div className="flex-1 min-w-[12rem]">
+            <div className="font-semibold text-sm">{i18next.t("newsletter.post-prompt-title", { list: label })}</div>
+            <div className="text-xs opacity-70">
+              {i18next.t(list.type === "creator" ? "newsletter.post-prompt-body-creator" : "newsletter.post-prompt-body-community")}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" appearance="gray-link" onClick={dismiss}>
+              {i18next.t("newsletter.post-prompt-dismiss")}
+            </Button>
+            <Button size="sm" onClick={() => setOpen(true)}>
+              {i18next.t("newsletter.post-prompt-subscribe")}
+            </Button>
+          </div>
         </div>
-      </div>
-      <div className="flex gap-2">
-        <Button size="sm" appearance="gray-link" onClick={dismiss}>
-          {i18next.t("newsletter.post-prompt-dismiss")}
-        </Button>
-        <Button size="sm" onClick={() => setOpen(true)}>
-          {i18next.t("newsletter.post-prompt-subscribe")}
-        </Button>
-      </div>
-      {open && <DigestSubscribeDialog type={list.type} target={list.target} targetLabel={list.label} source="post-page" show={open} onHide={() => setOpen(false)} />}
-    </div>
+      )}
+      {open && <DigestSubscribeDialog type={list.type} target={list.target} targetLabel={label} source="post-page" show={open} onHide={() => setOpen(false)} />}
+    </>
   );
 }

--- a/apps/web/src/features/newsletter/sender-status.tsx
+++ b/apps/web/src/features/newsletter/sender-status.tsx
@@ -30,6 +30,8 @@ export interface SenderStanding {
     complaintRate: number;
     bounceRate: number;
   };
+  /** Live, mailable subscribers per cadence. */
+  subscribers?: { weekly: number; monthly: number };
 }
 
 /**

--- a/apps/web/src/features/newsletter/types.ts
+++ b/apps/web/src/features/newsletter/types.ts
@@ -27,5 +27,5 @@ export interface SubscribeInput {
   target: string;
   targetLabel?: string;
   cadence: DigestCadence;
-  source: "community-page" | "creator-page" | "settings" | "landing-page" | "publish-prompt";
+  source: "community-page" | "creator-page" | "settings" | "landing-page" | "publish-prompt" | "post-page";
 }

--- a/apps/web/src/specs/features/newsletter/list-building.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/list-building.spec.tsx
@@ -13,6 +13,15 @@ vi.mock("@/config", () => ({
     getConfigValue: (fn: (c: unknown) => unknown) => fn({ visionFeatures: { newsletter: { enabled: flags.newsletter } } })
   }
 }));
+// The roster is answered by `roster.fn` so a test can hold it pending; the
+// community query answers with a title. Seeded roster data stays (staleTime is
+// Infinity in the test client), so seeding tests are unaffected.
+const roster = vi.hoisted(() => ({ fn: vi.fn(() => new Promise<{ members: string[] }>(() => {})) }));
+vi.mock("@ecency/sdk", async () => ({
+  ...(await vi.importActual<object>("@ecency/sdk")),
+  getProMembersQueryOptions: () => ({ queryKey: ["accounts", "pro-members"], queryFn: () => roster.fn() }),
+  getCommunityQueryOptions: (name: string) => ({ queryKey: ["community", name], queryFn: async () => ({ name, title: "Town Square", team: [] }) })
+}));
 vi.mock("@/utils", async () => ({
   ...(await vi.importActual<object>("@/utils")),
   random: vi.fn(),
@@ -59,6 +68,8 @@ describe("list building (vision-web#1537)", () => {
   afterEach(() => {
     cleanupModalContainers();
     vi.unstubAllGlobals();
+    window.history.replaceState(null, "", "/");
+    window.localStorage.clear();
   });
 
   it("subscribeLinkFor points at the list's own page with the opener parameter", () => {
@@ -82,6 +93,17 @@ describe("list building (vision-web#1537)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("when the clipboard is unavailable, the link is shown as selectable text instead", async () => {
+    fetchMock.mockReturnValue(json(200, standing({ weekly: 1, monthly: 0 })));
+    vi.stubGlobal("navigator", { ...navigator, clipboard: undefined });
+    render(<SubscriberCount type="creator" target="alice" isSender />);
+    await waitFor(() => expect(screen.getByText("newsletter.copy-subscribe-link")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("newsletter.copy-subscribe-link"));
+    const field = (await screen.findByLabelText("newsletter.subscribe-link")) as HTMLInputElement;
+    expect(field.value).toMatch(/\/@alice\?subscribe=digest$/);
+    expect(field.readOnly).toBe(true);
+  });
+
   it("a shared link (?subscribe=digest) opens the subscribe dialog once and cleans the URL", async () => {
     window.history.replaceState(null, "", "/@alice?subscribe=digest&x=1");
     fetchMock.mockReturnValue(json(200, { subscriptions: [] }));
@@ -92,6 +114,30 @@ describe("list building (vision-web#1537)", () => {
     await waitFor(() => expect(window.location.search).toBe("?x=1"));
     const dialog = document.querySelector("#modal-dialog-container") as HTMLElement;
     await waitFor(() => expect(within(dialog).getByText("newsletter.intro-creator")).toBeInTheDocument());
+  });
+
+  it("a shared creator link survives a roster that answers after mount: nothing is consumed until eligibility is known", async () => {
+    window.history.replaceState(null, "", "/@alice?subscribe=digest");
+    fetchMock.mockReturnValue(json(200, { subscriptions: [] }));
+    const client = createTestQueryClient();
+    let resolveRoster!: (v: { members: string[] }) => void;
+    roster.fn.mockImplementationOnce(() => new Promise<{ members: string[] }>((r) => (resolveRoster = r)));
+    render(<DigestSubscribeButton type="creator" target="alice" targetLabel="@alice" source="creator-page" />, client);
+    await new Promise((r) => setTimeout(r, 50));
+    // Roster still pending: the parameter is untouched and no dialog is open.
+    expect(window.location.search).toBe("?subscribe=digest");
+    expect(document.querySelector("#modal-dialog-container")?.textContent ?? "").toBe("");
+    resolveRoster({ members: ["alice"] });
+    await waitFor(() => expect(window.location.search).toBe(""));
+    const dialog = document.querySelector("#modal-dialog-container") as HTMLElement;
+    await waitFor(() => expect(within(dialog).getByText("newsletter.intro-creator")).toBeInTheDocument());
+    // A creator who turns out not to be Pro: the link is left alone, nothing opens.
+    window.history.replaceState(null, "", "/@bob?subscribe=digest");
+    const client2 = createTestQueryClient();
+    client2.setQueryData(["accounts", "pro-members"], { members: ["someone-else"] });
+    render(<DigestSubscribeButton type="creator" target="bob" targetLabel="@bob" source="creator-page" />, client2);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(window.location.search).toBe("?subscribe=digest");
   });
 
   it("at the end of a post, offers the author's digest to a signed-in reader who is not subscribed; remembers 'Not now'; nothing for the author, a subscriber, or when signed out", async () => {
@@ -134,15 +180,43 @@ describe("list building (vision-web#1537)", () => {
     expect(c4.textContent).toBe("");
   });
 
+  it("offers nothing while the Pro roster is still loading, so a Pro author's reader is not steered to the community list", async () => {
+    const client = createTestQueryClient();
+    client.setQueryData(digestSubscriptionsKey("alice"), []);
+    let resolveRoster!: (v: { members: string[] }) => void;
+    roster.fn.mockImplementationOnce(() => new Promise<{ members: string[] }>((r) => (resolveRoster = r)));
+    const entry = mockEntry({ author: "bob", permlink: "p", category: "hive-125125", parent_author: "", depth: 0 });
+    render(<PostSubscribePrompt entry={entry} communityTitle="Town Square" />, client);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByRole("region")).toBeNull();
+    resolveRoster({ members: ["bob"] });
+    await screen.findByRole("region", { name: "newsletter.post-prompt-title" });
+    expect(screen.getByText("newsletter.post-prompt-body-creator")).toBeInTheDocument();
+  });
+
   it("falls back to the community's digest for a post made in a community when the author is not Pro", async () => {
     const client = createTestQueryClient();
     client.setQueryData(["accounts", "pro-members"], { members: [] });
     client.setQueryData(digestSubscriptionsKey("alice"), []);
     window.localStorage.clear();
     const entry = mockEntry({ author: "bob", permlink: "p", category: "hive-125125", parent_author: "", depth: 0 });
-    render(<PostSubscribePrompt entry={entry} communityTitle="Town Square" />, client);
+    const { unmount: u0 } = render(<PostSubscribePrompt entry={entry} />, client);
     await screen.findByRole("region", { name: "newsletter.post-prompt-title" });
     expect(screen.getByText("newsletter.post-prompt-body-community")).toBeInTheDocument();
+    // The community's title comes from the community query when the page did not pass it.
+    await waitFor(() => expect(screen.getByText("newsletter.post-prompt-subscribe")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("newsletter.post-prompt-subscribe"));
+    const dialog = document.querySelector("#modal-dialog-container") as HTMLElement;
+    await waitFor(() => expect(within(dialog).getByText("newsletter.intro-community")).toBeInTheDocument());
+    // While the dialog is open, a subscription appearing (the refetch after subscribing) hides
+    // the card but keeps the dialog, so its "check your inbox" outcome is not lost.
+    client.setQueryData(digestSubscriptionsKey("alice"), [{ id: "1", type: "community", target: "hive-125125", cadence: "weekly", status: "pending_confirmation", email: "a@e.com" }]);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(screen.queryByRole("region")).toBeNull();
+    // Still mounted, now showing the pending state the dialog reads from the fresh subscription.
+    expect(within(dialog).getByText("newsletter.status-pending")).toBeInTheDocument();
+    u0();
+    client.setQueryData(digestSubscriptionsKey("alice"), []);
     // A comment gets no prompt.
     const comment = mockEntry({ author: "bob", permlink: "re", category: "hive-125125", parent_author: "x", depth: 1 });
     const { container } = render(<PostSubscribePrompt entry={comment} />, client);

--- a/apps/web/src/specs/features/newsletter/list-building.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/list-building.spec.tsx
@@ -1,0 +1,152 @@
+import "@testing-library/jest-dom";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactElement } from "react";
+import { NewsletterRuntimeProvider } from "@/features/newsletter/runtime";
+import { DigestSubscribeButton, PostSubscribePrompt, SubscriberCount, digestSubscriptionsKey, subscribeLinkFor } from "@/features/newsletter";
+import { useActiveAccount } from "@/core/hooks/use-active-account";
+import { cleanupModalContainers, createTestQueryClient, mockActiveUser, mockEntry, renderWithQueryClient, setupModalContainers } from "@/specs/test-utils";
+
+const flags = vi.hoisted(() => ({ newsletter: true }));
+vi.mock("@/config", () => ({
+  EcencyConfigManager: {
+    getConfigValue: (fn: (c: unknown) => unknown) => fn({ visionFeatures: { newsletter: { enabled: flags.newsletter } } })
+  }
+}));
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<object>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token"),
+  ensureValidToken: vi.fn(async () => "mock-token")
+}));
+
+const fetchMock = vi.fn();
+const json = (status: number, body: unknown) => Promise.resolve({ ok: status < 400, status, json: async () => body } as Response);
+function loggedIn(username: string | null) {
+  vi.mocked(useActiveAccount).mockReturnValue({
+    activeUser: username ? mockActiveUser({ username }) : null,
+    username,
+    account: null,
+    isLoading: false,
+    isPending: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isSuccess: true
+  } as never);
+}
+const render = (ui: ReactElement, client = createTestQueryClient()) =>
+  renderWithQueryClient(<NewsletterRuntimeProvider configured>{ui}</NewsletterRuntimeProvider>, { queryClient: client });
+const standing = (subscribers: { weekly: number; monthly: number }) => ({
+  type: "creator",
+  target: "alice",
+  status: "active",
+  reason: null,
+  since: null,
+  stats: { delivered: 0, bounced: 0, rejected: 0, complaints: 0, unsubscribed: 0, complaintRate: 0, bounceRate: 0 },
+  subscribers
+});
+
+describe("list building (vision-web#1537)", () => {
+  beforeEach(() => {
+    setupModalContainers();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    window.history.replaceState(null, "", "/@alice");
+    flags.newsletter = true;
+    loggedIn("alice");
+  });
+  afterEach(() => {
+    cleanupModalContainers();
+    vi.unstubAllGlobals();
+  });
+
+  it("subscribeLinkFor points at the list's own page with the opener parameter", () => {
+    expect(subscribeLinkFor("creator", "alice")).toBe("/@alice?subscribe=digest");
+    expect(subscribeLinkFor("community", "hive-125125", "https://ecency.com")).toBe("https://ecency.com/created/hive-125125?subscribe=digest");
+  });
+
+  it("shows the sender their subscriber count and copies the subscribe link; nothing for a non-sender", async () => {
+    fetchMock.mockReturnValue(json(200, standing({ weekly: 12, monthly: 3 })));
+    const writeText = vi.fn(async () => {});
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+    render(<SubscriberCount type="creator" target="alice" isSender />);
+    await waitFor(() => expect(screen.getByText("newsletter.subscriber-count")).toBeInTheDocument());
+    expect(screen.getByText("newsletter.subscriber-count-split")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("newsletter.copy-subscribe-link"));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(expect.stringMatching(/\/@alice\?subscribe=digest$/)));
+    fetchMock.mockReset();
+    const { container } = render(<SubscriberCount type="creator" target="alice" isSender={false} />);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(container.textContent).toBe("");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("a shared link (?subscribe=digest) opens the subscribe dialog once and cleans the URL", async () => {
+    window.history.replaceState(null, "", "/@alice?subscribe=digest&x=1");
+    fetchMock.mockReturnValue(json(200, { subscriptions: [] }));
+    const client = createTestQueryClient();
+    client.setQueryData(["accounts", "pro-members"], { members: ["alice"] });
+    render(<DigestSubscribeButton type="creator" target="alice" targetLabel="@alice" source="creator-page" />, client);
+    // The dialog is open, and the parameter is gone while the rest of the query is kept.
+    await waitFor(() => expect(window.location.search).toBe("?x=1"));
+    const dialog = document.querySelector("#modal-dialog-container") as HTMLElement;
+    await waitFor(() => expect(within(dialog).getByText("newsletter.intro-creator")).toBeInTheDocument());
+  });
+
+  it("at the end of a post, offers the author's digest to a signed-in reader who is not subscribed; remembers 'Not now'; nothing for the author, a subscriber, or when signed out", async () => {
+    const client = createTestQueryClient();
+    client.setQueryData(["accounts", "pro-members"], { members: ["bob"] });
+    client.setQueryData(digestSubscriptionsKey("alice"), []);
+    const entry = mockEntry({ author: "bob", permlink: "hello", category: "photography", parent_author: "", depth: 0 });
+    window.localStorage.clear();
+    const { unmount } = render(<PostSubscribePrompt entry={entry} />, client);
+    await screen.findByRole("region", { name: "newsletter.post-prompt-title" });
+    expect(screen.getByText("newsletter.post-prompt-body-creator")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("newsletter.post-prompt-dismiss"));
+    expect(screen.queryByRole("region")).toBeNull();
+    expect(window.localStorage.getItem("ecency:digest-post-prompt:alice:creator:bob")).toBe("1");
+    unmount();
+    // Remembered.
+    const { container: c1, unmount: u1 } = render(<PostSubscribePrompt entry={entry} />, client);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(c1.textContent).toBe("");
+    u1();
+    window.localStorage.clear();
+    // Already subscribed: nothing.
+    client.setQueryData(digestSubscriptionsKey("alice"), [{ id: "1", type: "creator", target: "bob", cadence: "weekly", status: "active", email: "a@e.com" }]);
+    const { container: c2, unmount: u2 } = render(<PostSubscribePrompt entry={entry} />, client);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(c2.textContent).toBe("");
+    u2();
+    client.setQueryData(digestSubscriptionsKey("alice"), []);
+    // The author reading their own post: nothing (no community either).
+    loggedIn("bob");
+    client.setQueryData(digestSubscriptionsKey("bob"), []);
+    const { container: c3, unmount: u3 } = render(<PostSubscribePrompt entry={entry} />, client);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(c3.textContent).toBe("");
+    u3();
+    // Signed out: nothing.
+    loggedIn(null);
+    const { container: c4 } = render(<PostSubscribePrompt entry={entry} />, client);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(c4.textContent).toBe("");
+  });
+
+  it("falls back to the community's digest for a post made in a community when the author is not Pro", async () => {
+    const client = createTestQueryClient();
+    client.setQueryData(["accounts", "pro-members"], { members: [] });
+    client.setQueryData(digestSubscriptionsKey("alice"), []);
+    window.localStorage.clear();
+    const entry = mockEntry({ author: "bob", permlink: "p", category: "hive-125125", parent_author: "", depth: 0 });
+    render(<PostSubscribePrompt entry={entry} communityTitle="Town Square" />, client);
+    await screen.findByRole("region", { name: "newsletter.post-prompt-title" });
+    expect(screen.getByText("newsletter.post-prompt-body-community")).toBeInTheDocument();
+    // A comment gets no prompt.
+    const comment = mockEntry({ author: "bob", permlink: "re", category: "hive-125125", parent_author: "x", depth: 1 });
+    const { container } = render(<PostSubscribePrompt entry={comment} />, client);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(container.textContent).toBe("");
+  });
+});


### PR DESCRIPTION
Part of #1537 (the self-hosted embed follows as its own PR under the issue). Creators and community teams can now see and grow their list, not only send to it.

- **Subscriber count** on the sender's own profile card and on the community card: live, mailable readers per cadence from `/api/newsletter/sender`, with **Copy subscribe link** (`/@alice?subscribe=digest`, `/created/hive-…?subscribe=digest`).
- **Shared subscribe link**: the list's own page opens the subscribe dialog once when reached with `?subscribe=digest` and cleans the parameter (keeping the rest of the query). Implemented on `window.location` + `history.replaceState`, which Next keeps in sync, so the button needs neither the app router nor a Suspense boundary and still works where it is rendered outside a page.
- **End-of-post prompt**: below a top-level post, a signed-in reader who is not subscribed is offered the author's digest (when the author is Pro) or the community's digest (when the post was made in one), with the existing subscribe dialog (`source: post-page`, accepted by the relay). "Not now" is remembered per list on the device; never shown to the author for their own list, to a subscriber, on comments, or signed out.
- Specs: link builder; count and copy; the shared link opening the dialog and cleaning the URL; the prompt's cases (creator, community fallback, dismissal remembered, subscriber, author, signed out, comment). Typecheck, eslint, icon audit, 2,315 specs green.