### PR TITLE
fix(nav): use a valid autocomplete value on the navbar search input

### DIFF
--- a/apps/web/src/features/shared/navbar/search/index.tsx
+++ b/apps/web/src/features/shared/navbar/search/index.tsx
@@ -512,9 +512,10 @@ export function Search({ containerClassName, autoFocus }: Props) {
           value={query}
           onChange={(e: ChangeEvent<HTMLInputElement>) => setQuery(e.target.value.toLowerCase())}
           onKeyDown={onKeyDown}
-          autoComplete="non-autocomplete-field"
-          name="non-autocomplete-field"
-          id="non-autocomplete-field"
+          type="search"
+          autoComplete="off"
+          name="search"
+          id="navbar-search"
           autoFocus={autoFocus}
         />
       </SearchSuggester>


### PR DESCRIPTION
The navbar search input carried `autocomplete="non-autocomplete-field"` with matching placeholder `name`/`id` to suppress the browser autofill dropdown. The value is not a spec-defined autocomplete token, so accessibility and agent-browsing audits flag the field as malformed.

Replaced with `autocomplete="off"` (browsers only override `off` on address/credential-classified fields, which a search box is not), meaningful `name="search"` / `id="navbar-search"`, and `type="search"` so the input exposes the native searchbox role. `type="search"` falls through FormControl's default branch to the plain text Input, and Tailwind preflight hides the native search decoration, so rendering is unchanged.

Closes #1682