### PR TITLE
Drop the voter records the two card-only renders never read

### DIFF
--- a/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-footer.tsx
+++ b/apps/web/src/app/(dynamicPages)/entry/[category]/[author]/[permlink]/_components/entry-related-footer.tsx
@@ -1,6 +1,6 @@
 import { Entry } from "@/entities";
 import { fetchQuery } from "@/core/react-query";
-import { withSlimPageEntries } from "@/core/entries/slim-entry";
+import { withCardOnlyPageEntries } from "@/core/entries/slim-entry";
 import {
   getAccountPostsQueryOptions,
   getPostsRankedQueryOptions,
@@ -54,16 +54,17 @@ export async function EntryRelatedFooter({ entry }: Props) {
         json_metadata: { tags: entry.json_metadata?.tags }
       })
     ),
-    // A row is an author, a permlink, a title and a thumbnail. Both feeds are
-    // fetched slim so this render does not hold 24 post bodies it never reads
-    // for the lifetime of the request-scoped cache (#1559). The similar-entries
+    // A row is an author, a permlink, a title and a thumbnail. There is no vote
+    // button, payout or count anywhere in this footer, so both feeds are fetched
+    // card-only: no bodies and no voter records, which together are the bulk of
+    // what these two pages would otherwise retain (#1559). The similar-entries
     // query above already answers with narrow rows.
     fetchQuery(
-      withSlimPageEntries(getAccountPostsQueryOptions(entry.author, "posts", "", "", FETCH_LIMIT))
+      withCardOnlyPageEntries(getAccountPostsQueryOptions(entry.author, "posts", "", "", FETCH_LIMIT))
     ),
     source
       ? fetchQuery(
-          withSlimPageEntries(
+          withCardOnlyPageEntries(
             getPostsRankedQueryOptions("created", "", "", FETCH_LIMIT, source.tag)
           )
         )

--- a/apps/web/src/app/_components/landing-page/landing-trending.tsx
+++ b/apps/web/src/app/_components/landing-page/landing-trending.tsx
@@ -3,7 +3,7 @@ import i18next from "i18next";
 import { getPostsRankedQueryOptions } from "@ecency/sdk";
 import { catchPostImage } from "@ecency/render-helper";
 import { prefetchQuery } from "@/core/react-query";
-import { withSlimPageEntries } from "@/core/entries/slim-entry";
+import { withCardOnlyPageEntries } from "@/core/entries/slim-entry";
 import { isNsfwEntry } from "@/utils/nsfw-detection";
 import { Entry } from "@/entities";
 
@@ -16,10 +16,10 @@ const LIMIT = 8;
  * HTML so crawlers follow the homepage's authority into fresh content, and
  * first-time visitors see the actual product instead of marketing copy.
  *
- * The strip reads a title, an author and a thumbnail, never a body, so the page
- * is fetched slim: the bodies of 8 trending posts are hundreds of KB that this
- * render would otherwise hold in the request-scoped cache for its gc window,
- * which is what bounds how many renderer replicas fit on a host (#1559).
+ * The strip reads a title, an author and a thumbnail. It renders no body and no
+ * vote state, so the page is fetched card-only: both go before anything is
+ * cached, and this render holds a list of links rather than 8 posts and every
+ * voter record attached to them (#1559).
  *
  * prefetchQuery has a built-in SSR timeout and swallows errors (returns
  * undefined), so a slow/failed RPC degrades to "no strip" rather than breaking
@@ -27,7 +27,7 @@ const LIMIT = 8;
  */
 export async function LandingTrending() {
   const data = (await prefetchQuery(
-    withSlimPageEntries(getPostsRankedQueryOptions("trending", "", "", LIMIT))
+    withCardOnlyPageEntries(getPostsRankedQueryOptions("trending", "", "", LIMIT))
   )) as Entry[] | undefined;
 
   const entries = (data ?? [])

--- a/apps/web/src/core/entries/slim-entry.ts
+++ b/apps/web/src/core/entries/slim-entry.ts
@@ -265,7 +265,9 @@ function cardOnlyEntryPage<T>(page: T): T {
   if (!Array.isArray(page)) {
     return page;
   }
-  return page.map((item) => {
+  // Read as unknown[] rather than leaning on Array.isArray, whose guard narrows
+  // to any[] and would leave `item` implicitly any.
+  return (page as unknown[]).map((item) => {
     try {
       return cardOnlyEntry(item as Entry);
     } catch {

--- a/apps/web/src/core/entries/slim-entry.ts
+++ b/apps/web/src/core/entries/slim-entry.ts
@@ -165,7 +165,11 @@ export function slimEntryPage<T>(page: T): T {
 
 type WithQueryFn = { queryFn?: unknown; queryKey?: unknown };
 
-function slimQueryFn<T extends WithQueryFn>(options: T, queryKey: unknown): T {
+function wrapQueryFn<T extends WithQueryFn>(
+  options: T,
+  queryKey: unknown,
+  transform: <P>(page: P) => P
+): T {
   const queryFn = options.queryFn;
   if (typeof queryFn !== "function") {
     return options;
@@ -174,7 +178,7 @@ function slimQueryFn<T extends WithQueryFn>(options: T, queryKey: unknown): T {
     ...options,
     queryKey,
     queryFn: async (...args: unknown[]) =>
-      slimEntryPage(await (queryFn as (...a: unknown[]) => Promise<unknown>)(...args))
+      transform(await (queryFn as (...a: unknown[]) => Promise<unknown>)(...args))
   } as T;
 }
 
@@ -195,7 +199,7 @@ function slimQueryFn<T extends WithQueryFn>(options: T, queryKey: unknown): T {
  * Every other option is passed through untouched.
  */
 export function withSlimEntries<T extends WithQueryFn>(options: T): T {
-  return slimQueryFn(options, options.queryKey);
+  return wrapQueryFn(options, options.queryKey, slimEntryPage);
 }
 
 /**
@@ -215,8 +219,77 @@ export function withSlimPageEntries<T extends WithQueryFn>(options: T): T {
   const queryKey = Array.isArray(options.queryKey)
     ? [...options.queryKey, SLIM_KEY_MARKER]
     : options.queryKey;
-  return slimQueryFn(options, queryKey);
+  return wrapQueryFn(options, queryKey, slimEntryPage);
 }
 
 /** Appended to a query key that holds slim pages, so nothing else reads them. */
 export const SLIM_KEY_MARKER = "slim";
+
+/** The same, for pages that have had their votes dropped as well. */
+export const CARD_ONLY_KEY_MARKER = "card-only";
+
+/**
+ * One entry reduced to what a link and a thumbnail need: no body, no votes.
+ *
+ * Measured on entries sampled from live traffic, `active_votes` is 54-71% of
+ * what a cached page retains, several times what the body was, because every
+ * `{voter, rshares}` record becomes an object. A render that shows no vote
+ * state has no use for any of it.
+ *
+ * The count invariant is the one `strip-active-votes.ts` already keeps: the
+ * records go only when a COUNT survives elsewhere, so nothing that reads a
+ * number ever reads zero. An entry that carries no count keeps its votes.
+ */
+function cardOnlyEntry<T extends Entry>(entry: T): T {
+  const slim = slimEntry(entry);
+  const hasCount =
+    typeof slim.stats?.total_votes === "number" || typeof slim.total_votes === "number";
+  const votes = slim.active_votes;
+
+  let next = slim;
+  if (hasCount && Array.isArray(votes) && votes.length > 0) {
+    next = { ...slim, active_votes: [] } as T;
+  }
+  // A cross-post card reads the nested original, which carries its own voters.
+  if (next.original_entry) {
+    const original = cardOnlyEntry(next.original_entry);
+    if (original !== next.original_entry) {
+      next = { ...next, original_entry: original } as T;
+    }
+  }
+  return next;
+}
+
+/** Card-only a page of results, with the same backstop slimEntryPage has. */
+function cardOnlyEntryPage<T>(page: T): T {
+  if (!Array.isArray(page)) {
+    return page;
+  }
+  return page.map((item) => {
+    try {
+      return cardOnlyEntry(item as Entry);
+    } catch {
+      return item;
+    }
+  }) as unknown as T;
+}
+
+/**
+ * For a single-page builder feeding a render that displays NO vote state.
+ *
+ * Today that is the landing page's trending strip and the entry page's related
+ * footer: both render a title, an author and a thumbnail, and neither has a
+ * vote button, a payout or a vote count anywhere in it. Under
+ * `withSlimPageEntries` they still hold every voter record of every row they
+ * list, for the whole gc window, to draw a list of links.
+ *
+ * Its own key marker, not the slim one. A slim reader expects an entry that
+ * still knows who voted on it, and handing it one that does not is the same
+ * class of bug as #1556. Nothing may read this key but the render that wrote it.
+ */
+export function withCardOnlyPageEntries<T extends WithQueryFn>(options: T): T {
+  const queryKey = Array.isArray(options.queryKey)
+    ? [...options.queryKey, CARD_ONLY_KEY_MARKER]
+    : options.queryKey;
+  return wrapQueryFn(options, queryKey, cardOnlyEntryPage);
+}

--- a/apps/web/src/specs/app/slim-server-prefetches.spec.tsx
+++ b/apps/web/src/specs/app/slim-server-prefetches.spec.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getQueryClient } from "@/core/react-query";
-import { SLIM_KEY_MARKER } from "@/core/entries/slim-entry";
+import { CARD_ONLY_KEY_MARKER } from "@/core/entries/slim-entry";
 import { mockEntry } from "@/specs/test-utils";
 import type { Entry } from "@/entities";
 
@@ -55,6 +55,8 @@ function fullRow(overrides: Partial<Entry> = {}): Entry {
     category: "photography",
     body: `Some words and a cover ![cover](https://example.com/${permlink}.jpg) then more words.`,
     json_metadata: { tags: ["photography"] },
+    active_votes: Array.from({ length: 300 }, (_, i) => ({ voter: `v${i}`, rshares: 1 })) as never,
+    stats: { total_votes: 300, flag_weight: 0, gray: false, hide: false },
     ...overrides
   });
 }
@@ -75,13 +77,13 @@ function cachedEntryKeys(): unknown[][] {
     .map((query) => [...query.queryKey]);
 }
 
-describe("server renders that never read a body fetch slim pages", () => {
+describe("server renders that read no body and no votes fetch card-only pages", () => {
   beforeEach(() => {
     getQueryClient().clear();
     answers.clear();
   });
 
-  it("keeps the landing strip's titles and thumbnails without its bodies", async () => {
+  it("keeps the landing strip's titles and thumbnails without its bodies or voters", async () => {
     // The strip reads a title, an author and a thumbnail. The bodies behind it
     // are hundreds of KB the render holds for the request's gc window (#1559).
     const rows = [fullRow(), fullRow()];
@@ -103,9 +105,13 @@ describe("server renders that never read a body fetch slim pages", () => {
       );
     }
     expect(cachedEntries().map((e) => e.body)).toEqual(["", ""]);
+    // The strip has no vote button, payout or count in it, and voter records are
+    // the larger half of what a cached row costs.
+    expect(cachedEntries().map((e) => e.active_votes)).toEqual([[], []]);
+    expect(cachedEntries().map((e) => e.stats?.total_votes)).toEqual([300, 300]);
   });
 
-  it("keeps the related footer's rows without their bodies", async () => {
+  it("keeps the related footer's rows without their bodies or voters", async () => {
     const authorRows = [fullRow(), fullRow()];
     const communityRows = [fullRow({ author: "bob" }), fullRow({ author: "carol" })];
     answers.set("account", authorRows);
@@ -119,6 +125,7 @@ describe("server renders that never read a body fetch slim pages", () => {
     }
     expect(cachedEntries()).toHaveLength(4);
     expect(cachedEntries().every((e) => e.body === "")).toBe(true);
+    expect(cachedEntries().every((e) => e.active_votes?.length === 0)).toBe(true);
   });
 
   it("answers under a key of its own, never the one deck columns read", async () => {
@@ -133,7 +140,7 @@ describe("server renders that never read a body fetch slim pages", () => {
     const keys = cachedEntryKeys();
     expect(keys.length).toBe(3);
     for (const key of keys) {
-      expect(key.at(-1)).toBe(SLIM_KEY_MARKER);
+      expect(key.at(-1)).toBe(CARD_ONLY_KEY_MARKER);
     }
   });
 

--- a/apps/web/src/specs/core/entries/slim-entry.spec.ts
+++ b/apps/web/src/specs/core/entries/slim-entry.spec.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import { catchPostImage, postBodySummary } from "@ecency/render-helper";
 import { ContentModerationReason } from "@ecency/sdk";
 import {
+  CARD_ONLY_KEY_MARKER,
   SLIM_KEY_MARKER,
   slimEntry,
   slimEntryPage,
+  withCardOnlyPageEntries,
   withSlimEntries,
   withSlimPageEntries
 } from "@/core/entries/slim-entry";
@@ -180,6 +182,95 @@ describe("slimEntryPage", () => {
 
     expect(page[0]).toBe(broken);
     expect(page[1].body).toBe("");
+  });
+});
+
+describe("withCardOnlyPageEntries", () => {
+  const page = () => [
+    entry({ body: "a body", active_votes: [{ voter: "a", rshares: 1 }] as never }),
+    entry({ body: "another body", active_votes: [{ voter: "b", rshares: 2 }] as never })
+  ];
+
+  async function run(options: Parameters<typeof withCardOnlyPageEntries>[0]) {
+    const wrapped = withCardOnlyPageEntries(options);
+    return (wrapped.queryFn as () => Promise<Entry[]>)();
+  }
+
+  it("drops the bodies and the voter records the render never reads", async () => {
+    const rows = await run({ queryKey: ["posts", "ranked"], queryFn: async () => page() });
+
+    expect(rows.map((e) => e.body)).toEqual(["", ""]);
+    expect(rows.map((e) => e.active_votes)).toEqual([[], []]);
+  });
+
+  it("keeps a vote count readable, so nothing that shows a number shows zero", async () => {
+    const [row] = await run({
+      queryKey: ["posts", "ranked"],
+      queryFn: async () => [
+        entry({
+          active_votes: [{ voter: "a", rshares: 1 }] as never,
+          stats: { total_votes: 7, flag_weight: 0, gray: false, hide: false }
+        })
+      ]
+    });
+
+    expect(row.active_votes).toEqual([]);
+    expect(row.stats?.total_votes).toBe(7);
+  });
+
+  it("leaves the votes alone when no count survives them", async () => {
+    // The invariant strip-active-votes keeps: an entry whose only vote signal is
+    // the array itself would otherwise start reporting zero votes.
+    const votes = [{ voter: "a", rshares: 1 }];
+    const [row] = await run({
+      queryKey: ["posts", "ranked"],
+      queryFn: async () => [
+        entry({ active_votes: votes as never, stats: undefined as never, total_votes: undefined })
+      ]
+    });
+
+    expect(row.active_votes).toHaveLength(1);
+  });
+
+  it("reaches the nested original of a cross-post", async () => {
+    const original = entry({
+      author: "bob",
+      body: "the original body",
+      active_votes: [{ voter: "c", rshares: 3 }] as never
+    });
+    const [row] = await run({
+      queryKey: ["posts", "ranked"],
+      queryFn: async () => [entry({ original_entry: original })]
+    });
+
+    expect(row.original_entry?.body).toBe("");
+    expect(row.original_entry?.active_votes).toEqual([]);
+  });
+
+  it("answers under its own marker, not the slim one", () => {
+    const wrapped = withCardOnlyPageEntries({
+      queryKey: ["posts", "ranked", "alice"],
+      queryFn: async () => []
+    });
+
+    expect((wrapped.queryKey as unknown[]).at(-1)).toBe(CARD_ONLY_KEY_MARKER);
+    expect(wrapped.queryKey).not.toContain(SLIM_KEY_MARKER);
+  });
+
+  it("passes a row through untouched rather than failing the page", async () => {
+    const broken = entry();
+    Object.defineProperty(broken, "json_metadata", {
+      get() {
+        throw new Error("unreadable metadata");
+      }
+    });
+    const rows = await run({
+      queryKey: ["posts", "ranked"],
+      queryFn: async () => [broken, entry({ body: "fine" })]
+    });
+
+    expect(rows[0]).toBe(broken);
+    expect(rows[1].body).toBe("");
   });
 });
 

--- a/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
+++ b/apps/web/src/specs/scripts/slim-entries-audit.spec.ts
@@ -10,7 +10,7 @@ import { auditSource } from "../../../../../scripts/slim-entries-audit.mjs";
  * whole class, and what remains is checked here.
  */
 const src = (body: string) =>
-  `import { withSlimEntries, withSlimPageEntries } from "@/core/entries/slim-entry";\n${body}\n`;
+  `import { withSlimEntries, withSlimPageEntries, withCardOnlyPageEntries } from "@/core/entries/slim-entry";\n${body}\n`;
 
 describe("slim-entries audit", () => {
   it("accepts a single-page builder wrapped with the page helper", () => {
@@ -23,6 +23,24 @@ describe("slim-entries audit", () => {
     expect(
       auditSource("f.ts", src(`const o = withSlimEntries(getPostsRankedInfiniteQueryOptions("trending", ""));`))
     ).toEqual([]);
+  });
+
+  it("accepts a single-page builder wrapped card-only, which also isolates its key", () => {
+    expect(
+      auditSource(
+        "f.ts",
+        src(`const o = withCardOnlyPageEntries(getAccountPostsQueryOptions("alice", "posts"));`)
+      )
+    ).toEqual([]);
+  });
+
+  it("flags an infinite builder wrapped card-only, since a feed does show vote state", () => {
+    const found = auditSource(
+      "f.ts",
+      src(`const o = withCardOnlyPageEntries(getPostsRankedInfiniteQueryOptions("trending", ""));`)
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("infinite builder");
   });
 
   it("flags a single-page builder that keeps the shared key", () => {

--- a/scripts/slim-entries-audit.mjs
+++ b/scripts/slim-entries-audit.mjs
@@ -268,7 +268,11 @@ export function auditSource(fileName, text) {
 
   (function visit(node) {
     const called = canonicalAt(node, calleeName(node), imports);
-    if (called === "withSlimEntries" || called === "withSlimPageEntries") {
+    if (
+      called === "withSlimEntries" ||
+      called === "withSlimPageEntries" ||
+      called === "withCardOnlyPageEntries"
+    ) {
       const { line } = src.getLineAndCharacterOfPosition(node.getStart());
       const where = `${fileName}:${line + 1}`;
       const wrapped = resolveBuilder(node.arguments[0], imports);
@@ -278,15 +282,21 @@ export function auditSource(fileName, text) {
           `${where}  cannot tell which builder ${called} wraps — pass the builder ` +
             `call directly, or assign it to one clearly named const in the same function`
         );
-      } else if (SINGLE_PAGE_BUILDERS.has(wrapped) && called !== "withSlimPageEntries") {
+      } else if (
+        SINGLE_PAGE_BUILDERS.has(wrapped) &&
+        called !== "withSlimPageEntries" &&
+        called !== "withCardOnlyPageEntries"
+      ) {
         findings.push(
-          `${where}  ${wrapped} is a single-page builder: use withSlimPageEntries, ` +
+          `${where}  ${wrapped} is a single-page builder: use withSlimPageEntries ` +
+            `(or withCardOnlyPageEntries when the render shows no vote state), ` +
             `or a deck column reading that page key renders an empty post`
         );
       } else if (INFINITE_BUILDERS.has(wrapped) && called !== "withSlimEntries") {
         findings.push(
           `${where}  ${wrapped} is an infinite builder: use withSlimEntries, ` +
-            `its key is hand-built elsewhere for the feed poll's merge`
+            `its key is hand-built elsewhere for the feed poll's merge, and a ` +
+            `feed shows vote state so it cannot be card-only either`
         );
       }
     }


### PR DESCRIPTION
Third item from #1559, and the last payload-side one worth doing.

The landing strip and the related footer render a title, an author, a date and a thumbnail. Neither has a vote button, a payout or a vote count anywhere in it, and both were still caching every voter record of every row they list for the whole gc window.

Measured with forced GC on entries sampled from live traffic, `active_votes` is 54-71% of what a cached page retains, several times what the body was, because every `{voter, rshares}` record becomes an object:

| cached page | full | slim | card-only |
| --- | --- | --- | --- |
| landing strip, 8 trending rows | 469 KB | 419 KB | 35 KB |
| related author feed, 12 rows | 103 KB | 80 KB | 24 KB |

`withCardOnlyPageEntries` is a third wrapper rather than a flag on the second, for the reason the second one exists at all: choosing the function names the intent, and the audit checks that the choice matches the builder. It takes its own key marker rather than the slim one, because a slim reader expects an entry that still knows who voted on it, and handing it one that does not is the same class of bug as #1556. The audit now also rejects card-only on an infinite builder, since a feed does show vote state.

The count invariant from `strip-active-votes.ts` is kept: records go only when `stats.total_votes` or `total_votes` survives, so nothing that displays a number can start displaying zero. An entry carrying no count keeps its votes.

Worth stating plainly, since #1559 is about replica capacity: at production render rates this is tens of megabytes per replica, low single-digit percent. The measurement recorded on that issue shows the request-scoped cache reaches steady state within one gc window while a replica's RSS keeps climbing for hours, so payload trimming is not what bounds replica count. This is worth doing because these two renders should not hold what they cannot display, not because it will change the replica maths.

Tests: card-only drops bodies and voters, keeps the count readable, leaves votes alone when no count survives, reaches a cross-post's nested original, uses its own key marker, and passes a row through untouched rather than failing the page. The server-prefetch spec asserts the same through the real prefetch path. Audit specs cover both new rules.
