### PR TITLE
perf(css): fold shared component stylesheets into one entry (52 render-blocking sheets -> 7)

### DIFF
--- a/apps/web/src/app/decks/_components/_index.scss
+++ b/apps/web/src/app/decks/_components/_index.scss
@@ -1,6 +1,12 @@
 @import "src/styles/vars_mixins";
 
-html, body {
+// Scoped to pages that actually render the decks UI. Unscoped, this hides the
+// window scrollbar on EVERY route, which cancels the `scrollbar-gutter: stable`
+// that styles/_base.scss reserves to stop modal-open CLS, and shifts every
+// centered element by 7px. That only stayed invisible while this file compiled
+// into a decks-only chunk; once CSS chunks are consolidated the rule is merged
+// into the shared sheet and leaks site-wide. See issue #1632.
+html:has(.decks), body:has(.decks) {
   &::-webkit-scrollbar {
     display: none;
   }

--- a/apps/web/src/features/announcement/index.tsx
+++ b/apps/web/src/features/announcement/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from "react";
 import dayjs from "@/utils/dayjs";
 import * as ls from "@/utils/local-storage";
 import { Announcement, LaterAnnouncement } from "./types";
-import "./index.scss";
 import { Button } from "@ui/button";
 import { usePathname } from "next/navigation";
 import { closeSvg } from "@ui/svg";

--- a/apps/web/src/features/post-renderer/components/extensions/hive-operation-extension.tsx
+++ b/apps/web/src/features/post-renderer/components/extensions/hive-operation-extension.tsx
@@ -2,7 +2,6 @@
 
 import React, { RefObject, useEffect, useMemo, useRef } from "react";
 import { createRoot } from "react-dom/client";
-import "./hive-operation-extension.scss";
 import type { Operation } from "@ecency/sdk";
 import defaults from "@/defaults";
 

--- a/apps/web/src/features/post-renderer/components/extensions/hive-post-link-extension.tsx
+++ b/apps/web/src/features/post-renderer/components/extensions/hive-post-link-extension.tsx
@@ -9,7 +9,6 @@ import React, {
   useState,
 } from "react";
 import { createRoot } from "react-dom/client";
-import "./hive-post-link-extension.scss";
 import {
   findPostLinkElements,
   isInvalidPermlinkLink,

--- a/apps/web/src/features/post-renderer/components/extensions/wave-like-post-extension.tsx
+++ b/apps/web/src/features/post-renderer/components/extensions/wave-like-post-extension.tsx
@@ -7,7 +7,6 @@ import { getPostQueryOptions, QueryKeys } from "@ecency/sdk";
 import { getQueryClient } from "@/core/react-query";
 import { makeEntryPath } from "@/utils";
 import { findPostLinkElements, isWaveLikePost } from "../functions";
-import "./wave-like-post-extension.scss";
 import { EcencyRenderer } from "../ecency-renderer";
 import { Logo } from "../icons";
 import defaults from "@/defaults";

--- a/apps/web/src/features/shared/available-credits/index.tsx
+++ b/apps/web/src/features/shared/available-credits/index.tsx
@@ -21,8 +21,6 @@ import dayjs, { Dayjs } from "@/utils/dayjs";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { PurchaseQrDialog } from "../purchase-qr";
-import "./index.scss";
-
 interface Props {
   username: string;
   operation: RcOperation;

--- a/apps/web/src/features/shared/bookmark-btn/index.tsx
+++ b/apps/web/src/features/shared/bookmark-btn/index.tsx
@@ -14,7 +14,6 @@ import { Button } from "@ui/button";
 import { Tooltip } from "@ui/tooltip";
 import i18next from "i18next";
 import { useMemo, useState } from "react";
-import "./_index.scss";
 import { error, success } from "../feedback";
 import { getAccessToken } from "@/utils";
 import { useGlobalStore } from "@/core/global-store";

--- a/apps/web/src/features/shared/bookmarks/index.tsx
+++ b/apps/web/src/features/shared/bookmarks/index.tsx
@@ -4,8 +4,6 @@ import { TabItem } from "@/features/ui";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import i18next from "i18next";
 import { useState } from "react";
-import "./_index.scss";
-
 interface Props {
   show: boolean;
   setShow: (v: boolean) => void;

--- a/apps/web/src/features/shared/boost/index.tsx
+++ b/apps/web/src/features/shared/boost/index.tsx
@@ -3,7 +3,6 @@
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 
 import React, { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import "./_index.scss";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import { FormControl } from "@ui/input";
 import { Button } from "@ui/button";

--- a/apps/web/src/features/shared/buy-sell-hive/index.tsx
+++ b/apps/web/src/features/shared/buy-sell-hive/index.tsx
@@ -3,7 +3,6 @@
 import React, { useCallback, useRef, useState } from "react";
 import { error } from "../feedback";
 import { formatError } from "@/api/format-error";
-import "./_index.scss";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import { Button } from "@ui/button";
 import i18next from "i18next";

--- a/apps/web/src/features/shared/comment/index.tsx
+++ b/apps/web/src/features/shared/comment/index.tsx
@@ -25,7 +25,6 @@ import React, {
 import { useDebounce, useMount } from "react-use";
 import useLocalStorage from "react-use/lib/useLocalStorage";
 import useUnmount from "react-use/lib/useUnmount";
-import "./_index.scss";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useIsMobile } from "@/features/ui/util/use-is-mobile";
 import { useQuery } from "@tanstack/react-query";

--- a/apps/web/src/features/shared/discussion/index.tsx
+++ b/apps/web/src/features/shared/discussion/index.tsx
@@ -22,8 +22,6 @@ import { EcencyEntriesCacheManagement } from "@/core/caches";
 import { UilComment } from "@tooni/iconscout-unicons-react";
 import defaults from "@/defaults";
 import { setProxyBase } from "@ecency/render-helper";
-import "./_index.scss";
-
 setProxyBase(defaults.imageServer);
 
 interface Props {

--- a/apps/web/src/features/shared/edit-history/index.tsx
+++ b/apps/web/src/features/shared/edit-history/index.tsx
@@ -3,7 +3,6 @@
 import React, { useMemo, useState } from "react";
 import defaults from "@/defaults";
 import { renderPostBody, setProxyBase } from "@ecency/render-helper";
-import "./index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import { FormControl } from "@ui/input";
 import { Entry } from "@/entities";

--- a/apps/web/src/features/shared/editor-toolbar/add-image-mobile/index.tsx
+++ b/apps/web/src/features/shared/editor-toolbar/add-image-mobile/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { proxifyImageSrc, setProxyBase } from "@ecency/render-helper";
-import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import { Button } from "@ui/button";
 import i18next from "i18next";

--- a/apps/web/src/features/shared/editor-toolbar/index.tsx
+++ b/apps/web/src/features/shared/editor-toolbar/index.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useMountedState } from "react-use";
 import { v4 } from "uuid";
 import { codeTagsSvg, emoticonHappyOutlineSvg, formatBoldSvg, formatItalicSvg, formatListBulletedSvg, formatListNumberedSvg, formatQuoteCloseSvg, formatTitleSvg, gifIcon, gridSvg, imageSvg, textShortSvg, videoSvg } from "@/assets/img/svg";
-import "./_index.scss";
 import { UilPanelAdd } from "@tooni/iconscout-unicons-react";
 import { PollsCreation, PollSnapshot } from "@/features/polls";
 import { useIsMobile } from "@/features/ui/util/use-is-mobile";

--- a/apps/web/src/features/shared/entry-info/index.tsx
+++ b/apps/web/src/features/shared/entry-info/index.tsx
@@ -1,4 +1,3 @@
-import "./_index.scss";
 import { accountReputation, parseDate } from "@/utils";
 import { Entry } from "@/entities";
 import {

--- a/apps/web/src/features/shared/entry-list-content/index.tsx
+++ b/apps/web/src/features/shared/entry-list-content/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import "./_index.scss";
 import { Account, Community, Entry } from "@/entities";
 import { EntryListItem } from "@/features/shared";
 import { useVisibleEntries } from "@/features/shared/entry-list-item/use-muted-authors";

--- a/apps/web/src/features/shared/entry-list-item/index.tsx
+++ b/apps/web/src/features/shared/entry-list-item/index.tsx
@@ -2,7 +2,6 @@
 
 import React from "react";
 import { setProxyBase } from "@ecency/render-helper";
-import "./_index.scss";
 import defaults from "@/defaults";
 import { Account, Community, Entry, FullAccount } from "@/entities";
 import { makeEntryPath } from "@/utils";

--- a/apps/web/src/features/shared/entry-list-loading-item/index.tsx
+++ b/apps/web/src/features/shared/entry-list-loading-item/index.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-import "./_index.scss";
-
 export function EntryListLoadingItem() {
   return (
     <>

--- a/apps/web/src/features/shared/entry-menu/index.tsx
+++ b/apps/web/src/features/shared/entry-menu/index.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { success } from "../feedback";
-import "./_index.scss";
 import { useMenuItemsGenerator } from "./menu-items-generator";
 import { Entry } from "@/entities";
 import { getCommunityCache, useCommunityPin } from "@/core/caches";

--- a/apps/web/src/features/shared/entry-payout/index.tsx
+++ b/apps/web/src/features/shared/entry-payout/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useRef, useState } from "react";
-import "./_index.scss";
 import { Popover, PopoverContent } from "@ui/popover";
 import { EntryPayoutDetail } from "@/features/shared/entry-payout/entry-payout-detail";
 import { parseAsset } from "@/utils";

--- a/apps/web/src/features/shared/entry-reblog-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-reblog-btn/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useMemo, useRef, useState } from "react";
-import "./_index.scss";
 import { Entry } from "@/entities";
 import { PopoverConfirm } from "@/features/ui";
 import i18next from "i18next";

--- a/apps/web/src/features/shared/entry-share/index.tsx
+++ b/apps/web/src/features/shared/entry-share/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import { Entry } from "@/entities";
 import {

--- a/apps/web/src/features/shared/entry-tip-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-tip-btn/index.tsx
@@ -3,7 +3,6 @@
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 
 import React, { useMemo, useState } from "react";
-import "./_index.scss";
 import dynamic from "next/dynamic";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import { Account, Entry } from "@/entities";

--- a/apps/web/src/features/shared/entry-vote-btn/index.tsx
+++ b/apps/web/src/features/shared/entry-vote-btn/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import "./_index.scss";
 import * as ss from "@/utils/session-storage";
 import { LoginRequired } from "@/features/shared";
 import useClickAway from "react-use/lib/useClickAway";

--- a/apps/web/src/features/shared/entry-votes/index.tsx
+++ b/apps/web/src/features/shared/entry-votes/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { ReactNode, useMemo, useRef, useState } from "react";
-import "./_index.scss";
 import { Entry } from "@/entities";
 import { Tooltip } from "@ui/tooltip";
 import i18next from "i18next";

--- a/apps/web/src/features/shared/feedback/feedback-modal/index.tsx
+++ b/apps/web/src/features/shared/feedback/feedback-modal/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { InsufficientResourceCreditsDetails } from "./insufficient-resource-credits-details";
 import { CommonDetails } from "./common-details";
-import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import { ErrorFeedbackObject } from "../feedback-events";
 import { ErrorTypes } from "@/enums";

--- a/apps/web/src/features/shared/feedback/feedback.tsx
+++ b/apps/web/src/features/shared/feedback/feedback.tsx
@@ -6,8 +6,6 @@ import { useMountTransition } from "@/core/hooks";
 import clsx from "clsx";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useMount, useSet, useUnmount } from "react-use";
-import "./_index.scss";
-
 interface FeedbackItemProps {
   feedback: FeedbackObject;
   live: boolean;

--- a/apps/web/src/features/shared/gallery/index.tsx
+++ b/apps/web/src/features/shared/gallery/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { setProxyBase } from "@ecency/render-helper";
 import defaults from "@/defaults";
-import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import i18next from "i18next";
 import { GalleryList } from "@/features/shared/gallery/gallery-list";

--- a/apps/web/src/features/shared/key-or-hot/index.tsx
+++ b/apps/web/src/features/shared/key-or-hot/index.tsx
@@ -12,7 +12,6 @@ import { useCallback, useState } from "react";
 import { OrDivider } from "../or-divider";
 import { MetaMaskSignButton } from "../metamask-sign-button";
 import { ExtensionChooser } from "../extension-chooser";
-import "./index.scss";
 import { shouldUseKeychainMobile } from "@/utils/client";
 import { isInAppBrowser } from "@/utils/keychain";
 import { getLoginType } from "@/utils/user-token";

--- a/apps/web/src/features/shared/linear-progress/index.tsx
+++ b/apps/web/src/features/shared/linear-progress/index.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import React from "react";
-import "./_index.scss";
-
 export function LinearProgress() {
   return (
     <div className="linear-progress">

--- a/apps/web/src/features/shared/list-style-toggle/index.tsx
+++ b/apps/web/src/features/shared/list-style-toggle/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import "./_index.scss";
 import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from "@ui/dropdown";
 import { gridView, listView, menuDownSvg } from "@ui/svg";
 import i18next from "i18next";

--- a/apps/web/src/features/shared/login/index.tsx
+++ b/apps/web/src/features/shared/login/index.tsx
@@ -2,7 +2,6 @@
 
 import { useGlobalStore } from "@/core/global-store";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
-import "./_index.scss";
 import i18next from "i18next";
 import Login from "./login";
 

--- a/apps/web/src/features/shared/message-no-data/index.tsx
+++ b/apps/web/src/features/shared/message-no-data/index.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from "react";
-import "./_index.scss";
 import { Button } from "@ui/button";
 import Image from "next/image";
 import Link from "next/link";

--- a/apps/web/src/features/shared/mute-btn/index.tsx
+++ b/apps/web/src/features/shared/mute-btn/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo, useState } from "react";
-import "./_index.scss";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import { FormControl, InputGroup } from "@ui/input";
 import { Button } from "@ui/button";

--- a/apps/web/src/features/shared/navbar/index.tsx
+++ b/apps/web/src/features/shared/navbar/index.tsx
@@ -4,7 +4,6 @@ import React, { lazy, Suspense, useEffect, useState } from "react";
 import usePrevious from "react-use/lib/usePrevious";
 import * as ls from "@/utils/local-storage";
 import useMount from "react-use/lib/useMount";
-import "./_index.scss";
 import { NavbarMobile } from "./navbar-mobile";
 import { NavbarDesktop } from "./navbar-desktop";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";

--- a/apps/web/src/features/shared/navbar/navbar-notifications-button.tsx
+++ b/apps/web/src/features/shared/navbar/navbar-notifications-button.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import "./_navbar-notifications-button.scss";
 import { Button } from "@ui/button";
 import { Tooltip } from "@ui/tooltip";
 import i18next from "i18next";

--- a/apps/web/src/features/shared/navbar/sidebar/navbar-side-theme-switcher.tsx
+++ b/apps/web/src/features/shared/navbar/sidebar/navbar-side-theme-switcher.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import "./_navbar-side-theme-switcher.scss";
 import { classNameObject } from "@ui/util";
 import { Theme } from "@/enums";
 import { brightnessSvg } from "@ui/svg";

--- a/apps/web/src/features/shared/notifications/index.tsx
+++ b/apps/web/src/features/shared/notifications/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { NotificationsContent } from "@/features/shared/notifications/notifications-content";
-import "./_index.scss";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { useGlobalStore } from "@/core/global-store";
 import { ModalSidebar } from "@ui/modal/modal-sidebar";

--- a/apps/web/src/features/shared/or-divider/index.tsx
+++ b/apps/web/src/features/shared/or-divider/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import "./_index.scss";
 import i18next from "i18next";
 
 export function OrDivider() {

--- a/apps/web/src/features/shared/profile-popover/index.tsx
+++ b/apps/web/src/features/shared/profile-popover/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useCallback, useState } from "react";
-import "./index.scss";
 import { Entry } from "@/entities";
 import ProfilePopoverCard from "@/features/shared/profile-popover/profile-popover-card";
 import { ProfilePopoverAuthor } from "@/features/shared/profile-popover/profile-popover-author";

--- a/apps/web/src/features/shared/promote/index.tsx
+++ b/apps/web/src/features/shared/promote/index.tsx
@@ -3,7 +3,6 @@
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import "./_index.scss";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import { FormControl } from "@ui/input";
 import { Button } from "@ui/button";

--- a/apps/web/src/features/shared/schedules/index.tsx
+++ b/apps/web/src/features/shared/schedules/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import defaults from "@/defaults";
 import { setProxyBase } from "@ecency/render-helper";
-import "./_index.scss";
 import { Modal, ModalBody, ModalHeader, ModalTitle } from "@ui/modal";
 import i18next from "i18next";
 import { SchedulesList } from "@/features/shared/schedules/schedules-list";

--- a/apps/web/src/features/shared/scroll-to-top/index.tsx
+++ b/apps/web/src/features/shared/scroll-to-top/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import "./_index.scss";
 import { chevronUpSvg } from "@/features/ui/svg";
 import i18next from "i18next";
 import { Tooltip } from "@ui/tooltip";

--- a/apps/web/src/features/shared/search-box/index.tsx
+++ b/apps/web/src/features/shared/search-box/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "./_index.scss";
 import { FormControl, InputGroup } from "@ui/input";
 import { Button } from "@ui/button";
 import { copyContent } from "@/features/ui/svg";

--- a/apps/web/src/features/shared/search-list-item/index.tsx
+++ b/apps/web/src/features/shared/search-list-item/index.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 import { catchPostImage, postBodySummary, setProxyBase } from "@ecency/render-helper";
-import "./_index.scss";
 import defaults from "@/defaults";
 import { SearchResult } from "@/entities";
 import {

--- a/apps/web/src/features/shared/skeleton/index.tsx
+++ b/apps/web/src/features/shared/skeleton/index.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-import "./index.scss";
-
 interface Props {
   className?: string;
   style?: object;

--- a/apps/web/src/features/shared/suggestion-list/index.tsx
+++ b/apps/web/src/features/shared/suggestion-list/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { CSSProperties, JSX, useEffect, useRef, useState } from "react";
-import "./_index.scss";
 import { classNameObject } from "@ui/util";
 import useClickAway from "react-use/lib/useClickAway";
 import i18next from "i18next";

--- a/apps/web/src/features/shared/switch-lang/index.tsx
+++ b/apps/web/src/features/shared/switch-lang/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useState } from "react";
-import "./_index.scss";
 import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from "@ui/dropdown";
 import Link from "next/link";
 import i18next from "i18next";

--- a/apps/web/src/features/shared/textarea-autocomplete/index.tsx
+++ b/apps/web/src/features/shared/textarea-autocomplete/index.tsx
@@ -6,7 +6,6 @@ import React, {
 } from "react";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import ReactTextareaAutocomplete from "@webscopeio/react-textarea-autocomplete";
-import "./_index.scss";
 import { lookupAccountsQueryOptions, searchPath } from "@ecency/sdk";
 import { UserAvatar } from "@/features/shared";
 import i18next from "i18next";

--- a/apps/web/src/features/shared/transactions/index.tsx
+++ b/apps/web/src/features/shared/transactions/index.tsx
@@ -1,3 +1,1 @@
-import "./_index.scss";
-
 export * from "./transaction-row";

--- a/apps/web/src/features/shared/transfer/index.tsx
+++ b/apps/web/src/features/shared/transfer/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import "./_index.scss";
 import { Modal, ModalBody, ModalHeader } from "@ui/modal";
 import i18next from "i18next";
 import { TransferStep1 } from "@/features/shared/transfer/transfer-step-1";

--- a/apps/web/src/features/shared/two-user-avatar/index.tsx
+++ b/apps/web/src/features/shared/two-user-avatar/index.tsx
@@ -1,6 +1,4 @@
 import defaults from "@/defaults";
-import "./_index.scss";
-
 interface Props {
   from: string;
   to: string;

--- a/apps/web/src/features/shared/user-avatar/index.tsx
+++ b/apps/web/src/features/shared/user-avatar/index.tsx
@@ -2,7 +2,6 @@
 
 import React, { useMemo } from "react";
 import { proxifyImageSrc, setProxyBase } from "@ecency/render-helper";
-import "./_index.scss";
 import defaults from "@/defaults";
 
 setProxyBase(defaults.imageServer);

--- a/apps/web/src/features/shared/video-upload-threespeak/index.tsx
+++ b/apps/web/src/features/shared/video-upload-threespeak/index.tsx
@@ -9,7 +9,6 @@ import { recordVideoSvg } from "@ui/svg";
 import i18next from "i18next";
 import React, { ChangeEvent, ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import useMountedState from "react-use/lib/useMountedState";
-import "./index.scss";
 import { VideoUploadItem } from "./video-upload-item";
 import { VideoUploadRecorder } from "./video-upload-recorder";
 import { useActiveAccount } from "@/core/hooks/use-active-account";

--- a/apps/web/src/features/ui/button-group/index.tsx
+++ b/apps/web/src/features/ui/button-group/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "./_index.scss";
 import { classNameObject } from "@/features/ui/util";
 
 interface Props {

--- a/apps/web/src/features/ui/emoji-picker/index.tsx
+++ b/apps/web/src/features/ui/emoji-picker/index.tsx
@@ -10,7 +10,6 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { flip, offset, shift, size, useFloating } from "@floating-ui/react-dom";
-import "./_index.scss";
 import Picker from "@emoji-mart/react";
 import emojiData from "@emoji-mart/data";
 import { useGlobalStore } from "@/core/global-store";

--- a/apps/web/src/features/ui/gif-picker/index.tsx
+++ b/apps/web/src/features/ui/gif-picker/index.tsx
@@ -6,7 +6,6 @@ import React, {
   useRef,
   useState
 } from "react";
-import "./_index.scss";
 import { SearchBox } from "@/features/shared";
 import Image from "next/image";
 import { insertOrReplace } from "@/utils/input-util";

--- a/apps/web/src/features/ui/input/input-vote.tsx
+++ b/apps/web/src/features/ui/input/input-vote.tsx
@@ -10,7 +10,6 @@ import React, {
   useState
 } from "react";
 import { UilArrowDown, UilArrowUp } from "@tooni/iconscout-unicons-react";
-import "./_input-vote.scss";
 import { InputGroup } from "@ui/input/input-group";
 import useInterval from "react-use/lib/useInterval";
 import { classNameObject } from "@ui/util";

--- a/apps/web/src/features/waves/components/wave-actions.tsx
+++ b/apps/web/src/features/waves/components/wave-actions.tsx
@@ -13,7 +13,6 @@ import { Button } from "@ui/button";
 import i18next from "i18next";
 import React, { ReactNode } from "react";
 import { WaveEntry } from "@/entities";
-import "./wave-actions.scss";
 import { useActiveAccount } from "@/core/hooks/use-active-account";
 import { PostTipsResponse } from "@ecency/sdk";
 import { commentSvg } from "@ui/svg";

--- a/apps/web/src/features/waves/components/wave-form/index.tsx
+++ b/apps/web/src/features/waves/components/wave-form/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
-import "./_index.scss";
 import { BeneficiaryRoute, Entry, WaveEntry } from "@/entities";
 import { PollsContext, PollsManager, useEntryPollExtractor } from "@/features/polls";
 import { useLocalStorage } from "react-use";

--- a/apps/web/src/styles/_shared-components.scss
+++ b/apps/web/src/styles/_shared-components.scss
@@ -1,11 +1,17 @@
-// Generated aggregate of component stylesheets (issue #1632).
-//
-// These were previously imported one-per-component from TS/TSX, which made the
-// build emit one render-blocking <link> per component: 52 of them on a post page.
-// Importing them from a single entry collapses that to one stylesheet, which keeps
-// the immutable long-cache and adds nothing to the HTML response.
-//
-// Keep this list sorted. Each file already pulls its own vars/mixins.
+// Aggregate of the SHARED (features/**) component stylesheets, imported once from
+// style.scss. These used to be imported one-per-component from TS/TSX, which made
+// the build emit one render-blocking <link> per component: 52 of them on a post
+// page. Importing them from a single entry collapses that to one stylesheet, keeps
+// the immutable long-cache, and adds nothing to the HTML response. See issue #1632.
+
+// ORDER IS CASCADE-SIGNIFICANT. The list is generated in source-path order (which
+// sorts "_index.scss" partials by their underscore-prefixed filename, so the
+// rendered paths below are not lexicographic). The equivalence of the compiled
+// output was verified against this exact order; do not hand-reorder it.
+
+// Route-scoped app/** stylesheets are deliberately NOT aggregated here: a route
+// sheet carrying a global element selector (html/body/*) would leak site-wide once
+// merged into the shared chunk.
 
 @import "../features/announcement/index";
 @import "../features/post-renderer/components/extensions/hive-operation-extension";

--- a/apps/web/src/styles/_shared-components.scss
+++ b/apps/web/src/styles/_shared-components.scss
@@ -1,0 +1,69 @@
+// Generated aggregate of component stylesheets (issue #1632).
+//
+// These were previously imported one-per-component from TS/TSX, which made the
+// build emit one render-blocking <link> per component: 52 of them on a post page.
+// Importing them from a single entry collapses that to one stylesheet, which keeps
+// the immutable long-cache and adds nothing to the HTML response.
+//
+// Keep this list sorted. Each file already pulls its own vars/mixins.
+
+@import "../features/announcement/index";
+@import "../features/post-renderer/components/extensions/hive-operation-extension";
+@import "../features/post-renderer/components/extensions/hive-post-link-extension";
+@import "../features/post-renderer/components/extensions/wave-like-post-extension";
+@import "../features/shared/available-credits/index";
+@import "../features/shared/bookmark-btn/index";
+@import "../features/shared/bookmarks/index";
+@import "../features/shared/boost/index";
+@import "../features/shared/buy-sell-hive/index";
+@import "../features/shared/comment/index";
+@import "../features/shared/discussion/index";
+@import "../features/shared/edit-history/index";
+@import "../features/shared/editor-toolbar/index";
+@import "../features/shared/editor-toolbar/add-image-mobile/index";
+@import "../features/shared/entry-info/index";
+@import "../features/shared/entry-list-content/index";
+@import "../features/shared/entry-list-item/index";
+@import "../features/shared/entry-list-loading-item/index";
+@import "../features/shared/entry-menu/index";
+@import "../features/shared/entry-payout/index";
+@import "../features/shared/entry-reblog-btn/index";
+@import "../features/shared/entry-share/index";
+@import "../features/shared/entry-tip-btn/index";
+@import "../features/shared/entry-vote-btn/index";
+@import "../features/shared/entry-votes/index";
+@import "../features/shared/feedback/index";
+@import "../features/shared/feedback/feedback-modal/index";
+@import "../features/shared/gallery/index";
+@import "../features/shared/key-or-hot/index";
+@import "../features/shared/linear-progress/index";
+@import "../features/shared/list-style-toggle/index";
+@import "../features/shared/login/index";
+@import "../features/shared/message-no-data/index";
+@import "../features/shared/mute-btn/index";
+@import "../features/shared/navbar/index";
+@import "../features/shared/navbar/navbar-notifications-button";
+@import "../features/shared/navbar/sidebar/navbar-side-theme-switcher";
+@import "../features/shared/notifications/index";
+@import "../features/shared/or-divider/index";
+@import "../features/shared/profile-popover/index";
+@import "../features/shared/promote/index";
+@import "../features/shared/schedules/index";
+@import "../features/shared/scroll-to-top/index";
+@import "../features/shared/search-box/index";
+@import "../features/shared/search-list-item/index";
+@import "../features/shared/skeleton/index";
+@import "../features/shared/suggestion-list/index";
+@import "../features/shared/switch-lang/index";
+@import "../features/shared/textarea-autocomplete/index";
+@import "../features/shared/transactions/index";
+@import "../features/shared/transfer/index";
+@import "../features/shared/two-user-avatar/index";
+@import "../features/shared/user-avatar/index";
+@import "../features/shared/video-upload-threespeak/index";
+@import "../features/ui/button-group/index";
+@import "../features/ui/emoji-picker/index";
+@import "../features/ui/gif-picker/index";
+@import "../features/ui/input/input-vote";
+@import "../features/waves/components/wave-actions";
+@import "../features/waves/components/wave-form/index";

--- a/apps/web/src/styles/style.scss
+++ b/apps/web/src/styles/style.scss
@@ -17,6 +17,9 @@
 
 @tailwind utilities;
 
+// Component stylesheets, collapsed into this entry (issue #1632).
+@import "./shared-components";
+
 @layer utilities {
   .no-scrollbar::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
Closes #1632.

A post page emits 52 render-blocking `<link rel="stylesheet">` in `<head>`. They gate the parser: the inline `beforeInteractive` bootstrap script at byte 11,277 cannot execute while stylesheets are pending, so a fully downloaded document sits unparsed for ~630ms before first paint. LCP equals FCP on that page and the LCP image is already downloaded at 745ms, so this stall is the LCP.

## What this does

Moves the **shared** component stylesheet imports out of TS/TSX and into one Sass entry, so webpack emits one stylesheet instead of one per component. No CSS rule is edited and no `.scss` file moves: only the import site changes.

- new `apps/web/src/styles/_shared-components.scss` `@import`s 60 shared `features/**` stylesheets, and `style.scss` imports it once
- the 60 matching `import "./_index.scss"` lines are removed from their components
- route-scoped `app/**` stylesheets (78 files, including all 16 decks sheets) are deliberately **not** folded, so route CSS stays route-scoped. That is why the count lands at 7 rather than the theoretical floor of 3; folding route sheets per-route is a sensible follow-up

## Measured, local production builds of this branch vs develop

| | develop | this branch |
|---|---|---|
| render-blocking stylesheets (post page) | 52 | 7 |
| `</head>` byte offset | 10,818 | 6,585 |
| HTML raw / gzip | 221,992 / 28,130 B | 208,811 / 26,223 B |

CSS wire bytes also improve: the same content as 52 separate gzip streams is 62,344 B, and as one stream 47,148 B, a 24% saving, because small streams compress poorly.

## Why not `experimental.inlineCss`

It was the other option on the issue and it does reach 0 render-blocking links, but measured on a real build it embeds the CSS **twice**, once as `<style>` and once inside the RSC Flight payload (144,307 → 439,160 chars), because client-side navigation needs it there. That is **+590KB raw / +95.9KB gzipped on every HTML response**, roughly +200GB/day of egress at current traffic, against an SSR cache already at its `max_size` and evicting. Rejected on cost, not on correctness.

## One rule had to be scoped

`app/decks/_components/_index.scss` declared `html, body { &::-webkit-scrollbar { display: none } }`. That was survivable only while it compiled into a decks-only chunk. With fewer CSS entry points, Next merges it into the shared sheet, where it hides the window scrollbar on every route, cancels the `scrollbar-gutter: stable` that `_base.scss:208` reserves against modal-open CLS, and shifts every centered element by 7px. It is now scoped with `:has(.decks)`.

Caught by pixel-diffing 6 routes in both themes against a `develop` build, after establishing that the screenshot noise floor is 0.000%.

## Verification

- **Sass equivalence**: compiling `style.scss` + each folded file standalone (before) against the folded `style.scss` (after) yields **1,239 rule blocks on both sides with identical content**. The fold changes no declaration. `.markdown-view` ordering (103 selectors shared with `_markdown.scss`, on the LCP element) is preserved.
- **Pixel diff**: 6 routes x 2 themes against develop, worst real diff 0.008% against a 0.000% noise floor (the one 0.26% reading is live leaderboard content changing between runs, verified by inspecting the diff image). Page geometry matches production exactly: document width 1351px, hero x=192.
- **Icon SCSS ledger audit** (CI): 0 unowned.
- lint (exit 0), typecheck (exit 0), unit tests (342 files, 3,221 tests, all passing).

## Notes for review

- `renderBlockingCSS` cannot reach 1 as the issue's criterion says. The floor is **3**: next/font's generated sheet and `react-day-picker` + `renderer.css` can never merge into the global chunk, which at 124,764 B already exceeds `CssChunkingPlugin`'s `MAX_CSS_CHUNK_SIZE` of 100,000. I will amend the criterion on the issue.
- `features/market/market-swap-form/**` is excluded: its CSS is pruned today by `sideEffects` and appears in none of the 52 live chunks, so folding it would make dead CSS unconditional.
- Four other files stay unfolded for concrete reasons: `ecency-renderer.scss` redefines shared Sass variables, and `thread-render.scss` carries a `url()` relative to its own directory.
- The remaining half of the 632ms stall is the `beforeInteractive` inline script in `layout.tsx`. Deliberately not touched here; it is a crash guard against browser translators and deserves its own change with its own revert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Consolidated shared component styling into the main application stylesheet.
  * Preserved existing visual styling across dialogs, controls, navigation, editors, and content features.
  * Limited scrollbar hiding to deck pages, preventing unintended scrollbar changes on other routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->