### PR TITLE
Let a named function or class expression bind its own name

### DIFF
--- a/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
+++ b/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
@@ -378,4 +378,42 @@ describe("slim-entries audit", () => {
     expect(found).toHaveLength(1);
     expect(found[0]).toContain("use withSlimPageEntries");
   });
+
+  it("does not mistake a named function expression's own name for the wrapper", () => {
+    // The name of a named function expression is bound inside its own body, so
+    // this recursive call is not our wrapper at all.
+    expect(
+      auditSource(
+        "f.ts",
+        `import { withSlimEntries } from "@/core/entries/slim-entry";
+         import { getPostsRankedQueryOptions } from "@ecency/sdk";
+         export const f = function withSlimEntries(o) {
+           return withSlimEntries(getPostsRankedQueryOptions("x"));
+         };`
+      )
+    ).toEqual([]);
+  });
+
+  it("treats a named class expression's own name the same way", () => {
+    const found = auditSource(
+      "f.ts",
+      `import { getPostsRankedQueryOptions } from "@ecency/sdk";
+       export const C = class getPostsRankedQueryOptions {
+         m() { return withSlimEntries(getPostsRankedQueryOptions()); }
+       };`
+    );
+    expect(found.every((f) => f.includes("cannot tell"))).toBe(true);
+    expect(found).toHaveLength(1);
+  });
+
+  it("still reports a genuine violation inside a class method", () => {
+    const found = auditSource(
+      "f.ts",
+      src(`export class Column {
+             load() { return withSlimEntries(getPostsRankedQueryOptions("t")); }
+           }`)
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("use withSlimPageEntries");
+  });
 });

--- a/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
+++ b/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
@@ -416,4 +416,33 @@ describe("slim-entries audit", () => {
     expect(found).toHaveLength(1);
     expect(found[0]).toContain("use withSlimPageEntries");
   });
+
+  it("stops at a self-binding reached through an identifier argument", () => {
+    // The identifier path resolves through resolveBuilder rather than the
+    // callee's own canonicalisation, so it needs its own case: without the
+    // self-binding check it climbed past the function and blamed the outer const.
+    const found = auditSource(
+      "f.ts",
+      `import { withSlimEntries } from "@/core/entries/slim-entry";
+       const options = getPostsRankedQueryOptions("x");
+       export const f = function options() { return withSlimEntries(options); };`
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("cannot tell");
+  });
+
+  it.each([
+    ["at module scope", `export class getPostsRankedQueryOptions { m() { return withSlimEntries(getPostsRankedQueryOptions()); } }`],
+    ["inside a function", `export function o() { class getPostsRankedQueryOptions { m() { return withSlimEntries(getPostsRankedQueryOptions()); } } }`],
+    ["inside a block", `export function o() { { class getPostsRankedQueryOptions { m() { return withSlimEntries(getPostsRankedQueryOptions()); } } } }`]
+  ])("does not attribute a class declaration's own name to an import, %s", (_label, body) => {
+    // Declarations bind in the scope AROUND them, which the child-level check
+    // already covers, so these are pinned here rather than in bindsOwnName.
+    const found = auditSource(
+      "f.ts",
+      `import { getPostsRankedQueryOptions } from "@ecency/sdk";\n${body}`
+    );
+    expect(found.every((f) => f.includes("cannot tell"))).toBe(true);
+    expect(found.length).toBeGreaterThan(0);
+  });
 });

--- a/scripts/slim-entries-audit.mjs
+++ b/scripts/slim-entries-audit.mjs
@@ -159,11 +159,11 @@ function bindsOwnName(scope, name) {
   ) {
     return true;
   }
-  // A class binds its own name inside its body as well as outside it.
+  // Only the EXPRESSION forms need this. A class or function DECLARATION binds
+  // its name in the scope around it, where bindingsIn already sees it as a
+  // child, so a branch for those here would never be reached.
   return (
-    (ts.isFunctionExpression(scope) ||
-      ts.isClassExpression(scope) ||
-      ts.isClassDeclaration(scope)) &&
+    (ts.isFunctionExpression(scope) || ts.isClassExpression(scope)) &&
     !!scope.name &&
     ts.isIdentifier(scope.name) &&
     scope.name.text === name

--- a/scripts/slim-entries-audit.mjs
+++ b/scripts/slim-entries-audit.mjs
@@ -73,6 +73,8 @@ function isScopeNode(node) {
     ts.isForInStatement(node) ||
     ts.isForOfStatement(node) ||
     ts.isCatchClause(node) ||
+    ts.isClassExpression(node) ||
+    ts.isClassDeclaration(node) ||
     ts.isModuleBlock(node)
   );
 }
@@ -121,12 +123,7 @@ function canonicalAt(node, name, imports, seen = new Set()) {
 
   for (let scope = node; scope; scope = scope.parent) {
     if (!isScopeNode(scope)) continue;
-    if (
-      ts.isCatchClause(scope) &&
-      scope.variableDeclaration &&
-      ts.isIdentifier(scope.variableDeclaration.name) &&
-      scope.variableDeclaration.name.text === name
-    ) {
+    if (bindsOwnName(scope, name)) {
       return null;
     }
     const bindings = bindingsIn(scope, name);
@@ -144,6 +141,33 @@ function canonicalAt(node, name, imports, seen = new Set()) {
     seen.add(current);
   }
   return current;
+}
+
+/**
+ * Whether the scope itself binds `name`, rather than one of its children doing
+ * so: a caught error, and the self-reference of a NAMED function or class
+ * expression, which is visible only inside its own body. Both shadow an outer
+ * binding of the same name, and reading past them reported correct code as a
+ * mismatch.
+ */
+function bindsOwnName(scope, name) {
+  if (
+    ts.isCatchClause(scope) &&
+    scope.variableDeclaration &&
+    ts.isIdentifier(scope.variableDeclaration.name) &&
+    scope.variableDeclaration.name.text === name
+  ) {
+    return true;
+  }
+  // A class binds its own name inside its body as well as outside it.
+  return (
+    (ts.isFunctionExpression(scope) ||
+      ts.isClassExpression(scope) ||
+      ts.isClassDeclaration(scope)) &&
+    !!scope.name &&
+    ts.isIdentifier(scope.name) &&
+    scope.name.text === name
+  );
 }
 
 /**
@@ -219,6 +243,7 @@ function resolveBuilder(arg, imports) {
 
   for (let scope = arg.parent; scope; scope = scope.parent) {
     if (!isScopeNode(scope)) continue;
+    if (bindsOwnName(scope, arg.text)) return null;
     const bindings = bindingsIn(scope, arg.text);
     if (bindings.length === 1) {
       const called = calleeName(bindings[0]);


### PR DESCRIPTION
A named function expression binds its own name inside its own body, so the recursive call in `const f = function withSlimEntries() { ... }` is not our wrapper at all. The audit read it as the imported one and reported correct code as a violation. A named class expression had the same problem, and worse: a class was not treated as a scope at all, so its own name never shadowed anything.

Both reproduced before the change, both flagged as violations.

Classes are scopes now, and the self-reference of a named function or class, like a caught error before it, stops resolution for that scope. A genuine violation inside a class method is still reported, which the tests pin alongside both shadowing shapes.

This is the last of the false-positive shapes found in this audit, and they all had one cause: a binding the walk could not see, resolved past, and blamed on an import the code never called. The rule is now that any binding it cannot read stops resolution and the call is reported as unclassifiable, which is the honest answer rather than a wrong one.

`pnpm typecheck` clean, `pnpm test` green (3028 tests), 33 of them on the audit itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit accuracy for named functions and classes, identifier arguments, and class declarations across module, function, and block scopes.
  * Prevented incorrect name resolution across self-binding, shadowed, and caught-error scopes.
  * Preserved reporting for genuine class-method wrapper violations.

* **Tests**
  * Added regression coverage for scope handling and class-method audit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->