### PR TITLE
Fetch slim pages for the two server renders that never read a body

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-footer.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-footer.tsx
@@ -1,5 +1,6 @@
 import { Entry } from "@/entities";
 import { fetchQuery } from "@/core/react-query";
+import { withSlimPageEntries } from "@/core/entries/slim-entry";
 import {
   getAccountPostsQueryOptions,
   getPostsRankedQueryOptions,
@@ -53,9 +54,19 @@ export async function EntryRelatedFooter({ entry }: Props) {
         json_metadata: { tags: entry.json_metadata?.tags }
       })
     ),
-    fetchQuery(getAccountPostsQueryOptions(entry.author, "posts", "", "", FETCH_LIMIT)),
+    // A row is an author, a permlink, a title and a thumbnail. Both feeds are
+    // fetched slim so this render does not hold 24 post bodies it never reads
+    // for the lifetime of the request-scoped cache (#1559). The similar-entries
+    // query above already answers with narrow rows.
+    fetchQuery(
+      withSlimPageEntries(getAccountPostsQueryOptions(entry.author, "posts", "", "", FETCH_LIMIT))
+    ),
     source
-      ? fetchQuery(getPostsRankedQueryOptions("created", "", "", FETCH_LIMIT, source.tag))
+      ? fetchQuery(
+          withSlimPageEntries(
+            getPostsRankedQueryOptions("created", "", "", FETCH_LIMIT, source.tag)
+          )
+        )
       : Promise.resolve(undefined)
   ]);
 

--- a/apps/web/src/app/_components/landing-page/landing-trending.tsx
+++ b/apps/web/src/app/_components/landing-page/landing-trending.tsx
@@ -3,6 +3,7 @@ import i18next from "i18next";
 import { getPostsRankedQueryOptions } from "@ecency/sdk";
 import { catchPostImage } from "@ecency/render-helper";
 import { prefetchQuery } from "@/core/react-query";
+import { withSlimPageEntries } from "@/core/entries/slim-entry";
 import { isNsfwEntry } from "@/utils/nsfw-detection";
 import { Entry } from "@/entities";
 
@@ -15,13 +16,18 @@ const LIMIT = 8;
  * HTML so crawlers follow the homepage's authority into fresh content, and
  * first-time visitors see the actual product instead of marketing copy.
  *
+ * The strip reads a title, an author and a thumbnail, never a body, so the page
+ * is fetched slim: the bodies of 8 trending posts are hundreds of KB that this
+ * render would otherwise hold in the request-scoped cache for its gc window,
+ * which is what bounds how many renderer replicas fit on a host (#1559).
+ *
  * prefetchQuery has a built-in SSR timeout and swallows errors (returns
  * undefined), so a slow/failed RPC degrades to "no strip" rather than breaking
  * "/". Thumbnails are below the hero and lazy-loaded, keeping the page light.
  */
 export async function LandingTrending() {
   const data = (await prefetchQuery(
-    getPostsRankedQueryOptions("trending", "", "", LIMIT)
+    withSlimPageEntries(getPostsRankedQueryOptions("trending", "", "", LIMIT))
   )) as Entry[] | undefined;
 
   const entries = (data ?? [])

--- a/apps/web/src/core/entries/slim-entry.ts
+++ b/apps/web/src/core/entries/slim-entry.ts
@@ -23,12 +23,27 @@ import { parseEntryLocationFromBody } from "./entry-location";
 /** Same length the card passes to postBodySummary, so the text is unchanged. */
 export const SLIM_SUMMARY_LENGTH = 200;
 
+/**
+ * The first usable URL in an author-written metadata field.
+ *
+ * Neither `image` nor `thumbnails` can be trusted to hold the type it is declared
+ * with: json_metadata is whatever the publishing client wrote. `image` really does
+ * arrive as a bare string, which is why catchPostImage handles both, and a
+ * `thumbnails` that is not an array used to throw straight out of the queryFn,
+ * failing the whole page rather than one card.
+ */
+function firstUrl(value: unknown): string | undefined {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.find((url): url is string => typeof url === "string" && url.length > 0);
+  }
+  return undefined;
+}
+
 function pickThumbnail(entry: Entry): string | undefined {
   const meta = entry.json_metadata;
-  // json_metadata is author-written: `image` is typed as an array but really does
-  // arrive as a bare string too, which is why catchPostImage handles both. Read it
-  // as unknown so the same runtime tolerance survives the narrower type.
-  const image: unknown = meta?.image;
 
   // Order requested for cards: an explicit thumbnail wins over the cover image,
   // since `thumbnails` is published for exactly this purpose (3Speak, Liketu).
@@ -37,26 +52,14 @@ function pickThumbnail(entry: Entry): string | undefined {
   // catchPostImage per author/permlink/update AND size, process-wide, so a card
   // (600x500) and the entry page's LCP preload (same size) share one cache slot.
   // They agree today because every sampled post that carries both fields sets
-  // them to the same URL (44 of 44 across trending/hot/created, tags and
-  // communities), so the value cached from a feed row is the value the post page
-  // would have computed. A publisher that set them to DIFFERENT urls would hand
+  // them to the same URL (70 of 70, out of 461 live rows across trending, hot,
+  // created, promoted, tags and communities), so the value cached from a feed row
+  // is the value the post page would have computed. A publisher that set them to DIFFERENT urls would hand
   // the post page a preload that its body does not render, and the LCP image
   // would download twice.
-  const thumbnail = meta?.thumbnails?.find((url) => typeof url === "string" && url.length > 0);
+  const thumbnail = firstUrl(meta?.thumbnails) ?? firstUrl(meta?.image);
   if (thumbnail) {
     return thumbnail;
-  }
-
-  if (typeof image === "string" && image.length > 0) {
-    return image;
-  }
-  if (Array.isArray(image)) {
-    const first = image.find(
-      (url): url is string => typeof url === "string" && url.length > 0
-    );
-    if (first) {
-      return first;
-    }
   }
 
   // Nothing in metadata: recover what catchPostImage would have found on the full
@@ -133,10 +136,29 @@ export function slimEntry<T extends Entry>(entry: T): T {
   return slimmed;
 }
 
+/**
+ * Slim one entry, or hand back exactly what arrived if that is not possible.
+ *
+ * This step only ever saves memory, so it must not be able to cost a page. It
+ * runs inside the queryFn, where a throw rejects the whole query: on the server
+ * prefetchQuery then returns undefined and the strip or the related row vanishes,
+ * and on the client the feed shows its error state. All of that from one field in
+ * one author-written json_metadata. The guards in pickThumbnail are the fix for
+ * the shape that did it; this is the backstop for the shape nobody thought of.
+ * An entry that comes back untouched still renders, it just keeps its body.
+ */
+function slimEntrySafely(entry: Entry): Entry {
+  try {
+    return slimEntry(entry);
+  } catch {
+    return entry;
+  }
+}
+
 /** Slim a page of feed results, leaving a non-array response shape untouched. */
 export function slimEntryPage<T>(page: T): T {
   if (Array.isArray(page)) {
-    return page.map((item) => slimEntry(item as Entry)) as unknown as T;
+    return page.map((item) => slimEntrySafely(item as Entry)) as unknown as T;
   }
   return page;
 }

--- a/apps/web/src/specs/app/slim-server-prefetches.spec.tsx
+++ b/apps/web/src/specs/app/slim-server-prefetches.spec.tsx
@@ -1,0 +1,148 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SLIM_KEY_MARKER } from "@/core/entries/slim-entry";
+import { mockEntry } from "@/specs/test-utils";
+import type { Entry } from "@/entities";
+
+interface Seen {
+  queryKey: unknown[];
+  result: unknown;
+}
+
+const seen = vi.hoisted(() => [] as Seen[]);
+const answers = vi.hoisted(() => new Map<string, unknown>());
+
+// Both server components reach the network through these two helpers. Running
+// the options they are handed, rather than stubbing the result, is the point:
+// what is under test is the queryFn the wrapper installed.
+vi.mock("@/core/react-query", () => {
+  const run = async (options: {
+    queryKey: unknown[];
+    queryFn: (ctx: unknown) => Promise<unknown>;
+  }) => {
+    const result = await options.queryFn({
+      queryKey: options.queryKey,
+      signal: new AbortController().signal
+    });
+    seen.push({ queryKey: options.queryKey, result });
+    return result;
+  };
+  return { prefetchQuery: run, fetchQuery: run };
+});
+
+vi.mock("@ecency/sdk", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@ecency/sdk");
+  const answer = (name: string) => ({
+    queryKey: [name],
+    queryFn: async () => answers.get(name) ?? []
+  });
+  return {
+    ...actual,
+    getPostsRankedQueryOptions: () => answer("ranked"),
+    getAccountPostsQueryOptions: () => answer("account"),
+    getSimilarEntriesQueryOptions: () => answer("similar")
+  };
+});
+
+vi.mock("@/features/i18n", () => ({ initI18next: async () => undefined }));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  )
+}));
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: any) => <img src={src} alt={alt} />
+}));
+
+import { LandingTrending } from "@/app/_components/landing-page/landing-trending";
+import { EntryRelatedFooter } from "@/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-footer";
+
+// render-helper memoizes per author/permlink/update, so every fixture needs its
+// own permlink or one case reads another's cached image.
+let seq = 0;
+
+/** A bridge row as it really arrives: whole body, no image in the metadata. */
+function fullRow(overrides: Partial<Entry> = {}): Entry {
+  const permlink = `prefetch-fixture-${++seq}`;
+  return mockEntry({
+    author: "alice",
+    permlink,
+    title: `Title ${permlink}`,
+    category: "photography",
+    body: `Some words and a cover ![cover](https://example.com/${permlink}.jpg) then more words.`,
+    json_metadata: { tags: ["photography"] },
+    ...overrides
+  });
+}
+
+function slimmed(): Entry[] {
+  return seen.flatMap((s) => (Array.isArray(s.result) ? (s.result as Entry[]) : []));
+}
+
+describe("server renders that never read a body fetch slim pages", () => {
+  beforeEach(() => {
+    seen.length = 0;
+    answers.clear();
+  });
+
+  it("keeps the landing strip's titles and thumbnails without its bodies", async () => {
+    // The strip reads a title, an author and a thumbnail. The bodies behind it
+    // are hundreds of KB the render holds for the request's gc window (#1559).
+    const rows = [fullRow(), fullRow()];
+    answers.set("ranked", rows);
+
+    const { container } = render(await LandingTrending());
+
+    for (const row of rows) {
+      expect(screen.getByText(row.title)).toBeInTheDocument();
+    }
+    // The cover lived only in the body, and the card still shows it: the
+    // thumbnail is derived before the body goes, not lost with it.
+    // Decorative, so alt is empty and the img carries no accessible role.
+    const images = [...container.querySelectorAll("img")];
+    expect(images).toHaveLength(2);
+    for (const img of images) {
+      expect(img.getAttribute("src")).toMatch(
+        /^https:\/\/i\.ecency\.com\/p\/.+width=320&height=180$/
+      );
+    }
+    expect(slimmed().map((e) => e.body)).toEqual(["", ""]);
+  });
+
+  it("keeps the related footer's rows without their bodies", async () => {
+    const authorRows = [fullRow(), fullRow()];
+    const communityRows = [fullRow({ author: "bob" }), fullRow({ author: "carol" })];
+    answers.set("account", authorRows);
+    answers.set("ranked", communityRows);
+
+    const entry = fullRow({ permlink: "the-post-being-read" });
+    render((await EntryRelatedFooter({ entry })) as React.ReactElement);
+
+    for (const row of [...authorRows, ...communityRows]) {
+      expect(screen.getByText(row.title)).toBeInTheDocument();
+    }
+    expect(slimmed()).toHaveLength(4);
+    expect(slimmed().every((e) => e.body === "")).toBe(true);
+  });
+
+  it("answers under a key of its own, never the one deck columns read", async () => {
+    // A slim page cached under the SDK's own page key is issue #1556: a deck
+    // column reads it inside the staleTime and renders an empty article.
+    answers.set("ranked", [fullRow()]);
+    answers.set("account", [fullRow()]);
+
+    render(await LandingTrending());
+    render((await EntryRelatedFooter({ entry: fullRow() })) as React.ReactElement);
+
+    const entryKeys = seen.filter((s) => s.queryKey[0] !== "similar");
+    expect(entryKeys.length).toBe(3);
+    for (const { queryKey } of entryKeys) {
+      expect(queryKey.at(-1)).toBe(SLIM_KEY_MARKER);
+    }
+  });
+});

--- a/apps/web/src/specs/app/slim-server-prefetches.spec.tsx
+++ b/apps/web/src/specs/app/slim-server-prefetches.spec.tsx
@@ -2,46 +2,27 @@ import "@testing-library/jest-dom";
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getQueryClient } from "@/core/react-query";
 import { SLIM_KEY_MARKER } from "@/core/entries/slim-entry";
 import { mockEntry } from "@/specs/test-utils";
 import type { Entry } from "@/entities";
 
-interface Seen {
-  queryKey: unknown[];
-  result: unknown;
-}
-
-const seen = vi.hoisted(() => [] as Seen[]);
 const answers = vi.hoisted(() => new Map<string, unknown>());
 
-// Both server components reach the network through these two helpers. Running
-// the options they are handed, rather than stubbing the result, is the point:
-// what is under test is the queryFn the wrapper installed.
-vi.mock("@/core/react-query", () => {
-  const run = async (options: {
-    queryKey: unknown[];
-    queryFn: (ctx: unknown) => Promise<unknown>;
-  }) => {
-    const result = await options.queryFn({
-      queryKey: options.queryKey,
-      signal: new AbortController().signal
-    });
-    seen.push({ queryKey: options.queryKey, result });
-    return result;
-  };
-  return { prefetchQuery: run, fetchQuery: run };
-});
-
+// Only the bridge is stubbed. The components reach it through the real
+// prefetchQuery/fetchQuery and the real request-scoped query client, which is
+// what makes the cache assertions below mean anything: they read what a server
+// render would actually be holding.
 vi.mock("@ecency/sdk", async () => {
   const actual = await vi.importActual<Record<string, unknown>>("@ecency/sdk");
-  const answer = (name: string) => ({
-    queryKey: [name],
+  const answer = (name: string, ...key: unknown[]) => ({
+    queryKey: [name, ...key],
     queryFn: async () => answers.get(name) ?? []
   });
   return {
     ...actual,
-    getPostsRankedQueryOptions: () => answer("ranked"),
-    getAccountPostsQueryOptions: () => answer("account"),
+    getPostsRankedQueryOptions: (sort: string, tag: string) => answer("ranked", sort, tag),
+    getAccountPostsQueryOptions: (username: string) => answer("account", username),
     getSimilarEntriesQueryOptions: () => answer("similar")
   };
 });
@@ -49,14 +30,12 @@ vi.mock("@ecency/sdk", async () => {
 vi.mock("@/features/i18n", () => ({ initI18next: async () => undefined }));
 
 vi.mock("next/link", () => ({
-  default: ({ href, children, ...rest }: any) => (
-    <a href={href} {...rest}>
-      {children}
-    </a>
+  default: ({ href, children }: React.PropsWithChildren<{ href: string }>) => (
+    <a href={href}>{children}</a>
   )
 }));
 vi.mock("next/image", () => ({
-  default: ({ src, alt }: any) => <img src={src} alt={alt} />
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />
 }));
 
 import { LandingTrending } from "@/app/_components/landing-page/landing-trending";
@@ -80,13 +59,25 @@ function fullRow(overrides: Partial<Entry> = {}): Entry {
   });
 }
 
-function slimmed(): Entry[] {
-  return seen.flatMap((s) => (Array.isArray(s.result) ? (s.result as Entry[]) : []));
+/** Every entry the render left behind in the request-scoped cache. */
+function cachedEntries(): Entry[] {
+  return getQueryClient()
+    .getQueryCache()
+    .getAll()
+    .flatMap((query) => (Array.isArray(query.state.data) ? (query.state.data as Entry[]) : []));
+}
+
+function cachedEntryKeys(): unknown[][] {
+  return getQueryClient()
+    .getQueryCache()
+    .getAll()
+    .filter((query) => Array.isArray(query.state.data) && query.state.data.length > 0)
+    .map((query) => [...query.queryKey]);
 }
 
 describe("server renders that never read a body fetch slim pages", () => {
   beforeEach(() => {
-    seen.length = 0;
+    getQueryClient().clear();
     answers.clear();
   });
 
@@ -111,7 +102,7 @@ describe("server renders that never read a body fetch slim pages", () => {
         /^https:\/\/i\.ecency\.com\/p\/.+width=320&height=180$/
       );
     }
-    expect(slimmed().map((e) => e.body)).toEqual(["", ""]);
+    expect(cachedEntries().map((e) => e.body)).toEqual(["", ""]);
   });
 
   it("keeps the related footer's rows without their bodies", async () => {
@@ -126,8 +117,8 @@ describe("server renders that never read a body fetch slim pages", () => {
     for (const row of [...authorRows, ...communityRows]) {
       expect(screen.getByText(row.title)).toBeInTheDocument();
     }
-    expect(slimmed()).toHaveLength(4);
-    expect(slimmed().every((e) => e.body === "")).toBe(true);
+    expect(cachedEntries()).toHaveLength(4);
+    expect(cachedEntries().every((e) => e.body === "")).toBe(true);
   });
 
   it("answers under a key of its own, never the one deck columns read", async () => {
@@ -139,10 +130,26 @@ describe("server renders that never read a body fetch slim pages", () => {
     render(await LandingTrending());
     render((await EntryRelatedFooter({ entry: fullRow() })) as React.ReactElement);
 
-    const entryKeys = seen.filter((s) => s.queryKey[0] !== "similar");
-    expect(entryKeys.length).toBe(3);
-    for (const { queryKey } of entryKeys) {
-      expect(queryKey.at(-1)).toBe(SLIM_KEY_MARKER);
+    const keys = cachedEntryKeys();
+    expect(keys.length).toBe(3);
+    for (const key of keys) {
+      expect(key.at(-1)).toBe(SLIM_KEY_MARKER);
     }
+  });
+
+  it("still renders when a row's metadata cannot be read", async () => {
+    // json_metadata is author-written. Before the guards in slimEntry, one row
+    // with a non-array `thumbnails` threw inside the queryFn, prefetchQuery
+    // swallowed it and the entire strip disappeared.
+    const hostile = fullRow({
+      json_metadata: { thumbnails: "https://example.com/not-an-array.jpg" } as never
+    });
+    const ordinary = fullRow();
+    answers.set("ranked", [hostile, ordinary]);
+
+    render(await LandingTrending());
+
+    expect(screen.getByText(hostile.title)).toBeInTheDocument();
+    expect(screen.getByText(ordinary.title)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/specs/core/entries/slim-entry.spec.ts
+++ b/apps/web/src/specs/core/entries/slim-entry.spec.ts
@@ -66,6 +66,36 @@ describe("slimEntry", () => {
     expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/in-body.png"]);
   });
 
+  it("survives thumbnails that are not an array", () => {
+    // json_metadata is author-written and `thumbnails` is only typed as string[].
+    // A bare string threw out of the queryFn, and a throw there is not one bad
+    // card: prefetchQuery returns undefined and the whole strip or feed is gone.
+    const e = entry({
+      json_metadata: { thumbnails: "https://images.hive.blog/single.png" } as never
+    });
+    expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/single.png"]);
+  });
+
+  it("ignores thumbnails of a shape no url can be read from", () => {
+    const e = entry({
+      json_metadata: {
+        thumbnails: { 0: "https://images.hive.blog/object.png" },
+        image: ["https://images.hive.blog/cover.png"]
+      } as never
+    });
+    expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/cover.png"]);
+  });
+
+  it("ignores non-string members of either metadata field", () => {
+    const e = entry({
+      json_metadata: {
+        thumbnails: [null, 42, ""],
+        image: [undefined, "https://images.hive.blog/real.png"]
+      } as never
+    });
+    expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/real.png"]);
+  });
+
   it("keeps a video post's poster, which only the full render finds", () => {
     // A bare YouTube URL becomes an <img class="no-replace video-thumbnail"> in
     // the rendered post, so the raw-markdown fast path sees no image at all.
@@ -131,6 +161,25 @@ describe("slimEntry", () => {
   it("passes through an entry that has no body already", () => {
     const e = entry({ body: "" });
     expect(slimEntry(e)).toBe(e);
+  });
+});
+
+describe("slimEntryPage", () => {
+  it("hands back a row it cannot slim, and still slims the rest of the page", () => {
+    // The backstop, for the metadata shape nobody thought of. Losing a row's
+    // saving costs memory; letting the queryFn reject costs the whole page.
+    const broken = entry();
+    Object.defineProperty(broken, "json_metadata", {
+      get() {
+        throw new Error("unreadable metadata");
+      }
+    });
+    const fine = entry({ body: "a body that should still go" });
+
+    const page = slimEntryPage([broken, fine]);
+
+    expect(page[0]).toBe(broken);
+    expect(page[1].body).toBe("");
   });
 });
 


### PR DESCRIPTION
Closes the second item of #1559.

Two server renders prefetch whole bridge pages and read no body from them:

- `landing-trending.tsx` renders a title, an author and a thumbnail for 8 trending posts.
- `entry-related-footer.tsx` renders a title, an author, a date and a thumbnail for up to 24 rows across two feeds.

Both now fetch through `withSlimPageEntries`, so the page arrives with the card fields derived and the body dropped, and neither render holds markdown it will not use for the request cache's gc window.

Measured on live pages:

| render | rows | page | of which body |
| --- | --- | --- | --- |
| landing strip | 8 | 234 KB | 39 KB |
| related footer, author feed | 12 | 394 KB | 33 KB |
| related footer, community feed | 12 | 134 KB | 38 KB |

The keys are isolated with the slim marker, because `postsRankedPage` and `accountPostsPage` are also read by deck columns that do render `entry.body` (#1556). The wire cost is unchanged: the bridge sends what it sends.

Worth knowing for whatever comes next on #1559: `active_votes` is the larger share of both renders, 181 KB of the strip and 422 KB of the footer's two feeds, and neither render reads a single vote.

Tests: `slim-server-prefetches.spec.tsx` runs both components through the options they actually hand to the prefetch helpers, asserting titles and thumbnails still render from a body-derived cover, that every page arrives with an empty body, and that the keys carry the slim marker. All three fail without the change.