### PR TITLE
Detect mixed-build dpl skew and escalate a dead retry to a reload

### DIFF
--- a/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
+++ b/apps/web/src/features/issue-reporter/sentry-error-boundary.tsx
@@ -40,8 +40,27 @@ interface State {
 export class SentryErrorBoundary extends Component<Props, State> {
   state: State = {};
 
+  // Message of the error that was showing when the user last pressed the
+  // fallback's retry. If the very next catch carries the SAME message with no
+  // successful commit of the children in between, re-rendering demonstrably
+  // cannot recover: the failing module is already loaded and throws
+  // identically forever (the mixed-build case a matcher doesn't know yet, or
+  // any other deterministic render crash). Escalate to a loop-guarded reload
+  // instead of leaving a retry button that visibly does nothing (#1674).
+  private retriedErrorMessage: string | null = null;
+
   static getDerivedStateFromError(error: Error): State {
     return { error };
+  }
+
+  componentDidUpdate() {
+    // A committed render of the children proves re-rendering CAN recover here,
+    // so a later crash — even one with an identical message, like a flaky
+    // network error recurring minutes after a successful retry — starts a
+    // fresh retry cycle instead of escalating straight to a reload.
+    if (!this.state.error) {
+      this.retriedErrorMessage = null;
+    }
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
@@ -62,13 +81,27 @@ export class SentryErrorBoundary extends Component<Props, State> {
       void Sentry.flush(2000).finally(() => reloadForSkew());
       return;
     }
+    // Did the user's retry just re-throw the identical error? (reset() records
+    // the message; componentDidUpdate clears it on any successful commit, so a
+    // match here means the retry never got a working render.)
+    const retryCannotRecover =
+      this.retriedErrorMessage !== null && this.retriedErrorMessage === error.message;
     const eventId = Sentry.captureException(error, {
-      contexts: { react: { componentStack: errorInfo.componentStack ?? undefined } }
+      contexts: { react: { componentStack: errorInfo.componentStack ?? undefined } },
+      ...(retryCannotRecover ? { tags: { retry_reload: "true" } } : {})
     });
+    // Set the eventId FIRST so the report dialog stays usable if the reload is
+    // loop-guarded away (reloadForSkew reloads at most once per session).
     this.setState({ eventId });
+    if (retryCannotRecover) {
+      void Sentry.flush(2000).finally(() => reloadForSkew());
+    }
   }
 
-  reset = () => this.setState({ error: undefined, eventId: undefined });
+  reset = () => {
+    this.retriedErrorMessage = this.state.error?.message ?? null;
+    this.setState({ error: undefined, eventId: undefined });
+  };
 
   render() {
     const { error, eventId } = this.state;

--- a/apps/web/src/specs/features/issue-reporter/sentry-error-boundary.spec.tsx
+++ b/apps/web/src/specs/features/issue-reporter/sentry-error-boundary.spec.tsx
@@ -128,4 +128,82 @@ describe("SentryErrorBoundary", () => {
     expect(screen.getByText("recovered child")).toBeInTheDocument();
     expect(screen.queryByTestId("fallback")).not.toBeInTheDocument();
   });
+
+  it("hard-reloads when retry re-throws the identical error (re-rendering cannot recover)", async () => {
+    const reloadMock = vi.fn();
+    const realLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...realLocation, reload: reloadMock }
+    });
+    sessionStorage.clear();
+
+    // shouldThrow stays true: the mixed-build case — the broken module is
+    // already registered, so a re-render throws the identical error instantly.
+    render(
+      <SentryErrorBoundary fallback={fallback}>
+        <Maybe />
+      </SentryErrorBoundary>
+    );
+    expect(screen.getByTestId("fallback")).toBeInTheDocument();
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(reloadMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "retry" }));
+
+    // The second, identical catch is tagged as a failed retry and escalates to
+    // a reload after the transport flush (so the event isn't lost on unload).
+    expect(Sentry.captureException).toHaveBeenCalledTimes(2);
+    expect(Sentry.captureException).toHaveBeenLastCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: { retry_reload: "true" } })
+    );
+    expect(Sentry.flush).toHaveBeenCalled();
+    await vi.waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
+
+    Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+  });
+
+  it("does NOT reload when an identical error recurs AFTER a successful retry", async () => {
+    const reloadMock = vi.fn();
+    const realLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...realLocation, reload: reloadMock }
+    });
+    sessionStorage.clear();
+
+    const { rerender } = render(
+      <SentryErrorBoundary fallback={fallback}>
+        <Maybe />
+      </SentryErrorBoundary>
+    );
+    expect(screen.getByTestId("fallback")).toBeInTheDocument();
+
+    // The retry recovers: a committed render of the children resets the
+    // escalation memory.
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole("button", { name: "retry" }));
+    expect(screen.getByText("recovered child")).toBeInTheDocument();
+
+    // A later crash with the very same message (e.g. the same flaky error
+    // minutes later) starts a fresh retry cycle: fallback, no reload.
+    shouldThrow = true;
+    rerender(
+      <SentryErrorBoundary fallback={fallback}>
+        <Maybe />
+      </SentryErrorBoundary>
+    );
+    expect(screen.getByTestId("fallback")).toBeInTheDocument();
+    // Drain the flush → reload microtask chain that a (wrong) escalation would
+    // have queued before asserting nothing reloaded.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(reloadMock).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: { retry_reload: "true" } })
+    );
+
+    Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+  });
 });

--- a/apps/web/src/specs/features/issue-reporter/sentry-error-boundary.spec.tsx
+++ b/apps/web/src/specs/features/issue-reporter/sentry-error-boundary.spec.tsx
@@ -138,30 +138,32 @@ describe("SentryErrorBoundary", () => {
     });
     sessionStorage.clear();
 
-    // shouldThrow stays true: the mixed-build case — the broken module is
-    // already registered, so a re-render throws the identical error instantly.
-    render(
-      <SentryErrorBoundary fallback={fallback}>
-        <Maybe />
-      </SentryErrorBoundary>
-    );
-    expect(screen.getByTestId("fallback")).toBeInTheDocument();
-    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
-    expect(reloadMock).not.toHaveBeenCalled();
+    try {
+      // shouldThrow stays true: the mixed-build case — the broken module is
+      // already registered, so a re-render throws the identical error instantly.
+      render(
+        <SentryErrorBoundary fallback={fallback}>
+          <Maybe />
+        </SentryErrorBoundary>
+      );
+      expect(screen.getByTestId("fallback")).toBeInTheDocument();
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      expect(reloadMock).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: "retry" }));
+      fireEvent.click(screen.getByRole("button", { name: "retry" }));
 
-    // The second, identical catch is tagged as a failed retry and escalates to
-    // a reload after the transport flush (so the event isn't lost on unload).
-    expect(Sentry.captureException).toHaveBeenCalledTimes(2);
-    expect(Sentry.captureException).toHaveBeenLastCalledWith(
-      expect.any(Error),
-      expect.objectContaining({ tags: { retry_reload: "true" } })
-    );
-    expect(Sentry.flush).toHaveBeenCalled();
-    await vi.waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
-
-    Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+      // The second, identical catch is tagged as a failed retry and escalates to
+      // a reload after the transport flush (so the event isn't lost on unload).
+      expect(Sentry.captureException).toHaveBeenCalledTimes(2);
+      expect(Sentry.captureException).toHaveBeenLastCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ tags: { retry_reload: "true" } })
+      );
+      expect(Sentry.flush).toHaveBeenCalled();
+      await vi.waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
+    } finally {
+      Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+    }
   });
 
   it("does NOT reload when an identical error recurs AFTER a successful retry", async () => {
@@ -173,37 +175,39 @@ describe("SentryErrorBoundary", () => {
     });
     sessionStorage.clear();
 
-    const { rerender } = render(
-      <SentryErrorBoundary fallback={fallback}>
-        <Maybe />
-      </SentryErrorBoundary>
-    );
-    expect(screen.getByTestId("fallback")).toBeInTheDocument();
+    try {
+      const { rerender } = render(
+        <SentryErrorBoundary fallback={fallback}>
+          <Maybe />
+        </SentryErrorBoundary>
+      );
+      expect(screen.getByTestId("fallback")).toBeInTheDocument();
 
-    // The retry recovers: a committed render of the children resets the
-    // escalation memory.
-    shouldThrow = false;
-    fireEvent.click(screen.getByRole("button", { name: "retry" }));
-    expect(screen.getByText("recovered child")).toBeInTheDocument();
+      // The retry recovers: a committed render of the children resets the
+      // escalation memory.
+      shouldThrow = false;
+      fireEvent.click(screen.getByRole("button", { name: "retry" }));
+      expect(screen.getByText("recovered child")).toBeInTheDocument();
 
-    // A later crash with the very same message (e.g. the same flaky error
-    // minutes later) starts a fresh retry cycle: fallback, no reload.
-    shouldThrow = true;
-    rerender(
-      <SentryErrorBoundary fallback={fallback}>
-        <Maybe />
-      </SentryErrorBoundary>
-    );
-    expect(screen.getByTestId("fallback")).toBeInTheDocument();
-    // Drain the flush → reload microtask chain that a (wrong) escalation would
-    // have queued before asserting nothing reloaded.
-    await new Promise((r) => setTimeout(r, 0));
-    expect(reloadMock).not.toHaveBeenCalled();
-    expect(Sentry.captureException).not.toHaveBeenCalledWith(
-      expect.any(Error),
-      expect.objectContaining({ tags: { retry_reload: "true" } })
-    );
-
-    Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+      // A later crash with the very same message (e.g. the same flaky error
+      // minutes later) starts a fresh retry cycle: fallback, no reload.
+      shouldThrow = true;
+      rerender(
+        <SentryErrorBoundary fallback={fallback}>
+          <Maybe />
+        </SentryErrorBoundary>
+      );
+      expect(screen.getByTestId("fallback")).toBeInTheDocument();
+      // Drain the flush → reload microtask chain that a (wrong) escalation would
+      // have queued before asserting nothing reloaded.
+      await new Promise((r) => setTimeout(r, 0));
+      expect(reloadMock).not.toHaveBeenCalled();
+      expect(Sentry.captureException).not.toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ tags: { retry_reload: "true" } })
+      );
+    } finally {
+      Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+    }
   });
 });

--- a/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
+++ b/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
@@ -117,6 +117,30 @@ describe("isDeploySkewError", () => {
       ).toBe(false);
     });
 
+    it("does NOT match a third-party script carrying its own dpl query", () => {
+      // A foreign script's dpl value is unrelated to our builds — classifying
+      // it as skew would burn the session's one guarded reload and bury the
+      // real error under the skew fingerprint.
+      expect(
+        isDeploySkewError({
+          message: "foreignSdk is not a function",
+          stack:
+            "    at init (https://cdn.example.com/analytics/sdk.js?dpl=deadbeef:1:100)\n" +
+            "    at l9 (https://ecency.com/_next/static/chunks/fab31ea0-a826f330bcfe7eac.js?dpl=9e6dd083:1:51471)"
+        })
+      ).toBe(false);
+    });
+
+    it("does NOT match a dpl value that isn't the 8-hex id our builds bake", () => {
+      expect(
+        isDeploySkewError({
+          message: "x is not a function",
+          stack:
+            "    at x (https://ecency.com/_next/static/chunks/app/page-abc123.js?dpl=67bf65841bc03b34:1:1)"
+        })
+      ).toBe(false);
+    });
+
     it("does NOT match dpl-less frames, and is inert when SENTRY_RELEASE is unset", () => {
       // No dpl in the stack (an app bug on a normal build) — never skew.
       expect(

--- a/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
+++ b/apps/web/src/specs/features/pwa-install/service-worker-recovery.spec.tsx
@@ -78,6 +78,64 @@ describe("isDeploySkewError", () => {
     expect(isDeploySkewError(undefined)).toBe(false);
     expect(isDeploySkewError(42)).toBe(false);
   });
+
+  describe("mixed-build frames (foreign ?dpl) — ECENCY-NEXT-1GNN", () => {
+    beforeEach(() => {
+      // The own build id derives from SENTRY_RELEASE exactly as next.config.js
+      // builds `deploymentId`: strip the app prefix, keep the first 8 hex.
+      vi.stubEnv("SENTRY_RELEASE", "ecency-next@9e6dd083a2a19c103c2bf813a8bd2a8dd3ad9a83");
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("matches an error executing a chunk from a DIFFERENT deployment", () => {
+      // The real crash shape: the foreign chunk LOADED fine (CDN cache), so no
+      // ChunkLoadError — it binds shifted module ids and a named export comes
+      // back undefined. No message grammar is required; the dpl mismatch alone
+      // proves a mixed build.
+      expect(
+        isDeploySkewError({
+          message: "(0 , y.useNewsletterEnabled) is not a function",
+          stack:
+            "TypeError: (0 , y.useNewsletterEnabled) is not a function\n" +
+            "    at x (https://ecency.com/_next/static/chunks/app/page-77d004dc07e923a7.js?dpl=67bf6584:1:7873)\n" +
+            "    at l9 (https://ecency.com/_next/static/chunks/fab31ea0-a826f330bcfe7eac.js?dpl=9e6dd083:1:51471)"
+        })
+      ).toBe(true);
+    });
+
+    it("does NOT match when every frame is from this build", () => {
+      expect(
+        isDeploySkewError({
+          message: "(0 , y.useNewsletterEnabled) is not a function",
+          stack:
+            "    at x (https://ecency.com/_next/static/chunks/app/page-abc123.js?dpl=9e6dd083:1:7873)\n" +
+            "    at l9 (https://ecency.com/_next/static/chunks/fab31ea0-a826f330bcfe7eac.js?dpl=9e6dd083:1:51471)"
+        })
+      ).toBe(false);
+    });
+
+    it("does NOT match dpl-less frames, and is inert when SENTRY_RELEASE is unset", () => {
+      // No dpl in the stack (an app bug on a normal build) — never skew.
+      expect(
+        isDeploySkewError({
+          message: "x is not a function",
+          stack: "    at x (https://ecency.com/_next/static/chunks/app/page-abc123.js:1:7873)"
+        })
+      ).toBe(false);
+
+      // Local dev: no release inlined, so there is no own id to compare against.
+      vi.stubEnv("SENTRY_RELEASE", undefined);
+      expect(
+        isDeploySkewError({
+          message: "x is not a function",
+          stack: "    at x (https://ecency.com/_next/static/chunks/app/page-abc123.js?dpl=67bf6584:1:1)"
+        })
+      ).toBe(false);
+    });
+  });
 });
 
 describe("ServiceWorkerRecovery", () => {

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { beforeSend } from "@/utils/sentry-before-send";
 
 type Ev = Parameters<typeof beforeSend>[0];
 
 function makeEvent(
   value: string,
-  frames: { filename?: string; function?: string }[] = [],
+  frames: { filename?: string; function?: string; abs_path?: string }[] = [],
   opts: { type?: string; handled?: boolean } = {}
 ): Ev {
   return {
@@ -74,6 +74,51 @@ describe("beforeSend — deploy-skew reclassification", () => {
     expect(out).not.toBeNull();
     expect(out!.level).toBeUndefined();
     expect(out!.fingerprint).toBeUndefined();
+  });
+
+  describe("mixed-build frames (foreign ?dpl) — ECENCY-NEXT-1GNN", () => {
+    const OWN_RELEASE = "ecency-next@9e6dd083a2a19c103c2bf813a8bd2a8dd3ad9a83";
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("reclassifies a chunk executing from a DIFFERENT deployment", () => {
+      vi.stubEnv("SENTRY_RELEASE", OWN_RELEASE);
+      // The chunk loaded fine, so the symptom is a missing export in an app
+      // frame — no webpack frame, no chunk-load message. Only the foreign dpl
+      // in the frame URL gives it away.
+      const ev = makeEvent("(0 , y.useNewsletterEnabled) is not a function", [
+        { filename: "app:///_next/static/chunks/app/page-77d004dc07e923a7.js?dpl=67bf6584" }
+      ]);
+      const out = beforeSend(ev);
+      expect(out).not.toBeNull();
+      expect(out!.level).toBe("warning");
+      expect(out!.tags?.deploy_skew).toBe("true");
+      expect(out!.fingerprint).toEqual(["deploy-skew-auto-recovered"]);
+    });
+
+    it("reads the dpl from abs_path when filename lost the query", () => {
+      vi.stubEnv("SENTRY_RELEASE", OWN_RELEASE);
+      const ev = makeEvent("(0 , y.useNewsletterEnabled) is not a function", [
+        {
+          filename: "app:///_next/static/chunks/app/page-77d004dc07e923a7.js",
+          abs_path: "https://ecency.com/_next/static/chunks/app/page-77d004dc07e923a7.js?dpl=67bf6584"
+        }
+      ]);
+      expect(beforeSend(ev)!.fingerprint).toEqual(["deploy-skew-auto-recovered"]);
+    });
+
+    it("does NOT reclassify a missing-export bug from this build's own chunks", () => {
+      vi.stubEnv("SENTRY_RELEASE", OWN_RELEASE);
+      const ev = makeEvent("(0 , y.someExport) is not a function", [
+        { filename: "app:///_next/static/chunks/app/page-abc123.js?dpl=9e6dd083" }
+      ]);
+      const out = beforeSend(ev);
+      expect(out).not.toBeNull();
+      expect(out!.level).toBeUndefined();
+      expect(out!.fingerprint).toBeUndefined();
+    });
   });
 });
 

--- a/apps/web/src/utils/deploy-skew.ts
+++ b/apps/web/src/utils/deploy-skew.ts
@@ -69,9 +69,14 @@ function hasForeignDeploymentFrame(error: { stack?: string }): boolean {
     return false;
   }
   const stack = error.stack ?? "";
-  const dplRe = /\.js\?dpl=([\w-]+)/g;
-  let match;
-  while ((match = dplRe.exec(stack)) !== null) {
+  // Only OUR build-versioned chunks may vote: require the `/_next/static/`
+  // path (the same narrowing the resource-error listener in
+  // service-worker-recovery uses) and the exact 8-hex id shape
+  // ownDeploymentId() produces. A third-party script that happens to carry a
+  // dpl query must not be classified as skew — that would burn the session's
+  // one guarded reload and bury the real error under the skew fingerprint.
+  const dplRe = /\/_next\/static\/\S*?\.js\?dpl=([0-9a-f]{8})\b/g;
+  for (const match of stack.matchAll(dplRe)) {
     if (match[1] !== own) {
       return true;
     }

--- a/apps/web/src/utils/deploy-skew.ts
+++ b/apps/web/src/utils/deploy-skew.ts
@@ -42,9 +42,47 @@ function isWebpackFactoryError(error: { message?: string; stack?: string }): boo
   );
 }
 
+// The 8-hex deployment id baked into this build's chunk URLs (`?dpl=<id>`),
+// derived from the inlined SENTRY_RELEASE exactly as next.config.js derives
+// `deploymentId`. Undefined in local dev, where chunks carry no dpl and the
+// mismatch rule below is inert. NOTE: this is NOT the always-false
+// event.release self-comparison — the id here is compared against dpl values
+// read out of the error's OWN stack frames, which come from the actual chunk
+// URLs that were executing.
+function ownDeploymentId(): string | undefined {
+  const release = process.env.SENTRY_RELEASE;
+  return release ? release.replace(/^ecency-next@/, "").slice(0, 8) : undefined;
+}
+
+// A stack frame from a chunk of a DIFFERENT deployment than the build running
+// this code: `page-<hash>.js?dpl=<foreign>` executing against this build's
+// module registry. This is the mixed-build skew that chunk-name matching can't
+// see — the foreign chunk LOADS fine (CDN still has it) but resolves shifted
+// module ids to the wrong modules, surfacing as e.g.
+// `(0 , y.useNewsletterEnabled) is not a function` in an app frame
+// (ECENCY-NEXT-1GNN, #1674). The dpl comparison is exact proof of a mixed
+// build, so no message grammar is required — whatever the symptom, the cure is
+// a reload onto one consistent build.
+function hasForeignDeploymentFrame(error: { stack?: string }): boolean {
+  const own = ownDeploymentId();
+  if (!own) {
+    return false;
+  }
+  const stack = error.stack ?? "";
+  const dplRe = /\.js\?dpl=([\w-]+)/g;
+  let match;
+  while ((match = dplRe.exec(stack)) !== null) {
+    if (match[1] !== own) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // True when the error indicates the client is running a build that no longer
-// matches what the server serves (chunk-load failures + webpack factory
-// mismatches). The cure is to reload onto the current build.
+// matches what the server serves (chunk-load failures, webpack factory
+// mismatches, or a chunk from another deployment in the stack). The cure is to
+// reload onto the current build.
 export function isDeploySkewError(error: unknown): boolean {
   if (typeof error === "string") {
     return isChunkLoadError(error);
@@ -53,5 +91,5 @@ export function isDeploySkewError(error: unknown): boolean {
     return false;
   }
   const e = error as { message?: string; stack?: string };
-  return isChunkLoadError(e.message) || isWebpackFactoryError(e);
+  return isChunkLoadError(e.message) || isWebpackFactoryError(e) || hasForeignDeploymentFrame(e);
 }

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -58,14 +58,16 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
   // boundaries and spawning a fresh error-level issue after every deploy. This is
   // the only hook that sees that path, so reclassify here too into the SAME shape
   // (so the events merge with the boundary-caught twin instead of grouping anew).
-  // isDeploySkewError matches on `stack`; beforeSend frames carry `filename`, so
-  // join them into a newline string. The webpack-<hash>.js frame requirement in
-  // the matcher keeps this off ordinary ".call of undefined" app bugs. We keep
-  // the event (at warning level) rather than dropping it so skew frequency and
-  // release-spread stay visible.
+  // isDeploySkewError matches on `stack`; beforeSend frames carry `filename` and
+  // `abs_path`, so join both into a newline string — the matcher's mixed-build
+  // rule needs the chunk URL's `?dpl=` query, and which of the two fields
+  // preserves it varies by SDK stack parser. The webpack-<hash>.js frame
+  // requirement in the matcher keeps this off ordinary ".call of undefined" app
+  // bugs. We keep the event (at warning level) rather than dropping it so skew
+  // frequency and release-spread stay visible.
   const skewCandidate = {
     message,
-    stack: frames.map((f) => f.filename ?? "").join("\n")
+    stack: frames.map((f) => `${f.filename ?? ""} ${f.abs_path ?? ""}`).join("\n")
   };
   if (isDeploySkewError(skewCandidate)) {
     event.level = "warning";


### PR DESCRIPTION
Closes #1674

Two changes, per the issue:

**1. Mixed-build (foreign `?dpl`) skew detection in `deploy-skew.ts`.** A chunk from another deployment can load fine (CDN still serves it) but bind shifted module ids against the running build's registry, surfacing as `(0 , y.useNewsletterEnabled) is not a function` in an app frame (ECENCY-NEXT-1GNN). None of the existing matchers see that shape. The new rule extracts every `.js?dpl=<id>` from the error's stack and compares it against the running build's own deployment id, derived from the inlined `SENTRY_RELEASE` exactly as next.config.js derives `deploymentId`. Any foreign id proves a mixed build, so no message grammar is needed. Inert in local dev (no release inlined, no dpl on chunks). Wired through `isDeploySkewError`, so both the boundary path (reload via loop-guarded `reloadForSkew`, reclassify to `deploy-skew-auto-recovered`) and `beforeSend` pick it up; the beforeSend skew candidate now joins `abs_path` alongside `filename` since which field keeps the URL query varies by stack parser.

**2. `SentryErrorBoundary` escalates a retry that cannot work.** `reset()` records the showing error's message; a successful commit of the children clears it (`componentDidUpdate`). If the very next catch carries the identical message with no successful commit in between, re-rendering demonstrably cannot recover (the failing module is already registered), so the boundary tags the capture `retry_reload`, flushes and calls the loop-guarded `reloadForSkew` instead of leaving a Try again button that visibly does nothing. An identical error recurring after a successful retry starts a fresh cycle and does not reload.

Specs: 3 new matcher cases, 3 new beforeSend cases, 2 new boundary cases; each new guard was verified by deleting it and watching its spec fail. Full web suite 3581 passed, typecheck and lint clean.