### PR TITLE
Carry the previous builds' static assets into each new image

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -77,7 +77,12 @@ jobs:
           file: ./apps/web/Dockerfile
           push: true
           tags: ecency/vision-web:latest
+          # Always fetch the image being replaced: the Dockerfile carries its static
+          # assets forward (retain-static.js, #1615), so a stale local copy would
+          # retain the wrong build.
+          pull: true
           build-args: |
+            PREVIOUS_IMAGE=ecency/vision-web:latest
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=ecency
             SENTRY_PROJECT=ecency-next

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -80,7 +80,12 @@ jobs:
           file: ./apps/web/Dockerfile
           push: true
           tags: ecency/vision-web:develop
+          # Always fetch the image being replaced: the Dockerfile carries its static
+          # assets forward (retain-static.js, #1615), so a stale local copy would
+          # retain the wrong build.
+          pull: true
           build-args: |
+            PREVIOUS_IMAGE=ecency/vision-web:develop
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=ecency
             SENTRY_PROJECT=ecency-next

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,12 @@
 # syntax=docker/dockerfile:1.7
+# The image this build replaces. Its hashed static assets are carried into the
+# new image (see retain-static.js and #1615) so HTML cached at the edge or the
+# origin before the rollout keeps resolving its chunks instead of loading 404s
+# and hard-reloading. Production builds replace :latest; staging passes its own
+# tag. The workflows pull this tag fresh on every build.
+ARG PREVIOUS_IMAGE=ecency/vision-web:latest
+FROM ${PREVIOUS_IMAGE} AS previous
+
 FROM node:24.16.0 AS base
 WORKDIR /var/app
 
@@ -57,6 +65,10 @@ ENV SENTRY_LOG_LEVEL=debug
 # Single build that emits the EXACT assets we ship
 # Build packages first, then the web app (exclude self-hosted)
 RUN pnpm build:packages && pnpm --filter @ecency/web build
+# The webpack build cache is only useful to a rebuild inside this same layer,
+# which never happens; it was ~2.8 GB of the ~3 GB .next that every origin
+# and every CI build pulled. Next recreates .next/cache at runtime as needed.
+RUN rm -rf apps/web/.next/cache/webpack
 
 # Prune runtime deps for the web workspace
 RUN pnpm deploy --filter @ecency/web --prod --legacy /var/app/.deploy-workdir \
@@ -111,6 +123,15 @@ COPY --from=base /var/app/apps/web/next-runtime-config.js ./apps/web/next-runtim
 COPY --from=base /var/app/apps/web/ssr-admission.js ./apps/web/ssr-admission.js
 COPY --from=base /var/app/apps/web/public ./apps/web/public
 COPY --from=base /var/app/apps/web/.next ./apps/web/.next
+# Previous builds' static assets, merged in and bounded by retain-static.js.
+# Read through a bind mount rather than COPY: a COPY would leave a dead layer in
+# the final image even after the merge deleted the directory. The whole
+# previous root is mounted and the script looks for the static dir inside it,
+# so a build against an image without one (a local `--build-arg
+# PREVIOUS_IMAGE=busybox`) is simply a no-op rather than a failed mount.
+COPY --from=base /var/app/apps/web/retain-static.js ./apps/web/retain-static.js
+RUN --mount=type=bind,from=previous,source=/,target=/previous \
+  node apps/web/retain-static.js /previous/var/app/apps/web/.next/static
 COPY --from=base /var/app/node_modules ./node_modules
 COPY --from=base /var/app/apps/web/node_modules ./apps/web/node_modules
 

--- a/apps/web/retain-static.js
+++ b/apps/web/retain-static.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/*
+ * Keep the previous builds' hashed static assets in the new image (#1615).
+ *
+ * HTML for post pages is cached at the edge and at the origin nginx for days.
+ * That HTML references the chunks of the build that rendered it, and those
+ * chunks disappear from the origins the moment a new image rolls out, so a
+ * visitor who gets a cached page loads 404s and is hard-reloaded onto the new
+ * build: two builds' worth of assets for one page view, for every cached post
+ * page, for as long as the cache lives.
+ *
+ * The Dockerfile bind-mounts the previous image's `.next/static` (first CLI
+ * argument; defaults to `.next/static-previous`) and runs this script, which
+ * merges the previous builds' files into the new directory (new files win on a
+ * clash, which never happens for hashed names) and records which files belong
+ * to which build, with its build time, in `retained-builds.json`. A build is
+ * kept while it is younger than MAX_AGE_MS: the longest HTML tier
+ * (entry-archive / entry-ancient) is s-maxage 30 days, honoured by Cloudflare's
+ * standard cache and by the origin nginx (the worker's own cache caps at 7
+ * days; stale-while-revalidate does not extend this, the revalidation fetches
+ * the new build). MAX_BUILDS and MAX_RETAINED_BYTES are backstops so the image
+ * cannot grow without bound: a retained build only adds the files it does not
+ * share with newer ones, roughly 1-2 MB for a typical deploy.
+ *
+ * Stale HTML then renders on the build it was made for. On that visitor's
+ * first navigation the old client talks to the new server; Next 15 self-hosted
+ * has no deployment-id handshake (the client sends x-deployment-id, nothing
+ * reads it), so a chunk mismatch there is caught by the app's own skew handler
+ * (utils/deploy-skew.ts) and reloads once. That moves the one reload from
+ * page load, where it doubled every cached page view, to the first navigation.
+ *
+ * Best effort by design: any failure logs and exits 0, leaving exactly the
+ * build that `next build` produced.
+ */
+const fs = require("fs");
+const path = require("path");
+
+const MANIFEST = "retained-builds.json";
+const MAX_AGE_MS = 31 * 24 * 60 * 60 * 1000;
+const MAX_BUILDS = 400;
+const MAX_RETAINED_BYTES = 1024 * 1024 * 1024;
+
+function walk(dir, base = dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, base, out);
+    else if (entry.isFile()) out.push(path.relative(base, full).split(path.sep).join("/"));
+  }
+  return out;
+}
+
+function readManifest(dir) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path.join(dir, MANIFEST), "utf8"));
+    return Array.isArray(parsed.builds) ? parsed.builds : [];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Merge `previousDir` into `currentDir`.
+ * @returns {{ current: string, retained: {id: string, builtAt: number, files: string[]}[], copied: number }}
+ */
+function retainStatic({
+  currentDir,
+  previousDir,
+  buildId,
+  now = Date.now(),
+  maxAgeMs = MAX_AGE_MS,
+  maxBuilds = MAX_BUILDS,
+  maxRetainedBytes = MAX_RETAINED_BYTES
+}) {
+  const currentFiles = walk(currentDir).filter((f) => f !== MANIFEST);
+  const result = { current: buildId, retained: [], copied: 0, retainedBytes: 0 };
+
+  if (previousDir && fs.existsSync(previousDir)) {
+    let previousBuilds = readManifest(previousDir);
+    if (!previousBuilds) {
+      // The previous image predates this script: treat everything it shipped
+      // as one build, dated now so it gets the full window.
+      previousBuilds = [
+        { id: "previous", builtAt: now, files: walk(previousDir).filter((f) => f !== MANIFEST) }
+      ];
+    }
+    const current = new Set(currentFiles);
+    const usedIds = new Set([buildId]);
+    for (const build of previousBuilds) {
+      const builtAt = typeof build.builtAt === "number" ? build.builtAt : now;
+      // A rebuild of the same commit reuses the BUILD_ID (a short git SHA) and
+      // normally the same hashed files, so merging costs nothing; if its output
+      // did differ, the earlier files are kept like any other build's, under an
+      // id made unique with the build's timestamp (and a counter should even
+      // that collide), so repeated rebuilds keep the manifest unambiguous.
+      const base = build.id === buildId ? `${build.id}#${builtAt}` : String(build.id);
+      let id = base;
+      for (let n = 2; usedIds.has(id); n++) id = `${base}-${n}`;
+      usedIds.add(id);
+      if (now - builtAt > maxAgeMs) continue;
+      if (result.retained.length >= maxBuilds) break;
+      if (result.retainedBytes >= maxRetainedBytes) break;
+      const kept = [];
+      for (const rel of build.files || []) {
+        if (current.has(rel) || kept.includes(rel)) continue;
+        const src = path.join(previousDir, rel);
+        if (!fs.existsSync(src)) continue;
+        const dest = path.join(currentDir, rel);
+        if (!fs.existsSync(dest)) {
+          fs.mkdirSync(path.dirname(dest), { recursive: true });
+          fs.copyFileSync(src, dest);
+          result.copied += 1;
+        }
+        result.retainedBytes += fs.statSync(dest).size;
+        kept.push(rel);
+        current.add(rel);
+      }
+      if (kept.length) result.retained.push({ id, builtAt, files: kept });
+    }
+  }
+
+  const manifest = {
+    builds: [{ id: buildId, builtAt: now, files: currentFiles }, ...result.retained]
+  };
+  fs.writeFileSync(path.join(currentDir, MANIFEST), JSON.stringify(manifest));
+  return result;
+}
+
+function main() {
+  const appDir = path.resolve(__dirname);
+  const currentDir = path.join(appDir, ".next", "static");
+  const defaultPrevious = path.join(appDir, ".next", "static-previous");
+  const previousDir = process.argv[2] ? path.resolve(process.argv[2]) : defaultPrevious;
+  let buildId = "unknown";
+  try {
+    buildId = fs.readFileSync(path.join(appDir, ".next", "BUILD_ID"), "utf8").trim() || buildId;
+  } catch {
+    /* keep "unknown" */
+  }
+  try {
+    const r = retainStatic({ currentDir, previousDir, buildId });
+    console.log(
+      `[retain-static] build ${r.current}: kept ${r.retained.length} previous build(s) ` +
+        `(${r.retained.map((b) => `${b.id}:${b.files.length}`).join(", ") || "none"}), ` +
+        `copied ${r.copied} file(s), ${(r.retainedBytes / 1048576).toFixed(1)} MB retained`
+    );
+  } catch (e) {
+    console.warn("[retain-static] skipped:", e && e.message ? e.message : e);
+  } finally {
+    // Only an in-tree copy is ours to remove; a bind mount is read-only and
+    // disappears with the build step.
+    if (previousDir === defaultPrevious) {
+      try {
+        fs.rmSync(previousDir, { recursive: true, force: true });
+      } catch {
+        /* nothing to clean */
+      }
+    }
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { retainStatic, walk, MANIFEST, MAX_AGE_MS, MAX_BUILDS, MAX_RETAINED_BYTES };

--- a/apps/web/src/specs/deploy/retain-static.spec.ts
+++ b/apps/web/src/specs/deploy/retain-static.spec.ts
@@ -1,0 +1,258 @@
+// @vitest-environment node
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * Post pages are cached at the edge and the origin for days, referencing the
+ * chunks of the build that rendered them. When a deploy removes those chunks
+ * the cached page loads 404s and hard-reloads onto the new build (#1615).
+ * retain-static.js carries the previous builds' static assets into the new
+ * image, bounded to the last few builds. These tests drive the merge on temp
+ * directories and pin the Dockerfile/workflow wiring that invokes it.
+ */
+const { retainStatic, MANIFEST, MAX_AGE_MS, MAX_BUILDS, MAX_RETAINED_BYTES } = require("../../../retain-static.js") as {
+  retainStatic: (o: {
+    currentDir: string;
+    previousDir?: string;
+    buildId: string;
+    now?: number;
+    maxAgeMs?: number;
+    maxBuilds?: number;
+    maxRetainedBytes?: number;
+  }) => {
+    current: string;
+    retained: { id: string; builtAt: number; files: string[] }[];
+    copied: number;
+    retainedBytes: number;
+  };
+  MANIFEST: string;
+  MAX_AGE_MS: number;
+  MAX_BUILDS: number;
+  MAX_RETAINED_BYTES: number;
+};
+const DAY = 24 * 60 * 60 * 1000;
+
+const root = join(__dirname, "..", "..", "..", "..", "..");
+const read = (p: string) => readFileSync(join(root, p), "utf8");
+
+const dirs: string[] = [];
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), "retain-"));
+  dirs.push(d);
+  return d;
+}
+function put(dir: string, rel: string, body = rel) {
+  mkdirSync(join(dir, rel, ".."), { recursive: true });
+  writeFileSync(join(dir, rel), body);
+}
+function manifest(dir: string) {
+  return JSON.parse(readFileSync(join(dir, MANIFEST), "utf8")) as {
+    builds: { id: string; builtAt: number; files: string[] }[];
+  };
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("retain-static", () => {
+  it("first run: treats a previous image without a manifest as one build and merges it", () => {
+    const prev = tmp();
+    put(prev, "chunks/old-a.js");
+    put(prev, "css/old.css");
+    put(prev, "oldbuild/_buildManifest.js");
+    const cur = tmp();
+    put(cur, "chunks/new-a.js");
+    put(cur, "newbuild/_buildManifest.js");
+
+    const r = retainStatic({ currentDir: cur, previousDir: prev, buildId: "newbuild" });
+    expect(r.copied).toBe(3);
+    expect(existsSync(join(cur, "chunks/old-a.js"))).toBe(true);
+    expect(existsSync(join(cur, "oldbuild/_buildManifest.js"))).toBe(true);
+    const m = manifest(cur);
+    expect(m.builds.map((b) => b.id)).toEqual(["newbuild", "previous"]);
+    expect(m.builds[0].files.sort()).toEqual(["chunks/new-a.js", "newbuild/_buildManifest.js"]);
+    expect(m.builds[1].files.sort()).toEqual(["chunks/old-a.js", "css/old.css", "oldbuild/_buildManifest.js"]);
+  });
+
+  it("keeps builds for the cache horizon, not a fixed count: many deploys a day all stay", () => {
+    // The longest HTML tier is s-maxage 30 days (entry-archive / entry-ancient),
+    // honoured by Cloudflare's standard cache and the origin nginx.
+    expect(MAX_AGE_MS).toBe(31 * DAY);
+    let prev = tmp();
+    put(prev, "chunks/b0.js");
+    writeFileSync(join(prev, MANIFEST), JSON.stringify({ builds: [{ id: "b0", builtAt: 0, files: ["chunks/b0.js"] }] }));
+    // Ten deploys over one day: every one of them is still retained.
+    let cur = prev;
+    for (let i = 1; i <= 10; i++) {
+      prev = cur;
+      cur = tmp();
+      put(cur, `chunks/b${i}.js`);
+      retainStatic({ currentDir: cur, previousDir: prev, buildId: `b${i}`, now: i * (DAY / 10) });
+    }
+    const ids = manifest(cur).builds.map((b) => b.id);
+    expect(ids).toEqual(["b10", "b9", "b8", "b7", "b6", "b5", "b4", "b3", "b2", "b1", "b0"]);
+    expect(existsSync(join(cur, "chunks/b0.js"))).toBe(true);
+    // 31.5 days later the builds older than the window (b0..b4, built in the
+    // first half of day one) have aged out; the rest stay.
+    prev = cur;
+    cur = tmp();
+    put(cur, "chunks/b11.js");
+    const r = retainStatic({ currentDir: cur, previousDir: prev, buildId: "b11", now: 31.5 * DAY });
+    const after = manifest(cur).builds.map((b) => b.id);
+    expect(after).toEqual(["b11", "b10", "b9", "b8", "b7", "b6", "b5"]);
+    expect(existsSync(join(cur, "chunks/b0.js"))).toBe(false);
+    expect(existsSync(join(cur, "chunks/b4.js"))).toBe(false);
+    expect(existsSync(join(cur, "chunks/b5.js"))).toBe(true);
+    expect(r.retained.every((b) => typeof b.builtAt === "number")).toBe(true);
+  });
+
+  it("caps the number of retained builds as a backstop", () => {
+    const prev = tmp();
+    const builds = [];
+    for (let i = 0; i < 5; i++) {
+      put(prev, `chunks/p${i}.js`);
+      builds.push({ id: `p${i}`, builtAt: 1000 - i, files: [`chunks/p${i}.js`] });
+    }
+    writeFileSync(join(prev, MANIFEST), JSON.stringify({ builds }));
+    const cur = tmp();
+    put(cur, "chunks/c.js");
+    retainStatic({ currentDir: cur, previousDir: prev, buildId: "c", now: 1000, maxBuilds: 3 });
+    expect(manifest(cur).builds.map((b) => b.id)).toEqual(["c", "p0", "p1", "p2"]);
+    expect(MAX_BUILDS).toBe(400);
+  });
+
+  it("stops retaining older builds once the retained bytes exceed the cap", () => {
+    const prev = tmp();
+    const builds = [];
+    for (let i = 0; i < 4; i++) {
+      put(prev, `chunks/p${i}.js`, "x".repeat(1000));
+      builds.push({ id: `p${i}`, builtAt: 100 - i, files: [`chunks/p${i}.js`] });
+    }
+    writeFileSync(join(prev, MANIFEST), JSON.stringify({ builds }));
+    const cur = tmp();
+    put(cur, "chunks/c.js");
+    const r = retainStatic({ currentDir: cur, previousDir: prev, buildId: "c", now: 100, maxRetainedBytes: 2500 });
+    // p0 (1000) + p1 (2000) + p2 (3000 > cap, but the check happens per build)
+    // => after p2 the cap is exceeded and p3 is not retained.
+    expect(manifest(cur).builds.map((b) => b.id)).toEqual(["c", "p0", "p1", "p2"]);
+    expect(r.retainedBytes).toBe(3000);
+    expect(MAX_RETAINED_BYTES).toBe(1024 * 1024 * 1024);
+  });
+
+  it("a file shared by several builds survives the older build aging out", () => {
+    const prev = tmp();
+    put(prev, "chunks/shared.js");
+    put(prev, "chunks/old-only.js");
+    writeFileSync(
+      join(prev, MANIFEST),
+      JSON.stringify({
+        builds: [
+          { id: "newer", builtAt: 100, files: ["chunks/shared.js"] },
+          { id: "older", builtAt: 0, files: ["chunks/shared.js", "chunks/old-only.js"] }
+        ]
+      })
+    );
+    const cur = tmp();
+    put(cur, "chunks/c.js");
+    retainStatic({ currentDir: cur, previousDir: prev, buildId: "c", now: 100, maxAgeMs: 50 });
+    expect(existsSync(join(cur, "chunks/shared.js"))).toBe(true);
+    expect(existsSync(join(cur, "chunks/old-only.js"))).toBe(false);
+    expect(manifest(cur).builds.map((b) => b.id)).toEqual(["c", "newer"]);
+  });
+
+  it("never overwrites a file the new build produced and does not duplicate shared files", () => {
+    const prev = tmp();
+    put(prev, "chunks/shared.js", "OLD");
+    put(prev, "chunks/only-old.js");
+    writeFileSync(join(prev, MANIFEST), JSON.stringify({ builds: [{ id: "p", files: ["chunks/shared.js", "chunks/only-old.js"] }] }));
+    const cur = tmp();
+    put(cur, "chunks/shared.js", "NEW");
+    const r = retainStatic({ currentDir: cur, previousDir: prev, buildId: "n" });
+    expect(readFileSync(join(cur, "chunks/shared.js"), "utf8")).toBe("NEW");
+    expect(r.copied).toBe(1);
+    // the shared file is attributed to the current build only
+    expect(manifest(cur).builds[1].files).toEqual(["chunks/only-old.js"]);
+  });
+
+  it("is a no-op without a previous directory and still writes the manifest", () => {
+    const cur = tmp();
+    put(cur, "chunks/a.js");
+    const r = retainStatic({ currentDir: cur, previousDir: join(cur, "does-not-exist"), buildId: "solo", now: 7 });
+    expect(r.copied).toBe(0);
+    expect(manifest(cur).builds).toEqual([{ id: "solo", builtAt: 7, files: ["chunks/a.js"] }]);
+  });
+
+  it("keeps a rebuilt commit's earlier files when the same BUILD_ID produced different output", () => {
+    const prev = tmp();
+    put(prev, "chunks/x.js");
+    put(prev, "chunks/only-in-first-build.js");
+    writeFileSync(
+      join(prev, MANIFEST),
+      JSON.stringify({ builds: [{ id: "same", builtAt: 1, files: ["chunks/x.js", "chunks/only-in-first-build.js"] }] })
+    );
+    const cur = tmp();
+    put(cur, "chunks/x.js");
+    const r = retainStatic({ currentDir: cur, previousDir: prev, buildId: "same", now: 2 });
+    // Identical files cost nothing; the differing one is retained under an id
+    // made unique with its build time so the manifest stays unambiguous.
+    expect(r.retained).toEqual([{ id: "same#1", builtAt: 1, files: ["chunks/only-in-first-build.js"] }]);
+    expect(existsSync(join(cur, "chunks/only-in-first-build.js"))).toBe(true);
+    expect(manifest(cur).builds.map((b) => b.id)).toEqual(["same", "same#1"]);
+
+    // A further rebuild of the same commit must not collide with that entry.
+    const cur2 = tmp();
+    put(cur2, "chunks/x.js");
+    put(cur2, "chunks/third-only.js");
+    retainStatic({ currentDir: cur2, previousDir: cur, buildId: "same", now: 3 });
+    const ids = manifest(cur2).builds.map((b) => b.id);
+    expect(ids).toEqual(["same", "same#1"]);
+    expect(new Set(ids).size).toBe(ids.length);
+    // and with a forged timestamp clash the counter keeps them apart
+    const prev3 = tmp();
+    put(prev3, "chunks/a.js");
+    put(prev3, "chunks/b.js");
+    writeFileSync(
+      join(prev3, MANIFEST),
+      JSON.stringify({
+        builds: [
+          { id: "same", builtAt: 5, files: ["chunks/a.js"] },
+          { id: "same#5", builtAt: 5, files: ["chunks/b.js"] }
+        ]
+      })
+    );
+    const cur3 = tmp();
+    put(cur3, "chunks/c.js");
+    retainStatic({ currentDir: cur3, previousDir: prev3, buildId: "same", now: 6 });
+    const ids3 = manifest(cur3).builds.map((b) => b.id);
+    expect(ids3).toEqual(["same", "same#5", "same#5-2"]);
+  });
+});
+
+describe("retain-static wiring", () => {
+  it("the Dockerfile pulls the previous image as a stage and runs the merge after copying .next", () => {
+    const df = read("apps/web/Dockerfile");
+    expect(df).toMatch(/^ARG PREVIOUS_IMAGE=ecency\/vision-web:latest$/m);
+    expect(df).toMatch(/^FROM \$\{PREVIOUS_IMAGE\} AS previous$/m);
+    const copyNext = df.indexOf("COPY --from=base /var/app/apps/web/.next ./apps/web/.next");
+    const run = df.indexOf("RUN --mount=type=bind,from=previous,source=/,target=/previous");
+    expect(copyNext).toBeGreaterThan(-1);
+    expect(run).toBeGreaterThan(copyNext);
+    expect(df.slice(run, run + 200)).toContain("node apps/web/retain-static.js /previous/var/app/apps/web/.next/static");
+    // The webpack build cache must not ship: it made the image ~2.8 GB heavier.
+    expect(df.indexOf("rm -rf apps/web/.next/cache/webpack")).toBeGreaterThan(df.indexOf("pnpm --filter @ecency/web build"));
+    // No COPY of the previous static dir: that would leave a dead layer behind.
+    expect(df).not.toContain("COPY --from=previous");
+  });
+
+  it.each([
+    ["master.yml", "ecency/vision-web:latest"],
+    ["staging.yml", "ecency/vision-web:develop"]
+  ])("%s pulls the tag it replaces and hands it to the build", (file, tag) => {
+    const wf = read(`.github/workflows/${file}`);
+    expect(wf).toContain(`tags: ${tag}`);
+    expect(wf).toContain("pull: true");
+    expect(wf).toContain(`PREVIOUS_IMAGE=${tag}`);
+  });
+});


### PR DESCRIPTION
Post pages are cached at the edge and at the origin nginx for days, and that HTML references the chunks of the build that rendered it. A deploy removed those chunks from the origins, so a visitor who got a cached page loaded 404s and was hard-reloaded onto the new build: two builds' worth of assets for one page view, for every cached post page, for as long as the cache lived. Measured right after the last promotion: a cached post page loaded 4.6 MB / 345 requests instead of 2.3 MB / 170.

The Dockerfile now pulls the image being replaced as a build stage (`PREVIOUS_IMAGE`, `ecency/vision-web:latest` for production, `:develop` for staging) and bind-mounts it while `apps/web/retain-static.js` merges the previous builds' static files into the new `.next/static`. New files win on a clash (hashed names never clash), and `retained-builds.json` records which files belong to which build with its build time. A build is kept while it is younger than 31 days: the longest HTML tier (entry-archive / entry-ancient) is `s-maxage` 30 days, honoured by Cloudflare's standard cache and by the origin nginx (the worker's own cache caps at 7 days; stale-while-revalidate does not extend this, the revalidation fetches the new build). Caps of 400 builds and 1 GB of retained files are backstops; a retained build only adds the files it does not share with newer ones, about 2 MB for a typical deploy (measured on the current production image). The merge is best effort: any failure logs and leaves exactly what `next build` produced; an image without a static dir (for example a local build with `--build-arg PREVIOUS_IMAGE=busybox`) is a no-op rather than a failed mount. `next start` serves any file under `.next/static` with the immutable cache policy and ignores the `?dpl=` value (verified on the current production image), so retained chunks resolve for stale HTML exactly like current ones.

What changes for a visitor on a stale page: it renders on the build it was made for, once. Next 15 self-hosted has no deployment-id handshake (the client sends `x-deployment-id`; nothing on the server reads it), so on that visitor's first navigation a chunk mismatch is caught by the app's existing skew handler and reloads once. The one reload moves from page load, where it doubled every cached page view, to the first navigation.

Also in this PR, because it makes the extra pull affordable: the webpack build cache is no longer copied into the image. It was about 2.8 GB of the 3 GB `.next` that every origin and every CI build pulled, and nothing reads it at runtime (Next recreates `.next/cache` as needed).

Test plan
- `retain-static.spec.ts`: first run against an image without a manifest, a chain of ten deploys in one day all retained and aged out after the window, the build cap, the retained-bytes cap, a file shared by several builds surviving the older one aging out, new files never overwritten, missing previous dir, same build id; plus wiring guards on the Dockerfile and both workflows.
- Rehearsed on the current production image's real `.next/static` (630 files): the merge, a second round, a read-only previous dir (as the bind mount is) and a missing path; `next lint` and `tsc --noEmit` clean.
- The first CI build after merge pulls a 1.66 GB image once; subsequent builds pull the slimmer one.

Closes #1615