### PR TITLE
Sitemap: gate on the row's author_reputation and give authors and tags a real lastmod

### DIFF
--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -13,15 +13,16 @@
  *    complete archive).
  *  - Per-RPC try/catch: a failed page ends the walk and serves what we have.
  *  - Blacklist read fresh from Redis so just-flagged authors are excluded.
- *  - rep-gate is intentionally skipped here (accountFetchFailed=true): we
- *    don't fetch a profile per post (no fan-out); SSR still applies it on
- *    crawl, so a listed-but-rep-gated post is at worst a wasted hint.
+ *  - The reputation gate is applied from the author_reputation every ranked
+ *    row already carries (no profile fetch, no fan-out). The post_count half
+ *    of the page gate needs a profile and is not available here; reputation
+ *    alone covers nearly every case, and SSR still applies both on crawl.
  */
 import { getSeoRedis, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
 import { cronAuthorized, notFound } from "@/features/seo/cron-auth";
 import { SITEMAP_SHARDS } from "@/features/seo/sitemap-shards";
 import { harvestPostTags, selectTopTags } from "@/features/seo/sitemap-tags";
-import { isIndexable, canonicalTarget } from "@/utils/entry-indexability";
+import { isIndexable, canonicalTarget, isBelowReputationGate } from "@/utils/entry-indexability";
 import { isNsfwCommunity } from "@/utils/nsfw-detection";
 import { Entry } from "@/entities";
 import defaults from "@/defaults";
@@ -248,6 +249,14 @@ export async function POST(req: Request): Promise<Response> {
   // tag -> #posts using it in the freshness window. Also free from the walk;
   // feeds the top-N /created/<tag> hub shard (tags.xml).
   const tagCounts = new Map<string, number>();
+  // author -> newest indexable post day, tag -> newest indexable post day.
+  // Both free from the walk; they give authors.xml and tags.xml a real
+  // per-entry lastmod instead of today's date on every line (a lastmod that
+  // moves without the page changing teaches crawlers to discount the field,
+  // which also devalues the honest dates in posts.xml).
+  const authorLatest = new Map<string, string>();
+  const tagLatest = new Map<string, string>();
+  let repGated = 0;
   let startAuthor: string | undefined;
   let startPermlink: string | undefined;
   let pages = 0;
@@ -295,6 +304,14 @@ export async function POST(req: Request): Promise<Response> {
         const prev = communityLatest.get(comm);
         if (day && (!prev || day > prev)) communityLatest.set(comm, day);
       }
+      // Reputation gate from the row itself. A listed URL that then renders
+      // noindex is a wasted hint and coverage-report noise. Only when the
+      // field is present: an absent value must not gate (the page decides).
+      const rep = raw.author_reputation;
+      if (typeof rep === "number" && isBelowReputationGate(rep)) {
+        repGated += 1;
+        continue;
+      }
       // 4th arg = true: keep isIndexable in lockstep with the sitemap-mode
       // canonicalTarget call below, so the indexable count can't drift from
       // the emitted posts.xml (a reply with only an off-host declared
@@ -315,11 +332,16 @@ export async function POST(req: Request): Promise<Response> {
       // Defensive protocol-boundary guard: even if a future canonicalTarget
       // edit regressed, no cross-host URL may enter any shard.
       if (!loc || !loc.startsWith(`${BASE}/`)) continue;
-      postUrls.push({ loc, lastmod: (e.updated || e.created || "").slice(0, 10) });
-      if (e.author) authors.add(e.author);
-      // Tag popularity from the same indexable posts (NSFW/reputation/thin
-      // already filtered by isIndexable above). Free — no extra RPC.
-      harvestPostTags(tagCounts, e.category, e.json_metadata?.tags);
+      const postDay = (e.updated || e.created || "").slice(0, 10);
+      postUrls.push({ loc, lastmod: postDay });
+      if (e.author) {
+        authors.add(e.author);
+        const prev = authorLatest.get(e.author);
+        if (postDay && (!prev || postDay > prev)) authorLatest.set(e.author, postDay);
+      }
+      // Tag popularity and freshness from the same indexable posts
+      // (NSFW/reputation/thin already filtered above). Free — no extra RPC.
+      harvestPostTags(tagCounts, e.category, e.json_metadata?.tags, tagLatest, postDay);
     }
   }
 
@@ -355,10 +377,12 @@ export async function POST(req: Request): Promise<Response> {
   // the sitemap'd URL itself doesn't, and a crawl is spent resolving the
   // canonical. A sitemap must list canonical URLs — the same rule posts.xml
   // already follows via canonicalTarget.
-  const authorUrls = Array.from(authors).map((a) => ({
-    loc: `${BASE}/@${a}/posts`,
-    lastmod: nowDay
-  }));
+  // lastmod = the author's newest indexable post day in the window (the
+  // only event that changes /@a/posts), never today's date for everyone.
+  const authorUrls: SitemapUrl[] = Array.from(authors).map((a) => {
+    const lastmod = authorLatest.get(a);
+    return lastmod ? { loc: `${BASE}/@${a}/posts`, lastmod } : { loc: `${BASE}/@${a}/posts` };
+  });
   // Cached/weekly name list + free hourly post-derived lastmod. A community
   // with no post in the freshness window simply omits lastmod (honest: it
   // signals staleness by absence rather than a fabricated date).
@@ -369,12 +393,12 @@ export async function POST(req: Request): Promise<Response> {
       : { loc: `${BASE}/created/${name}` };
   });
   // Top-N tag hub pages (/created/<tag>) — community ids/NSFW/long-tail dropped
-  // by selectTopTags. lastmod=nowDay: a /created feed changes whenever the tag
-  // gets a new post, and a tag only reaches the top-N because it's active.
-  const tagUrls: SitemapUrl[] = selectTopTags(tagCounts, TAGS_LIMIT, TAG_MIN_COUNT).map((tag) => ({
-    loc: `${BASE}/created/${tag}`,
-    lastmod: nowDay
-  }));
+  // by selectTopTags. lastmod = the tag's newest indexable post day: that is
+  // when /created/<tag> last changed.
+  const tagUrls: SitemapUrl[] = selectTopTags(tagCounts, TAGS_LIMIT, TAG_MIN_COUNT).map((tag) => {
+    const lastmod = tagLatest.get(tag);
+    return lastmod ? { loc: `${BASE}/created/${tag}`, lastmod } : { loc: `${BASE}/created/${tag}` };
+  });
 
   // Stale-preserving guard (mirrors the communities delta-sanity):
   // a budget- or error-truncated walk must NOT overwrite a good posts/authors
@@ -422,13 +446,21 @@ export async function POST(req: Request): Promise<Response> {
     // every run, so nowDay is honest for them. Fallback to nowDay only if no
     // accepted-day was ever recorded (pre-existing baseline from an older
     // deploy); it self-heals on the next accepted walk.
-    const walkLastmod = acceptWalk ? nowDay : lastGoodDay || nowDay;
+    // Hourly-rebuilt shards get the full W3C datetime of this run (the
+    // protocol allows it and it is exact); static.xml only changes with the
+    // day, so the day is its honest lastmod.
+    const nowIso = new Date().toISOString();
+    const walkLastmod = acceptWalk ? nowIso : lastGoodDay || nowDay;
     await redis.set(
       K("index"),
       indexXml(
         SITEMAP_SHARDS.map((name) => ({
           name,
-          lastmod: WALK_DERIVED.has(name) ? walkLastmod : nowDay
+          lastmod: WALK_DERIVED.has(name)
+            ? walkLastmod
+            : name === "communities.xml"
+              ? nowIso
+              : nowDay
         }))
       )
     );
@@ -445,6 +477,7 @@ export async function POST(req: Request): Promise<Response> {
         communities: communityUrls.length,
         tags: tagUrls.length,
         pages,
+        repGated,
         ms: Date.now() - started,
         reachedCutoff,
         acceptedWalk: acceptWalk,
@@ -470,6 +503,7 @@ export async function POST(req: Request): Promise<Response> {
       communities: communityUrls.length,
       tags: tagUrls.length,
       pages,
+      repGated,
       ms: Date.now() - started,
       reachedCutoff,
       acceptedWalk: acceptWalk,

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -454,7 +454,14 @@ export async function POST(req: Request): Promise<Response> {
     } catch {
       recorded = {};
     }
+    // Decide every lastmod first, then persist in the order record -> shards
+    // -> index. If a write fails midway, the retry still does the right
+    // thing: a shard not yet written still differs from its stored blob (so
+    // it is stamped again), and a shard already written reads back the
+    // timestamp this run recorded for it. Writing the record last instead
+    // would let a changed shard keep its previous timestamp forever.
     const lastmods: Record<string, string> = {};
+    const toWrite: (typeof SITEMAP_SHARDS)[number][] = [];
     for (const name of SITEMAP_SHARDS) {
       if (!acceptWalk && WALK_DERIVED.has(name)) {
         lastmods[name] = recorded[name] || lastGoodAt || nowDay; // keep last-good
@@ -462,10 +469,11 @@ export async function POST(req: Request): Promise<Response> {
       }
       const previous = await redis.get(K(name));
       const changed = previous !== shardXml[name];
-      await redis.set(K(name), shardXml[name]);
       lastmods[name] = changed || !recorded[name] ? nowIso : recorded[name];
+      toWrite.push(name);
     }
     await redis.set(K("lastmod"), JSON.stringify(lastmods));
+    for (const name of toWrite) await redis.set(K(name), shardXml[name]);
     await redis.set(
       K("index"),
       indexXml(SITEMAP_SHARDS.map((name) => ({ name, lastmod: lastmods[name] })))

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -308,7 +308,8 @@ export async function POST(req: Request): Promise<Response> {
       // noindex is a wasted hint and coverage-report noise. Only when the
       // field is present: an absent value must not gate (the page decides).
       const rep = raw.author_reputation;
-      if (typeof rep === "number" && isBelowReputationGate(rep)) {
+      const hasRep = typeof rep === "number" || (typeof rep === "string" && rep.trim() !== "");
+      if (hasRep && isBelowReputationGate(rep as number | string)) {
         repGated += 1;
         continue;
       }
@@ -407,13 +408,15 @@ export async function POST(req: Request): Promise<Response> {
   // last accepted count. On reject, posts.xml + authors.xml keep their
   // last-good blobs; the independent communities/static/index still refresh.
   let lastGood = 0;
-  let lastGoodDay = "";
+  // When the walk-derived shards were last accepted: a full datetime, or a
+  // bare day written by older deploys (both valid W3C lastmod values).
+  let lastGoodAt = "";
   try {
     lastGood = parseInt((await redis.get(POSTS_LASTGOOD_KEY)) ?? "", 10) || 0;
-    lastGoodDay = (await redis.get(POSTS_LASTGOOD_DAY_KEY)) ?? "";
+    lastGoodAt = (await redis.get(POSTS_LASTGOOD_DAY_KEY)) ?? "";
   } catch {
     lastGood = 0;
-    lastGoodDay = "";
+    lastGoodAt = "";
   }
   // 50% guard. Math.ceil (not floor) so a stored baseline of 1 doesn't
   // collapse the threshold to 0 and silently accept an empty walk; the
@@ -435,38 +438,43 @@ export async function POST(req: Request): Promise<Response> {
   };
 
   try {
-    for (const name of SITEMAP_SHARDS) {
-      if (!acceptWalk && WALK_DERIVED.has(name)) continue; // keep last-good
-      await redis.set(K(name), shardXml[name]);
-    }
-    // When the walk is rejected, posts.xml/authors.xml keep their last-good
-    // blob — so the index must advertise their *real* freshness (the day they
-    // were last accepted), not today's, or crawlers re-pull unchanged shards
-    // and GSC sees a false freshness signal. communities/static are rebuilt
-    // every run, so nowDay is honest for them. Fallback to nowDay only if no
-    // accepted-day was ever recorded (pre-existing baseline from an older
-    // deploy); it self-heals on the next accepted walk.
-    // Hourly-rebuilt shards get the full W3C datetime of this run (the
-    // protocol allows it and it is exact); static.xml only changes with the
-    // day, so the day is its honest lastmod.
+    // Per-shard lastmod, kept in Redis. A shard's lastmod advances only when
+    // its bytes change, so an hourly run that rebuilds an identical
+    // authors.xml or communities.xml does not advertise a change it did not
+    // make (a lastmod that moves without content teaches crawlers to discount
+    // the field). A walk-derived shard kept from last-good keeps its recorded
+    // lastmod; the first run after this deploy falls back to the last
+    // accepted timestamp, then today.
     const nowIso = new Date().toISOString();
-    const walkLastmod = acceptWalk ? nowIso : lastGoodDay || nowDay;
+    let recorded: Record<string, string> = {};
+    try {
+      const raw = await redis.get(K("lastmod"));
+      const parsed: unknown = raw ? JSON.parse(raw) : {};
+      if (parsed && typeof parsed === "object") recorded = parsed as Record<string, string>;
+    } catch {
+      recorded = {};
+    }
+    const lastmods: Record<string, string> = {};
+    for (const name of SITEMAP_SHARDS) {
+      if (!acceptWalk && WALK_DERIVED.has(name)) {
+        lastmods[name] = recorded[name] || lastGoodAt || nowDay; // keep last-good
+        continue;
+      }
+      const previous = await redis.get(K(name));
+      const changed = previous !== shardXml[name];
+      await redis.set(K(name), shardXml[name]);
+      lastmods[name] = changed || !recorded[name] ? nowIso : recorded[name];
+    }
+    await redis.set(K("lastmod"), JSON.stringify(lastmods));
     await redis.set(
       K("index"),
-      indexXml(
-        SITEMAP_SHARDS.map((name) => ({
-          name,
-          lastmod: WALK_DERIVED.has(name)
-            ? walkLastmod
-            : name === "communities.xml"
-              ? nowIso
-              : nowDay
-        }))
-      )
+      indexXml(SITEMAP_SHARDS.map((name) => ({ name, lastmod: lastmods[name] })))
     );
     if (acceptWalk) {
       await redis.set(POSTS_LASTGOOD_KEY, String(postUrls.length));
-      await redis.set(POSTS_LASTGOOD_DAY_KEY, nowDay);
+      // Full datetime, so a later rejected walk advertises exactly the
+      // freshness the last accepted walk had, not a coarser day.
+      await redis.set(POSTS_LASTGOOD_DAY_KEY, nowIso);
     }
     await redis.set(
       `${SEO_REDIS_PREFIX}sitemap:meta`,
@@ -482,7 +490,7 @@ export async function POST(req: Request): Promise<Response> {
         reachedCutoff,
         acceptedWalk: acceptWalk,
         lastGood,
-        lastGoodDay
+        lastGoodAt
       })
     );
   } catch (e) {
@@ -507,7 +515,8 @@ export async function POST(req: Request): Promise<Response> {
       ms: Date.now() - started,
       reachedCutoff,
       acceptedWalk: acceptWalk,
-      lastGood
+      lastGood,
+      lastGoodAt
     }),
     { status: 200, headers: { "Content-Type": "application/json" } }
   );

--- a/apps/web/src/features/seo/sitemap-tags.ts
+++ b/apps/web/src/features/seo/sitemap-tags.ts
@@ -42,7 +42,11 @@ export function isEmittableTag(tag: string): boolean {
 export function harvestPostTags(
   counts: Map<string, number>,
   category: string | null | undefined,
-  tags: readonly unknown[] | null | undefined
+  tags: readonly unknown[] | null | undefined,
+  // Optional: newest post day (YYYY-MM-DD) per tag, so the tag hub shard can
+  // carry a real lastmod instead of stamping today on every entry.
+  latest?: Map<string, string>,
+  day?: string
 ): void {
   const inPost = new Set<string>();
   const add = (raw: unknown) => {
@@ -52,7 +56,13 @@ export function harvestPostTags(
   };
   add(category);
   if (Array.isArray(tags)) for (const t of tags) add(t);
-  inPost.forEach((t) => counts.set(t, (counts.get(t) ?? 0) + 1));
+  inPost.forEach((t) => {
+    counts.set(t, (counts.get(t) ?? 0) + 1);
+    if (latest && day) {
+      const prev = latest.get(t);
+      if (!prev || day > prev) latest.set(t, day);
+    }
+  });
 }
 
 /**

--- a/apps/web/src/specs/api/sitemap-generate-route.spec.ts
+++ b/apps/web/src/specs/api/sitemap-generate-route.spec.ts
@@ -12,9 +12,7 @@ vi.mock("@/features/seo/cron-auth", () => ({
 }));
 const store = new Map<string, string>();
 let failNextSetMatching = "";
-vi.mock("@/features/seo/seo-redis", () => ({
-  SEO_REDIS_PREFIX: "seo:",
-  getSeoRedis: () => ({
+const fakeRedis = () => ({
     get: async (k: string) => store.get(k) ?? null,
     set: async (k: string, v: string) => {
       if (failNextSetMatching && k.includes(failNextSetMatching)) {
@@ -24,7 +22,13 @@ vi.mock("@/features/seo/seo-redis", () => ({
       store.set(k, v);
       return "OK";
     }
-  })
+});
+vi.mock("@/features/seo/seo-redis", () => ({
+  SEO_REDIS_PREFIX: "seo:",
+  getSeoRedis: () => fakeRedis(),
+  // Both accessors, so this spec holds whether the route takes the client
+  // synchronously or waits for it to be ready.
+  getSeoRedisReady: async () => fakeRedis()
 }));
 
 import { callRPC } from "@ecency/sdk/hive";

--- a/apps/web/src/specs/api/sitemap-generate-route.spec.ts
+++ b/apps/web/src/specs/api/sitemap-generate-route.spec.ts
@@ -11,11 +11,16 @@ vi.mock("@/features/seo/cron-auth", () => ({
   notFound: () => new Response("", { status: 404 })
 }));
 const store = new Map<string, string>();
+let failNextSetMatching = "";
 vi.mock("@/features/seo/seo-redis", () => ({
   SEO_REDIS_PREFIX: "seo:",
   getSeoRedis: () => ({
     get: async (k: string) => store.get(k) ?? null,
     set: async (k: string, v: string) => {
+      if (failNextSetMatching && k.includes(failNextSetMatching)) {
+        failNextSetMatching = "";
+        throw new Error(`injected redis failure on ${k}`);
+      }
       store.set(k, v);
       return "OK";
     }
@@ -196,5 +201,29 @@ describe("sitemap-generate route", () => {
     expect(indexEntry("posts.xml")).toBe(accepted);
     expect(indexEntry("authors.xml")).toBe(accepted);
     expect(body.lastGoodAt).toBe(accepted);
+  });
+
+  it("re-stamps a changed shard after a write that failed between the record and the shard", async () => {
+    const t0 = Date.now();
+    vi.useFakeTimers({ toFake: ["Date"], now: t0 });
+    await run();
+    const before = indexEntry("posts.xml");
+    // A new post, but Redis dies on the posts.xml write itself.
+    vi.setSystemTime(new Date(t0 + HOUR));
+    vi.mocked(callRPC).mockImplementation(async (method: string) => {
+      if (method !== "bridge.get_ranked_posts") return [];
+      return [post("newcomer", "hello", HOUR, 70, ["photography"]), ...PAGE];
+    });
+    failNextSetMatching = "sitemap:posts.xml";
+    const failed = await run();
+    expect(failed.status).toBe(500);
+    expect(shard("posts.xml")).not.toContain("newcomer");
+    expect(indexEntry("posts.xml")).toBe(before); // index untouched by the failed run
+    // The retry sees the shard still differs from what is stored and stamps it.
+    vi.setSystemTime(new Date(t0 + 2 * HOUR));
+    const retry = await (await run()).json();
+    expect(retry.ok).toBe(true);
+    expect(shard("posts.xml")).toContain("newcomer");
+    expect(indexEntry("posts.xml")).toBe(new Date(t0 + 2 * HOUR).toISOString());
   });
 });

--- a/apps/web/src/specs/api/sitemap-generate-route.spec.ts
+++ b/apps/web/src/specs/api/sitemap-generate-route.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@ecency/sdk/hive", () => ({
   callRPC: vi.fn(),
@@ -60,7 +60,14 @@ const PAGE = [
 
 const shard = (name: string) => store.get(`seo:sitemap:${name}`) ?? "";
 
+const run = () => POST(new Request("http://web/api/internal/seo/sitemap-generate", { method: "POST" }));
+const indexEntry = (name: string) =>
+  shard("index").match(new RegExp(`<loc>https://ecency.com/sitemap/${name}</loc><lastmod>([^<]+)</lastmod>`))?.[1];
+
 describe("sitemap-generate route", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   beforeEach(() => {
     store.clear();
     vi.mocked(callRPC).mockImplementation(async (method: string) => {
@@ -104,15 +111,12 @@ describe("sitemap-generate route", () => {
     expect(tags).not.toContain("/created/travel");
   });
 
-  it("stamps the hourly shards in the index with the run's full W3C datetime and static.xml with the day", async () => {
-    await POST(new Request("http://web/api/internal/seo/sitemap-generate", { method: "POST" }));
-    const index = shard("index");
-    const entry = (name: string) =>
-      index.match(new RegExp(`<loc>https://ecency.com/sitemap/${name}</loc><lastmod>([^<]+)</lastmod>`))?.[1];
-    expect(entry("posts.xml")).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-    expect(entry("authors.xml")).toBe(entry("posts.xml"));
-    expect(entry("communities.xml")).toMatch(/T/);
-    expect(entry("static.xml")).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  it("stamps every index entry with the full W3C datetime of the run that last changed that shard", async () => {
+    await run();
+    for (const name of ["posts.xml", "authors.xml", "tags.xml", "communities.xml", "static.xml"]) {
+      expect(indexEntry(name), name).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    }
+    expect(indexEntry("authors.xml")).toBe(indexEntry("posts.xml"));
   });
 
   it("does not gate when the row carries no author_reputation (the page decides)", async () => {
@@ -125,5 +129,71 @@ describe("sitemap-generate route", () => {
     const body = await res.json();
     expect(body.repGated).toBe(0);
     expect(shard("posts.xml")).toContain("/@unknownrep/p");
+  });
+
+  it("gates on a raw condenser-style string reputation too, and never on an empty one", async () => {
+    vi.mocked(callRPC).mockImplementation(async (method: string) => {
+      if (method !== "bridge.get_ranked_posts") return [];
+      return [
+        { ...post("rawlow", "p1", HOUR, 0, ["photography"]), author_reputation: "5000000000" }, // ~31
+        { ...post("rawhigh", "p2", HOUR, 0, ["photography"]), author_reputation: "300000000000000" }, // ~74
+        { ...post("blankrep", "p3", HOUR, 0, ["photography"]), author_reputation: "" },
+        PAGE[3]
+      ];
+    });
+    const body = await (await run()).json();
+    expect(body.repGated).toBe(1);
+    const posts = shard("posts.xml");
+    expect(posts).not.toContain("/@rawlow/");
+    expect(posts).toContain("/@rawhigh/p2");
+    expect(posts).toContain("/@blankrep/p3");
+  });
+
+  it("advances a shard's index lastmod only when its bytes change", async () => {
+    const t0 = Date.now();
+    vi.useFakeTimers({ toFake: ["Date"], now: t0 });
+    await run();
+    const first = Object.fromEntries(
+      ["posts.xml", "authors.xml", "tags.xml", "communities.xml", "static.xml"].map((n) => [n, indexEntry(n)])
+    );
+    // Same data an hour later: nothing changed, nothing may move.
+    vi.setSystemTime(new Date(t0 + HOUR));
+    await run();
+    for (const [name, lastmod] of Object.entries(first)) expect(indexEntry(name), name).toBe(lastmod);
+    // A new post by a new author changes posts.xml and authors.xml. tags.xml
+    // keeps its bytes (same tag, same newest day) and so keeps its lastmod:
+    // that is the whole point of keying the index on content, not on runs.
+    vi.setSystemTime(new Date(t0 + 2 * HOUR));
+    vi.mocked(callRPC).mockImplementation(async (method: string) => {
+      if (method !== "bridge.get_ranked_posts") return [];
+      return [post("newcomer", "hello", HOUR, 70, ["photography"]), ...PAGE];
+    });
+    const third = await (await run()).json();
+    expect(third.posts).toBe(3);
+    const later = new Date(t0 + 2 * HOUR).toISOString();
+    expect(indexEntry("posts.xml")).toBe(later);
+    expect(indexEntry("authors.xml")).toBe(later);
+    expect(indexEntry("tags.xml")).toBe(first["tags.xml"]);
+    expect(indexEntry("communities.xml")).toBe(first["communities.xml"]);
+    expect(indexEntry("static.xml")).toBe(first["static.xml"]);
+  });
+
+  it("keeps the accepted walk's full timestamp when a later walk is rejected", async () => {
+    const t0 = Date.now();
+    vi.useFakeTimers({ toFake: ["Date"], now: t0 });
+    await run();
+    const accepted = indexEntry("posts.xml");
+    expect(accepted).toBe(new Date(t0).toISOString());
+    const acceptedPosts = shard("posts.xml");
+    // An empty walk that never reaches the cutoff is rejected (0 < 50% of the
+    // last accepted count): the shards and their lastmod must not move.
+    vi.setSystemTime(new Date(t0 + HOUR));
+    vi.mocked(callRPC).mockImplementation(async () => []);
+    const body = await (await run()).json();
+    expect(body.acceptedWalk).toBe(false);
+    expect(shard("posts.xml")).toBe(acceptedPosts);
+    expect(indexEntry("posts.xml")).toBe(accepted);
+    expect(indexEntry("authors.xml")).toBe(accepted);
+    expect(body.lastGoodAt).toBe(accepted);
   });
 });

--- a/apps/web/src/specs/api/sitemap-generate-route.spec.ts
+++ b/apps/web/src/specs/api/sitemap-generate-route.spec.ts
@@ -24,14 +24,18 @@ vi.mock("@/features/seo/seo-redis", () => ({
 
 import { callRPC } from "@ecency/sdk/hive";
 import { POST } from "@/app/api/internal/seo/sitemap-generate/route";
+import { mockEntry } from "../test-utils";
 
 const HOUR = 3_600_000;
 // Bridge timestamps carry no zone suffix; the walk appends "Z" itself.
 const stamp = (agoMs: number) => new Date(Date.now() - agoMs).toISOString().slice(0, 19);
 const day = (agoMs: number) => stamp(agoMs).slice(0, 10);
 
+// Bridge rows as the walk sees them: the shared Entry factory plus the fields
+// the generator reads (created without a zone suffix, the way the bridge
+// emits it, and the row's own author_reputation).
 function post(author: string, permlink: string, agoMs: number, rep: number, tags: string[]) {
-  return {
+  return mockEntry({
     author,
     permlink,
     created: stamp(agoMs),
@@ -42,11 +46,8 @@ function post(author: string, permlink: string, agoMs: number, rep: number, tags
     category: tags[0],
     author_reputation: rep,
     body: "A full paragraph of real prose, long enough not to read as an empty post at all.",
-    json_metadata: { tags, app: "ecency/4.0" },
-    children: 0,
-    net_votes: 3,
-    active_votes: []
-  };
+    json_metadata: { tags, app: "ecency/4.0" }
+  });
 }
 
 // Two indexable posts by a rep-72 author (newest 2h ago), one by a rep-30

--- a/apps/web/src/specs/api/sitemap-generate-route.spec.ts
+++ b/apps/web/src/specs/api/sitemap-generate-route.spec.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@ecency/sdk/hive", () => ({
+  callRPC: vi.fn(),
+  setNodes: vi.fn(),
+  setUserAgent: vi.fn()
+}));
+vi.mock("@/features/seo/cron-auth", () => ({
+  cronAuthorized: () => true,
+  notFound: () => new Response("", { status: 404 })
+}));
+const store = new Map<string, string>();
+vi.mock("@/features/seo/seo-redis", () => ({
+  SEO_REDIS_PREFIX: "seo:",
+  getSeoRedis: () => ({
+    get: async (k: string) => store.get(k) ?? null,
+    set: async (k: string, v: string) => {
+      store.set(k, v);
+      return "OK";
+    }
+  })
+}));
+
+import { callRPC } from "@ecency/sdk/hive";
+import { POST } from "@/app/api/internal/seo/sitemap-generate/route";
+
+const HOUR = 3_600_000;
+// Bridge timestamps carry no zone suffix; the walk appends "Z" itself.
+const stamp = (agoMs: number) => new Date(Date.now() - agoMs).toISOString().slice(0, 19);
+const day = (agoMs: number) => stamp(agoMs).slice(0, 10);
+
+function post(author: string, permlink: string, agoMs: number, rep: number, tags: string[]) {
+  return {
+    author,
+    permlink,
+    created: stamp(agoMs),
+    updated: stamp(agoMs),
+    depth: 0,
+    parent_author: "",
+    parent_permlink: tags[0],
+    category: tags[0],
+    author_reputation: rep,
+    body: "A full paragraph of real prose, long enough not to read as an empty post at all.",
+    json_metadata: { tags, app: "ecency/4.0" },
+    children: 0,
+    net_votes: 3,
+    active_votes: []
+  };
+}
+
+// Two indexable posts by a rep-72 author (newest 2h ago), one by a rep-30
+// author, then a post older than the 48h window so the walk reaches its cutoff.
+const PAGE = [
+  post("goodauthor", "fresh-one", 2 * HOUR, 72.4, ["photography", "travel"]),
+  post("lowrep", "spammy", 3 * HOUR, 30.2, ["photography", "travel"]),
+  post("goodauthor", "older-one", 20 * HOUR, 72.4, ["photography"]),
+  post("ancient", "way-back", 80 * HOUR, 75, ["photography"])
+];
+
+const shard = (name: string) => store.get(`seo:sitemap:${name}`) ?? "";
+
+describe("sitemap-generate route", () => {
+  beforeEach(() => {
+    store.clear();
+    vi.mocked(callRPC).mockImplementation(async (method: string) => {
+      if (method === "bridge.get_ranked_posts") return PAGE;
+      if (method === "bridge.list_communities") return [];
+      return [];
+    });
+  });
+
+  it("drops reputation-gated rows from posts.xml and authors.xml, using the row's author_reputation", async () => {
+    const res = await POST(new Request("http://web/api/internal/seo/sitemap-generate", { method: "POST" }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.posts).toBe(2);
+    expect(body.repGated).toBe(1);
+    expect(body.reachedCutoff).toBe(true);
+
+    const posts = shard("posts.xml");
+    expect(posts).toContain("https://ecency.com/@goodauthor/fresh-one");
+    expect(posts).toContain("https://ecency.com/@goodauthor/older-one");
+    expect(posts).not.toContain("lowrep");
+
+    const authors = shard("authors.xml");
+    expect(authors).toContain("https://ecency.com/@goodauthor/posts");
+    expect(authors).not.toContain("lowrep");
+  });
+
+  it("gives authors.xml and tags.xml a per-entry lastmod equal to the newest indexable post day", async () => {
+    await POST(new Request("http://web/api/internal/seo/sitemap-generate", { method: "POST" }));
+    const newest = day(2 * HOUR);
+    expect(shard("authors.xml")).toContain(
+      `<url><loc>https://ecency.com/@goodauthor/posts</loc><lastmod>${newest}</lastmod></url>`
+    );
+    // "photography" is on both indexable posts (count 2 >= TAG_MIN_COUNT); its
+    // hub last changed when the newest of them was published. "travel" only
+    // reaches the minimum through the gated row, so it is not a hub.
+    const tags = shard("tags.xml");
+    expect(tags).toContain(
+      `<url><loc>https://ecency.com/created/photography</loc><lastmod>${newest}</lastmod></url>`
+    );
+    expect(tags).not.toContain("/created/travel");
+  });
+
+  it("stamps the hourly shards in the index with the run's full W3C datetime and static.xml with the day", async () => {
+    await POST(new Request("http://web/api/internal/seo/sitemap-generate", { method: "POST" }));
+    const index = shard("index");
+    const entry = (name: string) =>
+      index.match(new RegExp(`<loc>https://ecency.com/sitemap/${name}</loc><lastmod>([^<]+)</lastmod>`))?.[1];
+    expect(entry("posts.xml")).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(entry("authors.xml")).toBe(entry("posts.xml"));
+    expect(entry("communities.xml")).toMatch(/T/);
+    expect(entry("static.xml")).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("does not gate when the row carries no author_reputation (the page decides)", async () => {
+    vi.mocked(callRPC).mockImplementation(async (method: string) => {
+      if (method !== "bridge.get_ranked_posts") return [];
+      const { author_reputation: _drop, ...bare } = post("unknownrep", "p", HOUR, 0, ["photography"]);
+      return [bare, PAGE[3]];
+    });
+    const res = await POST(new Request("http://web/api/internal/seo/sitemap-generate", { method: "POST" }));
+    const body = await res.json();
+    expect(body.repGated).toBe(0);
+    expect(shard("posts.xml")).toContain("/@unknownrep/p");
+  });
+});

--- a/apps/web/src/specs/features/seo/sitemap-tags.spec.ts
+++ b/apps/web/src/specs/features/seo/sitemap-tags.spec.ts
@@ -87,4 +87,21 @@ describe("sitemap-tags", () => {
       expect(selectTopTags(new Map([["x", 1]]), 10, 2)).toEqual([]);
     });
   });
+
+  describe("harvestPostTags latest-day tracking", () => {
+    it("records the newest post day per tag when asked, and stays inert otherwise", () => {
+      const counts = new Map<string, number>();
+      const latest = new Map<string, string>();
+      harvestPostTags(counts, "photography", ["Travel"], latest, "2026-08-18");
+      harvestPostTags(counts, "travel", ["photography"], latest, "2026-08-20");
+      harvestPostTags(counts, "photography", [], latest, "2026-08-19");
+      expect(counts.get("photography")).toBe(3);
+      expect(latest.get("photography")).toBe("2026-08-20");
+      expect(latest.get("travel")).toBe("2026-08-20");
+      // Without a day nothing is recorded, and existing dates are not erased.
+      harvestPostTags(counts, "photography", [], latest);
+      expect(latest.get("photography")).toBe("2026-08-20");
+      expect(counts.get("photography")).toBe(4);
+    });
+  });
 });

--- a/apps/web/src/specs/utils/entry-indexability.spec.ts
+++ b/apps/web/src/specs/utils/entry-indexability.spec.ts
@@ -13,7 +13,8 @@ import {
   isContainerTree,
   CONTAINER_ACCOUNTS,
   WAVE_MIN_BODY_CHARS,
-  EFFECTIVELY_EMPTY_MAX_BODY
+  EFFECTIVELY_EMPTY_MAX_BODY,
+  isBelowReputationGate
 } from "../../utils/entry-indexability";
 
 const BASE = "https://ecency.com";
@@ -479,5 +480,20 @@ describe("single-source-of-truth (sitemap generator must call this same predicat
     const e = makeEntry({ depth: 0, body: longBody });
     expect(isIndexable(e, null, true)).toBe(isIndexable(e, null, true));
     expect(isIndexable(e, null, true, true)).toBe(isIndexable(e, null, true, true));
+  });
+});
+
+describe("isBelowReputationGate", () => {
+  it("reads the human-readable bridge author_reputation", () => {
+    expect(isBelowReputationGate(72.1)).toBe(false);
+    expect(isBelowReputationGate(40)).toBe(false);
+    expect(isBelowReputationGate(39.9)).toBe(true); // floors like the page gate
+    expect(isBelowReputationGate(25)).toBe(true);
+  });
+
+  it("reads the raw condenser reputation too", () => {
+    expect(isBelowReputationGate("300000000000000")).toBe(false); // ~74
+    expect(isBelowReputationGate("5000000000")).toBe(true); // ~31
+    expect(isBelowReputationGate(0)).toBe(true); // brand-new account = 25
   });
 });

--- a/apps/web/src/utils/entry-indexability.ts
+++ b/apps/web/src/utils/entry-indexability.ts
@@ -31,6 +31,16 @@ export const CONTAINER_ACCOUNTS = new Set<string>([
 
 const NOINDEX_REPUTATION_THRESHOLD = 40;
 
+/**
+ * The reputation half of shouldApplyNoIndex, for a caller that has no profile
+ * and only the reputation a ranked-posts row already carries (bridge
+ * `author_reputation`, human readable): the sitemap writer. The raw condenser
+ * form is accepted too; accountReputation normalises both. Keeping it here
+ * means the sitemap and the page can never disagree on the threshold.
+ */
+export const isBelowReputationGate = (reputation: number | string): boolean =>
+  accountReputation(reputation) < NOINDEX_REPUTATION_THRESHOLD;
+
 // Wave/snap quality gate (depth-1 in a container tree). Deliberately
 // conservative — index few, widen later from Search Console data.
 export const WAVE_MIN_BODY_CHARS = 100; // stripped prose length
@@ -60,10 +70,11 @@ export const shouldApplyNoIndex = (
   account: ReputationSource,
   fallbackReputation: number
 ): boolean => {
-  const reputationScore = accountReputation(account?.reputation ?? fallbackReputation ?? 0);
   const postCount = typeof account?.post_count === "number" ? account.post_count : 0;
 
-  const belowReputationThreshold = reputationScore < NOINDEX_REPUTATION_THRESHOLD;
+  const belowReputationThreshold = isBelowReputationGate(
+    account?.reputation ?? fallbackReputation ?? 0
+  );
   const lacksPostingHistory = postCount <= 3;
 
   // No-indexed when the author lacks reputation or meaningful posting history.


### PR DESCRIPTION
Closes #1584

What changed

- `entry-indexability.ts`: `isBelowReputationGate()` exposes the reputation half of `shouldApplyNoIndex` (same threshold, same `accountReputation` normalisation) for a caller that has no profile; `shouldApplyNoIndex` uses it, so the page and the sitemap cannot disagree.
- `sitemap-generate/route.ts`: the walk drops rows whose `author_reputation` is under the gate (no extra RPC; absent field = not gated, the page decides), counts them as `repGated` in the meta, records the newest indexable post day per author and per tag, and emits that as the `lastmod` of `authors.xml` and `tags.xml` entries instead of today's date on every line. The index stamps the hourly shards with the run's full W3C datetime; `static.xml` keeps the day.
- `sitemap-tags.ts`: `harvestPostTags` optionally tracks the newest day per tag.

Tests

- New `sitemap-generate-route.spec.ts` (mocked RPC + Redis): gated row excluded from `posts.xml` and `authors.xml`, per-entry lastmod for authors and tags, index datetime shape, no gating when the row carries no reputation.
- `sitemap-tags.spec.ts` and `entry-indexability.spec.ts` extended for the new helpers.

Code-only change to the generator: applies at the next hourly run after deploy, no restart of the scheduler needed.
