### PR TITLE
Keep the document security headers off hashed build assets

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -343,7 +343,20 @@ const config = {
         // provider returns JSON, not a framable document; HiveSigner uses popup
         // windows, not iframes. A future type:"rich" /embed route would add a
         // scoped frame-ancestors exception here.
-        source: "/:path*",
+        //
+        // Everything except hashed build assets. CSP, frame-ancestors,
+        // Permissions-Policy and Referrer-Policy have no effect on a script,
+        // stylesheet or font response, yet the two CSP headers alone are ~3.7 KB
+        // and rode on every one of the ~130 `/_next/static` responses a page
+        // makes. Lighthouse counts those header bytes (an 848-byte stylesheet
+        // reported as 5 KB of transfer), so a feed page carried ~600 KB of
+        // header weight in PageSpeed's model. Only `/_next/static/` is excluded:
+        // a miss there is a text/plain 404, whereas a miss under /assets or
+        // /scripts renders the HTML not-found page, which must keep its
+        // clickjacking protection. The `/_next/static` block below keeps
+        // nosniff, which does matter for scripts and styles. The service worker
+        // is served from /sw.js, so its CSP is unchanged.
+        source: "/((?!_next/static/).*)",
         headers: [
           { key: "X-Frame-Options", value: "SAMEORIGIN" },
           { key: "X-Content-Type-Options", value: "nosniff" },
@@ -502,6 +515,7 @@ const config = {
         // Hashed static assets (JS, CSS, media) - immutable, cache forever
         source: "/_next/static/:path*",
         headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Cache-Control", value: "public, max-age=31536000, immutable" }
         ]
       },

--- a/apps/web/src/specs/config/static-asset-headers.spec.ts
+++ b/apps/web/src/specs/config/static-asset-headers.spec.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+import path from "path";
+import { getPathMatch } from "next/dist/shared/lib/router/utils/path-match";
+
+/**
+ * The security headers (CSP, CSP-Report-Only, Permissions-Policy, X-Frame-Options,
+ * Referrer-Policy) are document headers. They used to ride on every hashed asset
+ * because the block matched `/:path*`, which put ~4.7 KB of headers on each of the
+ * ~130 `/_next/static` responses a page makes. Lighthouse counts header bytes in
+ * transfer size, so a feed page carried ~600 KB of header weight in PageSpeed's
+ * model (#1592). Only that prefix is excluded: a miss there is a text/plain 404,
+ * while a miss under /assets or /scripts renders the HTML not-found page, which
+ * must keep its clickjacking protection.
+ *
+ * This evaluates the real `headers()` from next.config.js with Next's own path
+ * matcher so the split cannot silently regress.
+ */
+type HeaderRule = { source: string; headers: { key: string; value: string }[] };
+
+const CONFIG = path.resolve(__dirname, "../../../next.config.js");
+const SECURITY = [
+  "Content-Security-Policy",
+  "Content-Security-Policy-Report-Only",
+  "Permissions-Policy",
+  "X-Frame-Options",
+  "Referrer-Policy"
+];
+
+let rules: HeaderRule[];
+
+beforeAll(async () => {
+  // next.config.js is CommonJS; both its production and development exports
+  // wrap the same base config, whose headers() is what ships.
+  const config = require(CONFIG) as { headers: () => Promise<HeaderRule[]> };
+  rules = await config.headers();
+});
+
+// Same matcher options the production server uses for the headers manifest
+// (next/dist/server/lib/router-utils/filesystem.js).
+const MATCH = { strict: true, removeUnnamedParams: true, sensitive: false };
+
+function headersFor(pathname: string): string[] {
+  return rules
+    .filter((rule) => getPathMatch(rule.source, MATCH)(pathname))
+    .flatMap((rule) => rule.headers.map((h) => h.key));
+}
+
+describe("security headers stay on documents (#1592)", () => {
+  it.each([
+    "/",
+    "/trending",
+    "/@good-karma",
+    "/hive-125125",
+    "/@ecency/some-post",
+    "/api/csp-report",
+    "/sw.js",
+    "/firebase-messaging-sw.js",
+    "/manifest.json",
+    "/favicon.ico",
+    // Public files keep the block: a miss under these prefixes renders the HTML
+    // not-found page, which needs its clickjacking protection.
+    "/assets/img/logo-circle.svg",
+    "/assets/nope.png",
+    "/scripts/x.js",
+    "/geo/cities.json",
+    // Only the exact prefix is excluded, not routes that merely start with
+    // the same letters.
+    "/_next/staticx",
+    "/_next/static"
+  ])("%s carries the full security block", (pathname) => {
+    const keys = headersFor(pathname);
+    for (const key of SECURITY) expect(keys).toContain(key);
+    expect(keys).toContain("X-Content-Type-Options");
+  });
+});
+
+describe("static responses carry only nosniff + cache headers (#1592)", () => {
+  it.each([
+    "/_next/static/css/8c78658f5066068d.css",
+    "/_next/static/chunks/49542-f010dbacf7effe19.js",
+    "/_next/static/media/e4af272ccee01ff0-s.p.woff2",
+    "/_next/static/chunks/nope.js"
+  ])("%s", (pathname) => {
+    const keys = headersFor(pathname);
+    for (const key of SECURITY) expect(keys).not.toContain(key);
+    expect(keys).toContain("X-Content-Type-Options");
+    expect(keys).toContain("Cache-Control");
+  });
+
+  it("keeps the immutable cache policy on hashed assets", () => {
+    const rule = rules.find((r) => r.source === "/_next/static/:path*");
+    expect(rule).toBeDefined();
+    expect(rule!.headers.find((h) => h.key === "Cache-Control")?.value).toBe(
+      "public, max-age=31536000, immutable"
+    );
+  });
+});


### PR DESCRIPTION
The security block in `headers()` matched `/:path*`, so every `/_next/static` script, stylesheet and font response carried Content-Security-Policy, the 3.6 KB Content-Security-Policy-Report-Only, Permissions-Policy, X-Frame-Options and Referrer-Policy: about 4.7 KB of headers per response that mean nothing on a subresource. Lighthouse counts header bytes in transfer size, so an 848-byte stylesheet reported as 5 KB and a feed page carried roughly 600 KB of header weight in PageSpeed's model (about 210 KB of it on the render-blocking stylesheets).

Only `/_next/static/` is excluded from the block: a miss there is a text/plain 404, whereas a miss under `/assets` or `/scripts` renders the HTML not-found page, which must keep its clickjacking protection. The `/_next/static` block gains `X-Content-Type-Options: nosniff`, which does still matter for scripts and styles. The service worker is served from `/sw.js`, so its CSP is unchanged.

Test plan
- New `static-asset-headers.spec.ts` evaluates the real `headers()` through Next's path matcher with the production options: documents, `/sw.js`, `/favicon.ico`, `/assets/*`, `/scripts/*`, `/geo/*` keep the full block; `/_next/static/*` gets only nosniff + the immutable cache policy.
- Production build: `routes-manifest.json` compiles the source to `^(?:/((?!_next/static/).*))(?:/)?$`; on `next start`, a chunk response carries only nosniff + Cache-Control, a missing chunk is a text/plain 404, and `/trending`, `/sw.js` and an HTML 404 under `/assets` still carry X-Frame-Options + CSP.

Closes #1592