### PR TITLE
Restore the Lora latin preload; the late swap repainted text posts

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -77,15 +77,17 @@ const inter = Inter({
   display: "swap"
 });
 
-/* Lora only styles entry/publish serif text, all of it below or at the fold
-   edge; painting it with the fallback serif first is acceptable, so no
-   preload at all. */
+/* Lora IS preloaded (latin), deliberately: without the preload its file is
+   only discovered from CSS after the first layout (measured start 1.5-3.3s),
+   and the swap then repaints the whole article seconds after it looked done
+   on text-heavy posts (#1670). One ~37 KB file in the preload wave costs
+   ~60 ms of transfer contention; the late repaint cost 1.5-2.7 s of visual
+   settle plus a layout shift. */
 const lora = Lora({
   subsets: ["latin"],
   weight: ["400", "700"],
   variable: "--font-lora",
-  display: "swap",
-  preload: false
+  display: "swap"
 });
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
Closes #1670

`preload: false` on Lora (from #1600) pushed the serif body font behind CSS discovery: measured starts at 1.5-3.3 s with the swap landing at 2.7-4.4 s, matching each run's visualComplete exactly (WPT `260824_V6_P`). On text-heavy posts the whole article repaints and re-wraps seconds after it looked done, and the swap is the source of the new warm CLS 0.029.

This restores Lora's latin preload with the rationale in a comment: two font preloads total (~85 KB) instead of the original four (~126 KB) or the regressed one. About 60 ms of transfer contention returns to the pre-paint window; a 1.5-2.7 s late full-article repaint leaves it.

Verification after the staging deploy: on the text-heavy `260824_V6_P` post, the Lora file must start in the preload wave, visualComplete must collapse to roughly the paint time and warm CLS must return toward 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Lora font loading by enabling the framework’s default preload behavior, helping the font become available sooner.
  * Added documentation clarifying the font-loading behavior and performance considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->