### PR TITLE
SSR admission: cap 48 in-flight renders per process

### DIFF
--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -131,12 +131,19 @@ services:
       # Normal load is a handful of renders in flight per process; the cap only
       # bites once renders have slowed enough to pile up, which is exactly the
       # state that used to end in a heap abort. Unset or 0 disables it.
-      # Sized from measurement, not as a choke: the heavier origin runs ~14
-      # renders in flight per replica at normal load (60 docs/s x 0.7s / 3),
-      # and at 16 the cap shed 3-5% of documents as 503 for the edge to fail
-      # over. 48 is ~3.5x that average with room for bursts, and 3 x 48 stays
-      # under the origin's site-wide SSR concurrency ceiling. Multi-second
-      # render stalls, the reason for a tight cap, no longer occur.
+      # A per-process backstop against one slow render dragging down everything
+      # sharing its event loop, sized from measurement rather than as a choke:
+      # the heavier origin runs ~14 renders in flight per replica at normal load
+      # (its document rate x mean render time / replicas), and at 16 the cap shed
+      # a few percent of documents as 503 for the edge to fail over. 48 is ~3.5x
+      # that average with room for bursts. Not a global concurrency budget:
+      # anonymous SSR concurrency is bounded separately at the origin (nginx,
+      # over a different population - this cap counts every render, including
+      # logged-in and verified-crawler traffic). Memory is not the constraint
+      # here: replica RSS is flat against in-flight renders (~2.2GB at 5, 11 and
+      # 15 concurrent), being dominated by per-process caches rather than the
+      # renders themselves, and the multi-second stalls this cap was tightened
+      # for no longer occur.
       - SSR_MAX_INFLIGHT=48
     restart: always
     ports:

--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -131,7 +131,13 @@ services:
       # Normal load is a handful of renders in flight per process; the cap only
       # bites once renders have slowed enough to pile up, which is exactly the
       # state that used to end in a heap abort. Unset or 0 disables it.
-      - SSR_MAX_INFLIGHT=16
+      # Sized from measurement, not as a choke: the heavier origin runs ~14
+      # renders in flight per replica at normal load (60 docs/s x 0.7s / 3),
+      # and at 16 the cap shed 3-5% of documents as 503 for the edge to fail
+      # over. 48 is ~3.5x that average with room for bursts, and 3 x 48 stays
+      # under the origin's site-wide SSR concurrency ceiling. Multi-second
+      # render stalls, the reason for a tight cap, no longer occur.
+      - SSR_MAX_INFLIGHT=48
     restart: always
     ports:
       - "3000:3000"

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -98,7 +98,13 @@ services:
       # semi-space size (fewer scavenges on allocation-heavy renders) and the
       # per-process render cap (ssr-admission.js, loaded by the image CMD).
       - NODE_OPTIONS=--max-semi-space-size=64
-      - SSR_MAX_INFLIGHT=16
+      # Sized from measurement, not as a choke: the heavier origin runs ~14
+      # renders in flight per replica at normal load (60 docs/s x 0.7s / 3),
+      # and at 16 the cap shed 3-5% of documents as 503 for the edge to fail
+      # over. 48 is ~3.5x that average with room for bursts, and 3 x 48 stays
+      # under the origin's site-wide SSR concurrency ceiling. Multi-second
+      # render stalls, the reason for a tight cap, no longer occur.
+      - SSR_MAX_INFLIGHT=48
       # Server-side read-through RPC proxy (core/sdk-init.ts): reads go to
       # vapi's /private-api/ssr/rpc over the overlay, with fallback to the node
       # pool on any failure. The secret is the switch for both services, and

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -98,12 +98,19 @@ services:
       # semi-space size (fewer scavenges on allocation-heavy renders) and the
       # per-process render cap (ssr-admission.js, loaded by the image CMD).
       - NODE_OPTIONS=--max-semi-space-size=64
-      # Sized from measurement, not as a choke: the heavier origin runs ~14
-      # renders in flight per replica at normal load (60 docs/s x 0.7s / 3),
-      # and at 16 the cap shed 3-5% of documents as 503 for the edge to fail
-      # over. 48 is ~3.5x that average with room for bursts, and 3 x 48 stays
-      # under the origin's site-wide SSR concurrency ceiling. Multi-second
-      # render stalls, the reason for a tight cap, no longer occur.
+      # A per-process backstop against one slow render dragging down everything
+      # sharing its event loop, sized from measurement rather than as a choke:
+      # the heavier origin runs ~14 renders in flight per replica at normal load
+      # (its document rate x mean render time / replicas), and at 16 the cap shed
+      # a few percent of documents as 503 for the edge to fail over. 48 is ~3.5x
+      # that average with room for bursts. Not a global concurrency budget:
+      # anonymous SSR concurrency is bounded separately at the origin (nginx,
+      # over a different population - this cap counts every render, including
+      # logged-in and verified-crawler traffic). Memory is not the constraint
+      # here: replica RSS is flat against in-flight renders (~2.2GB at 5, 11 and
+      # 15 concurrent), being dominated by per-process caches rather than the
+      # renders themselves, and the multi-second stalls this cap was tightened
+      # for no longer occur.
       - SSR_MAX_INFLIGHT=48
       # Server-side read-through RPC proxy (core/sdk-init.ts): reads go to
       # vapi's /private-api/ssr/rpc over the overlay, with fallback to the node


### PR DESCRIPTION
Closes #1630.

Six hours of production with the per-process render cap at 16: the heavier origin serves ~60 documents/s on 3 replicas at a mean render of ~0.69s, i.e. ~14 renders in flight per replica on average, so the cap binds at normal load. Summed from the admission log's per-minute lines, ~10,000 requests per replica were shed since the deploy (3-5% of documents, up to ~200 in a minute), answered 503 in 1-5ms and failed over by the edge to the other origin. The lighter origin never reaches the cap. Multi-second render stalls, the reason for a tight cap, are gone (every STUCK event since the deploy is under 1s on both origins).

Both stack files set `SSR_MAX_INFLIGHT=48`: ~3.5x the measured average concurrency with room for bursts; 3 x 48 stays under the origin's site-wide SSR concurrency ceiling. The admission spec asserts the shape of the line, not the value, so no test change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased the web application’s capacity to handle more simultaneous server-rendered requests in production and staging environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->