### PR TITLE
Guard the feed slimming, in behaviour and in shape

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -43,3 +43,10 @@ jobs:
         run: node scripts/icon-scss-audit.mjs
       - name: Icon convention audit (TSX)
         run: node scripts/icon-tsx-audit.mjs --fail
+      # Slim-entry convention (apps/web/src/core/entries/slim-entry.ts). Enforces
+      # how a feed query is slimmed: a single-page builder needs its own cache
+      # identity, because deck columns read those page keys and render the body
+      # from them, and an infinite builder must not take one, because the feed
+      # poll hand-builds that key for its merge.
+      - name: Slim-entry convention audit
+        run: node scripts/slim-entries-audit.mjs --fail

--- a/apps/web/src/app/(dynamicPages)/feed/_components/feed-layout.tsx
+++ b/apps/web/src/app/(dynamicPages)/feed/_components/feed-layout.tsx
@@ -10,7 +10,7 @@ import { LinearProgress } from "@/features/shared/linear-progress";
 import { UserAvatar } from "@/features/shared/user-avatar";
 import { getPostsRankedQueryOptions, QueryKeys } from "@ecency/sdk";
 import { getQueryClient } from "@/core/react-query";
-import { withSlimEntries } from "@/core/entries/slim-entry";
+import { withSlimPageEntries } from "@/core/entries/slim-entry";
 import type { InfiniteData } from "@tanstack/react-query";
 
 const MAX_PENDING = 20;
@@ -90,9 +90,8 @@ export function FeedLayout(props: PropsWithChildren<Props>) {
       // Own cache identity: this SDK page key is also read by deck columns,
       // which render whole posts. The merge below reads the returned value, not
       // the cache, so the marker costs nothing here.
-      const pollOptions = withSlimEntries(
-        getPostsRankedQueryOptions(props.filter, "", "", MAX_PENDING, props.tag, props.observer),
-        { isolateKey: true }
+      const pollOptions = withSlimPageEntries(
+        getPostsRankedQueryOptions(props.filter, "", "", MAX_PENDING, props.tag, props.observer)
       );
       const resp = await queryClient.fetchQuery({
         ...pollOptions,

--- a/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/author-archive.ts
+++ b/apps/web/src/app/(dynamicPages)/profile/[username]/_helpers/author-archive.ts
@@ -1,7 +1,7 @@
 import { Entry } from "@/entities";
 import { fetchQuery } from "@/core/react-query";
 import { getAccountPostsQueryOptions } from "@ecency/sdk";
-import { withSlimEntries } from "@/core/entries/slim-entry";
+import { withSlimPageEntries } from "@/core/entries/slim-entry";
 
 // Hive's bridge.get_account_posts caps `limit` at 20, and it's cursor-based
 // (start_author/start_permlink, exclusive). So archive pages use O(1)
@@ -70,7 +70,7 @@ export async function fetchAuthorCursorPage(
         ? options
         : // Own cache identity: this SDK page key is also read by deck columns,
           // which render whole posts.
-          withSlimEntries(options, { isolateKey: true })
+          withSlimPageEntries(options)
     )) as unknown as Entry[] | undefined) ?? [];
 
   const hasNext = entries.length === ARCHIVE_PAGE_SIZE;

--- a/apps/web/src/core/entries/slim-entry.ts
+++ b/apps/web/src/core/entries/slim-entry.ts
@@ -143,47 +143,11 @@ export function slimEntryPage<T>(page: T): T {
 
 type WithQueryFn = { queryFn?: unknown; queryKey?: unknown };
 
-interface SlimOptions {
-  /**
-   * Cache the slim pages under their own key instead of the SDK's.
-   *
-   * Needed wherever the SDK key is ALSO read by something that needs whole posts.
-   * The single-page keys (`postsRankedPage` / `accountPostsPage`) are shared with
-   * the deck columns, which fetch the same sort/cursor/limit and then render
-   * `entry.body` in their post viewer: a slim page cached under that key would be
-   * handed straight to a deck within the 60s staleTime, and the viewer would show
-   * an empty post. The feed's own infinite keys need no marker, since the server
-   * prefetch, the cache read and the client hook are the only readers and all
-   * three build their options through one slimmed builder.
-   */
-  isolateKey?: boolean;
-}
-
-/**
- * Wrap feed query options so their pages arrive slim.
- *
- * Applied to the queryFn rather than `select` on purpose: `select` runs after the
- * data is cached, so the bodies would still be dehydrated into the SSR payload and
- * still sit in the client cache. Wrapping the fetch means one slim copy exists,
- * server and client alike, and React Flight can dedupe it by reference.
- *
- * Every other option is passed through untouched, so this cannot split a cache
- * entry away from the one a page already renders.
- */
-export function withSlimEntries<T extends WithQueryFn>(
-  options: T,
-  { isolateKey = false }: SlimOptions = {}
-): T {
+function slimQueryFn<T extends WithQueryFn>(options: T, queryKey: unknown): T {
   const queryFn = options.queryFn;
   if (typeof queryFn !== "function") {
     return options;
   }
-
-  const queryKey =
-    isolateKey && Array.isArray(options.queryKey)
-      ? [...options.queryKey, SLIM_KEY_MARKER]
-      : options.queryKey;
-
   return {
     ...options,
     queryKey,
@@ -192,5 +156,45 @@ export function withSlimEntries<T extends WithQueryFn>(
   } as T;
 }
 
-/** Appended to a query key that holds slim pages. See SlimOptions.isolateKey. */
+/**
+ * Wrap feed query options so their pages arrive slim, keeping the SDK's key.
+ *
+ * For queries whose key is only ever read by slimmed readers: the feed's infinite
+ * keys, where the server prefetch, the cache read and the client hook all build
+ * their options through one builder, and the promoted feed. The feed poll also
+ * hand-builds the infinite key for its setQueryData merge, so that key must stay
+ * exactly what the SDK produced.
+ *
+ * Applied to the queryFn rather than `select` on purpose: `select` runs after the
+ * data is cached, so the bodies would still be dehydrated into the SSR payload and
+ * still sit in the client cache. Wrapping the fetch means one slim copy exists,
+ * server and client alike, and React Flight can dedupe it by reference.
+ *
+ * Every other option is passed through untouched.
+ */
+export function withSlimEntries<T extends WithQueryFn>(options: T): T {
+  return slimQueryFn(options, options.queryKey);
+}
+
+/**
+ * The same, for a SINGLE-PAGE builder, whose key gets its own identity.
+ *
+ * `postsRankedPage` and `accountPostsPage` are read by the deck columns too, and
+ * decks render `entry.body` from what they find there. A slim page cached under
+ * the SDK's own key is handed straight to a deck inside the staleTime and its
+ * post viewer renders an empty article, which is what issue #1556 was.
+ *
+ * This exists as a separate function rather than a flag on the one above because
+ * a flag can be forgotten, and forgetting it is exactly that bug. There is no
+ * argument here to get wrong: choosing the function names the intent, and an
+ * audit checks that the choice matches the builder.
+ */
+export function withSlimPageEntries<T extends WithQueryFn>(options: T): T {
+  const queryKey = Array.isArray(options.queryKey)
+    ? [...options.queryKey, SLIM_KEY_MARKER]
+    : options.queryKey;
+  return slimQueryFn(options, queryKey);
+}
+
+/** Appended to a query key that holds slim pages, so nothing else reads them. */
 export const SLIM_KEY_MARKER = "slim";

--- a/apps/web/src/features/seo/ranked-archive.ts
+++ b/apps/web/src/features/seo/ranked-archive.ts
@@ -1,5 +1,5 @@
 import { Entry } from "@/entities";
-import { withSlimEntries } from "@/core/entries/slim-entry";
+import { withSlimPageEntries } from "@/core/entries/slim-entry";
 import { fetchQuery } from "@/core/react-query";
 import { getPostsRankedQueryOptions } from "@ecency/sdk";
 
@@ -100,7 +100,7 @@ export async function fetchRankedCursorPage(
     ((await fetchQuery(
       // Slim like the live feed: these pages render the same cards, and they are
       // the crawler-facing copy, where payload weight matters most.
-      withSlimEntries(
+      withSlimPageEntries(
         getPostsRankedQueryOptions(
           sort,
           cursor.author,
@@ -108,10 +108,7 @@ export async function fetchRankedCursorPage(
           ARCHIVE_PAGE_SIZE,
           tag,
           observer
-        ),
-        // Own cache identity: this SDK page key is also read by deck columns,
-        // which render whole posts.
-        { isolateKey: true }
+        )
       )
     )) as unknown as Entry[] | undefined) ?? [];
   const last = entries[entries.length - 1];

--- a/apps/web/src/specs/api/queries/feed-slimming.spec.tsx
+++ b/apps/web/src/specs/api/queries/feed-slimming.spec.tsx
@@ -1,23 +1,14 @@
 import React from "react";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, type RenderHookResult } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Entry } from "@/entities";
+import { mockEntry } from "@/specs/test-utils";
 
 const BODY = "the whole post body, which a card never renders";
 
 function fullEntry(permlink: string): Entry {
-  return {
-    author: "alice",
-    permlink,
-    title: "A title",
-    body: BODY,
-    json_metadata: {},
-    active_votes: [],
-    created: "2026-08-01T00:00:00",
-    updated: "2026-08-01T00:00:00",
-    stats: { total_votes: 0, flag_weight: 0, gray: false, hide: false }
-  } as unknown as Entry;
+  return mockEntry({ author: "alice", permlink, body: BODY, json_metadata: {} });
 }
 
 vi.mock("@/utils", async () => ({
@@ -43,7 +34,10 @@ vi.mock("@ecency/sdk", async () => {
 
 import { usePostsFeedQuery } from "@/api/queries";
 
-function firstPage(what: string, tag: string) {
+function firstPage(what: string, tag: string): RenderHookResult<
+  ReturnType<typeof usePostsFeedQuery>,
+  unknown
+> {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
   return renderHook(() => usePostsFeedQuery(what, tag, "ecency"), {
     wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
@@ -59,6 +53,7 @@ function firstPage(what: string, tag: string) {
 describe("feed queries ship slim entries", () => {
   it.each([
     ["a ranked feed", "trending", ""],
+    ["the personal feed, which takes its own branch", "feed", ""],
     ["a tag feed", "created", "photography"],
     ["a profile's posts", "posts", "@alice"],
     ["a profile's blog", "blog", "@alice"]

--- a/apps/web/src/specs/api/queries/feed-slimming.spec.tsx
+++ b/apps/web/src/specs/api/queries/feed-slimming.spec.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Entry } from "@/entities";
+
+const BODY = "the whole post body, which a card never renders";
+
+function fullEntry(permlink: string): Entry {
+  return {
+    author: "alice",
+    permlink,
+    title: "A title",
+    body: BODY,
+    json_metadata: {},
+    active_votes: [],
+    created: "2026-08-01T00:00:00",
+    updated: "2026-08-01T00:00:00",
+    stats: { total_votes: 0, flag_weight: 0, gray: false, hide: false }
+  } as unknown as Entry;
+}
+
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<typeof import("@/utils")>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+
+vi.mock("@ecency/sdk", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@ecency/sdk");
+  const page = (key: string) => ({
+    queryKey: ["posts", key],
+    initialPageParam: { author: undefined, permlink: undefined },
+    getNextPageParam: () => undefined,
+    queryFn: async () => [fullEntry("p1"), fullEntry("p2")]
+  });
+  return {
+    ...actual,
+    getPostsRankedInfiniteQueryOptions: () => page("ranked"),
+    getAccountPostsInfiniteQueryOptions: () => page("account")
+  };
+});
+
+import { usePostsFeedQuery } from "@/api/queries";
+
+function firstPage(what: string, tag: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return renderHook(() => usePostsFeedQuery(what, tag, "ecency"), {
+    wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  });
+}
+
+/**
+ * The payload win from slimming is invisible to every other test: deleting
+ * withSlimEntries from the feed builder leaves lint, typecheck and the rest of
+ * the suite green, because they either test the helper in isolation or stub the
+ * queryFn. These drive the real builder and look at what a card would receive.
+ */
+describe("feed queries ship slim entries", () => {
+  it.each([
+    ["a ranked feed", "trending", ""],
+    ["a tag feed", "created", "photography"],
+    ["a profile's posts", "posts", "@alice"],
+    ["a profile's blog", "blog", "@alice"]
+  ])("drops the body on %s", async (_label, what, tag) => {
+    const { result } = firstPage(what, tag);
+    await waitFor(() => expect(result.current.data?.pages?.[0]).toBeTruthy());
+
+    const entries = result.current.data!.pages[0] as Entry[];
+    expect(entries.length).toBeGreaterThan(0);
+    for (const entry of entries) {
+      expect(entry.body).toBe("");
+      // and the card still has something to render
+      expect(entry.json_metadata?.description).toBeTruthy();
+    }
+  });
+
+  it.each([
+    ["comments", "comments"],
+    ["replies", "replies"]
+  ])("keeps the body on a profile's %s, where the card IS the body", async (_l, section) => {
+    const { result } = firstPage(section, "@alice");
+    await waitFor(() => expect(result.current.data?.pages?.[0]).toBeTruthy());
+
+    const entries = result.current.data!.pages[0] as Entry[];
+    for (const entry of entries) {
+      expect(entry.body).toBe(BODY);
+    }
+  });
+});

--- a/apps/web/src/specs/api/queries/feed-slimming.spec.tsx
+++ b/apps/web/src/specs/api/queries/feed-slimming.spec.tsx
@@ -78,6 +78,8 @@ describe("feed queries ship slim entries", () => {
     await waitFor(() => expect(result.current.data?.pages?.[0]).toBeTruthy());
 
     const entries = result.current.data!.pages[0] as Entry[];
+    // an empty page would satisfy the loop below without proving anything
+    expect(entries.length).toBeGreaterThan(0);
     for (const entry of entries) {
       expect(entry.body).toBe(BODY);
     }

--- a/apps/web/src/specs/core/entries/slim-entry.spec.ts
+++ b/apps/web/src/specs/core/entries/slim-entry.spec.ts
@@ -5,7 +5,8 @@ import {
   SLIM_KEY_MARKER,
   slimEntry,
   slimEntryPage,
-  withSlimEntries
+  withSlimEntries,
+  withSlimPageEntries
 } from "@/core/entries/slim-entry";
 import { getEntryModerationReason } from "@/core/entries/entry-moderation";
 import type { Entry } from "@/entities";
@@ -180,13 +181,15 @@ describe("withSlimEntries", () => {
     expect(withSlimEntries({ queryKey: key, queryFn: async () => [] }).queryKey).toBe(key);
   });
 
-  it("gives slim pages their own key when asked, so full-body readers cannot pick them up", () => {
+  it("gives a single page its own key, so full-body readers cannot pick it up", () => {
     // Deck columns fetch the same SDK page key and render entry.body, so slim
-    // pages must not be sitting under it when they do.
-    const wrapped = withSlimEntries(
-      { queryKey: ["posts", "ranked-page", "trending", "", "", 20], queryFn: async () => [] },
-      { isolateKey: true }
-    );
+    // pages must not be sitting under it when they do. This is a separate
+    // function rather than a flag precisely because a flag can be left off, and
+    // leaving it off was issue #1556.
+    const wrapped = withSlimPageEntries({
+      queryKey: ["posts", "ranked-page", "trending", "", "", 20],
+      queryFn: async () => []
+    });
     expect(wrapped.queryKey).toEqual([
       "posts",
       "ranked-page",
@@ -196,6 +199,15 @@ describe("withSlimEntries", () => {
       20,
       SLIM_KEY_MARKER
     ]);
+  });
+
+  it("slims the pages of a single-page query too", async () => {
+    const wrapped = withSlimPageEntries({
+      queryKey: ["posts", "ranked-page"],
+      queryFn: async () => [entry()]
+    });
+    const page = await wrapped.queryFn();
+    expect(page[0].body).toBe("");
   });
 
   it("returns options untouched when there is no queryFn", () => {

--- a/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
+++ b/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
@@ -235,4 +235,69 @@ describe("slim-entries audit", () => {
     expect(found).toHaveLength(1);
     expect(found[0]).toContain("use withSlimPageEntries");
   });
+
+  // Scope resolution, the whole model rather than the one shape reported. Both
+  // resolvers now share one collector, because they had drifted apart and each
+  // descended into child blocks.
+  it("does not let a closed if-block shadow a name used after it", () => {
+    const found = auditSource(
+      "f.ts",
+      `import { withSlimEntries } from "@/core/entries/slim-entry";
+       import { getPostsRankedQueryOptions as build } from "@ecency/sdk";
+       export function f(flag) {
+         if (flag) {
+           const build = getPostsRankedInfiniteQueryOptions;
+           void build;
+         }
+         return withSlimEntries(build("t", "", "", 20, "", ""));
+       }`
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("use withSlimPageEntries");
+  });
+
+  it("resolves to the inner const for a call inside that block", () => {
+    expect(
+      auditSource(
+        "f.ts",
+        src(`export function h(flag) {
+               if (flag) {
+                 const options = getPostsRankedInfiniteQueryOptions("t", "");
+                 return withSlimEntries(options);
+               }
+             }`)
+      )
+    ).toEqual([]);
+  });
+
+  it.each([
+    [
+      "a switch case",
+      `export function s(k) {
+         switch (k) {
+           case 1: {
+             const options = getPostsRankedQueryOptions("t");
+             return withSlimEntries(options);
+           }
+           default:
+             return null;
+         }
+       }`
+    ],
+    [
+      "a for loop that has already closed",
+      `export function l() {
+         for (let i = 0; i < 2; i++) {
+           const options = getPostsRankedInfiniteQueryOptions("t", "");
+           void options;
+         }
+         const options = getPostsRankedQueryOptions("t");
+         return withSlimEntries(options);
+       }`
+    ]
+  ])("gets the binding right across %s", (_label, body) => {
+    const found = auditSource("f.ts", src(body));
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("use withSlimPageEntries");
+  });
 });

--- a/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
+++ b/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { auditSource } from "../../../../../scripts/slim-entries-audit.mjs";
+
+/**
+ * The audit's first version only matched a builder written inline, so both real
+ * call sites, which pass the options through a local const, slipped past it: the
+ * guard reported "no findings" while the exact regressions it exists to prevent
+ * were present. These fixtures pin the shapes that actually appear in the app.
+ */
+const src = (body: string) => `import { withSlimEntries } from "@/core/entries/slim-entry";\n${body}\n`;
+
+describe("slim-entries audit", () => {
+  it("accepts a single-page builder that isolates its key", () => {
+    expect(
+      auditSource("f.ts", src(`const o = withSlimEntries(getPostsRankedQueryOptions("created"), { isolateKey: true });`))
+    ).toEqual([]);
+  });
+
+  it("flags a single-page builder written inline without isolateKey", () => {
+    const found = auditSource("f.ts", src(`const o = withSlimEntries(getPostsRankedQueryOptions("created"));`));
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("needs { isolateKey: true }");
+  });
+
+  it("flags a single-page builder passed through a variable, the real shape", () => {
+    const found = auditSource(
+      "f.ts",
+      src(`function load() {
+        const options = getAccountPostsQueryOptions("alice", "posts");
+        return withSlimEntries(options);
+      }`)
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("getAccountPostsQueryOptions");
+  });
+
+  it("accepts that same variable shape once it isolates the key", () => {
+    expect(
+      auditSource(
+        "f.ts",
+        src(`function load() {
+          const options = getAccountPostsQueryOptions("alice", "posts");
+          return withSlimEntries(options, { isolateKey: true });
+        }`)
+      )
+    ).toEqual([]);
+  });
+
+  it("flags an infinite builder that isolates its key, through a variable", () => {
+    const found = auditSource(
+      "f.ts",
+      src(`function build() {
+        const options = getAccountPostsInfiniteQueryOptions("alice", "posts");
+        return withSlimEntries(options, { isolateKey: true });
+      }`)
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("must NOT set isolateKey");
+  });
+
+  it("accepts an infinite builder with no options", () => {
+    expect(
+      auditSource("f.ts", src(`const o = withSlimEntries(getPostsRankedInfiniteQueryOptions("trending", ""));`))
+    ).toEqual([]);
+  });
+
+  it("reports an identifier it cannot trace rather than passing it", () => {
+    // A guard that silently ignores what it cannot read is not a guard: that is
+    // precisely how the variable shape went unchecked. An options value from
+    // outside the function cannot be classified, so it is reported.
+    const found = auditSource("f.ts", src(`const o = withSlimEntries(importedOptions);`));
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("cannot tell which builder is wrapped");
+  });
+
+  it("ignores a wrapper around something that is not a feed builder", () => {
+    // getPromotedPostsQuery is slimmed too and needs no key opinion.
+    expect(auditSource("f.ts", src(`const o = withSlimEntries(getPromotedPostsQuery());`))).toEqual([]);
+  });
+
+  it("reports options it cannot read literally", () => {
+    const found = auditSource(
+      "f.ts",
+      src(`const o = withSlimEntries(getPostsRankedQueryOptions("created"), opts);`)
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("cannot read");
+  });
+
+  it("says nothing about queries that are not slimmed", () => {
+    expect(auditSource("f.ts", src(`const o = getPostsRankedQueryOptions("created");`))).toEqual([]);
+  });
+});

--- a/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
+++ b/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
@@ -189,4 +189,50 @@ describe("slim-entries audit", () => {
     expect(found).toHaveLength(1);
     expect(found[0]).toContain("cannot tell");
   });
+
+  it("does not let a nested alias shadow an import at an outer call site", () => {
+    // The alias map used to be file-wide, so this inner `const build` overwrote
+    // the import alias and the outer violation disappeared entirely.
+    const found = auditSource(
+      "f.ts",
+      `import { withSlimEntries } from "@/core/entries/slim-entry";
+       import { getPostsRankedQueryOptions as build } from "@ecency/sdk";
+       export function outer() {
+         return withSlimEntries(build("trending", "", "", 20, "", ""));
+       }
+       export function inner() {
+         const build = getPostsRankedInfiniteQueryOptions;
+         return withSlimEntries(build("trending", ""));
+       }`
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("use withSlimPageEntries");
+    expect(found[0]).toContain(":4");
+  });
+
+  it("lets a local alias shadow an import where it really does", () => {
+    expect(
+      auditSource(
+        "f.ts",
+        `import { getPostsRankedQueryOptions as build } from "@ecency/sdk";
+         export function inner() {
+           const build = getPostsRankedInfiniteQueryOptions;
+           return withSlimEntries(build("trending", ""));
+         }`
+      )
+    ).toEqual([]);
+  });
+
+  it("sees a const declared in an enclosing function from a nested arrow", () => {
+    const found = auditSource(
+      "f.ts",
+      src(`export function outer() {
+             const options = getPostsRankedQueryOptions("x");
+             const go = () => withSlimEntries(options);
+             return go();
+           }`)
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("use withSlimPageEntries");
+  });
 });

--- a/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
+++ b/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
@@ -2,27 +2,38 @@ import { describe, expect, it } from "vitest";
 import { auditSource } from "../../../../../scripts/slim-entries-audit.mjs";
 
 /**
- * The audit's first version only matched a builder written inline, so both real
- * call sites, which pass the options through a local const, slipped past it: the
- * guard reported "no findings" while the exact regressions it exists to prevent
- * were present. These fixtures pin the shapes that actually appear in the app.
+ * The rule the audit backs up: a single-page builder goes with
+ * withSlimPageEntries, an infinite one with withSlimEntries. It used to be one
+ * function with an { isolateKey } flag, and every hole found in this audit came
+ * from trying to prove a flag was present: a builder passed as a variable, a
+ * trailing spread undoing the literal, a computed key. Two names removed that
+ * whole class, and what remains is checked here.
  */
-const src = (body: string) => `import { withSlimEntries } from "@/core/entries/slim-entry";\n${body}\n`;
+const src = (body: string) =>
+  `import { withSlimEntries, withSlimPageEntries } from "@/core/entries/slim-entry";\n${body}\n`;
 
 describe("slim-entries audit", () => {
-  it("accepts a single-page builder that isolates its key", () => {
+  it("accepts a single-page builder wrapped with the page helper", () => {
     expect(
-      auditSource("f.ts", src(`const o = withSlimEntries(getPostsRankedQueryOptions("created"), { isolateKey: true });`))
+      auditSource("f.ts", src(`const o = withSlimPageEntries(getPostsRankedQueryOptions("created"));`))
     ).toEqual([]);
   });
 
-  it("flags a single-page builder written inline without isolateKey", () => {
-    const found = auditSource("f.ts", src(`const o = withSlimEntries(getPostsRankedQueryOptions("created"));`));
-    expect(found).toHaveLength(1);
-    expect(found[0]).toContain("needs { isolateKey: true }");
+  it("accepts an infinite builder wrapped with the shared-key helper", () => {
+    expect(
+      auditSource("f.ts", src(`const o = withSlimEntries(getPostsRankedInfiniteQueryOptions("trending", ""));`))
+    ).toEqual([]);
   });
 
-  it("flags a single-page builder passed through a variable, the real shape", () => {
+  it("flags a single-page builder that keeps the shared key", () => {
+    const found = auditSource("f.ts", src(`const o = withSlimEntries(getPostsRankedQueryOptions("created"));`));
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("use withSlimPageEntries");
+  });
+
+  it("flags a single-page builder passed through a const, the real shape", () => {
+    // Both production call sites look like this, and the first version of this
+    // audit could not see either of them.
     const found = auditSource(
       "f.ts",
       src(`function load() {
@@ -34,60 +45,148 @@ describe("slim-entries audit", () => {
     expect(found[0]).toContain("getAccountPostsQueryOptions");
   });
 
-  it("accepts that same variable shape once it isolates the key", () => {
+  it("accepts that same const shape once it uses the page helper", () => {
     expect(
       auditSource(
         "f.ts",
         src(`function load() {
           const options = getAccountPostsQueryOptions("alice", "posts");
-          return withSlimEntries(options, { isolateKey: true });
+          return withSlimPageEntries(options);
         }`)
       )
     ).toEqual([]);
   });
 
-  it("flags an infinite builder that isolates its key, through a variable", () => {
+  it("flags an infinite builder given its own cache identity", () => {
     const found = auditSource(
       "f.ts",
       src(`function build() {
         const options = getAccountPostsInfiniteQueryOptions("alice", "posts");
-        return withSlimEntries(options, { isolateKey: true });
+        return withSlimPageEntries(options);
       }`)
     );
     expect(found).toHaveLength(1);
-    expect(found[0]).toContain("must NOT set isolateKey");
+    expect(found[0]).toContain("use withSlimEntries");
   });
 
-  it("accepts an infinite builder with no options", () => {
+  it("respects shadowing, where the inner declaration is the one that runs", () => {
     expect(
-      auditSource("f.ts", src(`const o = withSlimEntries(getPostsRankedInfiniteQueryOptions("trending", ""));`))
+      auditSource(
+        "f.ts",
+        src(`function build() {
+          const options = getPostsRankedQueryOptions("x");
+          {
+            const options = getPostsRankedInfiniteQueryOptions("y", "");
+            return withSlimEntries(options);
+          }
+        }`)
+      )
     ).toEqual([]);
   });
 
-  it("reports an identifier it cannot trace rather than passing it", () => {
-    // A guard that silently ignores what it cannot read is not a guard: that is
-    // precisely how the variable shape went unchecked. An options value from
-    // outside the function cannot be classified, so it is reported.
-    const found = auditSource("f.ts", src(`const o = withSlimEntries(importedOptions);`));
-    expect(found).toHaveLength(1);
-    expect(found[0]).toContain("cannot tell which builder is wrapped");
+  it("reports rather than guesses when one name has two declarations in scope", () => {
+    // Guessing here produced false failures on correct code, and a rule that is
+    // sometimes wrong about correct code is one people learn to ignore.
+    const found = auditSource(
+      "f.ts",
+      src(`function build(kind) {
+        if (kind) {
+          const options = getAccountPostsQueryOptions("a", "posts");
+          return withSlimPageEntries(options);
+        }
+        const options = getAccountPostsInfiniteQueryOptions("a", "posts");
+        return withSlimEntries(options);
+      }`)
+    );
+    expect(found.every((f) => f.includes("cannot tell"))).toBe(true);
   });
 
-  it("ignores a wrapper around something that is not a feed builder", () => {
-    // getPromotedPostsQuery is slimmed too and needs no key opinion.
+  it("reports a let, which can hold a different builder by the time it runs", () => {
+    const found = auditSource(
+      "f.ts",
+      src(`function build(k) {
+        let options = getAccountPostsQueryOptions("a", "posts");
+        if (k) options = getAccountPostsInfiniteQueryOptions("a", "posts");
+        return withSlimEntries(options);
+      }`)
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("cannot tell");
+  });
+
+  it("reports an identifier it cannot trace at all", () => {
+    const found = auditSource("f.ts", src(`const o = withSlimEntries(importedOptions);`));
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("cannot tell");
+  });
+
+  it("says nothing about a wrapper around something that is not a feed builder", () => {
+    // getPromotedPostsQuery is slimmed too and needs no opinion about its key.
     expect(auditSource("f.ts", src(`const o = withSlimEntries(getPromotedPostsQuery());`))).toEqual([]);
   });
 
-  it("reports options it cannot read literally", () => {
-    const found = auditSource(
-      "f.ts",
-      src(`const o = withSlimEntries(getPostsRankedQueryOptions("created"), opts);`)
-    );
-    expect(found).toHaveLength(1);
-    expect(found[0]).toContain("cannot read");
+  it("says nothing about a query that is not slimmed at all", () => {
+    expect(auditSource("f.ts", src(`const o = getPostsRankedQueryOptions("created");`))).toEqual([]);
   });
 
-  it("says nothing about queries that are not slimmed", () => {
-    expect(auditSource("f.ts", src(`const o = getPostsRankedQueryOptions("created");`))).toEqual([]);
+  // An adversarial sweep of 81 attempts against this audit confirmed these two.
+  // Both survived the split into two wrappers, because they are about telling
+  // WHICH builder is wrapped rather than about the argument that used to exist.
+  it("sees through a builder aliased on its import", () => {
+    // Aliasing an @ecency/sdk import is ordinary style in this repo, so the
+    // guard was silent on exactly the files most likely to do it.
+    const found = auditSource(
+      "f.ts",
+      `import { withSlimEntries } from "@/core/entries/slim-entry";
+       import { getPostsRankedQueryOptions as getRankedPage } from "@ecency/sdk";
+       export const o = withSlimEntries(getRankedPage("trending", "", "", 20, "", ""));`
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("use withSlimPageEntries");
+  });
+
+  it("sees through an infinite builder aliased on its import", () => {
+    const found = auditSource(
+      "f.ts",
+      `import { withSlimPageEntries } from "@/core/entries/slim-entry";
+       import { getPostsRankedInfiniteQueryOptions as rankedInf } from "@ecency/sdk";
+       export const o = withSlimPageEntries(rankedInf("trending", ""));`
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("use withSlimEntries");
+  });
+
+  it("sees through a builder renamed by a local const", () => {
+    const found = auditSource(
+      "f.ts",
+      src(`const getRankedPage = getPostsRankedQueryOptions;
+           const o = withSlimEntries(getRankedPage("trending"));`)
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("use withSlimPageEntries");
+  });
+
+  it("does not bind a name to a declaration in a different function", () => {
+    // The walk used to climb past arrow functions and search the whole file, so
+    // a branchy `let options` bound to an unrelated const elsewhere and the real
+    // violation went unreported.
+    const found = auditSource(
+      "f.ts",
+      src(`export function buildFeedQueryOptions(what, tag, limit, observer) {
+             const options = getPostsRankedInfiniteQueryOptions(what, tag, limit, observer);
+             return withSlimEntries(options);
+           }
+           export const buildArchiveOptions = (what, tag, limit) => {
+             let options;
+             if (tag.startsWith("@")) {
+               options = getAccountPostsInfiniteQueryOptions(tag, what, limit, "", true);
+             } else {
+               options = getPostsRankedQueryOptions(what, "", "", limit, tag, "");
+             }
+             return withSlimEntries(options);
+           };`)
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("cannot tell");
   });
 });

--- a/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
+++ b/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
@@ -84,21 +84,36 @@ describe("slim-entries audit", () => {
     ).toEqual([]);
   });
 
-  it("reports rather than guesses when one name has two declarations in scope", () => {
-    // Guessing here produced false failures on correct code, and a rule that is
-    // sometimes wrong about correct code is one people learn to ignore.
+  it("resolves each branch to its own const, because that is what runs", () => {
+    // This used to report "cannot tell" twice: the walk searched a whole
+    // function at once and saw two declarations of `options`. Each block is its
+    // own scope, both calls are correct, and correct code should be silent.
+    expect(
+      auditSource(
+        "f.ts",
+        src(`function build(kind) {
+          if (kind) {
+            const options = getAccountPostsQueryOptions("a", "posts");
+            return withSlimPageEntries(options);
+          }
+          const options = getAccountPostsInfiniteQueryOptions("a", "posts");
+          return withSlimEntries(options);
+        }`)
+      )
+    ).toEqual([]);
+  });
+
+  it("reports rather than guesses when one scope declares a name twice", () => {
     const found = auditSource(
       "f.ts",
-      src(`function build(kind) {
-        if (kind) {
-          const options = getAccountPostsQueryOptions("a", "posts");
-          return withSlimPageEntries(options);
-        }
+      src(`function build() {
+        const options = getAccountPostsQueryOptions("a", "posts");
         const options = getAccountPostsInfiniteQueryOptions("a", "posts");
         return withSlimEntries(options);
       }`)
     );
-    expect(found.every((f) => f.includes("cannot tell"))).toBe(true);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("cannot tell");
   });
 
   it("reports a let, which can hold a different builder by the time it runs", () => {
@@ -297,6 +312,69 @@ describe("slim-entries audit", () => {
     ]
   ])("gets the binding right across %s", (_label, body) => {
     const found = auditSource("f.ts", src(body));
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("use withSlimPageEntries");
+  });
+
+  // A name can be bound by something this cannot read, and such a binding still
+  // SHADOWS the outer one. Ignoring it meant resolving to an import the code
+  // never calls and reporting correct code as a mismatch.
+  it.each([
+    [
+      "a parameter shadowing the wrapper itself",
+      `import { withSlimEntries } from "@/core/entries/slim-entry";
+       import { getPostsRankedQueryOptions } from "@ecency/sdk";
+       export function harness(withSlimEntries) {
+         return withSlimEntries(getPostsRankedQueryOptions("trending"));
+       }`
+    ],
+    [
+      "a parameter shadowing the builder",
+      `import { getPostsRankedQueryOptions } from "@ecency/sdk";
+       export function f(getPostsRankedQueryOptions) {
+         return withSlimEntries(getPostsRankedQueryOptions("x"));
+       }`
+    ],
+    [
+      "a function declaration of the same name",
+      `import { getPostsRankedQueryOptions } from "@ecency/sdk";
+       export function g() {
+         function getPostsRankedQueryOptions() { return {}; }
+         return withSlimEntries(getPostsRankedQueryOptions());
+       }`
+    ],
+    [
+      "a destructured property",
+      `export function outer() {
+         const options = getPostsRankedQueryOptions("x");
+         return function inner(props) {
+           const { options } = props;
+           return withSlimEntries(options);
+         };
+       }`
+    ],
+    [
+      "a caught error",
+      `export function c() {
+         try {
+           return null;
+         } catch (options) {
+           return withSlimEntries(options);
+         }
+       }`
+    ]
+  ])("does not report correct code because of %s", (_label, body) => {
+    const found = auditSource("f.ts", body);
+    expect(found.every((f) => f.includes("cannot tell"))).toBe(true);
+  });
+
+  it("still reports the genuine violation next to such a binding", () => {
+    const found = auditSource(
+      "f.ts",
+      `import { withSlimEntries } from "@/core/entries/slim-entry";
+       import { getPostsRankedQueryOptions } from "@ecency/sdk";
+       export const o = withSlimEntries(getPostsRankedQueryOptions("trending"));`
+    );
     expect(found).toHaveLength(1);
     expect(found[0]).toContain("use withSlimPageEntries");
   });

--- a/scripts/slim-entries-audit.mjs
+++ b/scripts/slim-entries-audit.mjs
@@ -16,84 +16,123 @@
 //       a key nothing renders, and the "new posts" chip would stop updating
 //       stats without any error.
 //
+// Both real call sites pass the options through a local variable, so the wrapped
+// builder is resolved through simple `const x = builder(...)` declarations
+// rather than only matching a call written inline. Anything this cannot classify
+// is reported rather than skipped: a guard that silently ignores what it does
+// not understand is not a guard.
+//
 // CI runs with --fail: any finding exits 1.
 import { createRequire } from "node:module";
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
-const require = createRequire(new URL("../package.json", import.meta.url));
+const require = createRequire(import.meta.url);
 const ts = require("typescript");
 
-const ROOT = new URL("..", import.meta.url).pathname;
-const SINGLE_PAGE_BUILDERS = new Set([
+export const SINGLE_PAGE_BUILDERS = new Set([
   "getPostsRankedQueryOptions",
   "getAccountPostsQueryOptions"
 ]);
-const INFINITE_BUILDERS = new Set([
+export const INFINITE_BUILDERS = new Set([
   "getPostsRankedInfiniteQueryOptions",
   "getAccountPostsInfiniteQueryOptions"
 ]);
-const failing = process.argv.includes("--fail");
-
-const files = [];
-(function walk(dir) {
-  for (const e of readdirSync(dir)) {
-    const p = join(dir, e);
-    const s = statSync(p);
-    if (s.isDirectory()) {
-      if (e === "specs") continue;
-      walk(p);
-    } else if (/\.tsx?$/.test(e)) {
-      files.push(p);
-    }
-  }
-})(join(ROOT, "apps/web/src"));
 
 /** The identifier being called, for both `f()` and `ns.f()`. */
 function calleeName(node) {
-  if (!ts.isCallExpression(node)) return null;
+  if (!node || !ts.isCallExpression(node)) return null;
   const e = node.expression;
   if (ts.isIdentifier(e)) return e.text;
   if (ts.isPropertyAccessExpression(e) && ts.isIdentifier(e.name)) return e.name.text;
   return null;
 }
 
-/** True when an options argument literally sets isolateKey: true. */
-function hasIsolateKey(arg) {
-  if (!arg || !ts.isObjectLiteralExpression(arg)) return false;
-  return arg.properties.some(
-    (p) =>
-      ts.isPropertyAssignment(p) &&
-      ((ts.isIdentifier(p.name) && p.name.text === "isolateKey") ||
-        (ts.isStringLiteral(p.name) && p.name.text === "isolateKey")) &&
-      p.initializer.kind === ts.SyntaxKind.TrueKeyword
-  );
+/**
+ * The builder behind an argument, following one level of `const x = builder(...)`
+ * within the enclosing function. Returns null when it cannot be determined,
+ * which the caller reports rather than ignores.
+ */
+function resolveBuilder(arg) {
+  const direct = calleeName(arg);
+  if (direct) return direct;
+  if (!arg || !ts.isIdentifier(arg)) return null;
+
+  for (let scope = arg.parent; scope; scope = scope.parent) {
+    let found = null;
+    ts.forEachChild(scope, function walk(node) {
+      if (found) return;
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.name.text === arg.text &&
+        node.initializer
+      ) {
+        found = calleeName(node.initializer);
+        return;
+      }
+      ts.forEachChild(node, walk);
+    });
+    if (found) return found;
+    if (ts.isFunctionDeclaration(scope) || ts.isSourceFile(scope)) break;
+  }
+  return null;
 }
 
-const findings = [];
-for (const file of files) {
+/** true / false / "unknown" when the options argument cannot be read literally. */
+function isolateKeyOf(arg) {
+  if (arg === undefined) return false;
+  if (!ts.isObjectLiteralExpression(arg)) return "unknown";
+  for (const p of arg.properties) {
+    if (ts.isSpreadAssignment(p)) return "unknown";
+    const named =
+      ts.isPropertyAssignment(p) &&
+      ((ts.isIdentifier(p.name) && p.name.text === "isolateKey") ||
+        (ts.isStringLiteral(p.name) && p.name.text === "isolateKey"));
+    if (!named) continue;
+    if (p.initializer.kind === ts.SyntaxKind.TrueKeyword) return true;
+    if (p.initializer.kind === ts.SyntaxKind.FalseKeyword) return false;
+    return "unknown";
+  }
+  return false;
+}
+
+/** Findings for one source file. Exported so the audit itself can be tested. */
+export function auditSource(fileName, text) {
   const src = ts.createSourceFile(
-    file,
-    readFileSync(file, "utf-8"),
+    fileName,
+    text,
     ts.ScriptTarget.Latest,
     true,
-    /\.tsx$/.test(file) ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+    /\.tsx$/.test(fileName) ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   );
+  const findings = [];
 
   (function visit(node) {
     if (calleeName(node) === "withSlimEntries") {
-      const wrapped = calleeName(node.arguments[0]);
-      const isolated = hasIsolateKey(node.arguments[1]);
       const { line } = src.getLineAndCharacterOfPosition(node.getStart());
-      const where = `${relative(ROOT, file)}:${line + 1}`;
+      const where = `${fileName}:${line + 1}`;
+      const wrapped = resolveBuilder(node.arguments[0]);
+      const isolated = isolateKeyOf(node.arguments[1]);
 
-      if (wrapped && SINGLE_PAGE_BUILDERS.has(wrapped) && !isolated) {
+      if (!wrapped) {
         findings.push(
-          `${where}  withSlimEntries(${wrapped}) needs { isolateKey: true } — ` +
-            `deck columns read that page key and render entry.body from it`
+          `${where}  cannot tell which builder is wrapped — pass the builder call ` +
+            `directly, or assign it to a const in the same function, so this rule can see it`
         );
-      }
-      if (wrapped && INFINITE_BUILDERS.has(wrapped) && isolated) {
+      } else if (SINGLE_PAGE_BUILDERS.has(wrapped)) {
+        if (isolated === false) {
+          findings.push(
+            `${where}  withSlimEntries(${wrapped}) needs { isolateKey: true } — ` +
+              `deck columns read that page key and render entry.body from it`
+          );
+        } else if (isolated === "unknown") {
+          findings.push(
+            `${where}  withSlimEntries(${wrapped}) passes options this rule cannot read — ` +
+              `write { isolateKey: true } literally`
+          );
+        }
+      } else if (INFINITE_BUILDERS.has(wrapped) && isolated !== false) {
         findings.push(
           `${where}  withSlimEntries(${wrapped}) must NOT set isolateKey — ` +
             `the feed poll hand-builds this key for its setQueryData merge`
@@ -102,12 +141,40 @@ for (const file of files) {
     }
     ts.forEachChild(node, visit);
   })(src);
+
+  return findings;
 }
 
-if (findings.length === 0) {
-  console.log(`slim-entries audit: ${files.length} files, no findings`);
-  process.exit(0);
+function main() {
+  const ROOT = new URL("..", import.meta.url).pathname;
+  const failing = process.argv.includes("--fail");
+  const files = [];
+  (function walk(dir) {
+    for (const e of readdirSync(dir)) {
+      const p = join(dir, e);
+      const s = statSync(p);
+      if (s.isDirectory()) {
+        if (e === "specs") continue;
+        walk(p);
+      } else if (/\.tsx?$/.test(e)) {
+        files.push(p);
+      }
+    }
+  })(join(ROOT, "apps/web/src"));
+
+  const findings = files.flatMap((f) =>
+    auditSource(relative(ROOT, f), readFileSync(f, "utf-8"))
+  );
+
+  if (findings.length === 0) {
+    console.log(`slim-entries audit: ${files.length} files, no findings`);
+    return 0;
+  }
+  console.log(`slim-entries audit: ${findings.length} finding(s)`);
+  for (const f of findings) console.log(`  ${f}`);
+  return failing ? 1 : 0;
 }
-console.log(`slim-entries audit: ${findings.length} finding(s)`);
-for (const f of findings) console.log(`  ${f}`);
-process.exit(failing ? 1 : 0);
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/scripts/slim-entries-audit.mjs
+++ b/scripts/slim-entries-audit.mjs
@@ -1,0 +1,113 @@
+// Slim-entry convention audit (apps/web/src/core/entries/slim-entry.ts).
+//
+// TypeScript-AST walk over apps/web/src. One rule, in both directions, about
+// HOW a query is slimmed rather than whether it is:
+//
+//   i.  withSlimEntries() around a SINGLE-PAGE builder must pass
+//       { isolateKey: true }. Those builders key on postsRankedPage /
+//       accountPostsPage, which the deck columns also read and then render
+//       entry.body from. A slim page cached under that shared key is handed
+//       straight to a deck inside the staleTime and the post viewer renders
+//       empty. See PR #1545 and issue #1556.
+//
+//   ii. withSlimEntries() around an INFINITE builder must NOT pass it. The
+//       feed's infinite key is hand-built in feed-layout.tsx for the poll's
+//       setQueryData merge; marking it there would silently write the merge to
+//       a key nothing renders, and the "new posts" chip would stop updating
+//       stats without any error.
+//
+// CI runs with --fail: any finding exits 1.
+import { createRequire } from "node:module";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const require = createRequire(new URL("../package.json", import.meta.url));
+const ts = require("typescript");
+
+const ROOT = new URL("..", import.meta.url).pathname;
+const SINGLE_PAGE_BUILDERS = new Set([
+  "getPostsRankedQueryOptions",
+  "getAccountPostsQueryOptions"
+]);
+const INFINITE_BUILDERS = new Set([
+  "getPostsRankedInfiniteQueryOptions",
+  "getAccountPostsInfiniteQueryOptions"
+]);
+const failing = process.argv.includes("--fail");
+
+const files = [];
+(function walk(dir) {
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    const s = statSync(p);
+    if (s.isDirectory()) {
+      if (e === "specs") continue;
+      walk(p);
+    } else if (/\.tsx?$/.test(e)) {
+      files.push(p);
+    }
+  }
+})(join(ROOT, "apps/web/src"));
+
+/** The identifier being called, for both `f()` and `ns.f()`. */
+function calleeName(node) {
+  if (!ts.isCallExpression(node)) return null;
+  const e = node.expression;
+  if (ts.isIdentifier(e)) return e.text;
+  if (ts.isPropertyAccessExpression(e) && ts.isIdentifier(e.name)) return e.name.text;
+  return null;
+}
+
+/** True when an options argument literally sets isolateKey: true. */
+function hasIsolateKey(arg) {
+  if (!arg || !ts.isObjectLiteralExpression(arg)) return false;
+  return arg.properties.some(
+    (p) =>
+      ts.isPropertyAssignment(p) &&
+      ((ts.isIdentifier(p.name) && p.name.text === "isolateKey") ||
+        (ts.isStringLiteral(p.name) && p.name.text === "isolateKey")) &&
+      p.initializer.kind === ts.SyntaxKind.TrueKeyword
+  );
+}
+
+const findings = [];
+for (const file of files) {
+  const src = ts.createSourceFile(
+    file,
+    readFileSync(file, "utf-8"),
+    ts.ScriptTarget.Latest,
+    true,
+    /\.tsx$/.test(file) ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+
+  (function visit(node) {
+    if (calleeName(node) === "withSlimEntries") {
+      const wrapped = calleeName(node.arguments[0]);
+      const isolated = hasIsolateKey(node.arguments[1]);
+      const { line } = src.getLineAndCharacterOfPosition(node.getStart());
+      const where = `${relative(ROOT, file)}:${line + 1}`;
+
+      if (wrapped && SINGLE_PAGE_BUILDERS.has(wrapped) && !isolated) {
+        findings.push(
+          `${where}  withSlimEntries(${wrapped}) needs { isolateKey: true } — ` +
+            `deck columns read that page key and render entry.body from it`
+        );
+      }
+      if (wrapped && INFINITE_BUILDERS.has(wrapped) && isolated) {
+        findings.push(
+          `${where}  withSlimEntries(${wrapped}) must NOT set isolateKey — ` +
+            `the feed poll hand-builds this key for its setQueryData merge`
+        );
+      }
+    }
+    ts.forEachChild(node, visit);
+  })(src);
+}
+
+if (findings.length === 0) {
+  console.log(`slim-entries audit: ${files.length} files, no findings`);
+  process.exit(0);
+}
+console.log(`slim-entries audit: ${findings.length} finding(s)`);
+for (const f of findings) console.log(`  ${f}`);
+process.exit(failing ? 1 : 0);

--- a/scripts/slim-entries-audit.mjs
+++ b/scripts/slim-entries-audit.mjs
@@ -57,7 +57,27 @@ function calleeName(node) {
   return null;
 }
 
-/** Function-like nodes are scope boundaries for a local declaration. */
+/**
+ * Nodes that introduce a scope a `const` can live in. A declaration inside any
+ * of these is invisible from outside it, so resolution must neither descend into
+ * one nor stop short of the enclosing ones.
+ */
+function isScopeNode(node) {
+  return (
+    isScopeBoundary(node) ||
+    ts.isBlock(node) ||
+    ts.isCaseBlock(node) ||
+    ts.isCaseClause(node) ||
+    ts.isDefaultClause(node) ||
+    ts.isForStatement(node) ||
+    ts.isForInStatement(node) ||
+    ts.isForOfStatement(node) ||
+    ts.isCatchClause(node) ||
+    ts.isModuleBlock(node)
+  );
+}
+
+/** Function-like nodes, where an outer name can still be seen but a local one wins. */
 function isScopeBoundary(node) {
   return (
     ts.isFunctionDeclaration(node) ||
@@ -100,30 +120,14 @@ function canonicalAt(node, name, imports, seen = new Set()) {
   seen.add(name);
 
   for (let scope = node; scope; scope = scope.parent) {
-    if (!isScopeBoundary(scope) && !ts.isBlock(scope) && !ts.isCaseClause(scope)) continue;
-    const bindings = [];
-    ts.forEachChild(scope, function walk(child) {
-      if (child !== scope && isScopeBoundary(child)) return;
-      if (
-        ts.isVariableDeclaration(child) &&
-        ts.isIdentifier(child.name) &&
-        child.name.text === name
-      ) {
-        const isConst =
-          ts.isVariableDeclarationList(child.parent) &&
-          (child.parent.flags & ts.NodeFlags.Const) !== 0;
-        bindings.push(
-          isConst && child.initializer && ts.isIdentifier(child.initializer)
-            ? child.initializer.text
-            : null
-        );
-      }
-      ts.forEachChild(child, walk);
-    });
-    if (bindings.length === 1 && bindings[0]) {
-      return canonicalAt(scope, bindings[0], imports, seen);
+    if (!isScopeNode(scope)) continue;
+    const bindings = bindingsIn(scope, name);
+    if (bindings.length === 1) {
+      const init = bindings[0];
+      if (init && ts.isIdentifier(init)) return canonicalAt(scope, init.text, imports, seen);
+      return null;
     }
-    if (bindings.length > 0) return null;
+    if (bindings.length > 1) return null;
   }
 
   let current = name;
@@ -134,24 +138,32 @@ function canonicalAt(node, name, imports, seen = new Set()) {
   return current;
 }
 
-/** Declarations of `name` in this scope, not counting nested function bodies. */
-function declarationsIn(scope, name) {
+/**
+ * Declarations of `name` belonging to THIS scope: not those in nested scopes,
+ * which are invisible from here, and not those in enclosing ones, which the
+ * caller reaches by walking outwards.
+ *
+ * Both resolvers share this. They used to collect separately and drifted apart,
+ * each descending into child blocks and binding a name to a `const` declared in
+ * an `if` branch that had already closed.
+ */
+function bindingsIn(scope, name) {
   const found = [];
-  ts.forEachChild(scope, function walk(node) {
-    if (node !== scope && isScopeBoundary(node)) return; // another scope's business
+  ts.forEachChild(scope, function walk(child) {
+    if (child !== scope && isScopeNode(child)) return;
     if (
-      ts.isVariableDeclaration(node) &&
-      ts.isIdentifier(node.name) &&
-      node.name.text === name
+      ts.isVariableDeclaration(child) &&
+      ts.isIdentifier(child.name) &&
+      child.name.text === name
     ) {
-      // A `let` can hold a different builder by the time the call runs, and a
-      // declaration with no initializer says nothing at all.
       const isConst =
-        ts.isVariableDeclarationList(node.parent) &&
-        (node.parent.flags & ts.NodeFlags.Const) !== 0;
-      found.push(isConst && node.initializer ? calleeName(node.initializer) : null);
+        ts.isVariableDeclarationList(child.parent) &&
+        (child.parent.flags & ts.NodeFlags.Const) !== 0;
+      // A `let` can hold something else by the time the call runs, and a
+      // declaration with no initialiser says nothing at all.
+      found.push(isConst && child.initializer ? child.initializer : null);
     }
-    ts.forEachChild(node, walk);
+    ts.forEachChild(child, walk);
   });
   return found;
 }
@@ -171,12 +183,13 @@ function resolveBuilder(arg, imports) {
   if (!arg || !ts.isIdentifier(arg)) return null;
 
   for (let scope = arg.parent; scope; scope = scope.parent) {
-    if (!isScopeBoundary(scope) && !ts.isBlock(scope) && !ts.isCaseClause(scope)) continue;
-    const declarations = declarationsIn(scope, arg.text);
-    if (declarations.length === 1 && declarations[0]) {
-      return canonicalAt(scope, declarations[0], imports);
+    if (!isScopeNode(scope)) continue;
+    const bindings = bindingsIn(scope, arg.text);
+    if (bindings.length === 1) {
+      const called = calleeName(bindings[0]);
+      return called ? canonicalAt(scope, called, imports) : null;
     }
-    if (declarations.length > 0) return null;
+    if (bindings.length > 1) return null;
   }
   return null;
 }

--- a/scripts/slim-entries-audit.mjs
+++ b/scripts/slim-entries-audit.mjs
@@ -25,11 +25,11 @@
 // the wrong name.
 //
 // WHAT THIS CANNOT SEE, deliberately, rather than pretending otherwise:
-// it matches on identifier text, so a wrapper or builder renamed through an
-// import alias, a re-export or a local const is invisible to it. That is fine
-// for what it is: a guard against an accident, not against someone working
-// around it. Anything it cannot classify it REPORTS, so silence means it
-// understood the code, not that it gave up.
+// it resolves import aliases and local `const` aliases within one file, but it
+// never reads another module, so a wrapper or builder renamed by a re-export is
+// invisible to it. That is fine for what it is: a guard against an accident, not
+// against someone working around it. Anything it cannot classify it REPORTS, so
+// silence means it understood the code, not that it gave up.
 //
 // CI runs with --fail: any finding exits 1.
 import { createRequire } from "node:module";
@@ -121,6 +121,14 @@ function canonicalAt(node, name, imports, seen = new Set()) {
 
   for (let scope = node; scope; scope = scope.parent) {
     if (!isScopeNode(scope)) continue;
+    if (
+      ts.isCatchClause(scope) &&
+      scope.variableDeclaration &&
+      ts.isIdentifier(scope.variableDeclaration.name) &&
+      scope.variableDeclaration.name.text === name
+    ) {
+      return null;
+    }
     const bindings = bindingsIn(scope, name);
     if (bindings.length === 1) {
       const init = bindings[0];
@@ -150,7 +158,19 @@ function canonicalAt(node, name, imports, seen = new Set()) {
 function bindingsIn(scope, name) {
   const found = [];
   ts.forEachChild(scope, function walk(child) {
+    // A function or class binds its NAME in the scope around it, even though its
+    // body is a scope of its own, so this has to run before the descent stops.
+    if (
+      (ts.isFunctionDeclaration(child) || ts.isClassDeclaration(child)) &&
+      child.name &&
+      ts.isIdentifier(child.name) &&
+      child.name.text === name
+    ) {
+      found.push(null);
+      return;
+    }
     if (child !== scope && isScopeNode(child)) return;
+
     if (
       ts.isVariableDeclaration(child) &&
       ts.isIdentifier(child.name) &&
@@ -162,7 +182,22 @@ function bindingsIn(scope, name) {
       // A `let` can hold something else by the time the call runs, and a
       // declaration with no initialiser says nothing at all.
       found.push(isConst && child.initializer ? child.initializer : null);
+      return;
     }
+
+    // A name can also be bound by something this cannot read: a parameter, a
+    // destructured property, a function or class of that name, a caught error.
+    // Such a binding still SHADOWS the outer one, so ignoring it meant resolving
+    // to an import that the code never calls and reporting correct code as a
+    // mismatch. Record it as unreadable and let the caller say so.
+    const shadows =
+      (ts.isParameter(child) && ts.isIdentifier(child.name) && child.name.text === name) ||
+      (ts.isBindingElement(child) && ts.isIdentifier(child.name) && child.name.text === name);
+    if (shadows) {
+      found.push(null);
+      return;
+    }
+
     ts.forEachChild(child, walk);
   });
   return found;

--- a/scripts/slim-entries-audit.mjs
+++ b/scripts/slim-entries-audit.mjs
@@ -1,26 +1,35 @@
 // Slim-entry convention audit (apps/web/src/core/entries/slim-entry.ts).
 //
-// TypeScript-AST walk over apps/web/src. One rule, in both directions, about
-// HOW a query is slimmed rather than whether it is:
+// There are two wrappers, and the rule is that each goes with one kind of
+// builder:
 //
-//   i.  withSlimEntries() around a SINGLE-PAGE builder must pass
-//       { isolateKey: true }. Those builders key on postsRankedPage /
-//       accountPostsPage, which the deck columns also read and then render
-//       entry.body from. A slim page cached under that shared key is handed
-//       straight to a deck inside the staleTime and the post viewer renders
-//       empty. See PR #1545 and issue #1556.
+//   withSlimPageEntries(...)  SINGLE-PAGE builders (getPostsRankedQueryOptions,
+//                             getAccountPostsQueryOptions). It gives the slim
+//                             page its own cache identity, because the SDK's
+//                             page keys are also read by the deck columns, which
+//                             render entry.body from what they find there. A
+//                             slim page under the shared key reaches a deck
+//                             inside the staleTime and its post viewer renders
+//                             an empty article. That was issue #1556.
 //
-//   ii. withSlimEntries() around an INFINITE builder must NOT pass it. The
-//       feed's infinite key is hand-built in feed-layout.tsx for the poll's
-//       setQueryData merge; marking it there would silently write the merge to
-//       a key nothing renders, and the "new posts" chip would stop updating
-//       stats without any error.
+//   withSlimEntries(...)      INFINITE builders and the promoted feed, whose key
+//                             must stay exactly what the SDK produced: the feed
+//                             poll hand-builds that key for its setQueryData
+//                             merge, so an extra marker would write the merge to
+//                             a key nothing renders.
 //
-// Both real call sites pass the options through a local variable, so the wrapped
-// builder is resolved through simple `const x = builder(...)` declarations
-// rather than only matching a call written inline. Anything this cannot classify
-// is reported rather than skipped: a guard that silently ignores what it does
-// not understand is not a guard.
+// This used to be one function with an { isolateKey } flag, which meant the
+// dangerous mistake was an omission — and an omission is exactly what an AST
+// rule is worst at seeing. Two names make the wrong thing unrepresentable
+// rather than merely detectable, and leave this audit a backstop for picking
+// the wrong name.
+//
+// WHAT THIS CANNOT SEE, deliberately, rather than pretending otherwise:
+// it matches on identifier text, so a wrapper or builder renamed through an
+// import alias, a re-export or a local const is invisible to it. That is fine
+// for what it is: a guard against an accident, not against someone working
+// around it. Anything it cannot classify it REPORTS, so silence means it
+// understood the code, not that it gave up.
 //
 // CI runs with --fail: any finding exits 1.
 import { createRequire } from "node:module";
@@ -48,53 +57,102 @@ function calleeName(node) {
   return null;
 }
 
+/** Function-like nodes are scope boundaries for a local declaration. */
+function isScopeBoundary(node) {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isConstructorDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isSourceFile(node)
+  );
+}
+
 /**
- * The builder behind an argument, following one level of `const x = builder(...)`
- * within the enclosing function. Returns null when it cannot be determined,
- * which the caller reports rather than ignores.
+ * Local name -> the name it was imported or aliased from.
+ *
+ * `import { getPostsRankedQueryOptions as getRankedPage }` and
+ * `const getRankedPage = getPostsRankedQueryOptions` both hide a builder behind
+ * another name, and this rule matches on names. Aliasing an SDK import is
+ * ordinary house style here, so without this the guard is silent on exactly the
+ * files most likely to have it.
  */
-function resolveBuilder(arg) {
+function aliasMap(src) {
+  const aliases = new Map();
+  (function visit(node) {
+    if (ts.isImportSpecifier(node) && node.propertyName) {
+      aliases.set(node.name.text, node.propertyName.text);
+    }
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isIdentifier(node.initializer)
+    ) {
+      aliases.set(node.name.text, node.initializer.text);
+    }
+    ts.forEachChild(node, visit);
+  })(src);
+  return aliases;
+}
+
+function canonical(name, aliases) {
+  const seen = new Set();
+  let current = name;
+  while (current && aliases.has(current) && !seen.has(current)) {
+    seen.add(current);
+    current = aliases.get(current);
+  }
+  return current;
+}
+
+/** Declarations of `name` in this scope, not counting nested function bodies. */
+function declarationsIn(scope, name) {
+  const found = [];
+  ts.forEachChild(scope, function walk(node) {
+    if (node !== scope && isScopeBoundary(node)) return; // another scope's business
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name
+    ) {
+      // A `let` can hold a different builder by the time the call runs, and a
+      // declaration with no initializer says nothing at all.
+      const isConst =
+        ts.isVariableDeclarationList(node.parent) &&
+        (node.parent.flags & ts.NodeFlags.Const) !== 0;
+      found.push(isConst && node.initializer ? calleeName(node.initializer) : null);
+    }
+    ts.forEachChild(node, walk);
+  });
+  return found;
+}
+
+/**
+ * The builder behind an argument, following `const x = builder(...)` outwards
+ * through real lexical scopes.
+ *
+ * Returns null when it cannot be determined, INCLUDING when a name has more than
+ * one declaration in a scope. Guessing produced both misses and false failures
+ * on correct code, and a rule that is sometimes wrong about correct code is one
+ * people learn to ignore.
+ */
+function resolveBuilder(arg, aliases) {
   const direct = calleeName(arg);
-  if (direct) return direct;
+  if (direct) return canonical(direct, aliases);
   if (!arg || !ts.isIdentifier(arg)) return null;
 
   for (let scope = arg.parent; scope; scope = scope.parent) {
-    let found = null;
-    ts.forEachChild(scope, function walk(node) {
-      if (found) return;
-      if (
-        ts.isVariableDeclaration(node) &&
-        ts.isIdentifier(node.name) &&
-        node.name.text === arg.text &&
-        node.initializer
-      ) {
-        found = calleeName(node.initializer);
-        return;
-      }
-      ts.forEachChild(node, walk);
-    });
-    if (found) return found;
-    if (ts.isFunctionDeclaration(scope) || ts.isSourceFile(scope)) break;
+    if (!isScopeBoundary(scope) && !ts.isBlock(scope) && !ts.isCaseClause(scope)) continue;
+    const declarations = declarationsIn(scope, arg.text);
+    if (declarations.length === 1 && declarations[0]) return canonical(declarations[0], aliases);
+    if (declarations.length > 0) return null;
+    if (isScopeBoundary(scope)) break;
   }
   return null;
-}
-
-/** true / false / "unknown" when the options argument cannot be read literally. */
-function isolateKeyOf(arg) {
-  if (arg === undefined) return false;
-  if (!ts.isObjectLiteralExpression(arg)) return "unknown";
-  for (const p of arg.properties) {
-    if (ts.isSpreadAssignment(p)) return "unknown";
-    const named =
-      ts.isPropertyAssignment(p) &&
-      ((ts.isIdentifier(p.name) && p.name.text === "isolateKey") ||
-        (ts.isStringLiteral(p.name) && p.name.text === "isolateKey"));
-    if (!named) continue;
-    if (p.initializer.kind === ts.SyntaxKind.TrueKeyword) return true;
-    if (p.initializer.kind === ts.SyntaxKind.FalseKeyword) return false;
-    return "unknown";
-  }
-  return false;
 }
 
 /** Findings for one source file. Exported so the audit itself can be tested. */
@@ -107,35 +165,29 @@ export function auditSource(fileName, text) {
     /\.tsx$/.test(fileName) ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   );
   const findings = [];
+  const aliases = aliasMap(src);
 
   (function visit(node) {
-    if (calleeName(node) === "withSlimEntries") {
+    const called = canonical(calleeName(node), aliases);
+    if (called === "withSlimEntries" || called === "withSlimPageEntries") {
       const { line } = src.getLineAndCharacterOfPosition(node.getStart());
       const where = `${fileName}:${line + 1}`;
-      const wrapped = resolveBuilder(node.arguments[0]);
-      const isolated = isolateKeyOf(node.arguments[1]);
+      const wrapped = resolveBuilder(node.arguments[0], aliases);
 
       if (!wrapped) {
         findings.push(
-          `${where}  cannot tell which builder is wrapped — pass the builder call ` +
-            `directly, or assign it to a const in the same function, so this rule can see it`
+          `${where}  cannot tell which builder ${called} wraps — pass the builder ` +
+            `call directly, or assign it to one clearly named const in the same function`
         );
-      } else if (SINGLE_PAGE_BUILDERS.has(wrapped)) {
-        if (isolated === false) {
-          findings.push(
-            `${where}  withSlimEntries(${wrapped}) needs { isolateKey: true } — ` +
-              `deck columns read that page key and render entry.body from it`
-          );
-        } else if (isolated === "unknown") {
-          findings.push(
-            `${where}  withSlimEntries(${wrapped}) passes options this rule cannot read — ` +
-              `write { isolateKey: true } literally`
-          );
-        }
-      } else if (INFINITE_BUILDERS.has(wrapped) && isolated !== false) {
+      } else if (SINGLE_PAGE_BUILDERS.has(wrapped) && called !== "withSlimPageEntries") {
         findings.push(
-          `${where}  withSlimEntries(${wrapped}) must NOT set isolateKey — ` +
-            `the feed poll hand-builds this key for its setQueryData merge`
+          `${where}  ${wrapped} is a single-page builder: use withSlimPageEntries, ` +
+            `or a deck column reading that page key renders an empty post`
+        );
+      } else if (INFINITE_BUILDERS.has(wrapped) && called !== "withSlimEntries") {
+        findings.push(
+          `${where}  ${wrapped} is an infinite builder: use withSlimEntries, ` +
+            `its key is hand-built elsewhere for the feed poll's merge`
         );
       }
     }

--- a/scripts/slim-entries-audit.mjs
+++ b/scripts/slim-entries-audit.mjs
@@ -72,39 +72,64 @@ function isScopeBoundary(node) {
 }
 
 /**
- * Local name -> the name it was imported or aliased from.
- *
- * `import { getPostsRankedQueryOptions as getRankedPage }` and
- * `const getRankedPage = getPostsRankedQueryOptions` both hide a builder behind
- * another name, and this rule matches on names. Aliasing an SDK import is
- * ordinary house style here, so without this the guard is silent on exactly the
- * files most likely to have it.
+ * Local name -> the name it was imported from. Module scope, which is what an
+ * import is. Local `const a = b` aliases are NOT collected here: they belong to
+ * the scope that declares them, and folding them into one file-wide map let a
+ * nested `const build = ...` overwrite an outer `import { x as build }` and hide
+ * a violation at the outer call site.
  */
-function aliasMap(src) {
+function importAliases(src) {
   const aliases = new Map();
   (function visit(node) {
     if (ts.isImportSpecifier(node) && node.propertyName) {
       aliases.set(node.name.text, node.propertyName.text);
-    }
-    if (
-      ts.isVariableDeclaration(node) &&
-      ts.isIdentifier(node.name) &&
-      node.initializer &&
-      ts.isIdentifier(node.initializer)
-    ) {
-      aliases.set(node.name.text, node.initializer.text);
     }
     ts.forEachChild(node, visit);
   })(src);
   return aliases;
 }
 
-function canonical(name, aliases) {
-  const seen = new Set();
+/**
+ * The name behind `name` as seen FROM `node`: a local `const name = other` in
+ * the nearest enclosing scope wins over an import alias, exactly as it does at
+ * runtime. Returns null when the name is declared more than once in a scope, or
+ * bound by something this cannot read.
+ */
+function canonicalAt(node, name, imports, seen = new Set()) {
+  if (!name || seen.has(name)) return name ?? null;
+  seen.add(name);
+
+  for (let scope = node; scope; scope = scope.parent) {
+    if (!isScopeBoundary(scope) && !ts.isBlock(scope) && !ts.isCaseClause(scope)) continue;
+    const bindings = [];
+    ts.forEachChild(scope, function walk(child) {
+      if (child !== scope && isScopeBoundary(child)) return;
+      if (
+        ts.isVariableDeclaration(child) &&
+        ts.isIdentifier(child.name) &&
+        child.name.text === name
+      ) {
+        const isConst =
+          ts.isVariableDeclarationList(child.parent) &&
+          (child.parent.flags & ts.NodeFlags.Const) !== 0;
+        bindings.push(
+          isConst && child.initializer && ts.isIdentifier(child.initializer)
+            ? child.initializer.text
+            : null
+        );
+      }
+      ts.forEachChild(child, walk);
+    });
+    if (bindings.length === 1 && bindings[0]) {
+      return canonicalAt(scope, bindings[0], imports, seen);
+    }
+    if (bindings.length > 0) return null;
+  }
+
   let current = name;
-  while (current && aliases.has(current) && !seen.has(current)) {
+  while (imports.has(current) && !seen.has(imports.get(current))) {
+    current = imports.get(current);
     seen.add(current);
-    current = aliases.get(current);
   }
   return current;
 }
@@ -140,17 +165,18 @@ function declarationsIn(scope, name) {
  * on correct code, and a rule that is sometimes wrong about correct code is one
  * people learn to ignore.
  */
-function resolveBuilder(arg, aliases) {
+function resolveBuilder(arg, imports) {
   const direct = calleeName(arg);
-  if (direct) return canonical(direct, aliases);
+  if (direct) return canonicalAt(arg, direct, imports);
   if (!arg || !ts.isIdentifier(arg)) return null;
 
   for (let scope = arg.parent; scope; scope = scope.parent) {
     if (!isScopeBoundary(scope) && !ts.isBlock(scope) && !ts.isCaseClause(scope)) continue;
     const declarations = declarationsIn(scope, arg.text);
-    if (declarations.length === 1 && declarations[0]) return canonical(declarations[0], aliases);
+    if (declarations.length === 1 && declarations[0]) {
+      return canonicalAt(scope, declarations[0], imports);
+    }
     if (declarations.length > 0) return null;
-    if (isScopeBoundary(scope)) break;
   }
   return null;
 }
@@ -165,14 +191,14 @@ export function auditSource(fileName, text) {
     /\.tsx$/.test(fileName) ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   );
   const findings = [];
-  const aliases = aliasMap(src);
+  const imports = importAliases(src);
 
   (function visit(node) {
-    const called = canonical(calleeName(node), aliases);
+    const called = canonicalAt(node, calleeName(node), imports);
     if (called === "withSlimEntries" || called === "withSlimPageEntries") {
       const { line } = src.getLineAndCharacterOfPosition(node.getStart());
       const where = `${fileName}:${line + 1}`;
-      const wrapped = resolveBuilder(node.arguments[0], aliases);
+      const wrapped = resolveBuilder(node.arguments[0], imports);
 
       if (!wrapped) {
         findings.push(


### PR DESCRIPTION
Closes #1564.

Deleting `withSlimEntries(` from any production feed call site left lint, typecheck and the entire suite green. The helper is tested in isolation, and the feed query spec mocks the SDK and stubs every `queryFn`, so nothing observed what a card would actually receive. The payload saving from #1545 had no guard at all.

**A behavioural spec** drives the real feed query builder and looks at the entry a card would get: `body === ""` on ranked feeds, tag feeds, profile posts and profile blog, with `json_metadata.description` present so the card still has something to render, and the body still intact on comments and replies, where the card is the body. Verified it fails on all four slimmed branches when the wrapper is removed.

**An AST audit**, in the style of the existing icon audits, enforces how a query is slimmed rather than whether:

- `withSlimEntries` around a single-page builder must pass `{ isolateKey: true }`. Those keys are `postsRankedPage` / `accountPostsPage`, which deck columns also read and render `entry.body` from; a slim page there is handed to a deck inside the staleTime and the post viewer renders empty. That is #1556.
- `withSlimEntries` around an infinite builder must not pass it. The feed poll hand-builds that key for its `setQueryData` merge, so marking it would silently write to a key nothing renders and the chip would stop refreshing stats, with no error anywhere.

Both directions were verified by injecting each violation: the audit reports the file, line and reason, and exits 1. It walks 1899 files in about a second and runs in the typecheck workflow, which already gates `develop`.

I did not add a default-deny rule requiring every feed builder call to be slimmed. That would need roughly fifteen ledger entries for decks, waves, RSS, proposals and the wallet, all of which legitimately need whole entries, and a ledger that size becomes noise rather than a signal.

`pnpm typecheck` clean, `pnpm test` green (2986 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed and archive data handling by ensuring full post bodies remain available where needed while feed cards use slimmer content.
  * Preserved separate caching for single-page ranked and profile queries.

* **Tests**
  * Added coverage for slimming across ranked, personal, tag, and profile feeds.
  * Added validation for cache isolation and wrapper usage.

* **Chores**
  * Added an automated audit to detect incorrect slim-entry usage during type checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->