### PR TITLE
Newsletter: signup on the About page, and a way back from the confirmation

### DIFF
--- a/apps/self-hosted/src/core/i18n-strings.ts
+++ b/apps/self-hosted/src/core/i18n-strings.ts
@@ -310,6 +310,7 @@ export type TranslationKey =
   | 'newsletterCadence'
   | 'newsletterSubscribe'
   | 'newsletterCheckInbox'
+  | 'newsletterUseAnotherAddress'
   | 'newsletterError'
   | 'panel_configuration_instance_configuration_features_newsletter_label'
   | 'panel_configuration_instance_configuration_features_newsletter_enabled_label'
@@ -348,6 +349,7 @@ export const translations: { en: Translations } & Record<
     newsletterCadence: 'How often',
     newsletterSubscribe: 'Subscribe',
     newsletterCheckInbox: 'Almost there: confirm from the email we just sent.',
+    newsletterUseAnotherAddress: 'Use a different address',
     newsletterError: 'Could not subscribe right now. Please try again.',
     loading: "Loading...",
     hivesigner_login_failed: 'Sign in could not be completed. Please try again.',

--- a/apps/self-hosted/src/features/blog/components/about-heading.test.ts
+++ b/apps/self-hosted/src/features/blog/components/about-heading.test.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * A source guard for one rule: the About page has a heading in every outcome.
+ *
+ * The page sits under a newsletter section whose own heading is an h2
+ * (vision-web#1551). Three of the four shells carry a masthead h1 of their own,
+ * DefaultShell through BlogNavigation and journal and terminal directly, but
+ * the reader shell renders its title in a span. So on that template, any About
+ * outcome that skipped the page heading left the document starting at h2, which
+ * is exactly what the loading and failure branches used to do: they returned a
+ * bare line of text.
+ *
+ * Both variants now return through `AboutFrame`, which owns the h1, and the
+ * identity it needs comes from config rather than from the request. Checked in
+ * the source because the branch that regresses is a loading state behind a
+ * query, and the same approach as `failure-states.test.ts` next door.
+ */
+
+const FILE = join(__dirname, 'about-page.tsx');
+/** Every one of these must return through the frame, in every branch. */
+const VARIANTS = ['BlogAbout', 'CommunityAbout'];
+const FRAME = 'AboutFrame';
+
+function parse(): ts.SourceFile {
+  return ts.createSourceFile(
+    FILE,
+    readFileSync(FILE, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+}
+
+function each(node: ts.Node, visit: (n: ts.Node) => void): void {
+  visit(node);
+  ts.forEachChild(node, (child) => each(child, visit));
+}
+
+/**
+ * The return statements belonging to this function itself, not to callbacks
+ * nested inside it: a `useMemo(() => ...)` return is not what the component
+ * renders.
+ */
+function ownReturns(fn: ts.Node): ts.ReturnStatement[] {
+  const out: ts.ReturnStatement[] = [];
+  const walk = (node: ts.Node) => {
+    ts.forEachChild(node, (child) => {
+      if (
+        ts.isArrowFunction(child) ||
+        ts.isFunctionExpression(child) ||
+        ts.isFunctionDeclaration(child)
+      ) {
+        return;
+      }
+      if (ts.isReturnStatement(child)) out.push(child);
+      walk(child);
+    });
+  };
+  walk(fn);
+  return out;
+}
+
+function functionNamed(source: ts.SourceFile, name: string): ts.Node {
+  let found: ts.Node | undefined;
+  each(source, (n) => {
+    if (ts.isFunctionDeclaration(n) && n.name?.text === name) found = n;
+  });
+  if (!found) throw new Error(`${name} is no longer a function declaration`);
+  return found;
+}
+
+/** The tag name of a returned JSX element, or null for anything else. */
+function returnedTag(statement: ts.ReturnStatement): string | null {
+  const expr = statement.expression;
+  if (!expr) return null;
+  const jsx = ts.isParenthesizedExpression(expr) ? expr.expression : expr;
+  if (ts.isJsxElement(jsx)) return jsx.openingElement.tagName.getText();
+  if (ts.isJsxSelfClosingElement(jsx)) return jsx.tagName.getText();
+  return null;
+}
+
+describe('the About page always has a heading', () => {
+  const source = parse();
+
+  it.each(VARIANTS)('%s returns through the frame in every branch', (name) => {
+    // The component's OWN returns. Descending into nested functions would
+    // collect the `useMemo` callbacks' returns, which are not what renders.
+    const returns = ownReturns(functionNamed(source, name));
+
+    // Loading, failed and success. If a branch is ever added, it is covered by
+    // the same assertion rather than needing a new case here.
+    expect(returns.length).toBeGreaterThanOrEqual(3);
+    expect(returns.map(returnedTag)).toEqual(returns.map(() => FRAME));
+  });
+
+  it('the frame is the one place the page heading lives', () => {
+    const text = readFileSync(FILE, 'utf8');
+    // Exactly one, and it is inside the frame: two would give the page two
+    // titles in the success state, none would put us back where we started.
+    expect(text.match(/<h1[\s>]/g)?.length).toBe(1);
+
+    let headings = 0;
+    each(functionNamed(source, FRAME), (n) => {
+      if (ts.isJsxElement(n) && n.openingElement.tagName.getText() === 'h1') {
+        headings += 1;
+      }
+    });
+    expect(headings).toBe(1);
+  });
+});

--- a/apps/self-hosted/src/features/blog/components/about-page-structure.test.ts
+++ b/apps/self-hosted/src/features/blog/components/about-page-structure.test.ts
@@ -4,7 +4,8 @@ import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 /**
- * A source guard for one rule: the About page has a heading in every outcome.
+ * Source guards for the shape of the About page: it carries the signup, and it
+ * has a heading in every outcome.
  *
  * The page sits under a newsletter section whose own heading is an h2
  * (vision-web#1551). Three of the four shells carry a masthead h1 of their own,
@@ -82,6 +83,40 @@ function returnedTag(statement: ts.ReturnStatement): string | null {
   if (ts.isJsxSelfClosingElement(jsx)) return jsx.tagName.getText();
   return null;
 }
+
+describe('the About page carries the signup', () => {
+  const source = parse();
+
+  /**
+   * Checked here rather than by rendering: AboutPage sits behind the router,
+   * the config store and a react-query provider, and what can regress is the
+   * mount itself. Rendering NewsletterSignup directly, which the component
+   * suite does, cannot see whether the page still mounts it.
+   */
+  it('mounts it once, in the page frame, outside both variants', () => {
+    const body = functionNamed(source, 'AboutPage').getText();
+    expect(body).toContain('<NewsletterSignup placement="page" />');
+
+    // Outside the variant switch on purpose: both variants return early while
+    // their query is loading or failed, and the signup depends on neither.
+    for (const variant of VARIANTS) {
+      expect(functionNamed(source, variant).getText()).not.toContain(
+        'NewsletterSignup',
+      );
+    }
+
+    let mounts = 0;
+    each(source, (n) => {
+      if (
+        ts.isJsxSelfClosingElement(n) &&
+        n.tagName.getText() === 'NewsletterSignup'
+      ) {
+        mounts += 1;
+      }
+    });
+    expect(mounts).toBe(1);
+  });
+});
 
 describe('the About page always has a heading', () => {
   const source = parse();

--- a/apps/self-hosted/src/features/blog/components/about-page.tsx
+++ b/apps/self-hosted/src/features/blog/components/about-page.tsx
@@ -2,7 +2,7 @@
 
 import { getAccountFullQueryOptions } from '@ecency/sdk';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { formatMonthYear, InstanceConfigManager, t } from '@/core';
 import { UserAvatar } from '@/features/shared';
 import { ErrorMessage } from '@/features/shared/error-message';
@@ -39,6 +39,48 @@ export function AboutPage() {
           digest at all. */}
       <NewsletterSignup placement="page" />
     </>
+  );
+}
+
+/**
+ * The page frame, and the heading it always has. The identity is known from
+ * config before any query resolves, so a loading or failed About page is still
+ * a titled page rather than a bare line of text.
+ *
+ * That matters beyond tidiness: without it the first heading on the page is
+ * whatever renders next, which for the newsletter section below is an h2. Three
+ * of the four shells carry a masthead h1 of their own (DefaultShell through
+ * BlogNavigation, journal and terminal directly), but the reader shell renders
+ * its title in a span, so on that template the document would have started at
+ * h2 for as long as the query was loading or failed.
+ */
+function AboutFrame({
+  title,
+  handle,
+  avatar,
+  cover,
+  children,
+}: {
+  title: string;
+  handle?: string;
+  avatar?: ReactNode;
+  cover?: ReactNode;
+  children?: ReactNode;
+}) {
+  return (
+    <article className="max-w-3xl mx-auto">
+      {cover}
+      <div className="flex items-center gap-4 mb-6">
+        {avatar}
+        <div>
+          <h1 className="heading-theme text-2xl sm:text-3xl">{title}</h1>
+          {handle && (
+            <p className="text-sm text-theme-muted font-theme-ui">{handle}</p>
+          )}
+        </div>
+      </div>
+      {children}
+    </article>
   );
 }
 
@@ -87,34 +129,43 @@ function BlogAbout() {
     hasContent: !!data,
   });
 
+  // The handle and the avatar come from config, not from the request, so the
+  // page is recognisable in every outcome.
+  const identity = {
+    handle: `@${username}`,
+    avatar: <UserAvatar username={username} size="sLarge" />,
+  };
+
   if (outcome === 'failed') {
-    return <ErrorMessage onRetry={() => refetch()} />;
+    return (
+      <AboutFrame title={username} {...identity}>
+        <ErrorMessage onRetry={() => refetch()} />
+      </AboutFrame>
+    );
   }
   if (nothingToShow(outcome) || !data) {
     return (
-      <div className="text-center py-12 text-theme-muted">{t('loading')}</div>
+      <AboutFrame title={username} {...identity}>
+        <div className="text-center py-12 text-theme-muted">{t('loading')}</div>
+      </AboutFrame>
     );
   }
 
   return (
-    <article className="max-w-3xl mx-auto">
-      {coverUrl && (
-        <img
-          src={coverUrl}
-          alt=""
-          aria-hidden="true"
-          className="w-full h-40 sm:h-56 object-cover rounded-lg mb-6"
-        />
-      )}
-      <div className="flex items-center gap-4 mb-6">
-        <UserAvatar username={username} size="sLarge" />
-        <div>
-          <h1 className="heading-theme text-2xl sm:text-3xl">
-            {data.name || username}
-          </h1>
-          <p className="text-sm text-theme-muted font-theme-ui">@{username}</p>
-        </div>
-      </div>
+    <AboutFrame
+      title={data.name || username}
+      {...identity}
+      cover={
+        coverUrl && (
+          <img
+            src={coverUrl}
+            alt=""
+            aria-hidden="true"
+            className="w-full h-40 sm:h-56 object-cover rounded-lg mb-6"
+          />
+        )
+      }
+    >
 
       {profile?.about && (
         <p className="text-theme-secondary leading-relaxed mb-6">
@@ -151,7 +202,7 @@ function BlogAbout() {
           </div>
         )}
       </dl>
-    </article>
+    </AboutFrame>
   );
 }
 
@@ -172,11 +223,17 @@ function CommunityAbout() {
   });
 
   if (outcome === 'failed') {
-    return <ErrorMessage onRetry={() => refetch()} />;
+    return (
+      <AboutFrame title={communityId}>
+        <ErrorMessage onRetry={() => refetch()} />
+      </AboutFrame>
+    );
   }
   if (nothingToShow(outcome) || !community) {
     return (
-      <div className="text-center py-12 text-theme-muted">{t('loading')}</div>
+      <AboutFrame title={communityId}>
+        <div className="text-center py-12 text-theme-muted">{t('loading')}</div>
+      </AboutFrame>
     );
   }
 
@@ -185,25 +242,20 @@ function CommunityAbout() {
     : null;
 
   return (
-    <article className="max-w-3xl mx-auto">
-      <div className="flex items-center gap-4 mb-6">
-        {avatarUrl && (
+    <AboutFrame
+      title={community.title || communityId}
+      handle={community.name}
+      avatar={
+        avatarUrl && (
           <img
             src={avatarUrl}
             alt=""
             aria-hidden="true"
             className="size-14 rounded-full object-cover"
           />
-        )}
-        <div>
-          <h1 className="heading-theme text-2xl sm:text-3xl">
-            {community.title || communityId}
-          </h1>
-          <p className="text-sm text-theme-muted font-theme-ui">
-            {community.name}
-          </p>
-        </div>
-      </div>
+        )
+      }
+    >
 
       {community.about && (
         <p className="text-theme-secondary leading-relaxed mb-6">
@@ -215,6 +267,6 @@ function CommunityAbout() {
           {community.description}
         </div>
       )}
-    </article>
+    </AboutFrame>
   );
 }

--- a/apps/self-hosted/src/features/blog/components/about-page.tsx
+++ b/apps/self-hosted/src/features/blog/components/about-page.tsx
@@ -16,6 +16,7 @@ import {
   useInstanceConfig,
 } from '../hooks/use-instance-config';
 import { safeWebsiteUrl } from '../utils/safe-website';
+import { NewsletterSignup } from './newsletter-signup';
 
 /**
  * The About surface, generated from what already exists on chain: a blog
@@ -28,7 +29,17 @@ import { safeWebsiteUrl } from '../utils/safe-website';
 export function AboutPage() {
   useDocumentMeta({ title: t('about_title') });
   const { isCommunityMode } = useInstanceConfig();
-  return isCommunityMode ? <CommunityAbout /> : <BlogAbout />;
+  return (
+    <>
+      {isCommunityMode ? <CommunityAbout /> : <BlogAbout />}
+      {/* Outside the variant on purpose (vision-web#1551): both of them return
+          early while their account or community query is loading or has failed,
+          and the signup depends on neither. This is the one surface every
+          template has, so it is where the four sidebar-less templates offer the
+          digest at all. */}
+      <NewsletterSignup placement="page" />
+    </>
+  );
 }
 
 function BlogAbout() {

--- a/apps/self-hosted/src/features/blog/components/newsletter-signup.test.tsx
+++ b/apps/self-hosted/src/features/blog/components/newsletter-signup.test.tsx
@@ -159,6 +159,8 @@ const submitButton = () =>
 // Two regions, because a failure has to interrupt: role=status is the polite
 // one (the confirmation), role=alert the assertive one (the failure).
 const politeRegion = () => container.querySelector('[role="status"]');
+const resetControl = () =>
+  container.querySelector<HTMLButtonElement>('button[type="button"]');
 const errorRegion = () => container.querySelector('[role="alert"]');
 
 describe('NewsletterSignup', () => {
@@ -393,6 +395,92 @@ describe('NewsletterSignup', () => {
     expect(politeRegion()?.textContent).toBe(
       'Almost there: confirm from the email we just sent.',
     );
+  });
+
+  it('offers a way back from the confirmation, and puts focus on it (#1546)', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) => ({
+      ok: true,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await render();
+    // A plausible fat-finger: .cm for .com. The relay answers 2xx either way,
+    // because double opt-in means it cannot tell a typo from a real address,
+    // so the reader is told to check an inbox that will never receive anything.
+    await typeInto(emailInput(), 'reader@typo.cm');
+    // Where focus sits when a reader submits with the keyboard, on the very
+    // element the success state is about to remove.
+    submitButton()?.focus();
+    await submitForm();
+
+    const back = resetControl();
+    expect(back?.textContent).toBe('Use a different address');
+    // Without moving it, focus falls to <body> when the button is unmounted
+    // and the reader's next Tab restarts at the top of the document.
+    expect(document.activeElement).toBe(back);
+
+    await act(async () => {
+      back?.click();
+    });
+
+    // Back to a usable form, empty, focused, and no longer claiming success.
+    expect(form()).not.toBeNull();
+    expect(emailInput()?.value).toBe('');
+    expect(document.activeElement).toBe(emailInput());
+    expect(politeRegion()?.textContent).toBe('');
+  });
+
+  it('does not steal focus from a reader who moved on mid-request', async () => {
+    const pending = deferred<{ ok: boolean }>();
+    const fetchMock = vi.fn(
+      (_url: string, _init: RequestInit) => pending.promise,
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await render();
+    await typeInto(emailInput(), 'reader@example.com');
+    submitButton()?.focus();
+    await submitForm();
+
+    // They click something else on the page while the request is open.
+    const elsewhere = document.createElement('button');
+    document.body.appendChild(elsewhere);
+    elsewhere.focus();
+
+    await act(async () => {
+      pending.resolve({ ok: true });
+    });
+
+    expect(resetControl()).not.toBeNull();
+    expect(document.activeElement).toBe(elsewhere);
+    elsewhere.remove();
+  });
+
+  it('renders the same form in a page frame for the About page (#1551)', async () => {
+    const section = () =>
+      container.querySelector('[data-testid="newsletter-signup"]');
+
+    await render(<NewsletterSignup placement="page" />);
+    expect(section()?.className).toContain('max-w-3xl');
+    expect(section()?.className).not.toContain('sidebar-newsletter-section');
+    // h2, not h3: the About page opens with an h1 for the account or the
+    // community, and the rail's h3 would skip a level under it.
+    expect(section()?.querySelector('h2')?.textContent).toBe(
+      'Get new posts by email',
+    );
+    expect(section()?.querySelector('h3')).toBeNull();
+    // Only the frame differs: same controls, same accessible names.
+    expect(emailInput()?.getAttribute('aria-label')).toBe('Your email');
+    expect(cadenceSelect()?.getAttribute('aria-label')).toBe('How often');
+    expect(submitButton()?.textContent).toBe('Subscribe');
+
+    // And the default is still the rail section it was born as, where nothing
+    // outranks the heading so h3 is right.
+    await render();
+    expect(section()?.className).toContain('sidebar-newsletter-section');
+    expect(section()?.className).not.toContain('max-w-3xl');
+    expect(section()?.querySelector('h3')).not.toBeNull();
+    expect(section()?.querySelector('h2')).toBeNull();
   });
 
   it('survives an unmount mid-flight, and does not abort the request', async () => {

--- a/apps/self-hosted/src/features/blog/components/newsletter-signup.tsx
+++ b/apps/self-hosted/src/features/blog/components/newsletter-signup.tsx
@@ -14,7 +14,53 @@ import { newsletterSignupTarget, newsletterSubscribeBody } from '../utils/newsle
  * the form always says "check your inbox" on success and can learn nothing
  * about an address it does not own.
  */
-export function NewsletterSignup(): ReactElement | null {
+
+/**
+ * Where the form is being rendered. Only the frame differs: `sidebar` is the
+ * rail section it was born as, `page` is the wider block the About page shows
+ * (vision-web#1551), which is the only surface every template has. The rules,
+ * the request and the states are identical in both.
+ */
+export type NewsletterPlacement = 'sidebar' | 'page';
+
+interface Frame {
+  root: string;
+  /**
+   * The heading ELEMENT, not just its size. In the rail nothing outranks it,
+   * so h3 is fine; the About page opens with an h1 for the account or
+   * community, and jumping straight to h3 would skip a level on the one page
+   * here that has a real heading outline.
+   */
+  heading: 'h2' | 'h3';
+  title: string;
+  blurb: string;
+  /**
+   * The rail is narrow enough to be its own measure. The About column is 3xl
+   * prose, where a full-width email field looks like a mistake.
+   */
+  form: string;
+}
+
+const FRAME: Record<NewsletterPlacement, Frame> = {
+  sidebar: {
+    root: 'border-t border-theme pt-4 mt-4 sidebar-newsletter-section',
+    heading: 'h3',
+    title: 'text-sm font-semibold mb-1',
+    blurb: 'text-xs text-theme-muted mb-2',
+    form: 'flex flex-col gap-2',
+  },
+  page: {
+    root: 'max-w-3xl mx-auto border-t border-theme pt-6 mt-10 page-newsletter-section',
+    heading: 'h2',
+    title: 'heading-theme text-xl mb-1',
+    blurb: 'text-theme-secondary leading-relaxed mb-4',
+    form: 'flex flex-col gap-2 max-w-md',
+  },
+};
+
+export function NewsletterSignup({
+  placement = 'sidebar',
+}: { placement?: NewsletterPlacement } = {}): ReactElement | null {
   const target = InstanceConfigManager.useConfig(({ configuration }) =>
     newsletterSignupTarget({
       username: configuration.instanceConfiguration.username,
@@ -38,8 +84,36 @@ export function NewsletterSignup(): ReactElement | null {
     };
   }, []);
 
+  const root = useRef<HTMLDivElement>(null);
+  const resetButton = useRef<HTMLButtonElement>(null);
+  const emailField = useRef<HTMLInputElement>(null);
+  /**
+   * Set only for the two transitions that REMOVE whatever holds focus: the
+   * form being replaced by the confirmation, and the confirmation being
+   * replaced by the form again. Never on first render, or the page would hand
+   * focus to a sidebar form the moment it loads.
+   */
+  const restoreFocus = useRef(false);
+  useEffect(() => {
+    if (!restoreFocus.current) return;
+    restoreFocus.current = false;
+    const next = state === 'done' ? resetButton.current : state === 'idle' ? emailField.current : null;
+    if (!next) return;
+    // The browser drops focus to <body> when the focused element is removed,
+    // so that (or focus still inside this form) means the reader was here and
+    // has nowhere to stand. Anything else means they moved on while the
+    // request was in flight, and their place is theirs to keep.
+    const active = document.activeElement;
+    if (active && active !== document.body && !root.current?.contains(active)) return;
+    // Without preventScroll, a reader who has scrolled away from the form is
+    // yanked back to it by a request they may have forgotten about.
+    next.focus({ preventScroll: true });
+  }, [state]);
+
   if (!target) return null;
   const isCommunity = target.type === 'community';
+  const frame = FRAME[placement];
+  const Heading = frame.heading;
 
   const submit = async (e: FormEvent) => {
     e.preventDefault();
@@ -51,16 +125,31 @@ export function NewsletterSignup(): ReactElement | null {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(newsletterSubscribeBody(target, email, cadence)),
       });
-      if (mounted.current) setState(res.ok ? 'done' : 'error');
+      if (!mounted.current) return;
+      // Only success swaps the form out, so only success has focus to rescue.
+      restoreFocus.current = res.ok;
+      setState(res.ok ? 'done' : 'error');
     } catch {
       if (mounted.current) setState('error');
     }
   };
 
+  /**
+   * The way back from the confirmation (vision-web#1546). A typo gets the same
+   * 2xx as a real address, because double opt-in means the service cannot tell
+   * one from the other, so without this the reader waits for mail that will
+   * never arrive and the only way out is reloading the page.
+   */
+  const useAnotherAddress = () => {
+    restoreFocus.current = true;
+    setEmail('');
+    setState('idle');
+  };
+
   return (
-    <div className="border-t border-theme pt-4 mt-4 sidebar-newsletter-section" data-testid="newsletter-signup">
-      <h3 className="text-sm font-semibold mb-1">{t('newsletterTitle')}</h3>
-      <p className="text-xs text-theme-muted mb-2">{t(isCommunity ? 'newsletterCommunityBlurb' : 'newsletterBlurb')}</p>
+    <div ref={root} className={frame.root} data-testid="newsletter-signup">
+      <Heading className={frame.title}>{t('newsletterTitle')}</Heading>
+      <p className={frame.blurb}>{t(isCommunity ? 'newsletterCommunityBlurb' : 'newsletterBlurb')}</p>
       {/* Both regions are mounted from the first render, per the live-region
           contract: a region that appears at the same moment as its message is
           often not announced. Two of them, as community-join-button.tsx does,
@@ -73,12 +162,22 @@ export function NewsletterSignup(): ReactElement | null {
         message={state === 'error' ? t('newsletterError') : null}
         className="text-xs block mb-1 text-red-500 dark:text-red-400"
       />
-      {state !== 'done' && (
-        <form onSubmit={submit} className="flex flex-col gap-2">
+      {state === 'done' ? (
+        <button
+          type="button"
+          ref={resetButton}
+          onClick={useAnotherAddress}
+          className="text-xs underline text-theme-muted"
+        >
+          {t('newsletterUseAnotherAddress')}
+        </button>
+      ) : (
+        <form onSubmit={submit} className={frame.form}>
           <input
             type="email"
             required
             autoComplete="email"
+            ref={emailField}
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder={t('newsletterEmail')}

--- a/apps/self-hosted/src/features/blog/components/newsletter-signup.tsx
+++ b/apps/self-hosted/src/features/blog/components/newsletter-signup.tsx
@@ -115,7 +115,7 @@ export function NewsletterSignup({
   const frame = FRAME[placement];
   const Heading = frame.heading;
 
-  const submit = async (e: FormEvent) => {
+  const submit = async (e: FormEvent): Promise<void> => {
     e.preventDefault();
     if (state === 'busy' || !email.trim()) return;
     setState('busy');
@@ -140,7 +140,7 @@ export function NewsletterSignup({
    * one from the other, so without this the reader waits for mail that will
    * never arrive and the only way out is reloading the page.
    */
-  const useAnotherAddress = () => {
+  const useAnotherAddress = (): void => {
     restoreFocus.current = true;
     setEmail('');
     setState('idle');

--- a/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
+++ b/apps/self-hosted/src/features/blog/layout/blog-sidebar.tsx
@@ -1,5 +1,7 @@
 import { formatMonthYear, InstanceConfigManager, t } from "@/core";
+import { useRouterState } from "@tanstack/react-router";
 import { NewsletterSignup } from "../components/newsletter-signup";
+import { sidebarShowsNewsletter } from "../utils/newsletter-signup-target";
 import { useAuth } from "@/features/auth";
 import { InlineError } from "@/features/shared/inline-error";
 import {
@@ -39,7 +41,20 @@ export function BlogSidebar() {
   return <BlogSidebarContent username={username} />;
 }
 
+/**
+ * One signup form per page. The About page carries it in its content column
+ * (vision-web#1551), which is the only surface every template has, so the rail
+ * stands down there rather than showing a second copy. Decided by route rather
+ * than by theme because whether this rail is rendered at all is each
+ * template's own choice, and four of the nine do not render it.
+ */
+function useShowSidebarNewsletter(): boolean {
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  return sidebarShowsNewsletter(pathname);
+}
+
 function BlogSidebarContent({ username }: { username: string }) {
+  const showNewsletter = useShowSidebarNewsletter();
   const { data } = useQuery({
     ...getAccountFullQueryOptions(username),
     enabled: !!username,
@@ -104,7 +119,7 @@ function BlogSidebarContent({ username }: { username: string }) {
           </div>
         </div>
       )}
-      <NewsletterSignup />
+      {showNewsletter && <NewsletterSignup />}
       {data && (
         <div className="border-t border-theme pt-4 mt-4 sidebar-hive-info-section">
           <div className="text-xs font-medium mb-2 text-theme-muted">
@@ -171,6 +186,7 @@ function CommunitySidebarShell({ children }: { children: ReactNode }) {
 }
 
 function CommunitySidebar() {
+  const showNewsletter = useShowSidebarNewsletter();
   const {
     data: community,
     isEnabled,
@@ -319,7 +335,7 @@ function CommunitySidebar() {
         <CommunityJoinButton communityId={communityId} />
       </div>
 
-      <NewsletterSignup />
+      {showNewsletter && <NewsletterSignup />}
         <div className="border-t border-theme pt-4 mt-4 sidebar-hive-info-section">
         <div className="text-xs font-medium mb-2 text-theme-muted">
           {t("community_info")}

--- a/apps/self-hosted/src/features/blog/utils/newsletter-signup-target.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/newsletter-signup-target.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { newsletterSignupTarget, newsletterSubscribeBody } from './newsletter-signup-target';
+import {
+  newsletterSignupTarget,
+  newsletterSubscribeBody,
+  sidebarShowsNewsletter,
+} from './newsletter-signup-target';
 
 describe('newsletterSignupTarget', () => {
   const managedBlog = { username: 'Alice', managed: true, siteTitle: 'Alice Writes' };
@@ -41,5 +45,25 @@ describe('newsletterSignupTarget', () => {
       cadence: 'monthly',
       source: 'self-hosted-blog',
     });
+  });
+});
+
+describe('sidebarShowsNewsletter', () => {
+  it('stands down on the About page, which carries its own', () => {
+    // One form per page: the About page renders it in the content column, and
+    // it is the only surface every template has.
+    expect(sidebarShowsNewsletter('/about')).toBe(false);
+    expect(sidebarShowsNewsletter('/about/')).toBe(false);
+    expect(sidebarShowsNewsletter('/about//')).toBe(false);
+  });
+
+  it('shows it everywhere else, including paths that merely start with it', () => {
+    expect(sidebarShowsNewsletter('/')).toBe(true);
+    expect(sidebarShowsNewsletter('/@alice/hello')).toBe(true);
+    expect(sidebarShowsNewsletter('/search')).toBe(true);
+    // Not a prefix match: a post that happens to live under /about-something
+    // is an ordinary page and still gets the rail's form.
+    expect(sidebarShowsNewsletter('/aboutus')).toBe(true);
+    expect(sidebarShowsNewsletter('/about/extra')).toBe(true);
   });
 });

--- a/apps/self-hosted/src/features/blog/utils/newsletter-signup-target.ts
+++ b/apps/self-hosted/src/features/blog/utils/newsletter-signup-target.ts
@@ -53,3 +53,17 @@ export function newsletterSubscribeBody(t: NewsletterSignupTarget, email: string
     source: 'self-hosted-blog',
   };
 }
+
+/**
+ * Whether the sidebar should carry the signup form on this path. One form per
+ * page: the About page renders its own in the content column (vision-web#1551),
+ * which is the only surface every template has, so the rail stands down there.
+ *
+ * Decided by route rather than by theme on purpose. Whether the rail is
+ * rendered at all is each template's own choice (four of the nine never render
+ * it), so a theme-based rule would have to track every template's structure,
+ * while this one holds for all of them.
+ */
+export function sidebarShowsNewsletter(pathname: string): boolean {
+  return pathname.replace(/\/+$/, '') !== '/about';
+}


### PR DESCRIPTION
Closes #1551. Closes #1546.

### The About page mount

`NewsletterSignup` only ever lived in `blog-sidebar.tsx`, so an instance offered the digest only if its template rendered a rail. Four of the nine do not:

| template | rail | form before this |
| --- | --- | --- |
| medium, minimal, magazine, developer, modern-gradient | DefaultShell renders the seam | yes |
| journal, reader, terminal | their own Shell drops the seam | **no** |
| gallery | replaces the seam with `GallerySidebar`, which never mounted the form | **no** |

Readers of those blogs had no way to subscribe at all, while the owner saw the feature switched on in the editor.

Mounted in `AboutPage` itself rather than inside `BlogAbout` or `CommunityAbout`, because both return early while their account or community query is loading or has failed and the signup depends on neither. As a side effect the community rail's form, which today sits only in the success branch, is no longer the only copy.

**One form per page**: the rail stands down on `/about`. Route based rather than theme based on purpose. Whether the rail is rendered at all is each template's own decision, and gallery shows that "declares the sidebar options unsupported" and "renders no sidebar" are not the same question, so a theme based rule would have to track nine structures while this one holds for all of them. The predicate is pure and tested (`sidebarShowsNewsletter`), following the app's existing "pure half, separated so it is testable" convention.

The `placement` prop changes only the frame. Same rules, same request, same states. On the page it is an `h2` rather than the rail's `h3`, since the About page opens with an `h1` for the account or community and the rail has nothing above it, and the form keeps a `max-w-md` measure instead of stretching across 768px of prose.

### #1546

**The confirmation was a dead end.** A typo gets the same 2xx as a real address, because double opt-in means the service cannot tell them apart, so a reader who typed `reader@typo.cm` saw "Almost there: confirm from the email we just sent" and waited for mail that would never arrive. After success the section contained no buttons, no inputs and no links: the only way out was reloading the page. There is a "use a different address" control now, which clears the field and returns to idle.

**Focus was dropped.** The focused submit button is unmounted on success, so `document.activeElement` became `document.body` and the next Tab restarted at the top of the document. Focus now follows to the new control, and back to the email field on reset.

Focus is moved only when it was ours to move: when the active element is `body` (what the browser leaves behind when it removes the focused node) or still inside this form. A reader who clicked elsewhere while the request was in flight keeps their place. `preventScroll` so a reader who scrolled away is not yanked back by a request they may have forgotten.

### Verification

- 1000 tests pass (76 files), typecheck clean, `rsbuild build` clean and the node-globals guard passes.
- 5 new tests. The three behavioural ones were negative-controlled against the component: remove the focus move and the #1546 test fails; move focus unconditionally and the "does not steal focus" test fails; remove the reset control and 11 of 13 fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added newsletter signup to the About page.
  * Added a full-page newsletter layout alongside the sidebar version.
  * Added a “Use a different address” option after successful signup.
  * Improved focus handling when submitting, confirming, or resetting the form.
  * Newsletter visibility now adapts by page, remaining hidden from the About page sidebar.

* **Tests**
  * Added coverage for signup placement, focus behavior, confirmation recovery, and route-based visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->