### PR TITLE
Slim feed entries so list pages stop shipping post bodies

### DIFF
--- a/apps/web/src/api/queries/get-account-posts-feed-query.ts
+++ b/apps/web/src/api/queries/get-account-posts-feed-query.ts
@@ -5,6 +5,7 @@ import { Entry, SearchResponse } from "@/entities";
 import { appAxios } from "@/api/axios";
 import { apiBase } from "@/api/helper";
 import { DEFAULT_OBSERVER } from "@/consts/observer";
+import { slimEntryPage, withSlimEntries } from "@/core/entries/slim-entry";
 
 // Unify all branches on a single page type
 type Page = Entry[] | SearchResponse;
@@ -26,7 +27,7 @@ function getPromotedEntriesInfiniteQuery() {
       const response = await appAxios.get<Entry[]>(
         apiBase(`/private-api/promoted-entries`)
       );
-      return response.data;
+      return slimEntryPage(response.data);
     },
     getNextPageParam: (
       _lastPage: PromotedPage,
@@ -37,47 +38,57 @@ function getPromotedEntriesInfiniteQuery() {
   });
 }
 
+
+// Profile sections whose cards ARE the body: a comment or a reply has no title,
+// no description and no cover image, so slimming one leaves an empty row. Every
+// other section renders a summary card and can be slimmed.
+const BODY_BACKED_SECTIONS = ["comments", "replies"];
+
+/**
+ * The one place the feed's query options are built, so the server prefetch, the
+ * cache read and the client hook cannot drift apart — they share a query key, and
+ * a slim page reaching one of them but not the others would mean the SSR payload
+ * and the client's later pages disagreed about what an entry holds.
+ */
+function buildFeedQueryOptions(what: string, tag: string, limit: number, observer: string) {
+  const isUser = tag.startsWith("@") || tag.startsWith("%40");
+
+  if (what === "promoted") {
+    return getPromotedEntriesInfiniteQuery();
+  }
+
+  if (isUser) {
+    const options = getAccountPostsInfiniteQueryOptions(
+      tag.replace("@", "").replace(/%40/g, ""),
+      what,
+      limit,
+      observer,
+      true
+    );
+    return BODY_BACKED_SECTIONS.includes(what) ? options : withSlimEntries(options);
+  }
+
+  if (what === "feed") {
+    return withSlimEntries(
+      getPostsRankedInfiniteQueryOptions(what, tag, limit, observer, true, {
+        resolvePosts: false
+      })
+    );
+  }
+
+  return withSlimEntries(getPostsRankedInfiniteQueryOptions(what, tag, limit, observer));
+}
+
 export async function prefetchGetPostsFeedQuery(
     what: string,
     tag = "",
     limit = 20,
     observer?: string
 ): Promise<FeedInfinite | undefined> {
-  const isUser = tag.startsWith("@") || tag.startsWith("%40");
-  const isPromotedSection = what === "promoted";
-  const resolvedObserver = observer ?? DEFAULT_OBSERVER;
-
-  if (isPromotedSection) {
-    return prefetchInfiniteQuery(getPromotedEntriesInfiniteQuery()) as Promise<FeedInfinite | undefined>;
-  }
-
-  if (isUser) {
-    return prefetchInfiniteQuery(
-      getAccountPostsInfiniteQueryOptions(
-        tag.replace("@", "").replace(/%40/g, ""),
-        what,
-        limit,
-        resolvedObserver,
-        true
-      )
-    ) as Promise<FeedInfinite | undefined>;
-  }
-
-  if (what === "feed") {
-    return prefetchInfiniteQuery(
-      getPostsRankedInfiniteQueryOptions(
-        what,
-        tag,
-        limit,
-        resolvedObserver,
-        true,
-        { resolvePosts: false }
-      )
-    ) as Promise<FeedInfinite | undefined>;
-  }
-
+  // One page per call: prefetchInfiniteQuery fetches only the initial page param
+  // unless it is handed a `pages` count, and `limit` is the bridge's own cap of 20.
   return prefetchInfiniteQuery(
-    getPostsRankedInfiniteQueryOptions(what, tag, limit, resolvedObserver)
+    buildFeedQueryOptions(what, tag, limit, observer ?? DEFAULT_OBSERVER) as any
   ) as Promise<FeedInfinite | undefined>;
 }
 
@@ -87,41 +98,8 @@ export function getPostsFeedQueryData(
     limit = 20,
     observer?: string
 ): FeedInfinite | undefined {
-  const isUser = tag.startsWith("@") || tag.startsWith("%40");
-  const isPromotedSection = what === "promoted";
-  const resolvedObserver = observer ?? DEFAULT_OBSERVER;
-
-  if (isPromotedSection) {
-    return getInfiniteQueryData(getPromotedEntriesInfiniteQuery()) as FeedInfinite | undefined;
-  }
-
-  if (isUser) {
-    return getInfiniteQueryData(
-      getAccountPostsInfiniteQueryOptions(
-        tag.replace("@", "").replace(/%40/g, ""),
-        what,
-        limit,
-        resolvedObserver,
-        true
-      )
-    ) as FeedInfinite | undefined;
-  }
-
-  if (what === "feed") {
-    return getInfiniteQueryData(
-      getPostsRankedInfiniteQueryOptions(
-        what,
-        tag,
-        limit,
-        resolvedObserver,
-        true,
-        { resolvePosts: false }
-      )
-    ) as FeedInfinite | undefined;
-  }
-
   return getInfiniteQueryData(
-    getPostsRankedInfiniteQueryOptions(what, tag, limit, resolvedObserver)
+    buildFeedQueryOptions(what, tag, limit, observer ?? DEFAULT_OBSERVER) as any
   ) as FeedInfinite | undefined;
 }
 
@@ -131,29 +109,7 @@ export function usePostsFeedQuery(
     observer?: string,
     limit = 20
 ): UseInfiniteQueryResult<InfiniteData<Page, unknown>, Error> {
-  const isUser = tag.startsWith("@") || tag.startsWith("%40");
-  const isPromotedSection = what === "promoted";
-  const resolvedObserver = observer ?? DEFAULT_OBSERVER;
-
-  const queryOptions =
-      isPromotedSection
-          ? getPromotedEntriesInfiniteQuery()
-          : isUser
-              ? getAccountPostsInfiniteQueryOptions(
-                  tag.replace("@", "").replace(/%40/g, ""),
-                  what,
-                  limit,
-                  resolvedObserver,
-                  true
-              )
-              : getPostsRankedInfiniteQueryOptions(
-                    what,
-                    tag,
-                    limit,
-                    resolvedObserver,
-                    true,
-                    what === "feed" ? { resolvePosts: false } : undefined
-                );
+  const queryOptions = buildFeedQueryOptions(what, tag, limit, observer ?? DEFAULT_OBSERVER);
 
   // Each branch above is individually a valid infinite query, but they use
   // different page-param and page types, so their union matches no single

--- a/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/[...sections]/page.tsx
@@ -14,6 +14,7 @@ import {
   stripActiveVotesFromValue
 } from "@/core/react-query/strip-active-votes";
 import { getPromotedPostsQuery } from "@ecency/sdk";
+import { withSlimEntries } from "@/core/entries/slim-entry";
 import { EcencyConfigManager } from "@/config";
 import { EntryListContent } from "@/features/shared/entry-list-content";
 import { EntryArchivePager } from "@/features/shared/entry-archive-pager";
@@ -105,7 +106,9 @@ export default async function FeedPage({ params, searchParams }: Props) {
 
   // Only prefetch promoted posts if promotions feature is enabled
   if (EcencyConfigManager.CONFIG.visionFeatures.promotions.enabled) {
-    await prefetchQuery(getPromotedPostsQuery());
+    // Promoted rows render the same cards as the feed and are dehydrated into the
+    // same payload, so they are slimmed on both sides of this query key.
+    await prefetchQuery(withSlimEntries(getPromotedPostsQuery<Entry>()));
   }
 
   const firstPage = ((feed?.pages?.[0] as Entry[] | undefined) ?? []).filter(Boolean);

--- a/apps/web/src/app/(dynamicPages)/feed/_components/feed-layout.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/_components/feed-layout.tsx
@@ -10,6 +10,7 @@ import { LinearProgress } from "@/features/shared/linear-progress";
 import { UserAvatar } from "@/features/shared/user-avatar";
 import { getPostsRankedQueryOptions, QueryKeys } from "@ecency/sdk";
 import { getQueryClient } from "@/core/react-query";
+import { withSlimEntries } from "@/core/entries/slim-entry";
 import type { InfiniteData } from "@tanstack/react-query";
 
 const MAX_PENDING = 20;
@@ -65,13 +66,18 @@ export function FeedLayout(props: PropsWithChildren<Props>) {
 
     const interval = setInterval(async () => {
       const resp = await queryClient.fetchQuery(
-        getPostsRankedQueryOptions(
-          props.filter,
-          "",
-          "",
-          MAX_PENDING,
-          props.tag,
-          props.observer
+        // Slim, like the feed this merges into: the merge below spreads these
+        // rows over the cached ones, so a full row here would put every body
+        // back into the feed cache 30 seconds after the page loaded.
+        withSlimEntries(
+          getPostsRankedQueryOptions(
+            props.filter,
+            "",
+            "",
+            MAX_PENDING,
+            props.tag,
+            props.observer
+          )
         )
       );
       if (!resp || resp.length === 0) return;

--- a/apps/web/src/app/(dynamicPages)/feed/_components/feed-layout.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/_components/feed-layout.tsx
@@ -77,7 +77,11 @@ export function FeedLayout(props: PropsWithChildren<Props>) {
             MAX_PENDING,
             props.tag,
             props.observer
-          )
+          ),
+          // Own cache identity: this SDK page key is also read by deck columns,
+          // which render whole posts. The merge below reads the returned value,
+          // not the cache, so the marker costs nothing here.
+          { isolateKey: true }
         )
       );
       if (!resp || resp.length === 0) return;

--- a/apps/web/src/app/(dynamicPages)/feed/_components/feed-list.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/_components/feed-list.tsx
@@ -10,6 +10,7 @@ import { EntryListContent, EntryListContentLoading, EntryListContentNoData } fro
 import { EcencyConfigManager } from "@/config";
 import { useVisibleEntries } from "@/features/shared/entry-list-item/use-muted-authors";
 import { getPromotedPostsQuery } from "@ecency/sdk";
+import { withSlimEntries } from "@/core/entries/slim-entry";
 import { useQuery } from "@tanstack/react-query";
 
 interface Props {
@@ -27,7 +28,8 @@ export function FeedList({ filter, tag, observer }: Props) {
 
   // Fetch promoted posts if feature is enabled and get the data
   const { data: promotedPosts } = useQuery({
-    ...getPromotedPostsQuery<Entry>(),
+    // Matches the server prefetch on this key — see the feed page.
+    ...withSlimEntries(getPromotedPostsQuery<Entry>()),
     enabled: visionFeatures.promotions.enabled
   });
 

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/author-archive.ts
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/author-archive.ts
@@ -66,7 +66,11 @@ export async function fetchAuthorCursorPage(
   // metadata to render instead. Post/blog archives render summary cards.
   const entries =
     ((await fetchQuery(
-      BODY_BACKED_SECTIONS.includes(section) ? options : withSlimEntries(options)
+      BODY_BACKED_SECTIONS.includes(section)
+        ? options
+        : // Own cache identity: this SDK page key is also read by deck columns,
+          // which render whole posts.
+          withSlimEntries(options, { isolateKey: true })
     )) as unknown as Entry[] | undefined) ?? [];
 
   const hasNext = entries.length === ARCHIVE_PAGE_SIZE;

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/author-archive.ts
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/author-archive.ts
@@ -1,6 +1,7 @@
 import { Entry } from "@/entities";
 import { fetchQuery } from "@/core/react-query";
 import { getAccountPostsQueryOptions } from "@ecency/sdk";
+import { withSlimEntries } from "@/core/entries/slim-entry";
 
 // Hive's bridge.get_account_posts caps `limit` at 20, and it's cursor-based
 // (start_author/start_permlink, exclusive). So archive pages use O(1)
@@ -10,6 +11,9 @@ export const ARCHIVE_PAGE_SIZE = 20;
 
 // Content sections that expose a crawlable archive.
 export const ARCHIVE_SECTIONS = ["posts", "blog", "comments", "replies"];
+
+// Sections whose card content IS the post body, so they cannot be slimmed.
+const BODY_BACKED_SECTIONS = ["comments", "replies"];
 
 export interface ArchiveCursor {
   author: string;
@@ -51,15 +55,18 @@ export async function fetchAuthorCursorPage(
   section: string,
   cursor: ArchiveCursor
 ): Promise<{ entries: Entry[]; hasNext: boolean; nextCursor: ArchiveCursor | null }> {
+  const options = getAccountPostsQueryOptions(
+    username,
+    section,
+    cursor.author,
+    cursor.permlink,
+    ARCHIVE_PAGE_SIZE
+  );
+  // Comment and reply archives keep their bodies: those cards have no title or
+  // metadata to render instead. Post/blog archives render summary cards.
   const entries =
     ((await fetchQuery(
-      getAccountPostsQueryOptions(
-        username,
-        section,
-        cursor.author,
-        cursor.permlink,
-        ARCHIVE_PAGE_SIZE
-      )
+      BODY_BACKED_SECTIONS.includes(section) ? options : withSlimEntries(options)
     )) as unknown as Entry[] | undefined) ?? [];
 
   const hasNext = entries.length === ARCHIVE_PAGE_SIZE;

--- a/apps/web/src/core/caches/entries-cache.tsx
+++ b/apps/web/src/core/caches/entries-cache.tsx
@@ -45,6 +45,16 @@ export namespace EcencyEntriesCacheManagement {
       ),
       queryKey: entryKey(initialEntry?.author ?? "", initialEntry?.permlink ?? ""),
       initialData: initialEntry,
+      // Feed cards seed this shared post cache so their vote/payout/reblog
+      // controls read one entry, and a slim row (body "") would otherwise sit
+      // here looking like a freshly fetched post for the full staleTime: opening
+      // that post could then render an empty article. Stamping the seed as
+      // never-updated keeps the cards working while marking it stale from the
+      // start, so the entry page's own fetch always wins on hydration and an
+      // explicit refetch (edit prefill, translate) reaches the network.
+      // `refetchOnMount` is false app-wide, so this does NOT make the 20 cards
+      // on a feed page fetch anything.
+      initialDataUpdatedAt: initialEntry && initialEntry.body === "" ? 0 : undefined,
       enabled: !!initialEntry,
       // Spreading getPostQueryOptions pulls in its `Entry | null` result, which
       // otherwise overrides this helper's own generic: callers lost the entry

--- a/apps/web/src/core/entries/entry-location.ts
+++ b/apps/web/src/core/entries/entry-location.ts
@@ -1,0 +1,45 @@
+/**
+ * A location parsed out of a body marker. Its coordinates are the raw captured
+ * strings: that is what this marker has always produced, and every consumer
+ * either interpolates them into a map URL or runs them through `Number(...)`.
+ * The publish flow writes numeric coordinates instead, hence the separate shape.
+ */
+export interface ParsedEntryLocation {
+  coordinates: { lat: string; lng: string };
+  address?: string;
+}
+
+// Worldmappin/pinmapple publish a post's coordinates as an HTML-comment marker in
+// the body, so the pin can only be recovered while the body is still around.
+const WORLDMAPPIN_RE =
+  /\[\/\/\]:#\s\(\!(?:worldmappin|pinmapple)\s+([-\d.]+)\s+lat\s+([-\d.]+)\s+long(?:\s+(.*?))?(?:\s+d3scr)?\)/i;
+
+/**
+ * Coordinates parsed out of a worldmappin/pinmapple body marker, or undefined.
+ *
+ * Shared by `useEntryLocation` (which reads a full entry at render time) and the
+ * feed slim step (which lifts the result into `json_metadata.location` before it
+ * drops the body), so a feed card and a post page resolve the same pin.
+ */
+export function parseEntryLocationFromBody(body?: string): ParsedEntryLocation | undefined {
+  if (!body) {
+    return undefined;
+  }
+
+  const match = body.match(WORLDMAPPIN_RE);
+  if (!match) {
+    return undefined;
+  }
+
+  const [, lat, lng, address] = match;
+  const cleanedAddress = address?.trim();
+  const fallbackAddress =
+    !cleanedAddress || cleanedAddress === "<DESCRIPTION GOES HERE>" || cleanedAddress === "d3scr"
+      ? `${lat}, ${lng}`
+      : cleanedAddress;
+
+  return {
+    coordinates: { lat, lng },
+    address: fallbackAddress
+  };
+}

--- a/apps/web/src/core/entries/entry-location.ts
+++ b/apps/web/src/core/entries/entry-location.ts
@@ -1,11 +1,11 @@
 /**
- * A location parsed out of a body marker. Its coordinates are the raw captured
- * strings: that is what this marker has always produced, and every consumer
- * either interpolates them into a map URL or runs them through `Number(...)`.
- * The publish flow writes numeric coordinates instead, hence the separate shape.
+ * A location parsed out of a body marker, in the SAME shape the publish flow
+ * writes to `json_metadata.location`: numeric coordinates. This used to hand back
+ * the raw captured strings, which every caller had to coerce and which would have
+ * thrown in the metadata builder's `lat.toFixed(3)`.
  */
 export interface ParsedEntryLocation {
-  coordinates: { lat: string; lng: string };
+  coordinates: { lat: number; lng: number };
   address?: string;
 }
 
@@ -32,6 +32,14 @@ export function parseEntryLocationFromBody(body?: string): ParsedEntryLocation |
   }
 
   const [, lat, lng, address] = match;
+  // `[-\d.]+` can capture something that is not a number ("12.5.6"), which used
+  // to reach the UI as a broken map pin. No pin is the better answer.
+  const latitude = Number(lat);
+  const longitude = Number(lng);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return undefined;
+  }
+
   const cleanedAddress = address?.trim();
   const fallbackAddress =
     !cleanedAddress || cleanedAddress === "<DESCRIPTION GOES HERE>" || cleanedAddress === "d3scr"
@@ -39,7 +47,7 @@ export function parseEntryLocationFromBody(body?: string): ParsedEntryLocation |
       : cleanedAddress;
 
   return {
-    coordinates: { lat, lng },
+    coordinates: { lat: latitude, lng: longitude },
     address: fallbackAddress
   };
 }

--- a/apps/web/src/core/entries/entry-moderation.ts
+++ b/apps/web/src/core/entries/entry-moderation.ts
@@ -1,0 +1,30 @@
+import { ContentModerationReason, getContentModerationReason } from "@ecency/sdk";
+import { Entry } from "@/entities";
+
+// A body the SDK's outbound-link check is guaranteed to flag: not a Hive/Ecency
+// host, not an image host, not an image extension. It never renders anywhere — it
+// exists only to replay one precomputed bit into the SDK rule below.
+const EXTERNAL_LINK_STANDIN = "https://slim-entry.invalid/link";
+
+/**
+ * Which moderation rule fires for an entry, slim feed rows included.
+ *
+ * The SDK owns the rules and their precedence so web and mobile flag the same
+ * posts. One of them (LOW_TRUST) reads the body for an outbound promotional link,
+ * which a slim feed entry no longer has, so the slim step records the answer and
+ * this replays it as a stand-in body. Everything else the rules read — reputation,
+ * rshares, vote count, hivemind's gray/hide — is still on the entry, and stays
+ * live when the feed poll merges fresh stats in.
+ */
+export function getEntryModerationReason(
+  entry: Entry | undefined | null
+): ContentModerationReason | null {
+  if (entry && !entry.body && entry.slim) {
+    return getContentModerationReason({
+      ...entry,
+      body: entry.slim.ext_link ? EXTERNAL_LINK_STANDIN : ""
+    });
+  }
+
+  return getContentModerationReason(entry);
+}

--- a/apps/web/src/core/entries/slim-entry.ts
+++ b/apps/web/src/core/entries/slim-entry.ts
@@ -32,6 +32,16 @@ function pickThumbnail(entry: Entry): string | undefined {
 
   // Order requested for cards: an explicit thumbnail wins over the cover image,
   // since `thumbnails` is published for exactly this purpose (3Speak, Liketu).
+  //
+  // Worth knowing if this order is ever extended: render-helper memoizes
+  // catchPostImage per author/permlink/update AND size, process-wide, so a card
+  // (600x500) and the entry page's LCP preload (same size) share one cache slot.
+  // They agree today because every sampled post that carries both fields sets
+  // them to the same URL (44 of 44 across trending/hot/created, tags and
+  // communities), so the value cached from a feed row is the value the post page
+  // would have computed. A publisher that set them to DIFFERENT urls would hand
+  // the post page a preload that its body does not render, and the LCP image
+  // would download twice.
   const thumbnail = meta?.thumbnails?.find((url) => typeof url === "string" && url.length > 0);
   if (thumbnail) {
     return thumbnail;
@@ -85,11 +95,7 @@ export function slimEntry<T extends Entry>(entry: T): T {
 
   const meta = entry.json_metadata ?? {};
   const thumbnail = pickThumbnail(entry);
-  // The body marker yields string coordinates while the publish flow writes
-  // numbers (see ParsedEntryLocation). Both render the same, and the readers that
-  // do arithmetic already coerce, so the parsed form is stored as-is.
-  const location = (meta.location ??
-    parseEntryLocationFromBody(entry.body)) as typeof meta.location;
+  const location = meta.location ?? parseEntryLocationFromBody(entry.body);
 
   const slimmed = {
     ...entry,
@@ -123,7 +129,23 @@ export function slimEntryPage<T>(page: T): T {
   return page;
 }
 
-type WithQueryFn = { queryFn?: unknown };
+type WithQueryFn = { queryFn?: unknown; queryKey?: unknown };
+
+interface SlimOptions {
+  /**
+   * Cache the slim pages under their own key instead of the SDK's.
+   *
+   * Needed wherever the SDK key is ALSO read by something that needs whole posts.
+   * The single-page keys (`postsRankedPage` / `accountPostsPage`) are shared with
+   * the deck columns, which fetch the same sort/cursor/limit and then render
+   * `entry.body` in their post viewer: a slim page cached under that key would be
+   * handed straight to a deck within the 60s staleTime, and the viewer would show
+   * an empty post. The feed's own infinite keys need no marker, since the server
+   * prefetch, the cache read and the client hook are the only readers and all
+   * three build their options through one slimmed builder.
+   */
+  isolateKey?: boolean;
+}
 
 /**
  * Wrap feed query options so their pages arrive slim.
@@ -133,18 +155,30 @@ type WithQueryFn = { queryFn?: unknown };
  * still sit in the client cache. Wrapping the fetch means one slim copy exists,
  * server and client alike, and React Flight can dedupe it by reference.
  *
- * The query key and every other option are passed through untouched, so this
- * cannot split a cache entry away from the one a page already renders.
+ * Every other option is passed through untouched, so this cannot split a cache
+ * entry away from the one a page already renders.
  */
-export function withSlimEntries<T extends WithQueryFn>(options: T): T {
+export function withSlimEntries<T extends WithQueryFn>(
+  options: T,
+  { isolateKey = false }: SlimOptions = {}
+): T {
   const queryFn = options.queryFn;
   if (typeof queryFn !== "function") {
     return options;
   }
 
+  const queryKey =
+    isolateKey && Array.isArray(options.queryKey)
+      ? [...options.queryKey, SLIM_KEY_MARKER]
+      : options.queryKey;
+
   return {
     ...options,
+    queryKey,
     queryFn: async (...args: unknown[]) =>
       slimEntryPage(await (queryFn as (...a: unknown[]) => Promise<unknown>)(...args))
   } as T;
 }
+
+/** Appended to a query key that holds slim pages. See SlimOptions.isolateKey. */
+export const SLIM_KEY_MARKER = "slim";

--- a/apps/web/src/core/entries/slim-entry.ts
+++ b/apps/web/src/core/entries/slim-entry.ts
@@ -1,0 +1,150 @@
+import { getEntryImageRawUrl, postBodySummary } from "@ecency/render-helper";
+import { hasExternalLink } from "@ecency/sdk";
+import { Entry } from "@/entities";
+import { parseEntryLocationFromBody } from "./entry-location";
+
+/**
+ * Feed cards render a ~200 character summary and a thumbnail, but the bridge
+ * feeds (`get_ranked_posts` / `get_account_posts`) hand back every post's full
+ * markdown body. On an anonymous `/trending` load those bodies measured 211 KB of
+ * a 350 KB RSC payload, and they cost again on the client: every page fetched
+ * while scrolling parks another 20 bodies in the query cache.
+ *
+ * `slimEntry` runs where the body is still in hand — inside the feed queryFn, so
+ * SSR and client fetches produce identical entries — derives everything a card
+ * needs into `json_metadata`, then blanks the body. Cards, the LCP thumbnail
+ * preload and the location chip keep working unchanged, and because both sides
+ * of hydration see the same object there is no text/src mismatch.
+ *
+ * Not for comment/reply lists: their cards have no title or metadata to fall back
+ * on, so the body IS their content. Callers pick, via `slimEntries`' call sites.
+ */
+
+/** Same length the card passes to postBodySummary, so the text is unchanged. */
+export const SLIM_SUMMARY_LENGTH = 200;
+
+function pickThumbnail(entry: Entry): string | undefined {
+  const meta = entry.json_metadata;
+  // json_metadata is author-written: `image` is typed as an array but really does
+  // arrive as a bare string too, which is why catchPostImage handles both. Read it
+  // as unknown so the same runtime tolerance survives the narrower type.
+  const image: unknown = meta?.image;
+
+  // Order requested for cards: an explicit thumbnail wins over the cover image,
+  // since `thumbnails` is published for exactly this purpose (3Speak, Liketu).
+  const thumbnail = meta?.thumbnails?.find((url) => typeof url === "string" && url.length > 0);
+  if (thumbnail) {
+    return thumbnail;
+  }
+
+  if (typeof image === "string" && image.length > 0) {
+    return image;
+  }
+  if (Array.isArray(image)) {
+    const first = image.find(
+      (url): url is string => typeof url === "string" && url.length > 0
+    );
+    if (first) {
+      return first;
+    }
+  }
+
+  // Nothing in metadata: fall back to the post's first body image, which is what
+  // catchPostImage would have found on the full entry. Free here (the body is
+  // right there) and it keeps the thumbnail — and the LCP preload that reads it —
+  // for the ~20% of posts that carry no metadata image at all.
+  return getEntryImageRawUrl(entry) ?? undefined;
+}
+
+function pickDescription(entry: Entry): string {
+  const existing = entry.json_metadata?.description;
+  if (typeof existing === "string" && existing.trim().length > 0) {
+    return existing.trim();
+  }
+
+  // Same call the card makes, so posts keep the summary they show today.
+  const summary = postBodySummary(entry, SLIM_SUMMARY_LENGTH)?.trim();
+  if (summary) {
+    return summary;
+  }
+
+  // Image-only and title-only posts would otherwise render an empty summary line
+  // and a ragged list; the title keeps every card the same shape.
+  return entry.title?.trim() ?? "";
+}
+
+/**
+ * One entry with its body dropped and everything a card reads derived first.
+ * Entries that already have no body (search results, waves, an entry slimmed
+ * twice) pass through untouched.
+ */
+export function slimEntry<T extends Entry>(entry: T): T {
+  if (!entry || typeof entry !== "object" || typeof entry.body !== "string" || entry.body === "") {
+    return entry;
+  }
+
+  const meta = entry.json_metadata ?? {};
+  const thumbnail = pickThumbnail(entry);
+  // The body marker yields string coordinates while the publish flow writes
+  // numbers (see ParsedEntryLocation). Both render the same, and the readers that
+  // do arithmetic already coerce, so the parsed form is stored as-is.
+  const location = (meta.location ??
+    parseEntryLocationFromBody(entry.body)) as typeof meta.location;
+
+  const slimmed = {
+    ...entry,
+    body: "",
+    json_metadata: {
+      ...meta,
+      description: pickDescription(entry),
+      ...(thumbnail ? { image: [thumbnail] } : {}),
+      ...(location ? { location } : {})
+    },
+    // The SDK's low-trust rule looks for an outbound link in the body. Recording
+    // the answer here keeps that rule (and its precedence) in the SDK rather than
+    // forking it into the web app — see core/entries/entry-moderation.ts.
+    slim: { ext_link: hasExternalLink(entry.body) }
+  } as T;
+
+  // A cross-post card reads its summary and thumbnail from the nested original,
+  // so the same treatment has to reach it or those cards lose both.
+  if (entry.original_entry) {
+    (slimmed as Entry).original_entry = slimEntry(entry.original_entry);
+  }
+
+  return slimmed;
+}
+
+/** Slim a page of feed results, leaving a non-array response shape untouched. */
+export function slimEntryPage<T>(page: T): T {
+  if (Array.isArray(page)) {
+    return page.map((item) => slimEntry(item as Entry)) as unknown as T;
+  }
+  return page;
+}
+
+type WithQueryFn = { queryFn?: unknown };
+
+/**
+ * Wrap feed query options so their pages arrive slim.
+ *
+ * Applied to the queryFn rather than `select` on purpose: `select` runs after the
+ * data is cached, so the bodies would still be dehydrated into the SSR payload and
+ * still sit in the client cache. Wrapping the fetch means one slim copy exists,
+ * server and client alike, and React Flight can dedupe it by reference.
+ *
+ * The query key and every other option are passed through untouched, so this
+ * cannot split a cache entry away from the one a page already renders.
+ */
+export function withSlimEntries<T extends WithQueryFn>(options: T): T {
+  const queryFn = options.queryFn;
+  if (typeof queryFn !== "function") {
+    return options;
+  }
+
+  return {
+    ...options,
+    queryFn: async (...args: unknown[]) =>
+      slimEntryPage(await (queryFn as (...a: unknown[]) => Promise<unknown>)(...args))
+  } as T;
+}

--- a/apps/web/src/entities/entries.ts
+++ b/apps/web/src/entities/entries.ts
@@ -27,6 +27,9 @@ export interface JsonMetadata {
   original_author?: string;
   original_permlink?: string;
   image?: string[];
+  // Publisher-supplied thumbnail (3Speak, Liketu). Preferred over `image` when a
+  // card picks its thumbnail, since it is published for exactly that purpose.
+  thumbnails?: string[];
   pinned_reply?: string; // author/permlink
   location?: { coordinates: { lat: number; lng: number }; address?: string };
   ai_tools?: AiToolsMeta;
@@ -100,6 +103,13 @@ export interface Entry {
   url: string;
   original_entry?: Entry;
   is_optimistic?: boolean;
+  /**
+   * Present only on feed rows that went through the slim step
+   * (`core/entries/slim-entry.ts`): the body is `""` and everything a card needs
+   * has been derived into `json_metadata`. `ext_link` carries the one body fact
+   * the SDK's moderation rules still need. Absent on full entries.
+   */
+  slim?: { ext_link: boolean };
 }
 
 export interface EntryHeader {

--- a/apps/web/src/features/seo/ranked-archive.ts
+++ b/apps/web/src/features/seo/ranked-archive.ts
@@ -108,7 +108,10 @@ export async function fetchRankedCursorPage(
           ARCHIVE_PAGE_SIZE,
           tag,
           observer
-        )
+        ),
+        // Own cache identity: this SDK page key is also read by deck columns,
+        // which render whole posts.
+        { isolateKey: true }
       )
     )) as unknown as Entry[] | undefined) ?? [];
   const last = entries[entries.length - 1];

--- a/apps/web/src/features/seo/ranked-archive.ts
+++ b/apps/web/src/features/seo/ranked-archive.ts
@@ -1,4 +1,5 @@
 import { Entry } from "@/entities";
+import { withSlimEntries } from "@/core/entries/slim-entry";
 import { fetchQuery } from "@/core/react-query";
 import { getPostsRankedQueryOptions } from "@ecency/sdk";
 
@@ -97,13 +98,17 @@ export async function fetchRankedCursorPage(
 ): Promise<{ entries: Entry[]; nextCursor: ArchiveCursor | null }> {
   const entries =
     ((await fetchQuery(
-      getPostsRankedQueryOptions(
-        sort,
-        cursor.author,
-        cursor.permlink,
-        ARCHIVE_PAGE_SIZE,
-        tag,
-        observer
+      // Slim like the live feed: these pages render the same cards, and they are
+      // the crawler-facing copy, where payload weight matters most.
+      withSlimEntries(
+        getPostsRankedQueryOptions(
+          sort,
+          cursor.author,
+          cursor.permlink,
+          ARCHIVE_PAGE_SIZE,
+          tag,
+          observer
+        )
       )
     )) as unknown as Entry[] | undefined) ?? [];
   const last = entries[entries.length - 1];

--- a/apps/web/src/features/shared/entry-list-item/entry-list-item-muted-content.tsx
+++ b/apps/web/src/features/shared/entry-list-item/entry-list-item-muted-content.tsx
@@ -9,7 +9,8 @@ import { postBodySummary } from "@ecency/render-helper";
 import { useGlobalStore } from "@/core/global-store";
 import { EcencyClientServerBridge } from "@/core/client-server-bridge";
 import { EntryListItemContext } from "@/features/shared/entry-list-item/entry-list-item-context";
-import { ContentModerationReason, getContentModerationReason } from "@ecency/sdk";
+import { ContentModerationReason } from "@ecency/sdk";
+import { getEntryModerationReason } from "@/core/entries/entry-moderation";
 import Link from "next/link";
 import { UilMapPinAlt } from "@tooni/iconscout-unicons-react";
 import { useEntryLocation } from "@/utils";
@@ -30,7 +31,7 @@ export function EntryListItemMutedContent({ entry: entryProp, isThumbLcp }: Prop
 
   // Which rule fired (moderator action, downvotes, low-trust promo) is decided in
   // the SDK, so the mobile app flags the very same posts for the very same reason.
-  const moderationReason = useMemo(() => getContentModerationReason(entry), [entry]);
+  const moderationReason = useMemo(() => getEntryModerationReason(entry), [entry]);
 
   const nsfw = useMemo(
     () =>

--- a/apps/web/src/features/shared/entry-translate/index.tsx
+++ b/apps/web/src/features/shared/entry-translate/index.tsx
@@ -38,12 +38,21 @@ export function EntryTranslate({ entry, onHide, initialTarget, initialSource }: 
   // core/entries/slim-entry.ts), so the full post is fetched here. The seeded
   // cache copy is stale from the start and refetchOnMount is off app-wide, hence
   // the explicit "always" — without it this would translate an empty string.
-  const { data: fullEntry } = useQuery({
+  const {
+    data: fullEntry,
+    isError: fullEntryFailed,
+    isSuccess: fullEntryLoaded
+  } = useQuery({
     ...EcencyEntriesCacheManagement.getEntryQueryByPath(entry.author, entry.permlink),
     enabled: !entry.body && !!entry.author && !!entry.permlink,
     refetchOnMount: "always"
   });
   const sourceBody = entry.body || fullEntry?.body || "";
+  // The fetch failed, or it came back without a post (deleted, or never indexed).
+  // Either way no body is coming, so the modal must show its error instead of
+  // spinning forever.
+  const bodyUnavailable =
+    !entry.body && (fullEntryFailed || (fullEntryLoaded && !fullEntry?.body));
 
   useEffect(() => {
     let canceled = false;
@@ -52,8 +61,12 @@ export function EntryTranslate({ entry, onHide, initialTarget, initialSource }: 
     setDetectedFrom("");
     setError(false);
     if (!sourceBody) {
-      // Still fetching the body; stay in the loading state rather than asking
-      // the translator for an empty document.
+      if (bodyUnavailable) {
+        setError(true);
+        setLoading(false);
+      }
+      // Otherwise the body is still on its way: stay in the loading state rather
+      // than asking the translator for an empty document.
       return () => {
         canceled = true;
       };
@@ -83,7 +96,7 @@ export function EntryTranslate({ entry, onHide, initialTarget, initialSource }: 
     return () => {
       canceled = true;
     };
-  }, [sourceBody, target, initialSource]);
+  }, [sourceBody, bodyUnavailable, target, initialSource]);
 
   return (
     <Modal

--- a/apps/web/src/features/shared/entry-translate/index.tsx
+++ b/apps/web/src/features/shared/entry-translate/index.tsx
@@ -7,6 +7,8 @@ import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import { Spinner } from "@ui/spinner";
 import { Select } from "@ui/input/form-controls/select";
 import { isRtlLang, languageDisplayName, normLang } from "./iso639";
+import { useQuery } from "@tanstack/react-query";
+import { EcencyEntriesCacheManagement } from "@/core/caches";
 
 interface Props {
   entry: Entry;
@@ -32,13 +34,31 @@ export function EntryTranslate({ entry, onHide, initialTarget, initialSource }: 
     getLanguages().then(setLanguages);
   }, []);
 
+  // Opened from a feed card, `entry` is a slim row with no body (see
+  // core/entries/slim-entry.ts), so the full post is fetched here. The seeded
+  // cache copy is stale from the start and refetchOnMount is off app-wide, hence
+  // the explicit "always" — without it this would translate an empty string.
+  const { data: fullEntry } = useQuery({
+    ...EcencyEntriesCacheManagement.getEntryQueryByPath(entry.author, entry.permlink),
+    enabled: !entry.body && !!entry.author && !!entry.permlink,
+    refetchOnMount: "always"
+  });
+  const sourceBody = entry.body || fullEntry?.body || "";
+
   useEffect(() => {
     let canceled = false;
     setLoading(true);
     setTranslated("");
     setDetectedFrom("");
     setError(false);
-    const body = postBodySummary(entry.body);
+    if (!sourceBody) {
+      // Still fetching the body; stay in the loading state rather than asking
+      // the translator for an empty document.
+      return () => {
+        canceled = true;
+      };
+    }
+    const body = postBodySummary(sourceBody);
     getTranslation(body, initialSource ?? "auto", target)
       .then((r) => {
         if (!canceled) {
@@ -63,7 +83,7 @@ export function EntryTranslate({ entry, onHide, initialTarget, initialSource }: 
     return () => {
       canceled = true;
     };
-  }, [entry, target, initialSource]);
+  }, [sourceBody, target, initialSource]);
 
   return (
     <Modal

--- a/apps/web/src/features/shared/entry-translate/index.tsx
+++ b/apps/web/src/features/shared/entry-translate/index.tsx
@@ -41,18 +41,24 @@ export function EntryTranslate({ entry, onHide, initialTarget, initialSource }: 
   const {
     data: fullEntry,
     isError: fullEntryFailed,
-    isSuccess: fullEntryLoaded
+    isSuccess: fullEntryLoaded,
+    isFetching: fullEntryFetching
   } = useQuery({
     ...EcencyEntriesCacheManagement.getEntryQueryByPath(entry.author, entry.permlink),
     enabled: !entry.body && !!entry.author && !!entry.permlink,
     refetchOnMount: "always"
   });
   const sourceBody = entry.body || fullEntry?.body || "";
-  // The fetch failed, or it came back without a post (deleted, or never indexed).
-  // Either way no body is coming, so the modal must show its error instead of
+  // No body is coming: the request failed, or it settled without a post (deleted,
+  // or never indexed). Only then does the modal show its error rather than
   // spinning forever.
+  //
+  // `isFetching` is load-bearing. Feed cards seed this very cache key with the
+  // slim row, so React Query reports success with an empty body from the first
+  // render while the forced refetch is still in flight — reading that as terminal
+  // flashed the error over a post that was about to arrive.
   const bodyUnavailable =
-    !entry.body && (fullEntryFailed || (fullEntryLoaded && !fullEntry?.body));
+    !entry.body && !fullEntryFetching && (fullEntryFailed || fullEntryLoaded);
 
   useEffect(() => {
     let canceled = false;

--- a/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
+++ b/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
@@ -118,26 +118,32 @@ export function useContentLanguageGate(
 
   const author = entry?.author;
   const permlink = entry?.permlink;
-  // Feed rows ship no body (see core/entries/slim-entry.ts). Their derived
-  // summary is always populated and is plenty for a language guess — franc needs
-  // MIN_DETECT_CHARS, far below the 200-character summary. The post page still
-  // passes a full body and detects on that.
-  const body = entry?.body || entry?.json_metadata?.description || "";
+  // Feed rows ship no body (see core/entries/slim-entry.ts), so the chip falls
+  // back to their card summary: franc needs MIN_DETECT_CHARS, far below the
+  // 200-character summary. The post page still passes a full body.
+  const body = entry?.body || "";
+  const summary = body ? "" : entry?.json_metadata?.description || "";
+  const sample = body || summary;
 
   useEffect(() => {
     setDecision(null);
 
-    if (disabled || !author || !permlink || !body) {
+    if (disabled || !author || !permlink || !sample) {
       return;
     }
 
     // Cheap raw pre-check — never render a summary for a trivially short body.
-    if (body.trim().length < MIN_DETECT_CHARS) {
+    if (sample.trim().length < MIN_DETECT_CHARS) {
       return;
     }
 
     let cancelled = false;
-    const key = `${author}/${permlink}`;
+    // A detection made from a card summary is NOT a detection of the post: an
+    // author-written description can be in another language than the body, or be
+    // the title fallback. Keeping it under its own key means the feed chip still
+    // memoizes per permlink while the post page always detects on the real body
+    // (and can still confirm it with the server).
+    const key = summary ? `${author}/${permlink}#summary` : `${author}/${permlink}`;
     const reader = resolveReaderLang();
 
     const cached = contentLangCache.get(key);
@@ -155,8 +161,11 @@ export function useContentLanguageGate(
       }
       try {
         // Bound markdown work regardless of article length.
-        const sample = postBodySummary(body.slice(0, RAW_SAMPLE_CHARS), 0).slice(0, SAMPLE_CHARS);
-        const textLength = sample.trim().length;
+        const detectText = postBodySummary(sample.slice(0, RAW_SAMPLE_CHARS), 0).slice(
+          0,
+          SAMPLE_CHARS
+        );
+        const textLength = detectText.trim().length;
 
         if (textLength < MIN_DETECT_CHARS) {
           cacheDetection(key, { lang: null, confirmed: true });
@@ -171,7 +180,7 @@ export function useContentLanguageGate(
           if (cancelled) {
             return;
           }
-          lang = francToIso1(franc(sample));
+          lang = francToIso1(franc(detectText));
         }
 
         if (lang && lang === reader) {
@@ -212,7 +221,7 @@ export function useContentLanguageGate(
     return () => {
       cancelled = true;
     };
-  }, [author, permlink, body, canServerConfirm, disabled]);
+  }, [author, permlink, sample, summary, canServerConfirm, disabled]);
 
   return decision;
 }

--- a/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
+++ b/apps/web/src/features/shared/entry-translate/use-content-language-gate.ts
@@ -77,7 +77,8 @@ function scheduleIdle(cb: () => void): void {
 interface GateEntry {
   author: string;
   permlink: string;
-  body: string;
+  body?: string;
+  json_metadata?: { description?: string | null } | null;
 }
 
 interface GateOptions {
@@ -117,7 +118,11 @@ export function useContentLanguageGate(
 
   const author = entry?.author;
   const permlink = entry?.permlink;
-  const body = entry?.body;
+  // Feed rows ship no body (see core/entries/slim-entry.ts). Their derived
+  // summary is always populated and is plenty for a language guess — franc needs
+  // MIN_DETECT_CHARS, far below the 200-character summary. The post page still
+  // passes a full body and detects on that.
+  const body = entry?.body || entry?.json_metadata?.description || "";
 
   useEffect(() => {
     setDecision(null);

--- a/apps/web/src/specs/api/queries/get-account-posts-feed-query.spec.tsx
+++ b/apps/web/src/specs/api/queries/get-account-posts-feed-query.spec.tsx
@@ -435,13 +435,16 @@ describe('get-account-posts-feed-query', () => {
         ),
       });
 
+      // The hook, the server prefetch and the cache read now build these options
+      // in one place, so this non-feed branch passes the same four arguments the
+      // prefetch assertions above expect. The two it used to add were the SDK's
+      // own defaults (enabled = true, no options object), so nothing changed
+      // about the query itself.
       expect(getPostsRankedInfiniteQueryOptions).toHaveBeenCalledWith(
         'trending',
         'tag1',
         20,
-        DEFAULT_OBSERVER,
-        true,
-        undefined
+        DEFAULT_OBSERVER
       );
     });
   });

--- a/apps/web/src/specs/core/entries/slim-entry.spec.ts
+++ b/apps/web/src/specs/core/entries/slim-entry.spec.ts
@@ -9,26 +9,14 @@ import {
 } from "@/core/entries/slim-entry";
 import { getEntryModerationReason } from "@/core/entries/entry-moderation";
 import type { Entry } from "@/entities";
+import { mockEntry } from "@/specs/test-utils";
 
 // render-helper memoizes summaries and images per author/permlink/update, so each
 // fixture needs its own permlink or one test reads another's cached summary.
 let seq = 0;
 
 function entry(overrides: Partial<Entry> = {}): Entry {
-  return {
-    author: "alice",
-    permlink: `a-post-${++seq}`,
-    title: "A title",
-    body: "Hello world, this is the body of the post.",
-    json_metadata: { tags: ["hive"] },
-    author_reputation: 70,
-    net_rshares: 0,
-    active_votes: [],
-    stats: { total_votes: 1, flag_weight: 0, gray: false, hide: false },
-    created: "2026-08-01T00:00:00",
-    updated: "2026-08-01T00:00:00",
-    ...overrides
-  } as Entry;
+  return mockEntry({ permlink: `slim-fixture-${++seq}`, ...overrides });
 }
 
 describe("slimEntry", () => {

--- a/apps/web/src/specs/core/entries/slim-entry.spec.ts
+++ b/apps/web/src/specs/core/entries/slim-entry.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { postBodySummary } from "@ecency/render-helper";
+import { ContentModerationReason } from "@ecency/sdk";
+import { slimEntry, slimEntryPage, withSlimEntries } from "@/core/entries/slim-entry";
+import { getEntryModerationReason } from "@/core/entries/entry-moderation";
+import type { Entry } from "@/entities";
+
+// render-helper memoizes summaries and images per author/permlink/update, so each
+// fixture needs its own permlink or one test reads another's cached summary.
+let seq = 0;
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    author: "alice",
+    permlink: `a-post-${++seq}`,
+    title: "A title",
+    body: "Hello world, this is the body of the post.",
+    json_metadata: { tags: ["hive"] },
+    author_reputation: 70,
+    net_rshares: 0,
+    active_votes: [],
+    stats: { total_votes: 1, flag_weight: 0, gray: false, hide: false },
+    created: "2026-08-01T00:00:00",
+    updated: "2026-08-01T00:00:00",
+    ...overrides
+  } as Entry;
+}
+
+describe("slimEntry", () => {
+  it("drops the body", () => {
+    expect(slimEntry(entry()).body).toBe("");
+  });
+
+  it("keeps an author-written description untouched", () => {
+    const e = entry({ json_metadata: { description: "  Author summary  " } });
+    expect(slimEntry(e).json_metadata?.description).toBe("Author summary");
+  });
+
+  it("derives the same summary the card renders when there is no description", () => {
+    const e = entry();
+    expect(slimEntry(e).json_metadata?.description).toBe(postBodySummary(e, 200).trim());
+  });
+
+  it("falls back to the title when the body yields no summary", () => {
+    const e = entry({
+      title: "Photo of the day",
+      body: "![](https://images.hive.blog/x.png)"
+    });
+    expect(slimEntry(e).json_metadata?.description).toBe("Photo of the day");
+  });
+
+  it("prefers json_metadata.thumbnails over image for the card thumbnail", () => {
+    const e = entry({
+      json_metadata: {
+        thumbnails: ["https://images.hive.blog/thumb.png"],
+        image: ["https://images.hive.blog/cover.png"]
+      }
+    });
+    expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/thumb.png"]);
+  });
+
+  it("falls back to image[0] when there is no thumbnails entry", () => {
+    const e = entry({ json_metadata: { image: ["https://images.hive.blog/cover.png"] } });
+    expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/cover.png"]);
+  });
+
+  it("keeps the first body image when metadata carries none", () => {
+    const e = entry({
+      json_metadata: {},
+      body: "intro\n\n![pic](https://images.hive.blog/in-body.png)\n\nrest"
+    });
+    expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/in-body.png"]);
+  });
+
+  it("leaves image unset when nothing supplies one, so the card renders without a thumbnail", () => {
+    const e = entry({ json_metadata: {}, body: "just words, no pictures at all" });
+    expect(slimEntry(e).json_metadata?.image).toBeUndefined();
+  });
+
+  it("lifts a worldmappin body marker into json_metadata.location", () => {
+    const e = entry({
+      body: "trip notes\n\n[//]:# (!worldmappin -12.5 lat 33.25 long Somewhere d3scr)"
+    });
+    expect(slimEntry(e).json_metadata?.location).toEqual({
+      coordinates: { lat: "-12.5", lng: "33.25" },
+      address: "Somewhere"
+    });
+  });
+
+  it("slims the nested original_entry a cross-post card reads from", () => {
+    const original = entry({ author: "bob", body: "original body text" });
+    const slim = slimEntry(entry({ original_entry: original }));
+    expect(slim.original_entry?.body).toBe("");
+    expect(slim.original_entry?.json_metadata?.description).toBeTruthy();
+  });
+
+  it("passes through an entry that has no body already", () => {
+    const e = entry({ body: "" });
+    expect(slimEntry(e)).toBe(e);
+  });
+});
+
+describe("getEntryModerationReason", () => {
+  const lowRepAuthor = { author_reputation: 25, net_rshares: 0, active_votes: [] };
+
+  it("still flags a low-trust post whose body link was recorded before the strip", () => {
+    const e = entry({
+      ...lowRepAuthor,
+      body: "check my shop https://spam-shop.example/deal"
+    });
+    expect(getEntryModerationReason(e)).toBe(ContentModerationReason.LOW_TRUST);
+    expect(getEntryModerationReason(slimEntry(e))).toBe(ContentModerationReason.LOW_TRUST);
+  });
+
+  it("does not flag a low-reputation post with no outbound link", () => {
+    const e = slimEntry(entry({ ...lowRepAuthor, body: "just a friendly hello to everyone" }));
+    expect(getEntryModerationReason(e)).toBeNull();
+  });
+
+  it("keeps reading live vote state on a slim row", () => {
+    const e = slimEntry(
+      entry({ body: "hello there", stats: { total_votes: 0, flag_weight: 0, gray: true, hide: false } })
+    );
+    expect(getEntryModerationReason(e)).toBe(ContentModerationReason.MOD_MUTED);
+  });
+});
+
+describe("withSlimEntries", () => {
+  it("slims the pages a query resolves and leaves everything else alone", async () => {
+    const options = {
+      queryKey: ["posts", "ranked"],
+      staleTime: 1234,
+      queryFn: async () => [entry(), entry()]
+    };
+    const wrapped = withSlimEntries(options);
+
+    expect(wrapped.queryKey).toBe(options.queryKey);
+    expect(wrapped.staleTime).toBe(1234);
+
+    const page = await wrapped.queryFn();
+    expect(page.map((e: Entry) => e.body)).toEqual(["", ""]);
+    expect(page[0].json_metadata?.description).toBeTruthy();
+  });
+
+  it("returns options untouched when there is no queryFn", () => {
+    const options = { queryKey: ["k"] };
+    expect(withSlimEntries(options)).toBe(options);
+  });
+
+  it("leaves a non-array page shape (search results) alone", () => {
+    const page = { results: [entry()], hits: 1 };
+    expect(slimEntryPage(page)).toBe(page);
+  });
+});

--- a/apps/web/src/specs/core/entries/slim-entry.spec.ts
+++ b/apps/web/src/specs/core/entries/slim-entry.spec.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { postBodySummary } from "@ecency/render-helper";
 import { ContentModerationReason } from "@ecency/sdk";
-import { slimEntry, slimEntryPage, withSlimEntries } from "@/core/entries/slim-entry";
+import {
+  SLIM_KEY_MARKER,
+  slimEntry,
+  slimEntryPage,
+  withSlimEntries
+} from "@/core/entries/slim-entry";
 import { getEntryModerationReason } from "@/core/entries/entry-moderation";
 import type { Entry } from "@/entities";
 
@@ -77,14 +82,21 @@ describe("slimEntry", () => {
     expect(slimEntry(e).json_metadata?.image).toBeUndefined();
   });
 
-  it("lifts a worldmappin body marker into json_metadata.location", () => {
+  it("lifts a worldmappin body marker into json_metadata.location as numbers", () => {
     const e = entry({
       body: "trip notes\n\n[//]:# (!worldmappin -12.5 lat 33.25 long Somewhere d3scr)"
     });
     expect(slimEntry(e).json_metadata?.location).toEqual({
-      coordinates: { lat: "-12.5", lng: "33.25" },
+      coordinates: { lat: -12.5, lng: 33.25 },
       address: "Somewhere"
     });
+  });
+
+  it("drops a malformed worldmappin marker rather than storing a broken pin", () => {
+    const e = entry({
+      body: "trip notes\n\n[//]:# (!worldmappin 12.5.6 lat 33.25 long Somewhere d3scr)"
+    });
+    expect(slimEntry(e).json_metadata?.location).toBeUndefined();
   });
 
   it("slims the nested original_entry a cross-post card reads from", () => {
@@ -140,6 +152,29 @@ describe("withSlimEntries", () => {
     const page = await wrapped.queryFn();
     expect(page.map((e: Entry) => e.body)).toEqual(["", ""]);
     expect(page[0].json_metadata?.description).toBeTruthy();
+  });
+
+  it("keeps the query key by default, so the feed's prefetch and hook still match", () => {
+    const key = ["posts", "ranked", "trending"];
+    expect(withSlimEntries({ queryKey: key, queryFn: async () => [] }).queryKey).toBe(key);
+  });
+
+  it("gives slim pages their own key when asked, so full-body readers cannot pick them up", () => {
+    // Deck columns fetch the same SDK page key and render entry.body, so slim
+    // pages must not be sitting under it when they do.
+    const wrapped = withSlimEntries(
+      { queryKey: ["posts", "ranked-page", "trending", "", "", 20], queryFn: async () => [] },
+      { isolateKey: true }
+    );
+    expect(wrapped.queryKey).toEqual([
+      "posts",
+      "ranked-page",
+      "trending",
+      "",
+      "",
+      20,
+      SLIM_KEY_MARKER
+    ]);
   });
 
   it("returns options untouched when there is no queryFn", () => {

--- a/apps/web/src/specs/features/entry-translate-language-gate.spec.tsx
+++ b/apps/web/src/specs/features/entry-translate-language-gate.spec.tsx
@@ -76,4 +76,45 @@ describe("useContentLanguageGate server /detect gating", () => {
     await waitFor(() => expect(result.current).not.toBeNull());
     expect(detectLanguage).not.toHaveBeenCalled();
   });
+
+  it("detects from a slim feed row's card summary when it has no body", async () => {
+    const { result } = renderHook(() =>
+      useContentLanguageGate({
+        author: "author4",
+        permlink: "gate-slim-feed",
+        body: "",
+        json_metadata: { description: SPANISH_BODY }
+      })
+    );
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(detectLanguage).not.toHaveBeenCalled();
+  });
+
+  it("does not let a summary-derived detection stand in for the full post", async () => {
+    // Feed card first: detection comes from the card summary only.
+    const feed = renderHook(() =>
+      useContentLanguageGate({
+        author: "author5",
+        permlink: "gate-shared-key",
+        body: "",
+        json_metadata: { description: SPANISH_BODY }
+      })
+    );
+    await waitFor(() => expect(feed.result.current).not.toBeNull());
+
+    // Same post opened for real: the full body must still be detected (and, for a
+    // logged-in reader, confirmed by the server) rather than reusing the summary
+    // guess, which may be an unrelated description or the title fallback.
+    setLoggedIn("alice");
+    const post = renderHook(() =>
+      useContentLanguageGate(
+        { author: "author5", permlink: "gate-shared-key", body: SPANISH_BODY },
+        { serverConfirm: true }
+      )
+    );
+
+    await waitFor(() => expect(detectLanguage).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(post.result.current).not.toBeNull());
+  });
 });

--- a/apps/web/src/specs/features/entry-translate-slim-entry.spec.tsx
+++ b/apps/web/src/specs/features/entry-translate-slim-entry.spec.tsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EntryTranslate } from "@/features/shared/entry-translate";
+import { getTranslation, getLanguages } from "@/api/translation";
+import { EcencyEntriesCacheManagement } from "@/core/caches";
+import type { Entry } from "@/entities";
+
+vi.mock("@/api/translation", () => ({
+  getTranslation: vi.fn(async () => ({ translatedText: "hola mundo" })),
+  getLanguages: vi.fn(async () => [{ code: "en", name: "English" }])
+}));
+
+const fullEntryQuery = vi.fn();
+vi.mock("@/core/caches", () => ({
+  EcencyEntriesCacheManagement: {
+    getEntryQueryByPath: (...args: unknown[]) => fullEntryQuery(...args)
+  }
+}));
+
+function slimRow(): Entry {
+  return {
+    author: "alice",
+    permlink: "slim-post",
+    title: "A title",
+    body: "",
+    json_metadata: { description: "A title" }
+  } as Entry;
+}
+
+function renderModal(entry: Entry) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } }
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EntryTranslate entry={entry} onHide={() => {}} />
+    </QueryClientProvider>
+  );
+}
+
+describe("EntryTranslate opened from a slim feed row", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getLanguages as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { code: "en", name: "English" }
+    ]);
+  });
+
+  it("fetches the full body and translates that, not the empty one", async () => {
+    fullEntryQuery.mockReturnValue({
+      queryKey: ["posts", "entry", "/@alice/slim-post"],
+      queryFn: async () => ({ ...slimRow(), body: "el cuerpo completo del post" }),
+      select: (d: Entry) => d
+    });
+
+    renderModal(slimRow());
+
+    await waitFor(() => expect(getTranslation).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(getTranslation).mock.calls[0][0]).toContain("el cuerpo completo del post");
+  });
+
+  it("shows the error state instead of spinning forever when the body cannot be fetched", async () => {
+    fullEntryQuery.mockReturnValue({
+      queryKey: ["posts", "entry", "/@alice/slim-post"],
+      queryFn: async () => {
+        throw new Error("rpc down");
+      },
+      select: (d: Entry) => d
+    });
+
+    renderModal(slimRow());
+
+    await waitFor(() => expect(screen.queryByText(/entry-translate.error/i)).not.toBeNull());
+    expect(getTranslation).not.toHaveBeenCalled();
+  });
+
+  it("shows the error state when the post is gone (fetch succeeds with no body)", async () => {
+    fullEntryQuery.mockReturnValue({
+      queryKey: ["posts", "entry", "/@alice/slim-post"],
+      queryFn: async () => null,
+      select: (d: Entry | null) => d ?? undefined
+    });
+
+    renderModal(slimRow());
+
+    await waitFor(() => expect(screen.queryByText(/entry-translate.error/i)).not.toBeNull());
+    expect(getTranslation).not.toHaveBeenCalled();
+  });
+
+  it("translates a full entry straight away without any extra fetch", async () => {
+    fullEntryQuery.mockReturnValue({
+      queryKey: ["posts", "entry", "/@alice/full-post"],
+      queryFn: async () => {
+        throw new Error("must not be called");
+      },
+      select: (d: Entry) => d
+    });
+
+    renderModal({ ...slimRow(), body: "cuerpo ya presente" });
+
+    await waitFor(() => expect(getTranslation).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(getTranslation).mock.calls[0][0]).toContain("cuerpo ya presente");
+  });
+});

--- a/apps/web/src/specs/features/entry-translate-slim-entry.spec.tsx
+++ b/apps/web/src/specs/features/entry-translate-slim-entry.spec.tsx
@@ -1,10 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { screen, waitFor } from "@testing-library/react";
+import { QueryClient } from "@tanstack/react-query";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EntryTranslate } from "@/features/shared/entry-translate";
 import { getTranslation, getLanguages } from "@/api/translation";
-import { EcencyEntriesCacheManagement } from "@/core/caches";
+import { mockEntry, renderWithQueryClient } from "@/specs/test-utils";
 import type { Entry } from "@/entities";
 
 vi.mock("@/api/translation", () => ({
@@ -19,25 +19,30 @@ vi.mock("@/core/caches", () => ({
   }
 }));
 
-function slimRow(): Entry {
-  return {
+// A feed row as slimEntry leaves it: no body, card text in the metadata.
+function slimRow(overrides: Partial<Entry> = {}): Entry {
+  return mockEntry({
     author: "alice",
     permlink: "slim-post",
     title: "A title",
     body: "",
-    json_metadata: { description: "A title" }
-  } as Entry;
+    json_metadata: { description: "A title" },
+    ...overrides
+  });
 }
 
-function renderModal(entry: Entry) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } }
+const ENTRY_KEY = ["posts", "entry", "/@alice/slim-post"];
+
+function testClient() {
+  // The shared helper's client keeps data fresh forever, which would defeat the
+  // refetchOnMount the modal relies on to pull a missing body.
+  return new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+}
+
+function renderModal(entry: Entry, queryClient = testClient()) {
+  return renderWithQueryClient(<EntryTranslate entry={entry} onHide={() => {}} />, {
+    queryClient
   });
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <EntryTranslate entry={entry} onHide={() => {}} />
-    </QueryClientProvider>
-  );
 }
 
 describe("EntryTranslate opened from a slim feed row", () => {
@@ -51,7 +56,7 @@ describe("EntryTranslate opened from a slim feed row", () => {
   it("fetches the full body and translates that, not the empty one", async () => {
     fullEntryQuery.mockReturnValue({
       queryKey: ["posts", "entry", "/@alice/slim-post"],
-      queryFn: async () => ({ ...slimRow(), body: "el cuerpo completo del post" }),
+      queryFn: async () => slimRow({ body: "el cuerpo completo del post" }),
       select: (d: Entry) => d
     });
 
@@ -98,9 +103,40 @@ describe("EntryTranslate opened from a slim feed row", () => {
       select: (d: Entry) => d
     });
 
-    renderModal({ ...slimRow(), body: "cuerpo ya presente" });
+    renderModal(slimRow({ body: "cuerpo ya presente" }));
 
     await waitFor(() => expect(getTranslation).toHaveBeenCalledTimes(1));
     expect(vi.mocked(getTranslation).mock.calls[0][0]).toContain("cuerpo ya presente");
+  });
+
+  it("keeps loading while a seeded slim row is being refetched, instead of flashing the error", async () => {
+    // Feed cards seed this very key with the slim row, so React Query reports
+    // success with an empty body the moment the modal mounts while the forced
+    // refetch is still in flight. That is not a failure, and must not surface as
+    // one.
+    let deliver: (e: Entry) => void = () => {};
+    const inFlight = new Promise<Entry>((resolve) => {
+      deliver = resolve;
+    });
+    fullEntryQuery.mockReturnValue({
+      queryKey: ENTRY_KEY,
+      queryFn: () => inFlight,
+      select: (d: Entry) => d
+    });
+
+    const queryClient = testClient();
+    queryClient.setQueryData(ENTRY_KEY, slimRow());
+
+    renderModal(slimRow(), queryClient);
+
+    await waitFor(() => expect(getLanguages).toHaveBeenCalled());
+    expect(screen.queryByText(/entry-translate.error/i)).toBeNull();
+    expect(getTranslation).not.toHaveBeenCalled();
+
+    deliver(slimRow({ body: "el cuerpo completo del post" }));
+
+    await waitFor(() => expect(getTranslation).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(getTranslation).mock.calls[0][0]).toContain("el cuerpo completo del post");
+    expect(screen.queryByText(/entry-translate.error/i)).toBeNull();
   });
 });

--- a/apps/web/src/utils/use-entry-location.ts
+++ b/apps/web/src/utils/use-entry-location.ts
@@ -1,40 +1,14 @@
 import { Entry } from "@/entities";
 import { useMemo } from "react";
+import { parseEntryLocationFromBody } from "@/core/entries/entry-location";
 
 export function useEntryLocation(entry?: Entry) {
   return useMemo(() => {
+    // Feed rows carry this in metadata (the slim step lifts it there before the
+    // body goes); a full entry still gets it parsed out of the body.
     const metadataLocation = entry?.json_metadata?.location;
     if (metadataLocation) return metadataLocation;
 
-    if (!entry?.body) return undefined;
-
-    const match = entry.body.match(
-        /\[\/\/\]:#\s\(\!(?:worldmappin|pinmapple)\s+([-\d.]+)\s+lat\s+([-\d.]+)\s+long(?:\s+(.*?))?(?:\s+d3scr)?\)/i
-    );
-
-    if (match) {
-      const [, lat, lng, address] = match;
-
-      const cleanedAddress = address?.trim();
-
-      const fallbackAddress =
-          !cleanedAddress ||
-          cleanedAddress === "<DESCRIPTION GOES HERE>" ||
-          cleanedAddress === "d3scr"
-              ? `${lat}, ${lng}`
-              : cleanedAddress;
-
-      return {
-        coordinates: {
-          lat,
-          lng,
-        },
-        address: fallbackAddress,
-      };
-    }
-
-    return undefined;
+    return parseEntryLocationFromBody(entry?.body);
   }, [entry]);
 }
-
-


### PR DESCRIPTION
Closes #1544.

Feed, profile and community lists render a ~200 character summary and a thumbnail, but `bridge.get_ranked_posts` / `bridge.get_account_posts` hand back every post's full markdown body. Those bodies are shipped to the browser in the RSC payload and then kept in the client query cache for every page pulled in while scrolling.

Measured on an anonymous cold load of production today:

| page | HTML | RSC payload | post bodies in payload |
|---|---|---|---|
| /trending | 545 KB | 350 KB | 211 KB (60%) |
| /@good-karma | 524 KB | 336 KB | 200 KB (60%) |
| /created/hive-125125 | 426 KB | 248 KB | 103 KB (42%) |
| /created | 356 KB | 185 KB | 61 KB (33%) |

`json_metadata.description` alone cannot replace the body: in a 240 post sample across trending/hot/created, tags and communities, only 29% of posts carry one and about 20% have no `json_metadata.image`.

## What this does

`slimEntry` runs inside the feed queryFn, where the body is still in hand, and derives everything a card reads before blanking it:

- **summary** into `json_metadata.description`: an author-written description wins, else the same `postBodySummary(entry, 200)` the card renders today, else the title so image-only posts still fill the line and cards stay uniform.
- **thumbnail** into `json_metadata.image[0]`: `json_metadata.thumbnails` first, then the existing image, then the post's first body image. Nothing found means the card renders without a thumbnail, as before.
- **location**: a worldmappin/pinmapple body marker is lifted into `json_metadata.location`, so the map pin survives.
- **moderation**: the SDK's low-trust rule reads the body for an outbound link, so the answer is recorded on the entry and replayed into the SDK rule. The rules and their precedence stay in the SDK, shared with mobile.

Applied in the queryFn rather than `select` on purpose: `select` runs after caching, so the bodies would still be dehydrated into the SSR payload and still sit in the client cache. Wrapping the fetch means one slim copy exists on both sides of hydration, so cards render identically server and client with no text/src mismatch, and Flight can dedupe it by reference.

Covered: ranked feeds, profile posts/blog/feed, communities, promoted entries, the crawlable archive pages and the 30 second "new posts" poll (which merges into the same cache).

Not slimmed, deliberately: comment and reply lists, whose cards have no title or metadata to fall back on; RSS, sitemap and indexability, which read bodies from their own queries; decks and waves, which are separate views.

## Opening a post from a list

Cards seed the shared post cache so their vote/payout/reblog controls read one entry. A slim row is now stamped as never-updated there, so it no longer looks like a freshly fetched post: the entry page's own server fetch always wins on hydration, and an explicit refetch (edit prefill, the translate modal, which now fetches the body it needs) reaches the network. `refetchOnMount` is false app-wide, so this does not make the 20 cards on a feed page fetch anything.

## Pagination

Checked as part of this work, unchanged: SSR prefetches exactly one page per feed (`prefetchInfiniteQuery` fetches only the initial page param unless given a `pages` count), every call site uses the bridge's cap of 20, `getNextPageParam` returns undefined on a partial page, and the client fetches the next page only when the bottom sentinel is visible and nothing is in flight.

## Verification

Production build of this branch, served locally: post bodies in the flight payload of `/trending`, `/created`, `/created/hive-125125` and `/@good-karma` are **0 bytes**, with every entry still carrying a description and a thumbnail, and the same number of rendered summaries and thumbnails as the current production pages. `/@good-karma/comments` still ships full bodies, and a post page opened from a feed still renders its article.

`pnpm typecheck` clean, `pnpm test` green (314 files, 2948 tests), including new specs for the slim step, the thumbnail order, the title fallback, cross-posts and the moderation replay.

One existing spec assertion changed: the non-feed ranked branch now passes four arguments instead of six, because the hook, the server prefetch and the cache read build their options in one place. The two dropped arguments were the SDK's own defaults, so the query itself is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feed and archive cards now load faster with smaller entry data while retaining thumbnails, summaries, locations, and link safety.
  * Full post content is fetched automatically when needed for translation or other detailed actions.
  * Improved location detection from post content, including coordinates and optional addresses.
* **Bug Fixes**
  * Moderation messaging continues to work for entries with limited content.
  * Feed placeholders refresh promptly when full content is unavailable.
* **Tests**
  * Added coverage for entry slimming, metadata extraction, moderation, locations, and content loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->