### PR TITLE
Put the community identity above its digest sender tools

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecency/web",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "private": true,
   "packageManager": "pnpm@11.5.0",
   "sideEffects": [

--- a/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
+++ b/apps/web/src/app/(dynamicPages)/community/[community]/_components/community-card/index.tsx
@@ -59,13 +59,6 @@ export function CommunityCard({ community, account }: Props) {
 
   return (
     <div className="community-card">
-      {/* Policing (vision-web#1513): the team sees when this community's digest is suspended, and why. */}
-      <NewsletterGate>
-        <SenderStatusNotice type="community" target={community.name} isSender={isDigestSender} className="mb-4" />
-        <SubscriberCount type="community" target={community.name} isSender={isDigestSender} className="mb-2" />
-        <ComposeDigestButton target={{ type: "community", target: community.name, label: community.title || community.name }} isSender={canSendDigest} className="mb-2" />
-        <SentIssues type="community" target={community.name} isSender={isDigestSender} className="mb-4" />
-      </NewsletterGate>
       <div className="community-avatar inline-flex items-center justify-center md:justify-start">
         {canUpdatePic && (
           <CommunityCardEditPic
@@ -87,6 +80,18 @@ export function CommunityCard({ community, account }: Props) {
         <div className="about">{community.about}</div>
         {community.is_nsfw && <span className="nsfw">nsfw</span>}
       </div>
+      {/* Sender tools sit BELOW the community's identity, the same order the
+          profile card uses. Rendered first, they pushed the avatar and title
+          down the sidebar and the card opened on an admin utility ("0 email
+          subscribers") instead of the community itself.
+          Policing (vision-web#1513): the team sees when this community's digest
+          is suspended, and why. */}
+      <NewsletterGate>
+        <SenderStatusNotice type="community" target={community.name} isSender={isDigestSender} className="mb-4" />
+        <SubscriberCount type="community" target={community.name} isSender={isDigestSender} className="mb-2" />
+        <ComposeDigestButton target={{ type: "community", target: community.name, label: community.title || community.name }} isSender={canSendDigest} className="mb-2" />
+        <SentIssues type="community" target={community.name} isSender={isDigestSender} className="mb-4" />
+      </NewsletterGate>
       <div className="community-sections">
         <CommunityCardDescription community={community} toggleInfo={(e) => setInfo(e)} />
         <CommunityCardRules community={community} toggleInfo={(e) => setInfo(e)} />

--- a/apps/web/src/specs/app/community/community-card-order.spec.tsx
+++ b/apps/web/src/specs/app/community/community-card-order.spec.tsx
@@ -1,0 +1,80 @@
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CommunityCard } from "@/app/(dynamicPages)/community/[community]/_components/community-card";
+import { renderWithQueryClient } from "@/specs/test-utils";
+import type { Account, Community } from "@/entities";
+
+// The card's own sender tools, stubbed to identifiable text. What is under test
+// is where the CARD puts them, not what they render.
+vi.mock("@/features/newsletter", () => ({
+  communityDigestRoles: () => ({ canView: true, canSend: true }),
+  NewsletterGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SenderStatusNotice: () => <div>sender-status</div>,
+  SubscriberCount: () => <div>0 email subscribers</div>,
+  ComposeDigestButton: () => <div>Compose email digest</div>,
+  SentIssues: () => <div>sent-issues</div>
+}));
+
+// Sections and dialogs are irrelevant to ordering and drag in editors/modals.
+vi.mock(
+  "@/app/(dynamicPages)/community/[community]/_components/community-card/community-card-description",
+  () => ({ CommunityCardDescription: () => <div>description-section</div> })
+);
+vi.mock(
+  "@/app/(dynamicPages)/community/[community]/_components/community-card/community-card-rules",
+  () => ({ CommunityCardRules: () => <div>rules-section</div> })
+);
+vi.mock(
+  "@/app/(dynamicPages)/community/[community]/_components/community-card/community-card-team",
+  () => ({ CommunityCardTeam: () => <div>team-section</div> })
+);
+vi.mock("@/app/(dynamicPages)/community/[community]/_components/community-settings", () => ({
+  CommunitySettingsDialog: () => null
+}));
+vi.mock(
+  "@/app/(dynamicPages)/community/[community]/_components/community-rewards-registration",
+  () => ({ CommunityRewardsRegistrationDialog: () => null })
+);
+
+const community = {
+  name: "hive-125125",
+  title: "Town Square",
+  about: "The general community for Hive.",
+  team: [],
+  is_nsfw: false
+} as unknown as Community;
+
+const account = { name: "hive-125125", profile: {} } as unknown as Account;
+
+/** True when `first` appears before `second` in document order. */
+function precedes(first: HTMLElement, second: HTMLElement): boolean {
+  return !!(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING);
+}
+
+describe("community card ordering", () => {
+  it("opens with the community, not with the sender tools", () => {
+    // The sidebar used to render the digest panel first, so a moderator landing
+    // on the community saw "0 email subscribers" above the community's own
+    // avatar and title. Identity comes first, the way the profile card does it.
+    renderWithQueryClient(<CommunityCard community={community} account={account} />);
+
+    const title = screen.getByText("Town Square");
+    const about = screen.getByText("The general community for Hive.");
+    const subscribers = screen.getByText("0 email subscribers");
+    const compose = screen.getByText("Compose email digest");
+
+    expect(precedes(title, subscribers)).toBe(true);
+    expect(precedes(about, subscribers)).toBe(true);
+    expect(precedes(title, compose)).toBe(true);
+  });
+
+  it("keeps the sender tools above the description sections", () => {
+    renderWithQueryClient(<CommunityCard community={community} account={account} />);
+
+    const subscribers = screen.getByText("0 email subscribers");
+    const description = screen.getByText("description-section");
+
+    expect(precedes(subscribers, description)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1549.

The community sidebar rendered the digest sender panel first, so a moderator opening a community saw "0 email subscribers" and "Compose email digest" above the community's own avatar, title and description. The profile card already puts identity first and the sender tools after it; this makes the community card agree.

The `NewsletterGate` block now sits below `community-info` and above the description, rules and team sections, so the card reads community first and admin tools second. Nothing about the panel itself changed, only where it is rendered.

A regression test pins the order: it asserts the title and about text precede the subscriber count and compose button in document order, and it fails on the previous arrangement.

Also bumps the web app version from 4.4.1 to 4.4.2, as requested.

`pnpm typecheck` clean, `pnpm test` green (316 files, 2959 tests).
