### PR TITLE
Start the production server with the config the build resolved

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -107,6 +107,7 @@ COPY --from=base /var/app/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=base /var/app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=base /var/app/apps/web/package.json ./apps/web/package.json
 COPY --from=base /var/app/apps/web/healthCheck.js ./apps/web/healthCheck.js
+COPY --from=base /var/app/apps/web/next-runtime-config.js ./apps/web/next-runtime-config.js
 COPY --from=base /var/app/apps/web/public ./apps/web/public
 COPY --from=base /var/app/apps/web/.next ./apps/web/.next
 COPY --from=base /var/app/node_modules ./node_modules
@@ -123,5 +124,11 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 CMD node
 # to the previous image, so deploys went green while prod kept serving the old
 # build. Invoking next directly skips that check (and a per-start corepack
 # download of pnpm).
+#
+# The image carries no next.config.js, and without one `next start` falls back
+# to Next's defaults for every option it reads at request time (htmlLimitedBots,
+# images, experimental flags, compress, ...). The preload hands the server the
+# config the build resolved, from .next/required-server-files.json, the way
+# Next's own standalone server.js does. See next-runtime-config.js.
 WORKDIR /var/app/apps/web
-CMD ["node", "./node_modules/next/dist/bin/next", "start"]
+CMD ["node", "--require", "./next-runtime-config.js", "./node_modules/next/dist/bin/next", "start"]

--- a/apps/web/next-runtime-config.js
+++ b/apps/web/next-runtime-config.js
@@ -1,0 +1,33 @@
+// Runtime config for `next start` in the production image.
+//
+// The image ships the build output but not next.config.js (that file pulls in
+// build-only packages the pruned runtime node_modules does not carry). With no
+// config file present, `next start` resolves every request-time option to
+// Next's default: htmlLimitedBots, images, experimental flags, compress,
+// poweredByHeader and the like silently diverge from what the build used,
+// while build-time options (routes, headers, redirects, deploymentId) keep
+// working because they are baked into .next. That is why the gap stayed
+// invisible. Hand the server the config the build resolved, the same way
+// Next's own standalone server.js does.
+//
+// Loaded with `node --require ./next-runtime-config.js ... next start` (see
+// the Dockerfile CMD). Runs before Next, so it must stay dependency-free.
+const path = require("path");
+
+const manifest = path.join(__dirname, ".next", "required-server-files.json");
+
+let config;
+try {
+  config = require(manifest).config;
+} catch (err) {
+  console.error(`[next-runtime-config] cannot read ${manifest}: ${err.message}`);
+  process.exit(1);
+}
+if (!config || typeof config !== "object") {
+  console.error(`[next-runtime-config] ${manifest} carries no config object`);
+  process.exit(1);
+}
+
+if (!process.env.__NEXT_PRIVATE_STANDALONE_CONFIG) {
+  process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(config);
+}

--- a/apps/web/next-runtime-config.js
+++ b/apps/web/next-runtime-config.js
@@ -28,6 +28,17 @@ if (!config || typeof config !== "object") {
   process.exit(1);
 }
 
-if (!process.env.__NEXT_PRIVATE_STANDALONE_CONFIG) {
-  process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(config);
+// Unconditional on purpose: the shipped build is the only config this image
+// can legitimately run, so a value inherited from the environment must not win.
+process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(config);
+
+let nextVersion = "unknown";
+try {
+  nextVersion = require("next/package.json").version;
+} catch {
+  // Only used for the log line below.
 }
+// One line per process start, so a rollout log shows the hook was applied and
+// against which Next version (the hook is Next-internal; see the spec that
+// pins it).
+process.stderr.write(`[next-runtime-config] build config applied (next ${nextVersion})\n`);

--- a/apps/web/src/specs/next-runtime-config.spec.ts
+++ b/apps/web/src/specs/next-runtime-config.spec.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+import { describe, expect, it, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PHASE_PRODUCTION_SERVER } from "next/constants";
+
+/**
+ * The production image starts Next with `node --require ./next-runtime-config.js`
+ * (see the Dockerfile). Without it, `next start` in an image that carries no
+ * next.config.js resolves every request-time option to Next's default, which
+ * is the production-only drift this preload exists to close. These tests boot
+ * the real preload in a child process against a staged `.next/` directory, and
+ * the last one pins the Next-internal hook it relies on, so a Next upgrade
+ * that drops the hook fails here instead of silently reverting production.
+ */
+
+const PRELOAD = join(process.cwd(), "next-runtime-config.js");
+const ENV_KEY = "__NEXT_PRIVATE_STANDALONE_CONFIG";
+const staged: string[] = [];
+
+function stage(manifest?: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "next-runtime-config-"));
+  staged.push(dir);
+  copyFileSync(PRELOAD, join(dir, "next-runtime-config.js"));
+  if (manifest !== undefined) {
+    mkdirSync(join(dir, ".next"));
+    writeFileSync(join(dir, ".next", "required-server-files.json"), JSON.stringify(manifest));
+  }
+  return dir;
+}
+
+function boot(dir: string, env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(
+    process.execPath,
+    ["--require", "./next-runtime-config.js", "-e", `process.stdout.write(process.env.${ENV_KEY} || "")`],
+    { cwd: dir, encoding: "utf8", env: { ...process.env, [ENV_KEY]: "", ...env } }
+  );
+}
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+  for (const dir of staged.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("next-runtime-config preload", () => {
+  const config = { htmlLimitedBots: "Googlebot|Yeti", compress: true, experimental: {} };
+
+  it("hands Next the config the build resolved", () => {
+    const res = boot(stage({ version: 1, config }));
+    expect(res.status, res.stderr).toBe(0);
+    expect(JSON.parse(res.stdout)).toEqual(config);
+    expect(res.stderr).toContain("[next-runtime-config] build config applied");
+  });
+
+  it("does not let a value inherited from the environment win over the build", () => {
+    const res = boot(stage({ version: 1, config }), { [ENV_KEY]: JSON.stringify({ stale: true }) });
+    expect(res.status, res.stderr).toBe(0);
+    expect(JSON.parse(res.stdout)).toEqual(config);
+  });
+
+  it("fails loudly when the build manifest is missing", () => {
+    const res = boot(stage());
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain("cannot read");
+    expect(res.stdout).toBe("");
+  });
+
+  it("fails loudly when the manifest carries no config object", () => {
+    const res = boot(stage({ version: 1 }));
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain("carries no config object");
+  });
+
+  it("is honoured by Next's own config loader (pins the hook the preload relies on)", async () => {
+    // No next.config.js in the staged dir, exactly like the production image.
+    const dir = stage();
+    process.env[ENV_KEY] = JSON.stringify(config);
+    const { default: loadConfig } = await import("next/dist/server/config");
+    const loaded = await loadConfig(PHASE_PRODUCTION_SERVER, dir);
+    expect(loaded.htmlLimitedBots).toBe("Googlebot|Yeti");
+  });
+});


### PR DESCRIPTION
Closes #1582

The production image carries the build output but not `next.config.js`, and `next start` resolves its configuration from that file. With none present, every option Next reads at request time has been falling back to its default in production (`htmlLimitedBots`, `images`, `experimental.*`, `compress`, `poweredByHeader`, ...), while build-time options kept working because they are baked into `.next`. This is why #1581 had no visible effect.

What changed

- `apps/web/next-runtime-config.js`: a dependency-free preload that reads `.next/required-server-files.json` and hands the resolved config to Next through the same mechanism Next's own standalone `server.js` uses. Fails loudly if the manifest is missing.
- `apps/web/Dockerfile`: copies the preload into the production stage and starts the server with `node --require ./next-runtime-config.js ... next start`.

Test plan

- Throwaway container from the current image with this exact start command: boots, a Googlebot-UA request renders `rel=canonical` inside `<head>` (TTFB ≈ metadata wait), a Chrome-UA request keeps streaming metadata, no config warnings in the log.
- After deploy: fetch a post page from an origin with a Googlebot UA and confirm `<link rel="canonical">` precedes `</head>`; with a browser UA it does not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production startup reliability by ensuring runtime configuration is loaded before the application starts.
  * Added clearer failure handling when required production configuration is missing or invalid.

* **Tests**
  * Added coverage for configuration loading, environment-variable precedence, invalid configuration scenarios, and production startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->