### PR TITLE
Give the US origin a fourth replica, bounded by its own heap cap

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -173,6 +173,12 @@ jobs:
           export SEO_CRON_SECRET=$SEO_CRON_SECRET
           export TURNSTILE_SECRET=$TURNSTILE_SECRET
           export SSR_INTERNAL_SECRET=$SSR_INTERNAL_SECRET
+          # The web sizing knobs default in compose, so `docker-compose config`
+          # would otherwise read whatever the HOST happens to have exported and
+          # this region's memory profile could change with no commit behind it.
+          # EU pins its own values here: same numbers as the compose defaults,
+          # stated rather than inherited.
+          unset WEB_REPLICAS WEB_HEAP_MB WEB_MEM_LIMIT WEB_UPDATE_ORDER
           cd ~/vision-web
           git pull origin main
           cd apps/web
@@ -247,16 +253,35 @@ jobs:
         # region's URL is its own secret. Same token.
         NEWSLETTER_API_URL: ${{secrets.NEWSLETTER_API_URL_US}}
         NEWSLETTER_SERVICE_TOKEN: ${{secrets.NEWSLETTER_SERVICE_TOKEN}}
-        # The US box is smaller than EU (15GiB/8c vs 30GiB/16c). At 4 SSR
-        # replicas (the compose default) each plateaus ~3.7GiB RSS and the box
-        # ran out of RAM -> host global OOM cycling. 3 replicas fit with headroom.
-        WEB_REPLICAS: "3"
+        # This region's host is the smaller of the two. Four replicas once
+        # cycled it out of RAM: each settled far above where they sit now,
+        # because the heap climbed toward its cap for as long as the process
+        # lived. SSR_MAX_INFLIGHT removed that climb, which is what makes a
+        # fourth replica arguable at all.
+        #
+        # A plateau is behaviour, not a bound, so the sizing here is derived
+        # from the cgroup limit, which is enforced. The per-host budget behind
+        # these numbers lives with the infrastructure notes, not in this repo.
+        #
+        # stop-first belongs to that budget rather than being a preference:
+        # start-first runs a FIFTH task through every rollout and the budget
+        # does not cover one. Losing a replica briefly is what admission
+        # control already absorbs by shedding to the other region.
+        #
+        # The heap cap sits under the cgroup limit with room for what lives
+        # outside old space, and was measured on this host at this value
+        # before being set: it plateaued, with no restarts and a few percent
+        # more CPU, which four replicas repay by each carrying less traffic.
+        WEB_REPLICAS: "4"
+        WEB_HEAP_MB: "1536"
+        WEB_MEM_LIMIT: "2304M"
+        WEB_UPDATE_ORDER: "stop-first"
       with:
         host: ${{ secrets.SSH_HOST_US }}
         username: ${{ secrets.SSH_USERNAME }}
         key: ${{ secrets.SSH_KEY }}
         port: ${{ secrets.SSH_PORT }}
-        envs: USE_PRIVATE,PRIVATE_API_ADDR,PRIVATE_API_AUTH,HIVESIGNER_SECRET,SEARCH_API_ADDR,SEARCH_API_SECRET,STRIPE_INTERNAL_SECRET,HOSTING_INTERNAL_SECRET,HIVESEARCHER_ORIGIN_IP,PLAUSIBLE_API_KEY,BLOCKSTREAM_CLIENT_ID,BLOCKSTREAM_CLIENT_SECRET,MATTERMOST_TEAM_ID,MATTERMOST_ADMIN_TOKEN,MATTERMOST_BASE_URL,MATTERMOST_WS_ALLOWED_ORIGINS,THREESPEAK_EMBED_API_KEY,SEO_CRON_SECRET,TURNSTILE_SECRET,NEWSLETTER_API_URL,NEWSLETTER_SERVICE_TOKEN,WEB_REPLICAS,SSR_INTERNAL_SECRET
+        envs: USE_PRIVATE,PRIVATE_API_ADDR,PRIVATE_API_AUTH,HIVESIGNER_SECRET,SEARCH_API_ADDR,SEARCH_API_SECRET,STRIPE_INTERNAL_SECRET,HOSTING_INTERNAL_SECRET,HIVESEARCHER_ORIGIN_IP,PLAUSIBLE_API_KEY,BLOCKSTREAM_CLIENT_ID,BLOCKSTREAM_CLIENT_SECRET,MATTERMOST_TEAM_ID,MATTERMOST_ADMIN_TOKEN,MATTERMOST_BASE_URL,MATTERMOST_WS_ALLOWED_ORIGINS,THREESPEAK_EMBED_API_KEY,SEO_CRON_SECRET,TURNSTILE_SECRET,NEWSLETTER_API_URL,NEWSLETTER_SERVICE_TOKEN,WEB_REPLICAS,WEB_HEAP_MB,WEB_MEM_LIMIT,WEB_UPDATE_ORDER,SSR_INTERNAL_SECRET
         script: |
           set -eo pipefail
           export USE_PRIVATE=$USE_PRIVATE
@@ -282,6 +307,17 @@ jobs:
           export NEWSLETTER_API_URL=$NEWSLETTER_API_URL
           export NEWSLETTER_SERVICE_TOKEN=$NEWSLETTER_SERVICE_TOKEN
           export WEB_REPLICAS=$WEB_REPLICAS
+          # These three are this region's memory budget. Compose defaults to
+          # the other region's values, so a dropped variable would deploy four
+          # replicas at the wrong cap -- the configuration that cycled this
+          # host out of RAM. Fail the deploy instead of shipping it.
+          : "${WEB_HEAP_MB:?WEB_HEAP_MB is required for the US deploy}"
+          : "${WEB_MEM_LIMIT:?WEB_MEM_LIMIT is required for the US deploy}"
+          : "${WEB_UPDATE_ORDER:?WEB_UPDATE_ORDER is required for the US deploy}"
+          case "$WEB_HEAP_MB" in ''|*[!0-9]*) echo "WEB_HEAP_MB must be a number of MiB" >&2; exit 1;; esac
+          export WEB_HEAP_MB=$WEB_HEAP_MB
+          export WEB_MEM_LIMIT=$WEB_MEM_LIMIT
+          export WEB_UPDATE_ORDER=$WEB_UPDATE_ORDER
           cd ~/vision-web
           git pull origin main
           cd apps/web

--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -60,7 +60,7 @@ services:
       update_config:
         parallelism: 1
         delay: 15s
-        order: start-first
+        order: ${WEB_UPDATE_ORDER:-start-first}
         failure_action: rollback
         monitor: 30s
       rollback_config:
@@ -75,7 +75,7 @@ services:
       # plateaus too, so it never false-trips a healthy replica.
       resources:
         limits:
-          memory: 4608M
+          memory: ${WEB_MEM_LIMIT:-4608M}
     environment:
       - USE_PRIVATE
       - INTERNAL_API_HOST=http://vapi:4000
@@ -124,7 +124,11 @@ services:
       # The semi-space (young generation) is raised from V8's default so an
       # allocation-heavy render triggers fewer scavenges; costs ~128MiB of RSS
       # per replica, well inside the limit above.
-      - NODE_OPTIONS=--max-old-space-size=3072 --max-semi-space-size=64
+      # Per-region V8 old-space cap. It governs the heap, NOT the process: RSS
+      # is this plus young generation, native allocations and Buffers. The
+      # bound on total process memory is the cgroup limit above; the two are
+      # set together per region, never one without the other.
+      - NODE_OPTIONS=--max-old-space-size=${WEB_HEAP_MB:-3072} --max-semi-space-size=64
       # Per-process admission control (ssr-admission.js, loaded by the image
       # CMD): above this many in-flight page renders the process answers 503
       # with Retry-After, which the edge worker treats as a failover signal.

--- a/apps/web/docker-compose.production.yml
+++ b/apps/web/docker-compose.production.yml
@@ -66,13 +66,14 @@ services:
       rollback_config:
         parallelism: 1
         order: start-first
-      # Per-replica memory backstop. Web replicas plateau around 3.7GiB RSS
-      # (with MALLOC_ARENA_MAX=2 below); this cap sits above that so a genuine
-      # runaway is cgroup-OOM-killed and restarted in isolation instead of the
-      # host global OOM-killer picking an arbitrary victim (on the smaller US
-      # box it hit sshd/qemu-ga). 4.5GiB keeps 3 replicas (13.5GiB) under the
-      # 15GiB US box with headroom for redis/vapi/OS, and stays above the EU/SG
-      # plateaus too, so it never false-trips a healthy replica.
+      # Per-replica memory backstop, per region (WEB_MEM_LIMIT). It sits above
+      # where a replica settles, so a genuine runaway is cgroup-OOM-killed and
+      # restarted in isolation rather than the host's global OOM-killer picking
+      # an arbitrary victim -- on the smaller host it once took sshd and
+      # qemu-ga with it. Each region's value is chosen so its replica count
+      # fits that host with headroom for redis, vapi and the OS, and stays
+      # above where healthy replicas settle so it never false-trips one. The
+      # per-host figures behind it live with the infrastructure notes.
       resources:
         limits:
           memory: ${WEB_MEM_LIMIT:-4608M}


### PR DESCRIPTION
Renders per process run higher in this region than in the other, so it sheds under peak load while the other never does. A fourth replica lowers in-flight renders per process, which is the direct fix for that shedding.

Four replicas here once cycled the host out of RAM, and the comment this PR replaces records why: each settled far above where they sit now, because the heap climbed toward its cap for as long as the process lived. `SSR_MAX_INFLIGHT` removed that climb, which is what makes a fourth replica arguable at all.

**The first revision of this PR claimed a worst-case bound it did not have, and review was right to reject it.** A V8 old-space cap governs the heap, not the process: RSS is the cap plus young generation, native allocations and Buffers. The cgroup limit was still the other region's value, so lowering only the heap cap would not have prevented the failure it was meant to prevent.

The sizing is now derived from the cgroup limit, which is enforced. Three knobs become per-region and are always set together:

- `WEB_MEM_LIMIT` — the bound on total process memory, and the number the budget is built from.
- `WEB_HEAP_MB` — the V8 old-space cap, set to sit under that limit with room for what lives outside old space. This value was measured on the host before being chosen: it plateaued, with no restarts and a few percent more CPU per replica, which four replicas repay by each carrying less traffic.
- `WEB_UPDATE_ORDER` — `stop-first` here, which belongs to the budget rather than being a preference. `start-first` runs a fifth task through every rollout and the budget does not cover one; losing a replica briefly is exactly what admission control already absorbs by shedding to the other region.

Fail-closed: the deploy asserts all three and rejects a non-numeric heap cap, because compose defaults to the other region's values and a dropped variable would silently ship four replicas at the wrong cap. The other region unsets them before rendering, so its profile comes from the committed defaults rather than from whatever the host has exported. Both paths verified with `docker compose config`.

The per-host capacity figures behind these values are in the infrastructure notes rather than here.

After it deploys, the things that would falsify this: in-flight per replica and the shed rate should fall roughly in proportion to the replica count, host headroom should stay where the budget predicts, and settled RSS should land where it was measured. If shedding does not fall, the premise is wrong and this should be reverted rather than pushed further.
