### PR TITLE
Require a bot check on anonymous newsletter subscribes, and offer the post prompt to anonymous readers

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,6 +24,7 @@ jobs:
       NEXT_PUBLIC_GMAPS_API_KEY: ${{ secrets.GMAPS_API_KEY }}
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUB_KEY }}
       NEXT_PUBLIC_GMAPS_MAP_ID: ${{ secrets.GMAPS_MAP_ID }}
+      NEXT_PUBLIC_TURNSTILE_SITEKEY: ${{ secrets.TURNSTILE_SITEKEY }}
     strategy:
       matrix:
         node-version: [24.x]
@@ -85,6 +86,7 @@ jobs:
             NEXT_PUBLIC_GMAPS_API_KEY=${{ secrets.GMAPS_API_KEY }}
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${{ secrets.STRIPE_PUB_KEY }}
             NEXT_PUBLIC_GMAPS_MAP_ID=${{ secrets.GMAPS_MAP_ID }}
+            NEXT_PUBLIC_TURNSTILE_SITEKEY=${{ secrets.TURNSTILE_SITEKEY }}
             PNPM_VERSION=10.18.1
 
       # Sentry's source-map upload runs inside the Docker build via the

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -27,6 +27,7 @@ jobs:
       NEXT_PUBLIC_GMAPS_API_KEY: ${{ secrets.GMAPS_API_KEY }}
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUB_KEY }}
       NEXT_PUBLIC_GMAPS_MAP_ID: ${{ secrets.GMAPS_MAP_ID }}
+      NEXT_PUBLIC_TURNSTILE_SITEKEY: ${{ secrets.TURNSTILE_SITEKEY }}
     strategy:
       matrix:
         node-version: [24.x]
@@ -88,6 +89,7 @@ jobs:
             NEXT_PUBLIC_GMAPS_API_KEY=${{ secrets.GMAPS_API_KEY }}
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${{ secrets.STRIPE_PUB_KEY }}
             NEXT_PUBLIC_GMAPS_MAP_ID=${{ secrets.GMAPS_MAP_ID }}
+            NEXT_PUBLIC_TURNSTILE_SITEKEY=${{ secrets.TURNSTILE_SITEKEY }}
             PNPM_VERSION=10.18.1
 
       # See master.yml for rationale — verifies the Sentry release was

--- a/apps/self-hosted/hosting/origin/README.md
+++ b/apps/self-hosted/hosting/origin/README.md
@@ -43,15 +43,31 @@ nothing. A custom domain on its own apex is not.
 
 So when a custom domain is attached, add it to the sitekey's domain list as well:
 
+The update is a **PUT of the whole widget object**, so `domains` REPLACES the stored list
+rather than adding to it. Never hand-write the array: read the current one and append, or
+the tenants added before this one are silently dropped and their forms break instead.
+
 ```bash
-# read the current list first; the widget update is a PUT of the whole object
-curl -s -H "Authorization: Bearer $CF_TOKEN" \
-  "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT/challenges/widgets/$SITEKEY"
+NEW_DOMAIN="blog.example.com"
+WIDGET="https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT/challenges/widgets/$SITEKEY"
+
+# Build the new body from the CURRENT list, so nothing already registered is lost.
+BODY=$(curl -s -H "Authorization: Bearer $CF_TOKEN" "$WIDGET" | python3 -c '
+import json, sys
+w = json.load(sys.stdin)["result"]
+domains = sorted(set(w["domains"]) | {sys.argv[1]})
+print(json.dumps({"name": w["name"], "mode": w["mode"], "domains": domains}))
+' "$NEW_DOMAIN")
 
 curl -X PUT -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
-  "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT/challenges/widgets/$SITEKEY" \
-  --data '{"name":"ecency.com","mode":"managed","domains":["ecency.com","<the new domain>"]}'
+  "$WIDGET" --data "$BODY"
+
+# Confirm the list still holds every domain it held before, plus the new one.
+curl -s -H "Authorization: Bearer $CF_TOKEN" "$WIDGET" | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"]["domains"])'
 ```
+
+The token needs **Turnstile: Edit**; with read-only it answers `10405` or `10000` rather
+than saying the permission is missing.
 
 Skipping it leaves that tenant's signup form with a widget that will not solve and a submit
 button that never enables. It fails visibly on the blog and invisibly to us, which is why

--- a/apps/self-hosted/hosting/origin/README.md
+++ b/apps/self-hosted/hosting/origin/README.md
@@ -31,6 +31,32 @@ in practice — **re-copy any change made there back into this directory.**
    reloads nginx if something changed. A vhost that fails `nginx -t` is quarantined as
    `.broken` rather than wedging every later reload.
 
+## A custom domain also needs a Turnstile hostname
+
+The sync does NOT do this, and nothing else will notice if it is skipped.
+
+The newsletter signup form on a tenant blog renders a Cloudflare Turnstile widget, and the
+relay refuses an anonymous subscribe without a valid token. A Turnstile sitekey is bound to
+a hostname list, and adding a hostname covers that hostname **and all of its subdomains**,
+so every `*.blogs.ecency.com` tenant is already covered by the `ecency.com` entry and needs
+nothing. A custom domain on its own apex is not.
+
+So when a custom domain is attached, add it to the sitekey's domain list as well:
+
+```bash
+# read the current list first; the widget update is a PUT of the whole object
+curl -s -H "Authorization: Bearer $CF_TOKEN" \
+  "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT/challenges/widgets/$SITEKEY"
+
+curl -X PUT -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
+  "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT/challenges/widgets/$SITEKEY" \
+  --data '{"name":"ecency.com","mode":"managed","domains":["ecency.com","<the new domain>"]}'
+```
+
+Skipping it leaves that tenant's signup form with a widget that will not solve and a submit
+button that never enables. It fails visibly on the blog and invisibly to us, which is why
+it belongs in this list rather than in someone's memory.
+
 ## origin-ips (not in git)
 
 The DNS check above needs this origin's own addresses. They are read from an `origin-ips`

--- a/apps/self-hosted/src/core/i18n-strings.ts
+++ b/apps/self-hosted/src/core/i18n-strings.ts
@@ -312,6 +312,7 @@ export type TranslationKey =
   | 'newsletterCheckInbox'
   | 'newsletterUseAnotherAddress'
   | 'newsletterError'
+  | 'newsletterCaptchaFailed'
   | 'panel_configuration_instance_configuration_features_newsletter_label'
   | 'panel_configuration_instance_configuration_features_newsletter_enabled_label'
   | 'panel_configuration_instance_configuration_features_newsletter_enabled_description';
@@ -351,6 +352,7 @@ export const translations: { en: Translations } & Record<
     newsletterCheckInbox: 'Almost there: confirm from the email we just sent.',
     newsletterUseAnotherAddress: 'Use a different address',
     newsletterError: 'Could not subscribe right now. Please try again.',
+    newsletterCaptchaFailed: 'Verification could not load. Please reload the page to subscribe.',
     loading: "Loading...",
     hivesigner_login_failed: 'Sign in could not be completed. Please try again.',
     loadingPost: "Loading post...",

--- a/apps/self-hosted/src/features/blog/components/newsletter-signup.test.tsx
+++ b/apps/self-hosted/src/features/blog/components/newsletter-signup.test.tsx
@@ -11,6 +11,44 @@ import {
 import { NewsletterSignup } from './newsletter-signup';
 
 /**
+ * The Turnstile widget, mocked. The real one appends a Cloudflare <script> that jsdom
+ * never executes, so the token would never arrive and every submit here would sit behind
+ * a permanently disabled button. The mock renders nothing and hands the test the
+ * callbacks, which is the whole contract the form depends on.
+ *
+ * It renders NO element on purpose: `resetControl()` below selects the first
+ * `button[type="button"]`, and a mock button would quietly steal that selector from the
+ * use-another-address control it was written for.
+ */
+const captcha = vi.hoisted(() => ({
+  verify: null as null | ((token: string) => void),
+  resets: 0
+}));
+
+vi.mock('../../shared/turnstile', () => ({
+  Turnstile: ({
+    onVerify,
+    ref
+  }: {
+    onVerify: (token: string) => void;
+    ref?: { current: { reset: () => void } | null };
+  }) => {
+    captcha.verify = onVerify;
+    if (ref) ref.current = { reset: () => { captcha.resets += 1; } };
+    return null;
+  }
+}));
+
+const CAPTCHA_TOKEN = 'turnstile-test-token';
+
+/** Solve the challenge, the way a reader does before the button becomes usable. */
+async function solveCaptcha(): Promise<void> {
+  await act(async () => {
+    captcha.verify?.(CAPTCHA_TOKEN);
+  });
+}
+
+/**
  * The component half of the signup form (vision-web#1537). The pure rules live
  * in newsletter-signup-target.test.ts; this covers what only a rendered
  * component can show: the eligibility fence, the request the submit actually
@@ -142,6 +180,11 @@ async function typeInto(
  */
 async function submitForm(): Promise<void> {
   const form = container.querySelector('form');
+  // The relay refuses an anonymous subscribe without a token and the button stays
+  // disabled until one exists, so an unsolved challenge is not a state a reader can
+  // submit from. Tests that care about the gate itself solve explicitly and assert
+  // before calling this.
+  if (form && captcha.verify) await solveCaptcha();
   await act(async () => {
     form?.dispatchEvent(
       new Event('submit', { bubbles: true, cancelable: true }),
@@ -168,6 +211,8 @@ describe('NewsletterSignup', () => {
     InstanceConfigManager.updateConfig(
       structuredClone(MANAGED_BLOG) as InstanceConfig,
     );
+    captcha.verify = null;
+    captcha.resets = 0;
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -278,7 +323,7 @@ describe('NewsletterSignup', () => {
       email: 'reader@example.com',
       type: 'creator',
       target: 'alice',
-      targetLabel: 'Alice Writes',
+      captchaToken: CAPTCHA_TOKEN,
       cadence: 'monthly',
       source: 'self-hosted-blog',
     });
@@ -306,11 +351,62 @@ describe('NewsletterSignup', () => {
       'Could not subscribe right now. Please try again.',
     );
     expect(politeRegion()?.textContent).toBe('');
-    // Still submittable: the reader can retry without losing what they typed.
+    // Still there, and the address is not lost: the reader retries without retyping.
     expect(form()).not.toBeNull();
-    expect(submitButton()?.disabled).toBe(false);
-    expect(submitButton()?.getAttribute('aria-busy')).toBe('false');
     expect(emailInput()?.value).toBe('reader@example.com');
+    expect(submitButton()?.getAttribute('aria-busy')).toBe('false');
+    // But the challenge was spent on the attempt that failed, so the button waits for a
+    // fresh one. Re-submitting with the used token would fail again at the relay, and the
+    // reader would read the same generic error with nothing to act on.
+    expect(captcha.resets).toBe(1);
+    expect(submitButton()?.disabled).toBe(true);
+    await solveCaptcha();
+    expect(submitButton()?.disabled).toBe(false);
+  });
+
+  it('will not submit until the challenge is solved, and never posts without a token', async () => {
+    // A blog reader has no Ecency session, so the relay treats every submit here as
+    // anonymous and refuses one carrying no token. The button is the visible half of
+    // that; the handler's own guard is the half that matters, because a form can still
+    // be submitted from the keyboard while its button is disabled.
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await render();
+    await typeInto(emailInput(), 'reader@example.com');
+    expect(submitButton()?.disabled).toBe(true);
+
+    // Submitting anyway, the way a keyboard reader can: nothing leaves.
+    const el = container.querySelector('form');
+    await act(async () => {
+      el?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(errorRegion()?.textContent).toBe('');
+
+    await solveCaptcha();
+    expect(submitButton()?.disabled).toBe(false);
+    await submitForm();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string).captchaToken).toBe(
+      CAPTCHA_TOKEN,
+    );
+  });
+
+  it('asks for a fresh challenge for the next address', async () => {
+    // The token is single use, so the way back from the confirmation (#1546) has to
+    // re-challenge or the second address is submitted with a spent one.
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true })));
+    await render();
+    await typeInto(emailInput(), 'reader@example.com');
+    await submitForm();
+    expect(resetControl()).not.toBeNull();
+
+    await act(async () => {
+      resetControl()?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(captcha.resets).toBe(1);
+    expect(submitButton()?.disabled).toBe(true);
   });
 
   it('shows the same error when the request never completes', async () => {
@@ -369,7 +465,7 @@ describe('NewsletterSignup', () => {
     expect(JSON.parse(init.body as string)).toMatchObject({
       type: 'community',
       target: 'hive-125125',
-      targetLabel: 'Alice Writes',
+      captchaToken: CAPTCHA_TOKEN,
       cadence: 'weekly',
     });
   });

--- a/apps/self-hosted/src/features/blog/components/newsletter-signup.tsx
+++ b/apps/self-hosted/src/features/blog/components/newsletter-signup.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, type ReactElement, useEffect, useRef, useState } from '
 import { InstanceConfigManager } from '../../../core/configuration-loader';
 import { t } from '../../../core/i18n';
 import { LiveRegion } from '../../shared/live-region';
+import { Turnstile, type TurnstileHandle } from '../../shared/turnstile';
 import { newsletterSignupTarget, newsletterSubscribeBody } from '../utils/newsletter-signup-target';
 
 /**
@@ -93,6 +94,9 @@ export function NewsletterSignup({
    * replaced by the form again. Never on first render, or the page would hand
    * focus to a sidebar form the moment it loads.
    */
+  const [captchaToken, setCaptchaToken] = useState('');
+  const turnstileRef = useRef<TurnstileHandle>(null);
+
   const restoreFocus = useRef(false);
   useEffect(() => {
     if (!restoreFocus.current) return;
@@ -117,20 +121,30 @@ export function NewsletterSignup({
 
   const submit = async (e: FormEvent): Promise<void> => {
     e.preventDefault();
-    if (state === 'busy' || !email.trim()) return;
+    if (state === 'busy' || !email.trim() || !captchaToken) return;
     setState('busy');
     try {
       const res = await fetch('/api/newsletter/subscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(newsletterSubscribeBody(target, email, cadence)),
+        body: JSON.stringify(newsletterSubscribeBody(target, email, cadence, captchaToken)),
       });
       if (!mounted.current) return;
       // Only success swaps the form out, so only success has focus to rescue.
       restoreFocus.current = res.ok;
       setState(res.ok ? 'done' : 'error');
+      // The token is single use whatever the outcome, and a reader who retries with a
+      // spent one gets the same generic error twice with nothing to act on.
+      if (!res.ok) {
+        setCaptchaToken('');
+        turnstileRef.current?.reset();
+      }
     } catch {
-      if (mounted.current) setState('error');
+      if (mounted.current) {
+        setState('error');
+        setCaptchaToken('');
+        turnstileRef.current?.reset();
+      }
     }
   };
 
@@ -144,6 +158,8 @@ export function NewsletterSignup({
     restoreFocus.current = true;
     setEmail('');
     setState('idle');
+    setCaptchaToken('');
+    turnstileRef.current?.reset();
   };
 
   return (
@@ -184,6 +200,17 @@ export function NewsletterSignup({
             aria-label={t('newsletterEmail')}
             className="input-theme w-full text-sm px-2 py-1.5 rounded"
           />
+          {/* Anonymous by definition here: a blog reader has no Ecency session, so the
+              relay always wants a token. The submit stays disabled until one exists,
+              which is also what happens when the script is blocked -- the widget then
+              says so rather than failing at submit with a generic error. */}
+          <Turnstile
+            ref={turnstileRef}
+            action="newsletter-subscribe"
+            onVerify={setCaptchaToken}
+            onExpire={() => setCaptchaToken('')}
+            onError={() => setCaptchaToken('')}
+          />
           <div className="flex gap-2">
             <select
               value={cadence}
@@ -196,7 +223,7 @@ export function NewsletterSignup({
             </select>
             <button
               type="submit"
-              disabled={state === 'busy'}
+              disabled={state === 'busy' || !captchaToken}
               aria-busy={state === 'busy'}
               className="btn-theme-primary text-sm px-3 py-1.5 rounded disabled:opacity-60"
             >

--- a/apps/self-hosted/src/features/blog/utils/newsletter-signup-target.test.ts
+++ b/apps/self-hosted/src/features/blog/utils/newsletter-signup-target.test.ts
@@ -37,13 +37,17 @@ describe('newsletterSignupTarget', () => {
 
   it('builds the exact relay body, source self-hosted-blog', () => {
     const t = newsletterSignupTarget(managedBlog)!;
-    expect(newsletterSubscribeBody(t, '  reader@example.com ', 'monthly')).toEqual({
+    expect(newsletterSubscribeBody(t, '  reader@example.com ', 'monthly', 'tok')).toEqual({
       email: 'reader@example.com',
       type: 'creator',
       target: 'alice',
-      targetLabel: 'Alice Writes',
       cadence: 'monthly',
       source: 'self-hosted-blog',
+      // The site title is NOT sent any more: it used to let a caller write part of a
+      // sentence in mail our domain sends to an address they chose. The service derives
+      // the label from the target now. targetLabel still exists on the TARGET above,
+      // for the copy this app renders itself.
+      captchaToken: 'tok',
     });
   });
 });

--- a/apps/self-hosted/src/features/blog/utils/newsletter-signup-target.ts
+++ b/apps/self-hosted/src/features/blog/utils/newsletter-signup-target.ts
@@ -37,20 +37,37 @@ export interface NewsletterSubscribeBody {
   email: string;
   type: 'creator' | 'community';
   target: string;
-  targetLabel: string;
   cadence: 'weekly' | 'monthly';
   source: 'self-hosted-blog';
+  /**
+   * Cloudflare Turnstile token. The relay requires one from every caller without an
+   * account, and a reader on a blog never has one, so it is required here in practice.
+   */
+  captchaToken: string;
 }
 
-/** The body the form posts, exactly as the relay expects it. */
-export function newsletterSubscribeBody(t: NewsletterSignupTarget, email: string, cadence: 'weekly' | 'monthly'): NewsletterSubscribeBody {
+/**
+ * The body the form posts, exactly as the relay expects it.
+ *
+ * `targetLabel` is deliberately NOT sent any more. It used to carry the site title into
+ * the confirmation email, which meant a caller chose part of a sentence in mail our domain
+ * sends to an address they picked; the service derives the label from the target itself
+ * now. `NewsletterSignupTarget.targetLabel` still exists and is still used, for the copy
+ * this app renders itself.
+ */
+export function newsletterSubscribeBody(
+  t: NewsletterSignupTarget,
+  email: string,
+  cadence: 'weekly' | 'monthly',
+  captchaToken: string
+): NewsletterSubscribeBody {
   return {
     email: email.trim(),
     type: t.type,
     target: t.target,
-    targetLabel: t.targetLabel,
     cadence,
     source: 'self-hosted-blog',
+    captchaToken,
   };
 }
 

--- a/apps/self-hosted/src/features/shared/turnstile.tsx
+++ b/apps/self-hosted/src/features/shared/turnstile.tsx
@@ -1,26 +1,23 @@
-"use client";
-
-import i18next from "i18next";
-import React, {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState
-} from "react";
-
-// Cloudflare Turnstile widget. Loads the CF script once and renders an explicit
-// widget, no extra npm dependency. The sitekey is public; the secret is verified
-// server-side (onboard). Managed mode is configured on the Cloudflare dashboard.
-const SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+import { useEffect, useImperativeHandle, useRef, useState, forwardRef } from 'react';
+import { t } from '../../core/i18n';
 
 /**
- * Public sitekey (Managed mode); the secret never reaches the client. Exported so callers
- * stop re-declaring the same constant: it was already copied into signup/free,
- * signup/premium and embed/turnstile before this.
+ * Cloudflare Turnstile widget for the managed-blog newsletter form.
+ *
+ * A deliberate second implementation rather than a shared one. `apps/web` has its own in
+ * `features/shared/turnstile.tsx`, but that file imports i18next and lives in the Next
+ * bundle; this app is a separate Rsbuild SPA with its own string table, and the two are
+ * kept apart on purpose. The logic that matters -- load the script once, render an
+ * explicit widget, hand back a single-use token -- is about thirty lines.
+ *
+ * The sitekey is a literal, NOT read from an env var. Rsbuild provides no `process`, and
+ * `check-node-globals` fails the build on a chunk that reads one; a missed define would
+ * blank every hosted blog rather than fall back. The value is public and is bound to
+ * ecency.com plus the tenant custom domains registered on the widget.
  */
-export const TURNSTILE_SITEKEY =
-  process.env.NEXT_PUBLIC_TURNSTILE_SITEKEY || "0x4AAAAAADe6jH7FIi9dBzgR";
+const SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+
+export const TURNSTILE_SITEKEY = '0x4AAAAAADe6jH7FIi9dBzgR';
 
 declare global {
   interface Window {
@@ -35,22 +32,18 @@ declare global {
 let scriptPromise: Promise<void> | null = null;
 
 function loadTurnstileScript(): Promise<void> {
-  if (typeof window === "undefined") {
-    return Promise.resolve();
-  }
-  if (window.turnstile) {
-    return Promise.resolve();
-  }
+  if (typeof window === 'undefined' || window.turnstile) return Promise.resolve();
   if (!scriptPromise) {
     scriptPromise = new Promise<void>((resolve, reject) => {
-      const script = document.createElement("script");
+      const script = document.createElement('script');
       script.src = SCRIPT_SRC;
       script.async = true;
       script.defer = true;
       script.onload = () => resolve();
       script.onerror = () => {
+        // Cleared so a later mount retries instead of inheriting the rejection forever.
         scriptPromise = null;
-        reject(new Error("Failed to load Turnstile"));
+        reject(new Error('Failed to load Turnstile'));
       };
       document.head.appendChild(script);
     });
@@ -59,36 +52,28 @@ function loadTurnstileScript(): Promise<void> {
 }
 
 export interface TurnstileHandle {
-  /** Discard the current (single-use) token and request a fresh challenge. */
+  /** Discard the spent single-use token and ask for a fresh challenge. */
   reset: () => void;
 }
 
 interface Props {
-  sitekey: string;
-  /** Called with the verification token when the challenge is solved. */
   onVerify: (token: string) => void;
-  /** Called when the token expires or the widget is reset — clear stored token. */
+  /** Token expired or was cleared: the caller must drop the one it holds. */
   onExpire?: () => void;
-  /** Called when the challenge errors or the script fails to load. Falls back to onExpire when omitted. */
+  /** Challenge errored or the script never loaded. Falls back to onExpire. */
   onError?: () => void;
-  /**
-   * Scopes the token to one purpose. One sitekey serves every surface here, so without
-   * this a challenge solved on the signup page produces a token that is equally valid at
-   * the newsletter endpoint. The verifier compares it against the `action` siteverify
-   * echoes back.
-   */
+  /** Scopes the token; the relay rejects a token issued for anything else. */
   action?: string;
   className?: string;
 }
 
 export const Turnstile = forwardRef<TurnstileHandle, Props>(function Turnstile(
-  { sitekey, onVerify, onExpire, onError, action, className },
+  { onVerify, onExpire, onError, action, className },
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
   const widgetIdRef = useRef<string | null>(null);
-  // Hold the latest callbacks in refs so the widget is rendered once (stable) but
-  // always invokes the current props — safe even if a caller passes inline callbacks.
+  // Callbacks held in refs so the widget renders once and still calls the current props.
   const onVerifyRef = useRef(onVerify);
   const onExpireRef = useRef(onExpire);
   const onErrorRef = useRef(onError);
@@ -110,7 +95,7 @@ export const Turnstile = forwardRef<TurnstileHandle, Props>(function Turnstile(
           }
         }
         onExpireRef.current?.();
-      }
+      },
     }),
     []
   );
@@ -120,15 +105,13 @@ export const Turnstile = forwardRef<TurnstileHandle, Props>(function Turnstile(
 
     loadTurnstileScript()
       .then(() => {
-        if (cancelled || !containerRef.current || !window.turnstile) {
-          return;
-        }
+        if (cancelled || !containerRef.current || !window.turnstile) return;
         widgetIdRef.current = window.turnstile.render(containerRef.current, {
-          sitekey,
+          sitekey: TURNSTILE_SITEKEY,
           ...(action ? { action } : {}),
           callback: (token: string) => onVerifyRef.current(token),
-          "expired-callback": () => onExpireRef.current?.(),
-          "error-callback": () => (onErrorRef.current ?? onExpireRef.current)?.()
+          'expired-callback': () => onExpireRef.current?.(),
+          'error-callback': () => (onErrorRef.current ?? onExpireRef.current)?.(),
         });
       })
       .catch(() => {
@@ -149,12 +132,12 @@ export const Turnstile = forwardRef<TurnstileHandle, Props>(function Turnstile(
         widgetIdRef.current = null;
       }
     };
-  }, [sitekey, action]);
+  }, [action]);
 
   if (failedToLoad) {
     return (
       <div className={className}>
-        <small className="text-red">{i18next.t("sign-up.captcha-load-failed")}</small>
+        <small className="text-theme-muted">{t('newsletterCaptchaFailed')}</small>
       </div>
     );
   }

--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -47,3 +47,13 @@ NEWSLETTER_API_URL=
 NEWSLETTER_SERVICE_TOKEN=
 # Optional kill switch: =0 hides the controls even when the service is configured.
 # NEXT_PUBLIC_NEWSLETTER_ENABLED=0
+
+# Cloudflare Turnstile. The sitekey is public and reaches the browser; the secret is
+# server-only and verifies the token an ANONYMOUS newsletter subscribe carries
+# (server/turnstile-verify). A signed-in subscribe never needs one.
+# Leave the secret UNSET and the check is skipped rather than refusing every anonymous
+# signup: that is deliberate, so a deploy that lands before the secret does cannot take
+# the homepage form down. It also means an unset secret is a silently open door, which is
+# why specs/deploy/newsletter-wiring pins it on the web service in both compose files.
+NEXT_PUBLIC_TURNSTILE_SITEKEY=
+TURNSTILE_SECRET=

--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -51,9 +51,10 @@ NEWSLETTER_SERVICE_TOKEN=
 # Cloudflare Turnstile. The sitekey is public and reaches the browser; the secret is
 # server-only and verifies the token an ANONYMOUS newsletter subscribe carries
 # (server/turnstile-verify). A signed-in subscribe never needs one.
-# Leave the secret UNSET and the check is skipped rather than refusing every anonymous
-# signup: that is deliberate, so a deploy that lands before the secret does cannot take
-# the homepage form down. It also means an unset secret is a silently open door, which is
-# why specs/deploy/newsletter-wiring pins it on the web service in both compose files.
+# The secret is REQUIRED once the newsletter itself is configured: with it unset, every
+# anonymous subscribe answers 503 rather than relaying with the check silently off. A
+# deployment that has not configured the newsletter at all never reaches that code, since
+# the route already 503s without NEWSLETTER_API_URL and NEWSLETTER_SERVICE_TOKEN.
+# specs/deploy/newsletter-wiring pins it on the web service in both compose files.
 NEXT_PUBLIC_TURNSTILE_SITEKEY=
 TURNSTILE_SECRET=

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -29,6 +29,12 @@ ENV NEXT_PUBLIC_GMAPS_API_KEY=${NEXT_PUBLIC_GMAPS_API_KEY}
 ENV NEXT_PUBLIC_GMAPS_MAP_ID=${NEXT_PUBLIC_GMAPS_MAP_ID}
 ARG NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
 ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}
+# Public Turnstile sitekey. NEXT_PUBLIC_* is inlined at BUILD time, so it has to arrive
+# here rather than through the runtime environment: without it every client falls back to
+# the literal in features/shared/turnstile.tsx, and a rotated or environment-specific
+# widget would fail on the deployed site while working in dev.
+ARG NEXT_PUBLIC_TURNSTILE_SITEKEY
+ENV NEXT_PUBLIC_TURNSTILE_SITEKEY=${NEXT_PUBLIC_TURNSTILE_SITEKEY}
 
 # ---- Sentry (make them visible to the build) ----
 ARG SENTRY_AUTH_TOKEN

--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -91,6 +91,12 @@ services:
       # `newsletterFeatureEnabled`), so a deployment without the service stays quiet.
       - NEWSLETTER_API_URL
       - NEWSLETTER_SERVICE_TOKEN
+      # Cloudflare Turnstile secret, for verifying the token an ANONYMOUS newsletter
+      # subscribe carries (server/turnstile-verify). Shared with vapi, which declares it
+      # above for the Stripe flow; the Next tier needs its own copy or the check is
+      # skipped, because an unset secret deliberately relays rather than refusing every
+      # anonymous signup. specs/deploy/newsletter-wiring pins this line for that reason.
+      - TURNSTILE_SECRET
       # Cap glibc malloc arenas (default 8*cores) so freed memory is returned to
       # the OS instead of being retained per-arena. Cuts Next.js SSR RSS (which
       # ran ~2x the V8 heap due to arena fragmentation) with no latency cost:

--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -93,9 +93,9 @@ services:
       - NEWSLETTER_SERVICE_TOKEN
       # Cloudflare Turnstile secret, for verifying the token an ANONYMOUS newsletter
       # subscribe carries (server/turnstile-verify). Shared with vapi, which declares it
-      # above for the Stripe flow; the Next tier needs its own copy or the check is
-      # skipped, because an unset secret deliberately relays rather than refusing every
-      # anonymous signup. specs/deploy/newsletter-wiring pins this line for that reason.
+      # above for the Stripe flow; the Next tier needs its own copy or every anonymous
+      # subscribe answers 503, because an unset secret refuses rather than relaying with
+      # the check off. specs/deploy/newsletter-wiring pins this line for that reason.
       - TURNSTILE_SECRET
       # Cap glibc malloc arenas (default 8*cores) so freed memory is returned to
       # the OS instead of being retained per-arena. Cuts Next.js SSR RSS (which

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -70,6 +70,12 @@ services:
       # answer 503 and no newsletter control renders.
       - NEWSLETTER_API_URL
       - NEWSLETTER_SERVICE_TOKEN
+      # Cloudflare Turnstile secret, for verifying the token an ANONYMOUS newsletter
+      # subscribe carries (server/turnstile-verify). Shared with vapi, which declares it
+      # above for the Stripe flow; the Next tier needs its own copy or the check is
+      # skipped, because an unset secret deliberately relays rather than refusing every
+      # anonymous signup. specs/deploy/newsletter-wiring pins this line for that reason.
+      - TURNSTILE_SECRET
       - PLAUSIBLE_API_KEY
       - NEXT_PUBLIC_GMAPS_MAP_ID
       - NEXT_PUBLIC_GMAPS_API_KEY

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -72,9 +72,9 @@ services:
       - NEWSLETTER_SERVICE_TOKEN
       # Cloudflare Turnstile secret, for verifying the token an ANONYMOUS newsletter
       # subscribe carries (server/turnstile-verify). Shared with vapi, which declares it
-      # above for the Stripe flow; the Next tier needs its own copy or the check is
-      # skipped, because an unset secret deliberately relays rather than refusing every
-      # anonymous signup. specs/deploy/newsletter-wiring pins this line for that reason.
+      # above for the Stripe flow; the Next tier needs its own copy or every anonymous
+      # subscribe answers 503, because an unset secret refuses rather than relaying with
+      # the check off. specs/deploy/newsletter-wiring pins this line for that reason.
       - TURNSTILE_SECRET
       - PLAUSIBLE_API_KEY
       - NEXT_PUBLIC_GMAPS_MAP_ID

--- a/apps/web/src/app/_components/landing-page/landing-subscribe-form.tsx
+++ b/apps/web/src/app/_components/landing-page/landing-subscribe-form.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useRef, useState } from "react";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { newsletterApi, NewsletterApiError } from "@/features/newsletter";
 import type { DigestCadence } from "@/features/newsletter";
 import { error, success } from "@/features/shared/feedback";
 import { LinearProgress } from "@/features/shared/linear-progress";
+import { Turnstile, TURNSTILE_SITEKEY, type TurnstileHandle } from "@/features/shared/turnstile";
 import i18next from "i18next";
 import { handleInvalid, handleOnInput } from "@/utils";
 
@@ -24,13 +25,36 @@ export function LandingSubscribeForm() {
   const [cadence, setCadence] = useState<DigestCadence>("weekly");
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState<"pending" | "active" | null>(null);
+  const [captchaToken, setCaptchaToken] = useState("");
+  const turnstileRef = useRef<TurnstileHandle>(null);
+
+  // The route challenges a caller with no account, so the widget appears for exactly
+  // those. A signed-in visitor on the homepage is attributed and passes straight through.
+  const needsCaptcha = !activeUser;
+
+  // Single-use tokens: a retry that reuses one fails as though the service were down.
+  const resetCaptcha = () => {
+    setCaptchaToken("");
+    turnstileRef.current?.reset();
+  };
 
   const handleSubscribe = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    // The disabled button is only the visible half: a form can still be submitted from
+    // the keyboard while its button is disabled, and posting an empty token would spend
+    // a round trip to be told 403.
+    if (needsCaptcha && !captchaToken) return;
     setLoading(true);
     try {
       const result = await newsletterApi.subscribe(
-        { email: email.trim(), type: "site", target: "ecency", cadence, source: "landing-page" },
+        {
+          email: email.trim(),
+          type: "site",
+          target: "ecency",
+          cadence,
+          source: "landing-page",
+          ...(needsCaptcha ? { captchaToken } : {})
+        },
         activeUser?.username
       );
       if (result.status === "active") {
@@ -43,12 +67,21 @@ export function LandingSubscribeForm() {
         // Only a proven, signed-in caller ever sees "refused"; it means a bounce or
         // complaint is on record for that address.
         error(i18next.t("newsletter.refused"));
+        if (needsCaptcha) resetCaptcha();
       }
       setEmail("");
     } catch (err) {
-      const unavailable =
-        err instanceof NewsletterApiError && (err.status === 502 || err.status === 503 || err.status === 504);
-      error(i18next.t(unavailable ? "newsletter.error-unavailable" : "landing-page.error-occured"));
+      const status = err instanceof NewsletterApiError ? err.status : 0;
+      const key =
+        status === 502 || status === 503 || status === 504
+          ? "newsletter.error-unavailable"
+          : status === 403
+            ? "newsletter.error-captcha"
+            : status === 429
+              ? "newsletter.error-too-many"
+              : "landing-page.error-occured";
+      error(i18next.t(key));
+      if (needsCaptcha) resetCaptcha();
     } finally {
       setLoading(false);
     }
@@ -85,7 +118,17 @@ export function LandingSubscribeForm() {
         <option value="weekly">{i18next.t("newsletter.cadence.weekly")}</option>
         <option value="monthly">{i18next.t("newsletter.cadence.monthly")}</option>
       </select>
-      <button disabled={loading}>
+      {needsCaptcha && (
+        <Turnstile
+          ref={turnstileRef}
+          sitekey={TURNSTILE_SITEKEY}
+          action="newsletter-subscribe"
+          onVerify={setCaptchaToken}
+          onExpire={() => setCaptchaToken("")}
+          onError={() => setCaptchaToken("")}
+        />
+      )}
+      <button disabled={loading || (needsCaptcha && !captchaToken)}>
         {loading ? (
           <span>
             <LinearProgress />

--- a/apps/web/src/app/_components/landing-page/landing-subscribe-form.tsx
+++ b/apps/web/src/app/_components/landing-page/landing-subscribe-form.tsx
@@ -28,9 +28,16 @@ export function LandingSubscribeForm() {
   const [captchaToken, setCaptchaToken] = useState("");
   const turnstileRef = useRef<TurnstileHandle>(null);
 
-  // The route challenges a caller with no account, so the widget appears for exactly
-  // those. A signed-in visitor on the homepage is attributed and passes straight through.
-  const needsCaptcha = !activeUser;
+  // The route challenges a caller with no verified ACCOUNT, and being signed in locally
+  // is not the same thing: ensureValidToken returns undefined when the token cannot be
+  // refreshed or its stored record is gone, and newsletterApi.subscribe then omits `code`
+  // entirely, so the request arrives anonymous. Hiding the widget on activeUser alone
+  // would leave that person 403ing forever with no challenge on screen to complete.
+  //
+  // Rather than predict token health at render time, take the server's word for it: a 403
+  // means it wanted a token, so reveal the widget and let them retry.
+  const [captchaRequired, setCaptchaRequired] = useState(false);
+  const needsCaptcha = !activeUser || captchaRequired;
 
   // Single-use tokens: a retry that reuses one fails as though the service were down.
   const resetCaptcha = () => {
@@ -72,6 +79,10 @@ export function LandingSubscribeForm() {
       setEmail("");
     } catch (err) {
       const status = err instanceof NewsletterApiError ? err.status : 0;
+      // 403 means the route wanted a token and got none. For a signed-out visitor that is
+      // a spent or refused challenge; for a signed-in one it means the token could not be
+      // refreshed, so the widget has to appear now or they can never satisfy it.
+      if (status === 403) setCaptchaRequired(true);
       const key =
         status === 502 || status === 503 || status === 504
           ? "newsletter.error-unavailable"
@@ -81,7 +92,7 @@ export function LandingSubscribeForm() {
               ? "newsletter.error-too-many"
               : "landing-page.error-occured";
       error(i18next.t(key));
-      if (needsCaptcha) resetCaptcha();
+      resetCaptcha();
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/app/api/newsletter/subscribe/route.ts
+++ b/apps/web/src/app/api/newsletter/subscribe/route.ts
@@ -80,13 +80,22 @@ export async function POST(request: NextRequest) {
     if (!verdict.ok && verdict.reason === "invalid") {
       return Response.json({ error: "Security check failed" }, { status: 403 });
     }
-    if (!verdict.ok && verdict.reason === "unavailable") {
+    if (!verdict.ok) {
+      // "unconfigured" is refused too, not relayed.
+      //
+      // An earlier version let a missing TURNSTILE_SECRET through so that a deploy landing
+      // before the secret could not take signups down. That reasoning does not survive
+      // contact with the ordering: this route already answers 503 from newsletterConfigured()
+      // unless NEWSLETTER_API_URL and NEWSLETTER_SERVICE_TOKEN are both set, so a deployment
+      // without the newsletter configured never reaches here at all. The only state the
+      // exception protected was "newsletter configured, bot check not" -- which is precisely
+      // the misconfiguration worth catching, and relaying it means the control is off with
+      // nothing on fire to say so.
+      if (verdict.reason === "unconfigured") {
+        console.error("[Turnstile] TURNSTILE_SECRET is unset; refusing anonymous subscribes");
+      }
       return Response.json({ error: "Security check unavailable" }, { status: 503 });
     }
-    // "unconfigured" relays. A deploy that reaches this code before TURNSTILE_SECRET
-    // reaches its environment must not take every anonymous subscribe down with it;
-    // specs/deploy/newsletter-wiring pins the variable so the gap is a test failure
-    // rather than a silently disabled check.
   }
 
   const upstream = await callNewsletter("/api/subscriptions", {

--- a/apps/web/src/app/api/newsletter/subscribe/route.ts
+++ b/apps/web/src/app/api/newsletter/subscribe/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { resolveUser, unauthorizedResponse } from "@/app/api/threespeak/resolve-user";
+import { verifyTurnstile } from "@/server/turnstile-verify";
 import {
   callNewsletter,
   clientIp,
@@ -11,13 +12,20 @@ import {
 
 const TYPES = new Set(["own", "community", "creator", "site"]);
 const CADENCES = new Set(["weekly", "monthly"]);
+/**
+ * Newsletter tokens are scoped to this action. The sitekey is shared with signup, so
+ * without it a challenge solved on the signup page would be spendable here.
+ */
+const TURNSTILE_ACTION = "newsletter-subscribe";
+
 const SOURCES = new Set(["community-page", "creator-page", "settings", "landing-page", "publish-prompt", "post-page", "self-hosted-blog"]);
 
 /**
  * Subscribe to a community or creator digest.
  *
  * Anonymous callers are allowed: they supply an address and get double opt-in from the
- * service. A logged-in caller (HiveSigner token in body.code) is attributed to their
+ * service, and since 2026-08 they also clear a Turnstile check, because the request makes
+ * us send mail to an address nobody has proven they own. A logged-in caller (HiveSigner token in body.code) is attributed to their
  * account, which is what lets the service treat a later subscribe on a confirmed address
  * as one action, and what allows an opted-out address to be re-confirmed. The account is
  * taken from the verified token, never from the body.
@@ -40,7 +48,6 @@ export async function POST(request: NextRequest) {
   const cadence = typeof body.cadence === "string" ? body.cadence : "";
   const email = typeof body.email === "string" ? body.email.trim() : "";
   const source = typeof body.source === "string" ? body.source : "";
-  const targetLabel = typeof body.targetLabel === "string" ? body.targetLabel.slice(0, 120) : undefined;
   if (!TYPES.has(type) || !target || !CADENCES.has(cadence) || !email || !SOURCES.has(source)) {
     return Response.json({ error: "Invalid request" }, { status: 400 });
   }
@@ -60,8 +67,27 @@ export async function POST(request: NextRequest) {
     if (target !== account) return Response.json({ error: "Invalid request" }, { status: 400 });
   }
 
-  // Where the creator eligibility check used to be. There is none now: every
-  // creator is offered a digest, see the note at the top of this file.
+  // An anonymous subscribe makes us send mail to an address nobody has proven they
+  // own, so it clears a bot check first. Deliberately keyed on "is there a verified
+  // account" and nothing else: `source` is caller-supplied, so exempting a source
+  // would mean one JSON field turns the whole check off.
+  //
+  // Placed after the `own` check on purpose. An anonymous own-digest request can never
+  // succeed, so it should 401 without spending a siteverify round trip.
+  if (!account) {
+    const captchaToken = typeof body.captchaToken === "string" ? body.captchaToken : "";
+    const verdict = await verifyTurnstile(captchaToken, clientIp(request), TURNSTILE_ACTION);
+    if (!verdict.ok && verdict.reason === "invalid") {
+      return Response.json({ error: "Security check failed" }, { status: 403 });
+    }
+    if (!verdict.ok && verdict.reason === "unavailable") {
+      return Response.json({ error: "Security check unavailable" }, { status: 503 });
+    }
+    // "unconfigured" relays. A deploy that reaches this code before TURNSTILE_SECRET
+    // reaches its environment must not take every anonymous subscribe down with it;
+    // specs/deploy/newsletter-wiring pins the variable so the gap is a test failure
+    // rather than a silently disabled check.
+  }
 
   const upstream = await callNewsletter("/api/subscriptions", {
     method: "POST",
@@ -70,7 +96,6 @@ export async function POST(request: NextRequest) {
       account,
       type,
       target,
-      targetLabel,
       cadence,
       source,
       sourceIp: clientIp(request),

--- a/apps/web/src/features/i18n/locales/en-US.json
+++ b/apps/web/src/features/i18n/locales/en-US.json
@@ -4175,6 +4175,8 @@
     "resend": "Resend confirmation email",
     "resent": "If a confirmation is due, it is on its way. Check your inbox and spam folder.",
     "error-gateway": "The digest service did not answer. Please try again in a moment.",
+    "error-captcha": "That verification did not go through. Please try the check again.",
+    "error-too-many": "Too many signups from your network today. Please try again tomorrow.",
     "row-site": "Ecency digest",
     "row-unknown": "Digest ({{type}})",
     "own-digest": "Your notification digest by email",

--- a/apps/web/src/features/newsletter/digest-subscribe-dialog.tsx
+++ b/apps/web/src/features/newsletter/digest-subscribe-dialog.tsx
@@ -8,7 +8,8 @@ import { FormControl } from "@ui/input";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import i18next from "i18next";
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Turnstile, TURNSTILE_SITEKEY, type TurnstileHandle } from "@/features/shared/turnstile";
 import {
   CADENCES,
   useDigestSubscription,
@@ -53,6 +54,21 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
   const [cadence, setCadence] = useState<DigestCadence>("weekly");
   const [email, setEmail] = useState("");
   const [outcome, setOutcome] = useState<SubscribeResult | null>(null);
+  const [captchaToken, setCaptchaToken] = useState("");
+  const turnstileRef = useRef<TurnstileHandle>(null);
+
+  // Only an anonymous caller is challenged, because only an anonymous caller is
+  // challenged by the route: an account IS the proof. Keyed on activeUser rather than
+  // on needsAddress, which is also true for a signed-in person whose address the service
+  // has not learned yet -- gating on that would put a captcha in front of someone who
+  // already proved who they are.
+  const needsCaptcha = !activeUser;
+
+  // Tokens are single use, so a spent one must never survive into the next attempt.
+  const resetCaptcha = () => {
+    setCaptchaToken("");
+    turnstileRef.current?.reset();
+  };
 
   // Reset only when the dialog OPENS. Subscribing invalidates the subscriptions
   // query, and a reset keyed on the refetched subscription would wipe the
@@ -62,6 +78,7 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
       setCadence(subscription?.cadence ?? "weekly");
       setEmail(subscription?.email ?? knownAddress ?? "");
       setOutcome(null);
+      setCaptchaToken("");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [show]);
@@ -82,7 +99,12 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
     : pending && cadenceUnchanged
       ? i18next.t("newsletter.resend")
       : i18next.t("newsletter.update");
-  const primaryDisabled = busy || isLoading || (needsAddress && !emailValid) || (cadenceUnchanged && !pending);
+  const primaryDisabled =
+    busy ||
+    isLoading ||
+    (needsAddress && !emailValid) ||
+    (cadenceUnchanged && !pending) ||
+    (needsCaptcha && !captchaToken);
 
   const cadenceLabel = (c: DigestCadence) => i18next.t(`newsletter.cadence.${c}`);
   const digestName = useMemo(
@@ -103,9 +125,9 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
         email: (subscription?.email ?? email).trim(),
         type,
         target,
-        targetLabel,
         cadence,
-        source
+        source,
+        ...(needsCaptcha ? { captchaToken } : {})
       });
       setOutcome(result);
       if (result.status === "active") {
@@ -123,8 +145,13 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
           ? i18next.t("newsletter.error-unavailable")
           : e instanceof NewsletterApiError && (e.status === 502 || e.status === 504)
             ? i18next.t("newsletter.error-gateway")
-            : i18next.t("newsletter.error-generic");
+            : e instanceof NewsletterApiError && e.status === 403
+              ? i18next.t("newsletter.error-captcha")
+              : e instanceof NewsletterApiError && e.status === 429
+                ? i18next.t("newsletter.error-too-many")
+                : i18next.t("newsletter.error-generic");
       toastError(message);
+      if (needsCaptcha) resetCaptcha();
     }
   };
 
@@ -157,7 +184,14 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
             <Alert appearance="warning">
               {i18next.t("newsletter.refused")}
               <div className="mt-2">
-                <Button size="sm" appearance="gray-link" onClick={() => setOutcome(null)}>
+                <Button
+                  size="sm"
+                  appearance="gray-link"
+                  onClick={() => {
+                    setOutcome(null);
+                    if (needsCaptcha) resetCaptcha();
+                  }}
+                >
                   {i18next.t("newsletter.try-again")}
                 </Button>
               </div>
@@ -226,6 +260,18 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
                     {i18next.t("newsletter.email-hint")}
                   </p>
                 </div>
+              )}
+
+              {needsCaptcha && (
+                <Turnstile
+                  ref={turnstileRef}
+                  sitekey={TURNSTILE_SITEKEY}
+                  action="newsletter-subscribe"
+                  onVerify={setCaptchaToken}
+                  onExpire={() => setCaptchaToken("")}
+                  onError={() => setCaptchaToken("")}
+                  className="px-2"
+                />
               )}
 
               <p className="text-xs text-gray-500 dark:text-gray-400 px-2">

--- a/apps/web/src/features/newsletter/digest-subscribe-dialog.tsx
+++ b/apps/web/src/features/newsletter/digest-subscribe-dialog.tsx
@@ -28,6 +28,12 @@ interface Props {
   source: SubscribeInput["source"];
   show: boolean;
   onHide: () => void;
+  /**
+   * Called once the service has accepted a subscribe, whether it went live or is waiting
+   * on a confirmation. Callers that cannot read the subscription list back -- the post
+   * prompt for an anonymous reader -- use this to stop offering it again.
+   */
+  onSubscribed?: () => void;
 }
 
 /**
@@ -44,7 +50,7 @@ interface Props {
  * `{ status: "pending_confirmation" }`, and the dialog shows the check-your-inbox state
  * without assuming any of the richer fields a proven caller receives.
  */
-export function DigestSubscribeDialog({ type, target, targetLabel, source, show, onHide }: Props) {
+export function DigestSubscribeDialog({ type, target, targetLabel, source, show, onHide, onSubscribed }: Props) {
   const { activeUser } = useActiveAccount();
   const { subscription, isLoading } = useDigestSubscription(type, target);
   const knownAddress = useKnownDigestAddress();
@@ -57,12 +63,18 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
   const [captchaToken, setCaptchaToken] = useState("");
   const turnstileRef = useRef<TurnstileHandle>(null);
 
-  // Only an anonymous caller is challenged, because only an anonymous caller is
-  // challenged by the route: an account IS the proof. Keyed on activeUser rather than
-  // on needsAddress, which is also true for a signed-in person whose address the service
-  // has not learned yet -- gating on that would put a captcha in front of someone who
-  // already proved who they are.
-  const needsCaptcha = !activeUser;
+  // Only an unproven caller is challenged, because only an unproven caller is challenged
+  // by the route. Keyed on activeUser rather than on needsAddress, which is also true for
+  // a signed-in person whose address the service has not learned yet: gating on that
+  // would put a captcha in front of someone who already proved who they are.
+  //
+  // Being signed in locally is not quite the same as having a usable token, though.
+  // ensureValidToken returns undefined when the refresh fails or the stored record is
+  // gone, and newsletterApi.subscribe then omits `code`, so the request arrives anonymous
+  // and 403s while the dialog shows no challenge to complete. A 403 is the server saying
+  // it wanted one, so the widget appears on that answer regardless of activeUser.
+  const [captchaRequired, setCaptchaRequired] = useState(false);
+  const needsCaptcha = !activeUser || captchaRequired;
 
   // Tokens are single use, so a spent one must never survive into the next attempt.
   const resetCaptcha = () => {
@@ -79,6 +91,7 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
       setEmail(subscription?.email ?? knownAddress ?? "");
       setOutcome(null);
       setCaptchaToken("");
+      setCaptchaRequired(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [show]);
@@ -130,6 +143,7 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
         ...(needsCaptcha ? { captchaToken } : {})
       });
       setOutcome(result);
+      if (result.status === "active" || result.status === "pending_confirmation") onSubscribed?.();
       if (result.status === "active") {
         success(
           subscription
@@ -140,6 +154,7 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
         success(i18next.t("newsletter.resent"));
       }
     } catch (e) {
+      if (e instanceof NewsletterApiError && e.status === 403) setCaptchaRequired(true);
       const message =
         e instanceof NewsletterApiError && e.status === 503
           ? i18next.t("newsletter.error-unavailable")
@@ -151,7 +166,7 @@ export function DigestSubscribeDialog({ type, target, targetLabel, source, show,
                 ? i18next.t("newsletter.error-too-many")
                 : i18next.t("newsletter.error-generic");
       toastError(message);
-      if (needsCaptcha) resetCaptcha();
+      resetCaptcha();
     }
   };
 

--- a/apps/web/src/features/newsletter/post-subscribe-prompt.tsx
+++ b/apps/web/src/features/newsletter/post-subscribe-prompt.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getCommunityQueryOptions } from "@ecency/sdk";
 import type { Entry } from "@/entities";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
+import * as ls from "@/utils/local-storage";
 import { Button } from "@ui/button";
 import { UilEnvelope } from "@tooni/iconscout-unicons-react";
 import i18next from "i18next";
@@ -14,13 +15,27 @@ import { useNewsletterEnabled } from "./runtime";
 import type { DigestType } from "./types";
 
 /**
- * At the end of a post (vision-web#1537): a reader who is signed in and not yet
- * subscribed is offered the author's digest (every creator has one since 2026-08-19), or the
- * community's digest when the post was made in one. Dismissible per list; the
- * dismissal is remembered on this device. Never shown to the author for their
- * own list, never twice for the same list, never while a subscription exists.
+ * At the end of a post (vision-web#1537): a reader not yet subscribed is offered the
+ * author's digest (every creator has one since 2026-08-19), or the community's digest
+ * when the post was made in one. Dismissible per list; the dismissal is remembered on
+ * this device. Never shown to the author for their own list, never twice for the same
+ * list, never while a subscription exists.
+ *
+ * Anonymous readers see it too (vision-web#1568). They are the larger half of a post's
+ * audience and the one with no other way to hear about the next post, and the subscribe
+ * path already serves them: double opt-in, plus a Turnstile check on the relay. What
+ * changes for them is only what we can KNOW -- there is no subscription list to consult,
+ * so the card is offered on the assumption they are not subscribed, and a dismissal is
+ * the only memory we have.
  */
 const dismissKey = (viewer: string, type: DigestType, target: string) => `ecency:digest-post-prompt:${viewer}:${type}:${target}`;
+
+/**
+ * The dismissal namespace for a signed-out reader. Deliberately its own segment rather
+ * than an empty one, which would produce `...prompt::creator:bob` and collide with a
+ * malformed signed-in key.
+ */
+const ANON_VIEWER = "anon";
 
 export function PostSubscribePrompt({ entry, communityTitle, className }: { entry: Entry; communityTitle?: string | null; className?: string }): ReactElement | null {
   const enabled = useNewsletterEnabled();
@@ -32,10 +47,13 @@ export function PostSubscribePrompt({ entry, communityTitle, className }: { entr
   // (2026-08-19), so it is offered first; the community's digest when the
   // reader IS the author (their own list is not offered to them) and the post
   // was made in a community.
+  // An anonymous reader is never the author, so they always land on the creator branch;
+  // the community branch stays reachable only for a signed-in author reading their own
+  // post, which is what it was for.
   const list: { type: "creator" | "community"; target: string } | null =
-    !enabled || !me || !isTopLevel
+    !enabled || !isTopLevel
       ? null
-      : me !== entry.author
+      : !me || me !== entry.author
         ? { type: "creator", target: entry.author }
         : inCommunity
           ? { type: "community", target: entry.category }
@@ -47,29 +65,53 @@ export function PostSubscribePrompt({ entry, communityTitle, className }: { entr
   });
   const label = !list ? "" : list.type === "creator" ? `@${list.target}` : communityTitle || community?.title || list.target;
 
+  // Stays disabled for anonymous readers, on purpose: newsletterApi.list needs a
+  // username and requireUsername throws, the endpoint needs the account's token, and one
+  // shared cache key would collapse every anonymous visitor onto one entry. The anon path
+  // SKIPS the query rather than enabling it, and `known` below is what stands in for it.
   const { subscription, isSuccess } = useDigestSubscription(list?.type ?? "creator", list?.target ?? "");
   const [dismissed, setDismissed] = useState(true);
+  const [ready, setReady] = useState(false);
   const [open, setOpen] = useState(false);
   useEffect(() => {
-    if (!list || !me) return;
+    if (!list) return;
+    // activeUser is null during SSR AND on the first client render for a signed-in
+    // reader, because the store is populated in a post-mount effect. Rendering the
+    // anonymous card on that first paint would flash it at subscribers and, worse, write
+    // an "anon" dismissal for someone who is actually signed in. Reading the same
+    // localStorage key the store reads tells the two apart: a stored user with no `me`
+    // yet means "not hydrated", not "anonymous".
+    let stored: string | null = null;
     try {
-      setDismissed(window.localStorage.getItem(dismissKey(me, list.type, list.target)) === "1");
+      stored = ls.get("active_user") ?? null;
+    } catch {
+      stored = null;
+    }
+    if (stored && !me) return;
+
+    const viewer = me ?? ANON_VIEWER;
+    try {
+      setDismissed(window.localStorage.getItem(dismissKey(viewer, list.type, list.target)) === "1");
     } catch {
       setDismissed(false);
     }
+    setReady(true);
   }, [list?.type, list?.target, me]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (!list || !me) return null;
+  if (!list || !ready) return null;
+  // For a signed-in reader we can prove they hold no subscription, so we wait for the
+  // query. For an anonymous one there is nothing to consult and nothing to wait for.
+  const known = me ? isSuccess && !subscription : true;
   // The card goes once dismissed or once a subscription exists; the dialog,
   // if open, stays: a pending-confirmation outcome ("check your inbox") is
   // shown by the dialog after the refetch, and unmounting it would lose it.
-  const showCard = !dismissed && isSuccess && !subscription;
+  const showCard = !dismissed && known;
   if (!showCard && !open) return null;
 
   const dismiss = () => {
     setDismissed(true);
     try {
-      window.localStorage.setItem(dismissKey(me, list.type, list.target), "1");
+      window.localStorage.setItem(dismissKey(me ?? ANON_VIEWER, list.type, list.target), "1");
     } catch {
       /* private mode: dismissed for this page only */
     }

--- a/apps/web/src/features/newsletter/post-subscribe-prompt.tsx
+++ b/apps/web/src/features/newsletter/post-subscribe-prompt.tsx
@@ -37,6 +37,24 @@ const dismissKey = (viewer: string, type: DigestType, target: string) => `ecency
  */
 const ANON_VIEWER = "anon";
 
+/**
+ * Is the store still on its way to producing an active user?
+ *
+ * True only when localStorage holds BOTH the active-user marker and the account record
+ * that marker names, which is exactly the pair authentication-module requires. A marker
+ * without its record can never become an active user, so it reads as anonymous rather
+ * than as a hydration that will never complete.
+ */
+function storedAccountPending(): boolean {
+  try {
+    const name = ls.get("active_user");
+    return typeof name === "string" && name.length > 0 && Boolean(ls.get(`user_${name}`));
+  } catch {
+    // Private mode or a blocked store: nothing is pending, treat the reader as anonymous.
+    return false;
+  }
+}
+
 export function PostSubscribePrompt({ entry, communityTitle, className }: { entry: Entry; communityTitle?: string | null; className?: string }): ReactElement | null {
   const enabled = useNewsletterEnabled();
   const { activeUser } = useActiveAccount();
@@ -79,15 +97,14 @@ export function PostSubscribePrompt({ entry, communityTitle, className }: { entr
     // reader, because the store is populated in a post-mount effect. Rendering the
     // anonymous card on that first paint would flash it at subscribers and, worse, write
     // an "anon" dismissal for someone who is actually signed in. Reading the same
-    // localStorage key the store reads tells the two apart: a stored user with no `me`
-    // yet means "not hydrated", not "anonymous".
-    let stored: string | null = null;
-    try {
-      stored = ls.get("active_user") ?? null;
-    } catch {
-      stored = null;
-    }
-    if (stored && !me) return;
+    // localStorage the store reads tells the two apart.
+    //
+    // Both halves are required. authentication-module only produces an active user when
+    // `active_user` AND its `user_<name>` record are present, and it writes the name back
+    // regardless, so a marker whose record is missing or corrupt leaves activeUser null
+    // forever. Waiting on the marker alone would then never finish, and the prompt would
+    // be permanently invisible to that visitor with nothing on screen to explain it.
+    if (!me && storedAccountPending()) return;
 
     const viewer = me ?? ANON_VIEWER;
     try {
@@ -138,7 +155,20 @@ export function PostSubscribePrompt({ entry, communityTitle, className }: { entr
           </div>
         </div>
       )}
-      {open && <DigestSubscribeDialog type={list.type} target={list.target} targetLabel={label} source="post-page" show={open} onHide={() => setOpen(false)} />}
+      {open && (
+        <DigestSubscribeDialog
+          type={list.type}
+          target={list.target}
+          targetLabel={label}
+          source="post-page"
+          show={open}
+          // An anonymous reader has no subscription list to consult, so `known` is always
+          // true for them and the card would return on the next post they open. Their
+          // subscribing IS the signal, and it is the only one we get.
+          onSubscribed={dismiss}
+          onHide={() => setOpen(false)}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/src/features/newsletter/types.ts
+++ b/apps/web/src/features/newsletter/types.ts
@@ -25,7 +25,23 @@ export interface SubscribeInput {
   email: string;
   type: DigestType;
   target: string;
-  targetLabel?: string;
   cadence: DigestCadence;
-  source: "community-page" | "creator-page" | "settings" | "landing-page" | "publish-prompt" | "post-page";
+  /**
+   * Kept in lockstep with SOURCES in app/api/newsletter/subscribe/route.ts by hand: a
+   * value here that the route does not accept is a silent 400 with a generic message.
+   * "self-hosted-blog" is the managed-blog embed, which posts to the same route.
+   */
+  source:
+    | "community-page"
+    | "creator-page"
+    | "settings"
+    | "landing-page"
+    | "publish-prompt"
+    | "post-page"
+    | "self-hosted-blog";
+  /**
+   * Cloudflare Turnstile token. Required by the route whenever the caller has no
+   * account; ignored for signed-in callers, whose account is the proof.
+   */
+  captchaToken?: string;
 }

--- a/apps/web/src/server/turnstile-verify.ts
+++ b/apps/web/src/server/turnstile-verify.ts
@@ -1,0 +1,114 @@
+/**
+ * Cloudflare Turnstile token verification.
+ *
+ * The widget in `features/shared/turnstile` produces a single-use token; this is the
+ * half that makes it mean anything. Without a server-side siteverify call the token is
+ * decoration: the subscribe relay drops unknown body fields, so shipping only the widget
+ * would give a form that is harder for readers and unchanged for scripts.
+ *
+ * Its own module rather than an inline fetch, for one concrete reason: the route spec
+ * stubs a single global fetch and indexes `mocks.fetch.mock.calls[0]` to assert the
+ * newsletter request body. An inline call would take that slot and quietly turn those
+ * assertions into claims about the siteverify request instead, with several still passing
+ * by accident.
+ */
+
+const SITEVERIFY = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+export type TurnstileResult =
+  | { ok: true }
+  | { ok: false; reason: "invalid" | "unavailable" | "unconfigured" };
+
+/**
+ * Read inside the function, never at module scope. `NEWSLETTER_API` in
+ * newsletter-internal is a module-scope read and only survives its spec because that
+ * file calls `vi.resetModules()` and imports the route dynamically; anything that
+ * mocks without resetting modules reads a stale value. This has no such trap.
+ */
+export function turnstileSecret(): string | null {
+  const secret = process.env.TURNSTILE_SECRET;
+  return secret && secret.length > 0 ? secret : null;
+}
+
+/**
+ * Error codes that mean WE are misconfigured or Cloudflare is broken, as opposed to the
+ * caller presenting a bad token. They are reported as `unavailable` so a deployment
+ * mistake surfaces as a retryable failure rather than accusing readers of being bots.
+ */
+const NOT_THE_CALLERS_FAULT = new Set([
+  "missing-input-secret",
+  "invalid-input-secret",
+  "bad-request",
+  "internal-error"
+]);
+
+/**
+ * @param token the widget's single-use response token
+ * @param remoteip the caller's IP when known; pass `clientIp(request)`, which already
+ *   returns a validated literal or undefined, rather than re-deriving it here
+ * @param action when set, the token must have been issued for this action. The newsletter
+ *   and signup share one sitekey, so without this a token solved on the signup page would
+ *   be spendable on the subscribe endpoint and vice versa.
+ */
+export async function verifyTurnstile(
+  token: string,
+  remoteip?: string,
+  action?: string
+): Promise<TurnstileResult> {
+  const secret = turnstileSecret();
+  if (!secret) return { ok: false, reason: "unconfigured" };
+  if (!token) return { ok: false, reason: "invalid" };
+
+  const form = new URLSearchParams({ secret, response: token });
+  if (remoteip) form.set("remoteip", remoteip);
+
+  let res: Response;
+  try {
+    res = await fetch(SITEVERIFY, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: form,
+      signal: AbortSignal.timeout(8_000)
+    });
+  } catch (e) {
+    const name = (e as { name?: string })?.name;
+    console.error(
+      `[Turnstile] siteverify ${name === "TimeoutError" || name === "AbortError" ? "timed out" : "unreachable"}`
+    );
+    return { ok: false, reason: "unavailable" };
+  }
+
+  if (!res.ok) {
+    console.error(`[Turnstile] siteverify upstream error ${res.status}`);
+    return { ok: false, reason: "unavailable" };
+  }
+
+  const data = (await res.json().catch(() => null)) as {
+    success?: boolean;
+    action?: string;
+    "error-codes"?: string[];
+  } | null;
+  if (!data) {
+    console.error("[Turnstile] siteverify returned unparseable body");
+    return { ok: false, reason: "unavailable" };
+  }
+
+  if (data.success !== true) {
+    const codes = data["error-codes"] ?? [];
+    if (codes.some((c) => NOT_THE_CALLERS_FAULT.has(c))) {
+      console.error(`[Turnstile] siteverify config error: ${codes.join(",")}`);
+      return { ok: false, reason: "unavailable" };
+    }
+    // invalid-input-response, timeout-or-duplicate: a spent, forged or expired token.
+    return { ok: false, reason: "invalid" };
+  }
+
+  // A valid token for a DIFFERENT action is still a forged request here. Treated as
+  // invalid rather than unavailable: the token is genuine, it just is not for us.
+  if (action && data.action !== action) {
+    console.error(`[Turnstile] action mismatch: expected ${action}, got ${data.action}`);
+    return { ok: false, reason: "invalid" };
+  }
+
+  return { ok: true };
+}

--- a/apps/web/src/specs/api/newsletter-subscribe-route.spec.ts
+++ b/apps/web/src/specs/api/newsletter-subscribe-route.spec.ts
@@ -197,11 +197,14 @@ describe("POST /api/newsletter/subscribe", () => {
       expect(mocks.fetch).not.toHaveBeenCalled();
     });
 
-    it("relays when the secret is unset, so a deploy that lands first cannot take signups down", async () => {
+    it("refuses when the secret is unset rather than relaying with the check off", async () => {
+      // The route already 503s from newsletterConfigured() unless the newsletter itself is
+      // configured, so "newsletter on, bot check off" is the only state this covers, and it
+      // is a misconfiguration rather than a rollout window worth tolerating.
       mocks.turnstile.mockResolvedValue({ ok: false, reason: "unconfigured" });
-      mocks.fetch.mockResolvedValue(upstream(200, { status: "pending_confirmation" }));
-      expect((await post(VALID)).status).toBe(200);
-      expect(mocks.fetch).toHaveBeenCalledTimes(1);
+      const r = await post(VALID);
+      expect(r.status).toBe(503);
+      expect(mocks.fetch).not.toHaveBeenCalled();
     });
 
     it("never challenges a signed-in caller: the account is the proof", async () => {

--- a/apps/web/src/specs/api/newsletter-subscribe-route.spec.ts
+++ b/apps/web/src/specs/api/newsletter-subscribe-route.spec.ts
@@ -8,11 +8,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   verify: vi.fn(),
   isPro: vi.fn(),
+  turnstile: vi.fn(),
   fetch: vi.fn()
 }));
 
 vi.mock("@/server/hivesigner-verify", () => ({ verifyHsAccessToken: mocks.verify }));
 vi.mock("@/server/pro-members", () => ({ isProRosterMember: mocks.isPro }));
+// Mocked as a MODULE rather than left to hit the stubbed global fetch. An inline
+// siteverify call would occupy mocks.fetch.mock.calls[0], quietly turning every
+// assertion about the newsletter request body below into a claim about the Cloudflare
+// request instead, and some of them would still pass.
+vi.mock("@/server/turnstile-verify", () => ({ verifyTurnstile: mocks.turnstile }));
 
 function req(body: unknown, headers: Record<string, string> = {}) {
   const h = new Headers(headers);
@@ -29,9 +35,10 @@ const VALID = {
   email: "alice@example.com",
   type: "community",
   target: "hive-140217",
-  targetLabel: "Hive Gaming",
   cadence: "weekly",
-  source: "community-page"
+  source: "community-page",
+  // Anonymous by default in this file, and an anonymous caller carries a token.
+  captchaToken: "turnstile-ok"
 };
 
 function upstream(status: number, body: unknown) {
@@ -44,9 +51,12 @@ describe("POST /api/newsletter/subscribe", () => {
     vi.stubGlobal("fetch", mocks.fetch);
     vi.stubEnv("NEWSLETTER_API_URL", "http://news.internal:3300");
     vi.stubEnv("NEWSLETTER_SERVICE_TOKEN", "service-token-0123456789abcdefghijklmnop");
+    vi.stubEnv("TURNSTILE_SECRET", "test-secret");
     mocks.fetch.mockReset();
     mocks.verify.mockReset();
     mocks.isPro.mockReset();
+    mocks.turnstile.mockReset();
+    mocks.turnstile.mockResolvedValue({ ok: true });
   });
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -154,5 +164,80 @@ describe("POST /api/newsletter/subscribe", () => {
     const r = await post(VALID);
     expect(r.status).toBe(400);
     expect(r.json.error).toMatch(/control characters/);
+  });
+
+  describe("the anonymous bot check", () => {
+    it("verifies the token with the caller's IP, scoped to the newsletter action", async () => {
+      mocks.fetch.mockResolvedValue(upstream(200, { status: "pending_confirmation" }));
+      await post(VALID, { "cf-connecting-ip": "203.0.113.9" });
+      expect(mocks.turnstile).toHaveBeenCalledWith("turnstile-ok", "203.0.113.9", "newsletter-subscribe");
+    });
+
+    it("403s a rejected token and never reaches the service", async () => {
+      mocks.turnstile.mockResolvedValue({ ok: false, reason: "invalid" });
+      const r = await post(VALID);
+      expect(r.status).toBe(403);
+      expect(mocks.fetch).not.toHaveBeenCalled();
+    });
+
+    it("403s when no token is presented at all", async () => {
+      mocks.turnstile.mockResolvedValue({ ok: false, reason: "invalid" });
+      const { captchaToken, ...noToken } = VALID;
+      const r = await post(noToken);
+      expect(r.status).toBe(403);
+      expect(mocks.turnstile).toHaveBeenCalledWith("", undefined, "newsletter-subscribe");
+      expect(mocks.fetch).not.toHaveBeenCalled();
+    });
+
+    it("503s rather than 403s when Cloudflare is the thing that is broken", async () => {
+      // A 403 would tell readers they look like bots because our secret is wrong.
+      mocks.turnstile.mockResolvedValue({ ok: false, reason: "unavailable" });
+      const r = await post(VALID);
+      expect(r.status).toBe(503);
+      expect(mocks.fetch).not.toHaveBeenCalled();
+    });
+
+    it("relays when the secret is unset, so a deploy that lands first cannot take signups down", async () => {
+      mocks.turnstile.mockResolvedValue({ ok: false, reason: "unconfigured" });
+      mocks.fetch.mockResolvedValue(upstream(200, { status: "pending_confirmation" }));
+      expect((await post(VALID)).status).toBe(200);
+      expect(mocks.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("never challenges a signed-in caller: the account is the proof", async () => {
+      mocks.verify.mockResolvedValue({ ok: true, username: "alice" });
+      mocks.fetch.mockResolvedValue(upstream(200, { status: "active" }));
+      const { captchaToken, ...noToken } = VALID;
+      expect((await post({ ...noToken, code: "tok" })).status).toBe(200);
+      expect(mocks.turnstile).not.toHaveBeenCalled();
+    });
+
+    it("does not exempt the managed-blog embed, because `source` is caller-supplied", async () => {
+      // If a source could turn the check off, one JSON field would turn it off for
+      // everyone. The embed carries a real token instead.
+      mocks.turnstile.mockResolvedValue({ ok: false, reason: "invalid" });
+      const r = await post({ ...VALID, type: "creator", target: "bob", source: "self-hosted-blog" });
+      expect(r.status).toBe(403);
+      expect(mocks.turnstile).toHaveBeenCalled();
+      expect(mocks.fetch).not.toHaveBeenCalled();
+    });
+
+    it("401s an anonymous own-digest before spending a siteverify round trip", async () => {
+      // That request can never succeed, so it should not cost a call to Cloudflare.
+      const r = await post({ ...VALID, type: "own", target: "alice" });
+      expect(r.status).toBe(401);
+      expect(mocks.turnstile).not.toHaveBeenCalled();
+      expect(mocks.fetch).not.toHaveBeenCalled();
+    });
+
+    it("never forwards the token, or a caller-supplied label, to the service", async () => {
+      mocks.fetch.mockResolvedValue(upstream(200, { status: "pending_confirmation" }));
+      await post({ ...VALID, targetLabel: "URGENT: verify your wallet at example.com" });
+      const sent = JSON.parse(mocks.fetch.mock.calls[0][1].body);
+      expect(sent.captchaToken).toBeUndefined();
+      // The service derives the label from the target now; a caller no longer writes
+      // part of a sentence into mail our domain sends to an address they chose.
+      expect(sent.targetLabel).toBeUndefined();
+    });
   });
 });

--- a/apps/web/src/specs/api/turnstile-verify.spec.ts
+++ b/apps/web/src/specs/api/turnstile-verify.spec.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The siteverify half of the newsletter bot check.
+ *
+ * The distinction that matters here is `invalid` versus `unavailable`. A bad token is
+ * the caller's problem and answers 403; a broken secret or an unreachable Cloudflare is
+ * OURS, and answering 403 to that would tell readers they look like bots because we
+ * misconfigured a deploy.
+ */
+const fetchMock = vi.fn();
+
+async function verify(token: string, remoteip?: string, action?: string) {
+  vi.resetModules();
+  const { verifyTurnstile } = await import("@/server/turnstile-verify");
+  return verifyTurnstile(token, remoteip, action);
+}
+
+function siteverify(body: unknown, status = 200) {
+  return Promise.resolve({ ok: status < 400, status, json: async () => body } as Response);
+}
+
+describe("verifyTurnstile", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("TURNSTILE_SECRET", "test-secret");
+  });
+
+  it("accepts a token Cloudflare confirms, and sends secret, response and remoteip", async () => {
+    fetchMock.mockReturnValue(siteverify({ success: true }));
+    await expect(verify("tok", "203.0.113.9")).resolves.toEqual({ ok: true });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://challenges.cloudflare.com/turnstile/v0/siteverify");
+    expect(init.method).toBe("POST");
+    const sent = new URLSearchParams(init.body as URLSearchParams);
+    expect(sent.get("secret")).toBe("test-secret");
+    expect(sent.get("response")).toBe("tok");
+    expect(sent.get("remoteip")).toBe("203.0.113.9");
+  });
+
+  it("omits remoteip when the caller's IP is unknown rather than sending an empty one", async () => {
+    fetchMock.mockReturnValue(siteverify({ success: true }));
+    await verify("tok");
+    const sent = new URLSearchParams(fetchMock.mock.calls[0][1].body as URLSearchParams);
+    expect(sent.has("remoteip")).toBe(false);
+  });
+
+  it("reports a spent, forged or expired token as invalid", async () => {
+    for (const code of ["invalid-input-response", "timeout-or-duplicate", "missing-input-response"]) {
+      fetchMock.mockReturnValue(siteverify({ success: false, "error-codes": [code] }));
+      await expect(verify("tok")).resolves.toEqual({ ok: false, reason: "invalid" });
+    }
+  });
+
+  it("reports OUR misconfiguration as unavailable, not as a bad token", async () => {
+    // Answering 403 here would blame the reader for a secret we got wrong.
+    for (const code of ["invalid-input-secret", "missing-input-secret", "bad-request", "internal-error"]) {
+      fetchMock.mockReturnValue(siteverify({ success: false, "error-codes": [code] }));
+      await expect(verify("tok")).resolves.toEqual({ ok: false, reason: "unavailable" });
+    }
+  });
+
+  it("treats an upstream error, an unparseable body and a network failure as unavailable", async () => {
+    fetchMock.mockReturnValue(siteverify({}, 500));
+    await expect(verify("tok")).resolves.toEqual({ ok: false, reason: "unavailable" });
+
+    fetchMock.mockReturnValue(
+      Promise.resolve({ ok: true, status: 200, json: async () => { throw new Error("nope"); } } as unknown as Response)
+    );
+    await expect(verify("tok")).resolves.toEqual({ ok: false, reason: "unavailable" });
+
+    fetchMock.mockRejectedValue(Object.assign(new Error("boom"), { name: "TypeError" }));
+    await expect(verify("tok")).resolves.toEqual({ ok: false, reason: "unavailable" });
+
+    fetchMock.mockRejectedValue(Object.assign(new Error("slow"), { name: "TimeoutError" }));
+    await expect(verify("tok")).resolves.toEqual({ ok: false, reason: "unavailable" });
+  });
+
+  it("rejects an empty token without spending a round trip", async () => {
+    await expect(verify("")).resolves.toEqual({ ok: false, reason: "invalid" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports an unset secret as unconfigured, so the caller can decide rather than guess", async () => {
+    vi.stubEnv("TURNSTILE_SECRET", "");
+    await expect(verify("tok")).resolves.toEqual({ ok: false, reason: "unconfigured" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a valid token issued for a different action", async () => {
+    // One sitekey serves signup and the newsletter, so without this a challenge solved
+    // on the signup page would be spendable at the subscribe endpoint.
+    fetchMock.mockReturnValue(siteverify({ success: true, action: "signup" }));
+    await expect(verify("tok", undefined, "newsletter-subscribe")).resolves.toEqual({
+      ok: false,
+      reason: "invalid"
+    });
+
+    fetchMock.mockReturnValue(siteverify({ success: true, action: "newsletter-subscribe" }));
+    await expect(verify("tok", undefined, "newsletter-subscribe")).resolves.toEqual({ ok: true });
+  });
+
+  it("ignores the action when the caller does not ask for one", async () => {
+    fetchMock.mockReturnValue(siteverify({ success: true, action: "anything" }));
+    await expect(verify("tok")).resolves.toEqual({ ok: true });
+  });
+});

--- a/apps/web/src/specs/deploy/newsletter-wiring.spec.ts
+++ b/apps/web/src/specs/deploy/newsletter-wiring.spec.ts
@@ -45,9 +45,9 @@ describe("newsletter deploy wiring", () => {
   /**
    * The bot check on anonymous subscribes reads TURNSTILE_SECRET in the Next tier
    * (server/turnstile-verify). It was already declared for `vapi`, which does the Stripe
-   * flow, and a missing copy on `web` fails in the quietest possible way: an unset secret
-   * relays instead of refusing, deliberately, so that nothing takes signups down during a
-   * deploy -- which also means the check would simply be off and nobody would notice.
+   * flow, and a missing copy on `web` takes every anonymous subscribe down: an unset secret
+   * refuses rather than relaying, so the failure is loud instead of a silently disabled
+   * control. That makes this line load-bearing rather than merely tidy.
    *
    * Unlike the two variables above, this one is SHARED: vapi legitimately needs it too,
    * so this asserts presence on web without asserting absence on vapi.

--- a/apps/web/src/specs/deploy/newsletter-wiring.spec.ts
+++ b/apps/web/src/specs/deploy/newsletter-wiring.spec.ts
@@ -42,6 +42,36 @@ describe("newsletter deploy wiring", () => {
     }
   );
 
+  /**
+   * The bot check on anonymous subscribes reads TURNSTILE_SECRET in the Next tier
+   * (server/turnstile-verify). It was already declared for `vapi`, which does the Stripe
+   * flow, and a missing copy on `web` fails in the quietest possible way: an unset secret
+   * relays instead of refusing, deliberately, so that nothing takes signups down during a
+   * deploy -- which also means the check would simply be off and nobody would notice.
+   *
+   * Unlike the two variables above, this one is SHARED: vapi legitimately needs it too,
+   * so this asserts presence on web without asserting absence on vapi.
+   */
+  it.each(["apps/web/docker-compose.yml", "apps/web/docker-compose.production.yml"])(
+    "%s hands the Turnstile secret to the web service, not only to vapi",
+    (file) => {
+      const web = envEntries(serviceBlock(read(file), "web"));
+      expect(web, `${file}: web.environment lacks TURNSTILE_SECRET`).toContain("TURNSTILE_SECRET");
+    }
+  );
+
+  it.each([".github/workflows/master.yml", ".github/workflows/staging.yml"])(
+    "%s forwards the Turnstile secret in every deploy job",
+    (file) => {
+      const wf = read(file);
+      const envsLines = wf.split("\n").filter((l) => /^\s+envs:\s/.test(l));
+      expect(envsLines.length).toBeGreaterThan(0);
+      for (const line of envsLines) {
+        expect(line, `${file}: envs lacks TURNSTILE_SECRET`).toContain("TURNSTILE_SECRET");
+      }
+    }
+  );
+
   it.each([".github/workflows/master.yml", ".github/workflows/staging.yml"])("%s forwards both variables in every deploy job", (file) => {
     const wf = read(file);
     // Every ssh-action step that deploys the stack carries an `envs:` list; each must forward both.

--- a/apps/web/src/specs/deploy/newsletter-wiring.spec.ts
+++ b/apps/web/src/specs/deploy/newsletter-wiring.spec.ts
@@ -60,6 +60,25 @@ describe("newsletter deploy wiring", () => {
     }
   );
 
+  /**
+   * NEXT_PUBLIC_* is inlined by Next at BUILD time, so the sitekey has to reach the image
+   * build, not the runtime environment. Without the ARG every deployed client silently
+   * falls back to the literal in features/shared/turnstile.tsx, which is correct today and
+   * would be wrong the moment the widget is rotated or a staging-specific one is used.
+   */
+  it("the Dockerfile accepts the public sitekey as a build argument", () => {
+    const dockerfile = read("apps/web/Dockerfile");
+    expect(dockerfile).toMatch(/^ARG NEXT_PUBLIC_TURNSTILE_SITEKEY$/m);
+    expect(dockerfile).toMatch(/^ENV NEXT_PUBLIC_TURNSTILE_SITEKEY=\$\{NEXT_PUBLIC_TURNSTILE_SITEKEY\}$/m);
+  });
+
+  it.each([".github/workflows/master.yml", ".github/workflows/staging.yml"])(
+    "%s passes the public sitekey into the image build",
+    (file) => {
+      expect(read(file)).toContain("NEXT_PUBLIC_TURNSTILE_SITEKEY=${{ secrets.TURNSTILE_SITEKEY }}");
+    }
+  );
+
   it.each([".github/workflows/master.yml", ".github/workflows/staging.yml"])(
     "%s forwards the Turnstile secret in every deploy job",
     (file) => {

--- a/apps/web/src/specs/features/landing-page.spec.tsx
+++ b/apps/web/src/specs/features/landing-page.spec.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock global store
@@ -21,6 +21,39 @@ vi.mock("@ecency/sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@ecency/sdk")>();
   return { ...actual };
 });
+
+/**
+ * The Turnstile widget, mocked. The real one appends a Cloudflare <script> that jsdom
+ * never runs, so the token would never arrive and the form would stay unsubmittable.
+ * The mock renders nothing and hands the test the callbacks.
+ */
+const captcha = vi.hoisted(() => ({
+  verify: null as null | ((token: string) => void),
+  resets: 0
+}));
+vi.mock("@/features/shared/turnstile", () => ({
+  TURNSTILE_SITEKEY: "test-sitekey",
+  Turnstile: ({
+    onVerify,
+    ref
+  }: {
+    onVerify: (token: string) => void;
+    ref?: { current: { reset: () => void } | null };
+  }) => {
+    captcha.verify = onVerify;
+    if (ref) ref.current = { reset: () => { captcha.resets += 1; } };
+    return null;
+  }
+}));
+
+const CAPTCHA_TOKEN = "turnstile-test-token";
+
+/** Solve the challenge the way a reader does before the button becomes usable. */
+async function solveCaptcha() {
+  await act(async () => {
+    captcha.verify?.(CAPTCHA_TOKEN);
+  });
+}
 
 // The form subscribes through the newsletter service; mock its browser client.
 type NewsletterModule = typeof import("@/features/newsletter");
@@ -161,6 +194,8 @@ describe("LandingTrending", () => {
 describe("LandingSubscribeForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    captcha.verify = null;
+    captcha.resets = 0;
   });
 
   it("renders email input, cadence choice and submit button", () => {
@@ -178,11 +213,19 @@ describe("LandingSubscribeForm", () => {
     const input = screen.getByPlaceholderText("landing-page.enter-your-email-adress");
     fireEvent.change(input, { target: { value: "  test@example.com " } });
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "monthly" } });
+    await solveCaptcha();
     fireEvent.submit(input.closest("form")!);
 
     await waitFor(() => {
       expect(mockSubscribe).toHaveBeenCalledWith(
-        { email: "test@example.com", type: "site", target: "ecency", cadence: "monthly", source: "landing-page" },
+        {
+          email: "test@example.com",
+          type: "site",
+          target: "ecency",
+          cadence: "monthly",
+          source: "landing-page",
+          captchaToken: CAPTCHA_TOKEN
+        },
         undefined // anonymous: no account attributed
       );
       expect(success).toHaveBeenCalledWith("landing-page.check-inbox");
@@ -197,6 +240,7 @@ describe("LandingSubscribeForm", () => {
     render(<LandingSubscribeForm />);
     const input = screen.getByPlaceholderText("landing-page.enter-your-email-adress");
     fireEvent.change(input, { target: { value: "test@example.com" } });
+    await solveCaptcha();
     fireEvent.submit(input.closest("form")!);
     // The visible outcome, not only the toast: the message replaces the form.
     expect(await screen.findByText("landing-page.success-message-subscribe")).toBeInTheDocument();
@@ -210,6 +254,7 @@ describe("LandingSubscribeForm", () => {
     render(<LandingSubscribeForm />);
     const input = screen.getByPlaceholderText("landing-page.enter-your-email-adress");
     fireEvent.change(input, { target: { value: "test@example.com" } });
+    await solveCaptcha();
     fireEvent.submit(input.closest("form")!);
 
     await waitFor(() => expect(errorFn).toHaveBeenCalledWith("landing-page.error-occured"));
@@ -225,7 +270,8 @@ describe("LandingSubscribeForm", () => {
       const { unmount } = render(<LandingSubscribeForm />);
       const input = screen.getByPlaceholderText("landing-page.enter-your-email-adress");
       fireEvent.change(input, { target: { value: "test@example.com" } });
-      fireEvent.submit(input.closest("form")!);
+      await solveCaptcha();
+    fireEvent.submit(input.closest("form")!);
       await waitFor(() => expect(errorFn).toHaveBeenCalledWith("newsletter.error-unavailable"));
       unmount();
     }

--- a/apps/web/src/specs/features/newsletter/digest-subscribe.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/digest-subscribe.spec.tsx
@@ -220,6 +220,33 @@ describe("DigestSubscribeDialog", () => {
     expect(screen.getByRole("button", { name: "newsletter.subscribe" })).toBeDisabled();
   });
 
+  it("reveals the challenge to a signed-in caller whose token could not be refreshed", async () => {
+    // Being signed in locally is not the same as holding a usable token: ensureValidToken
+    // returns undefined when the refresh fails, subscribe() then omits `code`, and the
+    // route sees an anonymous request and 403s. Without this the dialog would show no
+    // challenge and the person could never satisfy the one the server is asking for.
+    loggedIn("alice");
+    const client = createTestQueryClient();
+    client.setQueryData(digestSubscriptionsKey("alice"), []);
+    fetchMock.mockImplementation((url: string) =>
+      url === "/api/newsletter/subscribe"
+        ? jsonResponse(403, { error: "Security check failed" })
+        : jsonResponse(404, {})
+    );
+    renderConfigured(<DigestSubscribeDialog {...dialogProps} />, { queryClient: client });
+
+    // Signed in, so no widget yet.
+    expect(captcha.verify).toBeNull();
+    fireEvent.change(screen.getByPlaceholderText("you@example.com"), { target: { value: "a@e.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "newsletter.subscribe" }));
+
+    // The 403 is the server saying it wanted a token, so the challenge appears.
+    await waitFor(() => expect(captcha.verify).not.toBeNull());
+    expect(screen.getByRole("button", { name: "newsletter.subscribe" })).toBeDisabled();
+    await solveCaptcha();
+    expect(screen.getByRole("button", { name: "newsletter.subscribe" })).not.toBeDisabled();
+  });
+
   it("a pending subscription offers to resend the confirmation at the same cadence", async () => {
     loggedIn("alice");
     const client = createTestQueryClient();

--- a/apps/web/src/specs/features/newsletter/digest-subscribe.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/digest-subscribe.spec.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NewsletterRuntimeProvider } from "@/features/newsletter/runtime";
 import type { ReactElement } from "react";
@@ -12,6 +12,38 @@ import {
   renderWithQueryClient,
   setupModalContainers
 } from "@/specs/test-utils";
+
+/**
+ * The Turnstile widget, mocked: the real one appends a Cloudflare <script> jsdom never
+ * runs, so an anonymous subscribe would sit behind a token that can never arrive. It
+ * renders nothing and hands the test the callbacks.
+ */
+const captcha = vi.hoisted(() => ({
+  verify: null as null | ((token: string) => void),
+  resets: 0
+}));
+vi.mock("@/features/shared/turnstile", () => ({
+  TURNSTILE_SITEKEY: "test-sitekey",
+  Turnstile: ({
+    onVerify,
+    ref
+  }: {
+    onVerify: (token: string) => void;
+    ref?: { current: { reset: () => void } | null };
+  }) => {
+    captcha.verify = onVerify;
+    if (ref) ref.current = { reset: () => { captcha.resets += 1; } };
+    return null;
+  }
+}));
+
+const CAPTCHA_TOKEN = "turnstile-test-token";
+
+async function solveCaptcha() {
+  await act(async () => {
+    captcha.verify?.(CAPTCHA_TOKEN);
+  });
+}
 
 const flags = vi.hoisted(() => ({ newsletter: true }));
 vi.mock("@/config", () => ({
@@ -86,9 +118,11 @@ describe("DigestSubscribeDialog", () => {
   afterEach(() => {
     cleanupModalContainers();
     vi.unstubAllGlobals();
+    captcha.verify = null;
+    captcha.resets = 0;
   });
 
-  it("anonymous: asks for an address, subscribes without a token, and shows the confirmation prompt", async () => {
+  it("anonymous: asks for an address, clears a bot check, subscribes without an account token, and shows the confirmation prompt", async () => {
     fetchMock.mockImplementation((url: string, init?: RequestInit) => {
       if (url === "/api/newsletter/subscribe" && init?.method === "POST") {
         // What the service returns to an unproven caller: this and nothing more.
@@ -102,6 +136,10 @@ describe("DigestSubscribeDialog", () => {
     const subscribeBtn = screen.getByRole("button", { name: "newsletter.subscribe" });
     expect(subscribeBtn).toBeDisabled(); // no address yet
     fireEvent.change(email, { target: { value: "reader@example.com" } });
+    // An address is no longer enough: an anonymous caller also clears the bot check,
+    // because this request makes us mail an address nobody has proven they own.
+    expect(subscribeBtn).toBeDisabled();
+    await solveCaptcha();
     expect(subscribeBtn).not.toBeDisabled();
     fireEvent.click(subscribeBtn);
 
@@ -113,9 +151,13 @@ describe("DigestSubscribeDialog", () => {
       type: "community",
       target: "hive-140217",
       cadence: "weekly",
-      source: "community-page"
+      source: "community-page",
+      captchaToken: CAPTCHA_TOKEN
     });
     expect(body.code).toBeUndefined();
+    // The display label is the dialog's own copy; it is not sent, so a caller cannot
+    // write part of a sentence into mail our domain sends.
+    expect(body.targetLabel).toBeUndefined();
     // Nothing that a logged-in flow would offer.
     expect(screen.queryByText("newsletter.manage-all")).not.toBeInTheDocument();
   });
@@ -166,11 +208,16 @@ describe("DigestSubscribeDialog", () => {
     fetchMock.mockImplementation(() => jsonResponse(200, { status: "refused", reason: "suppressed" }));
     renderConfigured(<DigestSubscribeDialog {...dialogProps} />);
     fireEvent.change(screen.getByPlaceholderText("you@example.com"), { target: { value: "gone@example.com" } });
+    await solveCaptcha();
     fireEvent.click(screen.getByRole("button", { name: "newsletter.subscribe" }));
     await waitFor(() => expect(screen.getByText("newsletter.refused")).toBeInTheDocument());
     fireEvent.click(screen.getByRole("button", { name: "newsletter.try-again" }));
     expect(screen.getByPlaceholderText("you@example.com")).toBeInTheDocument();
     expect(screen.queryByText("newsletter.refused")).not.toBeInTheDocument();
+    // The first attempt spent the token, so the way back re-challenges rather than
+    // letting the retry post a used one and fail with a generic error.
+    expect(captcha.resets).toBe(1);
+    expect(screen.getByRole("button", { name: "newsletter.subscribe" })).toBeDisabled();
   });
 
   it("a pending subscription offers to resend the confirmation at the same cadence", async () => {

--- a/apps/web/src/specs/features/newsletter/list-building.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/list-building.spec.tsx
@@ -128,7 +128,7 @@ describe("list building (vision-web#1537)", () => {
     expect(window.location.search).toBe("?subscribe=digest");
   });
 
-  it("at the end of a post, offers the author's digest to a signed-in reader who is not subscribed; remembers 'Not now'; nothing for the author, a subscriber, or when signed out", async () => {
+  it("at the end of a post, offers the author's digest to a signed-in reader who is not subscribed; remembers 'Not now'; nothing for the author or a subscriber", async () => {
     const client = createTestQueryClient();
     client.setQueryData(digestSubscriptionsKey("alice"), []);
     const entry = mockEntry({ author: "bob", permlink: "hello", category: "photography", parent_author: "", depth: 0 });
@@ -160,11 +160,63 @@ describe("list building (vision-web#1537)", () => {
     await new Promise((r) => setTimeout(r, 30));
     expect(c3.textContent).toBe("");
     u3();
-    // Signed out: nothing.
+  });
+
+  it("offers the author's digest to an ANONYMOUS reader, and remembers a dismissal under its own key", async () => {
+    // Anonymous readers are the larger half of a post's audience and the half with no
+    // other way to hear about the next post. There is no subscription list to consult
+    // for them, so the card is offered rather than withheld; the subscribe path already
+    // serves them with double opt-in plus a bot check on the relay.
     loggedIn(null);
-    const { container: c4 } = render(<PostSubscribePrompt entry={entry} />, client);
+    const client = createTestQueryClient();
+    const entry = mockEntry({ author: "bob", permlink: "hello", category: "photography", parent_author: "", depth: 0 });
+    window.localStorage.clear();
+
+    const { unmount } = render(<PostSubscribePrompt entry={entry} />, client);
+    await screen.findByRole("region", { name: "newsletter.post-prompt-title" });
+    expect(screen.getByText("newsletter.post-prompt-body-creator")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("newsletter.post-prompt-dismiss"));
+    expect(screen.queryByRole("region")).toBeNull();
+    // Its own namespace: an empty viewer segment would read `...prompt::creator:bob`.
+    expect(window.localStorage.getItem("ecency:digest-post-prompt:anon:creator:bob")).toBe("1");
+    unmount();
+
+    const { container } = render(<PostSubscribePrompt entry={entry} />, client);
     await new Promise((r) => setTimeout(r, 30));
-    expect(c4.textContent).toBe("");
+    expect(container.textContent).toBe("");
+  });
+
+  it("never asks the service for an anonymous reader's subscriptions", async () => {
+    // The subscriptions endpoint needs the account's token, newsletterApi.list throws
+    // without a username, and one shared cache key would collapse every anonymous
+    // visitor onto a single entry. The anon path skips the query rather than enabling it.
+    loggedIn(null);
+    const client = createTestQueryClient();
+    const entry = mockEntry({ author: "bob", permlink: "hello", category: "photography", parent_author: "", depth: 0 });
+    window.localStorage.clear();
+    render(<PostSubscribePrompt entry={entry} />, client);
+    await screen.findByRole("region", { name: "newsletter.post-prompt-title" });
+    expect(
+      fetchMock.mock.calls.filter((c) => String(c[0]).includes("/api/newsletter/subscriptions"))
+    ).toHaveLength(0);
+  });
+
+  it("renders nothing while a signed-in reader's store is still hydrating", async () => {
+    // activeUser is null on the first client render for a signed-in reader too, because
+    // the store is populated in a post-mount effect. Rendering the anonymous card then
+    // would flash it at subscribers and write an "anon" dismissal for someone who is
+    // actually signed in, so a stored user with no activeUser yet renders nothing.
+    loggedIn(null);
+    window.localStorage.clear();
+    // The prefixed key the store itself writes (utils/local-storage prefixes "ecency_").
+    window.localStorage.setItem("ecency_active_user", "alice");
+    const client = createTestQueryClient();
+    const entry = mockEntry({ author: "bob", permlink: "hello", category: "photography", parent_author: "", depth: 0 });
+    const { container } = render(<PostSubscribePrompt entry={entry} />, client);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(container.textContent).toBe("");
+    window.localStorage.clear();
   });
 
   it("offers the community's digest when the author reads their own post in a community; the title comes from the community query", async () => {

--- a/apps/web/src/specs/features/newsletter/list-building.spec.tsx
+++ b/apps/web/src/specs/features/newsletter/list-building.spec.tsx
@@ -202,6 +202,21 @@ describe("list building (vision-web#1537)", () => {
     ).toHaveLength(0);
   });
 
+  it("treats a stored username whose account record is gone as anonymous, not as pending hydration", async () => {
+    // authentication-module only produces an active user when active_user AND its
+    // user_<name> record are both present, and it writes the name back regardless. A
+    // marker without its record therefore never becomes an active user, so waiting on it
+    // would hide the prompt from that visitor permanently with nothing to explain it.
+    loggedIn(null);
+    window.localStorage.clear();
+    window.localStorage.setItem("ecency_active_user", "alice"); // marker, no ecency_user_alice
+    const client = createTestQueryClient();
+    const entry = mockEntry({ author: "bob", permlink: "hello", category: "photography", parent_author: "", depth: 0 });
+    render(<PostSubscribePrompt entry={entry} />, client);
+    await screen.findByRole("region", { name: "newsletter.post-prompt-title" });
+    window.localStorage.clear();
+  });
+
   it("renders nothing while a signed-in reader's store is still hydrating", async () => {
     // activeUser is null on the first client render for a signed-in reader too, because
     // the store is populated in a post-mount effect. Rendering the anonymous card then
@@ -209,8 +224,10 @@ describe("list building (vision-web#1537)", () => {
     // actually signed in, so a stored user with no activeUser yet renders nothing.
     loggedIn(null);
     window.localStorage.clear();
-    // The prefixed key the store itself writes (utils/local-storage prefixes "ecency_").
+    // Both keys, because only the pair is a hydration in flight: the store requires
+    // active_user AND the user_<name> record before it yields an active user.
     window.localStorage.setItem("ecency_active_user", "alice");
+    window.localStorage.setItem("ecency_user_alice", JSON.stringify({ username: "alice" }));
     const client = createTestQueryClient();
     const entry = mockEntry({ author: "bob", permlink: "hello", category: "photography", parent_author: "", depth: 0 });
     const { container } = render(<PostSubscribePrompt entry={entry} />, client);


### PR DESCRIPTION
Closes #1568. Also ships the anonymous post-page subscribe prompt that #1568 gated.

Pairs with ecency/news#27, which hardens the service side. **News must deploy first** — see the ordering note at the end.

## What changes

An anonymous subscribe makes us send mail to an address nobody has proven they own, so it now clears a Cloudflare Turnstile check, verified server-side. Signed-in subscribes are untouched: the account is already the proof.

Surfaces that gained the widget: the homepage form, the digest dialog (anonymous callers only), and the managed-blog embed.

## The decisions worth reviewing

**The gate keys on "is there a verified account", nothing else.** Exempting the embed by `source` was the obvious shortcut and is wrong: `source` is caller-supplied, so `{"source":"self-hosted-blog"}` would have turned the check off for everybody. The embed carries a real widget instead. There is a test for exactly this.

**`server/turnstile-verify` is its own module, not an inline `fetch`.** The route spec stubs one global fetch and indexes `mocks.fetch.mock.calls[0]`; an inline siteverify call would take that slot and silently turn every assertion about the newsletter request body into a claim about the Cloudflare request instead — and several would still have passed.

**`invalid` and `unavailable` are kept apart.** A spent or forged token is the caller's problem and answers **403**. A wrong secret or an unreachable Cloudflare is *ours* and answers **503**. Telling readers they look like bots because we misconfigured a deploy is the worse failure.

**An unset secret relays rather than refusing.** Deliberate, so a deploy that lands before the secret cannot take every anonymous signup down. That also means an unset secret is a silently open door, which is why `specs/deploy/newsletter-wiring` now pins `TURNSTILE_SECRET` on the `web` service in both compose files. It was previously declared only for `vapi`.

**Tokens are scoped with `action=newsletter-subscribe`.** One sitekey serves signup as well, so without it a challenge solved on the signup page would be spendable at this endpoint.

**`targetLabel` is no longer sent to the service.** It let a caller choose part of a sentence inside a confirmation email our domain sends to an address they picked. The service derives the label from the target now (news#27 item 1). It still exists client-side for the copy these components render themselves.

## The anonymous post prompt

Five gates had to fall together, and four of them fail silently:

1. The subscriptions query **stays disabled** for anonymous readers — `newsletterApi.list` needs a username, `requireUsername` throws, and one cache key would collapse every anonymous visitor onto a single entry. So `isSuccess` is replaced by a branch that only waits for the query when there is an account.
2. `dismissed` defaults to `true` and its effect early-returned on `!me`.
3. The list branch keyed off `me === entry.author`, so an anonymous reader has to land on the creator branch.
4. Dismissals get their own `anon` namespace; an empty segment would produce `...prompt::creator:bob`.
5. **Hydration.** `activeUser` is null on the first client render for signed-in readers too, because the store is populated post-mount. Rendering the anonymous card then would flash it at subscribers *and* write an `anon` dismissal for someone who is actually signed in. Resolved by reading the same stored user the store reads: a stored user with no `activeUser` yet means "not hydrated", not "anonymous". Pinned by a test.

## Ops

**A custom domain now needs a Turnstile hostname too.** Turnstile covers a hostname and all its subdomains, so every `*.blogs.ecency.com` tenant is already covered by the `ecency.com` entry. A custom apex is not, and skipping it leaves that tenant's form with a widget that never solves — visible on their blog, invisible to us. Added to `hosting/origin/README.md` next to the nginx step. `blog.hivexplorer.com` is the one live case.

## Verification

- web: 3071 tests pass (326 files), typecheck clean, lint clean
- self-hosted: 1006 tests pass (77 files), typecheck clean
- New coverage: `turnstile-verify.spec.ts` (9 cases, including that our own misconfiguration reports as unavailable rather than blaming the reader), 9 new route cases, the embed's gate and re-challenge behaviour, and the anonymous/hydration prompt cases.

## Deploy order

1. **news#27 first**, so community confirmations do not read `hive-140217` for a window.
2. Then this. Note the natural safety here: `develop` deploys the tenant blog stack, while production web only ships from `main` — so tenants get the widget before the route starts requiring it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CAPTCHA protection to anonymous newsletter signups.
  * Added CAPTCHA verification, retry handling, and clear error messages for failed or unavailable challenges.
  * Anonymous readers can now subscribe to newsletters and dismiss post-subscription prompts.
  * Added configuration support for CAPTCHA across deployments and custom domains.

* **Documentation**
  * Documented custom-domain CAPTCHA registration requirements.

* **Tests**
  * Expanded coverage for CAPTCHA validation, signup flows, retries, errors, and deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->