### PR TITLE
Supply the audit's marker list from the repository secret

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -57,6 +57,16 @@ jobs:
       # one matching no files and reloads clean, i.e. it fails OPEN). --self-test runs first
       # so a rule edited into uselessness fails here rather than passing silently.
       - name: Audit committed origin nginx config
+        env:
+          # Literals that must never appear in a committed file, kept out of the
+          # repository for the obvious reason. Registered as a secret, so if the
+          # audit ever does report one, the offending line is masked in this log
+          # rather than published a second time.
+          #
+          # Absent on a pull request from a fork, where secrets are not exposed:
+          # the rest of the rules still run, that one check is simply inert, and
+          # the same job on the base branch catches it after merge.
+          AUDIT_FORBIDDEN_MARKERS: ${{ secrets.AUDIT_FORBIDDEN_MARKERS }}
         run: |
           node scripts/origin-config-audit.mjs --self-test
           node scripts/origin-config-audit.mjs --fail


### PR DESCRIPTION
The rule that rejects forbidden literals reads them from `AUDIT_FORBIDDEN_MARKERS`, and nothing was setting that variable, so the check has been inert since it was added. This wires it to a repository secret of the same name.

Registering it as a secret does double duty: it keeps the list out of the repository, and if the audit ever does report a match, the offending line is masked in the job log rather than published a second time.

Verified locally by planting a marker in an audited file:

```
marker present, variable set:    exit 1
marker present, variable unset:  exit 0   (so the variable is what drives it)
clean tree, variable set:        exit 0
```

Note for fork pull requests: secrets are withheld there, so this one check is inert on those runs. Every other rule still applies, and the same job on the base branch catches it after merge.
