### PR TITLE
SSR RPC proxy: the shared secret is the switch

### DIFF
--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -88,11 +88,11 @@ services:
       - SEO_CRON_SECRET
       # Server-side read-through RPC proxy (core/sdk-init.ts): reads go to
       # vapi's /private-api/ssr/rpc over the overlay, with fallback to the node
-      # pool on any failure. Needs the same secret vapi was given above. The
-      # switch is an explicit value here, not a passthrough: production flips
-      # to 1 through a reviewed change to this line, after the alpha soak.
+      # pool on any failure. The secret is the switch for both services: set in
+      # the deploy job = on, blank = off on the next deploy. For an on-box kill
+      # without touching secrets: `docker service update --env-add
+      # SSR_RPC_PROXY=0 vision_web`.
       - SSR_INTERNAL_SECRET
-      - SSR_RPC_PROXY=0
       # Newsletter service (ecency/news), single instance on the EU box. EU reaches it
       # on the swarm gateway address, US through the IP-allowlisted TLS relay on the EU
       # origin; each deploy job supplies its own URL and refuses to deploy without them.

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -95,12 +95,10 @@ services:
       - SSR_MAX_INFLIGHT=16
       # Server-side read-through RPC proxy (core/sdk-init.ts): reads go to
       # vapi's /private-api/ssr/rpc over the overlay, with fallback to the node
-      # pool on any failure. Needs the same secret vapi was given above; the
-      # flag switches it on per deployment.
-      # The switch is on here, so the secret is required: a deploy without it
-      # would silently run without the proxy instead of exercising it.
-      - SSR_INTERNAL_SECRET=${SSR_INTERNAL_SECRET:?SSR_INTERNAL_SECRET is required while SSR_RPC_PROXY=1}
-      - SSR_RPC_PROXY=1
+      # pool on any failure. The secret is the switch for both services, and
+      # on alpha it is required: a deploy without it would silently run
+      # without the proxy instead of exercising it before production.
+      - SSR_INTERNAL_SECRET=${SSR_INTERNAL_SECRET:?SSR_INTERNAL_SECRET is required on alpha so staging always exercises the proxy}
     restart: always
     ports:
       - "3000:3000"

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -96,8 +96,9 @@ services:
       # Server-side read-through RPC proxy (core/sdk-init.ts): reads go to
       # vapi's /private-api/ssr/rpc over the overlay, with fallback to the node
       # pool on any failure. The secret is the switch for both services, and
-      # on alpha it is required: a deploy without it would silently run
-      # without the proxy instead of exercising it before production.
+      # on alpha it is required (`:?`): `docker-compose config` fails the deploy
+      # without it, instead of staging quietly running without the proxy it is
+      # meant to exercise before production.
       - SSR_INTERNAL_SECRET=${SSR_INTERNAL_SECRET:?SSR_INTERNAL_SECRET is required on alpha so staging always exercises the proxy}
     restart: always
     ports:

--- a/apps/web/src/core/sdk-init.ts
+++ b/apps/web/src/core/sdk-init.ts
@@ -60,15 +60,18 @@ if (isServer) {
   // per-tag feeds, posts) are answered from one cache per host instead of
   // being fetched by every renderer process on its own. An optimization, not
   // a dependency: the SDK falls back to the node pool on any proxy failure.
-  // Switched on per deployment (SSR_RPC_PROXY=1) and only when both sides
-  // carry the shared secret; INTERNAL_API_HOST is the overlay route to vapi.
+  // On whenever the deployment hands this process the shared secret (vapi
+  // switches its side on from the same value) and the overlay route to vapi
+  // (INTERNAL_API_HOST). No separate switch: the secret is the switch, in one
+  // place, for both services. SSR_RPC_PROXY=0 is an explicit off for an
+  // on-box kill that leaves the secret alone.
   // The timeout sits just above vapi's own lookup budget (1.5s), so a proxy
   // that cannot answer in time is its 504, and the SDK's per-node timeout
   // bounds it further; the prefetch's own abort signal bounds the whole call
   // either way, so the proxy can never extend a render past the SSR cap.
   const proxyHost = process.env.INTERNAL_API_HOST;
   const proxySecret = process.env.SSR_INTERNAL_SECRET;
-  if (process.env.SSR_RPC_PROXY === "1" && proxyHost && proxySecret) {
+  if (process.env.SSR_RPC_PROXY !== "0" && proxyHost && proxySecret) {
     ConfigManager.setServerRpcProxy({
       url: `${proxyHost.replace(/\/+$/, "")}/private-api/ssr/rpc`,
       headers: { "X-Ecency-Internal": proxySecret },

--- a/apps/web/src/specs/core/sdk-init-proxy.spec.ts
+++ b/apps/web/src/specs/core/sdk-init-proxy.spec.ts
@@ -29,10 +29,20 @@ vi.mock("@ecency/sdk", () => ({ ConfigManager: manager }));
 const REPORT_MS = 5 * 60 * 1000;
 const ON = { SSR_RPC_PROXY: undefined, SSR_INTERNAL_SECRET: "s3cret", INTERNAL_API_HOST: "http://vapi:4000" };
 
+const PROXY_VARS = ["SSR_RPC_PROXY", "SSR_INTERNAL_SECRET", "INTERNAL_API_HOST"] as const;
+
+/**
+ * Hermetic: every proxy variable is set from the case, and a case that omits
+ * one UNSETS it (stubEnv with undefined), so nothing leaks in from the test
+ * process and "missing" and "blank" are different environments.
+ */
 async function load(env: Record<string, string | undefined>): Promise<void> {
   vi.resetModules();
+  for (const k of PROXY_VARS) {
+    vi.stubEnv(k, env[k]);
+  }
   for (const [k, v] of Object.entries(env)) {
-    vi.stubEnv(k, v ?? "");
+    if (!(PROXY_VARS as readonly string[]).includes(k)) vi.stubEnv(k, v);
   }
   await import("@/core/sdk-init");
 }
@@ -64,6 +74,11 @@ describe("sdk-init server rpc proxy", () => {
   it("a legacy SSR_RPC_PROXY=1 changes nothing", async () => {
     await load({ ...ON, SSR_RPC_PROXY: "1" });
     expect(manager.setServerRpcProxy).toHaveBeenCalledTimes(1);
+    expect(manager.setServerRpcProxy).toHaveBeenCalledWith({
+      url: "http://vapi:4000/private-api/ssr/rpc",
+      headers: { "X-Ecency-Internal": "s3cret" },
+      timeoutMs: 1600
+    });
   });
 
   it.each([

--- a/apps/web/src/specs/core/sdk-init-proxy.spec.ts
+++ b/apps/web/src/specs/core/sdk-init-proxy.spec.ts
@@ -2,10 +2,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 /**
- * core/sdk-init.ts switches the server-side RPC proxy on at import time, and
- * only when the deployment asked for it AND both halves of the wiring are
- * present. A module with import-time side effects, so each case gets a fresh
- * module registry and its own environment.
+ * core/sdk-init.ts switches the server-side RPC proxy on at import time
+ * whenever both halves of the wiring (shared secret, overlay host) are
+ * present; the secret is the switch, SSR_RPC_PROXY=0 the explicit off. A
+ * module with import-time side effects, so each case gets a fresh module
+ * registry and its own environment.
  */
 const stats = {
   served: 0,
@@ -26,7 +27,7 @@ const manager = {
 vi.mock("@ecency/sdk", () => ({ ConfigManager: manager }));
 
 const REPORT_MS = 5 * 60 * 1000;
-const ON = { SSR_RPC_PROXY: "1", SSR_INTERNAL_SECRET: "s3cret", INTERNAL_API_HOST: "http://vapi:4000" };
+const ON = { SSR_RPC_PROXY: undefined, SSR_INTERNAL_SECRET: "s3cret", INTERNAL_API_HOST: "http://vapi:4000" };
 
 async function load(env: Record<string, string | undefined>): Promise<void> {
   vi.resetModules();
@@ -51,8 +52,8 @@ afterEach(() => {
 });
 
 describe("sdk-init server rpc proxy", () => {
-  it("enables the proxy against the overlay host with the shared secret when switched on", async () => {
-    await load({ SSR_RPC_PROXY: "1", SSR_INTERNAL_SECRET: "s3cret", INTERNAL_API_HOST: "http://vapi:4000/" });
+  it("enables the proxy against the overlay host as soon as the shared secret is present", async () => {
+    await load({ SSR_INTERNAL_SECRET: "s3cret", INTERNAL_API_HOST: "http://vapi:4000/" });
     expect(manager.setServerRpcProxy).toHaveBeenCalledWith({
       url: "http://vapi:4000/private-api/ssr/rpc",
       headers: { "X-Ecency-Internal": "s3cret" },
@@ -60,10 +61,16 @@ describe("sdk-init server rpc proxy", () => {
     });
   });
 
+  it("a legacy SSR_RPC_PROXY=1 changes nothing", async () => {
+    await load({ ...ON, SSR_RPC_PROXY: "1" });
+    expect(manager.setServerRpcProxy).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
-    ["the switch is off", { SSR_RPC_PROXY: undefined, SSR_INTERNAL_SECRET: "s3cret", INTERNAL_API_HOST: "http://vapi:4000" }],
-    ["the secret is missing", { SSR_RPC_PROXY: "1", SSR_INTERNAL_SECRET: undefined, INTERNAL_API_HOST: "http://vapi:4000" }],
-    ["the host is missing", { SSR_RPC_PROXY: "1", SSR_INTERNAL_SECRET: "s3cret", INTERNAL_API_HOST: undefined }]
+    ["explicitly switched off", { ...ON, SSR_RPC_PROXY: "0" }],
+    ["the secret is missing", { ...ON, SSR_INTERNAL_SECRET: undefined }],
+    ["the secret is blank", { ...ON, SSR_INTERNAL_SECRET: "" }],
+    ["the host is missing", { ...ON, INTERNAL_API_HOST: undefined }]
   ])("stays off when %s", async (_label, env) => {
     await load(env);
     expect(manager.setServerRpcProxy).not.toHaveBeenCalled();
@@ -100,7 +107,7 @@ describe("sdk-init server rpc proxy", () => {
     it("does not start when the proxy is off", async () => {
       vi.useFakeTimers();
       const log = vi.spyOn(console, "log").mockImplementation(() => {});
-      await load({ ...ON, SSR_RPC_PROXY: undefined });
+      await load({ ...ON, SSR_INTERNAL_SECRET: undefined });
       await vi.advanceTimersByTimeAsync(REPORT_MS * 2);
       expect(manager.getServerRpcProxyStats).not.toHaveBeenCalled();
       expect(log).not.toHaveBeenCalled();

--- a/apps/web/src/specs/deploy/ssr-proxy-wiring.spec.ts
+++ b/apps/web/src/specs/deploy/ssr-proxy-wiring.spec.ts
@@ -4,11 +4,13 @@ import { describe, expect, it } from "vitest";
 
 /**
  * The server-side RPC proxy is decided at process start in core/sdk-init.ts
- * from SSR_RPC_PROXY, SSR_INTERNAL_SECRET and INTERNAL_API_HOST, and vapi only
- * switches its side on when it holds the same secret. A variable missing from
- * any one of these places is silent: the SDK simply keeps going to the node
- * pool. This pins the whole chain: both services in both stack files, the
- * deploy jobs forwarding the secret, and the origin proxy hiding the path.
+ * from SSR_INTERNAL_SECRET and INTERNAL_API_HOST, and vapi only switches its
+ * side on when it holds the same secret: the secret is the switch for both.
+ * A variable missing from any one of these places is silent: the SDK simply
+ * keeps going to the node pool. This pins the whole chain: both services in
+ * both stack files, the deploy jobs forwarding the secret, the stack files
+ * not pinning the proxy off behind the secret's back, and the origin proxy
+ * hiding the path.
  */
 const root = join(__dirname, "..", "..", "..", "..", "..");
 const read = (p: string): string => readFileSync(join(root, p), "utf8");
@@ -33,23 +35,23 @@ const envNames = (entries: string[]): string[] => entries.map((e) => e.split("="
 
 describe("ssr rpc proxy deploy wiring", () => {
   it.each(["apps/web/docker-compose.yml", "apps/web/docker-compose.production.yml"])(
-    "%s hands the secret to vapi and to web, and web carries the switch",
+    "%s hands the secret to vapi and to web, and does not pin the proxy off behind it",
     (file) => {
       const compose = read(file);
       expect(envEntries(serviceBlock(compose, "vapi")), `${file}: vapi`).toContain("SSR_INTERNAL_SECRET");
       const web = envEntries(serviceBlock(compose, "web"));
       expect(envNames(web), `${file}: web`).toContain("SSR_INTERNAL_SECRET");
-      expect(web.some((e) => e === "SSR_RPC_PROXY=0" || e === "SSR_RPC_PROXY=1"), `${file}: web switch`).toBe(true);
+      // The secret is the switch. A literal SSR_RPC_PROXY here would make the
+      // stack file lie about what the deploy job handed over.
+      expect(envNames(web), `${file}: no separate switch`).not.toContain("SSR_RPC_PROXY");
     }
   );
 
-  it("alpha has the switch on and requires the secret; production carries an explicit value, never a bare passthrough", () => {
+  it("alpha requires the secret so staging always exercises the proxy; production passes it through", () => {
     const alpha = envEntries(serviceBlock(read("apps/web/docker-compose.yml"), "web"));
-    expect(alpha).toContain("SSR_RPC_PROXY=1");
     expect(alpha.some((e) => /^SSR_INTERNAL_SECRET=\$\{SSR_INTERNAL_SECRET:\?/.test(e))).toBe(true);
     const prod = envEntries(serviceBlock(read("apps/web/docker-compose.production.yml"), "web"));
-    expect(prod).not.toContain("SSR_RPC_PROXY");
-    expect(prod.some((e) => /^SSR_RPC_PROXY=[01]$/.test(e))).toBe(true);
+    expect(prod).toContain("SSR_INTERNAL_SECRET");
   });
 
   it.each(["master.yml", "staging.yml"])(".github/workflows/%s forwards the secret end to end", (file) => {

--- a/apps/web/src/specs/deploy/ssr-proxy-wiring.spec.ts
+++ b/apps/web/src/specs/deploy/ssr-proxy-wiring.spec.ts
@@ -41,9 +41,9 @@ describe("ssr rpc proxy deploy wiring", () => {
       expect(envEntries(serviceBlock(compose, "vapi")), `${file}: vapi`).toContain("SSR_INTERNAL_SECRET");
       const web = envEntries(serviceBlock(compose, "web"));
       expect(envNames(web), `${file}: web`).toContain("SSR_INTERNAL_SECRET");
-      // The secret is the switch. A literal SSR_RPC_PROXY here would make the
-      // stack file lie about what the deploy job handed over.
-      expect(envNames(web), `${file}: no separate switch`).not.toContain("SSR_RPC_PROXY");
+      // The secret is the switch. A literal SSR_RPC_PROXY anywhere in the stack
+      // file would make it lie about what the deploy job handed over.
+      expect(envNames(envEntries(compose)), `${file}: no separate switch`).not.toContain("SSR_RPC_PROXY");
     }
   );
 


### PR DESCRIPTION
Closes #1624.

The production stack file pinned the server-side RPC proxy off (`SSR_RPC_PROXY=0`), so every flip was a code change plus a main merge. Both services already receive `SSR_INTERNAL_SECRET` from the deploy jobs in every region, and vapi switches its side on from that value alone, so the secret becomes the switch for the web tier too.

- `core/sdk-init.ts`: the proxy is enabled whenever the secret and the overlay host are present, unless `SSR_RPC_PROXY=0` is set explicitly (on-box kill without touching secrets: `docker service update --env-add SSR_RPC_PROXY=0 vision_web`). A legacy `SSR_RPC_PROXY=1` changes nothing.
- Production compose: the pin is gone, the secret passes through as before. Alpha compose: the secret stays required so staging always exercises the proxy.
- Specs: sdk-init enables on secret + host, stays off on explicit `0`, missing or blank secret, missing host; the wiring spec now asserts neither stack file carries a literal `SSR_RPC_PROXY`, so a stack file cannot pin the proxy off behind the deploy job's back.

Effect: the next main deploy after this lands turns the proxy on in production. Off everywhere = blank the `SSR_INTERNAL_SECRET` repository secret and re-run the latest Master deploy (re-runs read current secrets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment Improvements**
  * Simplified SSR proxy activation: deployments now enable the proxy automatically when the internal API host and required secret are configured.
  * Removed the need to set a separate proxy activation flag.
  * Added an explicit emergency override to disable the proxy when needed.
  * Alpha deployments now require the internal secret, while production deployments pass it through for automatic activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->