### PR TITLE
sitemap spec: stop asserting static.xml is stable across a UTC day rollover

### DIFF
--- a/apps/web/src/specs/api/sitemap-generate-route.spec.ts
+++ b/apps/web/src/specs/api/sitemap-generate-route.spec.ts
@@ -164,8 +164,13 @@ describe("sitemap-generate route", () => {
     const t0 = Date.now();
     vi.useFakeTimers({ toFake: ["Date"], now: t0 });
     await run();
+    // static.xml is deliberately absent: its hub entries carry the current day,
+    // so its bytes DO change at UTC midnight and its lastmod moves with them.
+    // That is covered by its own test below, with the clock pinned either side
+    // of a rollover — asserting it here made the whole suite fail for any CI
+    // run started in the last two hours of a UTC day.
     const first = Object.fromEntries(
-      ["posts.xml", "authors.xml", "tags.xml", "communities.xml", "static.xml"].map((n) => [n, indexEntry(n)])
+      ["posts.xml", "authors.xml", "tags.xml", "communities.xml"].map((n) => [n, indexEntry(n)])
     );
     // Same data an hour later: nothing changed, nothing may move.
     vi.setSystemTime(new Date(t0 + HOUR));
@@ -186,7 +191,27 @@ describe("sitemap-generate route", () => {
     expect(indexEntry("authors.xml")).toBe(later);
     expect(indexEntry("tags.xml")).toBe(first["tags.xml"]);
     expect(indexEntry("communities.xml")).toBe(first["communities.xml"]);
-    expect(indexEntry("static.xml")).toBe(first["static.xml"]);
+  });
+
+  it("moves static.xml's lastmod across a UTC day rollover, and nothing else's", async () => {
+    // The hub entries (/, /discover, /communities, …) carry the current day, so
+    // static.xml's bytes change once a day by design — an honest signal for
+    // pages whose content really does turn over daily. Pinned either side of a
+    // midnight so it does not depend on when the suite runs.
+    const beforeMidnight = new Date();
+    beforeMidnight.setUTCHours(23, 50, 0, 0);
+    vi.useFakeTimers({ toFake: ["Date"], now: beforeMidnight.getTime() });
+    await run();
+    const first = Object.fromEntries(
+      ["tags.xml", "communities.xml", "static.xml"].map((n) => [n, indexEntry(n)])
+    );
+
+    vi.setSystemTime(new Date(beforeMidnight.getTime() + 20 * 60_000)); // 00:10 the next day
+    await run();
+    expect(indexEntry("static.xml"), "static.xml").not.toBe(first["static.xml"]);
+    // The content-stable shards must not be dragged along by the date.
+    expect(indexEntry("tags.xml"), "tags.xml").toBe(first["tags.xml"]);
+    expect(indexEntry("communities.xml"), "communities.xml").toBe(first["communities.xml"]);
   });
 
   it("keeps the accepted walk's full timestamp when a later walk is rejected", async () => {

--- a/apps/web/src/specs/api/sitemap-generate-route.spec.ts
+++ b/apps/web/src/specs/api/sitemap-generate-route.spec.ts
@@ -202,16 +202,18 @@ describe("sitemap-generate route", () => {
     beforeMidnight.setUTCHours(23, 50, 0, 0);
     vi.useFakeTimers({ toFake: ["Date"], now: beforeMidnight.getTime() });
     await run();
+    const stable = ["posts.xml", "authors.xml", "tags.xml", "communities.xml"];
     const first = Object.fromEntries(
-      ["tags.xml", "communities.xml", "static.xml"].map((n) => [n, indexEntry(n)])
+      [...stable, "static.xml"].map((n) => [n, indexEntry(n)])
     );
 
     vi.setSystemTime(new Date(beforeMidnight.getTime() + 20 * 60_000)); // 00:10 the next day
     await run();
     expect(indexEntry("static.xml"), "static.xml").not.toBe(first["static.xml"]);
-    // The content-stable shards must not be dragged along by the date.
-    expect(indexEntry("tags.xml"), "tags.xml").toBe(first["tags.xml"]);
-    expect(indexEntry("communities.xml"), "communities.xml").toBe(first["communities.xml"]);
+    // Every other shard is keyed on its own content — post days, tag names,
+    // community names — none of which the calendar touches. Same data either
+    // side of the rollover must mean the same lastmod.
+    for (const name of stable) expect(indexEntry(name), name).toBe(first[name]);
   });
 
   it("keeps the accepted walk's full timestamp when a later walk is rejected", async () => {


### PR DESCRIPTION
Closes #1635.

`sitemap-generate-route.spec.ts` fails for any CI run started in the last two hours of a UTC day. It hit PR #1633 at 22:56Z: the "advances a shard's index lastmod only when its bytes change" test snapshots every shard, advances the fake clock two hours, and asserts `static.xml` did not move — but that advance crossed midnight, and `static.xml`'s hub entries (`/`, `/discover`, `/communities`, `/witnesses`, `/proposals`, `/tags`) carry the current day, so its bytes really did change. The route was right and the assertion was only true within a day.

- The no-move invariant now covers the shards that are genuinely content-stable: `posts.xml`, `authors.xml`, `tags.xml`, `communities.xml`.
- A new test pins the clock at 23:50 UTC and again at 00:10 to assert the intended behaviour directly: `static.xml`'s lastmod moves across the rollover while `tags.xml` and `communities.xml` do not.

Verified two ways rather than by rerunning until green: a copy of the suite with its fake-clock base anchored at 22:56 UTC (the exact failure condition) passes 10/10, and flipping the new assertion to `toBe` fails exactly that test, so it is live rather than vacuous.