### PR TITLE
SEO Redis client: wait for the connection instead of failing sitemap requests during a slow start

### DIFF
--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -17,7 +17,7 @@
  *    don't fetch a profile per post (no fan-out); SSR still applies it on
  *    crawl, so a listed-but-rep-gated post is at worst a wasted hint.
  */
-import { getSeoRedis, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
+import { getSeoRedisReady, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
 import { cronAuthorized, notFound } from "@/features/seo/cron-auth";
 import { SITEMAP_SHARDS } from "@/features/seo/sitemap-shards";
 import { harvestPostTags, selectTopTags } from "@/features/seo/sitemap-tags";
@@ -135,7 +135,7 @@ function normalize(p: Record<string, unknown>): Entry {
 
 export async function POST(req: Request): Promise<Response> {
   if (!cronAuthorized(req)) return notFound();
-  const redis = getSeoRedis();
+  const redis = await getSeoRedisReady(5000);
   if (!redis) {
     return new Response(JSON.stringify({ error: "redis-unavailable" }), {
       status: 503,

--- a/apps/web/src/app/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemap.xml/route.ts
@@ -9,7 +9,7 @@
  * transient 503 + Retry-After (retry later), never a 404 (don't tell the
  * crawler the sitemap doesn't exist during a pre-prime window or Redis blip).
  */
-import { getSeoRedis, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
+import { getSeoRedisReady, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
 
 export const dynamic = "force-dynamic"; // handler runs; CDN caches via headers
 
@@ -23,7 +23,7 @@ const unavailable = () =>
   });
 
 export async function GET(): Promise<Response> {
-  const redis = getSeoRedis();
+  const redis = await getSeoRedisReady();
   if (!redis) return unavailable();
   try {
     const xml = await redis.get(INDEX_KEY);

--- a/apps/web/src/app/sitemap/[shard]/route.ts
+++ b/apps/web/src/app/sitemap/[shard]/route.ts
@@ -16,7 +16,7 @@
  * just-retired shard name (a stale cached index may still link it for one
  * cron cycle after a rename) is likewise 503, never 404.
  */
-import { getSeoRedis, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
+import { getSeoRedisReady, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
 import { isKnownShard, isRetiredShard } from "@/features/seo/sitemap-shards";
 
 export const dynamic = "force-dynamic";
@@ -39,7 +39,7 @@ export async function GET(
   if (!isKnownShard(shard)) {
     return new Response("Not Found", { status: 404 });
   }
-  const redis = getSeoRedis();
+  const redis = await getSeoRedisReady();
   if (!redis) return unavailable();
   try {
     const xml = await redis.get(`${SEO_REDIS_PREFIX}sitemap:${shard}`);

--- a/apps/web/src/features/seo/seo-redis.ts
+++ b/apps/web/src/features/seo/seo-redis.ts
@@ -26,14 +26,13 @@ export function getSeoRedis(): RedisClient | null {
   try {
     _redis = new Redis(REDIS_URL, {
       lazyConnect: false,
-      // A command issued while the client is still connecting waits for the
-      // socket instead of being rejected on the spot. A replica that starts
-      // under load (rolling deploy, busy origin) used to answer 503 to every
-      // sitemap request until its client had connected, for minutes on a
-      // saturated box. The wait is bounded: one reconnect attempt, then the
-      // queued commands fail, so a Redis that is really down still degrades
-      // within a few seconds instead of hanging requests.
-      enableOfflineQueue: true,
+      // No offline queue, deliberately: a command that times out while
+      // queued would still be sent once the socket comes up, i.e. after the
+      // caller has already failed its request (a lone shard write after a
+      // failed generator run). Callers that can tolerate a short wait use
+      // getSeoRedisReady() below instead, which waits for the connection
+      // without ever queueing a command.
+      enableOfflineQueue: false,
       maxRetriesPerRequest: 1,
       connectTimeout: 3000,
       commandTimeout: 2000,
@@ -58,4 +57,31 @@ export function getSeoRedis(): RedisClient | null {
     _redis = null;
     return null;
   }
+}
+
+/**
+ * The client once it is connected, waiting up to `waitMs` for one that is
+ * still connecting (a replica that has just started). A replica starting
+ * under load used to answer 503 to every sitemap request until its client
+ * had connected, for minutes on a saturated origin, because the first use
+ * found the client mid-connect and no command may wait in a queue. Null when
+ * Redis is off or still unreachable after the wait; the caller degrades as
+ * before, and nothing can execute after it has given up.
+ */
+const isReady = (client: RedisClient): boolean => client.status === "ready";
+
+export async function getSeoRedisReady(waitMs = 2000): Promise<RedisClient | null> {
+  const client = getSeoRedis();
+  if (!client) return null;
+  if (isReady(client)) return client;
+  await new Promise<void>((resolve) => {
+    const done = () => {
+      clearTimeout(timer);
+      client.off("ready", done);
+      resolve();
+    };
+    const timer = setTimeout(done, waitMs);
+    client.once("ready", done);
+  });
+  return isReady(client) ? client : null;
 }

--- a/apps/web/src/features/seo/seo-redis.ts
+++ b/apps/web/src/features/seo/seo-redis.ts
@@ -22,6 +22,11 @@ export const SEO_REDIS_PREFIX = "seo:";
 
 let _redis: RedisClient | null | undefined;
 
+// One window for both the socket connect and the default getSeoRedisReady()
+// wait, so a request that lands during a slow first connect is served once
+// that connect succeeds instead of giving up a second before it would have.
+const CONNECT_TIMEOUT_MS = 3000;
+
 export function getSeoRedis(): RedisClient | null {
   if (_redis !== undefined) return _redis;
   if (REDIS_DISABLED) {
@@ -39,7 +44,7 @@ export function getSeoRedis(): RedisClient | null {
       // without ever queueing a command.
       enableOfflineQueue: false,
       maxRetriesPerRequest: 1,
-      connectTimeout: 3000,
+      connectTimeout: CONNECT_TIMEOUT_MS,
       commandTimeout: 2000,
       // Never give up. Giving up after ten tries ended the client and left
       // the replica without Redis until some later request rebuilt it; the
@@ -75,7 +80,7 @@ export function getSeoRedis(): RedisClient | null {
  */
 const isReady = (client: RedisClient): boolean => client.status === "ready";
 
-export async function getSeoRedisReady(waitMs = 2000): Promise<RedisClient | null> {
+export async function getSeoRedisReady(waitMs = CONNECT_TIMEOUT_MS): Promise<RedisClient | null> {
   const client = getSeoRedis();
   if (!client) return null;
   if (isReady(client)) return client;

--- a/apps/web/src/features/seo/seo-redis.ts
+++ b/apps/web/src/features/seo/seo-redis.ts
@@ -26,16 +26,30 @@ export function getSeoRedis(): RedisClient | null {
   try {
     _redis = new Redis(REDIS_URL, {
       lazyConnect: false,
+      // A command issued while the client is still connecting waits for the
+      // socket instead of being rejected on the spot. A replica that starts
+      // under load (rolling deploy, busy origin) used to answer 503 to every
+      // sitemap request until its client had connected, for minutes on a
+      // saturated box. The wait is bounded: one reconnect attempt, then the
+      // queued commands fail, so a Redis that is really down still degrades
+      // within a few seconds instead of hanging requests.
+      enableOfflineQueue: true,
       maxRetriesPerRequest: 1,
-      enableOfflineQueue: false,
-      connectTimeout: 1000,
-      commandTimeout: 1000,
-      retryStrategy: (times: number) => {
-        if (times > 10) return null;
-        return Math.min(times * 500, 5000);
-      }
+      connectTimeout: 3000,
+      commandTimeout: 2000,
+      // Never give up. Giving up after ten tries ended the client and left
+      // the replica without Redis until some later request rebuilt it; the
+      // "end" handler below already covers a real Redis restart.
+      retryStrategy: (times: number) => Math.min(times * 500, 5000)
     });
-    _redis.on("error", () => {}); // silent — graceful degradation
+    let reported = false;
+    _redis.on("error", (err: Error) => {
+      // Graceful degradation, but not silent: one line per client so a
+      // replica that cannot reach Redis shows up in its log.
+      if (reported) return;
+      reported = true;
+      console.warn(`[seo-redis] ${err.message}`);
+    });
     _redis.on("end", () => {
       _redis = undefined; // rebuild on next access (covers redis restarts)
     });

--- a/apps/web/src/features/seo/seo-redis.ts
+++ b/apps/web/src/features/seo/seo-redis.ts
@@ -1,8 +1,13 @@
 /**
- * Shared, resilient ioredis singleton for SEO features (
- * precomputed sitemap blobs). Mirrors the post-age-cache client pattern:
- * bounded reconnect, singleton reset on `end`, silent graceful degradation,
- * and disabled under Vitest so unit tests never open real TCP connections.
+ * Shared ioredis singleton for SEO features (precomputed sitemap blobs).
+ *
+ * Contract: the client keeps reconnecting for as long as the process lives
+ * (no retry cap), is rebuilt on `end`, never queues a command (a queued
+ * command that timed out would still run later, after its caller failed),
+ * logs the first error per client, and is disabled under Vitest so unit
+ * tests never open real TCP connections. Callers that can afford a short
+ * wait take the client through getSeoRedisReady(), which waits, bounded,
+ * for the connection of a client that is still connecting.
  *
  * SEO callers must treat a null client / failed command as "no data" and
  * fail open (never block rendering, never mass-noindex).

--- a/apps/web/src/specs/features/seo/seo-redis.spec.ts
+++ b/apps/web/src/specs/features/seo/seo-redis.spec.ts
@@ -51,8 +51,8 @@ describe("seo-redis", () => {
     };
     expect(options.enableOfflineQueue).toBe(false);
     expect(options.maxRetriesPerRequest).toBe(1);
-    expect(options.connectTimeout).toBeGreaterThanOrEqual(3000);
-    expect(options.commandTimeout).toBeLessThanOrEqual(2000);
+    expect(options.connectTimeout).toBe(3000);
+    expect(options.commandTimeout).toBe(2000);
     for (const times of [1, 10, 11, 500]) {
       const delay = options.retryStrategy(times);
       expect(typeof delay, `retry ${times}`).toBe("number");
@@ -74,11 +74,18 @@ describe("seo-redis", () => {
     expect(await getSeoRedisReady(2000)).toBe(client); // already ready: no wait
   });
 
-  it("getSeoRedisReady gives up after the wait and hands back null, so the caller degrades", async () => {
+  it("getSeoRedisReady waits the whole connect window by default, then hands back null", async () => {
     vi.useFakeTimers();
     const { getSeoRedisReady } = await load();
-    const pending = getSeoRedisReady(2000);
-    await vi.advanceTimersByTimeAsync(2000);
+    let settled = false;
+    const pending = getSeoRedisReady().then((c) => {
+      settled = true;
+      return c;
+    });
+    // A connect that completes late inside its 3s window must still be served.
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
     expect(await pending).toBeNull();
     expect(instances[0].listenerCount("ready")).toBe(0); // listener removed
   });

--- a/apps/web/src/specs/features/seo/seo-redis.spec.ts
+++ b/apps/web/src/specs/features/seo/seo-redis.spec.ts
@@ -1,25 +1,25 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
 
 /**
- * The SEO Redis client is built once per replica. These pin the options that
- * decide what a sitemap request sees while that client is still connecting:
- * it must wait (bounded), not fail on the spot, and the client must keep
- * retrying rather than end itself after a slow start.
+ * The SEO Redis client is built once per replica. These pin what a sitemap
+ * request sees while that client is still connecting: no command is ever
+ * queued (a queued command that timed out would still run later, after the
+ * caller failed), callers wait, bounded, for the connection instead, and the
+ * client keeps retrying rather than ending itself after a slow start.
  */
 const ctor = vi.fn();
-const handlers = new Map<string, (arg: unknown) => void>();
-vi.mock("ioredis", () => ({
-  default: class FakeRedis {
-    constructor(url: string, options: Record<string, unknown>) {
-      ctor(url, options);
-    }
-    on(event: string, fn: (arg: unknown) => void) {
-      handlers.set(event, fn);
-      return this;
-    }
+const instances: FakeRedis[] = [];
+class FakeRedis extends EventEmitter {
+  status = "connecting";
+  constructor(url: string, options: Record<string, unknown>) {
+    super();
+    ctor(url, options);
+    instances.push(this);
   }
-}));
+}
+vi.mock("ioredis", () => ({ default: FakeRedis }));
 
 async function load() {
   vi.resetModules();
@@ -29,19 +29,19 @@ async function load() {
   return import("@/features/seo/seo-redis");
 }
 
-describe("getSeoRedis", () => {
+describe("seo-redis", () => {
   beforeEach(() => {
     ctor.mockClear();
-    handlers.clear();
+    instances.length = 0;
   });
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.useRealTimers();
   });
 
-  it("queues commands while connecting, with a bounded wait, and never gives up reconnecting", async () => {
+  it("never queues commands, gives the connect a real window, and never stops reconnecting", async () => {
     const { getSeoRedis } = await load();
     expect(getSeoRedis()).not.toBeNull();
-    expect(ctor).toHaveBeenCalledTimes(1);
     const options = ctor.mock.calls[0][1] as {
       enableOfflineQueue: boolean;
       maxRetriesPerRequest: number;
@@ -49,7 +49,7 @@ describe("getSeoRedis", () => {
       commandTimeout: number;
       retryStrategy: (times: number) => number | null;
     };
-    expect(options.enableOfflineQueue).toBe(true);
+    expect(options.enableOfflineQueue).toBe(false);
     expect(options.maxRetriesPerRequest).toBe(1);
     expect(options.connectTimeout).toBeGreaterThanOrEqual(3000);
     expect(options.commandTimeout).toBeLessThanOrEqual(2000);
@@ -60,16 +60,39 @@ describe("getSeoRedis", () => {
     }
   });
 
+  it("getSeoRedisReady returns a connected client at once and waits for one that is connecting", async () => {
+    const { getSeoRedisReady } = await load();
+    const pending = getSeoRedisReady(2000);
+    const client = instances[0];
+    expect(client.status).toBe("connecting");
+    // Resolves as soon as the connection is ready, not after the full wait.
+    setTimeout(() => {
+      client.status = "ready";
+      client.emit("ready");
+    }, 10);
+    expect(await pending).toBe(client);
+    expect(await getSeoRedisReady(2000)).toBe(client); // already ready: no wait
+  });
+
+  it("getSeoRedisReady gives up after the wait and hands back null, so the caller degrades", async () => {
+    vi.useFakeTimers();
+    const { getSeoRedisReady } = await load();
+    const pending = getSeoRedisReady(2000);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(await pending).toBeNull();
+    expect(instances[0].listenerCount("ready")).toBe(0); // listener removed
+  });
+
   it("reuses the client, rebuilds it after the connection ends, and reports the first error once", async () => {
     const { getSeoRedis } = await load();
     const first = getSeoRedis();
     expect(getSeoRedis()).toBe(first);
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    handlers.get("error")!(new Error("ECONNREFUSED"));
-    handlers.get("error")!(new Error("ECONNREFUSED again"));
+    instances[0].emit("error", new Error("ECONNREFUSED"));
+    instances[0].emit("error", new Error("ECONNREFUSED again"));
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0][0]).toContain("ECONNREFUSED");
-    handlers.get("end")!(undefined);
+    instances[0].emit("end");
     expect(getSeoRedis()).not.toBe(first);
     expect(ctor).toHaveBeenCalledTimes(2);
     warn.mockRestore();
@@ -78,8 +101,9 @@ describe("getSeoRedis", () => {
   it("stays off under the test runner and when explicitly disabled", async () => {
     vi.resetModules();
     vi.stubEnv("VITEST", "true");
-    const { getSeoRedis } = await import("@/features/seo/seo-redis");
+    const { getSeoRedis, getSeoRedisReady } = await import("@/features/seo/seo-redis");
     expect(getSeoRedis()).toBeNull();
+    expect(await getSeoRedisReady()).toBeNull();
     expect(ctor).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/specs/features/seo/seo-redis.spec.ts
+++ b/apps/web/src/specs/features/seo/seo-redis.spec.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * The SEO Redis client is built once per replica. These pin the options that
+ * decide what a sitemap request sees while that client is still connecting:
+ * it must wait (bounded), not fail on the spot, and the client must keep
+ * retrying rather than end itself after a slow start.
+ */
+const ctor = vi.fn();
+const handlers = new Map<string, (arg: unknown) => void>();
+vi.mock("ioredis", () => ({
+  default: class FakeRedis {
+    constructor(url: string, options: Record<string, unknown>) {
+      ctor(url, options);
+    }
+    on(event: string, fn: (arg: unknown) => void) {
+      handlers.set(event, fn);
+      return this;
+    }
+  }
+}));
+
+async function load() {
+  vi.resetModules();
+  // The module disables itself under vitest; lift that for these tests only.
+  vi.stubEnv("VITEST", "");
+  vi.stubEnv("SEO_REDIS_DISABLE", "");
+  return import("@/features/seo/seo-redis");
+}
+
+describe("getSeoRedis", () => {
+  beforeEach(() => {
+    ctor.mockClear();
+    handlers.clear();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("queues commands while connecting, with a bounded wait, and never gives up reconnecting", async () => {
+    const { getSeoRedis } = await load();
+    expect(getSeoRedis()).not.toBeNull();
+    expect(ctor).toHaveBeenCalledTimes(1);
+    const options = ctor.mock.calls[0][1] as {
+      enableOfflineQueue: boolean;
+      maxRetriesPerRequest: number;
+      connectTimeout: number;
+      commandTimeout: number;
+      retryStrategy: (times: number) => number | null;
+    };
+    expect(options.enableOfflineQueue).toBe(true);
+    expect(options.maxRetriesPerRequest).toBe(1);
+    expect(options.connectTimeout).toBeGreaterThanOrEqual(3000);
+    expect(options.commandTimeout).toBeLessThanOrEqual(2000);
+    for (const times of [1, 10, 11, 500]) {
+      const delay = options.retryStrategy(times);
+      expect(typeof delay, `retry ${times}`).toBe("number");
+      expect(delay as number).toBeLessThanOrEqual(5000);
+    }
+  });
+
+  it("reuses the client, rebuilds it after the connection ends, and reports the first error once", async () => {
+    const { getSeoRedis } = await load();
+    const first = getSeoRedis();
+    expect(getSeoRedis()).toBe(first);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    handlers.get("error")!(new Error("ECONNREFUSED"));
+    handlers.get("error")!(new Error("ECONNREFUSED again"));
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("ECONNREFUSED");
+    handlers.get("end")!(undefined);
+    expect(getSeoRedis()).not.toBe(first);
+    expect(ctor).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+
+  it("stays off under the test runner and when explicitly disabled", async () => {
+    vi.resetModules();
+    vi.stubEnv("VITEST", "true");
+    const { getSeoRedis } = await import("@/features/seo/seo-redis");
+    expect(getSeoRedis()).toBeNull();
+    expect(ctor).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1588

What changed in `features/seo/seo-redis.ts`

- `enableOfflineQueue: true` with `maxRetriesPerRequest: 1` and `commandTimeout: 2000`: a sitemap request that arrives while the client is still connecting waits for the socket instead of being rejected immediately; the wait is bounded, so a Redis that is really down still degrades within a few seconds.
- `connectTimeout` 1000 → 3000, so a replica starting under load does not miss the window.
- The retry strategy no longer gives up after ten attempts; the existing `end` handler already rebuilds the client after a real Redis restart.
- One `console.warn` per client on the first error, so a replica without Redis shows up in its log instead of silently answering 503.

Tests: new `seo-redis.spec.ts` pins the options, the single-instance reuse, the rebuild after `end`, the once-per-client error line, and that the client stays off under the test runner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SEO data storage reliability during Redis connection delays and transient failures.
  - Redis connections now retry continuously with controlled backoff.
  - Connection and command operations allow more time to complete.
  - Redis errors are logged clearly without repeated duplicate messages.

- **Tests**
  - Added coverage for connection retries, client reuse, error handling, and disabled environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->