### PR TITLE
fix(tiptap-editor): chip mentions in text nodes so image URLs survive

### DIFF
--- a/apps/web/src/features/tiptap-editor/functions/parse-all-extensions-to-doc.ts
+++ b/apps/web/src/features/tiptap-editor/functions/parse-all-extensions-to-doc.ts
@@ -67,6 +67,67 @@ function hasTextBefore(child: Element) {
   return false;
 }
 
+/** Elements whose text must stay literal. */
+const CHIP_EXCLUDED = "a, code, pre";
+
+/**
+ * Turns every `@name` / `#tag` occurrence into a chip span, editing TEXT NODES only.
+ *
+ * ⛔ Do not go back to `el.innerHTML.replace(...)`. innerHTML carries attribute
+ * values, so the replacement also fires inside `src` and `href`, and Hive image
+ * URLs contain `/@author/`: pasting a mention beside a hosted image used to tear
+ * the <img> tag apart and leak its tail into the document as text. Nothing throws,
+ * so the author simply loses the image.
+ *
+ * Working on text nodes also drops the need for `el.innerText`, which does not
+ * exist in jsdom and made this pass silently inert under test.
+ */
+function chipTextNodes(root: HTMLElement, regex: RegExp, type: "mention" | "tag") {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const targets: Text[] = [];
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode as Text;
+    // A global regex carries lastIndex between calls, so a shared instance would
+    // start mid-string and miss matches. Reset before every use.
+    regex.lastIndex = 0;
+    if (!node.parentElement?.closest(CHIP_EXCLUDED) && regex.test(node.data)) {
+      targets.push(node);
+    }
+  }
+
+  targets.forEach((node) => {
+    const fragment = document.createDocumentFragment();
+    const text = node.data;
+    let index = 0;
+    let match: RegExpExecArray | null;
+
+    regex.lastIndex = 0;
+    while ((match = regex.exec(text))) {
+      if (match.index > index) {
+        fragment.appendChild(document.createTextNode(text.slice(index, match.index)));
+      }
+
+      const chip = document.createElement("span");
+      chip.setAttribute("data-type", type);
+      chip.setAttribute("data-id", match[0].slice(1));
+      fragment.appendChild(chip);
+
+      index = match.index + match[0].length;
+      // A zero-length match would spin forever otherwise.
+      if (match[0].length === 0) {
+        regex.lastIndex += 1;
+      }
+    }
+
+    if (index < text.length) {
+      fragment.appendChild(document.createTextNode(text.slice(index)));
+    }
+
+    node.replaceWith(fragment);
+  });
+}
+
 export function parseAllExtensionsToDoc(value?: string) {
   const tree = document.createElement("body");
   tree.innerHTML = value ?? "";
@@ -163,29 +224,11 @@ export function parseAllExtensionsToDoc(value?: string) {
       el.parentElement?.replaceChild(newEl, el);
     });
 
-  // Handle mentions
-  // We cannot use :has selector because some browsers like Safari 15 doesn't support it well
-  // Skip code/pre elements so backtick-wrapped text like `@aws-sdk` stays as plain text
-  (Array.from(tree.querySelectorAll("*:not(a):not(code):not(pre)")) as HTMLElement[])
-    .filter((el) => !el.closest("code") && !el.closest("pre") && !el.querySelector("a") && USER_MENTION_PURE_REGEX.test(el.innerText))
-    .forEach((el) => {
-      el.innerHTML = el.innerHTML.replace(
-        USER_MENTION_PURE_REGEX,
-        (match) => `<span data-type="mention" data-id=${match.replace("@", "")}></span>`
-      );
-    });
-
-  // Handle tags
-  // We cannot use :has selector because some browsers like Safari 15 doesn't support it well
-  // Skip code/pre elements so backtick-wrapped text like `#tag` stays as plain text
-  (Array.from(tree.querySelectorAll("*:not(a):not(code):not(pre)")) as HTMLElement[])
-    .filter((el) => !el.closest("code") && !el.closest("pre") && !el.querySelector("a") && TAG_MENTION_PURE_REGEX.test(el.innerText))
-    .forEach((el) => {
-      el.innerHTML = el.innerHTML.replace(
-        TAG_MENTION_PURE_REGEX,
-        (match) => `<span data-type="tag" data-id=${match.replace("#", "")} /></span>`
-      );
-    });
+  // Handle mentions and tags.
+  // Skip code/pre so backtick-wrapped text like `@aws-sdk` or `#tag` stays plain,
+  // and skip anchors so a link whose text is a mention keeps working as a link.
+  chipTextNodes(tree, USER_MENTION_PURE_REGEX, "mention");
+  chipTextNodes(tree, TAG_MENTION_PURE_REGEX, "tag");
 
   // Handle image alignment wrappers
   (Array.from(tree.querySelectorAll("div.pull-left, div.pull-right")) as HTMLElement[]).forEach(

--- a/apps/web/src/specs/features/tiptap-editor/mention-chip-paste.spec.ts
+++ b/apps/web/src/specs/features/tiptap-editor/mention-chip-paste.spec.ts
@@ -1,0 +1,87 @@
+import { vi } from "vitest";
+
+vi.mock("@/features/tiptap-editor/extensions", () => ({
+  HIVE_POST_PURE_REGEX: /$a^/,
+  LOOM_REGEX: /$a^/,
+  YOUTUBE_REGEX: /$a^/,
+  TAG_MENTION_PURE_REGEX: /#\w+/gi,
+  USER_MENTION_PURE_REGEX:
+    /@(?=[a-zA-Z][a-zA-Z0-9.-]{1,15}\b)[a-zA-Z][a-zA-Z0-9-]{2,}(?:\.[a-zA-Z][a-zA-Z0-9-]{2,})*\b/gi
+}));
+
+import { simpleMarkdownToHTML } from "@ecency/render-helper";
+
+import { parseAllExtensionsToDoc } from "@/features/tiptap-editor/functions/parse-all-extensions-to-doc";
+
+const paste = (markdown: string) => parseAllExtensionsToDoc(simpleMarkdownToHTML(markdown));
+
+describe("turning mentions and tags into chips on paste", () => {
+  // Regression: the rewrite used to run over innerHTML, which carries attribute
+  // values. Hive image URLs contain /@author/, so a mention beside a hosted image
+  // tore the <img> tag apart and leaked its tail into the document as text.
+  // Nothing threw, so the author just lost the image.
+  it.each([
+    ["a peakd image", "https://files.peakd.com/file/peakd-hive/@bob/p.png"],
+    ["an ecency image", "https://images.ecency.com/DQm/@carol/x.png"]
+  ])("leaves the src of %s alone", (_label: string, src: string) => {
+    const doc = paste(`@alice ![pic](${src})`);
+
+    expect(doc).toContain(`src="${src}"`);
+    expect(doc).toContain('<span data-type="mention" data-id="alice"></span>');
+  });
+
+  it("does not rewrite an author handle inside a link href", () => {
+    const doc = parseAllExtensionsToDoc(
+      '<p>@alice <a href="https://ecency.com/@bob/post">post</a></p>'
+    );
+
+    expect(doc).toContain('href="https://ecency.com/@bob/post"');
+  });
+
+  it("chips a mention that shares a paragraph with a link", () => {
+    const doc = parseAllExtensionsToDoc('<p>@alice <a href="https://example.com">link</a></p>');
+
+    expect(doc).toContain('<span data-type="mention" data-id="alice"></span>');
+    expect(doc).toContain('<a href="https://example.com">link</a>');
+  });
+
+  it.each([
+    ["a mention", "hello @alice", '<span data-type="mention" data-id="alice"></span>'],
+    ["a tag", "hello #hive", '<span data-type="tag" data-id="hive"></span>']
+  ])("chips %s in plain text", (_label: string, markdown: string, chip: string) => {
+    expect(paste(markdown)).toContain(chip);
+  });
+
+  it("chips every mention in one paragraph, not just the first", () => {
+    const doc = paste("@alice and @bob and @carol");
+
+    expect((doc.match(/data-type="mention"/g) || []).length).toBe(3);
+  });
+
+  it("keeps the text around a mention", () => {
+    const doc = paste("ping @alice about it");
+
+    expect(doc).toContain("ping ");
+    expect(doc).toContain(" about it");
+  });
+
+  it("leaves the text of a link that is itself a mention alone", () => {
+    const html = '<p><a href="https://ecency.com/@alice">@alice</a></p>';
+
+    expect(parseAllExtensionsToDoc(html)).toBe(html);
+  });
+
+  it.each([
+    ["code", "`@aws-sdk`"],
+    ["a fenced block", "```\n@alice\n```"]
+  ])("leaves a mention inside %s as literal text", (_label: string, markdown: string) => {
+    expect(paste(markdown)).not.toContain('data-type="mention"');
+  });
+
+  it("does not treat markup characters in the text as html", () => {
+    const doc = parseAllExtensionsToDoc("<p>1 &lt; 2 &amp; @alice</p>");
+
+    expect(doc).toContain("1 &lt; 2 &amp; ");
+    expect(doc).toContain('data-id="alice"');
+  });
+});


### PR DESCRIPTION
Fixes #1652.

`parseAllExtensionsToDoc` chipped `@name` and `#tag` by rewriting an element's `innerHTML`. innerHTML carries attribute values, so the replacement fired inside `src` and `href` too, and Hive image URLs contain `/@author/`:

```
@alice ![pic](https://files.peakd.com/file/peakd-hive/@bob/p.png)
```

came back with the `<img>` tag torn apart and its tail leaking into the document as literal text. Nothing throws, so there is no error report and no Sentry signal; the author just loses the image.

Chipping now walks text nodes, which also settles three things the old form could not:

- `el.innerText` does not exist in jsdom, so this pass was **inert in every existing spec**. It is testable now, and the new spec fails 7 of its 12 cases on develop.
- Both regexes are global and `.test()` advances `lastIndex`, so the old filter was stateful across elements and could skip a real match. Reset before each use.
- The tag branch emitted `<span ... /></span>`, malformed and only surviving because the parser drops the stray closing tag.

One deliberate behaviour change: a mention sharing a paragraph with a link is now chipped. The old `!el.querySelector("a")` guard was a workaround for this same corruption, and a mention inside the anchor text is still left alone.

Should be a little cheaper too: `innerText` forces a layout flush per element in a real browser, and the tree is now walked twice rather than re-serialised per element.

Verified: 12 new cases, 118 in the tiptap suite, 3502 in the web suite, tsc and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mention and tag chip creation when pasting content into the editor.
  * Preserved image URLs, links, surrounding text, and HTML attributes during processing.
  * Prevented mentions and tags inside inline or fenced code from being converted.
  * Fixed handling of multiple mentions, escaped characters, and mentions adjacent to links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->