### PR TITLE
Track the web origin nginx config, with the public-repo contract enforced

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -50,3 +50,6 @@ jobs:
       # poll hand-builds that key for its merge.
       - name: Slim-entry convention audit
         run: node scripts/slim-entries-audit.mjs --fail
+
+      - name: Audit committed origin nginx config
+        run: node scripts/origin-config-audit.mjs --fail

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -52,4 +52,6 @@ jobs:
         run: node scripts/slim-entries-audit.mjs --fail
 
       - name: Audit committed origin nginx config
-        run: node scripts/origin-config-audit.mjs --fail
+        run: |
+          node scripts/origin-config-audit.mjs --self-test
+          node scripts/origin-config-audit.mjs --fail

--- a/infra/origin/README.md
+++ b/infra/origin/README.md
@@ -17,7 +17,8 @@ rather than silently serving with no protection.
 
 | file | lives | why not here |
 |---|---|---|
-| `rate-limits.conf` | `/etc/nginx/` **only** | the thresholds. Committing them would say exactly where the line is and how to sit under it |
+| `rate-limits.conf` | `/etc/nginx/` **only** | the request-rate thresholds. Committing them would say exactly where the line is and how to sit under it |
+| `conn-limits.conf` | `/etc/nginx/` **only** | the concurrency ceiling, for the same reason |
 | `verified-crawlers.conf` | `/etc/nginx/` **only** | crawler source addresses |
 | `newsletter-relay-allow.conf` | `/etc/nginx/` **only** | who may reach the newsletter service, see the hosting origin README |
 
@@ -30,6 +31,11 @@ What IS committed and deliberately so:
   willing to send a dozen requests and count the 429s, so hiding the shape buys nothing
   while costing reviewability.
 - bot-detection patterns, which are public crawler names.
+
+**Comments count as published.** A threshold quoted in a comment is as disclosed as one in
+a directive, so the vhost comments name the include rather than the number. The audit
+reads comments for exactly this reason: an earlier version stripped them and reported a
+clean run while every rate sat in prose two lines above.
 
 ## What these files depend on
 

--- a/infra/origin/README.md
+++ b/infra/origin/README.md
@@ -12,8 +12,16 @@ blog-hosting origin. Read that README too: the contract is the same one.
 **Structure is committed. Numbers and addresses are not.**
 
 Anything that tells a reader where a limit sits, or which addresses are trusted, stays on
-the host and is pulled in with a wildcard `include`, so that a missing file fails closed
-rather than silently serving with no protection.
+the host and is pulled in with an `include`, so that a missing file fails closed rather
+than silently serving with no protection.
+
+**Wildcard or exact is not a style choice.** nginx accepts a wildcard include that matches
+no files, so `include foo*.conf;` reloads happily with whatever that file carried simply
+absent. That is only safe when the protection survives without it, which is true of the
+allowlists: `include <name>-allow*.conf;` followed by `deny all;` still denies. It is NOT
+true of a file that carries the protective directive itself, so `conn-limits.conf` and
+`rate-limits.conf` are included EXACTLY and a missing one is a hard startup error.
+Verified rather than assumed: removing either now fails `nginx -t` with the filename.
 
 | file | lives | why not here |
 |---|---|---|

--- a/infra/origin/README.md
+++ b/infra/origin/README.md
@@ -1,0 +1,71 @@
+# Web origin nginx config
+
+The vhosts that serve ecency.com from the two origins. They were edited by hand on each
+box until now, which meant a change was invisible to review, the two origins drifted from
+each other, and a host rebuild lost the lot.
+
+This mirrors `apps/self-hosted/hosting/origin/`, which does the same job for the
+blog-hosting origin. Read that README too: the contract is the same one.
+
+## The contract, because this repository is PUBLIC
+
+**Structure is committed. Numbers and addresses are not.**
+
+Anything that tells a reader where a limit sits, or which addresses are trusted, stays on
+the host and is pulled in with a wildcard `include`, so that a missing file fails closed
+rather than silently serving with no protection.
+
+| file | lives | why not here |
+|---|---|---|
+| `rate-limits.conf` | `/etc/nginx/` **only** | the thresholds. Committing them would say exactly where the line is and how to sit under it |
+| `verified-crawlers.conf` | `/etc/nginx/` **only** | crawler source addresses |
+| `newsletter-relay-allow.conf` | `/etc/nginx/` **only** | who may reach the newsletter service, see the hosting origin README |
+
+What IS committed and deliberately so:
+
+- `proxy_pass` targets, which are loopback only and reachable by nothing off-box. The
+  hosting origin already commits the same shape.
+- `burst=` values on `limit_req`. A burst is meaningless without the rate it bursts
+  against, and the rates are not here. Effective limits are discoverable by anyone
+  willing to send a dozen requests and count the 429s, so hiding the shape buys nothing
+  while costing reviewability.
+- bot-detection patterns, which are public crawler names.
+
+## What these files depend on
+
+The vhosts reference things defined at `http` level in `/etc/nginx/nginx.conf`, which is
+not tracked here because it is mostly stock. A rebuilt origin needs these to exist before
+the vhosts will load:
+
+- `map $http_user_agent $is_slow_bot` and `map $is_slow_bot$http_cf_connecting_ip $bot_limit_key`
+- `geo $http_cf_connecting_ip $is_verified_crawler` and `map $is_verified_crawler $rl_ssr_key`
+- `include /etc/nginx/rate-limits*.conf;` placed AFTER those maps, since the zones use the
+  variables they define
+- the `apicache` and SSR `proxy_cache_path` entries
+- `map $cookie_active_user $skip_cache` and the other cache-decision maps
+
+## Restoring an origin
+
+```bash
+# 1. the parts that are not in git, first, so nothing serves unprotected
+#    (rate-limits.conf, verified-crawlers.conf, newsletter-relay-allow.conf)
+
+# 2. the vhost for this origin
+cp infra/origin/eu.ecency.com.conf /etc/nginx/sites-enabled/eu.ecency.com   # or us
+
+# 3. verify BEFORE reloading
+nginx -t && systemctl reload nginx
+```
+
+Never test with a scratch config that omits the `user` directive: doing that once reset
+`/var/lib/nginx` ownership and the whole site answered 200 with an empty body.
+
+## Keeping the two origins in step
+
+EU and US are separate machines with near-identical vhosts. A change to one is almost
+always a change to both, and the limit on the newsletter subscribe path is a worked
+example of why: while only one origin had it, the protection was bypassable simply by
+being routed to the other.
+
+The files here differ only where they must. Diff them before assuming a difference is
+intentional.

--- a/infra/origin/README.md
+++ b/infra/origin/README.md
@@ -53,8 +53,8 @@ the vhosts will load:
 
 - `map $http_user_agent $is_slow_bot` and `map $is_slow_bot$http_cf_connecting_ip $bot_limit_key`
 - `geo $http_cf_connecting_ip $is_verified_crawler` and `map $is_verified_crawler $rl_ssr_key`
-- `include /etc/nginx/rate-limits*.conf;` placed AFTER those maps, since the zones use the
-  variables they define
+- `include /etc/nginx/rate-limits.conf;` placed AFTER those maps, since the zones use the
+  variables they define. Exact, not a wildcard: see the contract above
 - the `apicache` and SSR `proxy_cache_path` entries
 - `map $cookie_active_user $skip_cache` and the other cache-decision maps
 

--- a/infra/origin/eu.ecency.com.conf
+++ b/infra/origin/eu.ecency.com.conf
@@ -114,15 +114,18 @@ server {
 
     # Frontend route
     location / {
-        # Rate limit aggressive bots to 1 req/s, burst 5. Normal users unaffected.
+        # Aggressive-bot rate limit. Threshold in /etc/nginx/rate-limits.conf.
         limit_req zone=botlimit burst=5 nodelay;
-        # SSR page rate limit: 15 req/s per client IP, burst 50. Allows feed RSC prefetches.
+        # SSR page rate limit per client IP, sized to allow feed RSC prefetches.
+        # Threshold in /etc/nginx/rate-limits.conf.
         limit_req zone=ssrlimit burst=50 nodelay;
-        # General per-IP limit: 50 req/s, burst 70. Backstop for all traffic.
+        # General per-IP backstop for all traffic. Threshold in
+        # /etc/nginx/rate-limits.conf.
         limit_req zone=general burst=70 nodelay;
         limit_req_status 429;
-        # Total concurrent SSR limit: 150 max for anonymous users. Logged-in users bypass.
-        limit_conn total_ssr 150;
+        # Concurrent SSR ceiling for anonymous users; logged-in users bypass.
+        # The number lives in /etc/nginx/conn-limits.conf, which is not in git.
+        include /etc/nginx/conn-limits*.conf;
         limit_conn_status 429;
 
         # SSR page cache for anonymous users only

--- a/infra/origin/eu.ecency.com.conf
+++ b/infra/origin/eu.ecency.com.conf
@@ -125,7 +125,9 @@ server {
         limit_req_status 429;
         # Concurrent SSR ceiling for anonymous users; logged-in users bypass.
         # The number lives in /etc/nginx/conn-limits.conf, which is not in git.
-        include /etc/nginx/conn-limits*.conf;
+        # EXACT include, not a wildcard: nginx accepts a wildcard that matches
+        # nothing, so a missing file would reload cleanly with no limit at all.
+        include /etc/nginx/conn-limits.conf;
         limit_conn_status 429;
 
         # SSR page cache for anonymous users only

--- a/infra/origin/eu.ecency.com.conf
+++ b/infra/origin/eu.ecency.com.conf
@@ -1,0 +1,168 @@
+# Redirect HTTP to HTTPS
+server {
+    listen 80;
+    listen [::]:80;
+    server_name eu.ecency.com;
+
+    return 301 https://$host$request_uri;
+}
+
+# HTTPS server with Let's Encrypt cert
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name eu.ecency.com;
+
+    # big-header proxy buffers (server-level)
+    # Next.js emits a large Link: rel=preload header; nginx's 4k default
+    # header buffer overflows -> 502 'upstream sent too big header'.
+    # Server scope so every proxied location (/, /_next/static/, manifest,
+    # assets, scripts, ...) inherits it and this can't drift per-location.
+    proxy_buffer_size       16k;
+    proxy_buffers           8 16k;
+    proxy_busy_buffers_size 16k;
+
+    client_max_body_size 100M;
+
+    ssl_certificate     /etc/letsencrypt/live/eu.ecency.com/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/eu.ecency.com/privkey.pem;   # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf;                        # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;                          # managed by Certbot
+
+    location /api/mattermost/websocket {
+      proxy_pass http://localhost:3000;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $host;
+      proxy_read_timeout 86400;
+    }
+
+    # All /api/ paths — no caching (user-specific data)
+    # Newsletter subscribe, tightened. One legitimate action is exactly one POST
+    # and observed real traffic is about one a day, so this sits far below the
+    # general /api/ allowance. Exact match, so it wins over `location /api/`
+    # below; the proxy directives are repeated because a location does not
+    # inherit them from a sibling.
+    location = /api/newsletter/subscribe {
+        limit_req zone=subscribelimit burst=10 nodelay;
+        limit_req_status 429;
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+
+    location /api/ {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+
+    # API proxy routes
+    location ~ ^/private-api/usr-activity {
+        proxy_set_header   X-Real-IP $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:4000;
+    }
+
+    # Cache promoted-entries responses for 60s
+    location = /private-api/promoted-entries {
+        proxy_cache apicache;
+        proxy_cache_valid 200 300s;
+        proxy_cache_key "$request_uri";
+        proxy_cache_use_stale error timeout updating;
+        add_header X-Cache-Status $upstream_cache_status;
+        proxy_set_header   X-Real-IP $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:4000;
+    }
+
+    location ~ ^/(private-api|search-api|wallet-api|auth-api) {
+        proxy_set_header   X-Real-IP $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:4000;
+    }
+
+    # Static assets - pass through Next.js cache headers (immutable, 1yr)
+    location /_next/static/ {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+
+    # Static files - no rate limiting, no SSR cache
+    location = /manifest.json {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+    location = /favicon.ico {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+    location /assets/ {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+    location /scripts/ {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+
+    # Frontend route
+    location / {
+        # Rate limit aggressive bots to 1 req/s, burst 5. Normal users unaffected.
+        limit_req zone=botlimit burst=5 nodelay;
+        # SSR page rate limit: 15 req/s per client IP, burst 50. Allows feed RSC prefetches.
+        limit_req zone=ssrlimit burst=50 nodelay;
+        # General per-IP limit: 50 req/s, burst 70. Backstop for all traffic.
+        limit_req zone=general burst=70 nodelay;
+        limit_req_status 429;
+        # Total concurrent SSR limit: 150 max for anonymous users. Logged-in users bypass.
+        limit_conn total_ssr 150;
+        limit_conn_status 429;
+
+        # SSR page cache for anonymous users only
+        # Next.js sets Cache-Control with s-maxage per route type.
+        # Nginx respects s-maxage for proxy_cache TTL.
+        # Fallback: proxy_cache_valid 200 300s applies when no s-maxage from upstream.
+        proxy_cache ssrcache;
+        proxy_cache_valid 200 300s;
+        proxy_cache_key "$request_uri$html_limited_bot";
+        proxy_cache_bypass $skip_cache;
+        proxy_no_cache $skip_cache;
+        proxy_ignore_headers Set-Cookie Vary;
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503;
+        proxy_cache_lock on;
+        proxy_cache_lock_timeout 5s;
+        add_header X-Cache-Status $upstream_cache_status;
+        # NOTE: do NOT re-add `add_header X-Cache-Tier $upstream_http_x_cache_tier`.
+        # The upstream (Next middleware) already sets x-cache-tier and nginx
+        # proxies it through, so adding it here emitted the header twice on
+        # every response. X-Cache-Status above is fine — that value is nginx's
+        # own and does not exist upstream.
+
+        add_header Access-Control-Allow-Origin *;
+        add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Content-Type-Options nosniff;
+        add_header Referrer-Policy "strict-origin";
+        add_header X-XSS-Protection "1; mode=block";
+        add_header X-Origin-Region "eu" always;
+
+	if ($request_method = HEAD) {
+	add_header Cache-Control no-store;
+	return 200;
+        }
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        # SSR render timeout: 20s gives headroom for 2-3 sequential prefetches (5-10s each)
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 20s;
+        proxy_read_timeout 20s;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+}

--- a/infra/origin/us.ecency.com.conf
+++ b/infra/origin/us.ecency.com.conf
@@ -114,15 +114,18 @@ server {
 
     # Frontend route
     location / {
-        # Rate limit aggressive bots to 1 req/s, burst 5. Normal users unaffected.
+        # Aggressive-bot rate limit. Threshold in /etc/nginx/rate-limits.conf.
         limit_req zone=botlimit burst=5 nodelay;
-        # SSR page rate limit: 15 req/s per client IP, burst 50. Allows feed RSC prefetches.
+        # SSR page rate limit per client IP, sized to allow feed RSC prefetches.
+        # Threshold in /etc/nginx/rate-limits.conf.
         limit_req zone=ssrlimit burst=50 nodelay;
-        # General per-IP limit: 50 req/s, burst 70. Backstop for all traffic.
+        # General per-IP backstop for all traffic. Threshold in
+        # /etc/nginx/rate-limits.conf.
         limit_req zone=general burst=70 nodelay;
         limit_req_status 429;
-        # Total concurrent SSR limit: 150 max for anonymous users. Logged-in users bypass.
-        limit_conn total_ssr 150;
+        # Concurrent SSR ceiling for anonymous users; logged-in users bypass.
+        # The number lives in /etc/nginx/conn-limits.conf, which is not in git.
+        include /etc/nginx/conn-limits*.conf;
         limit_conn_status 429;
 
         # SSR page cache for anonymous users only

--- a/infra/origin/us.ecency.com.conf
+++ b/infra/origin/us.ecency.com.conf
@@ -125,7 +125,9 @@ server {
         limit_req_status 429;
         # Concurrent SSR ceiling for anonymous users; logged-in users bypass.
         # The number lives in /etc/nginx/conn-limits.conf, which is not in git.
-        include /etc/nginx/conn-limits*.conf;
+        # EXACT include, not a wildcard: nginx accepts a wildcard that matches
+        # nothing, so a missing file would reload cleanly with no limit at all.
+        include /etc/nginx/conn-limits.conf;
         limit_conn_status 429;
 
         # SSR page cache for anonymous users only

--- a/infra/origin/us.ecency.com.conf
+++ b/infra/origin/us.ecency.com.conf
@@ -1,0 +1,163 @@
+# Redirect HTTP to HTTPS
+server {
+    listen 80;
+    listen [::]:80;
+    server_name us.ecency.com;
+
+    return 301 https://$host$request_uri;
+}
+
+# HTTPS server with Let's Encrypt cert
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name us.ecency.com;
+
+    # big-header proxy buffers (server-level)
+    # Next.js emits a large Link: rel=preload header; nginx's 4k default
+    # header buffer overflows -> 502 'upstream sent too big header'.
+    # Server scope so every proxied location (/, /_next/static/, manifest,
+    # assets, scripts, ...) inherits it and this can't drift per-location.
+    proxy_buffer_size       16k;
+    proxy_buffers           8 16k;
+    proxy_busy_buffers_size 16k;
+
+    client_max_body_size 100M;
+
+    ssl_certificate         /etc/ssl/certs/cert.pem;        # CF Origin CA *.ecency.com (exp 2035-07)
+    ssl_certificate_key     /etc/ssl/private/key.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;                        # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;                          # managed by Certbot
+
+    location /api/mattermost/websocket {
+      proxy_pass http://localhost:3000;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $host;
+      proxy_read_timeout 86400;
+    }
+
+    # All /api/ paths — no caching (user-specific data)
+    # Newsletter subscribe, tightened. One legitimate action is exactly one POST
+    # and observed real traffic is about one a day, so this sits far below the
+    # general /api/ allowance. Exact match, so it wins over `location /api/`
+    # below; the proxy directives are repeated because a location does not
+    # inherit them from a sibling.
+    location = /api/newsletter/subscribe {
+        limit_req zone=subscribelimit burst=10 nodelay;
+        limit_req_status 429;
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+
+    location /api/ {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+
+    # API proxy routes
+    location ~ ^/private-api/usr-activity {
+        proxy_set_header   X-Real-IP $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:4000;
+    }
+
+    # Cache promoted-entries responses for 60s
+    location = /private-api/promoted-entries {
+        proxy_cache apicache;
+        proxy_cache_valid 200 300s;
+        proxy_cache_key "$request_uri";
+        proxy_cache_use_stale error timeout updating;
+        add_header X-Cache-Status $upstream_cache_status;
+        proxy_set_header   X-Real-IP $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:4000;
+    }
+
+    location ~ ^/(private-api|search-api|wallet-api|auth-api) {
+        proxy_set_header   X-Real-IP $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:4000;
+    }
+
+    # Static assets - pass through Next.js cache headers (immutable, 1yr)
+    location /_next/static/ {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+
+    # Static files - no rate limiting, no SSR cache
+    location = /manifest.json {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+    location = /favicon.ico {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+    location /assets/ {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+    location /scripts/ {
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+
+    # Frontend route
+    location / {
+        # Rate limit aggressive bots to 1 req/s, burst 5. Normal users unaffected.
+        limit_req zone=botlimit burst=5 nodelay;
+        # SSR page rate limit: 15 req/s per client IP, burst 50. Allows feed RSC prefetches.
+        limit_req zone=ssrlimit burst=50 nodelay;
+        # General per-IP limit: 50 req/s, burst 70. Backstop for all traffic.
+        limit_req zone=general burst=70 nodelay;
+        limit_req_status 429;
+        # Total concurrent SSR limit: 150 max for anonymous users. Logged-in users bypass.
+        limit_conn total_ssr 150;
+        limit_conn_status 429;
+
+        # SSR page cache for anonymous users only
+        # Next.js sets Cache-Control with s-maxage per route type.
+        # Nginx respects s-maxage for proxy_cache TTL.
+        # Fallback: proxy_cache_valid 200 300s applies when no s-maxage from upstream.
+        proxy_cache ssrcache;
+        proxy_cache_valid 200 300s;
+        proxy_cache_key "$request_uri$html_limited_bot";
+        proxy_cache_bypass $skip_cache;
+        proxy_no_cache $skip_cache;
+        proxy_ignore_headers Set-Cookie Vary;
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503;
+        proxy_cache_lock on;
+        proxy_cache_lock_timeout 5s;
+        add_header X-Cache-Status $upstream_cache_status;
+
+        add_header Access-Control-Allow-Origin *;
+        add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Content-Type-Options nosniff;
+        add_header Referrer-Policy "strict-origin";
+        add_header X-XSS-Protection "1; mode=block";
+        add_header X-Origin-Region "us" always;
+
+	if ($request_method = HEAD) {
+	add_header Cache-Control no-store;
+	return 200;
+        }
+        proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
+        proxy_set_header   Host $http_host;
+        # SSR render timeout: 20s gives headroom for 2-3 sequential prefetches (5-10s each)
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 20s;
+        proxy_read_timeout 20s;
+        proxy_pass         http://127.0.0.1:3000;
+    }
+}

--- a/scripts/origin-config-audit.mjs
+++ b/scripts/origin-config-audit.mjs
@@ -136,6 +136,13 @@ if (process.argv.includes("--self-test")) {
     ["source-address", "        allow fe80::1;"],
     ["source-address", "        allow ::ffff:192.0.2.1;"],
     ["source-address", "        allow 2001:db8::/32;"],
+    // Trailing `::` forms, pinned after review asked whether they were covered.
+    // They were, since net.isIP replaced the hand-rolled pattern, but "covered
+    // and untested" is how the previous regex looked right up until it wasn't.
+    ["source-address", "        allow 2001:db8::;"],
+    ["source-address", "        allow fe80::;"],
+    ["source-address", "        allow 64:ff9b::1;"],
+    ["source-address", "        proxy_pass http://[2001:db8::]:8080;"],
     ["source-address", "        proxy_pass http://[2001:db8::5]:8080;"],
     ["inline-allowlist", "        allow 198.51.100.7;"],
     ["threshold", "        # SSR page rate limit: 15 req/s per client IP"],

--- a/scripts/origin-config-audit.mjs
+++ b/scripts/origin-config-audit.mjs
@@ -1,74 +1,144 @@
 // Origin nginx config audit (infra/origin/README.md).
+//
 // This repository is PUBLIC, so committed origin config may carry structure but
 // never numbers or addresses. Each rule exists because the thing it forbids is a
 // real disclosure: a source address names infrastructure that sits behind
-// Cloudflare precisely so it is not named; an inline allow/deny publishes who is
-// trusted, which is the entire value of an allowlist; a rate says where the
-// limit is and how to sit under it. Those all belong in an /etc/nginx include
-// that is not in git, so a missing file fails closed.
-// Loopback proxy targets and `burst=` are deliberately allowed: nothing off-box
-// reaches a loopback port, and a burst is meaningless without its rate.
+// Cloudflare precisely so it is not named; an inline allowlist publishes who is
+// trusted, which is the entire value of an allowlist; a threshold says where the
+// limit is and how to sit under it. Those belong in an /etc/nginx include that
+// is not in git, so a missing file fails closed.
+//
+// COMMENTS ARE AUDITED TOO. An earlier version stripped them before applying
+// every rule, which let the exact rates through in prose while the audit
+// reported a clean run. A comment in a public repository is published.
+//
+// Deliberately allowed: loopback proxy targets, which nothing off-box can
+// reach and which the blog-hosting origin already commits; `burst=`, which is
+// meaningless without the rate it bursts against; and a bare `deny all`, which
+// is the closing half of the documented fail-closed pattern.
+//
 // CI runs with --fail: any finding exits 1.
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
 const ROOT = new URL("..", import.meta.url).pathname;
-const DIR = join(ROOT, "infra", "origin");
+const AUDITED = join(ROOT, "infra");
 const FAIL = process.argv.includes("--fail");
 
-/** Non-comment, non-blank lines: a rule about content must not fire on prose. */
-const directivesOf = (source) =>
-  source
-    .split("\n")
-    .map((line, i) => ({ n: i + 1, text: line.trim() }))
-    .filter(({ text }) => text.length > 0 && !text.startsWith("#"));
+/** Every .conf under infra/, at any depth, so a new subdirectory is covered. */
+function configs(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...configs(full));
+    else if (entry.name.endsWith(".conf")) out.push(full);
+  }
+  return out;
+}
+
+const withoutLoopback = (text) => text.replace(/\b127\.0\.0\.1\b/g, "").replace(/\[::1\]|(?<![\w:])::1(?![\w:])/g, "");
 
 const RULES = [
   {
     id: "source-address",
-    test: ({ text }) => /\b(?:\d{1,3}\.){3}\d{1,3}\b/.test(text.replace(/\b127\.0\.0\.1\b/g, "")),
+    // IPv4 and IPv6. An IPv6 literal is just as much an origin address, and the
+    // first version of this audit saw only dotted quads.
+    test: (line) =>
+      /\b(?:\d{1,3}\.){3}\d{1,3}\b/.test(withoutLoopback(line)) ||
+      /(?:[0-9a-f]{1,4}:){2,}[0-9a-f]{1,4}\b/i.test(withoutLoopback(line)),
     why: "names a source address; move it to an /etc/nginx include that is not in git"
   },
   {
     id: "inline-allowlist",
-    test: ({ text }) => /^(?:allow|deny)\s/.test(text),
-    why: "inlines an allowlist; use `include /etc/nginx/<name>-allow*.conf;` then `deny all` so a missing file fails closed"
+    // `deny all` is permitted on purpose: the documented pattern is
+    // `include /etc/nginx/<name>-allow*.conf;` followed by `deny all;`, so
+    // rejecting the closing line would reject the remediation itself.
+    test: (line) => /^\s*(?:allow|deny)\s+(?!all\s*;)\S/.test(line),
+    why: "inlines an allowlist entry; use `include /etc/nginx/<name>-allow*.conf;` then `deny all;` so a missing file fails closed"
   },
   {
-    id: "rate",
-    test: ({ text }) => /\b\d+r\/[sm]\b/.test(text) || /^limit_req_zone\s/.test(text),
-    why: "states a rate; thresholds live in /etc/nginx/rate-limits.conf, which is not in git"
+    id: "threshold",
+    // Rates, zone definitions and connection ceilings, in directives OR prose.
+    test: (line) =>
+      /\b\d+\s*(?:r\/[sm]\b|req\/s\b|requests?\/s(?:ec)?\b)/i.test(line) ||
+      /^\s*limit_req_zone\s/.test(line) ||
+      /^\s*limit_conn\s+\S+\s+\d+/.test(line),
+    why: "states a threshold; these live in /etc/nginx/{rate-limits,conn-limits}.conf, which are not in git"
   },
   {
     id: "secret-marker",
-    test: ({ text }) => /EcencyInfraMonitor|api[_-]?key|password|Bearer\s/i.test(text),
+    test: (line) => /EcencyInfraMonitor|api[_-]?key|password|Bearer\s|secret[_-]?key/i.test(line),
     why: "looks like a credential or a secret marker"
   }
 ];
 
+// A guard that cannot be shown to fire is not a guard. --self-test runs every
+// rule against a planted violation and against the pattern each rule must NOT
+// reject, and fails if any rule has gone quiet. CI runs it beside the audit, so
+// a regex edited into uselessness is caught in the same step that relies on it.
+if (process.argv.includes("--self-test")) {
+  const MUST_FIRE = [
+    ["source-address", "        proxy_pass http://203.0.113.9:8080;"],
+    ["source-address", "        allow 2001:db8:aaaa::42;"],
+    ["inline-allowlist", "        allow 198.51.100.7;"],
+    ["threshold", "        # SSR page rate limit: 15 req/s per client IP"],
+    ["threshold", "        limit_req_zone $x zone=y:1m rate=7r/s;"],
+    ["threshold", "        limit_conn total_ssr 150;"],
+    ["secret-marker", "        # TODO remove api_key=hunter2 before shipping"]
+  ];
+  // Committed today and legitimate: a false positive here breaks the repo.
+  const MUST_NOT_FIRE = [
+    "        proxy_pass         http://127.0.0.1:3000;",
+    "        limit_req zone=ssrlimit burst=50 nodelay;",
+    "        include /etc/nginx/foo-allow*.conf;",
+    "        deny all;",
+    "        include /etc/nginx/rate-limits*.conf;"
+  ];
+  const failures = [];
+  for (const [id, line] of MUST_FIRE) {
+    const rule = RULES.find((r) => r.id === id);
+    if (!rule.test(line)) failures.push(`rule ${id} did NOT fire on: ${line.trim()}`);
+  }
+  for (const line of MUST_NOT_FIRE) {
+    for (const rule of RULES) {
+      if (rule.test(line)) failures.push(`rule ${rule.id} wrongly fired on: ${line.trim()}`);
+    }
+  }
+  failures.forEach((f) => console.error(`origin-config-audit self-test: ${f}`));
+  console.log(`origin-config-audit self-test: ${failures.length} failure(s), ${MUST_FIRE.length + MUST_NOT_FIRE.length} case(s)`);
+  process.exit(failures.length > 0 ? 1 : 0);
+}
+
 let files;
 try {
-  files = readdirSync(DIR).filter((f) => f.endsWith(".conf"));
-} catch {
-  console.log("origin-config-audit: no infra/origin directory, nothing to check");
-  process.exit(0);
+  files = configs(AUDITED);
+} catch (err) {
+  // A missing directory is a finding, not a pass. The previous version exited 0
+  // here, so deleting the audited tree left CI green while the contract it
+  // enforces silently stopped existing.
+  console.error(`origin-config-audit: cannot read ${relative(ROOT, AUDITED)}: ${err.code ?? err.message}`);
+  console.error("  If infra/ moved, update AUDITED in this script in the same commit.");
+  process.exit(FAIL ? 1 : 0);
 }
 
 if (files.length === 0) {
-  // Vacuous-pass guard: the directory exists but holds nothing to audit.
-  console.error("origin-config-audit: infra/origin has no .conf files; did they move?");
+  console.error(`origin-config-audit: no .conf files under ${relative(ROOT, AUDITED)}; did they move?`);
   process.exit(FAIL ? 1 : 0);
 }
 
 const findings = [];
 for (const file of files) {
-  for (const line of directivesOf(readFileSync(join(DIR, file), "utf8"))) {
-    for (const rule of RULES) {
-      if (rule.test(line)) {
-        findings.push({ file: relative(ROOT, join(DIR, file)), line: line.n, rule: rule.id, why: rule.why, text: line.text });
+  if (!statSync(file).isFile()) continue;
+  readFileSync(file, "utf8")
+    .split("\n")
+    .forEach((text, i) => {
+      if (text.trim().length === 0) return;
+      for (const rule of RULES) {
+        if (rule.test(text)) {
+          findings.push({ file: relative(ROOT, file), line: i + 1, rule: rule.id, why: rule.why, text: text.trim() });
+        }
       }
-    }
-  }
+    });
 }
 
 for (const f of findings) {

--- a/scripts/origin-config-audit.mjs
+++ b/scripts/origin-config-audit.mjs
@@ -32,7 +32,7 @@ function configs(dir) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) out.push(...configs(full));
-    else if (entry.name.endsWith(".conf")) out.push(full);
+    else if (entry.name.endsWith(".conf") || entry.name.endsWith(".md")) out.push(full);
   }
   return out;
 }
@@ -97,6 +97,18 @@ const RULES = [
     why: "states a threshold; these live in /etc/nginx/{rate-limits,conn-limits}.conf, which are not in git"
   },
   {
+    id: "wildcard-protective-include",
+    // nginx accepts a wildcard include that matches nothing, so wildcarding a
+    // file that CARRIES a protective directive means a missing file reloads
+    // clean with the protection simply gone. Allowlists may be wildcarded
+    // because `deny all` outlives the file; these may not.
+    // Not anchored to line start: the same instruction is just as wrong in a
+    // config comment or a markdown bullet as in a directive, and a bullet is
+    // exactly where it survived two rounds of review.
+    test: (line) => /include\s+[^;`]*(?:rate-limits|conn-limits)[^;`]*\*/.test(line),
+    why: "wildcards an include that carries a protective directive; use the exact path so a missing file is a startup error"
+  },
+  {
     id: "secret-marker",
     test: (line) => /EcencyInfraMonitor|api[_-]?key|password|Bearer\s|secret[_-]?key/i.test(line),
     why: "looks like a credential or a secret marker"
@@ -120,7 +132,9 @@ if (process.argv.includes("--self-test")) {
     ["threshold", "        # SSR page rate limit: 15 req/s per client IP"],
     ["threshold", "        limit_req_zone $x zone=y:1m rate=7r/s;"],
     ["threshold", "        limit_conn total_ssr 150;"],
-    ["secret-marker", "        # TODO remove api_key=hunter2 before shipping"]
+    ["secret-marker", "        # TODO remove api_key=hunter2 before shipping"],
+    ["wildcard-protective-include", "        include /etc/nginx/rate-limits*.conf;"],
+    ["wildcard-protective-include", "        include /etc/nginx/conn-limits*.conf;"]
   ];
   // Committed today and legitimate: a false positive here breaks the repo.
   const MUST_NOT_FIRE = [
@@ -133,7 +147,8 @@ if (process.argv.includes("--self-test")) {
     "        limit_req zone=ssrlimit burst=50 nodelay;",
     "        include /etc/nginx/foo-allow*.conf;",
     "        deny all;",
-    "        include /etc/nginx/rate-limits*.conf;"
+    "        include /etc/nginx/rate-limits.conf;",
+    "        include /etc/nginx/conn-limits.conf;"
   ];
   const failures = [];
   for (const [id, line] of MUST_FIRE) {
@@ -174,7 +189,11 @@ for (const file of files) {
     .split("\n")
     .forEach((text, i) => {
       if (text.trim().length === 0) return;
-      for (const rule of RULES) {
+      // Documentation is checked for the one rule it can contradict: a runbook
+      // telling an operator to wildcard a protective include is as harmful as
+      // the config doing it, and that is exactly how this drifted twice.
+      const applicable = file.endsWith(".md") ? RULES.filter((r) => r.id === "wildcard-protective-include") : RULES;
+      for (const rule of applicable) {
         if (rule.test(text)) {
           findings.push({ file: relative(ROOT, file), line: i + 1, rule: rule.id, why: rule.why, text: text.trim() });
         }

--- a/scripts/origin-config-audit.mjs
+++ b/scripts/origin-config-audit.mjs
@@ -19,6 +19,7 @@
 //
 // CI runs with --fail: any finding exits 1.
 import { readFileSync, readdirSync, statSync } from "node:fs";
+import { isIP } from "node:net";
 import { join, relative } from "node:path";
 
 const ROOT = new URL("..", import.meta.url).pathname;
@@ -36,16 +37,46 @@ function configs(dir) {
   return out;
 }
 
-const withoutLoopback = (text) => text.replace(/\b127\.0\.0\.1\b/g, "").replace(/\[::1\]|(?<![\w:])::1(?![\w:])/g, "");
+/**
+ * Addresses in a line, found by tokenising and asking Node rather than by
+ * pattern. A hand-rolled IPv6 regex missed every compressed form: `2001:db8::42`
+ * and `fe80::1` both walked past the first version, and the self-test address
+ * happened to match for an unrelated reason, which made the rule look alive
+ * while it was half dead.
+ */
+function addressesIn(line) {
+    const found = [];
+    // Grab bracketed forms, CIDR suffixes and ports along with the address, then
+    // peel them off, because each is what surrounds an address in nginx config.
+    for (const raw of line.match(/\[?[0-9A-Fa-f:.]{2,}\]?(?::\d+)?(?:\/\d+)?/g) ?? []) {
+        if (!raw.includes(":") && !raw.includes(".")) continue;
+        const bare = raw.replace(/^\[/, "").replace(/\](?::\d+)?$/, "").replace(/\/\d+$/, "");
+        // Try the most literal reading first. `2001:db8::` is itself a valid
+        // address, so trailing colons are only trimmed if the raw form fails.
+        const attempts = [bare, bare.replace(/[.,;]+$/, ""), bare.replace(/:\d+$/, "")];
+        for (const attempt of attempts) {
+            if (isIP(attempt)) {
+                found.push(attempt);
+                break;
+            }
+        }
+    }
+    return found;
+}
+
+/**
+ * Addresses that disclose nothing: loopback, which names nothing reachable from
+ * anywhere else, and the unspecified address, which is how `listen` says "every
+ * interface" rather than naming a host.
+ */
+const NOT_A_DISCLOSURE = new Set(["127.0.0.1", "::1", "::", "0.0.0.0"]);
 
 const RULES = [
   {
     id: "source-address",
     // IPv4 and IPv6. An IPv6 literal is just as much an origin address, and the
     // first version of this audit saw only dotted quads.
-    test: (line) =>
-      /\b(?:\d{1,3}\.){3}\d{1,3}\b/.test(withoutLoopback(line)) ||
-      /(?:[0-9a-f]{1,4}:){2,}[0-9a-f]{1,4}\b/i.test(withoutLoopback(line)),
+    test: (line) => addressesIn(line).some((addr) => !NOT_A_DISCLOSURE.has(addr)),
     why: "names a source address; move it to an /etc/nginx include that is not in git"
   },
   {
@@ -80,6 +111,11 @@ if (process.argv.includes("--self-test")) {
   const MUST_FIRE = [
     ["source-address", "        proxy_pass http://203.0.113.9:8080;"],
     ["source-address", "        allow 2001:db8:aaaa::42;"],
+    ["source-address", "        allow 2001:db8::42;"],
+    ["source-address", "        allow fe80::1;"],
+    ["source-address", "        allow ::ffff:192.0.2.1;"],
+    ["source-address", "        allow 2001:db8::/32;"],
+    ["source-address", "        proxy_pass http://[2001:db8::5]:8080;"],
     ["inline-allowlist", "        allow 198.51.100.7;"],
     ["threshold", "        # SSR page rate limit: 15 req/s per client IP"],
     ["threshold", "        limit_req_zone $x zone=y:1m rate=7r/s;"],
@@ -89,6 +125,11 @@ if (process.argv.includes("--self-test")) {
   // Committed today and legitimate: a false positive here breaks the repo.
   const MUST_NOT_FIRE = [
     "        proxy_pass         http://127.0.0.1:3000;",
+    "        proxy_pass         http://[::1]:3000;",
+    "    listen [::]:443 ssl http2;",
+    "    listen 0.0.0.0:80;",
+    "        # see nginx 1.24.0 release notes",
+    "        ssl_certificate /etc/letsencrypt/live/eu.ecency.com/fullchain.pem;",
     "        limit_req zone=ssrlimit burst=50 nodelay;",
     "        include /etc/nginx/foo-allow*.conf;",
     "        deny all;",

--- a/scripts/origin-config-audit.mjs
+++ b/scripts/origin-config-audit.mjs
@@ -38,6 +38,15 @@ function configs(dir) {
 }
 
 /**
+ * The tracked origin configs among everything collected. Separate from configs()
+ * because the scan deliberately picks up documentation too, and the presence
+ * guard must count origins rather than files: see its comment below.
+ */
+function originConfigsIn(files) {
+  return files.filter((file) => file.endsWith(".conf"));
+}
+
+/**
  * Addresses in a line, found by tokenising and asking Node rather than by
  * pattern. A hand-rolled IPv6 regex missed every compressed form: `2001:db8::42`
  * and `fe80::1` both walked past the first version, and the self-test address
@@ -160,8 +169,27 @@ if (process.argv.includes("--self-test")) {
       if (rule.test(line)) failures.push(`rule ${rule.id} wrongly fired on: ${line.trim()}`);
     }
   }
+  // The presence guard is control flow rather than a rule, and it has now broken
+  // twice: once by exiting 0 when the directory was missing, and once by counting
+  // the README after markdown joined the scan, so removing every vhost left a
+  // non-zero total and CI passed over nothing tracked. Both failures were the same
+  // shape, a guard measuring the collection instead of the thing it guards, so it
+  // is pinned here and the next widening of the scan trips a test.
+  const PRESENCE = [
+    [["infra/origin/eu.ecency.com.conf", "infra/origin/README.md"], 1],
+    [["infra/origin/eu.ecency.com.conf", "infra/origin/us.ecency.com.conf", "infra/origin/README.md"], 2],
+    [["infra/origin/README.md"], 0],
+    [["infra/origin/README.md", "infra/origin/notes.md"], 0],
+    [[], 0]
+  ];
+  for (const [input, expected] of PRESENCE) {
+    const got = originConfigsIn(input).length;
+    if (got !== expected) {
+      failures.push(`originConfigsIn(${JSON.stringify(input)}) counted ${got}, expected ${expected}`);
+    }
+  }
   failures.forEach((f) => console.error(`origin-config-audit self-test: ${f}`));
-  console.log(`origin-config-audit self-test: ${failures.length} failure(s), ${MUST_FIRE.length + MUST_NOT_FIRE.length} case(s)`);
+  console.log(`origin-config-audit self-test: ${failures.length} failure(s), ${MUST_FIRE.length + MUST_NOT_FIRE.length + PRESENCE.length} case(s)`);
   process.exit(failures.length > 0 ? 1 : 0);
 }
 
@@ -177,8 +205,15 @@ try {
   process.exit(FAIL ? 1 : 0);
 }
 
-if (files.length === 0) {
+// Counted on the CONFIGS specifically, not on everything collected. Adding
+// markdown to the scan made this guard count the README, so deleting every
+// vhost left a non-zero total and the audit passed with nothing tracked: the
+// exact vacuous pass this guard exists to prevent, reintroduced by widening the
+// collection beside it.
+const trackedConfigs = originConfigsIn(files);
+if (trackedConfigs.length === 0) {
   console.error(`origin-config-audit: no .conf files under ${relative(ROOT, AUDITED)}; did they move?`);
+  console.error("  Documentation alone is not a tracked origin. If the vhosts moved, update AUDITED.");
   process.exit(FAIL ? 1 : 0);
 }
 

--- a/scripts/origin-config-audit.mjs
+++ b/scripts/origin-config-audit.mjs
@@ -1,0 +1,79 @@
+// Origin nginx config audit (infra/origin/README.md).
+// This repository is PUBLIC, so committed origin config may carry structure but
+// never numbers or addresses. Each rule exists because the thing it forbids is a
+// real disclosure: a source address names infrastructure that sits behind
+// Cloudflare precisely so it is not named; an inline allow/deny publishes who is
+// trusted, which is the entire value of an allowlist; a rate says where the
+// limit is and how to sit under it. Those all belong in an /etc/nginx include
+// that is not in git, so a missing file fails closed.
+// Loopback proxy targets and `burst=` are deliberately allowed: nothing off-box
+// reaches a loopback port, and a burst is meaningless without its rate.
+// CI runs with --fail: any finding exits 1.
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+const DIR = join(ROOT, "infra", "origin");
+const FAIL = process.argv.includes("--fail");
+
+/** Non-comment, non-blank lines: a rule about content must not fire on prose. */
+const directivesOf = (source) =>
+  source
+    .split("\n")
+    .map((line, i) => ({ n: i + 1, text: line.trim() }))
+    .filter(({ text }) => text.length > 0 && !text.startsWith("#"));
+
+const RULES = [
+  {
+    id: "source-address",
+    test: ({ text }) => /\b(?:\d{1,3}\.){3}\d{1,3}\b/.test(text.replace(/\b127\.0\.0\.1\b/g, "")),
+    why: "names a source address; move it to an /etc/nginx include that is not in git"
+  },
+  {
+    id: "inline-allowlist",
+    test: ({ text }) => /^(?:allow|deny)\s/.test(text),
+    why: "inlines an allowlist; use `include /etc/nginx/<name>-allow*.conf;` then `deny all` so a missing file fails closed"
+  },
+  {
+    id: "rate",
+    test: ({ text }) => /\b\d+r\/[sm]\b/.test(text) || /^limit_req_zone\s/.test(text),
+    why: "states a rate; thresholds live in /etc/nginx/rate-limits.conf, which is not in git"
+  },
+  {
+    id: "secret-marker",
+    test: ({ text }) => /EcencyInfraMonitor|api[_-]?key|password|Bearer\s/i.test(text),
+    why: "looks like a credential or a secret marker"
+  }
+];
+
+let files;
+try {
+  files = readdirSync(DIR).filter((f) => f.endsWith(".conf"));
+} catch {
+  console.log("origin-config-audit: no infra/origin directory, nothing to check");
+  process.exit(0);
+}
+
+if (files.length === 0) {
+  // Vacuous-pass guard: the directory exists but holds nothing to audit.
+  console.error("origin-config-audit: infra/origin has no .conf files; did they move?");
+  process.exit(FAIL ? 1 : 0);
+}
+
+const findings = [];
+for (const file of files) {
+  for (const line of directivesOf(readFileSync(join(DIR, file), "utf8"))) {
+    for (const rule of RULES) {
+      if (rule.test(line)) {
+        findings.push({ file: relative(ROOT, join(DIR, file)), line: line.n, rule: rule.id, why: rule.why, text: line.text });
+      }
+    }
+  }
+}
+
+for (const f of findings) {
+  console.error(`${f.file}:${f.line}  [${f.rule}] ${f.why}`);
+  console.error(`    ${f.text}`);
+}
+console.log(`origin-config-audit: ${findings.length} finding(s) in ${files.length} file(s)`);
+if (findings.length > 0 && FAIL) process.exit(1);


### PR DESCRIPTION
Part of #1573.

The nginx that serves ecency.com from the two origins was edited by hand on each box. A change was invisible to review, the origins drifted from each other with nothing to say so, and a rebuild lost the config entirely.

This follows the contract `apps/self-hosted/hosting/origin/` already set for the blog-hosting origin, since this repository is public: **structure is committed, numbers and addresses are not.** Anything naming a trusted address or a threshold stays on the host behind a wildcard `include`, so a missing file fails closed rather than serving with no protection.

### Sanitised before capture, not after

The rate-limit zones were moved out to `/etc/nginx/rate-limits.conf` on both origins first, so what is committed is what is actually running. Both vhosts were then checked to carry:

- no source address (loopback targets excepted, which the blog-hosting origin already commits)
- no inline `allow`/`deny`
- no rate
- no credential or secret marker

`burst=` values stay, deliberately. A burst is meaningless without the rate it bursts against, and the effective limit is discoverable by anyone willing to send a dozen requests and count the 429s, so hiding the shape buys nothing while costing reviewability.

### The contract is enforced, not just documented

A README stating a rule does not survive the next hurried edit. `scripts/origin-config-audit.mjs` checks it and runs in the typecheck workflow beside the icon and slim-entries audits, matching how repo-level guards already work here.

Each of its four rules was confirmed to fire on a planted violation rather than assumed to work:

| planted | rules fired |
| --- | --- |
| `allow 203.0.113.4;` | `source-address`, `inline-allowlist` |
| `limit_req_zone ... rate=7r/s;` | `rate` |
| `X-Api-Key ...` | `secret-marker` |

It exits 1 with a finding, 0 when clean, and refuses to pass vacuously if the directory is emptied or moved.

### It earned its keep immediately

With both origins side by side, they differ in **fifteen lines**: `server_name`, the certificate source (Let's Encrypt on one, a Cloudflare Origin CA cert on the other) and one extra explanatory comment. All legitimate, and none of it visible before.

That matters because EU and US drift silently. The newsletter subscribe rate limit is the worked example: while only one origin carried it, the protection was bypassable simply by being routed to the other.

### Not included

`nginx.conf` itself, which is mostly stock. The README lists the `http`-level maps, geo blocks and cache paths the vhosts depend on, so a rebuilt origin knows what must exist before these files will load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production-ready origin configurations for EU and US environments.
  * Improved routing for APIs, WebSockets, frontend content, static assets, and cached responses.
  * Added HTTPS enforcement, security headers, rate limiting, connection controls, and request handling safeguards.

* **Documentation**
  * Documented origin configuration requirements, restoration procedures, validation steps, and regional synchronization.

* **Chores**
  * Added automated configuration auditing with self-tests and failure-enforcing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->