### PR TITLE
Stop fabricating 200 for every HEAD at the origins

### DIFF
--- a/infra/origin/eu.ecency.com.conf
+++ b/infra/origin/eu.ecency.com.conf
@@ -150,18 +150,14 @@ server {
         # every response. X-Cache-Status above is fine — that value is nginx's
         # own and does not exist upstream.
 
-        add_header Access-Control-Allow-Origin *;
-        add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
-        add_header X-Frame-Options "SAMEORIGIN";
-        add_header X-Content-Type-Options nosniff;
-        add_header Referrer-Policy "strict-origin";
-        add_header X-XSS-Protection "1; mode=block";
+        add_header Access-Control-Allow-Origin * always;
+        add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy "strict-origin" always;
+        add_header X-XSS-Protection "1; mode=block" always;
         add_header X-Origin-Region "eu" always;
 
-	if ($request_method = HEAD) {
-	add_header Cache-Control no-store;
-	return 200;
-        }
         proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
         proxy_set_header   Host $http_host;
         # SSR render timeout: 20s gives headroom for 2-3 sequential prefetches (5-10s each)

--- a/infra/origin/us.ecency.com.conf
+++ b/infra/origin/us.ecency.com.conf
@@ -145,18 +145,14 @@ server {
         proxy_cache_lock_timeout 5s;
         add_header X-Cache-Status $upstream_cache_status;
 
-        add_header Access-Control-Allow-Origin *;
-        add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
-        add_header X-Frame-Options "SAMEORIGIN";
-        add_header X-Content-Type-Options nosniff;
-        add_header Referrer-Policy "strict-origin";
-        add_header X-XSS-Protection "1; mode=block";
+        add_header Access-Control-Allow-Origin * always;
+        add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload' always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy "strict-origin" always;
+        add_header X-XSS-Protection "1; mode=block" always;
         add_header X-Origin-Region "us" always;
 
-	if ($request_method = HEAD) {
-	add_header Cache-Control no-store;
-	return 200;
-        }
         proxy_set_header   X-Forwarded-For $http_cf_connecting_ip;
         proxy_set_header   Host $http_host;
         # SSR render timeout: 20s gives headroom for 2-3 sequential prefetches (5-10s each)


### PR DESCRIPTION
Closes #1575.

`location /` short-circuited HEAD with a bare `return 200`, so a HEAD request never reached the app and reported a live page whatever the real status would have been.

Reproduced against both origins before the change:

```
EU origin      GET=307  HEAD=200  HEAD-HSTS=0
US origin      GET=307  HEAD=200  HEAD-HSTS=0
```

and after:

```
EU origin      GET=307  HEAD=307  HEAD-HSTS=1
US origin      GET=307  HEAD=307  HEAD-HSTS=1
```

### The `always` flags are the same fix, not a tidy-up

While every HEAD was a fabricated 200, the security headers applied because 200 is in `add_header`'s default status list. Deleting the block alone would therefore have made HEAD reach real 404/429/5xx responses **with the headers gone** — a security regression that looks correct in a 200/307 spot check. `always` on its own fixes nothing either, since an `add_header` nested inside the `if` suppresses inheritance regardless of it. Both halves ship together.

Verified after the change:

```
eu.ecency.com  HEAD 404 -> 404, security headers present
us.ecency.com  HEAD 404 -> 404, security headers present
```

`X-Cache-Status` deliberately keeps its default status list: it is a cache diagnostic, not something we owe an error response.

### Behaviour change worth stating

Error responses now carry CORS and HSTS where they previously did not. That is intended, and matches what `X-Origin-Region` already did.

### Verification notes

Both boxes were edited and reloaded in one window **before** this commit, so the tracked copies match what is running; one origin fixed and the other not would be the same bypass-by-routing failure the README's newsletter example describes.

Probing through `ecency.com` is a false negative for this bug — the edge normalises the request and already returned 307 with the headers. It only reproduces direct to the origin.

`origin-config-audit` passes unchanged: 0 findings, 34 self-test cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Security and cross-origin headers are now consistently included, including on error responses.
  * Removed special handling that returned empty responses for `HEAD` requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->