### PR TITLE
Sitemap: operator-seeded shards, listed in the index while their blob exists

### DIFF
--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -425,10 +425,11 @@ export async function POST(req: Request): Promise<Response> {
     reachedCutoff || lastGood === 0 || postUrls.length >= Math.ceil(lastGood * 0.5);
   const WALK_DERIVED = new Set<string>(["posts.xml", "authors.xml", "tags.xml"]);
 
-  // Writer/index/route stay in lockstep: every shard we emit — and every
-  // child the index points at — comes from the single shared SITEMAP_SHARDS
-  // allowlist the public route validates against. A name here that isn't in
-  // that list is a compile error (keyof typeof), not a silent prod 404.
+  // Writer/index/route stay in lockstep: every shard we emit comes from the
+  // shared SITEMAP_SHARDS allowlist, and the index may additionally list an
+  // OPERATOR_SHARDS entry while its blob exists (below). The public route
+  // validates against both. A generated name that isn't in SITEMAP_SHARDS is
+  // a compile error (keyof typeof), not a silent prod 404.
   const shardXml: Record<(typeof SITEMAP_SHARDS)[number], string> = {
     "posts.xml": urlset(postUrls),
     "authors.xml": urlset(authorUrls),
@@ -481,8 +482,8 @@ export async function POST(req: Request): Promise<Response> {
       lastmod: lastmods[name]
     }));
     for (const name of OPERATOR_SHARDS) {
-      const blob = await redis.get(K(name));
-      if (!blob) continue;
+      // Existence only: the blob may be large and is never read here.
+      if (!(await redis.exists(K(name)))) continue;
       const lastmod = (await redis.get(`${K(name)}:lastmod`)) || recorded[name] || nowDay;
       lastmods[name] = lastmod;
       children.push({ name, lastmod });

--- a/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
+++ b/apps/web/src/app/api/internal/seo/sitemap-generate/route.ts
@@ -20,7 +20,7 @@
  */
 import { getSeoRedis, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
 import { cronAuthorized, notFound } from "@/features/seo/cron-auth";
-import { SITEMAP_SHARDS } from "@/features/seo/sitemap-shards";
+import { SITEMAP_SHARDS, OPERATOR_SHARDS } from "@/features/seo/sitemap-shards";
 import { harvestPostTags, selectTopTags } from "@/features/seo/sitemap-tags";
 import { isIndexable, canonicalTarget, isBelowReputationGate } from "@/utils/entry-indexability";
 import { isNsfwCommunity } from "@/utils/nsfw-detection";
@@ -472,12 +472,24 @@ export async function POST(req: Request): Promise<Response> {
       lastmods[name] = changed || !recorded[name] ? nowIso : recorded[name];
       toWrite.push(name);
     }
+    // Operator-seeded shards ride along in the index while their blob
+    // exists; their lastmod is whatever the operator set beside the blob (or
+    // the previously recorded one), never this run's time: nothing here
+    // changed them.
+    const children: { name: string; lastmod: string }[] = SITEMAP_SHARDS.map((name) => ({
+      name,
+      lastmod: lastmods[name]
+    }));
+    for (const name of OPERATOR_SHARDS) {
+      const blob = await redis.get(K(name));
+      if (!blob) continue;
+      const lastmod = (await redis.get(`${K(name)}:lastmod`)) || recorded[name] || nowDay;
+      lastmods[name] = lastmod;
+      children.push({ name, lastmod });
+    }
     await redis.set(K("lastmod"), JSON.stringify(lastmods));
     for (const name of toWrite) await redis.set(K(name), shardXml[name]);
-    await redis.set(
-      K("index"),
-      indexXml(SITEMAP_SHARDS.map((name) => ({ name, lastmod: lastmods[name] })))
-    );
+    await redis.set(K("index"), indexXml(children));
     if (acceptWalk) {
       await redis.set(POSTS_LASTGOOD_KEY, String(postUrls.length));
       // Full datetime, so a later rejected walk advertises exactly the

--- a/apps/web/src/app/sitemap/[shard]/route.ts
+++ b/apps/web/src/app/sitemap/[shard]/route.ts
@@ -15,9 +15,15 @@
  * so the engine retries instead of dropping a real, advertised resource. A
  * just-retired shard name (a stale cached index may still link it for one
  * cron cycle after a rename) is likewise 503, never 404.
+ *
+ * Operator-seeded shards (`OPERATOR_SHARDS`) invert that last rule: their
+ * blob is the only thing that makes them exist, so a missing blob means the
+ * operator retired the shard and the answer is 404, not "retry later". The
+ * generator drops it from the index on its next run; until then a crawler
+ * holding the old index gets a clean "gone" and stops asking.
  */
 import { getSeoRedis, SEO_REDIS_PREFIX } from "@/features/seo/seo-redis";
-import { isKnownShard, isRetiredShard } from "@/features/seo/sitemap-shards";
+import { isKnownShard, isOperatorShard, isRetiredShard } from "@/features/seo/sitemap-shards";
 
 export const dynamic = "force-dynamic";
 
@@ -43,7 +49,10 @@ export async function GET(
   if (!redis) return unavailable();
   try {
     const xml = await redis.get(`${SEO_REDIS_PREFIX}sitemap:${shard}`);
-    if (!xml) return unavailable();
+    if (!xml) {
+      if (isOperatorShard(shard)) return new Response("Not Found", { status: 404 });
+      return unavailable();
+    }
     return new Response(xml, {
       status: 200,
       headers: {

--- a/apps/web/src/features/seo/sitemap-shards.ts
+++ b/apps/web/src/features/seo/sitemap-shards.ts
@@ -29,6 +29,12 @@ export const OPERATOR_SHARDS = ["recovery.xml"] as const;
 export type SitemapShard = (typeof SITEMAP_SHARDS)[number] | (typeof OPERATOR_SHARDS)[number];
 
 const SHARD_SET: ReadonlySet<string> = new Set<string>([...SITEMAP_SHARDS, ...OPERATOR_SHARDS]);
+const OPERATOR_SET: ReadonlySet<string> = new Set<string>(OPERATOR_SHARDS);
+
+/** An operator shard with no blob is retired, not pending: the route 404s it. */
+export function isOperatorShard(name: string): boolean {
+  return OPERATOR_SET.has(name);
+}
 
 export function isKnownShard(name: string): name is SitemapShard {
   return SHARD_SET.has(name);

--- a/apps/web/src/features/seo/sitemap-shards.ts
+++ b/apps/web/src/features/seo/sitemap-shards.ts
@@ -17,9 +17,18 @@ export const SITEMAP_SHARDS = [
   "static.xml"
 ] as const;
 
-export type SitemapShard = (typeof SITEMAP_SHARDS)[number];
+/**
+ * Shards an operator seeds straight into Redis (blob under the shard key, an
+ * optional `<key>:lastmod` beside it). The generator never writes them; it
+ * lists one in the sitemap index only while its blob exists, so removing the
+ * key retires the shard on the next run. Used for bounded, temporary lists,
+ * e.g. pages that need a recrawl after an indexability rule changed.
+ */
+export const OPERATOR_SHARDS = ["recovery.xml"] as const;
 
-const SHARD_SET: ReadonlySet<string> = new Set(SITEMAP_SHARDS);
+export type SitemapShard = (typeof SITEMAP_SHARDS)[number] | (typeof OPERATOR_SHARDS)[number];
+
+const SHARD_SET: ReadonlySet<string> = new Set<string>([...SITEMAP_SHARDS, ...OPERATOR_SHARDS]);
 
 export function isKnownShard(name: string): name is SitemapShard {
   return SHARD_SET.has(name);

--- a/apps/web/src/specs/api/sitemap-generate-route.spec.ts
+++ b/apps/web/src/specs/api/sitemap-generate-route.spec.ts
@@ -14,6 +14,7 @@ const store = new Map<string, string>();
 let failNextSetMatching = "";
 const fakeRedis = () => ({
     get: async (k: string) => store.get(k) ?? null,
+    exists: async (k: string) => (store.has(k) ? 1 : 0),
     set: async (k: string, v: string) => {
       if (failNextSetMatching && k.includes(failNextSetMatching)) {
         failNextSetMatching = "";
@@ -239,6 +240,10 @@ describe("sitemap-generate route", () => {
     await run();
     expect(indexEntry("recovery.xml")).toBe("2026-08-18");
     expect(shard("recovery.xml")).toBe("<urlset/>"); // untouched by the generator
+    // Presence is by key, not by content: an empty value still lists it.
+    store.set("seo:sitemap:recovery.xml", "");
+    await run();
+    expect(indexEntry("recovery.xml")).toBe("2026-08-18");
     store.delete("seo:sitemap:recovery.xml");
     await run();
     expect(shard("index")).not.toContain("recovery.xml");

--- a/apps/web/src/specs/api/sitemap-generate-route.spec.ts
+++ b/apps/web/src/specs/api/sitemap-generate-route.spec.ts
@@ -230,4 +230,17 @@ describe("sitemap-generate route", () => {
     expect(shard("posts.xml")).toContain("newcomer");
     expect(indexEntry("posts.xml")).toBe(new Date(t0 + 2 * HOUR).toISOString());
   });
+
+  it("lists an operator-seeded shard in the index only while its blob exists, with the operator's lastmod", async () => {
+    await run();
+    expect(shard("index")).not.toContain("recovery.xml");
+    store.set("seo:sitemap:recovery.xml", "<urlset/>");
+    store.set("seo:sitemap:recovery.xml:lastmod", "2026-08-18");
+    await run();
+    expect(indexEntry("recovery.xml")).toBe("2026-08-18");
+    expect(shard("recovery.xml")).toBe("<urlset/>"); // untouched by the generator
+    store.delete("seo:sitemap:recovery.xml");
+    await run();
+    expect(shard("index")).not.toContain("recovery.xml");
+  });
 });

--- a/apps/web/src/specs/api/sitemap-shard-route.spec.ts
+++ b/apps/web/src/specs/api/sitemap-shard-route.spec.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const store = new Map<string, string>();
+const fakeRedis = () => ({ get: async (k: string) => store.get(k) ?? null });
+vi.mock("@/features/seo/seo-redis", () => ({
+  SEO_REDIS_PREFIX: "seo:",
+  getSeoRedis: () => fakeRedis(),
+  getSeoRedisReady: async () => fakeRedis()
+}));
+
+import { GET } from "@/app/sitemap/[shard]/route";
+
+const get = (shard: string) =>
+  GET(new Request(`http://web/sitemap/${shard}`), { params: Promise.resolve({ shard }) });
+
+/**
+ * Status semantics the crawlers depend on: a generated shard that is missing
+ * from Redis is a transient 503 (it is advertised and will come back), an
+ * unknown name is 404, and an operator shard without a blob is 404 too: the
+ * blob is what makes it exist, so its absence means the operator retired it.
+ */
+describe("sitemap shard route", () => {
+  beforeEach(() => store.clear());
+
+  it("serves a generated shard from Redis and 503s while it is not there yet", async () => {
+    expect((await get("posts.xml")).status).toBe(503);
+    store.set("seo:sitemap:posts.xml", "<urlset/>");
+    const res = await get("posts.xml");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("<urlset/>");
+  });
+
+  it("404s an unknown name", async () => {
+    expect((await get("nope.xml")).status).toBe(404);
+  });
+
+  it("serves an operator shard while seeded and 404s it once the operator removed the blob", async () => {
+    expect((await get("recovery.xml")).status).toBe(404);
+    store.set("seo:sitemap:recovery.xml", "<urlset/>");
+    expect((await get("recovery.xml")).status).toBe(200);
+    store.delete("seo:sitemap:recovery.xml");
+    const gone = await get("recovery.xml");
+    expect(gone.status).toBe(404);
+    expect(gone.headers.get("Retry-After")).toBeNull();
+  });
+});

--- a/apps/web/src/specs/api/sitemap-shard-route.spec.ts
+++ b/apps/web/src/specs/api/sitemap-shard-route.spec.ts
@@ -2,7 +2,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const store = new Map<string, string>();
-const fakeRedis = () => ({ get: async (k: string) => store.get(k) ?? null });
+const fakeRedis = () => ({
+  get: async (k: string) => store.get(k) ?? null,
+  exists: async (k: string) => (store.has(k) ? 1 : 0)
+});
 vi.mock("@/features/seo/seo-redis", () => ({
   SEO_REDIS_PREFIX: "seo:",
   getSeoRedis: () => fakeRedis(),

--- a/apps/web/src/specs/features/seo/sitemap-shards.spec.ts
+++ b/apps/web/src/specs/features/seo/sitemap-shards.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   SITEMAP_SHARDS,
   OPERATOR_SHARDS,
+  isOperatorShard,
   isKnownShard,
   isRetiredShard
 } from "@/features/seo/sitemap-shards";
@@ -52,8 +53,10 @@ describe("sitemap-shards", () => {
     it("are known to the public route but never part of the generated set", () => {
       for (const shard of OPERATOR_SHARDS) {
         expect(isKnownShard(shard)).toBe(true);
+        expect(isOperatorShard(shard)).toBe(true);
         expect((SITEMAP_SHARDS as readonly string[]).includes(shard)).toBe(false);
       }
+      for (const shard of SITEMAP_SHARDS) expect(isOperatorShard(shard)).toBe(false);
     });
   });
 });

--- a/apps/web/src/specs/features/seo/sitemap-shards.spec.ts
+++ b/apps/web/src/specs/features/seo/sitemap-shards.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   SITEMAP_SHARDS,
+  OPERATOR_SHARDS,
   isKnownShard,
   isRetiredShard
 } from "@/features/seo/sitemap-shards";
@@ -43,6 +44,15 @@ describe("sitemap-shards", () => {
     it("never overlaps the live shard allowlist", () => {
       for (const shard of SITEMAP_SHARDS) {
         expect(isRetiredShard(shard)).toBe(false);
+      }
+    });
+  });
+
+  describe("operator shards", () => {
+    it("are known to the public route but never part of the generated set", () => {
+      for (const shard of OPERATOR_SHARDS) {
+        expect(isKnownShard(shard)).toBe(true);
+        expect((SITEMAP_SHARDS as readonly string[]).includes(shard)).toBe(false);
       }
     });
   });


### PR DESCRIPTION
Closes #1590

What changed

- `sitemap-shards.ts`: `OPERATOR_SHARDS` (`recovery.xml`), known to the public shard route but not part of the generated set.
- `sitemap-generate/route.ts`: after the generated shards, each operator shard whose blob exists in Redis is added to the sitemap index with the lastmod stored beside it (or the previously recorded one); the generator never writes the blob and never stamps it with the run's time. Removing the key retires the shard on the next run.
- Specs: allowlist test for operator shards; route test that the index lists the shard only while the blob exists and carries the operator's lastmod.

Operation (outside the repo): the recovery list is seeded per origin under `seo:sitemap:recovery.xml` with `seo:sitemap:recovery.xml:lastmod` set to the day the blacklist gate was removed; it is deleted once Search Console shows the affected pages recrawled.
