### PR TITLE
Drop the render-helper CJS workaround in the hosting API

### DIFF
--- a/apps/self-hosted/hosting/api/package-lock.json
+++ b/apps/self-hosted/hosting/api/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@ecency/hosting-api",
       "version": "1.0.0",
       "dependencies": {
-        "@ecency/render-helper": "^2.5.26",
+        "@ecency/render-helper": "^2.5.27",
         "@ecency/sdk": "^2.2.0",
         "@hiveio/x402": "^0.1.2",
         "@hono/node-server": "^2.0.11",
@@ -42,9 +42,10 @@
       }
     },
     "node_modules/@ecency/render-helper": {
-      "version": "2.5.26",
-      "resolved": "https://registry.npmjs.org/@ecency/render-helper/-/render-helper-2.5.26.tgz",
-      "integrity": "sha512-n6nOXQYkX8VaS1bxE5fKbBX7B5Ro7xzZrbfqGLHZc8gNgVm0w8wTIHQUd9ObfXOzpzDZhnK2F9OwOVKHPy8bYA==",
+      "version": "2.5.27",
+      "resolved": "https://registry.npmjs.org/@ecency/render-helper/-/render-helper-2.5.27.tgz",
+      "integrity": "sha512-v/Y4itxbAw5gSmQ+9vGSOF9WsJNRI3EkV00ePH2jSPXhZnA8+fGwV3Nckdkicu4IoaIBzfJOLDswTahEESk6Jg==",
+      "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10",
         "dom-serializer": "^2.0.0",

--- a/apps/self-hosted/hosting/api/package.json
+++ b/apps/self-hosted/hosting/api/package.json
@@ -12,7 +12,7 @@
     "generate-seo": "tsx scripts/generate-seo.ts"
   },
   "dependencies": {
-    "@ecency/render-helper": "^2.5.26",
+    "@ecency/render-helper": "^2.5.27",
     "@ecency/sdk": "^2.2.0",
     "@hiveio/x402": "^0.1.2",
     "@hono/node-server": "^2.0.11",

--- a/apps/self-hosted/hosting/api/src/services/post-meta.ts
+++ b/apps/self-hosted/hosting/api/src/services/post-meta.ts
@@ -1,19 +1,5 @@
-import { createRequire } from 'node:module';
+import { catchPostImage } from '@ecency/render-helper';
 import { callRPC } from '@ecency/sdk/hive';
-
-// render-helper through its CJS build: the package's node ESM entry carries
-// a directory import ('remarkable/linkify') that Node refuses, so the ESM
-// path crashes at module load. Tracked as a render-helper packaging fix;
-// until it ships, CJS resolution handles the directory import fine.
-const requireCjs = createRequire(import.meta.url);
-const { catchPostImage } = requireCjs('@ecency/render-helper') as {
-  catchPostImage: (
-    entry: unknown,
-    width?: number,
-    height?: number,
-    format?: string,
-  ) => string | null;
-};
 import type { Tenant } from '../types';
 import { ConfigService, escapeHtml } from './config-service';
 import { TenantService } from './tenant-service';


### PR DESCRIPTION
Part of #1461, item 1.

`@ecency/render-helper@2.5.27` inlines remarkable, so the package's ESM node entry no longer carries the `remarkable/linkify` directory import that Node refused. The hosting API can import `catchPostImage` directly instead of reaching for the CJS build through `createRequire`, and the hand-written type that stood in for the real one goes with it.

Verified in this project, not in the abstract:

- `npm ci` pulls 2.5.27, and `import("@ecency/render-helper")` in a plain node process from `hosting/api` returns the function
- `tsc` clean, 47 test files and 466 tests pass

The lockfile moves with the dependency, since this project sits outside the pnpm workspace and carries its own.
