### PR TITLE
Open notifications on the account that authored the post

### DIFF
--- a/apps/web/public/firebase-messaging-sw.js
+++ b/apps/web/public/firebase-messaging-sw.js
@@ -107,5 +107,7 @@ function buildNotificationUrl(data) {
 }
 
 self.addEventListener('notificationclick', function (event) {
-  clients.openWindow(buildNotificationUrl(event.notification.data), '_blank');
+  // waitUntil keeps the worker alive until the navigation settles; without it
+  // the worker can be terminated first and the click opens nothing.
+  event.waitUntil(clients.openWindow(buildNotificationUrl(event.notification.data)));
 });

--- a/apps/web/public/firebase-messaging-sw.js
+++ b/apps/web/public/firebase-messaging-sw.js
@@ -33,27 +33,79 @@ messaging.onBackgroundMessage(function (payload) {
   });
 });
 
-self.addEventListener('notificationclick', function (event) {
-  const data = event.notification.data;
-  let url = 'https://ecency.com';
-  const fullPermlink = data.permlink1 + data.permlink2 + data.permlink3;
-  // Allowlist target pages so a forged/misconfigured push can't route to an arbitrary
-  // ecency.com path. Add new deep-link targets here as they're introduced.
-  const ALLOWED_TARGET_PAGES = ['perks'];
-  if (data.target_page && ALLOWED_TARGET_PAGES.includes(data.target_page)) {
-    // e.g. the perks/quests reminder -> open the perks page directly
-    url += '/' + data.target_page;
-  } else {
-    if (['vote', 'unvote', 'spin', 'inactive'].includes(data.type)) {
-      url += '/@' + data.target;
-    } else {
-      // delegation, mention, transfer, follow, unfollow, ignore, blacklist, reblog
-      url += '/@' + data.source;
-    }
-    if (fullPermlink) {
-      url += '/' + fullPermlink;
-    }
+// Push payloads use their own type vocabulary, produced by enotify's
+// push/format.py. It is NOT the websocket/API vocabulary: "favorite" not
+// "favorites", "bookmark" not "bookmarks", "payout" not "payouts",
+// "delegation" not "delegations". Map on these spellings.
+//
+// `source` is the actor, `target` is the recipient (the signed-in user).
+// Which of the two authored the post a permlink belongs to depends on the
+// type, and getting it backwards opens /@<wrong-author>/<permlink>, which
+// renders the "couldn't load this post" screen.
+
+// The permlink belongs to the recipient's own post.
+var ENTRY_BY_TARGET = ['vote', 'unvote', 'reblog', 'payout'];
+// The permlink belongs to the actor's post: a favourite author's new post, a
+// reply to a bookmarked post, a mention, a reply, one's own scheduled post.
+var ENTRY_BY_SOURCE = ['mention', 'reply', 'favorite', 'bookmark', 'scheduled_published'];
+// Profile of the actor.
+var PROFILE_BY_SOURCE = ['follow', 'unfollow', 'ignore'];
+// The recipient's own wallet, matching where the in-app link for these goes.
+var WALLET_BY_TARGET = ['transfer', 'delegation'];
+// Allowlist target pages so a forged/misconfigured push can't route to an
+// arbitrary ecency.com path. Add new deep-link targets here as they're
+// introduced.
+var ALLOWED_TARGET_PAGES = ['perks'];
+
+function joinPermlink(data) {
+  // Only the entry types send permlink parts, and a part that carries no text
+  // arrives as '' (or as the string 'None' if it was ever serialized from a
+  // Python None). Filtering instead of concatenating keeps a missing part from
+  // landing in the URL as the literal "undefined".
+  return [data.permlink1, data.permlink2, data.permlink3]
+    .filter(function (part) {
+      return typeof part === 'string' && part !== 'None';
+    })
+    .join('')
+    .trim();
+}
+
+function buildNotificationUrl(data) {
+  var base = 'https://ecency.com';
+
+  if (!data) {
+    return base;
   }
 
-  clients.openWindow(url, '_blank');
+  if (data.target_page && ALLOWED_TARGET_PAGES.indexOf(data.target_page) !== -1) {
+    // e.g. the perks/quests reminder -> open the perks page directly
+    return base + '/' + data.target_page;
+  }
+
+  var type = data.type;
+
+  if (WALLET_BY_TARGET.indexOf(type) !== -1) {
+    return data.target ? base + '/@' + data.target + '/wallet' : base;
+  }
+
+  var isEntryBySource = ENTRY_BY_SOURCE.indexOf(type) !== -1;
+  // Everything not authored by the actor resolves against the recipient. That
+  // includes the informational types enotify sends with source 'ecency'
+  // (inactive, checkin, monthly_posts, weekly_earnings, account_update) and
+  // any type added later that isn't listed above: an unknown type lands on the
+  // recipient's own profile rather than on a stranger's permlink.
+  var author =
+    isEntryBySource || PROFILE_BY_SOURCE.indexOf(type) !== -1 ? data.source : data.target;
+
+  if (!author) {
+    return base;
+  }
+
+  var permlink = isEntryBySource || ENTRY_BY_TARGET.indexOf(type) !== -1 ? joinPermlink(data) : '';
+
+  return permlink ? base + '/@' + author + '/' + permlink : base + '/@' + author;
+}
+
+self.addEventListener('notificationclick', function (event) {
+  clients.openWindow(buildNotificationUrl(event.notification.data), '_blank');
 });

--- a/apps/web/src/api/firebase.ts
+++ b/apps/web/src/api/firebase.ts
@@ -1,5 +1,6 @@
 import { getMessaging, getToken, MessagePayload, Messaging, onMessage } from "@firebase/messaging";
 import { FirebaseApp, initializeApp } from "@firebase/app";
+import { buildPushNotificationUrl } from "./push-notification-link";
 
 let app: FirebaseApp;
 export let FCM: Messaging;
@@ -33,21 +34,9 @@ export const handleMessage = (payload: MessagePayload) => {
   });
 
   notification.onclick = () => {
-    let url = "https://ecency.com";
-    const data = (payload.data || {}) as any;
-    const fullPermlink = data.permlink1 + data.permlink2 + data.permlink3;
-
-    if (["vote", "unvote", "spin", "inactive"].includes(data.type)) {
-      url += "/@" + data.target;
-    } else {
-      // delegation, mention, transfer, follow, unfollow, ignore, blacklist, reblog
-      url += "/@" + data.source;
-    }
-    if (fullPermlink) {
-      url += "/" + fullPermlink;
-    }
-
-    window.open(url, "_blank");
+    // Same payload and same routing table as the background service worker;
+    // see api/push-notification-link.
+    window.open(buildPushNotificationUrl(payload.data), "_blank");
   };
 };
 

--- a/apps/web/src/api/notifications-ws-api.ts
+++ b/apps/web/src/api/notifications-ws-api.ts
@@ -157,16 +157,20 @@ export class NotificationsWebSocket {
 
     switch (data.type) {
       case "vote":
-      case "favorites":
-      case "bookmarks":
       case "reblog":
       case "payouts":
       case "scheduled_published":
         // Action on the user's own content — author is the recipient (target).
+        // (scheduled_published is self-targeted, so source === target.)
         return toEntry(data.target, data.extra?.permlink);
       case "mention":
       case "reply":
-        // The mentioning/reply content is authored by the actor (source).
+      case "favorites":
+      case "bookmarks":
+        // The linked content is authored by the actor (source), not by the
+        // recipient: a favourite author's new post, a reply to a bookmarked
+        // post, a mention, a reply. Resolving these from `target` opens
+        // /@<recipient>/<their-permlink>, which 404s.
         return toEntry(data.source, data.extra?.permlink);
       case "follow":
         return toProfile(data.source);

--- a/apps/web/src/api/notifications-ws-api.ts
+++ b/apps/web/src/api/notifications-ws-api.ts
@@ -147,30 +147,37 @@ export class NotificationsWebSocket {
     // (e.g. "/@" or "/@/wallet"); `extra` is read with optional chaining so a
     // malformed message can't throw and abort notification handling.
     const toEntry = (author?: string, permlink?: string) => {
-      if (!author || !permlink || permlink.trim().length === 0 || permlink === "undefined") {
+      // Both fields are typed as strings but arrive off the wire, so check the
+      // type as well as the value: a non-string permlink used to throw out of
+      // here and abort handling of the whole message.
+      if (typeof author !== "string" || typeof permlink !== "string") {
+        return undefined;
+      }
+      if (!author || permlink.trim().length === 0 || permlink === "undefined") {
         return undefined;
       }
       return `/@${author}/${permlink.trim()}`;
     };
     const toProfile = (username?: string, suffix = "") =>
-      username ? `/@${username}${suffix}` : undefined;
+      typeof username === "string" && username ? `/@${username}${suffix}` : undefined;
 
     switch (data.type) {
       case "vote":
       case "reblog":
       case "payouts":
-      case "scheduled_published":
         // Action on the user's own content — author is the recipient (target).
-        // (scheduled_published is self-targeted, so source === target.)
         return toEntry(data.target, data.extra?.permlink);
       case "mention":
       case "reply":
       case "favorites":
       case "bookmarks":
+      case "scheduled_published":
         // The linked content is authored by the actor (source), not by the
         // recipient: a favourite author's new post, a reply to a bookmarked
         // post, a mention, a reply. Resolving these from `target` opens
-        // /@<recipient>/<their-permlink>, which 404s.
+        // /@<recipient>/<their-permlink>, which 404s. scheduled_published is
+        // self-targeted so either field names the author, and reading `source`
+        // keeps this table identical to the push one.
         return toEntry(data.source, data.extra?.permlink);
       case "follow":
         return toProfile(data.source);

--- a/apps/web/src/api/push-notification-link.ts
+++ b/apps/web/src/api/push-notification-link.ts
@@ -1,0 +1,96 @@
+/**
+ * Where a push notification should open.
+ *
+ * Push payloads carry their own type vocabulary, produced by enotify's
+ * push/format.py, and it is NOT the websocket/API vocabulary the in-app links
+ * use: "favorite" not "favorites", "bookmark" not "bookmarks", "payout" not
+ * "payouts", "delegation" not "delegations".
+ *
+ * `source` is the actor and `target` is the recipient (the signed-in user).
+ * Which of the two authored the post a permlink belongs to depends on the type,
+ * and getting it backwards opens /@<wrong-author>/<permlink>, which renders the
+ * "couldn't load this post" screen.
+ *
+ * FCM delivers the same payload to the page (foreground, `api/firebase.ts`) and
+ * to the service worker (background, `public/firebase-messaging-sw.js`). The
+ * worker is a static public file with no bundler, so it cannot import this and
+ * keeps its own copy of the table; `specs/api/push-notification-link-cases.ts`
+ * is the shared fixture that holds the two to the same answers.
+ */
+
+const BASE = "https://ecency.com";
+
+/** The permlink belongs to the recipient's own post. */
+const ENTRY_BY_TARGET = ["vote", "unvote", "reblog", "payout"];
+/**
+ * The permlink belongs to the actor's post: a favourite author's new post, a
+ * reply to a bookmarked post, a mention, a reply, one's own scheduled post.
+ */
+const ENTRY_BY_SOURCE = ["mention", "reply", "favorite", "bookmark", "scheduled_published"];
+/** Profile of the actor. */
+const PROFILE_BY_SOURCE = ["follow", "unfollow", "ignore"];
+/** The recipient's own wallet, matching where the in-app link for these goes. */
+const WALLET_BY_TARGET = ["transfer", "delegation"];
+/**
+ * Allowlist target pages so a forged or misconfigured push can't route to an
+ * arbitrary ecency.com path. Add new deep-link targets here as they're
+ * introduced.
+ */
+const ALLOWED_TARGET_PAGES = ["perks"];
+
+export interface PushNotificationData {
+  type?: string;
+  source?: string;
+  target?: string;
+  target_page?: string;
+  permlink1?: string;
+  permlink2?: string;
+  permlink3?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * A permlink over 100 characters arrives split across three fields, and a part
+ * that carries no text arrives as "" (or as the string "None" when it was
+ * serialized from a Python None). Filtering rather than concatenating keeps a
+ * missing part from landing in the URL as the literal "undefined".
+ */
+function joinPermlink(data: PushNotificationData): string {
+  return [data.permlink1, data.permlink2, data.permlink3]
+    .filter((part): part is string => typeof part === "string" && part !== "None")
+    .join("")
+    .trim();
+}
+
+export function buildPushNotificationUrl(data: PushNotificationData | undefined | null): string {
+  if (!data) {
+    return BASE;
+  }
+
+  if (data.target_page && ALLOWED_TARGET_PAGES.includes(data.target_page)) {
+    // e.g. the perks/quests reminder -> open the perks page directly
+    return `${BASE}/${data.target_page}`;
+  }
+
+  const type = data.type ?? "";
+
+  if (WALLET_BY_TARGET.includes(type)) {
+    return data.target ? `${BASE}/@${data.target}/wallet` : BASE;
+  }
+
+  const isEntryBySource = ENTRY_BY_SOURCE.includes(type);
+  // Everything not authored by the actor resolves against the recipient. That
+  // includes the informational types enotify sends with source 'ecency'
+  // (inactive, checkin, monthly_posts, weekly_earnings, account_update) and any
+  // type added later that isn't listed above: an unknown type lands on the
+  // recipient's own profile rather than on a stranger's permlink.
+  const author = isEntryBySource || PROFILE_BY_SOURCE.includes(type) ? data.source : data.target;
+
+  if (!author) {
+    return BASE;
+  }
+
+  const permlink = isEntryBySource || ENTRY_BY_TARGET.includes(type) ? joinPermlink(data) : "";
+
+  return permlink ? `${BASE}/@${author}/${permlink}` : `${BASE}/@${author}`;
+}

--- a/apps/web/src/specs/api/firebase-messaging-sw-notification-click.spec.ts
+++ b/apps/web/src/specs/api/firebase-messaging-sw-notification-click.spec.ts
@@ -2,20 +2,18 @@ import { readFileSync } from "fs";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { beforeAll, describe, expect, it } from "vitest";
+import { PUSH_LINK_CASES } from "./push-notification-link-cases";
 
 /**
  * Exercises the shipped service worker (public/firebase-messaging-sw.js), which
  * is the click handler for background push. It cannot import from src, so its
- * routing table is a second copy of the one in notifications-ws-api.ts and has
- * to be tested against the same truth.
- *
- * Note the vocabularies differ: the push payload says "favorite"/"bookmark"/
- * "payout"/"delegation" where the websocket says "favorites"/"bookmarks"/
- * "payouts"/"delegations". Testing the real file is the only thing that keeps
- * that from drifting silently.
+ * routing table is a second copy of the one in api/push-notification-link.ts.
+ * Running the shared cases against the real file is what keeps the two from
+ * drifting apart silently.
  */
 describe("firebase-messaging-sw notificationclick", () => {
   let opened: string[];
+  let waited: unknown[];
   let click: (event: unknown) => void;
 
   beforeAll(() => {
@@ -28,6 +26,7 @@ describe("firebase-messaging-sw notificationclick", () => {
     );
 
     opened = [];
+    waited = [];
     const listeners: Record<string, (event: unknown) => void> = {};
     const selfStub = {
       addEventListener: (type: string, listener: (event: unknown) => void) => {
@@ -42,6 +41,7 @@ describe("firebase-messaging-sw notificationclick", () => {
     const clientsStub = {
       openWindow: (url: string) => {
         opened.push(url);
+        return Promise.resolve(null);
       }
     };
 
@@ -60,131 +60,28 @@ describe("firebase-messaging-sw notificationclick", () => {
     click = listeners.notificationclick;
   });
 
-  const openedFor = (data: Record<string, unknown>) => {
+  const openedFor = (data: Record<string, string>) => {
     opened.length = 0;
-    click({ notification: { data } });
+    click({
+      notification: { data },
+      waitUntil: (promise: unknown) => waited.push(promise)
+    });
     return opened[0];
   };
 
-  const withPermlink = (type: string) => ({
-    type,
-    source: "actor",
-    target: "recipient",
-    permlink1: "a-permlink",
-    permlink2: "",
-    permlink3: ""
-  });
-
-  it.each([
-    // The recipient's own post was voted on / reblogged / paid out.
-    ["vote", "https://ecency.com/@recipient/a-permlink"],
-    ["unvote", "https://ecency.com/@recipient/a-permlink"],
-    ["reblog", "https://ecency.com/@recipient/a-permlink"],
-    ["payout", "https://ecency.com/@recipient/a-permlink"],
-    // The linked content belongs to the actor.
-    ["mention", "https://ecency.com/@actor/a-permlink"],
-    ["reply", "https://ecency.com/@actor/a-permlink"],
-    ["favorite", "https://ecency.com/@actor/a-permlink"],
-    ["bookmark", "https://ecency.com/@actor/a-permlink"],
-    ["scheduled_published", "https://ecency.com/@actor/a-permlink"]
-  ])("opens %s at %s", (type, expected) => {
-    expect(openedFor(withPermlink(type))).toBe(expected);
-  });
-
-  it("opens a payout on the recipient's post, not on @ecency", () => {
-    // Regression: payouts are sent with source 'ecency', and routing by source
-    // opened /@ecency/<recipient's permlink>.
-    expect(
-      openedFor({
-        type: "payout",
-        source: "ecency",
-        target: "recipient",
-        permlink1: "my-paid-post",
-        permlink2: "",
-        permlink3: ""
-      })
-    ).toBe("https://ecency.com/@recipient/my-paid-post");
-  });
-
-  it("opens a reblog on the post's author, not on the account that reblogged", () => {
-    expect(
-      openedFor({
-        type: "reblog",
-        source: "reblogger",
-        target: "author",
-        permlink1: "my-post",
-        permlink2: "",
-        permlink3: ""
-      })
-    ).toBe("https://ecency.com/@author/my-post");
-  });
-
-  it("reassembles a permlink split across all three parts", () => {
-    const long = "a".repeat(100) + "b".repeat(100) + "c".repeat(20);
-    expect(
-      openedFor({
-        type: "favorite",
-        source: "actor",
-        target: "recipient",
-        permlink1: long.slice(0, 100),
-        permlink2: long.slice(100, 200),
-        permlink3: long.slice(200, 300)
-      })
-    ).toBe(`https://ecency.com/@actor/${long}`);
-  });
-
-  it("does not concatenate a missing permlink part into the url", () => {
-    expect(
-      openedFor({ type: "favorite", source: "actor", target: "recipient", permlink1: "a-permlink" })
-    ).toBe("https://ecency.com/@actor/a-permlink");
-  });
-
-  it.each(["follow", "unfollow", "ignore"])("opens %s on the actor's profile", (type) => {
-    expect(openedFor({ type, source: "actor", target: "recipient" })).toBe(
-      "https://ecency.com/@actor"
-    );
-  });
-
-  it.each(["transfer", "delegation"])("opens %s on the recipient's wallet", (type) => {
-    expect(openedFor({ type, source: "sender", target: "recipient", amount: "1.000 HIVE" })).toBe(
-      "https://ecency.com/@recipient/wallet"
-    );
-  });
-
-  it.each(["inactive", "checkin", "monthly_posts", "weekly_earnings", "account_update"])(
-    "opens the recipient's own profile for %s, which is sent by @ecency",
-    (type) => {
-      expect(openedFor({ type, source: "ecency", target: "recipient" })).toBe(
-        "https://ecency.com/@recipient"
-      );
+  it.each(PUSH_LINK_CASES.map((c) => [c.name, c.data, c.expected] as const))(
+    "%s",
+    (_name, data, expected) => {
+      expect(openedFor(data)).toBe(expected);
     }
   );
 
-  it("routes the quests reminder to the allowlisted perks page", () => {
-    expect(openedFor({ type: "spin", source: "ecency", target: "recipient", target_page: "perks" })).toBe(
-      "https://ecency.com/perks"
-    );
-  });
-
-  it("ignores a target_page that is not allowlisted", () => {
-    expect(
-      openedFor({ type: "spin", source: "ecency", target: "recipient", target_page: "../evil" })
-    ).toBe("https://ecency.com/@recipient");
-  });
-
-  it("sends an unknown type to the recipient's profile rather than a stranger's permlink", () => {
-    expect(
-      openedFor({
-        type: "some_future_type",
-        source: "ecency",
-        target: "recipient",
-        permlink1: "not-mine"
-      })
-    ).toBe("https://ecency.com/@recipient");
-  });
-
-  it("falls back to the home page when the payload names no account", () => {
-    expect(openedFor({ type: "favorite" })).toBe("https://ecency.com");
-    expect(openedFor({} as Record<string, unknown>)).toBe("https://ecency.com");
+  it("holds the worker open until the navigation settles", () => {
+    // Without waitUntil the worker can be terminated before openWindow
+    // resolves, and the click intermittently opens nothing.
+    waited.length = 0;
+    openedFor({ type: "favorite", source: "actor", target: "recipient", permlink1: "p" });
+    expect(waited).toHaveLength(1);
+    expect(waited[0]).toBeInstanceOf(Promise);
   });
 });

--- a/apps/web/src/specs/api/firebase-messaging-sw-notification-click.spec.ts
+++ b/apps/web/src/specs/api/firebase-messaging-sw-notification-click.spec.ts
@@ -1,0 +1,190 @@
+import { readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * Exercises the shipped service worker (public/firebase-messaging-sw.js), which
+ * is the click handler for background push. It cannot import from src, so its
+ * routing table is a second copy of the one in notifications-ws-api.ts and has
+ * to be tested against the same truth.
+ *
+ * Note the vocabularies differ: the push payload says "favorite"/"bookmark"/
+ * "payout"/"delegation" where the websocket says "favorites"/"bookmarks"/
+ * "payouts"/"delegations". Testing the real file is the only thing that keeps
+ * that from drifting silently.
+ */
+describe("firebase-messaging-sw notificationclick", () => {
+  let opened: string[];
+  let click: (event: unknown) => void;
+
+  beforeAll(() => {
+    // Build the path from the spec file string, not `new URL(...)` — the jsdom
+    // global URL isn't recognized by Node's fileURLToPath.
+    const specDir = dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(
+      resolve(specDir, "../../../public/firebase-messaging-sw.js"),
+      "utf-8"
+    );
+
+    opened = [];
+    const listeners: Record<string, (event: unknown) => void> = {};
+    const selfStub = {
+      addEventListener: (type: string, listener: (event: unknown) => void) => {
+        listeners[type] = listener;
+      },
+      registration: { showNotification: () => {} }
+    };
+    const firebaseStub = {
+      initializeApp: () => {},
+      messaging: () => ({ onBackgroundMessage: () => {} })
+    };
+    const clientsStub = {
+      openWindow: (url: string) => {
+        opened.push(url);
+      }
+    };
+
+    // Run the worker body with the service-worker globals it expects. The two
+    // importScripts calls at the top are what makes `firebase` exist in a real
+    // worker, so they're a no-op here and the stub stands in.
+    new Function(
+      "importScripts",
+      "firebase",
+      "self",
+      "clients",
+      source
+    )(() => {}, firebaseStub, selfStub, clientsStub);
+
+    expect(listeners.notificationclick).toBeTypeOf("function");
+    click = listeners.notificationclick;
+  });
+
+  const openedFor = (data: Record<string, unknown>) => {
+    opened.length = 0;
+    click({ notification: { data } });
+    return opened[0];
+  };
+
+  const withPermlink = (type: string) => ({
+    type,
+    source: "actor",
+    target: "recipient",
+    permlink1: "a-permlink",
+    permlink2: "",
+    permlink3: ""
+  });
+
+  it.each([
+    // The recipient's own post was voted on / reblogged / paid out.
+    ["vote", "https://ecency.com/@recipient/a-permlink"],
+    ["unvote", "https://ecency.com/@recipient/a-permlink"],
+    ["reblog", "https://ecency.com/@recipient/a-permlink"],
+    ["payout", "https://ecency.com/@recipient/a-permlink"],
+    // The linked content belongs to the actor.
+    ["mention", "https://ecency.com/@actor/a-permlink"],
+    ["reply", "https://ecency.com/@actor/a-permlink"],
+    ["favorite", "https://ecency.com/@actor/a-permlink"],
+    ["bookmark", "https://ecency.com/@actor/a-permlink"],
+    ["scheduled_published", "https://ecency.com/@actor/a-permlink"]
+  ])("opens %s at %s", (type, expected) => {
+    expect(openedFor(withPermlink(type))).toBe(expected);
+  });
+
+  it("opens a payout on the recipient's post, not on @ecency", () => {
+    // Regression: payouts are sent with source 'ecency', and routing by source
+    // opened /@ecency/<recipient's permlink>.
+    expect(
+      openedFor({
+        type: "payout",
+        source: "ecency",
+        target: "recipient",
+        permlink1: "my-paid-post",
+        permlink2: "",
+        permlink3: ""
+      })
+    ).toBe("https://ecency.com/@recipient/my-paid-post");
+  });
+
+  it("opens a reblog on the post's author, not on the account that reblogged", () => {
+    expect(
+      openedFor({
+        type: "reblog",
+        source: "reblogger",
+        target: "author",
+        permlink1: "my-post",
+        permlink2: "",
+        permlink3: ""
+      })
+    ).toBe("https://ecency.com/@author/my-post");
+  });
+
+  it("reassembles a permlink split across all three parts", () => {
+    const long = "a".repeat(100) + "b".repeat(100) + "c".repeat(20);
+    expect(
+      openedFor({
+        type: "favorite",
+        source: "actor",
+        target: "recipient",
+        permlink1: long.slice(0, 100),
+        permlink2: long.slice(100, 200),
+        permlink3: long.slice(200, 300)
+      })
+    ).toBe(`https://ecency.com/@actor/${long}`);
+  });
+
+  it("does not concatenate a missing permlink part into the url", () => {
+    expect(
+      openedFor({ type: "favorite", source: "actor", target: "recipient", permlink1: "a-permlink" })
+    ).toBe("https://ecency.com/@actor/a-permlink");
+  });
+
+  it.each(["follow", "unfollow", "ignore"])("opens %s on the actor's profile", (type) => {
+    expect(openedFor({ type, source: "actor", target: "recipient" })).toBe(
+      "https://ecency.com/@actor"
+    );
+  });
+
+  it.each(["transfer", "delegation"])("opens %s on the recipient's wallet", (type) => {
+    expect(openedFor({ type, source: "sender", target: "recipient", amount: "1.000 HIVE" })).toBe(
+      "https://ecency.com/@recipient/wallet"
+    );
+  });
+
+  it.each(["inactive", "checkin", "monthly_posts", "weekly_earnings", "account_update"])(
+    "opens the recipient's own profile for %s, which is sent by @ecency",
+    (type) => {
+      expect(openedFor({ type, source: "ecency", target: "recipient" })).toBe(
+        "https://ecency.com/@recipient"
+      );
+    }
+  );
+
+  it("routes the quests reminder to the allowlisted perks page", () => {
+    expect(openedFor({ type: "spin", source: "ecency", target: "recipient", target_page: "perks" })).toBe(
+      "https://ecency.com/perks"
+    );
+  });
+
+  it("ignores a target_page that is not allowlisted", () => {
+    expect(
+      openedFor({ type: "spin", source: "ecency", target: "recipient", target_page: "../evil" })
+    ).toBe("https://ecency.com/@recipient");
+  });
+
+  it("sends an unknown type to the recipient's profile rather than a stranger's permlink", () => {
+    expect(
+      openedFor({
+        type: "some_future_type",
+        source: "ecency",
+        target: "recipient",
+        permlink1: "not-mine"
+      })
+    ).toBe("https://ecency.com/@recipient");
+  });
+
+  it("falls back to the home page when the payload names no account", () => {
+    expect(openedFor({ type: "favorite" })).toBe("https://ecency.com");
+    expect(openedFor({} as Record<string, unknown>)).toBe("https://ecency.com");
+  });
+});

--- a/apps/web/src/specs/api/notification-link-adversarial.spec.ts
+++ b/apps/web/src/specs/api/notification-link-adversarial.spec.ts
@@ -1,0 +1,315 @@
+import { readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import { beforeAll, describe, expect, it } from "vitest";
+import { buildPushNotificationUrl } from "@/api/push-notification-link";
+import { NotificationsWebSocket } from "@/api/notifications-ws-api";
+
+/**
+ * Adversarial checks on notification click routing.
+ *
+ * A wrong author here is not a cosmetic bug: it sends the user to a URL that
+ * does not exist. Rather than restate the implementation's table, these tests
+ * hold the three copies of it against each other and against the notification
+ * service's own authorship rules, then attack them with payloads designed to
+ * produce a bad route.
+ */
+
+type Payload = Record<string, unknown>;
+
+const getLink = (data: Payload) =>
+  (
+    NotificationsWebSocket as unknown as {
+      getLink(data: Payload): string | undefined;
+    }
+  ).getLink(data);
+
+/** The shipped service worker's own copy, driven through its real listener. */
+let swUrlFor: (data: Record<string, string>) => string;
+
+beforeAll(() => {
+  const specDir = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(resolve(specDir, "../../../public/firebase-messaging-sw.js"), "utf-8");
+
+  const opened: string[] = [];
+  const listeners: Record<string, (event: unknown) => void> = {};
+  new Function(
+    "importScripts",
+    "firebase",
+    "self",
+    "clients",
+    source
+  )(
+    () => {},
+    { initializeApp: () => {}, messaging: () => ({ onBackgroundMessage: () => {} }) },
+    {
+      addEventListener: (type: string, listener: (event: unknown) => void) => {
+        listeners[type] = listener;
+      },
+      registration: { showNotification: () => {} }
+    },
+    { openWindow: (url: string) => (opened.push(url), Promise.resolve(null)) }
+  );
+
+  swUrlFor = (data) => {
+    opened.length = 0;
+    listeners.notificationclick({ notification: { data }, waitUntil: () => {} });
+    return opened[0];
+  };
+});
+
+/**
+ * Authorship as the notification service defines it, not as the app implements
+ * it. enotify's converters set `source` and `target` per type (sync.py), and its
+ * API serializer names the post's author from one of the two (api/endpoints.py).
+ * That is the ground truth both click paths have to agree with.
+ */
+const AUTHORSHIP: {
+  /** websocket / API type */
+  ws: string;
+  /** push payload type, which uses different spellings */
+  push: string;
+  /** which field the post's author is in */
+  author: "source" | "target";
+  /** whether the notification carries an entry at all */
+  entry: boolean;
+  /**
+   * Whether the in-app path delivers this type. `unvote` has no getBody branch,
+   * so the websocket message is dropped before a toast is ever queued.
+   */
+  inApp?: false;
+}[] = [
+  // enotify sync.py: source = voter, target = the post's author.
+  { ws: "vote", push: "vote", author: "target", entry: true },
+  { ws: "unvote", push: "unvote", author: "target", entry: true, inApp: false },
+  // source = the account that reblogged, target = the post's author.
+  { ws: "reblog", push: "reblog", author: "target", entry: true },
+  // source = 'ecency', target = the author being paid.
+  { ws: "payouts", push: "payout", author: "target", entry: true },
+  // source = the author of the mentioning post, target = the mentioned account.
+  { ws: "mention", push: "mention", author: "source", entry: true },
+  // source = the replier, target = the parent author.
+  { ws: "reply", push: "reply", author: "source", entry: true },
+  // source = the favourited author who just published, target = the follower.
+  { ws: "favorites", push: "favorite", author: "source", entry: true },
+  // source = the replier, target = whoever bookmarked the parent.
+  { ws: "bookmarks", push: "bookmark", author: "source", entry: true },
+  // self-targeted: source === target.
+  { ws: "scheduled_published", push: "scheduled_published", author: "source", entry: true },
+  // source = the follower, target = the followed account.
+  { ws: "follow", push: "follow", author: "source", entry: false }
+];
+
+describe("both click paths agree with the notification service's authorship", () => {
+  it.each(AUTHORSHIP.map((row) => [row.ws, row] as const))(
+    "%s resolves the entry author from the field enotify puts it in",
+    (_type, row) => {
+      const source = row.ws === "scheduled_published" ? "self" : "actor";
+      const target = row.ws === "scheduled_published" ? "self" : "recipient";
+      const expectedAuthor = row.author === "source" ? source : target;
+
+      const push = swUrlFor({
+        type: row.push,
+        source,
+        target,
+        ...(row.entry ? { permlink1: "the-permlink", permlink2: "", permlink3: "" } : {})
+      });
+      const inApp = getLink({
+        type: row.ws,
+        source,
+        target,
+        extra: row.entry ? { permlink: "the-permlink" } : {}
+      });
+
+      const expectedPath = row.entry
+        ? `/@${expectedAuthor}/the-permlink`
+        : `/@${expectedAuthor}`;
+
+      expect(push).toBe(`https://ecency.com${expectedPath}`);
+      expect(inApp).toBe(row.inApp === false ? undefined : expectedPath);
+    }
+  );
+
+  it("never points an entry link at the account that merely acted on it", () => {
+    // The reported failure in one sentence: a favourite author's post opened
+    // under the recipient's own blog.
+    for (const row of AUTHORSHIP.filter((r) => r.entry && r.ws !== "scheduled_published")) {
+      const wrongAccount = row.author === "source" ? "recipient" : "actor";
+
+      expect(
+        swUrlFor({ type: row.push, source: "actor", target: "recipient", permlink1: "p" })
+      ).not.toContain(`/@${wrongAccount}/`);
+
+      const inApp = getLink({
+        type: row.ws,
+        source: "actor",
+        target: "recipient",
+        extra: { permlink: "p" }
+      });
+      expect(inApp ?? "").not.toContain(`/@${wrongAccount}/`);
+    }
+  });
+});
+
+describe("the three copies of the table cannot drift apart", () => {
+  function makeRandom(seed: number) {
+    let state = seed >>> 0;
+    return () => {
+      state = (state * 1664525 + 1013904223) >>> 0;
+      return state / 0x100000000;
+    };
+  }
+
+  const KNOWN_PUSH_TYPES = [
+    "vote", "unvote", "mention", "favorite", "bookmark", "follow", "unfollow", "ignore",
+    "reply", "reblog", "transfer", "payout", "delegation", "spin", "inactive", "checkin",
+    "monthly_posts", "weekly_earnings", "account_update", "scheduled_published"
+  ];
+  const ODD_TYPES = ["", "favorites", "payouts", "delegations", "VOTE", "future_type", "__proto__"];
+  const ODD_ACCOUNTS = [
+    "alice", "", "..", "../..", "//evil.com", "https://evil.com", "a b",
+    "@doubled", "ünicode", "a".repeat(300), "x\ny", "%2e%2e", "__proto__"
+  ];
+
+  it("service worker and app answer identically on 1500 randomised payloads", () => {
+    const random = makeRandom(823);
+    const disagreements: unknown[] = [];
+
+    for (let i = 0; i < 1500; i++) {
+      const pool = random() < 0.8 ? KNOWN_PUSH_TYPES : ODD_TYPES;
+      const pick = <T,>(list: T[]) => list[Math.floor(random() * list.length)];
+
+      const data: Record<string, string> = { type: pick(pool) };
+      if (random() < 0.9) data.source = pick(ODD_ACCOUNTS);
+      if (random() < 0.9) data.target = pick(ODD_ACCOUNTS);
+      if (random() < 0.6) data.permlink1 = pick(["a-post", "", "None", "x".repeat(100)]);
+      if (random() < 0.4) data.permlink2 = pick(["", "tail", "None"]);
+      if (random() < 0.3) data.permlink3 = pick(["", "end"]);
+      if (random() < 0.15) data.target_page = pick(["perks", "../evil", "", "wallet"]);
+
+      const fromWorker = swUrlFor(data);
+      const fromApp = buildPushNotificationUrl(data);
+      if (fromWorker !== fromApp) {
+        disagreements.push({ i, data, fromWorker, fromApp });
+      }
+    }
+
+    expect(disagreements).toEqual([]);
+  });
+
+  it("never leaves ecency.com, whatever the payload says", () => {
+    // A push payload is attacker-influenceable in the sense that a compromised
+    // or misconfigured sender picks these fields. Nothing in them may turn the
+    // click into a navigation somewhere else.
+    const random = makeRandom(1607);
+    const offOrigin: unknown[] = [];
+
+    for (let i = 0; i < 1500; i++) {
+      const pick = <T,>(list: T[]) => list[Math.floor(random() * list.length)];
+      const data: Record<string, string> = {
+        type: pick([...KNOWN_PUSH_TYPES, ...ODD_TYPES]),
+        source: pick(ODD_ACCOUNTS),
+        target: pick(ODD_ACCOUNTS),
+        permlink1: pick(["p", "//evil.com", "..", "\\evil", ""]),
+        target_page: pick(["", "perks", "//evil.com", "..", "http://evil.com"])
+      };
+
+      const url = buildPushNotificationUrl(data);
+      // Resolve the way a browser would, so path traversal and stray slashes
+      // are normalised before the origin is checked.
+      const resolved = new URL(url, "https://ecency.com");
+      if (resolved.origin !== "https://ecency.com") {
+        offOrigin.push({ i, data, url, origin: resolved.origin });
+      }
+    }
+
+    expect(offOrigin).toEqual([]);
+  });
+
+  it("never emits the string undefined or null into a url", () => {
+    const cases: Record<string, string | undefined>[] = [
+      { type: "favorite", source: "alice", permlink1: "p", permlink2: undefined },
+      { type: "favorite", source: "alice", permlink1: undefined, permlink2: "tail" },
+      { type: "vote", target: "alice", permlink1: "p", permlink3: undefined },
+      { type: "payout", target: "alice", permlink1: "None", permlink2: "None" },
+      { type: undefined, source: "alice", target: "bob" }
+    ];
+
+    for (const data of cases) {
+      const url = buildPushNotificationUrl(data as Record<string, string>);
+      expect(url).not.toMatch(/undefined|null|NaN|None/);
+      expect(swUrlFor(data as Record<string, string>)).toBe(url);
+    }
+  });
+});
+
+describe("in-app links never produce a route that cannot resolve", () => {
+  const BAD_PERMLINKS = [undefined, null, "", "   ", "undefined", 0, false, {}, []];
+
+  it.each(BAD_PERMLINKS.map((p, i) => [i, p] as const))(
+    "returns no link rather than a broken one for permlink %o",
+    (_i, permlink) => {
+      for (const type of ["favorites", "bookmarks", "vote", "reblog", "payouts", "mention", "reply"]) {
+        const link = getLink({
+          type,
+          source: "actor",
+          target: "recipient",
+          extra: { permlink }
+        });
+        // Either no destination at all, or a two-segment entry route. Never
+        // "/@alice/" or "/@alice/undefined".
+        if (link !== undefined) {
+          expect(link).toMatch(/^\/@[^/]+\/[^/]+$/);
+        }
+      }
+    }
+  );
+
+  it.each(["favorites", "bookmarks", "vote", "reblog", "payouts", "mention", "reply", "follow"])(
+    "returns no link for %s when the account it needs is missing",
+    (type) => {
+      expect(getLink({ type, extra: { permlink: "p" } })).toBeUndefined();
+    }
+  );
+
+  it("does not throw on a message with no extra, a null extra or no fields at all", () => {
+    for (const data of [{ type: "favorites" }, { type: "favorites", extra: null }, {}]) {
+      expect(() => getLink(data)).not.toThrow();
+    }
+  });
+
+  it("agrees with the push path wherever it gives a destination", () => {
+    // The in-app toast and the push notification for the same event must not
+    // send the user to two different places.
+    const PAIRS: [string, string][] = [
+      ["vote", "vote"],
+      ["reblog", "reblog"],
+      ["payouts", "payout"],
+      ["mention", "mention"],
+      ["reply", "reply"],
+      ["favorites", "favorite"],
+      ["bookmarks", "bookmark"],
+      ["scheduled_published", "scheduled_published"],
+      ["follow", "follow"],
+      ["transfer", "transfer"],
+      ["delegations", "delegation"]
+    ];
+
+    for (const [ws, push] of PAIRS) {
+      const inApp = getLink({
+        type: ws,
+        source: "actor",
+        target: "recipient",
+        extra: { permlink: "the-permlink", amount: "1.000 HIVE" }
+      });
+      if (inApp === undefined) continue;
+
+      expect(buildPushNotificationUrl({
+        type: push,
+        source: "actor",
+        target: "recipient",
+        permlink1: "the-permlink"
+      })).toBe(`https://ecency.com${inApp}`);
+    }
+  });
+});

--- a/apps/web/src/specs/api/notifications-ws-link.spec.ts
+++ b/apps/web/src/specs/api/notifications-ws-link.spec.ts
@@ -36,8 +36,9 @@ describe("NotificationsWebSocket.getLink entry authorship", () => {
     ["vote", "/@recipient/a-permlink"],
     ["reblog", "/@recipient/a-permlink"],
     ["payouts", "/@recipient/a-permlink"],
-    // Self-targeted, so either account resolves to the same URL.
-    ["scheduled_published", "/@recipient/a-permlink"],
+    // Self-targeted, so source and target name the same account; read from
+    // source to match the push table exactly.
+    ["scheduled_published", "/@actor/a-permlink"],
     // The linked content belongs to the actor.
     ["mention", "/@actor/a-permlink"],
     ["reply", "/@actor/a-permlink"],

--- a/apps/web/src/specs/api/notifications-ws-link.spec.ts
+++ b/apps/web/src/specs/api/notifications-ws-link.spec.ts
@@ -12,7 +12,16 @@ import { NotificationsWebSocket } from "@/api/notifications-ws-api";
  * (enotify sync.py) and its API serializer, which is what the notification
  * panel rows already follow.
  */
-const getLink = (data: unknown) => (NotificationsWebSocket as any).getLink(data);
+// getLink is a private static; reach it through a narrow structural type
+// rather than `any`, and take a loose payload so malformed messages can be
+// exercised too.
+type LinkPayload = Record<string, unknown>;
+const getLink = (data: LinkPayload) =>
+  (
+    NotificationsWebSocket as unknown as {
+      getLink(data: LinkPayload): string | undefined;
+    }
+  ).getLink(data);
 
 const entry = (type: string, permlink = "a-permlink") => ({
   type,

--- a/apps/web/src/specs/api/notifications-ws-link.spec.ts
+++ b/apps/web/src/specs/api/notifications-ws-link.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { NotificationsWebSocket } from "@/api/notifications-ws-api";
+
+/**
+ * The websocket notification payload names two accounts: `source` is the actor
+ * and `target` is the recipient (the signed-in user). Which of the two authored
+ * the post a `permlink` belongs to depends on the type, and resolving it from
+ * the wrong one produces /@<wrong-author>/<permlink> — a URL that renders the
+ * "couldn't load this post" screen instead of the post.
+ *
+ * The truth table below is the notification service's own converters
+ * (enotify sync.py) and its API serializer, which is what the notification
+ * panel rows already follow.
+ */
+const getLink = (data: unknown) => (NotificationsWebSocket as any).getLink(data);
+
+const entry = (type: string, permlink = "a-permlink") => ({
+  type,
+  source: "actor",
+  target: "recipient",
+  extra: { permlink }
+});
+
+describe("NotificationsWebSocket.getLink entry authorship", () => {
+  it.each([
+    // The recipient's own post was acted on.
+    ["vote", "/@recipient/a-permlink"],
+    ["reblog", "/@recipient/a-permlink"],
+    ["payouts", "/@recipient/a-permlink"],
+    // Self-targeted, so either account resolves to the same URL.
+    ["scheduled_published", "/@recipient/a-permlink"],
+    // The linked content belongs to the actor.
+    ["mention", "/@actor/a-permlink"],
+    ["reply", "/@actor/a-permlink"],
+    ["favorites", "/@actor/a-permlink"],
+    ["bookmarks", "/@actor/a-permlink"]
+  ])("links %s to %s", (type, expected) => {
+    expect(getLink(entry(type))).toBe(expected);
+  });
+
+  it("links a favourite author's new post to the author, not to the recipient", () => {
+    // Regression: a favourites notification resolved from `target`, so the
+    // popup opened the signed-in user's own blog with someone else's permlink.
+    expect(
+      getLink({
+        type: "favorites",
+        source: "sagarkothari88",
+        target: "ecency",
+        extra: { permlink: "hivesuite-hive-inbox-dev-update", is_post: 1 }
+      })
+    ).toBe("/@sagarkothari88/hivesuite-hive-inbox-dev-update");
+  });
+
+  it("links a reply to a bookmarked post to the replier", () => {
+    expect(
+      getLink({
+        type: "bookmarks",
+        source: "replier",
+        target: "bookmarker",
+        extra: { permlink: "re-something", parent_author: "original", is_post: 0 }
+      })
+    ).toBe("/@replier/re-something");
+  });
+});
+
+describe("NotificationsWebSocket.getLink non-entry destinations", () => {
+  it("sends follow to the follower's profile", () => {
+    expect(getLink({ type: "follow", source: "actor", target: "recipient", extra: {} })).toBe(
+      "/@actor"
+    );
+  });
+
+  it.each(["transfer", "delegations"])("sends %s to the recipient's wallet", (type) => {
+    expect(getLink({ type, source: "actor", target: "recipient", extra: { amount: "1.000 HIVE" } })).toBe(
+      "/@recipient/wallet"
+    );
+  });
+
+  it.each(["checkins", "monthly_posts", "weekly_earnings", "account_update"])(
+    "leaves %s without a destination so the click opens the panel",
+    (type) => {
+      expect(getLink({ type, source: "ecency", target: "recipient", extra: {} })).toBeUndefined();
+    }
+  );
+});
+
+describe("NotificationsWebSocket.getLink malformed payloads", () => {
+  it.each([undefined, "", "   ", "undefined"])(
+    "returns no link for the permlink %o rather than a broken route",
+    (permlink) => {
+      expect(getLink({ ...entry("favorites"), extra: { permlink } })).toBeUndefined();
+    }
+  );
+
+  it("returns no link when the author field is missing", () => {
+    expect(getLink({ type: "favorites", target: "recipient", extra: { permlink: "p" } })).toBeUndefined();
+  });
+
+  it("does not throw when extra is absent", () => {
+    expect(getLink({ type: "favorites", source: "actor", target: "recipient" })).toBeUndefined();
+  });
+});

--- a/apps/web/src/specs/api/push-notification-link-cases.ts
+++ b/apps/web/src/specs/api/push-notification-link-cases.ts
@@ -1,0 +1,157 @@
+/**
+ * The one routing table for push notification clicks.
+ *
+ * FCM hands the same payload to two places: the page, when the tab is in the
+ * foreground (`api/firebase.ts`), and the service worker, when it is not
+ * (`public/firebase-messaging-sw.js`). The worker is a static public file with
+ * no bundler, so it cannot import the app's implementation and carries its own
+ * copy. Both specs run these cases, so a change to one copy that is not made to
+ * the other fails.
+ */
+export interface PushLinkCase {
+  name: string;
+  data: Record<string, string>;
+  expected: string;
+}
+
+const actorAndRecipient = { source: "actor", target: "recipient" };
+const permlinkParts = { permlink1: "a-permlink", permlink2: "", permlink3: "" };
+
+export const PUSH_LINK_CASES: PushLinkCase[] = [
+  // The recipient's own post was voted on, reblogged or paid out.
+  {
+    name: "vote opens the recipient's post",
+    data: { type: "vote", ...actorAndRecipient, ...permlinkParts },
+    expected: "https://ecency.com/@recipient/a-permlink"
+  },
+  {
+    name: "unvote opens the recipient's post",
+    data: { type: "unvote", ...actorAndRecipient, ...permlinkParts },
+    expected: "https://ecency.com/@recipient/a-permlink"
+  },
+  {
+    name: "reblog opens the post's author, not the account that reblogged",
+    data: { type: "reblog", source: "reblogger", target: "author", ...permlinkParts },
+    expected: "https://ecency.com/@author/a-permlink"
+  },
+  {
+    name: "payout opens the recipient's post, not @ecency",
+    // Payouts are sent with source 'ecency'; routing by source opened
+    // /@ecency/<the recipient's permlink>.
+    data: { type: "payout", source: "ecency", target: "recipient", ...permlinkParts },
+    expected: "https://ecency.com/@recipient/a-permlink"
+  },
+
+  // The linked content belongs to the actor.
+  {
+    name: "mention opens the mentioning post",
+    data: { type: "mention", ...actorAndRecipient, ...permlinkParts },
+    expected: "https://ecency.com/@actor/a-permlink"
+  },
+  {
+    name: "reply opens the reply",
+    data: { type: "reply", ...actorAndRecipient, ...permlinkParts },
+    expected: "https://ecency.com/@actor/a-permlink"
+  },
+  {
+    name: "favorite opens the favourite author's new post",
+    data: { type: "favorite", source: "sagarkothari88", target: "ecency", ...permlinkParts },
+    expected: "https://ecency.com/@sagarkothari88/a-permlink"
+  },
+  {
+    name: "bookmark opens the reply to the bookmarked post",
+    data: { type: "bookmark", source: "replier", target: "bookmarker", ...permlinkParts },
+    expected: "https://ecency.com/@replier/a-permlink"
+  },
+  {
+    name: "scheduled_published opens one's own post",
+    data: { type: "scheduled_published", source: "author", target: "author", ...permlinkParts },
+    expected: "https://ecency.com/@author/a-permlink"
+  },
+
+  // Profiles and wallets.
+  {
+    name: "follow opens the follower's profile",
+    data: { type: "follow", ...actorAndRecipient },
+    expected: "https://ecency.com/@actor"
+  },
+  {
+    name: "unfollow opens the actor's profile",
+    data: { type: "unfollow", ...actorAndRecipient },
+    expected: "https://ecency.com/@actor"
+  },
+  {
+    name: "ignore opens the actor's profile",
+    data: { type: "ignore", ...actorAndRecipient },
+    expected: "https://ecency.com/@actor"
+  },
+  {
+    name: "transfer opens the recipient's wallet",
+    data: { type: "transfer", source: "sender", target: "recipient", amount: "1.000 HIVE" },
+    expected: "https://ecency.com/@recipient/wallet"
+  },
+  {
+    name: "delegation opens the recipient's wallet",
+    data: { type: "delegation", source: "delegator", target: "recipient", amount: "1.000 HP" },
+    expected: "https://ecency.com/@recipient/wallet"
+  },
+
+  // Informational types, all sent with source 'ecency' and no permlink.
+  ...["inactive", "checkin", "monthly_posts", "weekly_earnings", "account_update"].map(
+    (type) => ({
+      name: `${type} opens the recipient's own profile, not @ecency`,
+      data: { type, source: "ecency", target: "recipient" },
+      expected: "https://ecency.com/@recipient"
+    })
+  ),
+
+  // Deep-link target pages.
+  {
+    name: "the quests reminder opens the allowlisted perks page",
+    data: { type: "spin", source: "ecency", target: "recipient", target_page: "perks" },
+    expected: "https://ecency.com/perks"
+  },
+  {
+    name: "a target_page outside the allowlist is ignored",
+    data: { type: "spin", source: "ecency", target: "recipient", target_page: "../evil" },
+    expected: "https://ecency.com/@recipient"
+  },
+
+  // Payload shapes that must not produce a broken route.
+  {
+    name: "a permlink split across all three parts is reassembled",
+    data: {
+      type: "favorite",
+      ...actorAndRecipient,
+      permlink1: "a".repeat(100),
+      permlink2: "b".repeat(100),
+      permlink3: "c".repeat(20)
+    },
+    expected: `https://ecency.com/@actor/${"a".repeat(100)}${"b".repeat(100)}${"c".repeat(20)}`
+  },
+  {
+    name: "a missing permlink part is not concatenated into the url",
+    data: { type: "favorite", ...actorAndRecipient, permlink1: "a-permlink" },
+    expected: "https://ecency.com/@actor/a-permlink"
+  },
+  {
+    name: "an unknown type opens the recipient's profile, not a stranger's permlink",
+    data: {
+      type: "some_future_type",
+      source: "ecency",
+      target: "recipient",
+      permlink1: "not-mine"
+    },
+    expected: "https://ecency.com/@recipient"
+  },
+  {
+    name: "a payload naming no account falls back to the home page",
+    data: { type: "favorite" },
+    expected: "https://ecency.com"
+  },
+  {
+    name: "an empty payload falls back to the home page",
+    data: {},
+    expected: "https://ecency.com"
+  }
+];

--- a/apps/web/src/specs/api/push-notification-link.spec.ts
+++ b/apps/web/src/specs/api/push-notification-link.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildPushNotificationUrl } from "@/api/push-notification-link";
+import { PUSH_LINK_CASES } from "./push-notification-link-cases";
+
+/**
+ * The foreground half of push handling: when the tab is open, FCM delivers the
+ * message to the page and `api/firebase.ts` builds the click destination from
+ * this. It answers the same cases as the service worker, which handles the same
+ * payload when the tab is not open.
+ */
+describe("buildPushNotificationUrl", () => {
+  it.each(PUSH_LINK_CASES.map((c) => [c.name, c.data, c.expected] as const))(
+    "%s",
+    (_name, data, expected) => {
+      expect(buildPushNotificationUrl(data)).toBe(expected);
+    }
+  );
+
+  it("falls back to the home page with no payload at all", () => {
+    expect(buildPushNotificationUrl(undefined)).toBe("https://ecency.com");
+  });
+});


### PR DESCRIPTION
Closes #1645

Clicking a notification could open `/@<wrong-author>/<permlink>` and land on the "couldn't load this post" screen. `source` is the actor and `target` is the recipient; which of the two authored the linked post depends on the type, and both click paths had it backwards for some types.

### In-tab popup, `NotificationsWebSocket.getLink`

`favorites` and `bookmarks` were grouped with the types whose post belongs to the recipient. For both the post belongs to the actor: a favourite author's new post, and the reply to a bookmarked post. This is the reported case, where a favourite author's post opened under the signed-in user's own blog.

The notification panel rows were already right, since they read `notification.author`, which the notification API serialises as `source` for both types.

### Background push, `public/firebase-messaging-sw.js`

The handler routed by exception (`vote`/`unvote`/`spin`/`inactive` from `target`, everything else from `source`):

- `reblog` resolved to the account that reblogged rather than the post's author.
- `payout` is sent with the actor set to `ecency`, so a payout push opened `/@ecency/<recipient's permlink>`.
- `inactive`, `checkin`, `monthly_posts`, `weekly_earnings` and `account_update` are also sent by `ecency` and carry no permlink, so they opened the `@ecency` profile.
- `transfer` and `delegation` opened the sender's profile, where the in-app link for the same notification goes to the recipient's wallet.
- Any type not in the four-entry exception list defaulted to `source`, i.e. defaulted to the failure above.

Routing is now an explicit per-type map, an unrecognised type falls back to the recipient's own profile, and the permlink parts are joined by filtering rather than concatenating so a missing part cannot appear in the URL as the literal `undefined`.

Note the push payload uses its own spellings (`favorite`, `bookmark`, `payout`, `delegation`) where the websocket uses the plural forms.

### Tests

- `notifications-ws-link.spec.ts` covers the full type table for the in-tab link, including the reported favourites case.
- `firebase-messaging-sw-notification-click.spec.ts` loads the shipped service worker file and drives its real `notificationclick` listener, so the worker's copy of the table cannot drift from the app's unnoticed.

`pnpm test` (3286 passing), `pnpm typecheck` and `pnpm lint` are green, along with the four script audits.
