### PR TITLE
Pin the thumbnail field order as a decision, not an accident

### DIFF
--- a/apps/web/src/specs/core/entries/slim-entry.spec.ts
+++ b/apps/web/src/specs/core/entries/slim-entry.spec.ts
@@ -66,6 +66,29 @@ describe("slimEntry", () => {
     expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/in-body.png"]);
   });
 
+  it("prefers thumbnails over image, which is a deliberate divergence", () => {
+    // catchPostImage never looks at `thumbnails`: getImage() in render-helper
+    // reads json_metadata.image as a string, then as an array, then falls back
+    // to the body. So a post that sets the two fields to DIFFERENT urls shows
+    // its cover on an unslimmed card and its thumbnail on a slim one.
+    //
+    // That divergence is chosen, not accidental. `thumbnails` is published for
+    // exactly this purpose by 3Speak and Liketu, and a publisher who sets a
+    // dedicated poster means it. It is also unobservable in practice: across
+    // 461 live rows from trending, hot, created, promoted, tags and
+    // communities, 70 carried both fields and 0 of them disagreed.
+    //
+    // This test exists so the next reader sees a decision rather than a bug,
+    // and so flipping the order has to be done on purpose.
+    const e = entry({
+      json_metadata: {
+        thumbnails: ["https://images.hive.blog/poster.png"],
+        image: ["https://images.hive.blog/cover.png"]
+      }
+    });
+    expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/poster.png"]);
+  });
+
   it("survives thumbnails that are not an array", () => {
     // json_metadata is author-written and `thumbnails` is only typed as string[].
     // A bare string threw out of the queryFn, and a throw there is not one bad

--- a/apps/web/src/specs/core/entries/slim-entry.spec.ts
+++ b/apps/web/src/specs/core/entries/slim-entry.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { catchPostImage, postBodySummary } from "@ecency/render-helper";
+import { catchPostImage, postBodySummary, proxifyImageSrc } from "@ecency/render-helper";
 import { ContentModerationReason } from "@ecency/sdk";
 import {
   SLIM_KEY_MARKER,
@@ -66,27 +66,40 @@ describe("slimEntry", () => {
     expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/in-body.png"]);
   });
 
-  it("prefers thumbnails over image, which is a deliberate divergence", () => {
+  it("shows the cover unslimmed and the poster slimmed, which is deliberate", () => {
     // catchPostImage never looks at `thumbnails`: getImage() in render-helper
     // reads json_metadata.image as a string, then as an array, then falls back
-    // to the body. So a post that sets the two fields to DIFFERENT urls shows
-    // its cover on an unslimmed card and its thumbnail on a slim one.
+    // to the body. Slimming puts the thumbnail first, so a post that sets the
+    // two fields to DIFFERENT urls renders its cover on an unslimmed card and
+    // its poster on a slim one.
     //
-    // That divergence is chosen, not accidental. `thumbnails` is published for
-    // exactly this purpose by 3Speak and Liketu, and a publisher who sets a
-    // dedicated poster means it. It is also unobservable in practice: across
-    // 461 live rows from trending, hot, created, promoted, tags and
-    // communities, 70 carried both fields and 0 of them disagreed.
+    // That divergence is chosen. `thumbnails` is published for exactly this
+    // purpose by 3Speak and Liketu, and a publisher who sets a dedicated poster
+    // means it. It is also unobservable in practice: across 461 live rows from
+    // trending, hot, created, promoted, tags and communities, 70 carried both
+    // fields and 0 of them disagreed.
     //
-    // This test exists so the next reader sees a decision rather than a bug,
-    // and so flipping the order has to be done on purpose.
-    const e = entry({
-      json_metadata: {
-        thumbnails: ["https://images.hive.blog/poster.png"],
-        image: ["https://images.hive.blog/cover.png"]
-      }
-    });
-    expect(slimEntry(e).json_metadata?.image).toEqual(["https://images.hive.blog/poster.png"]);
+    // BOTH halves are asserted on purpose. Pinning only the slim side would let
+    // the divergence disappear unnoticed if render-helper ever started honouring
+    // `thumbnails`, and this test exists to make that a decision rather than a
+    // surprise.
+    const meta = {
+      thumbnails: ["https://images.hive.blog/poster.png"],
+      image: ["https://images.hive.blog/cover.png"]
+    };
+    // Separate fixtures: render-helper memoizes per post AND size, so reusing
+    // one would serve the second call the first one's answer.
+    const unslimmed = entry({ json_metadata: meta });
+    const slimmed = slimEntry(entry({ json_metadata: meta }));
+    const card = (e: Entry) => catchPostImage(e, 320, 180, "match");
+
+    expect(card(unslimmed)).toBe(
+      proxifyImageSrc("https://images.hive.blog/cover.png", 320, 180, "match")
+    );
+    expect(card(slimmed)).toBe(
+      proxifyImageSrc("https://images.hive.blog/poster.png", 320, 180, "match")
+    );
+    expect(card(unslimmed)).not.toBe(card(slimmed));
   });
 
   it("survives thumbnails that are not an array", () => {


### PR DESCRIPTION
Follow-up to #1572, closing the loose end from its review.

`catchPostImage` never reads `json_metadata.thumbnails`: `getImage()` takes `image` as a string, then as an array, then falls back to the body. Slimming promotes `thumbnails[0]` ahead of `image[0]`, so a post that sets the two to different urls renders its cover on an unslimmed card and its poster on a slim one. Two review bots have now read that as a regression.

It is deliberate. `thumbnails` is published for exactly this purpose by 3Speak and Liketu, and a publisher who sets a dedicated poster means it. It is also unobservable in practice: across 461 live rows from trending, hot, created, promoted, tags and communities, 70 carry both fields and 0 of them disagree.

The test pins both halves, so the next reader sees a decision rather than a bug and flipping the order has to be done on purpose. Test only, no behaviour change.