### PR TITLE
Restore the card thumbnail slimming dropped, and stop a slim row blanking a body

### DIFF
--- a/apps/web/src/core/caches/entries-cache.tsx
+++ b/apps/web/src/core/caches/entries-cache.tsx
@@ -68,8 +68,15 @@ export namespace EcencyEntriesCacheManagement {
       // wins, which makes the subtype the result actually has. react-query
       // applies structural sharing to select output, so an unchanged entry
       // keeps its previous reference rather than re-rendering consumers.
+      // `data` spreads last so a refetched entry wins, but a feed card seeds this
+      // shared key with a SLIM row (body ""), and that would then blank the body
+      // for a caller that passed a full entry — the decks post viewer renders an
+      // empty article that way, and nothing refetches it because refetchOnMount
+      // is false app-wide. An empty body never overwrites a present one.
       select: (data: Entry | null | undefined) =>
-        data ? ({ ...initialEntry, ...data } as T) : undefined
+        data
+          ? ({ ...initialEntry, ...data, body: data.body || initialEntry?.body || "" } as T)
+          : undefined
     };
   }
 

--- a/apps/web/src/core/entries/slim-entry.ts
+++ b/apps/web/src/core/entries/slim-entry.ts
@@ -1,4 +1,4 @@
-import { getEntryImageRawUrl, postBodySummary } from "@ecency/render-helper";
+import { catchPostImage, getEntryImageRawUrl, postBodySummary } from "@ecency/render-helper";
 import { hasExternalLink } from "@ecency/sdk";
 import { Entry } from "@/entities";
 import { parseEntryLocationFromBody } from "./entry-location";
@@ -59,11 +59,23 @@ function pickThumbnail(entry: Entry): string | undefined {
     }
   }
 
-  // Nothing in metadata: fall back to the post's first body image, which is what
-  // catchPostImage would have found on the full entry. Free here (the body is
-  // right there) and it keeps the thumbnail — and the LCP preload that reads it —
-  // for the ~20% of posts that carry no metadata image at all.
-  return getEntryImageRawUrl(entry) ?? undefined;
+  // Nothing in metadata: recover what catchPostImage would have found on the full
+  // entry, while the body is still here to look at.
+  //
+  // Two steps, because they find different things. getEntryImageRawUrl is the
+  // regex fast path over raw markdown. catchPostImage falls back to a full
+  // markdown2Html plus DOM parse, and THAT is where a video post's poster
+  // (3Speak/YouTube render as <img class="no-replace video-thumbnail">) and
+  // <center>-wrapped bare image URLs are discovered. Stopping at the fast path
+  // dropped those cards to /assets/noimage.png: measured on live posts, 4 of 29
+  // rows that carry no metadata image, concentrated in the video communities.
+  //
+  // The second call only runs when the fast path found nothing, and it is work
+  // the card itself already did before this step existed. catchPostImage(0, 0)
+  // returns the proxied /p/ URL, and re-proxying it at card size reuses the same
+  // hash rather than nesting, so the card src stays byte-identical to what it was
+  // before slimming.
+  return getEntryImageRawUrl(entry) ?? catchPostImage(entry, 0, 0, "match") ?? undefined;
 }
 
 function pickDescription(entry: Entry): string {

--- a/apps/web/src/specs/core/entries-cache-slim.spec.ts
+++ b/apps/web/src/specs/core/entries-cache-slim.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+
+// The global mocks do not carry getPostQueryOptions or makeEntryPath, which
+// entries-cache uses to build the shared key. See CLAUDE.md on partial mocks.
+vi.mock("@ecency/sdk", async () => ({
+  ...(await vi.importActual<object>("@ecency/sdk"))
+}));
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<object>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+import { EcencyEntriesCacheManagement } from "@/core/caches";
+import type { Entry } from "@/entities";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    author: "alice",
+    permlink: "a-post",
+    title: "A title",
+    body: "the full article body",
+    json_metadata: { description: "card summary" },
+    active_votes: [],
+    stats: { total_votes: 0, flag_weight: 0, gray: false, hide: false },
+    ...overrides
+  } as Entry;
+}
+
+/**
+ * Feed cards seed the shared post cache with a SLIM row so their vote, payout and
+ * reblog controls read one entry. Anything else that later asks for the same post
+ * with a full entry in hand — the decks post viewer is the real case — must not be
+ * handed the slim body back.
+ */
+describe("shared entry cache with slim rows", () => {
+  it("does not let a cached slim row blank a full entry's body", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+    const slim = entry({ body: "", slim: { ext_link: false } });
+    const full = entry();
+
+    // A feed card seeds the key first.
+    const seed = EcencyEntriesCacheManagement.getEntryQuery(slim);
+    qc.setQueryData(seed.queryKey, slim);
+
+    // Then a consumer that already holds the whole post reads the same key.
+    const options = EcencyEntriesCacheManagement.getEntryQuery(full);
+    const observer = new QueryObserver(qc, { ...options, enabled: false } as never);
+    const result = observer.getCurrentResult().data as Entry | undefined;
+
+    expect(result?.body).toBe("the full article body");
+    observer.destroy();
+  });
+
+  it("still lets a refetched entry win over the value it was seeded with", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+    const initial = entry({ title: "stale title" });
+    const options = EcencyEntriesCacheManagement.getEntryQuery(initial);
+    qc.setQueryData(options.queryKey, entry({ title: "fresh title" }));
+
+    const observer = new QueryObserver(qc, { ...options, enabled: false } as never);
+    expect((observer.getCurrentResult().data as Entry).title).toBe("fresh title");
+    observer.destroy();
+  });
+});

--- a/apps/web/src/specs/core/entries/slim-entry.spec.ts
+++ b/apps/web/src/specs/core/entries/slim-entry.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { postBodySummary } from "@ecency/render-helper";
+import { catchPostImage, postBodySummary } from "@ecency/render-helper";
 import { ContentModerationReason } from "@ecency/sdk";
 import {
   SLIM_KEY_MARKER,
@@ -63,6 +63,39 @@ describe("slimEntry", () => {
       body: "intro\n\n![pic](https://images.hive.blog/in-body.png)\n\nrest"
     });
     expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/in-body.png"]);
+  });
+
+  it("keeps a video post's poster, which only the full render finds", () => {
+    // A bare YouTube URL becomes an <img class="no-replace video-thumbnail"> in
+    // the rendered post, so the raw-markdown fast path sees no image at all.
+    // Stopping there dropped these cards to the noimage placeholder.
+    const e = entry({
+      json_metadata: {},
+      body: "Check this out\n\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ\n\nthanks"
+    });
+    expect(slimEntry(e).json_metadata?.image?.[0]).toBeTruthy();
+  });
+
+  it("keeps a <center>-wrapped bare image URL, also full-render only", () => {
+    const e = entry({
+      json_metadata: {},
+      body: "<center>https://images.hive.blog/DQmb59qYM1czWSDDw2dRmUHJ7s97L6S6Rk3uZLyA5vCxAEr/pic.jpg</center>"
+    });
+    expect(slimEntry(e).json_metadata?.image?.[0]).toBeTruthy();
+  });
+
+  it("produces the same card src the full entry would have produced", () => {
+    // The whole point: slimming must not change what the card renders. The
+    // recovered URL is already proxied, and re-proxying at card size reuses the
+    // hash rather than nesting it.
+    const e = entry({
+      json_metadata: {},
+      body: "watch\n\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ\n\nend"
+    });
+    const before = catchPostImage(e, 600, 500, "match");
+    const after = catchPostImage(slimEntry(e), 600, 500, "match");
+    expect(after).toBe(before);
+    expect((after?.match(/\/p\//g) ?? []).length).toBe(1);
   });
 
   it("leaves image unset when nothing supplies one, so the card renders without a thumbnail", () => {


### PR DESCRIPTION
Closes #1556. Two defects from #1545, both reproduced against live posts before fixing and each covered by a test that fails without its fix.

### Video posts lost their card thumbnail

`pickThumbnail` ended at `getEntryImageRawUrl`, which is only the regex fast path over raw markdown. `catchPostImage` on a full entry falls back to a complete `markdown2Html` plus DOM parse, and that is where a video post's poster (3Speak and YouTube render as `<img class="no-replace video-thumbnail">`) and `<center>`-wrapped bare image URLs are discovered. Blanking the body made that fallback unreachable, so those cards fell to `/assets/noimage.png` permanently.

Measured on live posts: 4 of 29 rows carrying no metadata image, concentrated in the video communities.

The fallback now runs while the body is still in hand, and only when the fast path found nothing, so it costs nothing for the common case. It is also work the card itself already did before this step existed. The recovered URL is already proxied, and re-proxying it at card size reuses the same hash rather than nesting, so the card `src` is byte-identical to what it was before slimming, which a test asserts directly.

### A slim row could blank a full entry's body

Feed cards seed `QueryKeys.posts.entry` with the slim row so their vote, payout and reblog controls read one entry. `getEntryQuery`'s `select` spreads the cached value last, so a consumer that already held the whole post got `body: ""` back, and `refetchOnMount` being false app-wide meant nothing healed it. The decks post viewer renders an empty article that way.

Fixed centrally rather than per consumer: an empty body never overwrites a present one. A refetched entry still wins on every other field, which the second test pins.

`pnpm typecheck` clean, `pnpm test` green (317 files, 2964 tests).
