### PR TITLE
Prefetch feed links on intent instead of on viewport entry

### DIFF
--- a/apps/web/src/app/_components/community-list-item/index.tsx
+++ b/apps/web/src/app/_components/community-list-item/index.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import "./index.scss";
-import Link from "next/link";
+import { IntentLink } from "@/features/shared/intent-link";
 import { Community } from "@/entities";
 import { ProfileLink, UserAvatar } from "@/features/shared";
 import { SubscriptionBtn } from "../../communities/_components/subscription-btn";
@@ -34,7 +34,7 @@ export function CommunityListItem({ community, small, vertical }: Props) {
         <h2 className="item-title">
           <div className="item-details">
             <UserAvatar username={community.name} size={small ? "small" : "medium"} />
-            <Link href={makePath(AllFilter.hot, community.name)}>{community.title}</Link>
+            <IntentLink href={makePath(AllFilter.hot, community.name)}>{community.title}</IntentLink>
           </div>
           {small && (
             <div className="item-controls">

--- a/apps/web/src/features/shared/entry-link/index.tsx
+++ b/apps/web/src/features/shared/entry-link/index.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren } from "react";
 import { Entry } from "@/entities";
-import Link from "next/link";
+import { IntentLink } from "@/features/shared/intent-link";
 import { makeEntryPath } from "@/utils/make-path";
 
 export interface PartialEntry {
@@ -19,10 +19,8 @@ export function EntryLink({ children, entry, target, className }: PropsWithChild
   const path = makeEntryPath(entry.category, entry.author, entry.permlink);
 
   return (
-    <Link href={path} target={target} className={className + " no-style"}>
-
+    <IntentLink href={path} target={target} className={className + " no-style"}>
       {children}
-
-    </Link>
+    </IntentLink>
   );
 }

--- a/apps/web/src/features/shared/intent-link/index.tsx
+++ b/apps/web/src/features/shared/intent-link/index.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import Link from "next/link";
+import React, { useCallback, useContext, useRef } from "react";
+import {
+  AppRouterContext,
+  type PrefetchOptions
+} from "next/dist/shared/lib/app-router-context.shared-runtime";
+
+type LinkProps = React.ComponentProps<typeof Link>;
+
+// Every caller passes a path string; keeping the prop to strings means no
+// supported href shape can silently end up with neither kind of prefetch.
+export type IntentLinkProps = Omit<LinkProps, "prefetch" | "href"> & { href: string };
+
+// Same kind a Link's viewport prefetch uses (PrefetchKind.AUTO), written as the
+// literal so the only runtime import from Next internals is the router context,
+// which next/link itself reads.
+const AUTO: PrefetchOptions = { kind: "auto" as PrefetchOptions["kind"] };
+
+/**
+ * `next/link` that prefetches on intent (hover / touch / focus) instead of on
+ * viewport entry.
+ *
+ * A feed page renders ~120 links (five per card plus the tag and community
+ * widgets). With the default `prefetch`, every one of them fires an RSC request
+ * as it scrolls into view: ~100 requests and ~1 MB on a desktop /trending, and
+ * an origin render for each (#1593). Next's `prefetch={false}` switches ALL
+ * prefetching off, including hover, so this pairs it with an explicit
+ * `router.prefetch` the moment the reader signals intent, keeping soft
+ * navigation as quick as before for the link they actually click.
+ *
+ * The prefetch uses the same "auto" kind as the default viewport prefetch, so
+ * a hover costs the origin exactly what a viewport entry used to, never more.
+ */
+export function IntentLink({
+  href,
+  target,
+  onMouseEnter,
+  onTouchStart,
+  onFocus,
+  ...rest
+}: IntentLinkProps) {
+  // Read the context directly rather than via useRouter(): the wrappers that
+  // render this are also mounted in tests and in trees without an app router,
+  // and a missing router simply means nothing to prefetch.
+  const router = useContext(AppRouterContext);
+  const prefetched = useRef<string | null>(null);
+
+  const prefetch = useCallback(() => {
+    if (!router || !isInternal(href) || opensNewContext(target)) {
+      return;
+    }
+    if (prefetched.current === href || !networkAllowsPrefetch()) {
+      return;
+    }
+    try {
+      router.prefetch(href, AUTO);
+      // Only a prefetch that was issued counts; a throw leaves the next
+      // intent free to retry.
+      prefetched.current = href;
+    } catch {
+      // A failed prefetch only means the click fetches the route instead.
+    }
+  }, [router, href, target]);
+
+  return (
+    <Link
+      {...rest}
+      href={href}
+      target={target}
+      prefetch={false}
+      onMouseEnter={(e) => {
+        onMouseEnter?.(e);
+        prefetch();
+      }}
+      onTouchStart={(e) => {
+        onTouchStart?.(e);
+        prefetch();
+      }}
+      onFocus={(e) => {
+        onFocus?.(e);
+        prefetch();
+      }}
+    />
+  );
+}
+
+function isInternal(href: string): boolean {
+  return href.startsWith("/") && !href.startsWith("//");
+}
+
+// target keywords are case-insensitive in HTML.
+function opensNewContext(target: string | undefined): boolean {
+  return typeof target === "string" && target.toLowerCase() === "_blank";
+}
+
+interface NetworkInformationLike {
+  saveData?: boolean;
+  effectiveType?: string;
+}
+
+// Mirrors the conditions under which next/link itself declines to prefetch.
+function networkAllowsPrefetch(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  const connection = (navigator as Navigator & { connection?: NetworkInformationLike }).connection;
+  if (!connection) {
+    return true;
+  }
+  if (connection.saveData) {
+    return false;
+  }
+  return !/2g/.test(connection.effectiveType ?? "");
+}

--- a/apps/web/src/features/shared/profile-link/index.tsx
+++ b/apps/web/src/features/shared/profile-link/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import Link from "next/link";
+import { IntentLink } from "@/features/shared/intent-link";
 
 export const makePathProfile = (username: string) => `/@${username}`;
 
@@ -17,7 +17,7 @@ export function ProfileLink({ afterClick, target, className, children, username 
   };
 
   return (
-    <Link
+    <IntentLink
       href={makePathProfile(username)}
       target={target}
       className={className}
@@ -25,7 +25,7 @@ export function ProfileLink({ afterClick, target, className, children, username 
       aria-label={`@${username}`}
     >
       {children}
-    </Link>
+    </IntentLink>
   );
 }
 

--- a/apps/web/src/features/shared/tag/index.tsx
+++ b/apps/web/src/features/shared/tag/index.tsx
@@ -7,7 +7,7 @@ import { getCommunityCache } from "@/core/caches";
 import i18next from "i18next";
 import { useRouter } from "next/navigation";
 import { Badge } from "@ui/badge";
-import Link from "next/link";
+import { IntentLink } from "@/features/shared/intent-link";
 import { useQuery } from "@tanstack/react-query";
 
 export const makePathTag = (filter: string, tag: string): string => {
@@ -61,7 +61,7 @@ export function TagLink({ tag, type, children }: Props) {
       }
     );
 
-    return <Link {...props} />;
+    return <IntentLink {...props} />;
   } else if (type === "span") {
     const props = Object.assign({}, children.props);
 

--- a/apps/web/src/specs/features/shared/intent-link.spec.tsx
+++ b/apps/web/src/specs/features/shared/intent-link.spec.tsx
@@ -1,0 +1,181 @@
+import { vi } from "vitest";
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import { IntentLink } from "@/features/shared/intent-link";
+import { EntryLink } from "@/features/shared/entry-link";
+import { ProfileLink } from "@/features/shared/profile-link";
+
+function makeRouter() {
+  return {
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    hmrRefresh: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn()
+  };
+}
+
+function renderWithRouter(ui: React.ReactElement, router = makeRouter()) {
+  const result = render(
+    <AppRouterContext.Provider value={router as never}>{ui}</AppRouterContext.Provider>
+  );
+  return { ...result, router };
+}
+
+describe("IntentLink (#1593)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (navigator as Navigator & { connection?: unknown }).connection;
+  });
+
+  it("renders a plain anchor with the href and no viewport prefetch", () => {
+    renderWithRouter(
+      <IntentLink href="/@alice" className="x">
+        alice
+      </IntentLink>
+    );
+    const link = screen.getByRole("link", { name: "alice" });
+    expect(link).toHaveAttribute("href", "/@alice");
+    expect(link).toHaveClass("x");
+  });
+
+  it("prefetches once on hover with the same kind as a viewport prefetch", () => {
+    const { router } = renderWithRouter(<IntentLink href="/@alice">alice</IntentLink>);
+    const link = screen.getByRole("link");
+    fireEvent.mouseEnter(link);
+    fireEvent.mouseEnter(link);
+    fireEvent.focus(link);
+    expect(router.prefetch).toHaveBeenCalledTimes(1);
+    expect(router.prefetch).toHaveBeenCalledWith("/@alice", { kind: "auto" });
+  });
+
+  it("prefetches on touchstart, for readers without a hover", () => {
+    const { router } = renderWithRouter(<IntentLink href="/hot/hive-125125">c</IntentLink>);
+    fireEvent.touchStart(screen.getByRole("link"));
+    expect(router.prefetch).toHaveBeenCalledWith("/hot/hive-125125", { kind: "auto" });
+  });
+
+  it("still calls the caller's own hover/touch/focus handlers", () => {
+    const onMouseEnter = vi.fn();
+    const onTouchStart = vi.fn();
+    const onFocus = vi.fn();
+    renderWithRouter(
+      <IntentLink
+        href="/@alice"
+        onMouseEnter={onMouseEnter}
+        onTouchStart={onTouchStart}
+        onFocus={onFocus}
+      >
+        alice
+      </IntentLink>
+    );
+    const link = screen.getByRole("link");
+    fireEvent.mouseEnter(link);
+    fireEvent.touchStart(link);
+    fireEvent.focus(link);
+    expect(onMouseEnter).toHaveBeenCalledTimes(1);
+    expect(onTouchStart).toHaveBeenCalledTimes(1);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not prefetch external links or links that open a new tab", () => {
+    const { router } = renderWithRouter(
+      <>
+        <IntentLink href="https://maps.google.com/?q=1,2">map</IntentLink>
+        <IntentLink href="/@alice" target="_blank">
+          tab
+        </IntentLink>
+        <IntentLink href="/@alice" target="_BLANK">
+          TAB
+        </IntentLink>
+        <IntentLink href="//evil.example/x">proto</IntentLink>
+      </>
+    );
+    for (const name of ["map", "tab", "TAB", "proto"]) {
+      fireEvent.mouseEnter(screen.getByRole("link", { name }));
+    }
+    expect(router.prefetch).not.toHaveBeenCalled();
+  });
+
+  it("does not prefetch on a data-saver or 2g connection", () => {
+    (navigator as Navigator & { connection?: unknown }).connection = { saveData: true };
+    const { router } = renderWithRouter(<IntentLink href="/@alice">alice</IntentLink>);
+    fireEvent.mouseEnter(screen.getByRole("link"));
+    expect(router.prefetch).not.toHaveBeenCalled();
+
+    (navigator as Navigator & { connection?: unknown }).connection = { effectiveType: "slow-2g" };
+    const { router: second } = renderWithRouter(<IntentLink href="/@bob">bob</IntentLink>);
+    fireEvent.mouseEnter(screen.getByRole("link", { name: "bob" }));
+    expect(second.prefetch).not.toHaveBeenCalled();
+  });
+
+  it("is inert without an app router (tests, trees without a router)", () => {
+    render(<IntentLink href="/@alice">alice</IntentLink>);
+    expect(() => fireEvent.mouseEnter(screen.getByRole("link"))).not.toThrow();
+  });
+
+  it("swallows a prefetch that throws and lets the next intent retry", () => {
+    const router = makeRouter();
+    router.prefetch.mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+    renderWithRouter(<IntentLink href="/@alice">alice</IntentLink>, router);
+    const link = screen.getByRole("link");
+    expect(() => fireEvent.mouseEnter(link)).not.toThrow();
+    fireEvent.mouseEnter(link);
+    fireEvent.mouseEnter(link);
+    expect(router.prefetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-arms when the href changes", () => {
+    const router = makeRouter();
+    const { rerender } = render(
+      <AppRouterContext.Provider value={router as never}>
+        <IntentLink href="/@alice">who</IntentLink>
+      </AppRouterContext.Provider>
+    );
+    fireEvent.mouseEnter(screen.getByRole("link"));
+    rerender(
+      <AppRouterContext.Provider value={router as never}>
+        <IntentLink href="/@bob">who</IntentLink>
+      </AppRouterContext.Provider>
+    );
+    fireEvent.mouseEnter(screen.getByRole("link"));
+    expect(router.prefetch.mock.calls.map((c) => c[0])).toEqual(["/@alice", "/@bob"]);
+  });
+});
+
+describe("shared link wrappers prefetch on intent only (#1593)", () => {
+  it("EntryLink", () => {
+    const { router } = renderWithRouter(
+      <EntryLink entry={{ category: "hive-125125", author: "alice", permlink: "post" }}>
+        post
+      </EntryLink>
+    );
+    const link = screen.getByRole("link", { name: "post" });
+    expect(link).toHaveAttribute("href", "/@alice/post");
+    expect(router.prefetch).not.toHaveBeenCalled();
+    fireEvent.mouseEnter(link);
+    expect(router.prefetch).toHaveBeenCalledWith("/@alice/post", { kind: "auto" });
+  });
+
+  it("ProfileLink", () => {
+    const afterClick = vi.fn();
+    const { router } = renderWithRouter(
+      <ProfileLink username="alice" afterClick={afterClick}>
+        <span>alice</span>
+      </ProfileLink>
+    );
+    const link = screen.getByRole("link", { name: "@alice" });
+    fireEvent.mouseEnter(link);
+    expect(router.prefetch).toHaveBeenCalledWith("/@alice", { kind: "auto" });
+    // jsdom has no navigation; stop the default so only the click handlers run.
+    link.addEventListener("click", (e) => e.preventDefault());
+    fireEvent.click(link);
+    expect(afterClick).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
A feed page renders about 120 `next/link` elements: five per card plus the trending-tag chips and the community widget. With the default `prefetch`, every one of them fired an RSC request as it scrolled into view: roughly 100 requests and 1.1 MB on a desktop /trending, each one a dynamic render on the origin.

This adds `IntentLink`, a `next/link` with `prefetch={false}` that calls `router.prefetch` once on mouseenter, touchstart or focus, using the same `auto` kind as the viewport prefetch it replaces. External hrefs, new-tab links, save-data / 2g connections and trees without an app router are skipped. `EntryLink`, `ProfileLink`, `TagLink` and the community list item render it; the sort pills and navbar keep the default.

Measured on a production build of this branch in Chrome: prefetch requests after load on /trending went from 104 to 13 on desktop (the remaining ones are navbar links) and from 11 to 5 on mobile. Hovering a card fires exactly one prefetch, a second hover none, and the click still navigates client-side.

Test plan
- `intent-link.spec.tsx`: once-per-href prefetch on hover/touch/focus, caller handlers preserved, external / `_blank` / save-data / no-router cases, re-arming on href change, EntryLink and ProfileLink wiring.
- Existing specs for profile-link, entry-list-item, discussion-item, search panels and similar entries pass; full suite, `tsc --noEmit` and the production build are clean.

Closes #1593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added intent-based link prefetching for internal navigation when users hover, focus, or touch a link.
  - Prefetching adapts to network conditions and avoids unnecessary requests for external links or new-tab destinations.
  - Updated community, profile, tag, and entry links to provide consistent navigation behavior.

- **Bug Fixes**
  - Prevented link prefetch errors from interrupting navigation.
  - Preserved existing link destinations, accessibility behavior, and custom event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->