### PR TITLE
docs(waves): correct what the observer param actually filters

### DIFF
--- a/apps/web/src/app/waves/_components/waves-list-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-view.tsx
@@ -36,11 +36,14 @@ export function WavesListView({ feedType, username }: Props) {
   // tag / following / source are just filters on the same stream. A source feed
   // scopes to a single container host (e.g. peak.snaps); tag/following overlay
   // the For You stream.
-  // The logged-in user is the observer: server-side mute filtering keeps each
-  // page full of waves they can see (client-side filtering would shrink pages).
-  // Logged out, Ecency's moderation account stands in so anonymous visitors get
-  // the same spam filtering. Note esync actually drops muted authors here,
-  // unlike the Hive bridge, which only flags them `stats.gray`.
+  // The logged-in user is the observer, so esync applies THEIR mute list
+  // server-side and each page still arrives full (client-side filtering would
+  // shrink pages). Note esync actually drops muted authors here, unlike the
+  // Hive bridge, which only flags them `stats.gray`.
+  // Ecency's own moderation mutes are not this parameter's job: esync applies
+  // that list to every waves request on top of the observer's, so it holds for
+  // signed-in viewers too. The fallback below only keeps anonymous requests
+  // shaped like the rest.
   const observer = username || DEFAULT_OBSERVER;
   const queryOptions = useMemo(() => {
     if (selectedSource) {

--- a/apps/web/src/consts/observer.ts
+++ b/apps/web/src/consts/observer.ts
@@ -7,7 +7,7 @@
  * (`discussion-item.tsx`). Logged-out visitors therefore inherit Ecency's
  * moderation instead of an unfiltered firehose.
  *
- * Three things worth knowing before using this:
+ * Four things worth knowing before using this:
  *
  * 1. On the Hive bridge an observer only *marks* content. Muted authors' posts
  *    are still returned, so swapping the observer never shortens a feed or a
@@ -18,7 +18,14 @@
  *    swapping to the logged-in user client-side would filter every page except
  *    the one people actually look at. Feeds personalise instead at the server,
  *    where cache-policy already marks those tiers user-specific.
- * 3. Kept as a plain literal on purpose. This mirrors `CONFIG.defaultObserver`
+ * 3. This is NOT how Ecency's moderation mutes reach the waves feed. An
+ *    observer only ever carries the mute list of whoever is viewing, so before
+ *    esync applied the moderation list itself, signed-in users (who send their
+ *    own name) got none of it. esync now ANDs `@ecency`'s on-chain mutes into
+ *    every waves query on top of the observer's, so muting an account there is
+ *    what takes it out of the feed for everyone. Bridge reads still behave as
+ *    described above.
+ * 4. Kept as a plain literal on purpose. This mirrors `CONFIG.defaultObserver`
  *    in @ecency/sdk, but reading it from the SDK would make every module that
  *    touches an observer depend on the SDK being mocked in specs, and several
  *    specs install their own partial `@ecency/sdk` factory.

--- a/packages/sdk/src/modules/posts/queries/get-shorts-feed-query-options.ts
+++ b/packages/sdk/src/modules/posts/queries/get-shorts-feed-query-options.ts
@@ -37,7 +37,10 @@ export interface ShortsFeedParams {
   tag?: string;
   /** Only this author's shorts (across all containers). */
   author?: string;
-  /** The viewing user; exclude authors they currently mute. */
+  /**
+   * The viewing user; exclude authors they currently mute. Ecency's own
+   * moderation mutes are applied by esync regardless of this value.
+   */
   observer?: string;
   /** Page size (default 20). */
   limit?: number;

--- a/packages/sdk/src/modules/posts/queries/get-waves-feed-query-options.ts
+++ b/packages/sdk/src/modules/posts/queries/get-waves-feed-query-options.ts
@@ -27,7 +27,11 @@ export interface WavesFeedParams {
   following?: string;
   /** Only this author's waves (across all containers); the per-author feed. */
   author?: string;
-  /** The viewing user; exclude authors they currently mute. */
+  /**
+   * The viewing user; exclude authors they currently mute. Ecency's own
+   * moderation mutes are applied by esync regardless of this value, so leaving
+   * it unset drops the viewer's personal mutes, not the platform ones.
+   */
   observer?: string;
   /** Page size (default 20). */
   limit?: number;


### PR DESCRIPTION
Comments only, no behaviour change.

The docs around `DEFAULT_OBSERVER` read as though sending `observer=ecency` when logged out is how Ecency's moderation mutes reach the waves feed. They are not: an observer only ever carries the mute list of whoever is viewing, so a signed-in user sends their own username and gets none of the moderation list.

That gap was real. Against production before the fix, with `hive.airdrops` (muted on chain from `@ecency`) having posted 697 waves into `leothreads` in 24h:

```
/api/waves/feed?limit=50                     -> 50 rows, muted present: ['hive.airdrops']
/api/waves/feed?limit=50&observer=good-karma -> 50 rows, muted present: ['hive.airdrops']
/api/waves/feed?limit=50&observer=ecency     -> 50 rows, muted present: -
```

ecency/esync-py#28 moves that filter into the feed queries themselves, ANDed on top of the observer's own mutes, so it holds for every viewer on both clients. These comments now say where the platform filter lives, so the next person hitting a moderation gap in waves does not reach for the observer param again.

Touched:

- `apps/web/src/consts/observer.ts` — new point 3 separating "observer = the viewer's mutes" from "esync applies Ecency's list regardless"
- `apps/web/src/app/waves/_components/waves-list-view.tsx` — the `username || DEFAULT_OBSERVER` comment no longer claims the fallback is what gives anonymous visitors spam filtering
- `packages/sdk/.../get-waves-feed-query-options.ts`, `get-shorts-feed-query-options.ts` — `observer` param doc notes that omitting it drops the viewer's personal mutes, not the platform ones


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how personal mute lists and platform moderation mutes are applied to Waves and Shorts feeds.
  * Documented that moderation mutes are consistently enforced, including for anonymous viewers.
  * Explained the fallback observer behavior and how muted authors are excluded from feed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->