### PR TITLE
Embed: proxy buffers for the subscribe response headers

### DIFF
--- a/apps/self-hosted/hosting/nginx-multi-tenant.conf
+++ b/apps/self-hosted/hosting/nginx-multi-tenant.conf
@@ -143,6 +143,16 @@ server {
         proxy_set_header CF-Connecting-IP $http_x_real_ip;
         proxy_read_timeout 15s;
         client_max_body_size 16k;
+        # The origin is Next, which attaches a ~3.5KB report-only CSP to every
+        # response, so even a 400 carries about 4.2KB of headers and overflows
+        # nginx's 4k default: the read fails with "upstream sent too big header"
+        # and the reader gets a 502 from their own signup form. eu.ecency.com
+        # carries the same buffers for the same reason. Location scope, because
+        # this is the only location here that proxies to the web tier; the rest
+        # go to hosting_api, whose headers are small.
+        proxy_buffer_size 16k;
+        proxy_buffers 8 16k;
+        proxy_busy_buffers_size 16k;
     }
 
     location = /robots.txt {
@@ -252,6 +262,16 @@ server {
         proxy_set_header CF-Connecting-IP $http_x_real_ip;
         proxy_read_timeout 15s;
         client_max_body_size 16k;
+        # The origin is Next, which attaches a ~3.5KB report-only CSP to every
+        # response, so even a 400 carries about 4.2KB of headers and overflows
+        # nginx's 4k default: the read fails with "upstream sent too big header"
+        # and the reader gets a 502 from their own signup form. eu.ecency.com
+        # carries the same buffers for the same reason. Location scope, because
+        # this is the only location here that proxies to the web tier; the rest
+        # go to hosting_api, whose headers are small.
+        proxy_buffer_size 16k;
+        proxy_buffers 8 16k;
+        proxy_busy_buffers_size 16k;
     }
 
     location = /robots.txt {


### PR DESCRIPTION
Fixes #1547.

A tenant blog answers 502 to its own signup form. The routing added in #1542 is correct: `host.docker.internal` resolves through `extra_hosts`, TLS is fine and the origin answers. The read is what fails.

```
upstream sent too big header while reading response header from upstream,
upstream: "https://172.17.0.1:443/api/newsletter/subscribe"
```

Next attaches a ~3.5KB report-only CSP to every response, so even a 400 from the route carries about 4.2KB of headers, over nginx's 4k default `proxy_buffer_size`. Measured on alpha, which runs develop and so has the route, with an invalid body so nobody was subscribed: `400`, 4250 bytes of response headers.

`eu.ecency.com` already carries these buffers with the same explanation. Here they go on the location rather than the server block, because the newsletter location is the only one proxying to the web tier; the others proxy to `hosting_api`, whose headers are small.

### Verification

Run against the **live** origin, using the production image `ecency/self-hosted:sha-4eead79` on the `ecency-hosting` network with the same `host.docker.internal:host-gateway` alias production has:

| config | result |
| --- | --- |
| committed (develop) | `502` |
| this branch | `404`, the origin's own answer, passed through |

`nginx -t` passes in that image on that network.

The remaining 404 is a separate and expected thing: the production origin has no `newsletter` route yet. `.next/server/app/api/` in the running `ecency/vision-web:latest` lists `threespeak`, `hosting`, `oembed` and the rest, with no `newsletter`, so the relay reaches ecency.com only with the next develop to main deploy. Both this fix and that deploy are needed before a reader on a tenant blog can subscribe.