### PR TITLE
SSR RPC cache: raise vapi's fill gate in the stack files

### DIFF
--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -20,6 +20,12 @@ services:
       # Shared secret for the internal SSR RPC cache (/private-api/ssr/*); the
       # web service sends it on every proxied read. Unset = those routes are off.
       - SSR_INTERNAL_SECRET
+      # Upstream fills the SSR RPC cache may run at once, and how many may wait
+      # for a slot. An origin with ~90 misses/s against a 200-900ms node path
+      # needs 45-85 fills in flight; the defaults (64/256) queued fills past the
+      # lookup budget and rejected the rest (first production hour, 2026-08-21).
+      - SSR_RPC_MAX_FILLS=256
+      - SSR_RPC_MAX_QUEUED_FILLS=512
       - STRIPE_INTERNAL_SECRET
       - BLOCKSTREAM_CLIENT_ID
       - BLOCKSTREAM_CLIENT_SECRET

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -20,6 +20,12 @@ services:
       # Shared secret for the internal SSR RPC cache (/private-api/ssr/*); the
       # web service sends it on every proxied read. Unset = those routes are off.
       - SSR_INTERNAL_SECRET
+      # Upstream fills the SSR RPC cache may run at once, and how many may wait
+      # for a slot. An origin with ~90 misses/s against a 200-900ms node path
+      # needs 45-85 fills in flight; the defaults (64/256) queued fills past the
+      # lookup budget and rejected the rest (first production hour, 2026-08-21).
+      - SSR_RPC_MAX_FILLS=256
+      - SSR_RPC_MAX_QUEUED_FILLS=512
       - BLOCKSTREAM_CLIENT_ID
       - BLOCKSTREAM_CLIENT_SECRET
       # Pinned to Warning at deploy time (the CI deploy env does not forward


### PR DESCRIPTION
Closes #1626.

First production hour of the SSR RPC cache: one origin runs ~90 misses/s against a node path that answers in 200-900ms, so it needs 45-85 upstream fills in flight. vapi's defaults (64 concurrent fills, 256 queued) queued fills past the 1.5s lookup budget and rejected the overflow; raising the gate on that box to 256/512 cut timeouts from ~100-240 per minute to ~12-35.

Both stack files now set `SSR_RPC_MAX_FILLS=256` and `SSR_RPC_MAX_QUEUED_FILLS=512` on the vapi service, so the value survives the next stack deploy (which resets anything applied with `docker service update`). The other origin sits at ~4 fills in flight and is unaffected by the larger bound.