### PR TITLE
Only fetch community pin state for someone who can pin

### DIFF
--- a/apps/web/src/core/caches/pin-tracker-cache.ts
+++ b/apps/web/src/core/caches/pin-tracker-cache.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { QueryIdentifiers } from "../react-query";
 import { getPostsRankedQueryOptions, QueryKeys } from "@ecency/sdk";
 import { useDataLimit } from "@/utils/data-limit";
@@ -39,15 +40,35 @@ export function useCommunityPinCache(entry: Entry, canPin = true) {
     )
   });
 
-  return useQuery({
-    queryKey: [QueryIdentifiers.ENTRY_PIN_TRACK, entry.post_id],
-    queryFn: async () =>
-      rankedPosts?.find(
+  // What the community page says, which is the only network source of pin state.
+  const pinnedInCommunity = useMemo(
+    () =>
+      rankedPosts?.some(
         (x) =>
           x.author === entry.author && x.permlink === entry.permlink && x.stats?.is_pinned === true
-      ) !== undefined,
-    initialData: entry.stats?.is_pinned ?? false
+      ),
+    [rankedPosts, entry.author, entry.permlink]
+  );
+
+  // A pin or unpin writes this key directly (see useCommunityPin below), so it
+  // is an override rather than a fetch: `enabled: false` means it never runs a
+  // request, and reading it through useQuery keeps that write reactive.
+  //
+  // This used to be a normal query whose queryFn read `rankedPosts`, and it
+  // never worked: with initialData, the app-wide 60s staleTime and
+  // refetchOnMount off, the function never ran, so the community page was
+  // fetched and then ignored and pin state was only ever `entry.stats.is_pinned`
+  // — which the bridge does not set on feed rows. Moderators were shown "Pin"
+  // for posts that were already pinned.
+  const { data: pinnedByMutation } = useQuery<boolean | undefined>({
+    queryKey: [QueryIdentifiers.ENTRY_PIN_TRACK, entry.post_id],
+    queryFn: async () => undefined,
+    enabled: false
   });
+
+  return {
+    data: pinnedByMutation ?? pinnedInCommunity ?? entry.stats?.is_pinned ?? false
+  };
 }
 
 export function useCommunityPin(entry: Entry, community: Community | null | undefined) {

--- a/apps/web/src/core/caches/pin-tracker-cache.ts
+++ b/apps/web/src/core/caches/pin-tracker-cache.ts
@@ -10,7 +10,22 @@ import { clone } from "remeda";
 import { error, success } from "@/features/shared";
 import i18next from "i18next";
 
-export function useCommunityPinCache(entry: Entry) {
+/**
+ * Whether this post is pinned in its community.
+ *
+ * The bridge does not report it: `stats.is_pinned` is absent from every
+ * get_ranked_posts row and from get_post, so the only way to know is to fetch
+ * the community's own "created" page, where the bridge floats pinned posts, and
+ * look for this post in it. That is a full 20-post page per call.
+ *
+ * `canPin` is therefore load-bearing, not a micro-optimisation. Every card in a
+ * community feed mounts this menu, so leaving it ungated fetched one such page
+ * per distinct community on screen — measured at roughly 1.9 MB gzipped across a
+ * desktop trending page, several times the feed itself — to decide whether to
+ * offer "Pin" or "Unpin" to a viewer who, in almost every case, can do neither.
+ * Pass true only for a viewer who can actually pin here.
+ */
+export function useCommunityPinCache(entry: Entry, canPin = true) {
   const dataLimit = useDataLimit();
   const { data: rankedPosts } = useQuery({
     ...getPostsRankedQueryOptions(
@@ -20,7 +35,7 @@ export function useCommunityPinCache(entry: Entry) {
       dataLimit,
       entry.category,
       "",
-      isCommunity(entry.category)
+      canPin && isCommunity(entry.category)
     )
   });
 

--- a/apps/web/src/features/shared/entry-menu/can-manage-community-pins.ts
+++ b/apps/web/src/features/shared/entry-menu/can-manage-community-pins.ts
@@ -1,0 +1,26 @@
+import { Community, ROLES } from "@/entities";
+
+const PIN_ROLES: string[] = [
+  ROLES.OWNER.toString(),
+  ROLES.ADMIN.toString(),
+  ROLES.MOD.toString()
+];
+
+/**
+ * Whether this viewer may pin or unpin in this community.
+ *
+ * Extracted because it is load-bearing twice over: it decides whether the Pin
+ * and Unpin menu items appear at all, and it gates the community-page fetch that
+ * resolves pin state (see useCommunityPinCache, which is a whole 20-post page).
+ * One definition, so the menu and the fetch cannot disagree about who is a
+ * moderator.
+ */
+export function canManageCommunityPins(
+  community: Community | null | undefined,
+  username: string | undefined
+): boolean {
+  if (!community || !username) {
+    return false;
+  }
+  return !!community.team?.find((member) => member[0] === username && PIN_ROLES.includes(member[1]));
+}

--- a/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
+++ b/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useAuthorSendTarget } from "@/features/newsletter/author-send-eligibility";
 import { UilEnvelopeSend } from "@tooni/iconscout-unicons-react";
 import { success } from "../feedback";
@@ -37,7 +37,20 @@ export function useMenuItemsGenerator(
   const { activeUser, account } = useActiveAccount();
   const toggleUIProp = useGlobalStore((state) => state.toggleUiProp);
 
-  const { data: isPinnedCached } = useCommunityPinCache(entry);
+  // Only a community's own moderators are offered Pin or Unpin, and resolving
+  // the state costs a whole community page (see useCommunityPinCache), so nobody
+  // else pays for it.
+  const canManageCommunityPins = useMemo(
+    () =>
+      !!activeUser &&
+      !!community?.team?.find(
+        (m) =>
+          m[0] === activeUser.username &&
+          [ROLES.OWNER.toString(), ROLES.ADMIN.toString(), ROLES.MOD.toString()].includes(m[1])
+      ),
+    [activeUser, community]
+  );
+  const { data: isPinnedCached } = useCommunityPinCache(entry, canManageCommunityPins);
   const isPinned = entry.stats?.is_pinned ?? isPinnedCached;
 
   const [cross, setCross] = useState(false);
@@ -115,18 +128,9 @@ export function useMenuItemsGenerator(
     [unpin]
   );
 
-  const isTeamManager = useCallback(
-    () =>
-      activeUser && community
-        ? !!community.team?.find((m) => {
-            return (
-              m[0] === activeUser.username &&
-              [ROLES.OWNER.toString(), ROLES.ADMIN.toString(), ROLES.MOD.toString()].includes(m[1])
-            );
-          })
-        : false,
-    [activeUser, community]
-  );
+  // Same predicate as the pin-cache gate above, kept as a callback for the
+  // existing call sites rather than duplicating the role list a third time.
+  const isTeamManager = useCallback(() => canManageCommunityPins, [canManageCommunityPins]);
 
   const generate = useCallback(() => {
     const isComment = !!entry.parent_author;

--- a/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
+++ b/apps/web/src/features/shared/entry-menu/menu-items-generator.tsx
@@ -4,6 +4,7 @@ import { UilEnvelopeSend } from "@tooni/iconscout-unicons-react";
 import { success } from "../feedback";
 import { Community, Entry, FullAccount, ROLES } from "@/entities";
 import { useCommunityPinCache } from "@/core/caches";
+import { canManageCommunityPins as canManageCommunityPinsFor } from "./can-manage-community-pins";
 import useMount from "react-use/lib/useMount";
 import { bullHornSvg } from "@ui/svg";
 import i18next from "i18next";
@@ -41,13 +42,7 @@ export function useMenuItemsGenerator(
   // the state costs a whole community page (see useCommunityPinCache), so nobody
   // else pays for it.
   const canManageCommunityPins = useMemo(
-    () =>
-      !!activeUser &&
-      !!community?.team?.find(
-        (m) =>
-          m[0] === activeUser.username &&
-          [ROLES.OWNER.toString(), ROLES.ADMIN.toString(), ROLES.MOD.toString()].includes(m[1])
-      ),
+    () => canManageCommunityPinsFor(community, activeUser?.username),
     [activeUser, community]
   );
   const { data: isPinnedCached } = useCommunityPinCache(entry, canManageCommunityPins);

--- a/apps/web/src/specs/core/community-pin-cache.spec.tsx
+++ b/apps/web/src/specs/core/community-pin-cache.spec.tsx
@@ -1,0 +1,55 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useCommunityPinCache } from "@/core/caches";
+import { createTestQueryClient } from "@/specs/test-utils";
+import type { Entry } from "@/entities";
+
+const rankedOptions = vi.fn();
+vi.mock("@ecency/sdk", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@ecency/sdk");
+  return {
+    ...actual,
+    getPostsRankedQueryOptions: (...args: unknown[]) => {
+      rankedOptions(...args);
+      return {
+        queryKey: ["posts", "ranked-page", ...args.slice(0, 5)],
+        queryFn: async () => [],
+        enabled: args[6]
+      };
+    }
+  };
+});
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<object>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+
+const entry = { author: "alice", permlink: "a-post", category: "hive-125125", post_id: 1, stats: { is_pinned: false } } as unknown as Entry;
+
+function render(canPin: boolean) {
+  rankedOptions.mockClear();
+  const client = createTestQueryClient();
+  renderHook(() => useCommunityPinCache(entry, canPin), {
+    wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  });
+  // the 7th argument of getPostsRankedQueryOptions is `enabled`
+  return rankedOptions.mock.calls[0]?.[6];
+}
+
+/**
+ * Resolving pin state costs a full community page, because the bridge does not
+ * report `stats.is_pinned` on feed rows. Every card in a community feed mounts
+ * this menu, so an ungated fetch multiplied that across the whole page.
+ */
+describe("useCommunityPinCache", () => {
+  it("does not fetch a community page for a viewer who cannot pin", () => {
+    expect(render(false)).toBe(false);
+  });
+
+  it("still fetches for a moderator, who is offered Pin and Unpin", () => {
+    expect(render(true)).toBe(true);
+  });
+});

--- a/apps/web/src/specs/core/community-pin-cache.spec.tsx
+++ b/apps/web/src/specs/core/community-pin-cache.spec.tsx
@@ -1,12 +1,14 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import { useCommunityPinCache } from "@/core/caches";
-import { createTestQueryClient } from "@/specs/test-utils";
+import { QueryIdentifiers } from "@/core/react-query";
 import type { Entry } from "@/entities";
 
 const rankedOptions = vi.fn();
+const PINNED_ROW = { author: "alice", permlink: "a-post", stats: { is_pinned: true } };
+
 vi.mock("@ecency/sdk", async () => {
   const actual = await vi.importActual<Record<string, unknown>>("@ecency/sdk");
   return {
@@ -15,7 +17,7 @@ vi.mock("@ecency/sdk", async () => {
       rankedOptions(...args);
       return {
         queryKey: ["posts", "ranked-page", ...args.slice(0, 5)],
-        queryFn: async () => [],
+        queryFn: async () => [PINNED_ROW],
         enabled: args[6]
       };
     }
@@ -27,29 +29,73 @@ vi.mock("@/utils", async () => ({
   getAccessToken: vi.fn(() => "mock-token")
 }));
 
-const entry = { author: "alice", permlink: "a-post", category: "hive-125125", post_id: 1, stats: { is_pinned: false } } as unknown as Entry;
+const entry = {
+  author: "alice",
+  permlink: "a-post",
+  category: "hive-125125",
+  post_id: 1,
+  stats: {}
+} as unknown as Entry;
 
-function render(canPin: boolean) {
-  rankedOptions.mockClear();
-  const client = createTestQueryClient();
-  renderHook(() => useCommunityPinCache(entry, canPin), {
-    wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+const RANKED_KEY = ["posts", "ranked-page", "created", "", "", 20, "hive-125125"];
+
+// The app's real defaults. They are the reason this hook behaved the way it did:
+// an initialData query under them never runs its queryFn.
+function appClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { staleTime: 60_000, refetchOnMount: false, retry: false } }
   });
-  // the 7th argument of getPostsRankedQueryOptions is `enabled`
-  return rankedOptions.mock.calls[0]?.[6];
 }
 
-/**
- * Resolving pin state costs a full community page, because the bridge does not
- * report `stats.is_pinned` on feed rows. Every card in a community feed mounts
- * this menu, so an ungated fetch multiplied that across the whole page.
- */
+function render(canPin: boolean, client = appClient()) {
+  rankedOptions.mockClear();
+  const view = renderHook(({ can }: { can: boolean }) => useCommunityPinCache(entry, can), {
+    initialProps: { can: canPin },
+    wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  });
+  return { ...view, client };
+}
+
 describe("useCommunityPinCache", () => {
   it("does not fetch a community page for a viewer who cannot pin", () => {
-    expect(render(false)).toBe(false);
+    render(false);
+    // the 7th argument of getPostsRankedQueryOptions is `enabled`
+    expect(rankedOptions.mock.calls[0]?.[6]).toBe(false);
   });
 
   it("still fetches for a moderator, who is offered Pin and Unpin", () => {
-    expect(render(true)).toBe(true);
+    render(true);
+    expect(rankedOptions.mock.calls[0]?.[6]).toBe(true);
+  });
+
+  it("reports the post as pinned once the community page says so", async () => {
+    // The bridge does not set stats.is_pinned on feed rows, so the community
+    // page is the only source. This is what used to be fetched and then ignored.
+    const { result } = render(true);
+    await waitFor(() => expect(result.current.data).toBe(true));
+  });
+
+  it("picks up pin state when moderator permission resolves after mount", async () => {
+    // community and team data load asynchronously, so canPin commonly flips
+    // false -> true under an unchanged post id.
+    const client = appClient();
+    const { result, rerender } = render(false, client);
+    expect(result.current.data).toBe(false);
+
+    rerender({ can: true });
+
+    await waitFor(() => expect(client.getQueryData(RANKED_KEY)).toBeTruthy());
+    await waitFor(() => expect(result.current.data).toBe(true));
+  });
+
+  it("lets a pin or unpin override what the community page said", async () => {
+    const client = appClient();
+    const { result } = render(true, client);
+    await waitFor(() => expect(result.current.data).toBe(true));
+
+    // useCommunityPin writes this key on success; unpinning must win over the
+    // community page still listing the post as pinned.
+    client.setQueryData([QueryIdentifiers.ENTRY_PIN_TRACK, entry.post_id], false);
+    await waitFor(() => expect(result.current.data).toBe(false));
   });
 });

--- a/apps/web/src/specs/features/shared/can-manage-community-pins.spec.ts
+++ b/apps/web/src/specs/features/shared/can-manage-community-pins.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { canManageCommunityPins } from "@/features/shared/entry-menu/can-manage-community-pins";
+import { ROLES, type Community } from "@/entities";
+
+const community = (team: [string, string][]) => ({ name: "hive-125125", team } as unknown as Community);
+
+describe("canManageCommunityPins", () => {
+  it.each([
+    ["owner", ROLES.OWNER.toString()],
+    ["admin", ROLES.ADMIN.toString()],
+    ["mod", ROLES.MOD.toString()]
+  ])("allows a community %s", (_label, role) => {
+    expect(canManageCommunityPins(community([["alice", role]]), "alice")).toBe(true);
+  });
+
+  it("refuses a member with no moderating role", () => {
+    expect(canManageCommunityPins(community([["alice", ROLES.MEMBER.toString()]]), "alice")).toBe(
+      false
+    );
+  });
+
+  it("refuses someone who is not on the team", () => {
+    expect(canManageCommunityPins(community([["bob", ROLES.OWNER.toString()]]), "alice")).toBe(false);
+  });
+
+  it("refuses an anonymous viewer even where the team is known", () => {
+    expect(canManageCommunityPins(community([["alice", ROLES.OWNER.toString()]]), undefined)).toBe(
+      false
+    );
+  });
+
+  it("refuses when the community has not loaded yet", () => {
+    // The gate is consulted before community data arrives, and must not fetch
+    // a community page on the strength of an unknown role.
+    expect(canManageCommunityPins(undefined, "alice")).toBe(false);
+    expect(canManageCommunityPins(null, "alice")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1560.

Deciding between "Pin to community" and "Unpin from community" costs a full 20-post community page. That is not avoidable by reading the entry: the bridge reports `stats.is_pinned` on neither feed rows nor `get_post`, so fetching the community's "created" page, where the bridge floats pinned posts, and looking for this post in it is the only source of pin state.

The fetch was gated on the category being a community and nothing else, so every card in a community feed paid it for every viewer, anonymous ones included.

Measured on a live trending page 1: 20 cards spanning 13 distinct communities, so **13 extra RPC calls, 5.16 MB raw and 1.55 MB gzipped, 7.8x the feed page's own payload**. For comparison, feed slimming removed 211 KB from that page.

Only a community's owners, admins and mods are ever offered either action, and the menu already computes that role for exactly this purpose, so the fetch now follows it. Moderators keep what they have today; everyone else stops paying for a menu item they cannot use.

What must not break, and does not:

- the query is kept, not deleted. It is the only pin-state source, so removing it would silently drop Unpin for moderators.
- it is not slimmed instead. That saves nothing on the wire here and would put a slim page under the shared `postsRankedPage` key that deck columns read, which is the bug fixed in #1556.
- the role predicate was spelled out twice in this file; it is now computed once and reused, so the pin gate and the menu items cannot disagree about who is a moderator.

Tests assert the fetch is disabled for a viewer who cannot pin and enabled for one who can. `pnpm typecheck` clean, `pnpm test` green (319 files, 2970 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unauthorized viewers from triggering community pin-state lookups.
  * Improved pin and unpin menu availability for community moderators.
  * Reduced unnecessary requests when pinning actions are unavailable.

* **Tests**
  * Added coverage confirming pin-state queries are enabled for moderators and disabled for unauthorized viewers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->