### PR TITLE
chore(dmca): add 13 further image entries to blocklist

### DIFF
--- a/apps/web/public/dmca/dmca-images.json
+++ b/apps/web/public/dmca/dmca-images.json
@@ -3408,8 +3408,21 @@
     "https://uploadbay.net/uploads/zliG1DOVN.jpg",
     "https://uploadbay.net/uploads/zmDegYrNs.jpg",
     "https://uploadbay.net/uploads/zqPZ68Uwh.jpg",
-    "https://uploadbay.net/uploads/zx5pg920F.jpg"
+    "https://uploadbay.net/uploads/zx5pg920F.jpg",
+    "https://uploadbay.net/uploads/AMG8pVHP1.jpg",
+    "https://uploadbay.net/uploads/AfPCst3Hb.jpg",
+    "https://uploadbay.net/uploads/J6ih7x1sG.jpg",
+    "https://uploadbay.net/uploads/LxIBItw0U.jpg",
+    "https://uploadbay.net/uploads/Pm2SW7vgg.jpg",
+    "https://uploadbay.net/uploads/R2gLEXyzh.jpg",
+    "https://uploadbay.net/uploads/V8FfbN81U.jpg",
+    "https://uploadbay.net/uploads/i92gZkmIm.jpg",
+    "https://uploadbay.net/uploads/iyajRIH3M.jpg",
+    "https://uploadbay.net/uploads/nLSlKqN1p.jpg",
+    "https://uploadbay.net/uploads/rqerKiE0f.jpg",
+    "https://uploadbay.net/uploads/rsa3gmaI4.jpg",
+    "https://uploadbay.net/uploads/y9A5oT5XX.jpg"
   ],
-  "updated": "2026-08-27T11:00:00.000Z",
+  "updated": "2026-08-27T12:00:00.000Z",
   "version": "1.0"
 }


### PR DESCRIPTION
Adds 13 entries to `dmca-images.json`, same source host as #1695/#1696 (`uploadbay.net`, already in `dmca-domains.json`).

These were missed by the earlier passes: they appear in origin logs only in the plaintext `/0x0/<url>` request form, not as `/p/<token>`, so a token-only sweep did not see them. Found by the new log-sweep tooling, which harvests tokens, plaintext URL forms and service logs.