### PR TITLE
Preload only Inter latin; drop Lora and cyrillic font preloads

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -64,17 +64,28 @@ export const viewport: Viewport = {
   ]
 };
 
+/*
+  Only Inter's latin subset is preloaded. The generated @font-face rules keep
+  every subset via unicode-range, so cyrillic text still upgrades to the
+  webfont after a fallback-first paint. The four preloaded woff2 (~126 KB,
+  priority High) were racing the last render-blocking stylesheet on the same
+  connection and delaying first paint (#1600).
+*/
 const inter = Inter({
-  subsets: ["latin", "cyrillic"],
+  subsets: ["latin"],
   variable: "--font-inter",
   display: "swap"
 });
 
+/* Lora only styles entry/publish serif text, all of it below or at the fold
+   edge; painting it with the fallback serif first is acceptable, so no
+   preload at all. */
 const lora = Lora({
-  subsets: ["latin", "cyrillic"],
+  subsets: ["latin"],
   weight: ["400", "700"],
   variable: "--font-lora",
-  display: "swap"
+  display: "swap",
+  preload: false
 });
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
Closes #1600

Every page preloaded four woff2 files (~126 KB, priority High): Inter latin + cyrillic and Lora latin + cyrillic. WebPageTest traces on the entry route show six of the seven render-blocking stylesheets finishing by ~380 ms while the last one contends with the font preloads on the same connection until ~650 ms, and the parser resumes only then.

Changes in `apps/web/src/app/layout.tsx`:

- Inter: `subsets: ["latin"]`, so only the latin file is preloaded. The generated `@font-face` rules keep every subset through `unicode-range`, so cyrillic text still upgrades to the webfont once it loads.
- Lora: `preload: false` and latin subset. Lora only styles entry/publish serif text; painting it with the metric-adjusted fallback first is acceptable.

Verified on a production build:

- rendered head carries 1 font preload instead of 4
- built CSS keeps cyrillic `@font-face` blocks (`unicode-range` U+0400..) for both families
- size-adjusted fallback faces unchanged, so no CLS change is expected

Lab A/B against the deployed build follows after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized font loading by limiting Inter and Lora to the Latin character set.
  * Disabled preloading for Lora while preserving its available weights and display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->