### PR TITLE
Cap in-flight page renders per process and raise the V8 semi-space

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -108,6 +108,7 @@ COPY --from=base /var/app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=base /var/app/apps/web/package.json ./apps/web/package.json
 COPY --from=base /var/app/apps/web/healthCheck.js ./apps/web/healthCheck.js
 COPY --from=base /var/app/apps/web/next-runtime-config.js ./apps/web/next-runtime-config.js
+COPY --from=base /var/app/apps/web/ssr-admission.js ./apps/web/ssr-admission.js
 COPY --from=base /var/app/apps/web/public ./apps/web/public
 COPY --from=base /var/app/apps/web/.next ./apps/web/.next
 COPY --from=base /var/app/node_modules ./node_modules
@@ -130,5 +131,9 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 CMD node
 # images, experimental flags, compress, ...). The preload hands the server the
 # config the build resolved, from .next/required-server-files.json, the way
 # Next's own standalone server.js does. See next-runtime-config.js.
+#
+# ssr-admission.js caps in-flight page renders per process (SSR_MAX_INFLIGHT,
+# set in the stack file) and answers 503 above the cap before Next sees the
+# request, so the edge fails over instead of queueing behind a stuck loop.
 WORKDIR /var/app/apps/web
-CMD ["node", "--require", "./next-runtime-config.js", "./node_modules/next/dist/bin/next", "start"]
+CMD ["node", "--require", "./next-runtime-config.js", "--require", "./ssr-admission.js", "./node_modules/next/dist/bin/next", "start"]

--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -105,7 +105,17 @@ services:
       # Bound the V8 old-space so a pathological single render crashes (and the
       # replica restarts) rather than ballooning the heap unbounded. Heap working
       # set is ~2GiB, so 3GiB leaves headroom without clipping normal renders.
-      - NODE_OPTIONS=--max-old-space-size=3072
+      # The semi-space (young generation) is raised from V8's default so an
+      # allocation-heavy render triggers fewer scavenges; costs ~128MiB of RSS
+      # per replica, well inside the limit above.
+      - NODE_OPTIONS=--max-old-space-size=3072 --max-semi-space-size=64
+      # Per-process admission control (ssr-admission.js, loaded by the image
+      # CMD): above this many in-flight page renders the process answers 503
+      # with Retry-After, which the edge worker treats as a failover signal.
+      # Normal load is a handful of renders in flight per process; the cap only
+      # bites once renders have slowed enough to pile up, which is exactly the
+      # state that used to end in a heap abort. Unset or 0 disables it.
+      - SSR_MAX_INFLIGHT=16
     restart: always
     ports:
       - "3000:3000"

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -85,6 +85,11 @@ services:
       - MATTERMOST_WS_ALLOWED_ORIGINS
       - THREESPEAK_EMBED_API_KEY
       - SEO_CRON_SECRET
+      # Same runtime knobs as production, so alpha exercises them first:
+      # semi-space size (fewer scavenges on allocation-heavy renders) and the
+      # per-process render cap (ssr-admission.js, loaded by the image CMD).
+      - NODE_OPTIONS=--max-semi-space-size=64
+      - SSR_MAX_INFLIGHT=16
     restart: always
     ports:
       - "3000:3000"
@@ -104,11 +109,6 @@ services:
     image: curlimages/curl:8.11.1
     environment:
       - SEO_CRON_SECRET
-      # Same runtime knobs as production, so alpha exercises them first:
-      # semi-space size (fewer scavenges on allocation-heavy renders) and the
-      # per-process render cap (ssr-admission.js, loaded by the image CMD).
-      - NODE_OPTIONS=--max-semi-space-size=64
-      - SSR_MAX_INFLIGHT=16
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -104,6 +104,11 @@ services:
     image: curlimages/curl:8.11.1
     environment:
       - SEO_CRON_SECRET
+      # Same runtime knobs as production, so alpha exercises them first:
+      # semi-space size (fewer scavenges on allocation-heavy renders) and the
+      # per-process render cap (ssr-admission.js, loaded by the image CMD).
+      - NODE_OPTIONS=--max-semi-space-size=64
+      - SSR_MAX_INFLIGHT=16
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |

--- a/apps/web/src/specs/ssr-admission.spec.ts
+++ b/apps/web/src/specs/ssr-admission.spec.ts
@@ -227,10 +227,25 @@ describe("ssr-admission preload", () => {
     const dockerfile = readFileSync(join(process.cwd(), "Dockerfile"), "utf8");
     expect(dockerfile).toContain("ssr-admission.js ./apps/web/ssr-admission.js");
     expect(dockerfile).toMatch(/CMD \[.*"--require", "\.\/ssr-admission\.js".*\]/);
+    // Under the web service specifically: a variable placed under another
+    // service is silent (the preload just reports itself disabled).
+    const webBlock = (compose: string): string => {
+      const lines = compose.split("\n");
+      const start = lines.findIndex((l) => l === "  web:");
+      expect(start, "web service").toBeGreaterThan(-1);
+      let end = lines.length;
+      for (let i = start + 1; i < lines.length; i++) {
+        if (/^  [A-Za-z_-]+:/.test(lines[i]) || /^[A-Za-z_-]+:/.test(lines[i])) {
+          end = i;
+          break;
+        }
+      }
+      return lines.slice(start, end).join("\n");
+    };
     for (const file of ["docker-compose.production.yml", "docker-compose.yml"]) {
-      const compose = readFileSync(join(process.cwd(), file), "utf8");
-      expect(compose, file).toMatch(/^\s*- SSR_MAX_INFLIGHT=\d+$/m);
-      expect(compose, file).toMatch(/--max-semi-space-size=\d+/);
+      const web = webBlock(readFileSync(join(process.cwd(), file), "utf8"));
+      expect(web, file).toMatch(/^\s*- SSR_MAX_INFLIGHT=\d+$/m);
+      expect(web, file).toMatch(/^\s*- NODE_OPTIONS=.*--max-semi-space-size=\d+/m);
     }
   });
 });

--- a/apps/web/src/specs/ssr-admission.spec.ts
+++ b/apps/web/src/specs/ssr-admission.spec.ts
@@ -131,7 +131,7 @@ describe("ssr-admission preload", () => {
     await a.done;
   });
 
-  it("never sheds the named static paths, and counts everything else including file-like entry routes", async () => {
+  it("never sheds the named static paths, and counts everything else including file-like unknown paths", async () => {
     const { port } = await boot({ SSR_MAX_INFLIGHT: "1" });
     const a = start(port, "/slow/doc");
     await settle();
@@ -161,8 +161,9 @@ describe("ssr-admission preload", () => {
       expect((await get(port, path)).status, path).toBe(200);
     }
     // Everything that renders on the loop is shed while the slot is held: a
-    // page, a dotted username, an RSS feed, the agent routes (rewritten from
-    // .md/.json/.discussion.json) and an unknown data-looking path.
+    // page, a dotted username, an RSS feed, the agent routes (a suffix the
+    // middleware appends to a permlink), and unknown file-looking paths, which
+    // render the not-found page (permlinks never contain a dot).
     for (const path of [
       "/hot",
       "/@demo.com",

--- a/apps/web/src/specs/ssr-admission.spec.ts
+++ b/apps/web/src/specs/ssr-admission.spec.ts
@@ -40,7 +40,11 @@ const CHILD_SERVER = `
 
 const children: ChildProcess[] = [];
 
-function boot(env: NodeJS.ProcessEnv): Promise<{ port: number; stderr: () => string }> {
+type Booted = { port: number; stderr: () => string };
+type Reply = { status: number; headers: http.IncomingHttpHeaders; body: string };
+type Started = { done: Promise<{ status: number; headers: http.IncomingHttpHeaders }>; abort: () => void };
+
+function boot(env: NodeJS.ProcessEnv): Promise<Booted> {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, ["--require", PRELOAD, "-e", CHILD_SERVER], {
       cwd: process.cwd(),
@@ -55,8 +59,8 @@ function boot(env: NodeJS.ProcessEnv): Promise<{ port: number; stderr: () => str
   });
 }
 
-function get(port: number, path: string, headers: Record<string, string> = {}) {
-  return new Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }>((resolve, reject) => {
+function get(port: number, path: string, headers: Record<string, string> = {}): Promise<Reply> {
+  return new Promise<Reply>((resolve, reject) => {
     const req = http.get({ host: "127.0.0.1", port, path, headers }, (res) => {
       let body = "";
       res.on("data", (d) => (body += String(d)));
@@ -68,7 +72,7 @@ function get(port: number, path: string, headers: Record<string, string> = {}) {
 
 // Start a request and resolve once it is on the wire (the server has parked
 // it) without waiting for the response.
-function start(port: number, path: string) {
+function start(port: number, path: string): Started {
   let settle!: (r: { status: number; headers: http.IncomingHttpHeaders }) => void;
   const done = new Promise<{ status: number; headers: http.IncomingHttpHeaders }>((r) => (settle = r));
   const req = http.get({ host: "127.0.0.1", port, path }, (res) => {
@@ -79,7 +83,7 @@ function start(port: number, path: string) {
   return { done, abort: () => req.destroy() };
 }
 
-const settle = () => new Promise((r) => setTimeout(r, 150));
+const settle = (ms = 150): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 afterEach(() => {
   for (const c of children.splice(0)) c.kill("SIGKILL");
@@ -139,12 +143,19 @@ describe("ssr-admission preload", () => {
       "/scripts/x.js",
       "/favicon.ico",
       "/manifest.json",
-      "/robots.txt"
+      "/robots.txt",
+      "/sw.js",
+      "/firebase-messaging-sw.js",
+      "/og.jpg",
+      "/geo/cities.min.json",
+      "/sitemap.xml",
+      "/fonts/inter.woff2"
     ]) {
       expect((await get(port, path)).status, path).toBe(200);
     }
-    // And a page is still shed while the slot is held.
+    // And a page is still shed while the slot is held, a dotted username too.
     expect((await get(port, "/hot")).status).toBe(503);
+    expect((await get(port, "/@demo.com")).status).toBe(503);
     await get(port, "/api/release");
     await a.done;
   });
@@ -153,7 +164,7 @@ describe("ssr-admission preload", () => {
     const { port } = await boot({ SSR_MAX_INFLIGHT: "1" });
     const a = start(port, "/slow/doc");
     await settle();
-    const status = await new Promise<number>((resolve, reject) => {
+    const status: number = await new Promise<number>((resolve, reject) => {
       const req = http.request({ host: "127.0.0.1", port, path: "/some-form", method: "POST" }, (res) => {
         res.resume();
         res.on("end", () => resolve(res.statusCode ?? 0));
@@ -166,22 +177,60 @@ describe("ssr-admission preload", () => {
     await a.done;
   });
 
-  it("frees the slot when the client goes away before the render finishes", async () => {
-    const { port } = await boot({ SSR_MAX_INFLIGHT: "1" });
+  it("keeps the slot for the grace period after the client goes away, then frees it", async () => {
+    const { port } = await boot({ SSR_MAX_INFLIGHT: "1", SSR_ABANDONED_GRACE_MS: "400" });
     const a = start(port, "/slow/abandoned");
     await settle();
     expect((await get(port, "/page")).status).toBe(503);
     a.abort();
     await settle();
+    // The render is still running on the server; the slot is still held.
+    expect((await get(port, "/page")).status).toBe(503);
+    await settle(500);
     expect((await get(port, "/page")).status).toBe(200);
     await get(port, "/api/release");
+  });
+
+  it("frees the slot as soon as an abandoned render finishes, before the grace period ends", async () => {
+    const { port } = await boot({ SSR_MAX_INFLIGHT: "1", SSR_ABANDONED_GRACE_MS: "5000" });
+    const a = start(port, "/slow/abandoned");
+    await settle();
+    a.abort();
+    await settle();
+    expect((await get(port, "/page")).status).toBe(503);
+    await get(port, "/api/release");
+    await settle();
+    expect((await get(port, "/page")).status).toBe(200);
+  });
+
+  it("ignores an invalid cap or Retry-After rather than crashing or silently misreporting", async () => {
+    const bad = await boot({ SSR_MAX_INFLIGHT: "lots" });
+    const a = start(bad.port, "/slow/1");
+    await settle();
+    expect((await get(bad.port, "/page")).status).toBe(200);
+    expect(bad.stderr()).toContain("is not a positive number");
+    await get(bad.port, "/api/release");
+    await a.done;
+
+    const odd = await boot({ SSR_MAX_INFLIGHT: "1", SSR_SHED_RETRY_AFTER: "2\r\nX-Injected: 1" });
+    const b = start(odd.port, "/slow/1");
+    await settle();
+    const shed = await get(odd.port, "/page");
+    expect(shed.status).toBe(503);
+    expect(shed.headers["retry-after"]).toBe("1");
+    expect(shed.headers["x-injected"]).toBeUndefined();
+    await get(odd.port, "/api/release");
+    await b.done;
   });
 
   it("is wired into the production image and the stack", () => {
     const dockerfile = readFileSync(join(process.cwd(), "Dockerfile"), "utf8");
     expect(dockerfile).toContain("ssr-admission.js ./apps/web/ssr-admission.js");
     expect(dockerfile).toMatch(/CMD \[.*"--require", "\.\/ssr-admission\.js".*\]/);
-    const compose = readFileSync(join(process.cwd(), "docker-compose.production.yml"), "utf8");
-    expect(compose).toMatch(/^\s*- SSR_MAX_INFLIGHT=\d+$/m);
+    for (const file of ["docker-compose.production.yml", "docker-compose.yml"]) {
+      const compose = readFileSync(join(process.cwd(), file), "utf8");
+      expect(compose, file).toMatch(/^\s*- SSR_MAX_INFLIGHT=\d+$/m);
+      expect(compose, file).toMatch(/--max-semi-space-size=\d+/);
+    }
   });
 });

--- a/apps/web/src/specs/ssr-admission.spec.ts
+++ b/apps/web/src/specs/ssr-admission.spec.ts
@@ -1,0 +1,187 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from "vitest";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import http from "node:http";
+import { join } from "node:path";
+
+/**
+ * The production image starts Next with `node --require ./ssr-admission.js`
+ * (see the Dockerfile). These tests boot the real preload in a child process
+ * in front of a plain http server whose handler holds each page render open
+ * until told to finish, then drive it over real sockets: that is the same
+ * 'request' emission the preload intercepts for `next start`.
+ */
+
+const PRELOAD = join(process.cwd(), "ssr-admission.js");
+
+// The child: a server that parks /slow renders until /api/release is called
+// (an /api/ path, so the preload never counts or sheds the control call itself),
+// and answers everything else straight away. Prints its port on stdout.
+const CHILD_SERVER = `
+  const http = require("http");
+  const parked = [];
+  const server = http.createServer((req, res) => {
+    const path = req.url.split("?")[0];
+    if (path === "/api/release") {
+      const n = parked.length;
+      for (const r of parked.splice(0)) r.end("released");
+      res.end(String(n));
+      return;
+    }
+    if (path.startsWith("/slow")) {
+      parked.push(res);
+      return;
+    }
+    res.end("ok " + path);
+  });
+  server.listen(0, "127.0.0.1", () => process.stdout.write(String(server.address().port) + "\\n"));
+`;
+
+const children: ChildProcess[] = [];
+
+function boot(env: NodeJS.ProcessEnv): Promise<{ port: number; stderr: () => string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--require", PRELOAD, "-e", CHILD_SERVER], {
+      cwd: process.cwd(),
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    children.push(child);
+    let err = "";
+    child.stderr!.on("data", (d) => (err += String(d)));
+    child.stdout!.once("data", (d) => resolve({ port: Number(String(d).trim()), stderr: () => err }));
+    child.once("exit", (code) => reject(new Error(`child exited ${code}: ${err}`)));
+  });
+}
+
+function get(port: number, path: string, headers: Record<string, string> = {}) {
+  return new Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }>((resolve, reject) => {
+    const req = http.get({ host: "127.0.0.1", port, path, headers }, (res) => {
+      let body = "";
+      res.on("data", (d) => (body += String(d)));
+      res.on("end", () => resolve({ status: res.statusCode ?? 0, headers: res.headers, body }));
+    });
+    req.on("error", reject);
+  });
+}
+
+// Start a request and resolve once it is on the wire (the server has parked
+// it) without waiting for the response.
+function start(port: number, path: string) {
+  let settle!: (r: { status: number; headers: http.IncomingHttpHeaders }) => void;
+  const done = new Promise<{ status: number; headers: http.IncomingHttpHeaders }>((r) => (settle = r));
+  const req = http.get({ host: "127.0.0.1", port, path }, (res) => {
+    res.resume();
+    res.on("end", () => settle({ status: res.statusCode ?? 0, headers: res.headers }));
+  });
+  req.on("error", () => settle({ status: 0, headers: {} }));
+  return { done, abort: () => req.destroy() };
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 150));
+
+afterEach(() => {
+  for (const c of children.splice(0)) c.kill("SIGKILL");
+});
+
+describe("ssr-admission preload", () => {
+  it("is inert without SSR_MAX_INFLIGHT", async () => {
+    const { port, stderr } = await boot({ SSR_MAX_INFLIGHT: "" });
+    const a = start(port, "/slow/1");
+    const b = start(port, "/slow/2");
+    await settle();
+    expect((await get(port, "/page")).status).toBe(200);
+    await get(port, "/api/release");
+    expect((await a.done).status).toBe(200);
+    expect((await b.done).status).toBe(200);
+    expect(stderr()).toContain("disabled");
+  });
+
+  it("answers 503 with Retry-After above the cap and frees the slot when a render finishes", async () => {
+    const { port } = await boot({ SSR_MAX_INFLIGHT: "2", SSR_SHED_RETRY_AFTER: "3" });
+    const a = start(port, "/slow/1");
+    const b = start(port, "/slow/2");
+    await settle();
+
+    const shed = await get(port, "/@someone/some-post");
+    expect(shed.status).toBe(503);
+    expect(shed.headers["retry-after"]).toBe("3");
+    expect(shed.headers["cache-control"]).toBe("no-store");
+
+    // The parked renders were never touched by the shed.
+    expect((await get(port, "/api/release")).body).toBe("2");
+    expect((await a.done).status).toBe(200);
+    expect((await b.done).status).toBe(200);
+
+    // Slots are free again.
+    expect((await get(port, "/@someone/some-post")).status).toBe(200);
+  });
+
+  it("counts RSC navigations as renders too", async () => {
+    const { port } = await boot({ SSR_MAX_INFLIGHT: "1" });
+    const a = start(port, "/slow/doc");
+    await settle();
+    expect((await get(port, "/trending?_rsc=abc12")).status).toBe(503);
+    await get(port, "/api/release");
+    await a.done;
+  });
+
+  it("never sheds static assets, API routes or the well-known files", async () => {
+    const { port } = await boot({ SSR_MAX_INFLIGHT: "1" });
+    const a = start(port, "/slow/doc");
+    await settle();
+    for (const path of [
+      "/_next/static/chunks/app.js",
+      "/api/healthcheck",
+      "/api/mattermost/channels",
+      "/assets/noimage.png",
+      "/scripts/x.js",
+      "/favicon.ico",
+      "/manifest.json",
+      "/robots.txt"
+    ]) {
+      expect((await get(port, path)).status, path).toBe(200);
+    }
+    // And a page is still shed while the slot is held.
+    expect((await get(port, "/hot")).status).toBe(503);
+    await get(port, "/api/release");
+    await a.done;
+  });
+
+  it("does not count writes against the cap", async () => {
+    const { port } = await boot({ SSR_MAX_INFLIGHT: "1" });
+    const a = start(port, "/slow/doc");
+    await settle();
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = http.request({ host: "127.0.0.1", port, path: "/some-form", method: "POST" }, (res) => {
+        res.resume();
+        res.on("end", () => resolve(res.statusCode ?? 0));
+      });
+      req.on("error", reject);
+      req.end("x");
+    });
+    expect(status).toBe(200);
+    await get(port, "/api/release");
+    await a.done;
+  });
+
+  it("frees the slot when the client goes away before the render finishes", async () => {
+    const { port } = await boot({ SSR_MAX_INFLIGHT: "1" });
+    const a = start(port, "/slow/abandoned");
+    await settle();
+    expect((await get(port, "/page")).status).toBe(503);
+    a.abort();
+    await settle();
+    expect((await get(port, "/page")).status).toBe(200);
+    await get(port, "/api/release");
+  });
+
+  it("is wired into the production image and the stack", () => {
+    const dockerfile = readFileSync(join(process.cwd(), "Dockerfile"), "utf8");
+    expect(dockerfile).toContain("ssr-admission.js ./apps/web/ssr-admission.js");
+    expect(dockerfile).toMatch(/CMD \[.*"--require", "\.\/ssr-admission\.js".*\]/);
+    const compose = readFileSync(join(process.cwd(), "docker-compose.production.yml"), "utf8");
+    expect(compose).toMatch(/^\s*- SSR_MAX_INFLIGHT=\d+$/m);
+  });
+});

--- a/apps/web/src/specs/ssr-admission.spec.ts
+++ b/apps/web/src/specs/ssr-admission.spec.ts
@@ -148,14 +148,34 @@ describe("ssr-admission preload", () => {
       "/firebase-messaging-sw.js",
       "/og.jpg",
       "/geo/cities.min.json",
+      "/dmca/dmca-accounts.json",
+      "/.well-known/assetlinks.json",
+      "/public-nodes.json",
+      "/apple-app-site-association",
+      "/llms.txt",
       "/sitemap.xml",
+      "/sitemap/posts-1.xml",
       "/fonts/inter.woff2"
     ]) {
       expect((await get(port, path)).status, path).toBe(200);
     }
-    // And a page is still shed while the slot is held, a dotted username too.
-    expect((await get(port, "/hot")).status).toBe(503);
-    expect((await get(port, "/@demo.com")).status).toBe(503);
+    // Everything that renders on the loop is shed while the slot is held: a
+    // page, a dotted username, an RSS feed, the agent routes (rewritten from
+    // .md/.json/.discussion.json) and an unknown data-looking path.
+    for (const path of [
+      "/hot",
+      "/@demo.com",
+      "/@someone/rss.xml",
+      "/@someone/rss",
+      "/created/photography/rss.xml",
+      "/@someone/some-post.md",
+      "/@someone/some-post.json",
+      "/@someone/some-post.discussion.json",
+      "/feed.xml",
+      "/notes.txt"
+    ]) {
+      expect((await get(port, path)).status, path).toBe(503);
+    }
     await get(port, "/api/release");
     await a.done;
   });

--- a/apps/web/src/specs/ssr-admission.spec.ts
+++ b/apps/web/src/specs/ssr-admission.spec.ts
@@ -131,7 +131,7 @@ describe("ssr-admission preload", () => {
     await a.done;
   });
 
-  it("never sheds static assets, API routes or the well-known files", async () => {
+  it("never sheds the named static paths, and counts everything else including file-like entry routes", async () => {
     const { port } = await boot({ SSR_MAX_INFLIGHT: "1" });
     const a = start(port, "/slow/doc");
     await settle();
@@ -155,7 +155,8 @@ describe("ssr-admission preload", () => {
       "/llms.txt",
       "/sitemap.xml",
       "/sitemap/posts-1.xml",
-      "/fonts/inter.woff2"
+      "/assets/fonts/inter.woff2",
+      "/_next/static/media/inter.woff2"
     ]) {
       expect((await get(port, path)).status, path).toBe(200);
     }
@@ -171,8 +172,12 @@ describe("ssr-admission preload", () => {
       "/@someone/some-post.md",
       "/@someone/some-post.json",
       "/@someone/some-post.discussion.json",
+      "/@demo/post.png",
+      "/@demo/post.js",
+      "/@demo.com/avatar.jpg",
       "/feed.xml",
-      "/notes.txt"
+      "/notes.txt",
+      "/logo.png"
     ]) {
       expect((await get(port, path)).status, path).toBe(503);
     }

--- a/apps/web/ssr-admission.js
+++ b/apps/web/ssr-admission.js
@@ -1,0 +1,87 @@
+// Per-process admission control for page renders.
+//
+// Nothing inside the Next.js process limits how many renders it accepts at
+// once; shedding happens only upstream and site-wide. When one render turns
+// slow, requests pile up on that process, every one of them slows down, and
+// the heap runaway behind the exit-134 history becomes reachable. This preload
+// caps the number of in-flight page renders per process: above the cap a
+// request is answered 503 with Retry-After before Next ever sees it, so the
+// edge fails over to another origin instead of queueing behind a stuck loop.
+//
+// Hooks http.Server's 'request' emission, which is how Node hands a request to
+// `next start`, so the check runs before any Next code. Only document and RSC
+// renders are counted: static assets, API routes and the health check pass
+// through uncounted. Disabled unless SSR_MAX_INFLIGHT is a positive number.
+//
+// Loaded with `node --require ./ssr-admission.js` (see the Dockerfile CMD).
+// Runs before Next, so it must stay dependency-free.
+const http = require("http");
+
+const max = Number(process.env.SSR_MAX_INFLIGHT || 0);
+const retryAfter = String(process.env.SSR_SHED_RETRY_AFTER || "1");
+
+// Paths that are not page renders. Anything else that reaches this process is
+// a document or an RSC navigation (the reverse proxy keeps private-api and
+// friends away from it), so those are what the cap protects.
+const PASS_PREFIXES = ["/_next/", "/api/", "/assets/", "/scripts/"];
+const PASS_EXACT = new Set(["/favicon.ico", "/manifest.json", "/robots.txt"]);
+
+function isRender(req) {
+  if (req.method !== "GET" && req.method !== "HEAD") return false;
+  const url = req.url || "/";
+  const q = url.indexOf("?");
+  const path = q === -1 ? url : url.slice(0, q);
+  if (PASS_EXACT.has(path)) return false;
+  for (const prefix of PASS_PREFIXES) {
+    if (path.startsWith(prefix)) return false;
+  }
+  return true;
+}
+
+const state = { max, inflight: 0, shed: 0 };
+// Read by the event-loop monitor's log lines; never written from outside.
+globalThis.__ecencySsrAdmission = state;
+
+if (max > 0) {
+  const originalEmit = http.Server.prototype.emit;
+  http.Server.prototype.emit = function emit(event, req, res) {
+    if (event === "request" && req && res && isRender(req)) {
+      if (state.inflight >= state.max) {
+        state.shed += 1;
+        res.statusCode = 503;
+        res.setHeader("Retry-After", retryAfter);
+        res.setHeader("Cache-Control", "no-store");
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.end("Server busy, retry shortly");
+        return true;
+      }
+      state.inflight += 1;
+      let released = false;
+      const release = () => {
+        if (released) return;
+        released = true;
+        state.inflight -= 1;
+      };
+      // finish = response written; close = client went away first (the CF
+      // worker's timeout, a navigation away). Either way the slot is free.
+      res.once("finish", release);
+      res.once("close", release);
+    }
+    return originalEmit.apply(this, arguments);
+  };
+
+  // One line per minute at most, and only when something was shed, so a
+  // saturated process shows up in the container log without flooding it.
+  let lastShed = 0;
+  setInterval(() => {
+    if (state.shed === lastShed) return;
+    process.stderr.write(
+      `[ssr-admission] shed ${state.shed - lastShed} requests in the last 60s (inflight=${state.inflight}, max=${state.max})\n`
+    );
+    lastShed = state.shed;
+  }, 60_000).unref();
+
+  process.stderr.write(`[ssr-admission] max in-flight renders per process: ${max}\n`);
+} else {
+  process.stderr.write("[ssr-admission] disabled (SSR_MAX_INFLIGHT unset)\n");
+}

--- a/apps/web/ssr-admission.js
+++ b/apps/web/ssr-admission.js
@@ -39,15 +39,15 @@ const rawGrace = process.env.SSR_ABANDONED_GRACE_MS;
 const abandonedGraceMs = /^\d{1,6}$/.test(rawGrace || "") ? Number(rawGrace) : 30_000;
 
 // Paths that are not page renders, named precisely: the build output, API
-// routes, the public/ directories, the static root files the app serves, the
-// Redis-backed sitemap routes, and media or font files by extension. Anything
-// else that reaches this process is work on the render loop and counts: a
-// document, an RSC navigation, an RSS feed (`/@user/rss.xml` renders twenty
-// posts) or an agent route (`/@author/permlink.md|.json|.discussion.json`
-// renders the post), which is why data extensions such as .xml, .json, .md
-// and .txt are deliberately NOT in the extension list. Usernames can contain
-// a dot (`/@demo.com`), another reason the list is fixed rather than "has any
-// extension".
+// routes, the public/ directories, the static root files the app serves, and
+// the Redis-backed sitemap routes. Anything else that reaches this process is
+// work on the render loop and counts: a document, an RSC navigation, an RSS
+// feed (`/@user/rss.xml` renders twenty posts), an agent route
+// (`/@author/permlink.md|.json|.discussion.json` renders the post), and a
+// post whose permlink happens to end like a file (`/@author/post.png` is a
+// valid entry route). That last case is why there is no extension-based
+// bypass at all: every static file this app serves lives under a prefix or
+// at a root path listed here, so a name is the only safe test.
 const PASS_PREFIXES = ["/_next/", "/api/", "/assets/", "/scripts/", "/geo/", "/dmca/", "/.well-known/", "/sitemap/"];
 const PASS_EXACT = new Set([
   "/favicon.ico",
@@ -63,7 +63,6 @@ const PASS_EXACT = new Set([
   "/public-nodes.json",
   "/apple-app-site-association"
 ]);
-const PASS_EXTENSIONS = /\.(?:js|mjs|css|map|webmanifest|ico|png|jpe?g|gif|svg|webp|avif|woff2?|ttf|otf|eot|mp4|webm|mp3|m4a|pdf)$/i;
 
 function isRender(req) {
   if (req.method !== "GET" && req.method !== "HEAD") return false;
@@ -74,7 +73,7 @@ function isRender(req) {
   for (const prefix of PASS_PREFIXES) {
     if (path.startsWith(prefix)) return false;
   }
-  return !PASS_EXTENSIONS.test(path);
+  return true;
 }
 
 const state = { max, inflight: 0, shed: 0, abandoned: 0 };

--- a/apps/web/ssr-admission.js
+++ b/apps/web/ssr-admission.js
@@ -10,39 +10,55 @@
 //
 // Hooks http.Server's 'request' emission, which is how Node hands a request to
 // `next start`, so the check runs before any Next code. Only document and RSC
-// renders are counted: static assets, API routes and the health check pass
-// through uncounted. Disabled unless SSR_MAX_INFLIGHT is a positive number.
+// renders are counted: static assets, files served from public/, API routes and
+// the health check pass through uncounted. Disabled unless SSR_MAX_INFLIGHT is
+// a positive number.
 //
 // Loaded with `node --require ./ssr-admission.js` (see the Dockerfile CMD).
 // Runs before Next, so it must stay dependency-free.
 const http = require("http");
 
-const max = Number(process.env.SSR_MAX_INFLIGHT || 0);
-const retryAfter = String(process.env.SSR_SHED_RETRY_AFTER || "1");
+const rawMax = process.env.SSR_MAX_INFLIGHT;
+const max = rawMax === undefined || rawMax === "" ? 0 : Number(rawMax);
+
+// Retry-After must be a plain number of seconds; anything else would throw
+// from setHeader at the worst possible moment, so it falls back to 1.
+const rawRetryAfter = process.env.SSR_SHED_RETRY_AFTER;
+const retryAfter = /^\d{1,4}$/.test(rawRetryAfter || "") ? rawRetryAfter : "1";
+
+// A client that goes away mid-render (the edge worker's timeout, a navigation)
+// does not stop the render: the server prefetches run on until their own
+// timeout. The slot is therefore held for this long after the socket closes
+// unless the response finishes first, so abandoned renders still count as the
+// work they are. Matches the server-side prefetch timeout.
+const rawGrace = process.env.SSR_ABANDONED_GRACE_MS;
+const abandonedGraceMs = /^\d{1,6}$/.test(rawGrace || "") ? Number(rawGrace) : 10_000;
 
 // Paths that are not page renders. Anything else that reaches this process is
 // a document or an RSC navigation (the reverse proxy keeps private-api and
 // friends away from it), so those are what the cap protects.
 const PASS_PREFIXES = ["/_next/", "/api/", "/assets/", "/scripts/"];
-const PASS_EXACT = new Set(["/favicon.ico", "/manifest.json", "/robots.txt"]);
+// Files served from public/ (service workers, social images, geo data, fonts,
+// manifests) carry a file extension; page paths do not. Usernames can contain
+// a dot (`/@demo.com`), hence a fixed list rather than "has any extension".
+const PASS_EXTENSIONS = /\.(?:js|mjs|css|map|json|webmanifest|txt|xml|ico|png|jpe?g|gif|svg|webp|avif|woff2?|ttf|otf|eot|mp4|webm|mp3|m4a|pdf|html?)$/i;
 
 function isRender(req) {
   if (req.method !== "GET" && req.method !== "HEAD") return false;
   const url = req.url || "/";
   const q = url.indexOf("?");
   const path = q === -1 ? url : url.slice(0, q);
-  if (PASS_EXACT.has(path)) return false;
   for (const prefix of PASS_PREFIXES) {
     if (path.startsWith(prefix)) return false;
   }
-  return true;
+  return !PASS_EXTENSIONS.test(path);
 }
 
 const state = { max, inflight: 0, shed: 0 };
 // Read by the event-loop monitor's log lines; never written from outside.
 globalThis.__ecencySsrAdmission = state;
 
-if (max > 0) {
+if (Number.isFinite(max) && max > 0) {
   const originalEmit = http.Server.prototype.emit;
   http.Server.prototype.emit = function emit(event, req, res) {
     if (event === "request" && req && res && isRender(req)) {
@@ -57,15 +73,33 @@ if (max > 0) {
       }
       state.inflight += 1;
       let released = false;
+      let graceTimer = null;
       const release = () => {
         if (released) return;
         released = true;
+        if (graceTimer) clearTimeout(graceTimer);
         state.inflight -= 1;
       };
-      // finish = response written; close = client went away first (the CF
-      // worker's timeout, a navigation away). Either way the slot is free.
+      // finish = the response was written: the render is over. When the
+      // client has already gone, a destroyed response never emits finish, so
+      // the end() call itself (Next writing its last byte) releases too.
       res.once("finish", release);
-      res.once("close", release);
+      const originalEnd = res.end;
+      res.end = function end() {
+        release();
+        return originalEnd.apply(this, arguments);
+      };
+      // close before the render ends = the client went away while it runs on;
+      // keep the slot for the grace period, or until end(), whichever first.
+      res.once("close", () => {
+        if (released) return;
+        if (abandonedGraceMs === 0) {
+          release();
+          return;
+        }
+        graceTimer = setTimeout(release, abandonedGraceMs);
+        graceTimer.unref();
+      });
     }
     return originalEmit.apply(this, arguments);
   };
@@ -82,6 +116,8 @@ if (max > 0) {
   }, 60_000).unref();
 
   process.stderr.write(`[ssr-admission] max in-flight renders per process: ${max}\n`);
+} else if (rawMax !== undefined && rawMax !== "" && !(Number.isFinite(max) && max > 0) && max !== 0) {
+  process.stderr.write(`[ssr-admission] SSR_MAX_INFLIGHT=${JSON.stringify(rawMax)} is not a positive number; disabled\n`);
 } else {
-  process.stderr.write("[ssr-admission] disabled (SSR_MAX_INFLIGHT unset)\n");
+  process.stderr.write("[ssr-admission] disabled (SSR_MAX_INFLIGHT unset or 0)\n");
 }

--- a/apps/web/ssr-admission.js
+++ b/apps/web/ssr-admission.js
@@ -27,12 +27,16 @@ const rawRetryAfter = process.env.SSR_SHED_RETRY_AFTER;
 const retryAfter = /^\d{1,4}$/.test(rawRetryAfter || "") ? rawRetryAfter : "1";
 
 // A client that goes away mid-render (the edge worker's timeout, a navigation)
-// does not stop the render: the server prefetches run on until their own
-// timeout. The slot is therefore held for this long after the socket closes
-// unless the response finishes first, so abandoned renders still count as the
-// work they are. Matches the server-side prefetch timeout.
+// does not end the render in a way this layer can see: Next aborts the stream
+// and destroys the response (no end(), no finish), the render stops at its
+// next chunk boundary, but an async server component already inside a chain
+// of awaited prefetches runs on, each leg bounded by the server prefetch
+// timeout (10s). There is no completion signal for that tail, so the slot is
+// held for a fixed grace after the socket closes, long enough to cover several
+// sequential legs, and the undercount is bounded to renders that outlive it,
+// which the event-loop monitor reports as pathological anyway.
 const rawGrace = process.env.SSR_ABANDONED_GRACE_MS;
-const abandonedGraceMs = /^\d{1,6}$/.test(rawGrace || "") ? Number(rawGrace) : 10_000;
+const abandonedGraceMs = /^\d{1,6}$/.test(rawGrace || "") ? Number(rawGrace) : 30_000;
 
 // Paths that are not page renders. Anything else that reaches this process is
 // a document or an RSC navigation (the reverse proxy keeps private-api and
@@ -54,7 +58,7 @@ function isRender(req) {
   return !PASS_EXTENSIONS.test(path);
 }
 
-const state = { max, inflight: 0, shed: 0 };
+const state = { max, inflight: 0, shed: 0, abandoned: 0 };
 // Read by the event-loop monitor's log lines; never written from outside.
 globalThis.__ecencySsrAdmission = state;
 
@@ -93,6 +97,7 @@ if (Number.isFinite(max) && max > 0) {
       // keep the slot for the grace period, or until end(), whichever first.
       res.once("close", () => {
         if (released) return;
+        state.abandoned += 1;
         if (abandonedGraceMs === 0) {
           release();
           return;
@@ -110,7 +115,7 @@ if (Number.isFinite(max) && max > 0) {
   setInterval(() => {
     if (state.shed === lastShed) return;
     process.stderr.write(
-      `[ssr-admission] shed ${state.shed - lastShed} requests in the last 60s (inflight=${state.inflight}, max=${state.max})\n`
+      `[ssr-admission] shed ${state.shed - lastShed} requests in the last 60s (inflight=${state.inflight}, max=${state.max}, abandoned=${state.abandoned})\n`
     );
     lastShed = state.shed;
   }, 60_000).unref();

--- a/apps/web/ssr-admission.js
+++ b/apps/web/ssr-admission.js
@@ -38,20 +38,39 @@ const retryAfter = /^\d{1,4}$/.test(rawRetryAfter || "") ? rawRetryAfter : "1";
 const rawGrace = process.env.SSR_ABANDONED_GRACE_MS;
 const abandonedGraceMs = /^\d{1,6}$/.test(rawGrace || "") ? Number(rawGrace) : 30_000;
 
-// Paths that are not page renders. Anything else that reaches this process is
-// a document or an RSC navigation (the reverse proxy keeps private-api and
-// friends away from it), so those are what the cap protects.
-const PASS_PREFIXES = ["/_next/", "/api/", "/assets/", "/scripts/"];
-// Files served from public/ (service workers, social images, geo data, fonts,
-// manifests) carry a file extension; page paths do not. Usernames can contain
-// a dot (`/@demo.com`), hence a fixed list rather than "has any extension".
-const PASS_EXTENSIONS = /\.(?:js|mjs|css|map|json|webmanifest|txt|xml|ico|png|jpe?g|gif|svg|webp|avif|woff2?|ttf|otf|eot|mp4|webm|mp3|m4a|pdf|html?)$/i;
+// Paths that are not page renders, named precisely: the build output, API
+// routes, the public/ directories, the static root files the app serves, the
+// Redis-backed sitemap routes, and media or font files by extension. Anything
+// else that reaches this process is work on the render loop and counts: a
+// document, an RSC navigation, an RSS feed (`/@user/rss.xml` renders twenty
+// posts) or an agent route (`/@author/permlink.md|.json|.discussion.json`
+// renders the post), which is why data extensions such as .xml, .json, .md
+// and .txt are deliberately NOT in the extension list. Usernames can contain
+// a dot (`/@demo.com`), another reason the list is fixed rather than "has any
+// extension".
+const PASS_PREFIXES = ["/_next/", "/api/", "/assets/", "/scripts/", "/geo/", "/dmca/", "/.well-known/", "/sitemap/"];
+const PASS_EXACT = new Set([
+  "/favicon.ico",
+  "/manifest.json",
+  "/robots.txt",
+  "/llms.txt",
+  "/sitemap.xml",
+  "/sw.js",
+  "/firebase-messaging-sw.js",
+  "/og.jpg",
+  "/next.svg",
+  "/vercel.svg",
+  "/public-nodes.json",
+  "/apple-app-site-association"
+]);
+const PASS_EXTENSIONS = /\.(?:js|mjs|css|map|webmanifest|ico|png|jpe?g|gif|svg|webp|avif|woff2?|ttf|otf|eot|mp4|webm|mp3|m4a|pdf)$/i;
 
 function isRender(req) {
   if (req.method !== "GET" && req.method !== "HEAD") return false;
   const url = req.url || "/";
   const q = url.indexOf("?");
   const path = q === -1 ? url : url.slice(0, q);
+  if (PASS_EXACT.has(path)) return false;
   for (const prefix of PASS_PREFIXES) {
     if (path.startsWith(prefix)) return false;
   }

--- a/apps/web/ssr-admission.js
+++ b/apps/web/ssr-admission.js
@@ -43,11 +43,12 @@ const abandonedGraceMs = /^\d{1,6}$/.test(rawGrace || "") ? Number(rawGrace) : 3
 // the Redis-backed sitemap routes. Anything else that reaches this process is
 // work on the render loop and counts: a document, an RSC navigation, an RSS
 // feed (`/@user/rss.xml` renders twenty posts), an agent route
-// (`/@author/permlink.md|.json|.discussion.json` renders the post), and a
-// post whose permlink happens to end like a file (`/@author/post.png` is a
-// valid entry route). That last case is why there is no extension-based
-// bypass at all: every static file this app serves lives under a prefix or
-// at a root path listed here, so a name is the only safe test.
+// (`/@author/permlink.md|.json|.discussion.json`, a suffix the middleware
+// appends to a permlink, renders the post), and an unknown path such as
+// `/@author/post.png` (permlinks never contain a dot, so that is the
+// not-found page, still a render). Hence no extension-based bypass at all:
+// every static file this app serves lives under a prefix or at a root path
+// listed here, so a name is the only safe test.
 const PASS_PREFIXES = ["/_next/", "/api/", "/assets/", "/scripts/", "/geo/", "/dmca/", "/.well-known/", "/sitemap/"];
 const PASS_EXACT = new Set([
   "/favicon.ico",


### PR DESCRIPTION
Closes #1609

## What

- `apps/web/ssr-admission.js`: dependency-free preload (`node --require`, next to `next-runtime-config.js` in the image CMD). Hooks `http.Server`'s `request` emission, counts in-flight document and RSC renders, and above `SSR_MAX_INFLIGHT` answers 503 with `Retry-After` before Next sees the request. `/_next/`, `/api/`, `/assets/`, `/scripts/` and the well-known files pass through uncounted; writes are not counted; a slot is freed on `finish` or `close`. Logs one line per minute at most, and only when something was shed. Unset or 0 disables it.
- `docker-compose.production.yml`: `SSR_MAX_INFLIGHT=16`, and `--max-semi-space-size=64` added to `NODE_OPTIONS`.
- `Dockerfile`: copies and requires the preload.

## Why

Nothing inside the process bounded concurrency; shedding happened only upstream and site-wide. One slow render pulled every concurrent render down with it, which is the state the heap-abort incidents started from. Above the cap the edge worker already treats 503 as a failover signal for idempotent requests, so the visitor is served by the other origin instead of waiting on a stuck loop.

The cap only bites once renders have slowed enough to pile up: at normal render times a process holds a handful of renders, and 16 in flight corresponds to far more throughput per process than the site sees.

## Tests

`src/specs/ssr-admission.spec.ts` boots the real preload in a child process in front of a plain `http` server and drives it over sockets: inert when unset, 503 + `Retry-After` above the cap, slot freed on finish and on client abort, RSC counted, assets/API/well-known/writes never shed, and the image/stack wiring pinned.

## Rollout

Alpha first. The semi-space change is a throughput trade and should be read from the event-loop SPIKE records and GC share there before production.