### PR TITLE
perf(head): take the translate guard off beforeInteractive (removes the last parser-blocking script)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -108,11 +108,28 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         {/*
           Guards React against in-page translators (Google/Chrome Translate)
           that wrap text nodes in <font> tags and crash the commit phase with a
-          NotFoundError on insertBefore/removeChild. beforeInteractive installs
-          the Node.prototype patch before React hydrates, so it's in place for
-          the first commit.
+          NotFoundError on insertBefore/removeChild.
+
+          `async` with an explicit high priority, NOT next/script's
+          beforeInteractive. That strategy emits an inline
+          `(self.__next_s=self.__next_s||[]).push([...])` bootstrap into <head>,
+          and an inline classic script cannot execute while render-blocking
+          stylesheets are pending, so it was the one parser-blocking element in
+          the head (issue #1641). An async script never blocks the parser.
+
+          beforeInteractive does not run this file from <head> anyway:
+          next/dist/client/app-bootstrap.js calls
+          loadScriptsInSequence(self.__next_s, hydrate), creating the element at
+          hydration time. Measured on a slow-4G profile, the guard installed at
+          ~2.77s under beforeInteractive versus ~1.12s here.
+
+          fetchPriority is load-bearing, do not drop it. Plain `async` gets low
+          priority and queues behind the app bundle: measured, the file landed at
+          ~6.3s, AFTER React's first commit at ~5.9s, in 5 of 5 runs. That is the
+          exact window this guard exists to cover. With the hint it is installed
+          before the first commit in 5 of 5.
         */}
-        <Script src="/scripts/translate-dom-guard.js" strategy="beforeInteractive" />
+        <script async fetchPriority="high" src="/scripts/translate-dom-guard.js" />
         <script async src="/scripts/config-stub.js" />
         <link rel="dns-prefetch" href="https://i.ecency.com" />
         <link rel="dns-prefetch" href="https://ecency.com" />


### PR DESCRIPTION
Closes #1641.

`<head>` contained exactly one parser-blocking element: the inline `(self.__next_s=self.__next_s||[]).push([...])` bootstrap that `next/script`'s `beforeInteractive` emits. An inline classic script cannot execute while render-blocking stylesheets are pending, so the parser stalled there. Production, after the CSS fold in #1638: **397-424 ms**; before it: ~630 ms.

This replaces it with a plain async tag carrying an explicit high fetch priority.

## The priority hint is load-bearing, and the issue's original proposal was unsafe

#1641 proposed plain `<script async>`. I built it and measured it, and it breaks the guarantee the guard exists for. Slow-4G profile (1.6 Mbps / 750 kbps / 150 ms RTT), 5 runs per variant, guard install time detected by polling `Node.prototype.removeChild` for the patch, first commit detected via `__REACT_DEVTOOLS_GLOBAL_HOOK__.onCommitFiberRoot`:

| variant | guard fetched | guard installed | before React's first commit | parser-blocking scripts in head |
|---|---|---|---|---|
| `beforeInteractive` (today) | 198 -> 1097 ms | 2771 ms | **5/5** | 1 |
| `async`, no priority | 200 -> 6274 ms | 6284 ms | **0/5** | 0 |
| `async` + `fetchPriority="high"` | 199 -> 1105 ms | **1116 ms** | **5/5** | 0 |

Plain async is fetched at low priority and queues behind roughly 1 MB of app JS, landing at ~6.3 s, *after* React's first commit at ~5.9 s. That is precisely the window the guard covers, so it would have reintroduced the crash it prevents. With the hint, the guard is installed **1.65 s earlier than today** and still ahead of the first commit in every run.

## The ordering guarantee never came from the head position

The old comment said `beforeInteractive` "installs the Node.prototype patch before React hydrates, so it's in place for the first commit". True, but not because of where the tag sits. `next/dist/client/app-bootstrap.js` runs `loadScriptsInSequence(self.__next_s, hydrate)`, i.e. it creates the script element at hydration time. That is why the file is *fetched* at ~200 ms today but only *executes* at ~2771 ms. Moving to async makes it execute when it arrives instead.

## What is verified and what is not

- **Verified:** the parser-blocking element is gone from `<head>` (1 -> 0); the guard installs earlier than today and before the first commit in 5/5 runs; typecheck, lint and the full suite (343 files, 3,236 tests) pass.
- **Not verified locally:** the parser-gap reduction itself. On loopback the stylesheets always arrive before the document finishes, so the stall cannot reproduce, at any throttling profile I tried. The gap is a production-path phenomenon. It should be validated the same way #1638 was: 3-run WPT before/after against the deployed environment, comparing document `load_end` to the first `ParseHTML` with `endLine > 0`.

Prod baselines to compare against: `260822_V7_9` (entry, gap 397 ms) and `260822_7X_A` (home, gap 424 ms).

## Rollback

Single commit, revert on its own. Trigger: any new `NotFoundError: Failed to execute 'removeChild'/'insertBefore' on 'Node'` in Sentry on a release carrying this change. That signature is unambiguous and is exactly what the guard suppresses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation safeguards during page loading.
  * The safeguard now loads asynchronously with high priority, helping prevent translation-related layout or behavior issues without blocking the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->