### PR TITLE
Give the default shell the bottom room the other three already have

### DIFF
--- a/apps/self-hosted/src/features/blog/layout/default-shell.tsx
+++ b/apps/self-hosted/src/features/blog/layout/default-shell.tsx
@@ -22,7 +22,12 @@ export function DefaultShell(props: PropsWithChildren) {
           </div>
 
           {/* Main content - appears second on mobile/tablet */}
-          <main id="main-content" className="blog-main-container order-2 items-start mt-4 sm:mt-8 section-gap-theme">
+          {/* pb-16 because the last thing on a page should not sit flush
+              against the viewport: the About page ends in the newsletter
+              section, and the archive ends in a card. The other three shells
+              already reserve the same room (journal and terminal pb-16, reader
+              py-6 on its inner column); this one only ever had a top margin. */}
+          <main id="main-content" className="blog-main-container order-2 items-start mt-4 sm:mt-8 pb-16 section-gap-theme">
             <Navigation />
             <BlogPage>{props.children}</BlogPage>
           </main>


### PR DESCRIPTION
Follow-up to #1552, from looking at the merged result: the About page ends in the newsletter section and it sat flush against the bottom of the viewport.

The cause is not that section. `DefaultShell`'s `<main>` carried a top margin and nothing below it, so the last element of **every** page it frames sat flush. The other three shells already reserve the room:

| shell | bottom room |
| --- | --- |
| journal | `<main className="pb-16">` |
| terminal | `<main className="pb-16">` |
| reader | `py-6` on its inner column |
| **default** | **none** |

So this is one class, in the shell, matching the value the other two already chose, rather than padding bolted onto the newsletter section. It fixes the archive's last card and the post page's last block on the same five templates (medium, minimal, magazine, developer, modern-gradient).

Verified: 1004 tests, typecheck clean, `rsbuild build` clean with the node-globals check passing.