### PR TITLE
Stripe: defer PaymentIntent creation to the Pay click

### DIFF
--- a/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getStripePromise } from "@/features/shared/purchase-stripe";
+import { getStripePromise, skuUsdCents } from "@/features/shared/purchase-stripe";
 import { StripeCheckoutForm } from "@/features/shared/purchase-stripe/stripe-checkout-form";
 import {
   fetchStripeOrderStatus,
@@ -28,8 +28,7 @@ interface Props {
   sku: string;
   /** Optional: activate a DIFFERENT tenant than the payer -- e.g. a community (hive-NNNNN) whose
    *  owner (the `username` above) pays. Omit for a personal blog (the payer's own account is
-   *  activated). The parent MUST include this in the component `key` so a target change remounts
-   *  with a fresh nonce (the intent is minted once per mount). */
+   *  activated). */
   hostingTarget?: string;
   payLabel: string;
   returnUrl: string;
@@ -40,12 +39,14 @@ interface Props {
 }
 
 /**
- * Card payment for hosting, riding the shared ePoints Stripe rail: create a PaymentIntent for
- * a hosting SKU via vapi, confirm with the Payment Element, then poll the order status. For a
- * hosting SKU the order reaching "success" means ePoints has already called the hosting
- * service's activate endpoint, so the blog is live. The activated tenant is `hostingTarget` when
- * supplied (e.g. a community), otherwise the payer's own account. The tenant must already exist
- * (the signup flow creates it before this renders).
+ * Card payment for hosting, riding the shared ePoints Stripe rail. Deferred intent flow:
+ * the Payment Element renders immediately and the PaymentIntent is minted only on the Pay
+ * click, so switching terms or abandoning the form never creates an intent. After
+ * confirmation the order status is polled; for a hosting SKU the order reaching "success"
+ * means ePoints has already called the hosting service's activate endpoint, so the blog is
+ * live. The activated tenant is `hostingTarget` when supplied (e.g. a community),
+ * otherwise the payer's own account. The tenant must already exist (the signup flow
+ * creates it before this renders).
  */
 export function HostingCardCheckout({
   username,
@@ -56,17 +57,18 @@ export function HostingCardCheckout({
   onActivated,
   onConfirmed
 }: Props) {
-  // The nonce is the create-intent idempotency key, so it must change when the checkout identity
-  // (sku or target tenant) changes; otherwise a re-mint for a new target would return the
-  // PaymentIntent already created for the previous one. Fresh nonce per (sku, hostingTarget).
+  // The nonce is the create-intent idempotency key (user:sku:nonce server-side), so it must
+  // change when the checkout identity (sku or target tenant) changes; otherwise a mint for a
+  // new target would return the PaymentIntent already created for the previous one. Fresh
+  // nonce per (sku, hostingTarget).
   const nonce = useMemo(genNonce, [sku, hostingTarget]);
-  const [clientSecret, setClientSecret] = useState("");
-  // Terminal states that replace the whole checkout (mint failure, order failed, activation
-  // pending). A card decline is NOT terminal — it uses formError below so the user can retry.
+  // Terminal states that replace the whole checkout (order failed, activation pending).
+  // A card decline or a failed mint is NOT terminal -- it uses formError below so the user
+  // can retry.
   const [error, setError] = useState("");
   const [errorAppearance, setErrorAppearance] = useState<"danger" | "primary">("danger");
-  // Decline / validation error shown ABOVE the still-mounted payment form so the buyer can
-  // fix the card and try again instead of dead-ending on a red alert.
+  // Decline / validation / mint error shown ABOVE the still-mounted payment form so the
+  // buyer can fix the card and try again instead of dead-ending on a red alert.
   const [formError, setFormError] = useState("");
   const [activating, setActivating] = useState(false);
   const pollingRef = useRef(false);
@@ -74,31 +76,7 @@ export function HostingCardCheckout({
 
   const createIntent = useCreateStripeIntent(username);
   const stripePromise = getStripePromise();
-
-  // Mint the PaymentIntent for this checkout. Re-mint when the SKU or the target tenant changes so
-  // the active clientSecret always matches what the UI shows: paying with a stale intent would
-  // charge for the previously minted (sku, hostingTarget) rather than the current one.
-  useEffect(() => {
-    let alive = true;
-    setClientSecret("");
-    (async () => {
-      try {
-        const { client_secret } = await createIntent.mutateAsync({ sku, nonce, hosting_target: hostingTarget });
-        if (alive) setClientSecret(client_secret);
-      } catch {
-        // Intent-mint failures throw raw messages / i18n keys (e.g. "stripe-points.not-
-        // authenticated") and axios status text; show a stable user-facing message instead.
-        if (alive) {
-          setErrorAppearance("danger");
-          setError(i18next.t("hosting.card-unavailable"));
-        }
-      }
-    })();
-    return () => {
-      alive = false;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sku, nonce, hostingTarget]);
+  const amountCents = skuUsdCents(sku);
 
   // Stop polling on unmount.
   useEffect(
@@ -109,82 +87,99 @@ export function HostingCardCheckout({
     []
   );
 
-  const paymentIntentId = clientSecret ? clientSecret.split("_secret_")[0] : "";
+  // Mints the PaymentIntent at Pay time with the CURRENT sku + target tenant, so the
+  // intent always matches what the UI shows.
+  const mintIntent = useCallback(async () => {
+    const { client_secret } = await createIntent.mutateAsync({
+      sku,
+      nonce,
+      hosting_target: hostingTarget
+    });
+    return client_secret;
+  }, [createIntent, sku, nonce, hostingTarget]);
 
-  const startPoll = useCallback(() => {
-    if (!paymentIntentId || pollingRef.current) return;
-    pollingRef.current = true;
-    setActivating(true);
-    // Payment is confirmed at this point -- lock the term selector in the parent so a remount
-    // cannot cancel this poll and strand a paid user.
-    onConfirmed?.();
-    let attempts = 0;
-    const MAX_ATTEMPTS = 45; // ~90s
-    const poll = async () => {
-      if (!pollingRef.current) return;
-      try {
-        const st = await fetchStripeOrderStatus(username, paymentIntentId);
+  // The poll takes the confirmed intent id from onPaid; with deferred minting there is no
+  // client secret in render state to derive it from.
+  const startPoll = useCallback(
+    (intentId: string) => {
+      if (!intentId || pollingRef.current) return;
+      pollingRef.current = true;
+      setActivating(true);
+      // Payment is confirmed at this point -- lock the term selector in the parent so a remount
+      // cannot cancel this poll and strand a paid user.
+      onConfirmed?.();
+      let attempts = 0;
+      const MAX_ATTEMPTS = 45; // ~90s
+      const poll = async () => {
         if (!pollingRef.current) return;
-        if (st.status === "success") {
-          pollingRef.current = false;
-          onActivated();
-          return;
+        try {
+          const st = await fetchStripeOrderStatus(username, intentId);
+          if (!pollingRef.current) return;
+          if (st.status === "success") {
+            pollingRef.current = false;
+            onActivated();
+            return;
+          }
+          if (st.status === "failed") {
+            pollingRef.current = false;
+            setActivating(false);
+            setErrorAppearance("danger");
+            setError(i18next.t("hosting.card-failed"));
+            return;
+          }
+        } catch {
+          // transient (network / not-yet-recorded) -> keep polling
         }
-        if (st.status === "failed") {
+        attempts += 1;
+        if (attempts >= MAX_ATTEMPTS) {
+          // Payment succeeded; ePoints keeps retrying activation with backoff, so this is not a
+          // hard failure -- stop the spinner and reassure (primary, not danger) rather than loop.
           pollingRef.current = false;
           setActivating(false);
-          setErrorAppearance("danger");
-          setError(i18next.t("hosting.card-failed"));
+          setErrorAppearance("primary");
+          setError(i18next.t("hosting.activation-pending"));
           return;
         }
-      } catch {
-        // transient (network / not-yet-recorded) -> keep polling
-      }
-      attempts += 1;
-      if (attempts >= MAX_ATTEMPTS) {
-        // Payment succeeded; ePoints keeps retrying activation with backoff, so this is not a
-        // hard failure -- stop the spinner and reassure (primary, not danger) rather than loop.
-        pollingRef.current = false;
-        setActivating(false);
-        setErrorAppearance("primary");
-        setError(i18next.t("hosting.activation-pending"));
-        return;
-      }
-      timerRef.current = setTimeout(poll, 2000);
-    };
-    poll();
-  }, [paymentIntentId, username, onActivated, onConfirmed]);
+        timerRef.current = setTimeout(poll, 2000);
+      };
+      poll();
+    },
+    [username, onActivated, onConfirmed]
+  );
 
-  if (!stripePromise) {
+  if (!stripePromise || amountCents === 0) {
     return <Alert appearance="danger">{i18next.t("hosting.card-unavailable")}</Alert>;
   }
-  // Terminal states (mint failure, order failed, activation pending) replace the checkout.
+  // Terminal states (order failed, activation pending) replace the checkout.
   if (error) {
     return <Alert appearance={errorAppearance}>{error}</Alert>;
   }
   if (activating) {
-    return <div className="py-6 text-center text-sm opacity-75">{i18next.t("hosting.activating")}</div>;
-  }
-  if (!clientSecret) {
     return (
-      <div className="py-6 text-center text-sm opacity-75">{i18next.t("hosting.preparing-checkout")}</div>
+      <div className="py-6 text-center text-sm opacity-75">{i18next.t("hosting.activating")}</div>
     );
   }
 
   return (
     <div className="flex flex-col gap-3">
-      {/* A card decline keeps the form mounted so the buyer can correct and retry. */}
+      {/* A card decline or a failed mint keeps the form mounted so the buyer can retry. */}
       {formError && <Alert appearance="danger">{formError}</Alert>}
       <Elements
         stripe={stripePromise}
-        options={{ clientSecret, appearance: { theme: isDarkMode() ? "night" : "stripe" } }}
+        options={{
+          mode: "payment",
+          amount: amountCents,
+          currency: "usd",
+          appearance: { theme: isDarkMode() ? "night" : "stripe" }
+        }}
       >
         <StripeCheckoutForm
           returnUrl={returnUrl}
           payLabel={payLabel}
-          onPaid={() => {
+          createIntent={mintIntent}
+          onPaid={(paymentIntentId) => {
             setFormError("");
-            startPoll();
+            startPoll(paymentIntentId);
           }}
           onError={setFormError}
         />

--- a/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-card-checkout.tsx
@@ -36,6 +36,12 @@ interface Props {
   /** Fired once the card is confirmed (payment taken); the parent locks the term selector so
    *  a remount can't cancel the poll for an already-paid intent. */
   onConfirmed?: () => void;
+  /** Forwarded from the payment form: true while a Pay submit is in flight (validate,
+   *  mint, confirm), false once it settles. The parent must disable the term, add-on and
+   *  method controls while true so an in-flight payment cannot be detached from what the
+   *  buyer sees; a decline flips it back to false so the controls stay editable after a
+   *  failed attempt. */
+  onSubmittingChange?: (submitting: boolean) => void;
 }
 
 /**
@@ -55,7 +61,8 @@ export function HostingCardCheckout({
   payLabel,
   returnUrl,
   onActivated,
-  onConfirmed
+  onConfirmed,
+  onSubmittingChange
 }: Props) {
   // The nonce is the create-intent idempotency key (user:sku:nonce server-side), so it must
   // change when the checkout identity (sku or target tenant) changes; otherwise a mint for a
@@ -182,6 +189,7 @@ export function HostingCardCheckout({
             startPoll(paymentIntentId);
           }}
           onError={setFormError}
+          onSubmittingChange={onSubmittingChange}
         />
       </Elements>
     </div>

--- a/apps/web/src/features/hosting-signup/hosting-signup.tsx
+++ b/apps/web/src/features/hosting-signup/hosting-signup.tsx
@@ -137,6 +137,12 @@ export function HostingSignup() {
   const [busy, setBusy] = useState(false);
   // Card confirmed -> the term/method are locked so a remount can't cancel the activation poll.
   const [paying, setPaying] = useState(false);
+  // True while a card Pay submit is in flight (validate, mint, confirm). The term, add-on
+  // and method controls must be frozen for that whole window: once confirmPayment is
+  // dispatched the charge can complete server side, so an edit mid-confirm would remount
+  // the keyed checkout and show a fresh form for a purchase that already went through. A
+  // decline sets this back to false so the controls stay editable after a failed attempt.
+  const [cardSubmitting, setCardSubmitting] = useState(false);
   // Whether this payment-step entry is for an UNPAID reservation (fresh create, refresh or
   // resume), which is what the grace-window notice is about. Deliberately not derived from
   // renewBaselineExpiryRef: that is also null for expired and suspended tenants, whose names
@@ -167,7 +173,9 @@ export function HostingSignup() {
   // blog account itself; for a community the owner (any logged-in account) pays and the community is
   // activated via hostingTarget, so it does not need to equal the tenant.
   const cardEnabled =
-    !!methods?.card.enabled && !!activeUser && (isCommunity || tenantUsername === activeUser.username);
+    !!methods?.card.enabled &&
+    !!activeUser &&
+    (isCommunity || tenantUsername === activeUser.username);
 
   // The custom-domain add-on is only offered to a logged-in OWNER of the tenant (their own personal
   // blog, or a community they own) — on either rail. This matches the condition that gates the
@@ -183,7 +191,10 @@ export function HostingSignup() {
   const canOneClickHive = !!activeUser && getLoginType(activeUser.username) === "keychain";
 
   useEffect(() => {
-    hostingApi.paymentMethods().then(setMethods).catch(() => setMethods(null));
+    hostingApi
+      .paymentMethods()
+      .then(setMethods)
+      .catch(() => setMethods(null));
   }, []);
 
   // Default to HBD whenever card is not actually available to this visitor (logged out, or
@@ -323,7 +334,14 @@ export function HostingSignup() {
     try {
       localStorage.setItem(
         customizeDraftKey(tenantUsername),
-        JSON.stringify({ styleTemplate, accent, fontPreset, title, description, savedAt: Date.now() })
+        JSON.stringify({
+          styleTemplate,
+          accent,
+          fontPreset,
+          title,
+          description,
+          savedAt: Date.now()
+        })
       );
     } catch {}
   }, [step, tenantUsername, styleTemplate, accent, fontPreset, title, description]);
@@ -446,7 +464,16 @@ export function HostingSignup() {
     } finally {
       setBusy(false);
     }
-  }, [tenantUsername, isCommunity, title, description, styleTemplate, accent, fontPreset, activeUser]);
+  }, [
+    tenantUsername,
+    isCommunity,
+    title,
+    description,
+    styleTemplate,
+    accent,
+    fontPreset,
+    activeUser
+  ]);
 
   // Mint a one-time handoff CODE as soon as the success screen shows: the
   // Customize link used to carry the session bearer itself in its fragment,
@@ -456,9 +483,7 @@ export function HostingSignup() {
   // worthless afterwards. Re-minted on an interval while the screen stays
   // open (codes outlive nobody's coffee break); a failed mint leaves the
   // click on the credential-free fallback href.
-  const [handoff, setHandoff] = useState<{ code: string; expiresAt: number } | null>(
-    null
-  );
+  const [handoff, setHandoff] = useState<{ code: string; expiresAt: number } | null>(null);
   // Bumped by a click: the opened code is consumed by the instance, so the
   // click clears it and this forces a fresh mint for any further click.
   const [mintNonce, setMintNonce] = useState(0);
@@ -668,7 +693,11 @@ export function HostingSignup() {
     try {
       sessionStorage.setItem(
         PENDING_HBD_KEY,
-        JSON.stringify({ tenant: tenantUsername, blogUrl, baseline: renewBaselineExpiryRef.current })
+        JSON.stringify({
+          tenant: tenantUsername,
+          blogUrl,
+          baseline: renewBaselineExpiryRef.current
+        })
       );
     } catch {}
     try {
@@ -758,6 +787,9 @@ export function HostingSignup() {
   const usdPer = customDomain ? HOSTING_CUSTOM_DOMAIN_MONTHLY_USD : usdPerBase;
   const hbdPer = customDomain ? hbdPerBase + 1 : hbdPerBase;
   const cardSku = customDomain ? hostingProSkuForMonths(months) : hostingSkuForMonths(months);
+  // The payment-step selection controls are locked while a card submit is in flight
+  // (cardSubmitting) and stay locked once the payment is confirmed (paying).
+  const payLocked = paying || cardSubmitting;
 
   // Only surface a well-formed https URL as a link so a validated subdomain or API-returned blog URL
   // cannot carry an unexpected scheme into the href (guards CodeQL js/xss-through-dom).
@@ -811,7 +843,9 @@ export function HostingSignup() {
             <button
               onClick={() => setInstanceType("blog")}
               className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
-                !isCommunity ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
+                !isCommunity
+                  ? "border-blue-dark-sky bg-blue-dark-sky/10"
+                  : "border-[--border-color]"
               }`}
             >
               {i18next.t("hosting.type-blog")}
@@ -937,9 +971,7 @@ export function HostingSignup() {
 
           <p className="text-sm opacity-60">{i18next.t("hosting.changeable-later")}</p>
 
-          <label className="text-sm font-semibold">
-            {i18next.t("hosting.destination-label")}
-          </label>
+          <label className="text-sm font-semibold">{i18next.t("hosting.destination-label")}</label>
           <DestinationPicker
             value={destination}
             onChange={setDestination}
@@ -993,10 +1025,12 @@ export function HostingSignup() {
               <button
                 key={m}
                 onClick={() => setMonths(m)}
-                disabled={paying}
+                disabled={payLocked}
                 className={`px-3 py-2 rounded-lg border text-sm ${
-                  months === m ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
-                } ${paying ? "opacity-50 cursor-not-allowed" : ""}`}
+                  months === m
+                    ? "border-blue-dark-sky bg-blue-dark-sky/10"
+                    : "border-[--border-color]"
+                } ${payLocked ? "opacity-50 cursor-not-allowed" : ""}`}
               >
                 {i18next.t("hosting.term-months", { n: m })}
               </button>
@@ -1009,18 +1043,24 @@ export function HostingSignup() {
           {methods && canManageDomain && (
             <button
               onClick={() => setCustomDomain((v) => !v)}
-              disabled={paying}
+              disabled={payLocked}
               className={`text-left px-4 py-3 rounded-lg border ${
-                customDomain ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
-              } ${paying ? "opacity-50 cursor-not-allowed" : ""}`}
+                customDomain
+                  ? "border-blue-dark-sky bg-blue-dark-sky/10"
+                  : "border-[--border-color]"
+              } ${payLocked ? "opacity-50 cursor-not-allowed" : ""}`}
             >
               <div className="flex items-center justify-between gap-2">
                 <span className="font-semibold">{i18next.t("hosting.custom-domain-option")}</span>
                 <span className="text-sm text-blue-dark-sky">
-                  {customDomain ? i18next.t("hosting.custom-domain-added") : i18next.t("hosting.custom-domain-price")}
+                  {customDomain
+                    ? i18next.t("hosting.custom-domain-added")
+                    : i18next.t("hosting.custom-domain-price")}
                 </span>
               </div>
-              <p className="text-sm opacity-75 mt-1">{i18next.t("hosting.custom-domain-explainer")}</p>
+              <p className="text-sm opacity-75 mt-1">
+                {i18next.t("hosting.custom-domain-explainer")}
+              </p>
             </button>
           )}
 
@@ -1029,20 +1069,24 @@ export function HostingSignup() {
             {cardEnabled && (
               <button
                 onClick={() => setMethod("card")}
-                disabled={paying}
+                disabled={payLocked}
                 className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
-                  method === "card" ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
-                } ${paying ? "opacity-50 cursor-not-allowed" : ""}`}
+                  method === "card"
+                    ? "border-blue-dark-sky bg-blue-dark-sky/10"
+                    : "border-[--border-color]"
+                } ${payLocked ? "opacity-50 cursor-not-allowed" : ""}`}
               >
                 {i18next.t("hosting.pay-card", { amount: (usdPer * months).toFixed(2) })}
               </button>
             )}
             <button
               onClick={() => setMethod("hbd")}
-              disabled={paying}
+              disabled={payLocked}
               className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
-                method === "hbd" ? "border-blue-dark-sky bg-blue-dark-sky/10" : "border-[--border-color]"
-              } ${paying ? "opacity-50 cursor-not-allowed" : ""}`}
+                method === "hbd"
+                  ? "border-blue-dark-sky bg-blue-dark-sky/10"
+                  : "border-[--border-color]"
+              } ${payLocked ? "opacity-50 cursor-not-allowed" : ""}`}
             >
               {i18next.t("hosting.pay-hbd", { amount: (hbdPer * months).toFixed(3) })}
             </button>
@@ -1061,6 +1105,7 @@ export function HostingSignup() {
               payLabel={i18next.t("hosting.pay-now")}
               returnUrl={typeof window !== "undefined" ? window.location.href : ""}
               onConfirmed={() => setPaying(true)}
+              onSubmittingChange={setCardSubmitting}
               onActivated={() => setStep("success")}
             />
           )}
@@ -1214,12 +1259,14 @@ export function HostingSignup() {
               community the tenant is the community id while the logged-in owner authorizes.
               Compare the normalized tenantUsername (not the raw field) so "Alice"/"alice "
               still shows the manager for tenant "alice". */}
-          {customDomain && activeUser && (isCommunity || tenantUsername === activeUser.username) && (
-            <CustomDomainManager
-              username={activeUser.username}
-              tenant={isCommunity ? tenantUsername : undefined}
-            />
-          )}
+          {customDomain &&
+            activeUser &&
+            (isCommunity || tenantUsername === activeUser.username) && (
+              <CustomDomainManager
+                username={activeUser.username}
+                tenant={isCommunity ? tenantUsername : undefined}
+              />
+            )}
         </div>
       )}
     </div>

--- a/apps/web/src/features/points-gift/gift-card-checkout.tsx
+++ b/apps/web/src/features/points-gift/gift-card-checkout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getStripePromise } from "@/features/shared/purchase-stripe";
+import { getStripePromise, skuUsdCents } from "@/features/shared/purchase-stripe";
 import { StripeCheckoutForm } from "@/features/shared/purchase-stripe/stripe-checkout-form";
 import {
   fetchStripeOrderStatus,
@@ -42,12 +42,11 @@ interface Props {
 }
 
 /**
- * Card payment for gifting Points, riding the shared ePoints Stripe rail: create a
- * PaymentIntent for a Points SKU via vapi -- passing `gift_recipient` + `gift_message` so
- * ePoints credits the recipient instead of the payer -- confirm with the Payment Element,
- * then poll the order status until the worker delivers. The parent MUST include `sku` and
- * `recipient` in this component's `key` so a change remounts with a fresh nonce (the intent
- * is minted once per mount).
+ * Card payment for gifting Points, riding the shared ePoints Stripe rail. Deferred intent
+ * flow: the Payment Element renders immediately and the PaymentIntent is minted only on
+ * the Pay click -- passing `gift_recipient` + `gift_message` so ePoints credits the
+ * recipient instead of the payer -- then confirmed, then the order status is polled until
+ * the worker delivers. Browsing packs or abandoning the form never creates an intent.
  */
 export function GiftCardCheckout({
   username,
@@ -60,11 +59,15 @@ export function GiftCardCheckout({
   onPending,
   onConfirmed
 }: Props) {
-  // The nonce is the create-intent idempotency key, so it must change when the checkout
-  // identity (sku, recipient or message) changes; otherwise a re-mint would return the
-  // PaymentIntent already created for the previous gift. Fresh nonce per (sku, recipient, message).
+  // The nonce is the create-intent idempotency key (user:sku:nonce server-side), so it
+  // must change when the checkout identity (sku, recipient or message) changes: a Pay for
+  // recipient A followed by an edit to recipient B and a second Pay would otherwise reuse
+  // intent A with A's gift metadata. Fresh nonce per (sku, recipient, message).
   const nonce = useMemo(genNonce, [sku, recipient, message]);
-  const [clientSecret, setClientSecret] = useState("");
+  // Non-terminal problems (a decline, a failed mint, element validation): shown above the
+  // still-mounted payment form so the buyer can correct and retry.
+  const [formError, setFormError] = useState("");
+  // Terminal states that replace the checkout (order failed after payment).
   const [error, setError] = useState("");
   const [delivering, setDelivering] = useState(false);
   const pollingRef = useRef(false);
@@ -72,30 +75,7 @@ export function GiftCardCheckout({
 
   const createIntent = useCreateStripeIntent(username);
   const stripePromise = getStripePromise();
-
-  // Mint the PaymentIntent for this checkout. Re-mint when the sku/recipient/message changes so
-  // the active clientSecret always matches what the UI shows.
-  useEffect(() => {
-    let alive = true;
-    setClientSecret("");
-    (async () => {
-      try {
-        const { client_secret } = await createIntent.mutateAsync({
-          sku,
-          nonce,
-          gift_recipient: recipient,
-          gift_message: message?.trim() || undefined
-        });
-        if (alive) setClientSecret(client_secret);
-      } catch (e) {
-        if (alive) setError((e as Error).message || i18next.t("points-gift.card-unavailable"));
-      }
-    })();
-    return () => {
-      alive = false;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sku, nonce, recipient, message]);
+  const amountCents = skuUsdCents(sku);
 
   // Stop polling on unmount.
   useEffect(
@@ -106,51 +86,66 @@ export function GiftCardCheckout({
     []
   );
 
-  const paymentIntentId = clientSecret ? clientSecret.split("_secret_")[0] : "";
+  // Mints the PaymentIntent at Pay time with the CURRENT gift fields, so the intent's
+  // metadata always matches what the UI shows.
+  const mintIntent = useCallback(async () => {
+    const { client_secret } = await createIntent.mutateAsync({
+      sku,
+      nonce,
+      gift_recipient: recipient,
+      gift_message: message?.trim() || undefined
+    });
+    return client_secret;
+  }, [createIntent, sku, nonce, recipient, message]);
 
-  const startPoll = useCallback(() => {
-    if (!paymentIntentId || pollingRef.current) return;
-    pollingRef.current = true;
-    setDelivering(true);
-    // Payment is confirmed -- tell the parent to lock the form so a remount can't cancel
-    // this poll and strand a paid user.
-    onConfirmed?.();
-    let attempts = 0;
-    const MAX_ATTEMPTS = 45; // ~90s
-    const poll = async () => {
-      if (!pollingRef.current) return;
-      try {
-        const st = await fetchStripeOrderStatus(username, paymentIntentId);
+  // The poll takes the confirmed intent id from onPaid; with deferred minting there is no
+  // client secret in render state to derive it from.
+  const startPoll = useCallback(
+    (intentId: string) => {
+      if (!intentId || pollingRef.current) return;
+      pollingRef.current = true;
+      setDelivering(true);
+      // Payment is confirmed -- tell the parent to lock the form so a remount can't cancel
+      // this poll and strand a paid user.
+      onConfirmed?.();
+      let attempts = 0;
+      const MAX_ATTEMPTS = 45; // ~90s
+      const poll = async () => {
         if (!pollingRef.current) return;
-        if (st.status === "success") {
+        try {
+          const st = await fetchStripeOrderStatus(username, intentId);
+          if (!pollingRef.current) return;
+          if (st.status === "success") {
+            pollingRef.current = false;
+            onDelivered();
+            return;
+          }
+          if (st.status === "failed") {
+            pollingRef.current = false;
+            setDelivering(false);
+            setError(i18next.t("points-gift.delivery-failed"));
+            return;
+          }
+        } catch {
+          // transient (network / not-yet-recorded) -> keep polling
+        }
+        attempts += 1;
+        if (attempts >= MAX_ATTEMPTS) {
+          // Payment succeeded but delivery never confirmed within the window. ePoints keeps
+          // retrying, so this is not a hard failure -- but we have NOT seen `success`, so report
+          // it as pending (in flight) rather than telling the buyer the gift was delivered.
           pollingRef.current = false;
-          onDelivered();
+          onPending?.();
           return;
         }
-        if (st.status === "failed") {
-          pollingRef.current = false;
-          setDelivering(false);
-          setError(i18next.t("points-gift.delivery-failed"));
-          return;
-        }
-      } catch {
-        // transient (network / not-yet-recorded) -> keep polling
-      }
-      attempts += 1;
-      if (attempts >= MAX_ATTEMPTS) {
-        // Payment succeeded but delivery never confirmed within the window. ePoints keeps
-        // retrying, so this is not a hard failure -- but we have NOT seen `success`, so report
-        // it as pending (in flight) rather than telling the buyer the gift was delivered.
-        pollingRef.current = false;
-        onPending?.();
-        return;
-      }
-      timerRef.current = setTimeout(poll, 2000);
-    };
-    poll();
-  }, [paymentIntentId, username, onDelivered, onPending, onConfirmed]);
+        timerRef.current = setTimeout(poll, 2000);
+      };
+      poll();
+    },
+    [username, onDelivered, onPending, onConfirmed]
+  );
 
-  if (!stripePromise) {
+  if (!stripePromise || amountCents === 0) {
     return <Alert appearance="danger">{i18next.t("points-gift.card-unavailable")}</Alert>;
   }
   if (error) {
@@ -163,25 +158,31 @@ export function GiftCardCheckout({
       </div>
     );
   }
-  if (!clientSecret) {
-    return (
-      <div className="py-6 text-center text-sm opacity-75">
-        {i18next.t("points-gift.preparing-checkout")}
-      </div>
-    );
-  }
 
   return (
-    <Elements
-      stripe={stripePromise}
-      options={{ clientSecret, appearance: { theme: isDarkMode() ? "night" : "stripe" } }}
-    >
-      <StripeCheckoutForm
-        returnUrl={returnUrl}
-        payLabel={payLabel}
-        onPaid={startPoll}
-        onError={setError}
-      />
-    </Elements>
+    <div className="flex flex-col gap-3">
+      {/* A decline or failed mint keeps the form mounted so the buyer can retry. */}
+      {formError && <Alert appearance="danger">{formError}</Alert>}
+      <Elements
+        stripe={stripePromise}
+        options={{
+          mode: "payment",
+          amount: amountCents,
+          currency: "usd",
+          appearance: { theme: isDarkMode() ? "night" : "stripe" }
+        }}
+      >
+        <StripeCheckoutForm
+          returnUrl={returnUrl}
+          payLabel={payLabel}
+          createIntent={mintIntent}
+          onPaid={(paymentIntentId) => {
+            setFormError("");
+            startPoll(paymentIntentId);
+          }}
+          onError={setFormError}
+        />
+      </Elements>
+    </div>
   );
 }

--- a/apps/web/src/features/points-gift/gift-card-checkout.tsx
+++ b/apps/web/src/features/points-gift/gift-card-checkout.tsx
@@ -39,6 +39,12 @@ interface Props {
   onPending?: () => void;
   /** Fired once the card is confirmed (payment taken) so the parent can lock the form. */
   onConfirmed?: () => void;
+  /** Forwarded from the payment form: true while a Pay submit is in flight (validate,
+   *  mint, confirm), false once it settles. The parent must disable the gift selection
+   *  controls while true so an in-flight payment cannot be detached from what the buyer
+   *  sees; a decline flips it back to false so selections stay editable after a failed
+   *  attempt. */
+  onSubmittingChange?: (submitting: boolean) => void;
 }
 
 /**
@@ -57,7 +63,8 @@ export function GiftCardCheckout({
   returnUrl,
   onDelivered,
   onPending,
-  onConfirmed
+  onConfirmed,
+  onSubmittingChange
 }: Props) {
   // The nonce is the create-intent idempotency key (user:sku:nonce server-side), so it
   // must change when the checkout identity (sku, recipient or message) changes: a Pay for
@@ -181,6 +188,7 @@ export function GiftCardCheckout({
             startPoll(paymentIntentId);
           }}
           onError={setFormError}
+          onSubmittingChange={onSubmittingChange}
         />
       </Elements>
     </div>

--- a/apps/web/src/features/points-gift/points-gift-page.tsx
+++ b/apps/web/src/features/points-gift/points-gift-page.tsx
@@ -48,6 +48,12 @@ export function PointsGiftPage() {
   const [sku, setSku] = useState(DEFAULT_STRIPE_TIER_SKU);
   // Locked once the card is confirmed so a remount can't cancel the delivery poll.
   const [locked, setLocked] = useState(false);
+  // True while a Pay submit is in flight (validate, mint, confirm). The selection controls
+  // must be frozen for that whole window: once confirmPayment is dispatched the charge can
+  // complete server side, so an edit mid-confirm would remount the keyed checkout and show
+  // a fresh form for a purchase that already went through. A decline sets this back to
+  // false so the buyer can still change selections after a failed attempt.
+  const [cardSubmitting, setCardSubmitting] = useState(false);
   const [deliveredPoints, setDeliveredPoints] = useState<number | undefined>(undefined);
   const [errorMsg, setErrorMsg] = useState("");
   // Payment intent to resume delivery polling for after a redirect-based method returns.
@@ -156,6 +162,7 @@ export function PointsGiftPage() {
     pollingRef.current = false;
     setStep("form");
     setLocked(false);
+    setCardSubmitting(false);
     setResumePi(undefined);
     setDeliveredPoints(undefined);
     setErrorMsg("");
@@ -208,9 +215,7 @@ export function PointsGiftPage() {
         </div>
       )}
 
-      {step === "pending" && (
-        <Alert appearance="primary">{i18next.t("points-gift.pending")}</Alert>
-      )}
+      {step === "pending" && <Alert appearance="primary">{i18next.t("points-gift.pending")}</Alert>}
 
       {step === "delivering" && (
         <div className="py-6 text-center text-sm opacity-75">
@@ -236,7 +241,7 @@ export function PointsGiftPage() {
             <FormControl
               type="text"
               value={recipient}
-              disabled={locked}
+              disabled={locked || cardSubmitting}
               onChange={(e: any) => setRecipient(e.target.value)}
               placeholder={i18next.t("points-gift.recipient-placeholder")}
             />
@@ -246,15 +251,13 @@ export function PointsGiftPage() {
           </div>
 
           <div className="flex flex-col gap-2">
-            <label className="text-sm font-semibold">
-              {i18next.t("points-gift.amount-label")}
-            </label>
+            <label className="text-sm font-semibold">{i18next.t("points-gift.amount-label")}</label>
             <div className="grid grid-cols-2 gap-2">
               {STRIPE_POINTS_TIERS.map((t) => (
                 <button
                   key={t.sku}
                   type="button"
-                  disabled={locked}
+                  disabled={locked || cardSubmitting}
                   onClick={() => setSku(t.sku)}
                   className={`rounded-lg p-3 text-left transition-colors disabled:opacity-60 ${
                     t.sku === sku
@@ -279,7 +282,7 @@ export function PointsGiftPage() {
               type="textarea"
               rows={2}
               value={message}
-              disabled={locked}
+              disabled={locked || cardSubmitting}
               maxLength={MESSAGE_MAX}
               onChange={(e: any) => setMessage(e.target.value.slice(0, MESSAGE_MAX))}
               placeholder={i18next.t("points-gift.message-placeholder")}
@@ -307,6 +310,7 @@ export function PointsGiftPage() {
               payLabel={i18next.t("points-gift.pay", { usd: `$${selectedTier.usd.toFixed(2)}` })}
               returnUrl={typeof window !== "undefined" ? window.location.href : ""}
               onConfirmed={() => setLocked(true)}
+              onSubmittingChange={setCardSubmitting}
               onDelivered={() => {
                 setDeliveredPoints(selectedTier.points);
                 setStep("done");

--- a/apps/web/src/features/pro/pro-checkout.tsx
+++ b/apps/web/src/features/pro/pro-checkout.tsx
@@ -29,6 +29,10 @@ interface Props {
   /** Set when returning from a redirect-based method: the intent already exists, so skip
    *  minting and go straight to polling it (Stripe re-appends payment_intent to returnUrl). */
   resumePaymentIntent?: string;
+  /** Forwarded from the payment form: true while a Pay submit is in flight (validate,
+   *  mint, confirm), false once it settles. The dialog uses it to block closing while a
+   *  charge may be completing; a decline flips it back to false. */
+  onSubmittingChange?: (submitting: boolean) => void;
 }
 
 /**
@@ -39,7 +43,13 @@ interface Props {
  * it reaches "success" ePoints has granted the membership. No tenant step (unlike
  * hosting) -- the SKU alone drives the grant.
  */
-export function ProCheckout({ username, returnUrl, onActivated, resumePaymentIntent }: Props) {
+export function ProCheckout({
+  username,
+  returnUrl,
+  onActivated,
+  resumePaymentIntent,
+  onSubmittingChange
+}: Props) {
   const [nonce] = useState(genNonce);
   // Non-terminal problems (a decline, a failed mint, element validation): shown above the
   // still-mounted payment form so the buyer can correct and retry.
@@ -154,6 +164,7 @@ export function ProCheckout({ username, returnUrl, onActivated, resumePaymentInt
             startPoll(paymentIntentId);
           }}
           onError={setFormError}
+          onSubmittingChange={onSubmittingChange}
         />
       </Elements>
     </div>

--- a/apps/web/src/features/pro/pro-checkout.tsx
+++ b/apps/web/src/features/pro/pro-checkout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getStripePromise } from "@/features/shared/purchase-stripe";
+import { getStripePromise, skuUsdCents } from "@/features/shared/purchase-stripe";
 import { StripeCheckoutForm } from "@/features/shared/purchase-stripe/stripe-checkout-form";
 import {
   fetchStripeOrderStatus,
@@ -32,14 +32,19 @@ interface Props {
 }
 
 /**
- * Card payment for Ecency Pro, riding the shared ePoints Stripe rail: create a
- * PaymentIntent for the Pro SKU via vapi, confirm with the Payment Element, then poll the
- * order status. When the order reaches "success" ePoints has granted the membership. No
- * tenant step (unlike hosting) -- the SKU alone drives the grant.
+ * Card payment for Ecency Pro, riding the shared ePoints Stripe rail. Deferred intent
+ * flow: the Payment Element renders immediately (mode/amount/currency only) and the
+ * PaymentIntent is minted only when the buyer clicks Pay, so an opened-then-closed dialog
+ * never creates an abandoned intent. After confirmation the order status is polled; when
+ * it reaches "success" ePoints has granted the membership. No tenant step (unlike
+ * hosting) -- the SKU alone drives the grant.
  */
 export function ProCheckout({ username, returnUrl, onActivated, resumePaymentIntent }: Props) {
   const [nonce] = useState(genNonce);
-  const [clientSecret, setClientSecret] = useState("");
+  // Non-terminal problems (a decline, a failed mint, element validation): shown above the
+  // still-mounted payment form so the buyer can correct and retry.
+  const [formError, setFormError] = useState("");
+  // Terminal states that replace the checkout (order failed, activation pending).
   const [error, setError] = useState("");
   // On a redirect return the payment is already made; go straight to the activation poll.
   const [activating, setActivating] = useState(!!resumePaymentIntent);
@@ -48,27 +53,7 @@ export function ProCheckout({ username, returnUrl, onActivated, resumePaymentInt
 
   const createIntent = useCreateStripeIntent(username);
   const stripePromise = getStripePromise();
-
-  // Mint the PaymentIntent once for this checkout -- SKIPPED on a redirect resume (the intent
-  // already exists; minting a new one would charge twice).
-  useEffect(() => {
-    if (resumePaymentIntent) return;
-    let alive = true;
-    (async () => {
-      try {
-        const { client_secret } = await createIntent.mutateAsync({ sku: PRO_SKU, nonce });
-        if (alive) setClientSecret(client_secret);
-      } catch {
-        // Upstream throws raw i18n keys / axios technical strings ("Request failed with status
-        // code 500"); never surface those on the payment path -- show a friendly fallback.
-        if (alive) setError(i18next.t("pro.card-unavailable"));
-      }
-    })();
-    return () => {
-      alive = false;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nonce, resumePaymentIntent]);
+  const amountCents = skuUsdCents(PRO_SKU);
 
   // Stop polling on unmount.
   useEffect(
@@ -79,54 +64,65 @@ export function ProCheckout({ username, returnUrl, onActivated, resumePaymentInt
     []
   );
 
-  const paymentIntentId = resumePaymentIntent || (clientSecret ? clientSecret.split("_secret_")[0] : "");
+  // Mints the PaymentIntent at Pay time (deferred flow). The same nonce is reused on a
+  // retry so a double-submit returns the same intent instead of charging twice.
+  const mintIntent = useCallback(async () => {
+    const { client_secret } = await createIntent.mutateAsync({ sku: PRO_SKU, nonce });
+    return client_secret;
+  }, [createIntent, nonce]);
 
-  const startPoll = useCallback(() => {
-    if (!paymentIntentId || pollingRef.current) return;
-    pollingRef.current = true;
-    setActivating(true);
-    let attempts = 0;
-    const MAX_ATTEMPTS = 45; // ~90s
-    const poll = async () => {
-      if (!pollingRef.current) return;
-      try {
-        const st = await fetchStripeOrderStatus(username, paymentIntentId);
+  // The poll takes the confirmed intent id as an argument (from onPaid or the resume
+  // prop). With deferred minting there is no id in state when the submit closure is
+  // created, so deriving it from render-time state here would poll with "".
+  const startPoll = useCallback(
+    (intentId: string) => {
+      if (!intentId || pollingRef.current) return;
+      pollingRef.current = true;
+      setActivating(true);
+      let attempts = 0;
+      const MAX_ATTEMPTS = 45; // ~90s
+      const poll = async () => {
         if (!pollingRef.current) return;
-        if (st.status === "success") {
-          pollingRef.current = false;
-          onActivated();
-          return;
+        try {
+          const st = await fetchStripeOrderStatus(username, intentId);
+          if (!pollingRef.current) return;
+          if (st.status === "success") {
+            pollingRef.current = false;
+            onActivated();
+            return;
+          }
+          if (st.status === "failed") {
+            pollingRef.current = false;
+            setActivating(false);
+            setError(i18next.t("pro.card-failed"));
+            return;
+          }
+        } catch {
+          // transient (network / not-yet-recorded) -> keep polling
         }
-        if (st.status === "failed") {
+        attempts += 1;
+        if (attempts >= MAX_ATTEMPTS) {
+          // Payment succeeded; ePoints keeps retrying the grant with backoff, so this is not a
+          // hard failure -- stop the spinner and reassure rather than loop forever.
           pollingRef.current = false;
           setActivating(false);
-          setError(i18next.t("pro.card-failed"));
+          setError(i18next.t("pro.activation-pending"));
           return;
         }
-      } catch {
-        // transient (network / not-yet-recorded) -> keep polling
-      }
-      attempts += 1;
-      if (attempts >= MAX_ATTEMPTS) {
-        // Payment succeeded; ePoints keeps retrying the grant with backoff, so this is not a
-        // hard failure -- stop the spinner and reassure rather than loop forever.
-        pollingRef.current = false;
-        setActivating(false);
-        setError(i18next.t("pro.activation-pending"));
-        return;
-      }
-      timerRef.current = setTimeout(poll, 2000);
-    };
-    poll();
-  }, [paymentIntentId, username, onActivated]);
+        timerRef.current = setTimeout(poll, 2000);
+      };
+      poll();
+    },
+    [username, onActivated]
+  );
 
   // Redirect return: the payment already completed off-page, so start the grant poll on mount.
   useEffect(() => {
-    if (resumePaymentIntent) startPoll();
+    if (resumePaymentIntent) startPoll(resumePaymentIntent);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resumePaymentIntent]);
 
-  if (!stripePromise) {
+  if (!stripePromise || amountCents === 0) {
     return <Alert appearance="danger">{i18next.t("pro.card-unavailable")}</Alert>;
   }
   if (error) {
@@ -135,25 +131,31 @@ export function ProCheckout({ username, returnUrl, onActivated, resumePaymentInt
   if (activating) {
     return <div className="py-6 text-center text-sm opacity-75">{i18next.t("pro.activating")}</div>;
   }
-  if (!clientSecret) {
-    return (
-      <div className="py-6 text-center text-sm opacity-75">
-        {i18next.t("pro.preparing-checkout")}
-      </div>
-    );
-  }
 
   return (
-    <Elements
-      stripe={stripePromise}
-      options={{ clientSecret, appearance: { theme: isDarkMode() ? "night" : "stripe" } }}
-    >
-      <StripeCheckoutForm
-        returnUrl={returnUrl}
-        payLabel={i18next.t("pro.pay-now", { amount: PRO_PRICE_USD.toFixed(2) })}
-        onPaid={startPoll}
-        onError={setError}
-      />
-    </Elements>
+    <div className="flex flex-col gap-3">
+      {/* A decline or failed mint keeps the form mounted so the buyer can retry. */}
+      {formError && <Alert appearance="danger">{formError}</Alert>}
+      <Elements
+        stripe={stripePromise}
+        options={{
+          mode: "payment",
+          amount: amountCents,
+          currency: "usd",
+          appearance: { theme: isDarkMode() ? "night" : "stripe" }
+        }}
+      >
+        <StripeCheckoutForm
+          returnUrl={returnUrl}
+          payLabel={i18next.t("pro.pay-now", { amount: PRO_PRICE_USD.toFixed(2) })}
+          createIntent={mintIntent}
+          onPaid={(paymentIntentId) => {
+            setFormError("");
+            startPoll(paymentIntentId);
+          }}
+          onError={setFormError}
+        />
+      </Elements>
+    </div>
   );
 }

--- a/apps/web/src/features/pro/pro-dialog.tsx
+++ b/apps/web/src/features/pro/pro-dialog.tsx
@@ -23,6 +23,11 @@ interface Props {
  */
 export function ProDialog({ username, onHide, resumePaymentIntent }: Props) {
   const [done, setDone] = useState(false);
+  // True while a Pay submit is in flight (validate, mint, confirm). The dialog must not
+  // close in that window: once confirmPayment is dispatched the charge can complete
+  // server side; a closed dialog would offer the buyer a fresh checkout for a
+  // payment that already went through. A decline flips this back to false.
+  const [submitting, setSubmitting] = useState(false);
   const queryClient = useQueryClient();
 
   // On activation, reflect the new membership immediately. The /perks card and every ProBadge
@@ -47,7 +52,22 @@ export function ProDialog({ username, onHide, resumePaymentIntent }: Props) {
   const returnUrl = typeof window !== "undefined" ? `${window.location.origin}/perks?pro=1` : "";
 
   return (
-    <Modal show={true} centered={true} onHide={onHide} size="md">
+    // dismissViaOnHide routes the close button, backdrop and Escape through onHide, so
+    // the submitting guard below actually decides whether the dialog closes.
+    <Modal
+      show={true}
+      centered={true}
+      onHide={() => {
+        // No close while a Pay submit is in flight: the confirm may already have charged
+        // the card and the buyer must stay on this dialog to see the outcome.
+        if (submitting) {
+          return;
+        }
+        onHide();
+      }}
+      dismissViaOnHide={true}
+      size="md"
+    >
       <ModalHeader closeButton={true}>{i18next.t("pro.title")}</ModalHeader>
       <ModalBody>
         {done ? (
@@ -75,6 +95,7 @@ export function ProDialog({ username, onHide, resumePaymentIntent }: Props) {
               returnUrl={returnUrl}
               resumePaymentIntent={resumePaymentIntent}
               onActivated={handleActivated}
+              onSubmittingChange={setSubmitting}
             />
           </div>
         )}

--- a/apps/web/src/features/shared/purchase-stripe/stripe-account-checkout.tsx
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-account-checkout.tsx
@@ -6,10 +6,11 @@ import { Button } from "@ui/button";
 import i18next from "i18next";
 import { useEffect, useRef, useState } from "react";
 import { StripeCheckoutForm } from "./stripe-checkout-form";
-import { getStripePromise } from "./stripe-config";
+import { getStripePromise, skuUsdCents } from "./stripe-config";
 import {
   AccountPurchaseMeta,
   fetchStripeAccountStatus,
+  STRIPE_ACCOUNT_SKU,
   STRIPE_ACCOUNT_USD,
   useCreateAccountIntent
 } from "./use-stripe-account-purchase";
@@ -70,6 +71,13 @@ function createIntentError(e: any): string {
  * are created + emailed by the onboard service, so "done" means requested, not delivered.
  * When `resumePaymentIntent` is set the order already exists (redirect-return), so minting is
  * skipped and we go straight to polling.
+ *
+ * Deliberate exception to the deferred-mint rule the other card rails follow: the single
+ * use Turnstile token is consumed at create intent and expires within minutes, so deferring
+ * the mint to the Pay click would let it expire while the buyer types card details. This
+ * step is only reached after an explicit submit on the signup form, so mint-on-mount does
+ * not create browse-and-abandon intents here. The already-minted client secret is handed to
+ * the shared form via createIntent.
  */
 export function StripeAccountCheckout({ meta, captchaToken, onBack, resumePaymentIntent }: Props) {
   const [step, setStep] = useState<Step>(resumePaymentIntent ? "delivering" : "creating");
@@ -182,11 +190,20 @@ export function StripeAccountCheckout({ meta, captchaToken, onBack, resumePaymen
       {step === "pay" && stripePromise && clientSecret && (
         <Elements
           stripe={stripePromise}
-          options={{ clientSecret, appearance: { theme: isDarkMode() ? "night" : "stripe" } }}
+          options={{
+            mode: "payment",
+            amount: skuUsdCents(STRIPE_ACCOUNT_SKU),
+            currency: "usd",
+            appearance: { theme: isDarkMode() ? "night" : "stripe" }
+          }}
         >
           <StripeCheckoutForm
             returnUrl={buildReturnUrl(meta.username)}
-            payLabel={i18next.t("sign-up.account-pay", { usd: `$${STRIPE_ACCOUNT_USD.toFixed(2)}` })}
+            payLabel={i18next.t("sign-up.account-pay", {
+              usd: `$${STRIPE_ACCOUNT_USD.toFixed(2)}`
+            })}
+            /* The intent already exists (minted on mount, captcha-gated); hand its secret over. */
+            createIntent={async () => clientSecret}
             onPaid={() => setStep("delivering")}
             onError={(m) => {
               setErrorMsg(m);

--- a/apps/web/src/features/shared/purchase-stripe/stripe-checkout-form.tsx
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-checkout-form.tsx
@@ -15,9 +15,19 @@ interface Props {
    * creates an intent. A rejection keeps the form mounted so the buyer can retry.
    */
   createIntent: () => Promise<string>;
-  /** Fired with the confirmed PaymentIntent id (drives the caller's delivery poll). */
+  /**
+   * Fired with the confirmed PaymentIntent id (drives the caller's delivery poll). Fires
+   * even if this form instance unmounted mid-confirm: once the confirm resolved succeeded
+   * or processing, money moved; a completed payment is never silently discarded.
+   */
   onPaid: (paymentIntentId: string) => void;
   onError: (message: string) => void;
+  /**
+   * Fired with true when a Pay submit starts and false when it settles (success, decline
+   * or mint failure). Parents use it to lock every control that could remount this form
+   * or alter the purchase identity while the submit-mint-confirm window is open.
+   */
+  onSubmittingChange?: (submitting: boolean) => void;
 }
 
 /**
@@ -27,7 +37,14 @@ interface Props {
  * then confirm with the fresh client secret. Card payments resolve in-place; a
  * redirect-only method would bounce to returnUrl.
  */
-export function StripeCheckoutForm({ returnUrl, payLabel, createIntent, onPaid, onError }: Props) {
+export function StripeCheckoutForm({
+  returnUrl,
+  payLabel,
+  createIntent,
+  onPaid,
+  onError,
+  onSubmittingChange
+}: Props) {
   const stripe = useStripe();
   const elements = useElements();
   const [submitting, setSubmitting] = useState(false);
@@ -50,6 +67,10 @@ export function StripeCheckoutForm({ returnUrl, payLabel, createIntent, onPaid, 
       return;
     }
     setSubmitting(true);
+    // Tell the parent FIRST, before any await: it must lock selection controls for the
+    // whole submit-mint-confirm window so the purchase identity cannot change (and the
+    // keyed checkout cannot remount) while money may be moving.
+    onSubmittingChange?.(true);
     try {
       // Validate the Payment Element (and collect wallet data) BEFORE minting, so an
       // incomplete card never creates an intent. On error the form stays usable.
@@ -90,8 +111,17 @@ export function StripeCheckoutForm({ returnUrl, payLabel, createIntent, onPaid, 
         redirect: "if_required",
         confirmParams: { return_url: returnUrl }
       });
-      // No bail can help mid-confirm (Stripe owns that window and destroys the Payment
-      // Element on unmount), but the result must not drive a stale caller's state.
+      // Once confirmPayment is dispatched, nothing here can cancel it: Stripe owns that
+      // window and the charge can complete server side even if this instance unmounts.
+      // So the success path below reports to onPaid UNCONDITIONALLY, mounted or not - a
+      // completed payment must never be silently discarded. At worst the parent is gone
+      // and the call is a no-op; when only this form subtree was replaced, the parent
+      // still reacts and starts its delivery poll. Only the cosmetic error paths keep a
+      // mounted bail (there is no state worth painting into a replaced form).
+      if (paymentIntent && ["succeeded", "processing"].includes(paymentIntent.status)) {
+        onPaid(paymentIntent.id);
+        return;
+      }
       if (!mountedRef.current) {
         return;
       }
@@ -100,14 +130,13 @@ export function StripeCheckoutForm({ returnUrl, payLabel, createIntent, onPaid, 
         onError(error.message ?? i18next.t("stripe-points.pay-failed"));
         return;
       }
-      if (paymentIntent && ["succeeded", "processing"].includes(paymentIntent.status)) {
-        onPaid(paymentIntent.id);
-        return;
-      }
       // requires_action handled by Stripe.js; anything else here is unexpected
       onError(i18next.t("stripe-points.pay-failed"));
     } finally {
-      // guarantee the button unlocks even if confirmPayment throws
+      // Unlock the parent's controls in every outcome (the parent outlives this form
+      // subtree, so no mounted bail here) and guarantee the button unlocks even if
+      // confirmPayment throws.
+      onSubmittingChange?.(false);
       if (mountedRef.current) {
         setSubmitting(false);
       }

--- a/apps/web/src/features/shared/purchase-stripe/stripe-checkout-form.tsx
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-checkout-form.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@ui/button";
 import { PaymentElement, useElements, useStripe } from "@stripe/react-stripe-js";
 import i18next from "i18next";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface Props {
   /** Where redirect-based methods return to; card resolves in-page (redirect: if_required). */
@@ -32,6 +32,17 @@ export function StripeCheckoutForm({ returnUrl, payLabel, createIntent, onPaid, 
   const elements = useElements();
   const [submitting, setSubmitting] = useState(false);
   const [ready, setReady] = useState(false);
+  const mountedRef = useRef(true);
+
+  // Track real mount state for the async Pay handler below. Set in its OWN mount effect so
+  // React StrictMode's dev setup->cleanup->setup leaves it TRUE (the final setup wins); a
+  // per-mount closure flag would be torn down to a stale `false` and swallow the result.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -43,6 +54,12 @@ export function StripeCheckoutForm({ returnUrl, payLabel, createIntent, onPaid, 
       // Validate the Payment Element (and collect wallet data) BEFORE minting, so an
       // incomplete card never creates an intent. On error the form stays usable.
       const { error: submitError } = await elements.submit();
+      // A still-enabled selection (hosting term, gift recipient) may change while this
+      // handler is in flight; the keyed checkout remounts and THIS instance unmounts.
+      // Bail after every await so a discarded selection never mints or confirms.
+      if (!mountedRef.current) {
+        return;
+      }
       if (submitError) {
         onError(submitError.message ?? i18next.t("stripe-points.pay-failed"));
         return;
@@ -55,7 +72,13 @@ export function StripeCheckoutForm({ returnUrl, payLabel, createIntent, onPaid, 
       try {
         clientSecret = await createIntent();
       } catch {
+        if (!mountedRef.current) {
+          return;
+        }
         onError(i18next.t("stripe-points.create-failed"));
+        return;
+      }
+      if (!mountedRef.current) {
         return;
       }
 
@@ -67,6 +90,11 @@ export function StripeCheckoutForm({ returnUrl, payLabel, createIntent, onPaid, 
         redirect: "if_required",
         confirmParams: { return_url: returnUrl }
       });
+      // No bail can help mid-confirm (Stripe owns that window and destroys the Payment
+      // Element on unmount), but the result must not drive a stale caller's state.
+      if (!mountedRef.current) {
+        return;
+      }
       if (error) {
         // card declined / validation / network -- surface Stripe's localized message
         onError(error.message ?? i18next.t("stripe-points.pay-failed"));
@@ -80,7 +108,9 @@ export function StripeCheckoutForm({ returnUrl, payLabel, createIntent, onPaid, 
       onError(i18next.t("stripe-points.pay-failed"));
     } finally {
       // guarantee the button unlocks even if confirmPayment throws
-      setSubmitting(false);
+      if (mountedRef.current) {
+        setSubmitting(false);
+      }
     }
   };
 

--- a/apps/web/src/features/shared/purchase-stripe/stripe-checkout-form.tsx
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-checkout-form.tsx
@@ -9,16 +9,25 @@ interface Props {
   /** Where redirect-based methods return to; card resolves in-page (redirect: if_required). */
   returnUrl: string;
   payLabel: string;
-  onPaid: () => void;
+  /**
+   * Mints the PaymentIntent at Pay time and resolves to its client_secret. Called only
+   * after the Payment Element validated (elements.submit), so an abandoned checkout never
+   * creates an intent. A rejection keeps the form mounted so the buyer can retry.
+   */
+  createIntent: () => Promise<string>;
+  /** Fired with the confirmed PaymentIntent id (drives the caller's delivery poll). */
+  onPaid: (paymentIntentId: string) => void;
   onError: (message: string) => void;
 }
 
 /**
- * The Payment Element + confirm button. Rendered ONLY inside <Elements> (it uses the
- * Stripe context). Card payments resolve in-place; a redirect-only method would bounce
- * to returnUrl.
+ * The Payment Element + confirm button, in Stripe's deferred-intent flow. Rendered ONLY
+ * inside an <Elements> initialized with mode/amount/currency (no clientSecret) - it uses
+ * the Stripe context. On submit: validate the element, mint the intent via createIntent,
+ * then confirm with the fresh client secret. Card payments resolve in-place; a
+ * redirect-only method would bounce to returnUrl.
  */
-export function StripeCheckoutForm({ returnUrl, payLabel, onPaid, onError }: Props) {
+export function StripeCheckoutForm({ returnUrl, payLabel, createIntent, onPaid, onError }: Props) {
   const stripe = useStripe();
   const elements = useElements();
   const [submitting, setSubmitting] = useState(false);
@@ -31,10 +40,30 @@ export function StripeCheckoutForm({ returnUrl, payLabel, onPaid, onError }: Pro
     }
     setSubmitting(true);
     try {
+      // Validate the Payment Element (and collect wallet data) BEFORE minting, so an
+      // incomplete card never creates an intent. On error the form stays usable.
+      const { error: submitError } = await elements.submit();
+      if (submitError) {
+        onError(submitError.message ?? i18next.t("stripe-points.pay-failed"));
+        return;
+      }
+
+      // Mint the PaymentIntent now, at the Pay click. Upstream throws raw i18n keys /
+      // axios technical strings; show a stable friendly message and keep the form
+      // mounted so the buyer can retry.
+      let clientSecret: string;
+      try {
+        clientSecret = await createIntent();
+      } catch {
+        onError(i18next.t("stripe-points.create-failed"));
+        return;
+      }
+
       // Card confirms in-place; a redirect-based method (if enabled in the dashboard)
-      // navigates to return_url and the perks/points page resumes the flow on return.
+      // navigates to return_url and the calling page resumes the flow on return.
       const { error, paymentIntent } = await stripe.confirmPayment({
         elements,
+        clientSecret,
         redirect: "if_required",
         confirmParams: { return_url: returnUrl }
       });
@@ -44,7 +73,7 @@ export function StripeCheckoutForm({ returnUrl, payLabel, onPaid, onError }: Pro
         return;
       }
       if (paymentIntent && ["succeeded", "processing"].includes(paymentIntent.status)) {
-        onPaid();
+        onPaid(paymentIntent.id);
         return;
       }
       // requires_action handled by Stripe.js; anything else here is unexpected

--- a/apps/web/src/features/shared/purchase-stripe/stripe-config.ts
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-config.ts
@@ -8,6 +8,7 @@ export {
   STRIPE_POINTS_TIERS,
   isKnownTierSku,
   isStripeEnabled,
+  skuUsdCents,
   suggestPointsSkuForDeficit,
   type StripePointsTier
 } from "./stripe-tiers";

--- a/apps/web/src/features/shared/purchase-stripe/stripe-points-dialog.tsx
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-points-dialog.tsx
@@ -11,6 +11,7 @@ import { StripeCheckoutForm } from "./stripe-checkout-form";
 import {
   DEFAULT_STRIPE_TIER_SKU,
   getStripePromise,
+  skuUsdCents,
   STRIPE_POINTS_TIERS
 } from "./stripe-config";
 import { fetchStripeOrderStatus, useCreateStripeIntent } from "./use-stripe-points-purchase";
@@ -37,10 +38,12 @@ const genNonce = (): string =>
     : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
 /**
- * Reusable card-payment dialog for buying Points. Flow: pick a tier -> create a
- * PaymentIntent via vapi -> confirm with the Stripe Payment Element -> poll the order
- * status until the worker delivers. Credits the authenticated user (vapi forces it).
- * Card payment is hidden entirely when the publishable key is unconfigured.
+ * Reusable card-payment dialog for buying Points. Flow: pick a tier -> render the Payment
+ * Element (deferred: no intent yet) -> mint the PaymentIntent via vapi on the Pay click ->
+ * confirm -> poll the order status until the worker delivers. Credits the authenticated
+ * user (vapi forces it). Deferring the mint to the Pay click means browsing tiers or
+ * closing the dialog never creates an abandoned intent. Card payment is hidden entirely
+ * when the publishable key is unconfigured.
  */
 export function StripePointsDialog({
   show,
@@ -55,7 +58,9 @@ export function StripePointsDialog({
   const [step, setStep] = useState<Step>("select");
   const [sku, setSku] = useState(defaultSku ?? DEFAULT_STRIPE_TIER_SKU);
   const [nonce, setNonce] = useState("");
-  const [clientSecret, setClientSecret] = useState("");
+  // The confirmed PaymentIntent id, handed over by onPaid. With deferred minting there is
+  // no client secret in state to derive it from; the confirm result is the source.
+  const [paidIntentId, setPaidIntentId] = useState("");
   const [deliveredPoints, setDeliveredPoints] = useState<number | undefined>(undefined);
   const [errorMsg, setErrorMsg] = useState("");
   const pollingRef = useRef(false);
@@ -68,7 +73,7 @@ export function StripePointsDialog({
     if (show) {
       setNonce(genNonce());
       setSku(defaultSku ?? DEFAULT_STRIPE_TIER_SKU);
-      setClientSecret("");
+      setPaidIntentId("");
       setDeliveredPoints(undefined);
       setErrorMsg("");
       pollingRef.current = true;
@@ -79,20 +84,14 @@ export function StripePointsDialog({
     }
   }, [show, defaultSku, resumePaymentIntent]);
 
-  // The PaymentIntent id is the resume value (redirect return) or the client-secret prefix.
-  const paymentIntentId =
-    resumePaymentIntent || (clientSecret ? clientSecret.split("_secret_")[0] : "");
+  // The PaymentIntent id is the resume value (redirect return) or the one from onPaid.
+  const paymentIntentId = resumePaymentIntent || paidIntentId;
 
-  const startPayment = useCallback(async () => {
-    setErrorMsg("");
-    try {
-      const { client_secret } = await createIntent.mutateAsync({ sku, nonce });
-      setClientSecret(client_secret);
-      setStep("pay");
-    } catch {
-      setErrorMsg(i18next.t("stripe-points.create-failed"));
-      setStep("error");
-    }
+  // Mints the PaymentIntent at Pay time (deferred flow) for the selected tier. The nonce
+  // is stable for the session, so a double-submit returns the same intent.
+  const mintIntent = useCallback(async () => {
+    const { client_secret } = await createIntent.mutateAsync({ sku, nonce });
+    return client_secret;
   }, [createIntent, sku, nonce]);
 
   // After the intent is confirmed, poll until the worker delivers the Points.
@@ -140,6 +139,7 @@ export function StripePointsDialog({
   }, [step, username, paymentIntentId, onDelivered]);
 
   const selectedTier = STRIPE_POINTS_TIERS.find((t) => t.sku === sku);
+  const amountCents = skuUsdCents(sku);
 
   return (
     <Modal show={show} centered={true} onHide={() => setShow(false)} size="md">
@@ -174,16 +174,28 @@ export function StripePointsDialog({
                 </button>
               ))}
             </div>
-            <Button full={true} isLoading={createIntent.isPending} onClick={startPayment}>
+            {/* Advances to the payment form only; the intent is minted on the Pay click. */}
+            <Button
+              full={true}
+              onClick={() => {
+                setErrorMsg("");
+                setStep("pay");
+              }}
+            >
               {i18next.t("stripe-points.continue")}
             </Button>
           </div>
         )}
 
-        {step === "pay" && stripePromise && clientSecret && (
+        {step === "pay" && stripePromise && amountCents > 0 && (
           <Elements
             stripe={stripePromise}
-            options={{ clientSecret, appearance: { theme: isDarkMode() ? "night" : "stripe" } }}
+            options={{
+              mode: "payment",
+              amount: amountCents,
+              currency: "usd",
+              appearance: { theme: isDarkMode() ? "night" : "stripe" }
+            }}
           >
             <StripeCheckoutForm
               returnUrl={typeof window !== "undefined" ? window.location.href : ""}
@@ -192,7 +204,11 @@ export function StripePointsDialog({
                   ? i18next.t("stripe-points.pay", { usd: `$${selectedTier.usd.toFixed(2)}` })
                   : i18next.t("stripe-points.pay-generic")
               }
-              onPaid={() => setStep("delivering")}
+              createIntent={mintIntent}
+              onPaid={(paymentIntent) => {
+                setPaidIntentId(paymentIntent);
+                setStep("delivering");
+              }}
               onError={(m) => {
                 setErrorMsg(m);
                 setStep("error");

--- a/apps/web/src/features/shared/purchase-stripe/stripe-points-dialog.tsx
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-points-dialog.tsx
@@ -11,6 +11,7 @@ import { StripeCheckoutForm } from "./stripe-checkout-form";
 import {
   DEFAULT_STRIPE_TIER_SKU,
   getStripePromise,
+  isKnownTierSku,
   skuUsdCents,
   STRIPE_POINTS_TIERS
 } from "./stripe-config";
@@ -37,6 +38,11 @@ const genNonce = (): string =>
     ? crypto.randomUUID()
     : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
+// An unknown defaultSku (a stale caller, a renamed tier) must not leave the dialog with no
+// selected tile and a zero-cent pay step; fall back to the default tier instead.
+const resolveTierSku = (sku?: string): string =>
+  sku && isKnownTierSku(sku) ? sku : DEFAULT_STRIPE_TIER_SKU;
+
 /**
  * Reusable card-payment dialog for buying Points. Flow: pick a tier -> render the Payment
  * Element (deferred: no intent yet) -> mint the PaymentIntent via vapi on the Pay click ->
@@ -56,7 +62,7 @@ export function StripePointsDialog({
   const username = activeUser?.username;
 
   const [step, setStep] = useState<Step>("select");
-  const [sku, setSku] = useState(defaultSku ?? DEFAULT_STRIPE_TIER_SKU);
+  const [sku, setSku] = useState(() => resolveTierSku(defaultSku));
   const [nonce, setNonce] = useState("");
   // The confirmed PaymentIntent id, handed over by onPaid. With deferred minting there is
   // no client secret in state to derive it from; the confirm result is the source.
@@ -72,7 +78,7 @@ export function StripePointsDialog({
   useEffect(() => {
     if (show) {
       setNonce(genNonce());
-      setSku(defaultSku ?? DEFAULT_STRIPE_TIER_SKU);
+      setSku(resolveTierSku(defaultSku));
       setPaidIntentId("");
       setDeliveredPoints(undefined);
       setErrorMsg("");
@@ -88,8 +94,10 @@ export function StripePointsDialog({
   const paymentIntentId = resumePaymentIntent || paidIntentId;
 
   // Mints the PaymentIntent at Pay time (deferred flow) for the selected tier. The nonce
-  // is stable for the session, so a double-submit returns the same intent.
+  // is stable for the session, so a double-submit returns the same intent. Clears the
+  // inline pay-step error so a retry starts clean.
   const mintIntent = useCallback(async () => {
+    setErrorMsg("");
     const { client_secret } = await createIntent.mutateAsync({ sku, nonce });
     return client_secret;
   }, [createIntent, sku, nonce]);
@@ -188,33 +196,37 @@ export function StripePointsDialog({
         )}
 
         {step === "pay" && stripePromise && amountCents > 0 && (
-          <Elements
-            stripe={stripePromise}
-            options={{
-              mode: "payment",
-              amount: amountCents,
-              currency: "usd",
-              appearance: { theme: isDarkMode() ? "night" : "stripe" }
-            }}
-          >
-            <StripeCheckoutForm
-              returnUrl={typeof window !== "undefined" ? window.location.href : ""}
-              payLabel={
-                selectedTier
-                  ? i18next.t("stripe-points.pay", { usd: `$${selectedTier.usd.toFixed(2)}` })
-                  : i18next.t("stripe-points.pay-generic")
-              }
-              createIntent={mintIntent}
-              onPaid={(paymentIntent) => {
-                setPaidIntentId(paymentIntent);
-                setStep("delivering");
+          <div className="flex flex-col gap-3">
+            {/* A mint failure or card decline surfaces HERE, above the still-mounted form,
+                so the buyer retries without retyping the card. The terminal error step is
+                reserved for a failed delivery poll. */}
+            {errorMsg && <Alert appearance="danger">{errorMsg}</Alert>}
+            <Elements
+              stripe={stripePromise}
+              options={{
+                mode: "payment",
+                amount: amountCents,
+                currency: "usd",
+                appearance: { theme: isDarkMode() ? "night" : "stripe" }
               }}
-              onError={(m) => {
-                setErrorMsg(m);
-                setStep("error");
-              }}
-            />
-          </Elements>
+            >
+              <StripeCheckoutForm
+                returnUrl={typeof window !== "undefined" ? window.location.href : ""}
+                payLabel={
+                  selectedTier
+                    ? i18next.t("stripe-points.pay", { usd: `$${selectedTier.usd.toFixed(2)}` })
+                    : i18next.t("stripe-points.pay-generic")
+                }
+                createIntent={mintIntent}
+                onPaid={(paymentIntent) => {
+                  setErrorMsg("");
+                  setPaidIntentId(paymentIntent);
+                  setStep("delivering");
+                }}
+                onError={setErrorMsg}
+              />
+            </Elements>
+          </div>
         )}
 
         {step === "delivering" && (

--- a/apps/web/src/features/shared/purchase-stripe/stripe-points-dialog.tsx
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-points-dialog.tsx
@@ -69,6 +69,12 @@ export function StripePointsDialog({
   const [paidIntentId, setPaidIntentId] = useState("");
   const [deliveredPoints, setDeliveredPoints] = useState<number | undefined>(undefined);
   const [errorMsg, setErrorMsg] = useState("");
+  // True while a Pay submit is in flight (validate, mint, confirm). The dialog must not
+  // close in that window: once confirmPayment is dispatched the charge can complete
+  // server side; a closed dialog would show the buyer a fresh checkout for a payment
+  // that already went through. Delivering stays closable (the payment is acknowledged by
+  // then) and a decline flips this back to false so the dialog closes normally again.
+  const [submitting, setSubmitting] = useState(false);
   const pollingRef = useRef(false);
 
   const createIntent = useCreateStripeIntent(username);
@@ -82,6 +88,7 @@ export function StripePointsDialog({
       setPaidIntentId("");
       setDeliveredPoints(undefined);
       setErrorMsg("");
+      setSubmitting(false);
       pollingRef.current = true;
       // Returning from a redirect-based method: skip straight to the delivery poll.
       setStep(resumePaymentIntent ? "delivering" : "select");
@@ -150,7 +157,22 @@ export function StripePointsDialog({
   const amountCents = skuUsdCents(sku);
 
   return (
-    <Modal show={show} centered={true} onHide={() => setShow(false)} size="md">
+    // dismissViaOnHide routes the close button, backdrop and Escape through onHide, so
+    // the submitting guard below actually decides whether the dialog closes.
+    <Modal
+      show={show}
+      centered={true}
+      onHide={() => {
+        // No close while a Pay submit is in flight: the confirm may already have charged
+        // the card and the buyer must stay on this dialog to see the outcome.
+        if (submitting) {
+          return;
+        }
+        setShow(false);
+      }}
+      dismissViaOnHide={true}
+      size="md"
+    >
       <ModalHeader closeButton={true}>
         <ModalTitle>{i18next.t("stripe-points.title")}</ModalTitle>
       </ModalHeader>
@@ -224,6 +246,7 @@ export function StripePointsDialog({
                   setStep("delivering");
                 }}
                 onError={setErrorMsg}
+                onSubmittingChange={setSubmitting}
               />
             </Elements>
           </div>

--- a/apps/web/src/features/shared/purchase-stripe/stripe-tiers.ts
+++ b/apps/web/src/features/shared/purchase-stripe/stripe-tiers.ts
@@ -35,6 +35,17 @@ export const STRIPE_POINTS_TIERS: StripePointsTier[] = [
 
 export const DEFAULT_STRIPE_TIER_SKU = "999points";
 
+/**
+ * USD price in cents derived from the SKU's leading number. Every SKU on the ePoints
+ * card rail encodes its price this way (499points, 1999pro, 200hosting, 3600prohosting),
+ * mirroring the server product map. Returns 0 for a malformed SKU; callers treat 0 as
+ * unconfigured and refuse to render a checkout for it.
+ */
+export function skuUsdCents(sku: string): number {
+  const cents = parseInt(sku, 10);
+  return Number.isFinite(cents) && cents > 0 ? cents : 0;
+}
+
 /** Whether a sku string is one of the known card-rail tiers. */
 export const isKnownTierSku = (sku: string): boolean =>
   STRIPE_POINTS_TIERS.some((tier) => tier.sku === sku);

--- a/apps/web/src/features/ui/modal/index.tsx
+++ b/apps/web/src/features/ui/modal/index.tsx
@@ -20,6 +20,13 @@ interface Props {
   // stays mounted this long after closing so CSS exits can play
   // (e.g. ModalSidebar's 300ms slide).
   exitDurationMs?: number;
+  // Route every dismiss gesture (header close button, backdrop click, Escape)
+  // through onHide instead of closing internally, so the parent DECIDES whether
+  // the modal closes: it closes only when the parent flips `show` to false. By
+  // default a gesture closes the modal first and onHide is only a notification,
+  // which makes an onHide guard useless. Opt in when a flow must stay on screen
+  // (e.g. a card payment confirm in flight).
+  dismissViaOnHide?: boolean;
 }
 
 export function Modal(props: Omit<HTMLProps<HTMLDivElement>, "size"> & Props) {
@@ -33,7 +40,8 @@ export function Modal(props: Omit<HTMLProps<HTMLDivElement>, "size"> & Props) {
     "centered",
     "dialogClassName",
     "raw",
-    "exitDurationMs"
+    "exitDurationMs",
+    "dismissViaOnHide"
   ]);
   const isAnimated = useMemo(() => props.animation ?? true, [props.animation]);
 
@@ -63,10 +71,24 @@ export function Modal(props: Omit<HTMLProps<HTMLDivElement>, "size"> & Props) {
   // open→close transition (see the effect below). Updated inside that effect.
   const prevShowRef = useRef(show);
 
+  // A dismiss GESTURE (as opposed to the parent clearing `show`). With
+  // dismissViaOnHide the gesture is forwarded to the parent, which closes by
+  // flipping `show`; otherwise it closes internally as before. Kept in a ref so
+  // the mount-scoped Escape listener always sees the current props.
+  const dismiss = () => {
+    if (props.dismissViaOnHide) {
+      props.onHide();
+    } else {
+      setShow(false);
+    }
+  };
+  const dismissRef = useRef(dismiss);
+  dismissRef.current = dismiss;
+
   useEffect(() => {
     const onKeyUp = (e: KeyboardEvent) => {
       if (e.key === "Escape" && showRef.current === true) {
-        setShow(false);
+        dismissRef.current();
       }
     };
     document.addEventListener("keyup", onKeyUp);
@@ -106,16 +128,25 @@ export function Modal(props: Omit<HTMLProps<HTMLDivElement>, "size"> & Props) {
     };
   }, [show]);
 
+  // Children (e.g. the header close button) close via context.setShow(false);
+  // that is a dismiss gesture too, so route it the same way. Opening stays direct.
+  const contextSetShow = (v: boolean) => {
+    if (v === false) {
+      dismiss();
+    } else {
+      setShow(v);
+    }
+  };
+
   return (
-    <ModalContext.Provider value={{ show, setShow, open }}>
+    <ModalContext.Provider value={{ show, setShow: contextSetShow, open }}>
       {isMounted() &&
         portalContainer &&
         mounted &&
         createPortal(
           <div
             className={classNameObject({
-              "bg-black z-[1100] fixed top-0 left-0 right-0 bottom-0 transition-opacity duration-200":
-                true,
+              "bg-black z-[1100] fixed top-0 left-0 right-0 bottom-0 transition-opacity duration-200": true,
               "opacity-50": open,
               // While closing, let clicks reach the page instead of the dying
               // overlay/wrapper (restored automatically on mid-exit reopen).
@@ -133,13 +164,12 @@ export function Modal(props: Omit<HTMLProps<HTMLDivElement>, "size"> & Props) {
           <div
             {...nativeProps}
             className={classNameObject({
-              "z-[1100] fixed top-0 pt-24 sm:py-4 md:py-8 left-0 right-0 bottom-0 overflow-y-auto h-full sm:h-auto":
-                true,
+              "z-[1100] fixed top-0 pt-24 sm:py-4 md:py-8 left-0 right-0 bottom-0 overflow-y-auto h-full sm:h-auto": true,
               [props.className ?? ""]: true,
               "pointer-events-none": !open,
               "flex justify-center items-start": props.centered
             })}
-            onClick={() => setShow(false)}
+            onClick={() => dismiss()}
           >
             <div
               onClick={(e) => e.stopPropagation()}

--- a/apps/web/src/specs/features/hosting-signup/hosting-card-checkout.spec.tsx
+++ b/apps/web/src/specs/features/hosting-signup/hosting-card-checkout.spec.tsx
@@ -1,0 +1,215 @@
+import { HostingCardCheckout } from "@/features/hosting-signup/hosting-card-checkout";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shared stubs, hoisted so the vi.mock factories (which run before top-level consts
+// initialize) can reference them. callOrder pins the deferred sequence: validate the
+// Payment Element FIRST, mint the intent second, confirm third.
+const h = vi.hoisted(() => {
+  const callOrder: string[] = [];
+  return {
+    callOrder,
+    elementsOptions: [] as any[],
+    submitMock: vi.fn(async () => {
+      callOrder.push("elements.submit");
+      return {};
+    }),
+    // The confirmed intent id is DELIBERATELY different from the minted secret's prefix:
+    // the activation poll must use the id handed to onPaid (from the confirm result),
+    // never one derived from state captured at render.
+    confirmPaymentMock: vi.fn(async (_args: any) => {
+      callOrder.push("confirmPayment");
+      return { paymentIntent: { id: "pi_confirmed_888", status: "succeeded" } };
+    }),
+    mintMock: vi.fn(async (_args: any) => {
+      callOrder.push("createIntent");
+      return { client_secret: "pi_minted_host_secret_xyz" };
+    }),
+    statusMock: vi.fn(async (_username: string, _intentId: string) => ({ status: "success" }))
+  };
+});
+
+vi.mock("@stripe/react-stripe-js", async () => {
+  const React = await import("react");
+  return {
+    Elements: ({ options, children }: any) => {
+      h.elementsOptions.push(options);
+      return React.createElement("div", { "data-testid": "elements" }, children);
+    },
+    useStripe: () => ({ confirmPayment: h.confirmPaymentMock }),
+    useElements: () => ({ submit: h.submitMock }),
+    PaymentElement: ({ onReady }: any) => {
+      React.useEffect(() => {
+        onReady?.();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return React.createElement("div", { "data-testid": "payment-element" });
+    }
+  };
+});
+
+// The barrel hands HostingCardCheckout getStripePromise + skuUsdCents; keep the real
+// tier helpers (skuUsdCents drives the Elements amount) and stub only the Stripe.js loader.
+vi.mock("@/features/shared/purchase-stripe", async () => ({
+  ...(await vi.importActual<Record<string, unknown>>(
+    "@/features/shared/purchase-stripe/stripe-tiers"
+  )),
+  getStripePromise: () => Promise.resolve({})
+}));
+
+vi.mock("@/features/shared/purchase-stripe/use-stripe-points-purchase", () => ({
+  useCreateStripeIntent: () => ({ mutateAsync: h.mintMock, isPending: false }),
+  fetchStripeOrderStatus: h.statusMock
+}));
+
+describe("HostingCardCheckout (deferred intent)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.callOrder.length = 0;
+    h.elementsOptions.length = 0;
+    h.mintMock.mockImplementation(async () => {
+      h.callOrder.push("createIntent");
+      return { client_secret: "pi_minted_host_secret_xyz" };
+    });
+    h.confirmPaymentMock.mockImplementation(async () => {
+      h.callOrder.push("confirmPayment");
+      return { paymentIntent: { id: "pi_confirmed_888", status: "succeeded" } };
+    });
+  });
+
+  interface Overrides {
+    hostingTarget?: string;
+    onActivated?: () => void;
+    onConfirmed?: () => void;
+  }
+
+  const checkout = ({
+    hostingTarget,
+    onActivated = vi.fn(),
+    onConfirmed = vi.fn()
+  }: Overrides = {}) => (
+    <HostingCardCheckout
+      username="alice"
+      sku="200hosting"
+      hostingTarget={hostingTarget}
+      payLabel="hosting.pay-now"
+      returnUrl="https://ecency.com/hosting"
+      onActivated={onActivated}
+      onConfirmed={onConfirmed}
+    />
+  );
+
+  const clickPay = async () => {
+    const payButton = await screen.findByRole("button", { name: "hosting.pay-now" });
+    await waitFor(() => expect(payButton).not.toBeDisabled());
+    fireEvent.click(payButton);
+  };
+
+  it("renders the payment form in deferred mode without creating an intent", async () => {
+    render(checkout());
+    // Opening the payment step must not mint: switching terms or abandoning the form
+    // used to leave incomplete intents behind under the old mint-on-mount effect.
+    expect(h.mintMock).not.toHaveBeenCalled();
+    await screen.findByTestId("payment-element");
+    expect(h.mintMock).not.toHaveBeenCalled();
+    expect(h.confirmPaymentMock).not.toHaveBeenCalled();
+    expect(h.elementsOptions[0]).toMatchObject({
+      mode: "payment",
+      amount: 200,
+      currency: "usd"
+    });
+    expect(h.elementsOptions[0].clientSecret).toBeUndefined();
+  });
+
+  it("on Pay for a community: mints with hosting_target, confirms with the minted secret and polls with the confirmed id", async () => {
+    const onActivated = vi.fn();
+    const onConfirmed = vi.fn();
+    render(checkout({ hostingTarget: "hive-125125", onActivated, onConfirmed }));
+
+    await clickPay();
+
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
+    // The mint carries the CURRENT target tenant so ePoints activates the community, not
+    // the payer's own blog.
+    expect(h.mintMock).toHaveBeenCalledWith({
+      sku: "200hosting",
+      nonce: expect.any(String),
+      hosting_target: "hive-125125"
+    });
+
+    await waitFor(() => expect(h.confirmPaymentMock).toHaveBeenCalledTimes(1));
+    // elements.submit ran BEFORE the intent was minted and the confirm used the fresh secret.
+    expect(h.callOrder).toEqual(["elements.submit", "createIntent", "confirmPayment"]);
+    expect(h.confirmPaymentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientSecret: "pi_minted_host_secret_xyz",
+        redirect: "if_required"
+      })
+    );
+
+    // The activation poll queries with the CONFIRMED intent id from onPaid, not anything
+    // derived from render-time state (which is empty under deferred minting).
+    await waitFor(() => expect(h.statusMock).toHaveBeenCalledWith("alice", "pi_confirmed_888"));
+    await waitFor(() => expect(onActivated).toHaveBeenCalledTimes(1));
+    // onConfirmed fired when the poll started, so the parent locked the term selector.
+    expect(onConfirmed).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends no hosting_target for a personal blog (the payer's own account is activated)", async () => {
+    render(checkout());
+
+    await clickPay();
+
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
+    expect((h.mintMock.mock.calls[0][0] as any).hosting_target).toBeUndefined();
+    expect((h.mintMock.mock.calls[0][0] as any).sku).toBe("200hosting");
+  });
+
+  it("keeps the form mounted with a friendly message when the mint fails", async () => {
+    h.mintMock.mockImplementation(async () => {
+      h.callOrder.push("createIntent");
+      throw new Error("Request failed with status code 500");
+    });
+    render(checkout());
+
+    await clickPay();
+
+    await screen.findByText("stripe-points.create-failed");
+    // The raw axios message never surfaces and the form stays mounted for a retry.
+    expect(screen.queryByText("Request failed with status code 500")).not.toBeInTheDocument();
+    expect(screen.getByTestId("payment-element")).toBeInTheDocument();
+    expect(h.confirmPaymentMock).not.toHaveBeenCalled();
+    expect(h.statusMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the nonce across a same-target retry and regenerates it when the target changes", async () => {
+    // Every confirm declines so the form stays mounted for the next Pay. The server
+    // idempotency key is user:sku:nonce, so a changed target MUST carry a fresh nonce
+    // (otherwise the mint replays the previous intent, activating the previous tenant)
+    // while an unchanged retry MUST reuse the nonce so the retry stays idempotent.
+    h.confirmPaymentMock.mockImplementation(async () => {
+      h.callOrder.push("confirmPayment");
+      return { error: { message: "stripe-decline-message" } };
+    });
+    const { rerender } = render(checkout({ hostingTarget: "hive-125125" }));
+
+    await clickPay();
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
+
+    // Retry with the SAME sku and target: the nonce must not change.
+    await clickPay();
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(2));
+
+    // Switch the target tenant: fresh nonce and the payload follows the edit.
+    rerender(checkout({ hostingTarget: "hive-999999" }));
+    await clickPay();
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(3));
+
+    const payloads = h.mintMock.mock.calls.map((call) => call[0] as any);
+    expect(payloads[1].nonce).toBe(payloads[0].nonce);
+    expect(payloads[2].nonce).not.toBe(payloads[1].nonce);
+    expect(payloads[2].hosting_target).toBe("hive-999999");
+    expect(h.statusMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/specs/features/hosting-signup/hosting-card-checkout.spec.tsx
+++ b/apps/web/src/specs/features/hosting-signup/hosting-card-checkout.spec.tsx
@@ -1,7 +1,28 @@
 import { HostingCardCheckout } from "@/features/hosting-signup/hosting-card-checkout";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shapes the mocks exchange with the component under test; typed so the assertions on
+// mock.calls stay checked instead of being cast through any.
+interface MockElementsOptions {
+  mode?: string;
+  amount?: number;
+  currency?: string;
+  clientSecret?: string;
+}
+
+interface MintPayload {
+  sku: string;
+  nonce: string;
+  hosting_target?: string;
+}
+
+interface MockConfirmResult {
+  paymentIntent?: { id: string; status: string };
+  error?: { message: string };
+}
 
 // Shared stubs, hoisted so the vi.mock factories (which run before top-level consts
 // initialize) can reference them. callOrder pins the deferred sequence: validate the
@@ -10,7 +31,7 @@ const h = vi.hoisted(() => {
   const callOrder: string[] = [];
   return {
     callOrder,
-    elementsOptions: [] as any[],
+    elementsOptions: [] as MockElementsOptions[],
     submitMock: vi.fn(async () => {
       callOrder.push("elements.submit");
       return {};
@@ -18,11 +39,11 @@ const h = vi.hoisted(() => {
     // The confirmed intent id is DELIBERATELY different from the minted secret's prefix:
     // the activation poll must use the id handed to onPaid (from the confirm result),
     // never one derived from state captured at render.
-    confirmPaymentMock: vi.fn(async (_args: any) => {
+    confirmPaymentMock: vi.fn(async (): Promise<MockConfirmResult> => {
       callOrder.push("confirmPayment");
       return { paymentIntent: { id: "pi_confirmed_888", status: "succeeded" } };
     }),
-    mintMock: vi.fn(async (_args: any) => {
+    mintMock: vi.fn(async (_payload: MintPayload) => {
       callOrder.push("createIntent");
       return { client_secret: "pi_minted_host_secret_xyz" };
     }),
@@ -33,13 +54,13 @@ const h = vi.hoisted(() => {
 vi.mock("@stripe/react-stripe-js", async () => {
   const React = await import("react");
   return {
-    Elements: ({ options, children }: any) => {
+    Elements: ({ options, children }: { options: MockElementsOptions; children?: ReactNode }) => {
       h.elementsOptions.push(options);
       return React.createElement("div", { "data-testid": "elements" }, children);
     },
     useStripe: () => ({ confirmPayment: h.confirmPaymentMock }),
     useElements: () => ({ submit: h.submitMock }),
-    PaymentElement: ({ onReady }: any) => {
+    PaymentElement: ({ onReady }: { onReady?: () => void }) => {
       React.useEffect(() => {
         onReady?.();
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -162,8 +183,8 @@ describe("HostingCardCheckout (deferred intent)", () => {
     await clickPay();
 
     await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
-    expect((h.mintMock.mock.calls[0][0] as any).hosting_target).toBeUndefined();
-    expect((h.mintMock.mock.calls[0][0] as any).sku).toBe("200hosting");
+    expect(h.mintMock.mock.calls[0][0].hosting_target).toBeUndefined();
+    expect(h.mintMock.mock.calls[0][0].sku).toBe("200hosting");
   });
 
   it("keeps the form mounted with a friendly message when the mint fails", async () => {
@@ -206,7 +227,7 @@ describe("HostingCardCheckout (deferred intent)", () => {
     await clickPay();
     await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(3));
 
-    const payloads = h.mintMock.mock.calls.map((call) => call[0] as any);
+    const payloads = h.mintMock.mock.calls.map((call) => call[0]);
     expect(payloads[1].nonce).toBe(payloads[0].nonce);
     expect(payloads[2].nonce).not.toBe(payloads[1].nonce);
     expect(payloads[2].hosting_target).toBe("hive-999999");

--- a/apps/web/src/specs/features/hosting-signup/hosting-card-checkout.spec.tsx
+++ b/apps/web/src/specs/features/hosting-signup/hosting-card-checkout.spec.tsx
@@ -1,8 +1,18 @@
 import { HostingCardCheckout } from "@/features/hosting-signup/hosting-card-checkout";
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// A promise resolvable from the test body, to hold the confirm in flight while the
+// submitting lock is asserted.
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 // Shapes the mocks exchange with the component under test; typed so the assertions on
 // mock.calls stay checked instead of being cast through any.
@@ -103,12 +113,14 @@ describe("HostingCardCheckout (deferred intent)", () => {
     hostingTarget?: string;
     onActivated?: () => void;
     onConfirmed?: () => void;
+    onSubmittingChange?: (submitting: boolean) => void;
   }
 
   const checkout = ({
     hostingTarget,
     onActivated = vi.fn(),
-    onConfirmed = vi.fn()
+    onConfirmed = vi.fn(),
+    onSubmittingChange
   }: Overrides = {}) => (
     <HostingCardCheckout
       username="alice"
@@ -118,6 +130,7 @@ describe("HostingCardCheckout (deferred intent)", () => {
       returnUrl="https://ecency.com/hosting"
       onActivated={onActivated}
       onConfirmed={onConfirmed}
+      onSubmittingChange={onSubmittingChange}
     />
   );
 
@@ -231,6 +244,32 @@ describe("HostingCardCheckout (deferred intent)", () => {
     expect(payloads[1].nonce).toBe(payloads[0].nonce);
     expect(payloads[2].nonce).not.toBe(payloads[1].nonce);
     expect(payloads[2].hosting_target).toBe("hive-999999");
+    expect(h.statusMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards onSubmittingChange: true while the confirm is pending, false after a decline", async () => {
+    const confirmGate = deferred<MockConfirmResult>();
+    h.confirmPaymentMock.mockImplementation(() => {
+      h.callOrder.push("confirmPayment");
+      return confirmGate.promise;
+    });
+    const onSubmittingChange = vi.fn();
+    render(checkout({ onSubmittingChange }));
+
+    await clickPay();
+
+    // While the confirm is in flight the parent has been told to lock the term, add-on
+    // and method controls: a change now would remount the keyed checkout under a charge
+    // that can still complete server side.
+    await waitFor(() => expect(h.confirmPaymentMock).toHaveBeenCalledTimes(1));
+    expect(onSubmittingChange).toHaveBeenCalledWith(true);
+    expect(onSubmittingChange).not.toHaveBeenCalledWith(false);
+
+    // A decline settles the submit: the parent unlocks so the buyer can edit and retry.
+    await act(async () => {
+      confirmGate.resolve({ error: { message: "stripe-decline-message" } });
+    });
+    await waitFor(() => expect(onSubmittingChange).toHaveBeenLastCalledWith(false));
     expect(h.statusMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/specs/features/points-gift/gift-card-checkout.spec.tsx
+++ b/apps/web/src/specs/features/points-gift/gift-card-checkout.spec.tsx
@@ -1,8 +1,18 @@
 import { GiftCardCheckout } from "@/features/points-gift/gift-card-checkout";
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// A promise resolvable from the test body, to hold the confirm in flight while the
+// submitting lock is asserted.
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 // Shapes the mocks exchange with the component under test; typed so the assertions on
 // mock.calls stay checked instead of being cast through any.
@@ -105,13 +115,15 @@ describe("GiftCardCheckout (deferred intent)", () => {
     message?: string;
     onDelivered?: () => void;
     onConfirmed?: () => void;
+    onSubmittingChange?: (submitting: boolean) => void;
   }
 
   const checkout = ({
     recipient = "friend-a",
     message = "happy birthday",
     onDelivered = vi.fn(),
-    onConfirmed = vi.fn()
+    onConfirmed = vi.fn(),
+    onSubmittingChange
   }: Overrides = {}) => (
     <GiftCardCheckout
       username="alice"
@@ -122,6 +134,7 @@ describe("GiftCardCheckout (deferred intent)", () => {
       returnUrl="https://ecency.com/points-gift"
       onDelivered={onDelivered}
       onConfirmed={onConfirmed}
+      onSubmittingChange={onSubmittingChange}
     />
   );
 
@@ -244,6 +257,32 @@ describe("GiftCardCheckout (deferred intent)", () => {
     expect(payloads[3].nonce).not.toBe(payloads[2].nonce);
     expect(payloads[3].gift_recipient).toBe("friend-b");
     expect(payloads[3].gift_message).toBe("happy new year");
+    expect(h.statusMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards onSubmittingChange: true while the confirm is pending, false after a decline", async () => {
+    const confirmGate = deferred<MockConfirmResult>();
+    h.confirmPaymentMock.mockImplementation(() => {
+      h.callOrder.push("confirmPayment");
+      return confirmGate.promise;
+    });
+    const onSubmittingChange = vi.fn();
+    render(checkout({ onSubmittingChange }));
+
+    await clickPay();
+
+    // While the confirm is in flight the parent has been told to lock the gift selection
+    // controls (recipient, message, pack): a change now would remount the keyed checkout
+    // under a charge that can still complete server side.
+    await waitFor(() => expect(h.confirmPaymentMock).toHaveBeenCalledTimes(1));
+    expect(onSubmittingChange).toHaveBeenCalledWith(true);
+    expect(onSubmittingChange).not.toHaveBeenCalledWith(false);
+
+    // A decline settles the submit: the parent unlocks so the buyer can edit and retry.
+    await act(async () => {
+      confirmGate.resolve({ error: { message: "stripe-decline-message" } });
+    });
+    await waitFor(() => expect(onSubmittingChange).toHaveBeenLastCalledWith(false));
     expect(h.statusMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/specs/features/points-gift/gift-card-checkout.spec.tsx
+++ b/apps/web/src/specs/features/points-gift/gift-card-checkout.spec.tsx
@@ -1,7 +1,29 @@
 import { GiftCardCheckout } from "@/features/points-gift/gift-card-checkout";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shapes the mocks exchange with the component under test; typed so the assertions on
+// mock.calls stay checked instead of being cast through any.
+interface MockElementsOptions {
+  mode?: string;
+  amount?: number;
+  currency?: string;
+  clientSecret?: string;
+}
+
+interface MintPayload {
+  sku: string;
+  nonce: string;
+  gift_recipient?: string;
+  gift_message?: string;
+}
+
+interface MockConfirmResult {
+  paymentIntent?: { id: string; status: string };
+  error?: { message: string };
+}
 
 // Shared stubs, hoisted so the vi.mock factories (which run before top-level consts
 // initialize) can reference them. callOrder pins the deferred sequence: validate the
@@ -10,7 +32,7 @@ const h = vi.hoisted(() => {
   const callOrder: string[] = [];
   return {
     callOrder,
-    elementsOptions: [] as any[],
+    elementsOptions: [] as MockElementsOptions[],
     submitMock: vi.fn(async () => {
       callOrder.push("elements.submit");
       return {};
@@ -18,11 +40,11 @@ const h = vi.hoisted(() => {
     // The confirmed intent id is DELIBERATELY different from the minted secret's prefix:
     // the delivery poll must use the id handed to onPaid (from the confirm result), never
     // one derived from state captured at render.
-    confirmPaymentMock: vi.fn(async (_args: any) => {
+    confirmPaymentMock: vi.fn(async (): Promise<MockConfirmResult> => {
       callOrder.push("confirmPayment");
       return { paymentIntent: { id: "pi_confirmed_777", status: "succeeded" } };
     }),
-    mintMock: vi.fn(async (_args: any) => {
+    mintMock: vi.fn(async (_payload: MintPayload) => {
       callOrder.push("createIntent");
       return { client_secret: "pi_minted_abc_secret_xyz" };
     }),
@@ -33,13 +55,13 @@ const h = vi.hoisted(() => {
 vi.mock("@stripe/react-stripe-js", async () => {
   const React = await import("react");
   return {
-    Elements: ({ options, children }: any) => {
+    Elements: ({ options, children }: { options: MockElementsOptions; children?: ReactNode }) => {
       h.elementsOptions.push(options);
       return React.createElement("div", { "data-testid": "elements" }, children);
     },
     useStripe: () => ({ confirmPayment: h.confirmPaymentMock }),
     useElements: () => ({ submit: h.submitMock }),
-    PaymentElement: ({ onReady }: any) => {
+    PaymentElement: ({ onReady }: { onReady?: () => void }) => {
       React.useEffect(() => {
         onReady?.();
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -166,8 +188,8 @@ describe("GiftCardCheckout (deferred intent)", () => {
     await clickPay();
 
     await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
-    expect((h.mintMock.mock.calls[0][0] as any).gift_message).toBeUndefined();
-    expect((h.mintMock.mock.calls[0][0] as any).gift_recipient).toBe("friend-a");
+    expect(h.mintMock.mock.calls[0][0].gift_message).toBeUndefined();
+    expect(h.mintMock.mock.calls[0][0].gift_recipient).toBe("friend-a");
   });
 
   it("keeps the form mounted with a friendly message when the mint fails", async () => {
@@ -216,7 +238,7 @@ describe("GiftCardCheckout (deferred intent)", () => {
     await clickPay();
     await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(4));
 
-    const payloads = h.mintMock.mock.calls.map((call) => call[0] as any);
+    const payloads = h.mintMock.mock.calls.map((call) => call[0]);
     expect(payloads[1].nonce).toBe(payloads[0].nonce);
     expect(payloads[2].nonce).not.toBe(payloads[1].nonce);
     expect(payloads[3].nonce).not.toBe(payloads[2].nonce);

--- a/apps/web/src/specs/features/points-gift/gift-card-checkout.spec.tsx
+++ b/apps/web/src/specs/features/points-gift/gift-card-checkout.spec.tsx
@@ -1,0 +1,227 @@
+import { GiftCardCheckout } from "@/features/points-gift/gift-card-checkout";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shared stubs, hoisted so the vi.mock factories (which run before top-level consts
+// initialize) can reference them. callOrder pins the deferred sequence: validate the
+// Payment Element FIRST, mint the intent second, confirm third.
+const h = vi.hoisted(() => {
+  const callOrder: string[] = [];
+  return {
+    callOrder,
+    elementsOptions: [] as any[],
+    submitMock: vi.fn(async () => {
+      callOrder.push("elements.submit");
+      return {};
+    }),
+    // The confirmed intent id is DELIBERATELY different from the minted secret's prefix:
+    // the delivery poll must use the id handed to onPaid (from the confirm result), never
+    // one derived from state captured at render.
+    confirmPaymentMock: vi.fn(async (_args: any) => {
+      callOrder.push("confirmPayment");
+      return { paymentIntent: { id: "pi_confirmed_777", status: "succeeded" } };
+    }),
+    mintMock: vi.fn(async (_args: any) => {
+      callOrder.push("createIntent");
+      return { client_secret: "pi_minted_abc_secret_xyz" };
+    }),
+    statusMock: vi.fn(async (_username: string, _intentId: string) => ({ status: "success" }))
+  };
+});
+
+vi.mock("@stripe/react-stripe-js", async () => {
+  const React = await import("react");
+  return {
+    Elements: ({ options, children }: any) => {
+      h.elementsOptions.push(options);
+      return React.createElement("div", { "data-testid": "elements" }, children);
+    },
+    useStripe: () => ({ confirmPayment: h.confirmPaymentMock }),
+    useElements: () => ({ submit: h.submitMock }),
+    PaymentElement: ({ onReady }: any) => {
+      React.useEffect(() => {
+        onReady?.();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return React.createElement("div", { "data-testid": "payment-element" });
+    }
+  };
+});
+
+// The barrel hands GiftCardCheckout getStripePromise + skuUsdCents; keep the real tier
+// helpers (skuUsdCents drives the Elements amount) and stub only the Stripe.js loader.
+vi.mock("@/features/shared/purchase-stripe", async () => ({
+  ...(await vi.importActual<Record<string, unknown>>(
+    "@/features/shared/purchase-stripe/stripe-tiers"
+  )),
+  getStripePromise: () => Promise.resolve({})
+}));
+
+vi.mock("@/features/shared/purchase-stripe/use-stripe-points-purchase", () => ({
+  useCreateStripeIntent: () => ({ mutateAsync: h.mintMock, isPending: false }),
+  fetchStripeOrderStatus: h.statusMock
+}));
+
+describe("GiftCardCheckout (deferred intent)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.callOrder.length = 0;
+    h.elementsOptions.length = 0;
+    h.mintMock.mockImplementation(async () => {
+      h.callOrder.push("createIntent");
+      return { client_secret: "pi_minted_abc_secret_xyz" };
+    });
+    h.confirmPaymentMock.mockImplementation(async () => {
+      h.callOrder.push("confirmPayment");
+      return { paymentIntent: { id: "pi_confirmed_777", status: "succeeded" } };
+    });
+  });
+
+  interface Overrides {
+    recipient?: string;
+    message?: string;
+    onDelivered?: () => void;
+    onConfirmed?: () => void;
+  }
+
+  const checkout = ({
+    recipient = "friend-a",
+    message = "happy birthday",
+    onDelivered = vi.fn(),
+    onConfirmed = vi.fn()
+  }: Overrides = {}) => (
+    <GiftCardCheckout
+      username="alice"
+      sku="999points"
+      recipient={recipient}
+      message={message}
+      payLabel="points-gift.pay"
+      returnUrl="https://ecency.com/points-gift"
+      onDelivered={onDelivered}
+      onConfirmed={onConfirmed}
+    />
+  );
+
+  const clickPay = async () => {
+    const payButton = await screen.findByRole("button", { name: "points-gift.pay" });
+    await waitFor(() => expect(payButton).not.toBeDisabled());
+    fireEvent.click(payButton);
+  };
+
+  it("renders the payment form in deferred mode without creating an intent", async () => {
+    render(checkout());
+    // Opening the gift checkout must not mint: the production ratio of abandoned to paid
+    // intents came from the old mint-on-mount effect.
+    expect(h.mintMock).not.toHaveBeenCalled();
+    await screen.findByTestId("payment-element");
+    expect(h.mintMock).not.toHaveBeenCalled();
+    expect(h.confirmPaymentMock).not.toHaveBeenCalled();
+    expect(h.elementsOptions[0]).toMatchObject({
+      mode: "payment",
+      amount: 999,
+      currency: "usd"
+    });
+    expect(h.elementsOptions[0].clientSecret).toBeUndefined();
+  });
+
+  it("on Pay: mints with the gift fields, confirms with the minted secret and polls with the confirmed id", async () => {
+    const onDelivered = vi.fn();
+    const onConfirmed = vi.fn();
+    render(checkout({ message: " happy birthday ", onDelivered, onConfirmed }));
+
+    await clickPay();
+
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
+    // The mint carries the CURRENT gift fields (message trimmed) so ePoints credits the
+    // recipient, not the payer.
+    expect(h.mintMock).toHaveBeenCalledWith({
+      sku: "999points",
+      nonce: expect.any(String),
+      gift_recipient: "friend-a",
+      gift_message: "happy birthday"
+    });
+
+    await waitFor(() => expect(h.confirmPaymentMock).toHaveBeenCalledTimes(1));
+    // elements.submit ran BEFORE the intent was minted and the confirm used the fresh secret.
+    expect(h.callOrder).toEqual(["elements.submit", "createIntent", "confirmPayment"]);
+    expect(h.confirmPaymentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientSecret: "pi_minted_abc_secret_xyz",
+        redirect: "if_required"
+      })
+    );
+
+    // The delivery poll queries with the CONFIRMED intent id from onPaid, not anything
+    // derived from render-time state (which is empty under deferred minting).
+    await waitFor(() => expect(h.statusMock).toHaveBeenCalledWith("alice", "pi_confirmed_777"));
+    await waitFor(() => expect(onDelivered).toHaveBeenCalledTimes(1));
+    // onConfirmed fired when the poll started, so the parent locked the form before delivery.
+    expect(onConfirmed).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends no gift_message when the message is whitespace only", async () => {
+    render(checkout({ message: "   " }));
+
+    await clickPay();
+
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
+    expect((h.mintMock.mock.calls[0][0] as any).gift_message).toBeUndefined();
+    expect((h.mintMock.mock.calls[0][0] as any).gift_recipient).toBe("friend-a");
+  });
+
+  it("keeps the form mounted with a friendly message when the mint fails", async () => {
+    h.mintMock.mockImplementation(async () => {
+      h.callOrder.push("createIntent");
+      throw new Error("Request failed with status code 500");
+    });
+    render(checkout());
+
+    await clickPay();
+
+    await screen.findByText("stripe-points.create-failed");
+    // The raw axios message never surfaces and the form stays mounted for a retry.
+    expect(screen.queryByText("Request failed with status code 500")).not.toBeInTheDocument();
+    expect(screen.getByTestId("payment-element")).toBeInTheDocument();
+    expect(h.confirmPaymentMock).not.toHaveBeenCalled();
+    expect(h.statusMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the nonce across a same-gift retry and regenerates it when recipient or message changes", async () => {
+    // Every confirm declines so the form stays mounted for the next Pay. This mirrors the
+    // real hazard: pay for A, decline, edit the gift, pay again. The server idempotency
+    // key is user:sku:nonce, so an edited gift MUST carry a fresh nonce (otherwise the
+    // mint replays the previous intent with the previous gift metadata) while an
+    // unchanged retry MUST reuse the nonce (so the retry stays idempotent).
+    h.confirmPaymentMock.mockImplementation(async () => {
+      h.callOrder.push("confirmPayment");
+      return { error: { message: "stripe-decline-message" } };
+    });
+    const { rerender } = render(checkout());
+
+    await clickPay();
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
+
+    // Retry with the SAME sku, recipient and message: the nonce must not change.
+    await clickPay();
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(2));
+
+    // Edit only the message: fresh nonce.
+    rerender(checkout({ message: "happy new year" }));
+    await clickPay();
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(3));
+
+    // Edit only the recipient: fresh nonce again and the payload follows the edit.
+    rerender(checkout({ recipient: "friend-b", message: "happy new year" }));
+    await clickPay();
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(4));
+
+    const payloads = h.mintMock.mock.calls.map((call) => call[0] as any);
+    expect(payloads[1].nonce).toBe(payloads[0].nonce);
+    expect(payloads[2].nonce).not.toBe(payloads[1].nonce);
+    expect(payloads[3].nonce).not.toBe(payloads[2].nonce);
+    expect(payloads[3].gift_recipient).toBe("friend-b");
+    expect(payloads[3].gift_message).toBe("happy new year");
+    expect(h.statusMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/specs/features/pro/pro-checkout.spec.tsx
+++ b/apps/web/src/specs/features/pro/pro-checkout.spec.tsx
@@ -1,7 +1,27 @@
 import { ProCheckout } from "@/features/pro/pro-checkout";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shapes the mocks exchange with the component under test; typed so the assertions on
+// mock.calls stay checked instead of being cast through any.
+interface MockElementsOptions {
+  mode?: string;
+  amount?: number;
+  currency?: string;
+  clientSecret?: string;
+}
+
+interface MintPayload {
+  sku: string;
+  nonce: string;
+}
+
+interface MockConfirmResult {
+  paymentIntent?: { id: string; status: string };
+  error?: { message: string };
+}
 
 // Shared stubs, hoisted so the vi.mock factories (which run before top-level consts
 // initialize) can reference them. callOrder pins the deferred sequence: validate the
@@ -10,7 +30,7 @@ const h = vi.hoisted(() => {
   const callOrder: string[] = [];
   return {
     callOrder,
-    elementsOptions: [] as any[],
+    elementsOptions: [] as MockElementsOptions[],
     submitMock: vi.fn(async () => {
       callOrder.push("elements.submit");
       return {};
@@ -18,11 +38,11 @@ const h = vi.hoisted(() => {
     // The confirmed intent id is DELIBERATELY different from the minted secret's prefix:
     // the delivery poll must use the id handed to onPaid (from the confirm result), never
     // one derived from state captured at render.
-    confirmPaymentMock: vi.fn(async (_args: any) => {
+    confirmPaymentMock: vi.fn(async (): Promise<MockConfirmResult> => {
       callOrder.push("confirmPayment");
       return { paymentIntent: { id: "pi_confirmed_777", status: "succeeded" } };
     }),
-    mintMock: vi.fn(async (_args: any) => {
+    mintMock: vi.fn(async (_payload: MintPayload) => {
       callOrder.push("createIntent");
       return { client_secret: "pi_minted_abc_secret_xyz" };
     }),
@@ -33,13 +53,13 @@ const h = vi.hoisted(() => {
 vi.mock("@stripe/react-stripe-js", async () => {
   const React = await import("react");
   return {
-    Elements: ({ options, children }: any) => {
+    Elements: ({ options, children }: { options: MockElementsOptions; children?: ReactNode }) => {
       h.elementsOptions.push(options);
       return React.createElement("div", { "data-testid": "elements" }, children);
     },
     useStripe: () => ({ confirmPayment: h.confirmPaymentMock }),
     useElements: () => ({ submit: h.submitMock }),
-    PaymentElement: ({ onReady }: any) => {
+    PaymentElement: ({ onReady }: { onReady?: () => void }) => {
       React.useEffect(() => {
         onReady?.();
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -115,7 +135,7 @@ describe("ProCheckout (deferred intent)", () => {
 
     await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
     expect(h.mintMock).toHaveBeenCalledWith({ sku: "1999pro", nonce: expect.any(String) });
-    expect((h.mintMock.mock.calls[0][0] as any).nonce.length).toBeGreaterThan(0);
+    expect(h.mintMock.mock.calls[0][0].nonce.length).toBeGreaterThan(0);
 
     await waitFor(() => expect(h.confirmPaymentMock).toHaveBeenCalledTimes(1));
     // elements.submit ran BEFORE the intent was minted, and the confirm used the fresh secret.

--- a/apps/web/src/specs/features/pro/pro-checkout.spec.tsx
+++ b/apps/web/src/specs/features/pro/pro-checkout.spec.tsx
@@ -1,0 +1,154 @@
+import { ProCheckout } from "@/features/pro/pro-checkout";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shared stubs, hoisted so the vi.mock factories (which run before top-level consts
+// initialize) can reference them. callOrder pins the deferred sequence: validate the
+// Payment Element FIRST, mint the intent second, confirm third.
+const h = vi.hoisted(() => {
+  const callOrder: string[] = [];
+  return {
+    callOrder,
+    elementsOptions: [] as any[],
+    submitMock: vi.fn(async () => {
+      callOrder.push("elements.submit");
+      return {};
+    }),
+    // The confirmed intent id is DELIBERATELY different from the minted secret's prefix:
+    // the delivery poll must use the id handed to onPaid (from the confirm result), never
+    // one derived from state captured at render.
+    confirmPaymentMock: vi.fn(async (_args: any) => {
+      callOrder.push("confirmPayment");
+      return { paymentIntent: { id: "pi_confirmed_777", status: "succeeded" } };
+    }),
+    mintMock: vi.fn(async (_args: any) => {
+      callOrder.push("createIntent");
+      return { client_secret: "pi_minted_abc_secret_xyz" };
+    }),
+    statusMock: vi.fn(async (_username: string, _intentId: string) => ({ status: "success" }))
+  };
+});
+
+vi.mock("@stripe/react-stripe-js", async () => {
+  const React = await import("react");
+  return {
+    Elements: ({ options, children }: any) => {
+      h.elementsOptions.push(options);
+      return React.createElement("div", { "data-testid": "elements" }, children);
+    },
+    useStripe: () => ({ confirmPayment: h.confirmPaymentMock }),
+    useElements: () => ({ submit: h.submitMock }),
+    PaymentElement: ({ onReady }: any) => {
+      React.useEffect(() => {
+        onReady?.();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return React.createElement("div", { "data-testid": "payment-element" });
+    }
+  };
+});
+
+// The barrel hands ProCheckout getStripePromise + skuUsdCents; keep the real tier helpers
+// (skuUsdCents drives the Elements amount) and stub only the Stripe.js loader.
+vi.mock("@/features/shared/purchase-stripe", async () => ({
+  ...(await vi.importActual<Record<string, unknown>>(
+    "@/features/shared/purchase-stripe/stripe-tiers"
+  )),
+  getStripePromise: () => Promise.resolve({})
+}));
+
+vi.mock("@/features/shared/purchase-stripe/use-stripe-points-purchase", () => ({
+  useCreateStripeIntent: () => ({ mutateAsync: h.mintMock, isPending: false }),
+  fetchStripeOrderStatus: h.statusMock
+}));
+
+describe("ProCheckout (deferred intent)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.callOrder.length = 0;
+    h.elementsOptions.length = 0;
+    h.mintMock.mockImplementation(async () => {
+      h.callOrder.push("createIntent");
+      return { client_secret: "pi_minted_abc_secret_xyz" };
+    });
+  });
+
+  const renderCheckout = (onActivated = vi.fn()) => {
+    render(
+      <ProCheckout
+        username="alice"
+        returnUrl="https://ecency.com/perks?pro=1"
+        onActivated={onActivated}
+      />
+    );
+    return onActivated;
+  };
+
+  it("renders the payment form without creating an intent", async () => {
+    renderCheckout();
+    // Opening the checkout must not mint: the production ratio of abandoned to paid
+    // intents came from the old mint-on-mount effect.
+    expect(h.mintMock).not.toHaveBeenCalled();
+    await screen.findByTestId("payment-element");
+    expect(h.mintMock).not.toHaveBeenCalled();
+    expect(h.confirmPaymentMock).not.toHaveBeenCalled();
+  });
+
+  it("initializes Elements in deferred mode with the Pro price in cents", async () => {
+    renderCheckout();
+    await screen.findByTestId("elements");
+    expect(h.elementsOptions[0]).toMatchObject({
+      mode: "payment",
+      amount: 1999,
+      currency: "usd"
+    });
+    expect(h.elementsOptions[0].clientSecret).toBeUndefined();
+  });
+
+  it("on Pay: validates the element, mints, confirms with the minted secret and polls with the confirmed id", async () => {
+    const onActivated = renderCheckout();
+
+    const payButton = await screen.findByRole("button", { name: "pro.pay-now" });
+    await waitFor(() => expect(payButton).not.toBeDisabled());
+    fireEvent.click(payButton);
+
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
+    expect(h.mintMock).toHaveBeenCalledWith({ sku: "1999pro", nonce: expect.any(String) });
+    expect((h.mintMock.mock.calls[0][0] as any).nonce.length).toBeGreaterThan(0);
+
+    await waitFor(() => expect(h.confirmPaymentMock).toHaveBeenCalledTimes(1));
+    // elements.submit ran BEFORE the intent was minted, and the confirm used the fresh secret.
+    expect(h.callOrder).toEqual(["elements.submit", "createIntent", "confirmPayment"]);
+    expect(h.confirmPaymentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientSecret: "pi_minted_abc_secret_xyz",
+        redirect: "if_required"
+      })
+    );
+
+    // The delivery poll queries with the CONFIRMED intent id from onPaid, not anything
+    // derived from render-time state (which is empty under deferred minting).
+    await waitFor(() => expect(h.statusMock).toHaveBeenCalledWith("alice", "pi_confirmed_777"));
+    await waitFor(() => expect(onActivated).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the form mounted with a friendly message when the mint fails", async () => {
+    h.mintMock.mockImplementation(async () => {
+      h.callOrder.push("createIntent");
+      throw new Error("Request failed with status code 500");
+    });
+    renderCheckout();
+
+    const payButton = await screen.findByRole("button", { name: "pro.pay-now" });
+    await waitFor(() => expect(payButton).not.toBeDisabled());
+    fireEvent.click(payButton);
+
+    await screen.findByText("stripe-points.create-failed");
+    // The raw axios message never surfaces and the form stays mounted for a retry.
+    expect(screen.queryByText("Request failed with status code 500")).not.toBeInTheDocument();
+    expect(screen.getByTestId("payment-element")).toBeInTheDocument();
+    expect(h.confirmPaymentMock).not.toHaveBeenCalled();
+    expect(h.statusMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/specs/features/purchase-stripe/stripe-checkout-form.spec.tsx
+++ b/apps/web/src/specs/features/purchase-stripe/stripe-checkout-form.spec.tsx
@@ -59,11 +59,13 @@ describe("StripeCheckoutForm (unmount during the Pay handler)", () => {
   const renderForm = ({
     createIntent = vi.fn(async () => "pi_minted_123_secret_x"),
     onPaid = vi.fn(),
-    onError = vi.fn()
+    onError = vi.fn(),
+    onSubmittingChange
   }: {
     createIntent?: () => Promise<string>;
     onPaid?: (paymentIntentId: string) => void;
     onError?: (message: string) => void;
+    onSubmittingChange?: (submitting: boolean) => void;
   } = {}) => {
     const view = render(
       <StripeCheckoutForm
@@ -72,6 +74,7 @@ describe("StripeCheckoutForm (unmount during the Pay handler)", () => {
         createIntent={createIntent}
         onPaid={onPaid}
         onError={onError}
+        onSubmittingChange={onSubmittingChange}
       />
     );
     return { ...view, createIntent, onPaid, onError };
@@ -125,7 +128,7 @@ describe("StripeCheckoutForm (unmount during the Pay handler)", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
-  it("drops the confirm result when the form unmounts while confirmPayment is in flight", async () => {
+  it("still calls onPaid with the confirmed intent id when the form unmounts mid-confirm", async () => {
     const confirmGate = deferred<MockConfirmResult>();
     h.confirmPaymentMock.mockImplementation(() => confirmGate.promise);
     const { unmount, onPaid, onError } = renderForm();
@@ -138,9 +141,44 @@ describe("StripeCheckoutForm (unmount during the Pay handler)", () => {
       confirmGate.resolve({ paymentIntent: { id: "pi_confirmed_123", status: "succeeded" } });
     });
 
-    // The dispatch itself cannot be aborted (Stripe owns that window), but the result
-    // must not drive a stale caller's state after the unmount.
-    expect(onPaid).not.toHaveBeenCalled();
+    // Once confirmPayment is dispatched the charge can complete server side; unmounting
+    // cannot cancel it. A confirm that resolves succeeded is a payment that HAPPENED, so
+    // it must always reach onPaid - a mounted bail here would silently discard a real
+    // charge and offer the buyer a fresh checkout to pay again. Only the cosmetic error
+    // path stays gated on mount.
+    expect(onPaid).toHaveBeenCalledTimes(1);
+    expect(onPaid).toHaveBeenCalledWith("pi_confirmed_123");
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("reports submitting true on Pay and false after a decline", async () => {
+    const onSubmittingChange = vi.fn();
+    h.confirmPaymentMock.mockImplementation(async () => ({
+      error: { message: "Your card was declined." }
+    }));
+    const { onError } = renderForm({ onSubmittingChange });
+
+    await clickPay();
+
+    // The parent locked its controls for the whole submit-mint-confirm window and
+    // unlocked them once the decline settled, so the buyer can edit and retry.
+    await waitFor(() => expect(onError).toHaveBeenCalledWith("Your card was declined."));
+    await waitFor(() => expect(onSubmittingChange).toHaveBeenLastCalledWith(false));
+    expect(onSubmittingChange.mock.calls).toEqual([[true], [false]]);
+  });
+
+  it("reports submitting false after a mint failure", async () => {
+    const onSubmittingChange = vi.fn();
+    const createIntent = vi.fn(async (): Promise<string> => {
+      throw new Error("Request failed with status code 500");
+    });
+    const { onError } = renderForm({ createIntent, onSubmittingChange });
+
+    await clickPay();
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith("stripe-points.create-failed"));
+    await waitFor(() => expect(onSubmittingChange).toHaveBeenLastCalledWith(false));
+    expect(onSubmittingChange.mock.calls).toEqual([[true], [false]]);
+    expect(h.confirmPaymentMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/specs/features/purchase-stripe/stripe-checkout-form.spec.tsx
+++ b/apps/web/src/specs/features/purchase-stripe/stripe-checkout-form.spec.tsx
@@ -1,0 +1,146 @@
+import { StripeCheckoutForm } from "@/features/shared/purchase-stripe/stripe-checkout-form";
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// A promise resolvable from the test body, to freeze the async Pay handler at a chosen
+// await and unmount the form underneath it.
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+interface MockConfirmResult {
+  paymentIntent?: { id: string; status: string };
+  error?: { message: string };
+}
+
+type SubmitResult = { error?: { message?: string } };
+
+// Shared stubs, hoisted so the vi.mock factory can reference them.
+const h = vi.hoisted(() => ({
+  submitMock: vi.fn(async (): Promise<SubmitResult> => ({})),
+  confirmPaymentMock: vi.fn(
+    async (): Promise<MockConfirmResult> => ({
+      paymentIntent: { id: "pi_confirmed_123", status: "succeeded" }
+    })
+  )
+}));
+
+vi.mock("@stripe/react-stripe-js", async () => {
+  const React = await import("react");
+  return {
+    useStripe: () => ({ confirmPayment: h.confirmPaymentMock }),
+    useElements: () => ({ submit: h.submitMock }),
+    PaymentElement: ({ onReady }: { onReady?: () => void }) => {
+      React.useEffect(() => {
+        onReady?.();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return React.createElement("div", { "data-testid": "payment-element" });
+    }
+  };
+});
+
+describe("StripeCheckoutForm (unmount during the Pay handler)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Re-pin implementations: clearAllMocks resets calls but a per-test
+    // mockImplementation would otherwise leak into the next test.
+    h.submitMock.mockImplementation(async () => ({}));
+    h.confirmPaymentMock.mockImplementation(async () => ({
+      paymentIntent: { id: "pi_confirmed_123", status: "succeeded" }
+    }));
+  });
+
+  const renderForm = ({
+    createIntent = vi.fn(async () => "pi_minted_123_secret_x"),
+    onPaid = vi.fn(),
+    onError = vi.fn()
+  }: {
+    createIntent?: () => Promise<string>;
+    onPaid?: (paymentIntentId: string) => void;
+    onError?: (message: string) => void;
+  } = {}) => {
+    const view = render(
+      <StripeCheckoutForm
+        returnUrl="https://ecency.com/perks"
+        payLabel="pay"
+        createIntent={createIntent}
+        onPaid={onPaid}
+        onError={onError}
+      />
+    );
+    return { ...view, createIntent, onPaid, onError };
+  };
+
+  const clickPay = async () => {
+    const payButton = await screen.findByRole("button", { name: "pay" });
+    await waitFor(() => expect(payButton).not.toBeDisabled());
+    fireEvent.click(payButton);
+  };
+
+  it("does not mint when the form unmounts while elements.submit is in flight", async () => {
+    // A still-enabled selection change remounts the keyed checkout; the OLD handler's
+    // submit resolves after the unmount and must not mint an intent for the discarded
+    // selection.
+    const submitGate = deferred<SubmitResult>();
+    h.submitMock.mockImplementation(() => submitGate.promise);
+    const { unmount, createIntent, onPaid, onError } = renderForm();
+
+    await clickPay();
+    await waitFor(() => expect(h.submitMock).toHaveBeenCalledTimes(1));
+    unmount();
+
+    await act(async () => {
+      submitGate.resolve({});
+    });
+
+    expect(createIntent).not.toHaveBeenCalled();
+    expect(h.confirmPaymentMock).not.toHaveBeenCalled();
+    expect(onPaid).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does not confirm when the form unmounts while createIntent is in flight", async () => {
+    const mintGate = deferred<string>();
+    const createIntent = vi.fn(() => mintGate.promise);
+    const { unmount, onPaid, onError } = renderForm({ createIntent });
+
+    await clickPay();
+    await waitFor(() => expect(createIntent).toHaveBeenCalledTimes(1));
+    unmount();
+
+    await act(async () => {
+      mintGate.resolve("pi_discarded_secret_x");
+    });
+
+    // The minted intent for the discarded selection is never confirmed and no stale
+    // callback fires into the replaced checkout.
+    expect(h.confirmPaymentMock).not.toHaveBeenCalled();
+    expect(onPaid).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("drops the confirm result when the form unmounts while confirmPayment is in flight", async () => {
+    const confirmGate = deferred<MockConfirmResult>();
+    h.confirmPaymentMock.mockImplementation(() => confirmGate.promise);
+    const { unmount, onPaid, onError } = renderForm();
+
+    await clickPay();
+    await waitFor(() => expect(h.confirmPaymentMock).toHaveBeenCalledTimes(1));
+    unmount();
+
+    await act(async () => {
+      confirmGate.resolve({ paymentIntent: { id: "pi_confirmed_123", status: "succeeded" } });
+    });
+
+    // The dispatch itself cannot be aborted (Stripe owns that window), but the result
+    // must not drive a stale caller's state after the unmount.
+    expect(onPaid).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/specs/features/purchase-stripe/stripe-config.spec.ts
+++ b/apps/web/src/specs/features/purchase-stripe/stripe-config.spec.ts
@@ -1,5 +1,13 @@
 import {
+  HOSTING_CUSTOM_DOMAIN_MONTHLY_USD,
+  HOSTING_MONTHLY_USD,
+  hostingProSkuForMonths,
+  hostingSkuForMonths
+} from "@/features/hosting-signup/hosting-api";
+import { PRO_PRICE_USD, PRO_SKU } from "@/features/pro/pro-config";
+import {
   DEFAULT_STRIPE_TIER_SKU,
+  skuUsdCents,
   STRIPE_POINTS_TIERS
 } from "@/features/shared/purchase-stripe/stripe-config";
 import { describe, expect, it } from "vitest";
@@ -33,5 +41,39 @@ describe("stripe-config", () => {
 
   it("uses a default tier that exists in the catalog", () => {
     expect(STRIPE_POINTS_TIERS.some((t) => t.sku === DEFAULT_STRIPE_TIER_SKU)).toBe(true);
+  });
+});
+
+// The deferred Elements render prices from skuUsdCents BEFORE any intent exists, so this
+// derivation must stay in lockstep with the server product map on every rail: a drift
+// would show one price on the Payment Element and charge another.
+describe("skuUsdCents", () => {
+  it("matches the USD price in cents for every Points tier", () => {
+    STRIPE_POINTS_TIERS.forEach((t) => {
+      expect(skuUsdCents(t.sku)).toBe(Math.round(t.usd * 100));
+    });
+  });
+
+  it("matches the Pro price for the Pro SKU", () => {
+    expect(skuUsdCents(PRO_SKU)).toBe(Math.round(PRO_PRICE_USD * 100));
+  });
+
+  it("prices every hosting term from the SKU leading number", () => {
+    [1, 3, 6, 12].forEach((months) => {
+      const standard = hostingSkuForMonths(months);
+      expect(standard.endsWith("hosting")).toBe(true);
+      expect(skuUsdCents(standard)).toBe(HOSTING_MONTHLY_USD * 100 * months);
+
+      const custom = hostingProSkuForMonths(months);
+      expect(custom.endsWith("prohosting")).toBe(true);
+      expect(skuUsdCents(custom)).toBe(HOSTING_CUSTOM_DOMAIN_MONTHLY_USD * 100 * months);
+    });
+  });
+
+  it("returns 0 (unconfigured) for a SKU without a leading number", () => {
+    expect(skuUsdCents("")).toBe(0);
+    expect(skuUsdCents("points")).toBe(0);
+    expect(skuUsdCents("garbage")).toBe(0);
+    expect(skuUsdCents("-499points")).toBe(0);
   });
 });

--- a/apps/web/src/specs/features/purchase-stripe/stripe-points-dialog.spec.tsx
+++ b/apps/web/src/specs/features/purchase-stripe/stripe-points-dialog.spec.tsx
@@ -162,6 +162,39 @@ describe("StripePointsDialog (deferred intent)", () => {
     expect(payloads[1].nonce).toBe(payloads[0].nonce);
   });
 
+  it("keeps the form mounted after a decline and reuses the same intent on retry", async () => {
+    h.confirmPaymentMock.mockImplementationOnce(async () => ({
+      error: { message: "Your card was declined." }
+    }));
+    openDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "stripe-points.continue" }));
+    const payButton = await screen.findByRole("button", { name: "stripe-points.pay" });
+    await waitFor(() => expect(payButton).not.toBeDisabled());
+    fireEvent.click(payButton);
+
+    // The intent WAS minted, then the confirm was declined: Stripe's message renders
+    // above the still-mounted form instead of dead-ending on the terminal error step.
+    await screen.findByText("Your card was declined.");
+    expect(screen.getByTestId("payment-element")).toBeInTheDocument();
+    expect(screen.queryByText("stripe-points.try-again")).not.toBeInTheDocument();
+    expect(h.mintMock).toHaveBeenCalledTimes(1);
+
+    // Retry: the session nonce is unchanged, so the re-mint hits the same server
+    // idempotency key and returns the SAME intent instead of leaving another
+    // incomplete one behind; the second confirm then succeeds with that secret.
+    fireEvent.click(payButton);
+    await screen.findByText("stripe-points.delivering");
+    expect(h.confirmPaymentMock).toHaveBeenCalledTimes(2);
+    expect(h.confirmPaymentMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ clientSecret: "pi_minted_555_secret_abc" })
+    );
+    const payloads = h.mintMock.mock.calls.map((call) => call[0]);
+    expect(payloads).toHaveLength(2);
+    expect(payloads[1].nonce).toBe(payloads[0].nonce);
+    expect(screen.queryByText("Your card was declined.")).not.toBeInTheDocument();
+  });
+
   it("falls back to the default tier when defaultSku is unknown", async () => {
     openDialog("nope");
 

--- a/apps/web/src/specs/features/purchase-stripe/stripe-points-dialog.spec.tsx
+++ b/apps/web/src/specs/features/purchase-stripe/stripe-points-dialog.spec.tsx
@@ -1,0 +1,106 @@
+import { StripePointsDialog } from "@/features/shared/purchase-stripe/stripe-points-dialog";
+import { cleanupModalContainers, setupModalContainers } from "@/specs/test-utils";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shared stubs, hoisted so the vi.mock factories can reference them.
+const h = vi.hoisted(() => ({
+  elementsOptions: [] as any[],
+  submitMock: vi.fn(async () => ({})),
+  confirmPaymentMock: vi.fn(async (_args: any) => ({
+    paymentIntent: { id: "pi_confirmed_555", status: "succeeded" }
+  })),
+  mintMock: vi.fn(async (_args: any) => ({ client_secret: "pi_minted_555_secret_abc" })),
+  statusMock: vi.fn(async () => ({ status: "pending" }))
+}));
+
+vi.mock("@stripe/react-stripe-js", async () => {
+  const React = await import("react");
+  return {
+    Elements: ({ options, children }: any) => {
+      h.elementsOptions.push(options);
+      return React.createElement("div", { "data-testid": "elements" }, children);
+    },
+    useStripe: () => ({ confirmPayment: h.confirmPaymentMock }),
+    useElements: () => ({ submit: h.submitMock }),
+    PaymentElement: ({ onReady }: any) => {
+      React.useEffect(() => {
+        onReady?.();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return React.createElement("div", { "data-testid": "payment-element" });
+    }
+  };
+});
+
+// Keep the real tier catalog + skuUsdCents (they drive the Elements amount) and stub only
+// the Stripe.js loader so the pay step renders in jsdom.
+vi.mock("@/features/shared/purchase-stripe/stripe-config", async () => ({
+  ...(await vi.importActual<Record<string, unknown>>(
+    "@/features/shared/purchase-stripe/stripe-tiers"
+  )),
+  getStripePromise: () => Promise.resolve({})
+}));
+
+vi.mock("@/features/shared/purchase-stripe/use-stripe-points-purchase", () => ({
+  useCreateStripeIntent: () => ({ mutateAsync: h.mintMock, isPending: false }),
+  fetchStripeOrderStatus: h.statusMock
+}));
+
+describe("StripePointsDialog (deferred intent)", () => {
+  beforeEach(() => {
+    setupModalContainers();
+    vi.clearAllMocks();
+    h.elementsOptions.length = 0;
+  });
+
+  afterEach(() => {
+    cleanupModalContainers();
+  });
+
+  const openDialog = () => render(<StripePointsDialog show={true} setShow={vi.fn()} />);
+
+  it("advances to the pay step on Continue WITHOUT creating an intent", async () => {
+    openDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "stripe-points.continue" }));
+
+    await screen.findByTestId("payment-element");
+    // Browsing tiers and opening the payment form must not mint; the intent is created
+    // only on the Pay click.
+    expect(h.mintMock).not.toHaveBeenCalled();
+    expect(h.elementsOptions[0]).toMatchObject({
+      mode: "payment",
+      amount: 999,
+      currency: "usd"
+    });
+    expect(h.elementsOptions[0].clientSecret).toBeUndefined();
+  });
+
+  it("mints exactly once on Pay, with the selected sku and the session nonce", async () => {
+    openDialog();
+
+    // Select a non-default tier, then continue to the pay step.
+    fireEvent.click(screen.getByText("$4.99"));
+    fireEvent.click(screen.getByRole("button", { name: "stripe-points.continue" }));
+
+    const payButton = await screen.findByRole("button", { name: "stripe-points.pay" });
+    await waitFor(() => expect(payButton).not.toBeDisabled());
+    expect(h.mintMock).not.toHaveBeenCalled();
+
+    fireEvent.click(payButton);
+
+    await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
+    expect(h.mintMock).toHaveBeenCalledWith({ sku: "499points", nonce: expect.any(String) });
+    expect((h.mintMock.mock.calls[0][0] as any).nonce.length).toBeGreaterThan(0);
+
+    // The confirm used the freshly minted secret, and the dialog moved on to delivery.
+    await waitFor(() => expect(h.confirmPaymentMock).toHaveBeenCalledTimes(1));
+    expect(h.confirmPaymentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ clientSecret: "pi_minted_555_secret_abc" })
+    );
+    await screen.findByText("stripe-points.delivering");
+    expect(h.mintMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/specs/features/purchase-stripe/stripe-points-dialog.spec.tsx
+++ b/apps/web/src/specs/features/purchase-stripe/stripe-points-dialog.spec.tsx
@@ -1,9 +1,19 @@
 import { StripePointsDialog } from "@/features/shared/purchase-stripe/stripe-points-dialog";
 import { cleanupModalContainers, setupModalContainers } from "@/specs/test-utils";
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// A promise resolvable from the test body, to hold the confirm in flight while the
+// close-blocking behavior is asserted.
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 // Shapes the mocks exchange with the component under test; typed so the assertions on
 // mock.calls stay checked instead of being cast through any.
@@ -81,14 +91,17 @@ describe("StripePointsDialog (deferred intent)", () => {
     // mockImplementation would otherwise leak into the next test.
     h.mintMock.mockImplementation(async () => ({ client_secret: "pi_minted_555_secret_abc" }));
     h.statusMock.mockImplementation(async () => ({ status: "pending" }));
+    h.confirmPaymentMock.mockImplementation(async () => ({
+      paymentIntent: { id: "pi_confirmed_555", status: "succeeded" }
+    }));
   });
 
   afterEach(() => {
     cleanupModalContainers();
   });
 
-  const openDialog = (defaultSku?: string) =>
-    render(<StripePointsDialog show={true} setShow={vi.fn()} defaultSku={defaultSku} />);
+  const openDialog = (defaultSku?: string, setShow: (v: boolean) => void = vi.fn()) =>
+    render(<StripePointsDialog show={true} setShow={setShow} defaultSku={defaultSku} />);
 
   it("advances to the pay step on Continue WITHOUT creating an intent", async () => {
     openDialog();
@@ -193,6 +206,36 @@ describe("StripePointsDialog (deferred intent)", () => {
     expect(payloads).toHaveLength(2);
     expect(payloads[1].nonce).toBe(payloads[0].nonce);
     expect(screen.queryByText("Your card was declined.")).not.toBeInTheDocument();
+  });
+
+  it("blocks closing while a confirm is in flight and closes normally when idle", async () => {
+    // Hold the confirm open: this is the window where the charge can complete server
+    // side, so the dialog must refuse to close (a closed dialog would offer the buyer a
+    // fresh checkout for a payment that already went through).
+    const confirmGate = deferred<MockConfirmResult>();
+    h.confirmPaymentMock.mockImplementation(() => confirmGate.promise);
+    const setShow = vi.fn();
+    openDialog(undefined, setShow);
+
+    fireEvent.click(screen.getByRole("button", { name: "stripe-points.continue" }));
+    const payButton = await screen.findByRole("button", { name: "stripe-points.pay" });
+    await waitFor(() => expect(payButton).not.toBeDisabled());
+    fireEvent.click(payButton);
+    await waitFor(() => expect(h.confirmPaymentMock).toHaveBeenCalledTimes(1));
+
+    // The header close button routes through the guarded onHide: mid-confirm it must be
+    // a no-op, leaving the dialog open and the payment element mounted.
+    fireEvent.click(screen.getByLabelText("g.close"));
+    expect(setShow).not.toHaveBeenCalled();
+    expect(screen.getByTestId("payment-element")).toBeInTheDocument();
+
+    // A decline settles the submit; the dialog is idle again and closes normally.
+    await act(async () => {
+      confirmGate.resolve({ error: { message: "Your card was declined." } });
+    });
+    await screen.findByText("Your card was declined.");
+    fireEvent.click(screen.getByLabelText("g.close"));
+    await waitFor(() => expect(setShow).toHaveBeenCalledWith(false));
   });
 
   it("falls back to the default tier when defaultSku is unknown", async () => {

--- a/apps/web/src/specs/features/purchase-stripe/stripe-points-dialog.spec.tsx
+++ b/apps/web/src/specs/features/purchase-stripe/stripe-points-dialog.spec.tsx
@@ -2,29 +2,53 @@ import { StripePointsDialog } from "@/features/shared/purchase-stripe/stripe-poi
 import { cleanupModalContainers, setupModalContainers } from "@/specs/test-utils";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shapes the mocks exchange with the component under test; typed so the assertions on
+// mock.calls stay checked instead of being cast through any.
+interface MockElementsOptions {
+  mode?: string;
+  amount?: number;
+  currency?: string;
+  clientSecret?: string;
+}
+
+interface MintPayload {
+  sku: string;
+  nonce: string;
+}
+
+interface MockConfirmResult {
+  paymentIntent?: { id: string; status: string };
+  error?: { message: string };
+}
 
 // Shared stubs, hoisted so the vi.mock factories can reference them.
 const h = vi.hoisted(() => ({
-  elementsOptions: [] as any[],
-  submitMock: vi.fn(async () => ({})),
-  confirmPaymentMock: vi.fn(async (_args: any) => ({
-    paymentIntent: { id: "pi_confirmed_555", status: "succeeded" }
+  elementsOptions: [] as MockElementsOptions[],
+  submitMock: vi.fn(async (): Promise<{ error?: { message?: string } }> => ({})),
+  confirmPaymentMock: vi.fn(
+    async (): Promise<MockConfirmResult> => ({
+      paymentIntent: { id: "pi_confirmed_555", status: "succeeded" }
+    })
+  ),
+  mintMock: vi.fn(async (_payload: MintPayload) => ({
+    client_secret: "pi_minted_555_secret_abc"
   })),
-  mintMock: vi.fn(async (_args: any) => ({ client_secret: "pi_minted_555_secret_abc" })),
-  statusMock: vi.fn(async () => ({ status: "pending" }))
+  statusMock: vi.fn(async (): Promise<{ status: string }> => ({ status: "pending" }))
 }));
 
 vi.mock("@stripe/react-stripe-js", async () => {
   const React = await import("react");
   return {
-    Elements: ({ options, children }: any) => {
+    Elements: ({ options, children }: { options: MockElementsOptions; children?: ReactNode }) => {
       h.elementsOptions.push(options);
       return React.createElement("div", { "data-testid": "elements" }, children);
     },
     useStripe: () => ({ confirmPayment: h.confirmPaymentMock }),
     useElements: () => ({ submit: h.submitMock }),
-    PaymentElement: ({ onReady }: any) => {
+    PaymentElement: ({ onReady }: { onReady?: () => void }) => {
       React.useEffect(() => {
         onReady?.();
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -53,13 +77,18 @@ describe("StripePointsDialog (deferred intent)", () => {
     setupModalContainers();
     vi.clearAllMocks();
     h.elementsOptions.length = 0;
+    // Re-pin implementations: clearAllMocks resets calls but a per-test
+    // mockImplementation would otherwise leak into the next test.
+    h.mintMock.mockImplementation(async () => ({ client_secret: "pi_minted_555_secret_abc" }));
+    h.statusMock.mockImplementation(async () => ({ status: "pending" }));
   });
 
   afterEach(() => {
     cleanupModalContainers();
   });
 
-  const openDialog = () => render(<StripePointsDialog show={true} setShow={vi.fn()} />);
+  const openDialog = (defaultSku?: string) =>
+    render(<StripePointsDialog show={true} setShow={vi.fn()} defaultSku={defaultSku} />);
 
   it("advances to the pay step on Continue WITHOUT creating an intent", async () => {
     openDialog();
@@ -93,7 +122,7 @@ describe("StripePointsDialog (deferred intent)", () => {
 
     await waitFor(() => expect(h.mintMock).toHaveBeenCalledTimes(1));
     expect(h.mintMock).toHaveBeenCalledWith({ sku: "499points", nonce: expect.any(String) });
-    expect((h.mintMock.mock.calls[0][0] as any).nonce.length).toBeGreaterThan(0);
+    expect(h.mintMock.mock.calls[0][0].nonce.length).toBeGreaterThan(0);
 
     // The confirm used the freshly minted secret, and the dialog moved on to delivery.
     await waitFor(() => expect(h.confirmPaymentMock).toHaveBeenCalledTimes(1));
@@ -102,5 +131,51 @@ describe("StripePointsDialog (deferred intent)", () => {
     );
     await screen.findByText("stripe-points.delivering");
     expect(h.mintMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the payment form mounted with the error when the mint fails", async () => {
+    h.mintMock.mockImplementation(async () => {
+      throw new Error("Request failed with status code 500");
+    });
+    openDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "stripe-points.continue" }));
+    const payButton = await screen.findByRole("button", { name: "stripe-points.pay" });
+    await waitFor(() => expect(payButton).not.toBeDisabled());
+    fireEvent.click(payButton);
+
+    // The failure happens AFTER the buyer typed card details, so the dialog must not
+    // jump to the terminal error step and throw the entered card away: the message
+    // renders above the still-mounted form for an in-place retry.
+    await screen.findByText("stripe-points.create-failed");
+    expect(screen.getByTestId("payment-element")).toBeInTheDocument();
+    expect(screen.queryByText("stripe-points.try-again")).not.toBeInTheDocument();
+    expect(h.confirmPaymentMock).not.toHaveBeenCalled();
+
+    // A retry clears the inline error and mints again with the same session nonce.
+    h.mintMock.mockImplementation(async () => ({ client_secret: "pi_minted_555_secret_abc" }));
+    fireEvent.click(payButton);
+    await waitFor(() => expect(h.confirmPaymentMock).toHaveBeenCalledTimes(1));
+    await screen.findByText("stripe-points.delivering");
+    expect(screen.queryByText("stripe-points.create-failed")).not.toBeInTheDocument();
+    const payloads = h.mintMock.mock.calls.map((call) => call[0]);
+    expect(payloads[1].nonce).toBe(payloads[0].nonce);
+  });
+
+  it("falls back to the default tier when defaultSku is unknown", async () => {
+    openDialog("nope");
+
+    // The default tier tile is selected, so the dialog stays usable instead of carrying
+    // an unknown sku into a zero-cent (and therefore empty) pay step.
+    const defaultTile = screen.getByText("$9.99").closest("button");
+    expect(defaultTile?.className).toContain("border-2");
+
+    fireEvent.click(screen.getByRole("button", { name: "stripe-points.continue" }));
+    await screen.findByTestId("payment-element");
+    expect(h.elementsOptions[0]).toMatchObject({
+      mode: "payment",
+      amount: 999,
+      currency: "usd"
+    });
   });
 });


### PR DESCRIPTION
Every card checkout minted its PaymentIntent before the buyer entered a card, so opening the Pro dialog or browsing tiers created incomplete intents that heavily outnumber paid ones.

### Deferred flow
- `StripeCheckoutForm` now runs Stripe's deferred intent flow: callers render `<Elements>` with `mode: "payment"`, `amount`, `currency` immediately (no clientSecret) and pass a `createIntent` callback. On submit the form validates via `elements.submit()`, mints the intent, then confirms with the fresh secret (`redirect: "if_required"` unchanged). A failed mint or a decline shows a friendly message and keeps the form mounted for retry.
- `onPaid` now receives the confirmed PaymentIntent id from the confirm result, and every caller's delivery poll takes that id as an argument instead of deriving it from render-time state (which is empty under deferred minting).
- `pro-checkout` drops its mint-on-mount effect; `stripe-points-dialog`'s Continue only advances to the pay step; `gift-card-checkout` and `hosting-card-checkout` drop their re-mint effects and mint with the current gift fields / hosting target at Pay time. The nonce memos stay keyed on the checkout identity (sku, recipient, message / sku, hostingTarget) because the server idempotency key is `user:sku:nonce`, so an edit between two Pay clicks must not reuse the previous intent's metadata. Redirect-resume paths are unchanged.

### Account checkout exception
`stripe-account-checkout` keeps minting on mount: its single use Turnstile token is consumed at create intent and expires within minutes, so deferring the mint would let it expire while the buyer types card details, and that step is only reached after an explicit submit anyway. It hands the already-minted secret to the shared form via `createIntent`.

### SKU cents derivation
New dependency free `skuUsdCents(sku)` in `stripe-tiers.ts` returns the SKU's leading number, which is the price in usd cents on every rail per the server product map (`499points`, `1999pro`, `200hosting`, `3600prohosting`). Malformed SKUs return 0 and callers treat 0 as unconfigured (card-unavailable alert), never rendering a zero-amount Elements.

### Test plan
- `stripe-config.spec.ts`: skuUsdCents parity for every Points tier against `Math.round(usd * 100)`, for `PRO_SKU` against `PRO_PRICE_USD`, hosting SKU shape and price per term, NaN/negative guard.
- New `pro-checkout.spec.tsx`: no mint on mount; Elements gets `mode: "payment"` with amount 1999; on Pay the order is `elements.submit` then create intent then `confirmPayment` with the minted secret; the poll queries with the confirmed intent id (deliberately different from the minted secret prefix); a failed mint keeps the form mounted with a friendly message.
- New `stripe-points-dialog.spec.tsx`: Continue reaches the pay step without creating an intent; Pay mints exactly once with the selected sku and the session nonce.
- Mutation-checked: reintroducing the mint-on-mount effect, returning dollars from skuUsdCents and dropping the `elements.submit()` call each make the suite fail.
- Full runs green: purchase-stripe, pro, points-gift, hosting-signup and points-topup-cta suites (122 tests), `tsc --noEmit` clean, eslint and prettier clean on touched files.

Closes #1689


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stripe payment forms now load immediately and create payment intents only when Pay is selected.
  * Checkout amounts are calculated from the selected product or plan, with improved payment configuration.
* **Bug Fixes**
  * Payment and minting errors remain visible with the form available for retry.
  * Payment confirmation and delivery tracking now reliably continue using the confirmed payment.
  * Invalid or unavailable products display an unavailable message instead of entering a preparation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->