### PR TITLE
perf(waves): stop sending an observer on anonymous waves requests

### DIFF
--- a/apps/web/src/app/waves/_components/waves-list-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-list-view.tsx
@@ -20,7 +20,6 @@ import {
 import { useWavesTagFilter } from "@/app/waves/_context";
 import { useBottomPagination } from "@/core/hooks";
 import { Button } from "@ui/button";
-import { DEFAULT_OBSERVER } from "@/consts/observer";
 import i18next from "i18next";
 import { sentry } from "@/core/sentry/lazy-sentry";
 
@@ -40,11 +39,15 @@ export function WavesListView({ feedType, username }: Props) {
   // server-side and each page still arrives full (client-side filtering would
   // shrink pages). Note esync actually drops muted authors here, unlike the
   // Hive bridge, which only flags them `stats.gray`.
-  // Ecency's own moderation mutes are not this parameter's job: esync applies
-  // that list to every waves request on top of the observer's, so it holds for
-  // signed-in viewers too. The fallback below only keeps anonymous requests
-  // shaped like the rest.
-  const observer = username || DEFAULT_OBSERVER;
+  //
+  // Logged out this stays undefined rather than falling back to Ecency's
+  // moderation account. That fallback used to be what filtered the anonymous
+  // feed; esync now applies the moderation mute list to every waves request on
+  // its own, so sending it changed nothing except the cache tier: any observer
+  // marks a request personalised, and personalised requests skip the 60s shared
+  // response cache. Every anonymous visitor was paying for a per-viewer cache
+  // entry that no other viewer could ever reuse.
+  const observer = username;
   const queryOptions = useMemo(() => {
     if (selectedSource) {
       return getWavesFeedQueryOptions({ containers: [selectedSource], observer });

--- a/apps/web/src/app/waves/_components/waves-reels-view.tsx
+++ b/apps/web/src/app/waves/_components/waves-reels-view.tsx
@@ -8,7 +8,6 @@ import { Button } from "@ui/button";
 import { useInfiniteDataFlow } from "@/utils";
 import { WavesReelItem } from "@/app/waves/_components/waves-reel-item";
 import { WavesFastReplyDialog } from "@/app/waves/_components/waves-fast-reply-dialog";
-import { DEFAULT_OBSERVER } from "@/consts/observer";
 
 interface Props {
   username?: string;
@@ -20,7 +19,10 @@ interface Props {
  * Selected via the "Shorts" source tab; renders in place of the wave card list.
  */
 export function WavesReelsView({ username }: Props) {
-  const observer = username || DEFAULT_OBSERVER;
+  // Undefined when logged out, like the waves list: esync applies the
+  // moderation mute list to the shorts feed itself, and an observer would only
+  // push the request off the shared 60s response cache (see waves-list-view).
+  const observer = username;
   const queryOptions = useMemo(() => getShortsFeedQueryOptions({ observer }), [observer]);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, refetch } =

--- a/apps/web/src/consts/observer.ts
+++ b/apps/web/src/consts/observer.ts
@@ -18,13 +18,15 @@
  *    swapping to the logged-in user client-side would filter every page except
  *    the one people actually look at. Feeds personalise instead at the server,
  *    where cache-policy already marks those tiers user-specific.
- * 3. This is NOT how Ecency's moderation mutes reach the waves feed. An
- *    observer only ever carries the mute list of whoever is viewing, so before
- *    esync applied the moderation list itself, signed-in users (who send their
- *    own name) got none of it. esync now ANDs `@ecency`'s on-chain mutes into
- *    every waves query on top of the observer's, so muting an account there is
- *    what takes it out of the feed for everyone. Bridge reads still behave as
- *    described above.
+ * 3. This is NOT how Ecency's moderation mutes reach the waves feed, and the
+ *    waves feed no longer sends this default at all. An observer only ever
+ *    carries the mute list of whoever is viewing, so before esync applied the
+ *    moderation list itself, signed-in users (who send their own name) got none
+ *    of it. esync now ANDs `@ecency`'s on-chain mutes into every waves query on
+ *    top of the observer's, so muting an account there is what takes it out of
+ *    the feed for everyone, and the waves views pass `undefined` when logged
+ *    out so the request stays on the shared response cache. Bridge reads still
+ *    behave as described above.
  * 4. Kept as a plain literal on purpose. This mirrors `CONFIG.defaultObserver`
  *    in @ecency/sdk, but reading it from the SDK would make every module that
  *    touches an observer depend on the SDK being mocked in specs, and several

--- a/apps/web/src/consts/observer.ts
+++ b/apps/web/src/consts/observer.ts
@@ -9,9 +9,15 @@
  *
  * Four things worth knowing before using this:
  *
- * 1. On the Hive bridge an observer only *marks* content. Muted authors' posts
- *    are still returned, so swapping the observer never shortens a feed or a
- *    comment thread. The waves feed (esync) is the exception: it drops them.
+ * 1. On the Hive bridge an observer marks ranked-feed content rather than
+ *    removing it: muted authors' posts come back flagged `stats.gray`, so
+ *    swapping the observer does not shorten a feed. Comment threads are NOT
+ *    like that, despite what this comment used to claim. `bridge.get_discussion`
+ *    drops the observer's muted authors outright — the same thread measured
+ *    2026-08-23 returns 303 nodes under a neutral observer and 60 under this
+ *    one. (An observer that is not a real account returns nothing at all, so
+ *    never pass an unvalidated name here.) The waves feed (esync) also drops
+ *    them, and applies Ecency's moderation list besides — see 3.
  * 2. Only personalise the observer where the whole list is fetched under it.
  *    Profile and community routes server-render their first page as this
  *    default and their infinite lists then discard their own first page, so

--- a/apps/web/src/specs/app/waves/waves-observer.spec.tsx
+++ b/apps/web/src/specs/app/waves/waves-observer.spec.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+/**
+ * What the waves views send as `observer`.
+ *
+ * The parameter carries the *viewer's* mute list, and esync treats any request
+ * that has one as personalised, skipping its shared response cache. Logged out
+ * there is no viewer, so it must be absent: a fallback there costs every
+ * anonymous visitor a cache entry nobody else can reuse, and filters nothing
+ * that esync does not already filter server-side.
+ *
+ * Logged in it must still be the viewer's own name, or their personal mutes
+ * stop being applied at all.
+ */
+
+const getWavesFeedQueryOptions = vi.hoisted(() => vi.fn());
+const getShortsFeedQueryOptions = vi.hoisted(() => vi.fn());
+
+const stubInfiniteQuery = (queryKey: unknown[]) => ({
+  queryKey,
+  initialPageParam: undefined,
+  queryFn: async () => [],
+  getNextPageParam: () => undefined,
+  enabled: false
+});
+
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<typeof import("@/utils")>("@/utils")),
+  random: vi.fn(),
+  getAccessToken: vi.fn(() => "mock-token")
+}));
+
+vi.mock("@ecency/sdk", async () => ({
+  ...(await vi.importActual<Record<string, unknown>>("@ecency/sdk")),
+  getWavesFeedQueryOptions: getWavesFeedQueryOptions.mockImplementation(() =>
+    stubInfiniteQuery(["waves-feed"])
+  ),
+  getShortsFeedQueryOptions: getShortsFeedQueryOptions.mockImplementation(() =>
+    stubInfiniteQuery(["shorts-feed"])
+  ),
+  getPromotedPostsQuery: vi.fn(() => ({
+    queryKey: ["promoted"],
+    queryFn: async () => [],
+    enabled: false
+  }))
+}));
+
+vi.mock("@/app/waves/_context", () => ({
+  useWavesTagFilter: () => ({ selectedTag: null, selectedSource: null })
+}));
+vi.mock("@/app/waves/_hooks", () => ({
+  useWavesAutoRefresh: () => ({ newWaves: [], clear: vi.fn(), now: 0 })
+}));
+vi.mock("@/app/waves/_components", () => ({ WavesRefreshPopup: () => null }));
+vi.mock("@/app/waves/_components/waves-list-item", () => ({ WavesListItem: () => null }));
+vi.mock("@/app/waves/_components/waves-list-loader", () => ({ WavesListLoader: () => null }));
+vi.mock("@/app/waves/_components/waves-reel-item", () => ({ WavesReelItem: () => null }));
+vi.mock("@/app/waves/_components/waves-fast-reply-dialog", () => ({
+  WavesFastReplyDialog: () => null
+}));
+vi.mock("@/features/shared", () => ({ DetectBottom: () => null }));
+vi.mock("@/core/hooks", () => ({ useBottomPagination: () => [vi.fn(), vi.fn()] }));
+
+import { WavesListView } from "@/app/waves/_components/waves-list-view";
+import { WavesReelsView } from "@/app/waves/_components/waves-reels-view";
+
+function renderView(node: React.ReactElement) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{node}</QueryClientProvider>);
+}
+
+describe("waves observer", () => {
+  beforeEach(() => {
+    getWavesFeedQueryOptions.mockClear();
+    getShortsFeedQueryOptions.mockClear();
+  });
+
+  it("omits the observer on the anonymous waves feed", () => {
+    renderView(<WavesListView feedType="for-you" />);
+
+    expect(getWavesFeedQueryOptions).toHaveBeenCalled();
+    for (const [params] of getWavesFeedQueryOptions.mock.calls) {
+      expect(params.observer).toBeUndefined();
+    }
+  });
+
+  it("sends the logged-in viewer as the observer on the waves feed", () => {
+    renderView(<WavesListView feedType="for-you" username="viewer" />);
+
+    expect(getWavesFeedQueryOptions).toHaveBeenCalled();
+    for (const [params] of getWavesFeedQueryOptions.mock.calls) {
+      expect(params.observer).toBe("viewer");
+    }
+  });
+
+  it("omits the observer on the anonymous shorts feed", () => {
+    renderView(<WavesReelsView />);
+
+    expect(getShortsFeedQueryOptions).toHaveBeenCalled();
+    for (const [params] of getShortsFeedQueryOptions.mock.calls) {
+      expect(params.observer).toBeUndefined();
+    }
+  });
+
+  it("sends the logged-in viewer as the observer on the shorts feed", () => {
+    renderView(<WavesReelsView username="viewer" />);
+
+    expect(getShortsFeedQueryOptions).toHaveBeenCalled();
+    for (const [params] of getShortsFeedQueryOptions.mock.calls) {
+      expect(params.observer).toBe("viewer");
+    }
+  });
+
+  it("never substitutes Ecency's moderation account for a missing viewer", () => {
+    // The regression this guards: `username || DEFAULT_OBSERVER` reads as a
+    // harmless default, and the response is identical either way, so nothing
+    // visible breaks when it comes back -- only the cache tier changes.
+    renderView(<WavesListView feedType="for-you" />);
+    renderView(<WavesReelsView />);
+
+    const observers = [
+      ...getWavesFeedQueryOptions.mock.calls,
+      ...getShortsFeedQueryOptions.mock.calls
+    ].map(([params]) => params.observer);
+
+    expect(observers.length).toBeGreaterThan(0);
+    expect(observers).not.toContain("ecency");
+  });
+});

--- a/apps/web/src/specs/app/waves/waves-observer.spec.tsx
+++ b/apps/web/src/specs/app/waves/waves-observer.spec.tsx
@@ -3,6 +3,7 @@ import { render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryKeys } from "@ecency/sdk";
 
 /**
  * What the waves views send as `observer`.
@@ -20,7 +21,15 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 const getWavesFeedQueryOptions = vi.hoisted(() => vi.fn());
 const getShortsFeedQueryOptions = vi.hoisted(() => vi.fn());
 
-const stubInfiniteQuery = (queryKey: unknown[]) => ({
+/**
+ * Keys come from `QueryKeys` rather than a literal, so a mocked feed lands on
+ * the same cache entry production would give it. That matters here: the key
+ * carries the observer, so anonymous and logged-in renders are distinct
+ * entries, exactly as they are in the app. A literal would collapse them onto
+ * one and quietly hide a cache-sharing bug from any later test that seeds or
+ * asserts on cache state.
+ */
+const stubInfiniteQuery = (queryKey: readonly unknown[]) => ({
   queryKey,
   initialPageParam: undefined,
   queryFn: async () => [],
@@ -36,14 +45,16 @@ vi.mock("@/utils", async () => ({
 
 vi.mock("@ecency/sdk", async () => ({
   ...(await vi.importActual<Record<string, unknown>>("@ecency/sdk")),
-  getWavesFeedQueryOptions: getWavesFeedQueryOptions.mockImplementation(() =>
-    stubInfiniteQuery(["waves-feed"])
+  getWavesFeedQueryOptions: getWavesFeedQueryOptions.mockImplementation(
+    (params: Parameters<typeof QueryKeys.posts.wavesFeed>[0] = {}) =>
+      stubInfiniteQuery(QueryKeys.posts.wavesFeed(params))
   ),
-  getShortsFeedQueryOptions: getShortsFeedQueryOptions.mockImplementation(() =>
-    stubInfiniteQuery(["shorts-feed"])
+  getShortsFeedQueryOptions: getShortsFeedQueryOptions.mockImplementation(
+    (params: Parameters<typeof QueryKeys.posts.shortsFeed>[0] = {}) =>
+      stubInfiniteQuery(QueryKeys.posts.shortsFeed(params))
   ),
-  getPromotedPostsQuery: vi.fn(() => ({
-    queryKey: ["promoted"],
+  getPromotedPostsQuery: vi.fn((type: string = "feed") => ({
+    queryKey: QueryKeys.posts.promoted(type),
     queryFn: async () => [],
     enabled: false
   }))
@@ -113,6 +124,22 @@ describe("waves observer", () => {
     for (const [params] of getShortsFeedQueryOptions.mock.calls) {
       expect(params.observer).toBe("viewer");
     }
+  });
+
+  it("puts the anonymous and logged-in feeds on different cache keys", () => {
+    // The whole point of dropping the observer is the cache tier, so the key
+    // has to actually differ. Also guards the mocks above: if they went back to
+    // a literal key, the two renders would share one entry and every
+    // cache-sensitive test written after this would be testing a fiction.
+    renderView(<WavesListView feedType="for-you" />);
+    const anonymous = getWavesFeedQueryOptions.mock.results[0].value.queryKey;
+
+    getWavesFeedQueryOptions.mockClear();
+    renderView(<WavesListView feedType="for-you" username="viewer" />);
+    const signedIn = getWavesFeedQueryOptions.mock.results[0].value.queryKey;
+
+    expect(anonymous).not.toEqual(signedIn);
+    expect(signedIn).toContain("viewer");
   });
 
   it("never substitutes Ecency's moderation account for a missing viewer", () => {


### PR DESCRIPTION
Follow-up from #1644 / ecency/esync-py#28, and safe to land now that the moderation filter is live in production.

Logged out, `WavesListView` and `WavesReelsView` both fell back to `DEFAULT_OBSERVER` (`"ecency"`). That fallback used to be what filtered the anonymous feed. It no longer is: esync applies the moderation mute list to every waves query on its own, so the parameter changes nothing about the response.

Confirmed against the live API rather than assumed:

```
no-observer rows: 50   observer=ecency rows: 50
identical ordered list: True
set difference: none
shorts identical: True
```

What it does change is the cache tier. esync treats any request carrying an `observer` as personalised and skips its 60s shared response cache — correct reasoning for a per-viewer key space, but anonymous traffic is the opposite: one key every visitor could share. So every anonymous visitor was paying for a cache entry no one else could reuse.

Six consecutive requests, live API:

```
without observer (cacheable):   0.0091  0.0015  0.0013  0.0011  0.0016  0.0013
with observer=ecency:           0.0077  0.0086  0.0078  0.0081  0.0083  0.0081

shorts, without observer:       0.0103  0.0013  0.0015  0.0014  0.0014  0.0013
shorts, with observer=ecency:   0.0081  0.0071  0.0085  0.0070  0.0096  0.0078
```

First request fills the cache, the rest serve from it at ~1.3ms instead of ~8ms. The larger win is upstream: N anonymous requests collapse to one database query per 60s per key instead of one each.

Logged-in behaviour is unchanged — the viewer's own username still goes as the observer, so their personal mutes still apply server-side and pages still arrive full.

Also updates the `DEFAULT_OBSERVER` doc to say the waves feed no longer sends it. Bridge reads still use it exactly as before; only the waves and shorts views changed.

## Checks

```
pnpm --filter @ecency/web typecheck   0
pnpm --filter @ecency/web test        343 files, 3236 tests passed
pnpm --filter @ecency/web lint        0 (warnings pre-existing, all in spec files)
slim-entries-audit --fail             0
icon-tsx-audit --fail                 0
icon-scss-audit                       0
origin-config-audit --self-test       0
origin-config-audit --fail            0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anonymous Waves and Shorts feed requests by removing unintended default personalization.
  * Logged-out viewers now receive shared, cache-friendly feed responses, while signed-in viewers continue to receive personalized feeds.
  * Preserved moderation mute handling across Waves feeds.

* **Tests**
  * Added coverage verifying observer behavior for anonymous and signed-in feed views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->