### PR TITLE
Revert #1642: removing the parser gate starves render-blocking CSS (FCP 1200ms -> 3000ms on staging)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -108,28 +108,11 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         {/*
           Guards React against in-page translators (Google/Chrome Translate)
           that wrap text nodes in <font> tags and crash the commit phase with a
-          NotFoundError on insertBefore/removeChild.
-
-          `async` with an explicit high priority, NOT next/script's
-          beforeInteractive. That strategy emits an inline
-          `(self.__next_s=self.__next_s||[]).push([...])` bootstrap into <head>,
-          and an inline classic script cannot execute while render-blocking
-          stylesheets are pending, so it was the one parser-blocking element in
-          the head (issue #1641). An async script never blocks the parser.
-
-          beforeInteractive does not run this file from <head> anyway:
-          next/dist/client/app-bootstrap.js calls
-          loadScriptsInSequence(self.__next_s, hydrate), creating the element at
-          hydration time. Measured on a slow-4G profile, the guard installed at
-          ~2.77s under beforeInteractive versus ~1.12s here.
-
-          fetchPriority is load-bearing, do not drop it. Plain `async` gets low
-          priority and queues behind the app bundle: measured, the file landed at
-          ~6.3s, AFTER React's first commit at ~5.9s, in 5 of 5 runs. That is the
-          exact window this guard exists to cover. With the hint it is installed
-          before the first commit in 5 of 5.
+          NotFoundError on insertBefore/removeChild. beforeInteractive installs
+          the Node.prototype patch before React hydrates, so it's in place for
+          the first commit.
         */}
-        <script async fetchPriority="high" src="/scripts/translate-dom-guard.js" />
+        <Script src="/scripts/translate-dom-guard.js" strategy="beforeInteractive" />
         <script async src="/scripts/config-stub.js" />
         <link rel="dns-prefetch" href="https://i.ecency.com" />
         <link rel="dns-prefetch" href="https://ecency.com" />


### PR DESCRIPTION
Reverts #1642. Measured on staging, it is a **large regression**, and the premise of #1641 turns out to be wrong.

## Measured on alpha, same post, same agent, same profile, 5 warm runs

| | pre-#1642 | post-#1642 |
|---|---|---|
| FCP | 1200 ms | **3000 ms** |
| LCP | 2087 ms | **4197 ms** |
| SpeedIndex | 1907 ms | 3903 ms |
| TTFB | 259 ms | 269 ms |
| CSS | 7 req / 51,195 B | 7 req / 51,195 B |

Identical CSS, unchanged TTFB, and alpha is now slower than production, which still carries only #1638.

## Why: the parser-blocking script was an accidental bandwidth guard

| | requests in flight during global CSS download | global CSS download | FCP |
|---|---|---|---|
| pre-#1642 | 14-19 | 140-464 ms | 1200 ms |
| post-#1642 | **72-75** | **1915-2756 ms** | 3000 ms |

Same 40,717 B stylesheet, Cloudflare cache `HIT` on both sides, so this is not a cold-cache effect.

Stalling the parser at the inline script kept concurrency low until the stylesheets landed, so the render-blocking CSS effectively had the connection to itself and finished in ~140 ms. With the block removed, the parser runs ahead and queues ~75 concurrent requests; the CSS then competes with roughly 84 JS chunks for a 5 Mbps link and takes 2.3 s, delaying first paint by the same amount.

So the ~400 ms "stall" #1641 targeted was not idle waste. It was the critical path being serialised in a way that helped.

## What survives from #1642

The two findings underneath it still hold and are worth keeping in mind for any future attempt:

- `beforeInteractive` does not execute the guard from `<head>`; `app-bootstrap.js` creates the element at hydration, so the file is fetched at ~200 ms but runs at ~2771 ms.
- Plain `<script async>` without a priority hint is **unsafe** here: the guard landed after React's first commit in 5 of 5 runs.

Any future work on this needs to keep CSS ahead of the JS chunk wave, not just unblock the parser. Reverting first because #1642 is on `develop` and alpha now, and should not reach production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation handling during page loading by installing the translation safeguard before the app becomes interactive.
  * Reduced the risk of translation-related display issues during initial page hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->