### PR TITLE
Give Googlebot blocking metadata so the canonical lands in head

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -173,8 +173,12 @@ const config = {
   // canonical is left to Google's own duplicate clustering, which is the wrong
   // trade for a page that is also published by other frontends of the same
   // chain. Blocking metadata costs the crawler the streamed shell, which no
-  // crawler benefits from anyway. Google-InspectionTool is included so the
-  // console's live test sees exactly what the indexer sees. Real browsers keep
+  // crawler benefits from anyway. The two generic patterns are the ones from
+  // Next's own default list (configuring this option replaces that list
+  // wholesale, it does not extend it): they cover Google-InspectionTool, so
+  // the console's live test sees exactly what the indexer sees, plus
+  // Google-PageRenderer, AdsBot-Google, Storebot-Google, Mediapartners-Google
+  // and any future agent in either naming family. Real browsers keep
   // streaming (see the spec that pins a Chrome UA to the streaming path).
   //
   // ⚠️ This list is MIRRORED in the origin nginx SSR cache (`$html_limited_bot`
@@ -186,7 +190,7 @@ const config = {
   // Note: Next.js applies this as `new RegExp(htmlLimitedBots, 'i')`, so
   // matching is case-insensitive regardless of the flags written here.
   htmlLimitedBots:
-    /Googlebot|Google-InspectionTool|Storebot-Google|AdsBot-Google|Mediapartners-Google|googleweblight|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|TelegramBot|WhatsApp|SkypeUriPreview|Yeti/,
+    /Googlebot|[\w-]+-Google|Google-[\w-]+|googleweblight|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|TelegramBot|WhatsApp|SkypeUriPreview|Yeti/,
   sassOptions: {
     implementation: require.resolve("sass-embedded"),
     includePaths: [path.join(__dirname), path.join(__dirname, "src/styles")],

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -163,8 +163,19 @@ const config = {
     ...(process.env.SENTRY_ENVIRONMENT && { SENTRY_ENVIRONMENT: process.env.SENTRY_ENVIRONMENT })
   },
   // UAs that get metadata rendered into <head> (blocking) instead of streamed
-  // into the body. Googlebot is intentionally absent — it executes JS, and
-  // blocking would cost it the streaming TTFB win for no benefit.
+  // into the body.
+  //
+  // Googlebot is on the list on purpose. It does execute JS, and it does pick
+  // up a streamed <title> / description / robots tag, but it does not register
+  // a `<link rel="canonical">` that arrives in the body: Search Console's URL
+  // Inspection reports no user-declared canonical for any streamed page, while
+  // the pages whose metadata lands in <head> do show one. A post page with no
+  // canonical is left to Google's own duplicate clustering, which is the wrong
+  // trade for a page that is also published by other frontends of the same
+  // chain. Blocking metadata costs the crawler the streamed shell, which no
+  // crawler benefits from anyway. Google-InspectionTool is included so the
+  // console's live test sees exactly what the indexer sees. Real browsers keep
+  // streaming (see the spec that pins a Chrome UA to the streaming path).
   //
   // ⚠️ This list is MIRRORED in the origin nginx SSR cache (`$html_limited_bot`
   // in the `proxy_cache_key`). If the two drift, cached responses get served to
@@ -175,7 +186,7 @@ const config = {
   // Note: Next.js applies this as `new RegExp(htmlLimitedBots, 'i')`, so
   // matching is case-insensitive regardless of the flags written here.
   htmlLimitedBots:
-    /Mediapartners-Google|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|TelegramBot|WhatsApp|SkypeUriPreview|Yeti/,
+    /Googlebot|Google-InspectionTool|Storebot-Google|AdsBot-Google|Mediapartners-Google|googleweblight|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|TelegramBot|WhatsApp|SkypeUriPreview|Yeti/,
   sassOptions: {
     implementation: require.resolve("sass-embedded"),
     includePaths: [path.join(__dirname), path.join(__dirname, "src/styles")],

--- a/apps/web/src/specs/features/next-middleware/social-bot-metadata.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/social-bot-metadata.spec.ts
@@ -62,6 +62,35 @@ describe("social crawler routing", () => {
     }
   });
 
+  it("gives Google's indexing crawlers blocking metadata and keeps browsers streaming", async () => {
+    // Googlebot executes JS and reads a streamed title or robots tag, but it
+    // does not register a rel=canonical that arrives in the body: URL
+    // Inspection shows no user-declared canonical for streamed pages and a
+    // populated one for pages whose metadata lands in <head>. So the indexer
+    // and the console's live-test agent both get the blocking render. A real
+    // browser must not: blocking metadata would cost every visitor the
+    // streamed shell, which is why the list is an allowlist of crawlers and
+    // not a "render everything in head" switch.
+    const { htmlLimitedBots } = await import("../../../../next.config.js").then(
+      (m) => (m.default ?? m) as { htmlLimitedBots: RegExp }
+    );
+    const re = new RegExp(htmlLimitedBots, "i");
+    for (const agent of [
+      "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/126.0.0.0 Safari/537.36",
+      "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+      "Mozilla/5.0 (compatible; Google-InspectionTool/1.0;)"
+    ]) {
+      expect(re.test(agent), `${agent} must get blocking metadata`).toBe(true);
+    }
+    for (const agent of [
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+      "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"
+    ]) {
+      expect(re.test(agent), `${agent} must keep streaming metadata`).toBe(false);
+    }
+  });
+
   /**
    * The origin nginx SSR cache puts this same UA class in its `proxy_cache_key`
    * (`$html_limited_bot`), so the two lists have to agree. When they drift, a

--- a/apps/web/src/specs/features/next-middleware/social-bot-metadata.spec.ts
+++ b/apps/web/src/specs/features/next-middleware/social-bot-metadata.spec.ts
@@ -78,7 +78,14 @@ describe("social crawler routing", () => {
     for (const agent of [
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/126.0.0.0 Safari/537.36",
       "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
-      "Mozilla/5.0 (compatible; Google-InspectionTool/1.0;)"
+      "Mozilla/5.0 (compatible; Google-InspectionTool/1.0;)",
+      // The two generic families from Next's default list. Setting
+      // htmlLimitedBots replaces that list, so these have to be carried over
+      // explicitly or they silently drop to the streaming path.
+      "Google-PageRenderer Google (+https://developers.google.com/+/web/snippet/)",
+      "Mediapartners-Google",
+      "AdsBot-Google (+http://www.google.com/adsbot.html)",
+      "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36 (compatible; Storebot-Google/1.0)"
     ]) {
       expect(re.test(agent), `${agent} must get blocking metadata`).toBe(true);
     }

--- a/docs/cache/nginx.md
+++ b/docs/cache/nginx.md
@@ -29,7 +29,7 @@ proxy_cache_path /var/cache/nginx/ssr levels=1:2
 # See "Why the bot UA class is in the cache key" below.
 map $http_user_agent $html_limited_bot {
   default "";
-  "~*(Mediapartners-Google|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|TelegramBot|WhatsApp|SkypeUriPreview|Yeti)" "|htmlbot";
+  "~*(Googlebot|Google-InspectionTool|Storebot-Google|AdsBot-Google|Mediapartners-Google|googleweblight|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|TelegramBot|WhatsApp|SkypeUriPreview|Yeti)" "|htmlbot";
 }
 
 server {
@@ -68,9 +68,11 @@ server {
 
 `htmlLimitedBots` in `apps/web/next.config.js` makes Next.js render metadata
 (title, description, og:*, canonical) into `<head>` for crawlers that do not
-execute JavaScript. Every other client gets **streaming metadata**, where those
-tags are emitted far down the body instead. Googlebot is deliberately *not* on
-the list, because it renders JS.
+execute JavaScript, and for Googlebot. Every other client gets **streaming
+metadata**, where those tags are emitted far down the body instead. Googlebot
+renders JS and reads a streamed title or robots tag, but it does not register a
+streamed `rel=canonical`, so it is on the list as well (see the comment on
+`htmlLimitedBots` in `next.config.js`).
 
 That means one URL has two legitimate response shapes. Keying the SSR cache on
 `$request_uri` alone let them share a single entry — and since real users vastly

--- a/docs/cache/nginx.md
+++ b/docs/cache/nginx.md
@@ -29,7 +29,7 @@ proxy_cache_path /var/cache/nginx/ssr levels=1:2
 # See "Why the bot UA class is in the cache key" below.
 map $http_user_agent $html_limited_bot {
   default "";
-  "~*(Googlebot|Google-InspectionTool|Storebot-Google|AdsBot-Google|Mediapartners-Google|googleweblight|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|TelegramBot|WhatsApp|SkypeUriPreview|Yeti)" "|htmlbot";
+  "~*(Googlebot|[\w-]+-Google|Google-[\w-]+|googleweblight|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|TelegramBot|WhatsApp|SkypeUriPreview|Yeti)" "|htmlbot";
 }
 
 server {

--- a/infra/origin/README.md
+++ b/infra/origin/README.md
@@ -57,6 +57,11 @@ the vhosts will load:
   variables they define. Exact, not a wildcard: see the contract above
 - the `apicache` and SSR `proxy_cache_path` entries
 - `map $cookie_active_user $skip_cache` and the other cache-decision maps
+- `map $http_user_agent $html_limited_bot`, the crawler class that the SSR `proxy_cache_key`
+  appends to `$request_uri`. Its pattern must equal `htmlLimitedBots` in
+  `apps/web/next.config.js`; the documented copy and the parity spec live in
+  `docs/cache/nginx.md`. Deploying a change to that list means editing the map on every
+  origin in the same rollout, otherwise a browser-primed entry is served to the crawler
 
 ## Restoring an origin
 


### PR DESCRIPTION
Closes #1580

Googlebot executes JS and reads a streamed title or robots tag, but it does not register a `rel=canonical` that arrives in the body: URL Inspection shows no user-declared canonical for any page whose metadata is streamed, and a populated one for the pages whose metadata is rendered into `<head>`. Entry pages therefore declare no canonical to Google today.

What changed

- `htmlLimitedBots` now includes `Googlebot`, `Google-InspectionTool`, `Storebot-Google`, `AdsBot-Google` and `googleweblight` (the Google crawlers the Next.js default list also covers), so those agents get the blocking render with metadata in `<head>`. Browsers keep streaming.
- `docs/cache/nginx.md` mirrors the list in the `$html_limited_bot` cache-key map; the running origin maps need the same one-line edit (operations, outside this PR), as does the edge cache key.
- `social-bot-metadata.spec.ts` pins that the Googlebot desktop and smartphone UAs and Google-InspectionTool match, and that Chrome, Safari and Firefox UAs do not, so the list cannot silently widen into "render everything in head".

Test plan

- `vitest run src/specs/features/next-middleware/social-bot-metadata.spec.ts` (5 passed).
- After deploy: fetch a post page from the origin with a Googlebot UA and confirm `<link rel="canonical">` precedes `</head>`; a week later, re-inspect a recently crawled post in Search Console and confirm the user-declared canonical is populated.
