### PR TITLE
fix(sentry): collapse browser-injected stack-overflow noise into one bucket

### DIFF
--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -896,6 +896,30 @@ describe("beforeSend — browser-injected stack overflow is reclassified", () =>
     }
   });
 
+  it("still collapses when the page URL carries a query or hash ending in .js", () => {
+    // `?ref=widget.js` is part of the page address, not a script frame.
+    for (const page of ["app:///@wotjsozm/following?ref=widget.js", "app:///@wotjsozm#widget.js"]) {
+      const out = beforeSend(makeEvent(OVERFLOW, [{ filename: page, abs_path: page }]));
+      expect(out!.fingerprint).toEqual(["browser-injected-stack-overflow"]);
+    }
+  });
+
+  it("still collapses a permlink that merely mentions .js mid-path", () => {
+    // Only a TRAILING extension names a file. `@user/why-i-left-node.js-for-deno`
+    // is a page, and a dotted account name (`@ecency.app`) is too.
+    for (const page of ["app:///@wotjsozm/why-i-left-node.js-for-deno", "app:///@ecency.app"]) {
+      const out = beforeSend(makeEvent(OVERFLOW, [{ filename: page, abs_path: page }]));
+      expect(out!.fingerprint).toEqual(["browser-injected-stack-overflow"]);
+    }
+  });
+
+  it("does NOT touch a chunk whose extension sits before a ?dpl= query", () => {
+    const ev = makeEvent(OVERFLOW, [
+      { filename: "app:///_next/static/chunks/app/page-77d.js?dpl=67bf6584" }
+    ]);
+    expect(beforeSend(ev)!.fingerprint).toBeUndefined();
+  });
+
   it("does NOT touch an overflow inside WebAssembly", () => {
     const ev = makeEvent(OVERFLOW, [{ filename: "app:///_next/static/media/codec.wasm" }]);
     expect(beforeSend(ev)!.fingerprint).toBeUndefined();

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -777,3 +777,103 @@ describe("beforeSend — @noble/ciphers module-init self-test failure is reclass
     expect(out!.fingerprint).toBeUndefined();
   });
 });
+
+describe("beforeSend — browser-injected stack overflow is reclassified", () => {
+  // ECENCY-NEXT-1GP9 and 16 siblings (issue #1699). Google's iOS browsers inject a
+  // script that recurses over the DOM until the stack blows. Being inline it has no
+  // URL of its own, so WebKit attributes every frame to the PAGE URL, which is also
+  // what Sentry groups on: one visitor produced 12 issues in a single session.
+  const OVERFLOW = "Maximum call stack size exceeded.";
+  const injectedFrames = (page: string) => [
+    { filename: `app:///${page}`, function: "Gk", abs_path: `app:///${page}` },
+    { filename: `app:///${page}`, function: "Ik", abs_path: `app:///${page}` }
+  ];
+
+  it("reclassifies the injected-script recursion into a single fingerprint", () => {
+    const ev = makeEvent(OVERFLOW, injectedFrames("@wotjsozm/following"), {
+      type: "RangeError",
+      handled: false
+    });
+    const out = beforeSend(ev);
+    expect(out).not.toBeNull();
+    expect(out!.level).toBe("warning");
+    expect(out!.tags?.injected_script_overflow).toBe("true");
+    expect(out!.fingerprint).toEqual(["browser-injected-stack-overflow"]);
+  });
+
+  it("groups every page URL into the SAME bucket (the fan-out this fixes)", () => {
+    const a = beforeSend(
+      makeEvent(OVERFLOW, injectedFrames("@wotjsozm/following"), { type: "RangeError" })
+    );
+    const b = beforeSend(
+      makeEvent(OVERFLOW, injectedFrames("@dasunkwo/my-poetry"), { type: "RangeError" })
+    );
+    expect(a!.fingerprint).toEqual(["browser-injected-stack-overflow"]);
+    expect(b!.fingerprint).toEqual(a!.fingerprint);
+  });
+
+  it("catches the frame-less copy (ECENCY-NEXT-MC8's single unparsed frame)", () => {
+    // The long-running bucket carries one frame whose filename is the literal
+    // string "undefined". Nothing to act on, so it belongs in the same bucket.
+    const ev = makeEvent(OVERFLOW, [{ filename: "undefined" }], { type: "RangeError" });
+    const out = beforeSend(ev);
+    expect(out!.fingerprint).toEqual(["browser-injected-stack-overflow"]);
+  });
+
+  it("does NOT touch a real overflow recursing inside our own bundle", () => {
+    // A runaway recursion in app code always carries chunk frames: it must stay an
+    // error-level issue with its own grouping.
+    const ev = makeEvent(OVERFLOW, [APP_FRAME, APP_FRAME], { type: "RangeError" });
+    const out = beforeSend(ev);
+    expect(out!.level).toBeUndefined();
+    expect(out!.tags?.injected_script_overflow).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch a mixed stack where our code appears even once", () => {
+    const ev = makeEvent(OVERFLOW, [...injectedFrames("@wotjsozm/following"), WEBPACK_FRAME], {
+      type: "RangeError"
+    });
+    const out = beforeSend(ev);
+    expect(out!.fingerprint).toBeUndefined();
+  });
+
+  it("reads abs_path too, not just filename", () => {
+    const ev = makeEvent(
+      OVERFLOW,
+      [{ abs_path: "app:///_next/static/chunks/9959-4f643fb493706780.js" }],
+      { type: "RangeError" }
+    );
+    const out = beforeSend(ev);
+    expect(out!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch a different RangeError with no app frames", () => {
+    // e.g. `new Array(-1)` from a third-party script: not this family, not this bucket.
+    const ev = makeEvent("Invalid array length", injectedFrames("@wotjsozm"), {
+      type: "RangeError"
+    });
+    const out = beforeSend(ev);
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+
+  it("collapses a copy that arrives wrapped as a plain Error (no RangeError type)", () => {
+    // The rule reads the message, not the exception type: the phrase is engine-thrown
+    // and appears in none of our own throw sites.
+    const ev = makeEvent(OVERFLOW, injectedFrames("@wotjsozm"), { type: "Error" });
+    const out = beforeSend(ev);
+    expect(out!.fingerprint).toEqual(["browser-injected-stack-overflow"]);
+  });
+
+  it("does NOT touch the Firefox phrasing of a recursion limit", () => {
+    // "InternalError: too much recursion" was never observed in this family (it is
+    // exclusively Google's iOS browsers), so it stays reported as it arrives.
+    const ev = makeEvent("too much recursion", injectedFrames("@wotjsozm"), {
+      type: "InternalError"
+    });
+    const out = beforeSend(ev);
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+});

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -801,6 +801,27 @@ describe("beforeSend — browser-injected stack overflow is reclassified", () =>
     expect(out!.fingerprint).toEqual(["browser-injected-stack-overflow"]);
   });
 
+  it("collapses the real ECENCY-NEXT-1GP9 shape, whose frames span TWO page URLs", () => {
+    // A client nav means frames compiled under the previous URL sit in the same
+    // stack as frames from the current one. Verbatim from event fb68d39c: 50
+    // frames alternating Gk/Ik on the profile URL, bottoming out in anonymous
+    // frames on the /following URL.
+    const frames = [
+      ...Array.from({ length: 46 }, (_, i) => ({
+        filename: "app:///@wotjsozm",
+        abs_path: "app:///@wotjsozm",
+        function: i % 2 === 0 ? "Gk" : "Ik"
+      })),
+      ...Array.from({ length: 4 }, () => ({
+        filename: "app:///@wotjsozm/following",
+        abs_path: "app:///@wotjsozm/following"
+      }))
+    ];
+    const out = beforeSend(makeEvent(OVERFLOW, frames, { type: "RangeError", handled: false }));
+    expect(out!.level).toBe("warning");
+    expect(out!.fingerprint).toEqual(["browser-injected-stack-overflow"]);
+  });
+
   it("groups every page URL into the SAME bucket (the fan-out this fixes)", () => {
     const a = beforeSend(
       makeEvent(OVERFLOW, injectedFrames("@wotjsozm/following"), { type: "RangeError" })
@@ -812,12 +833,19 @@ describe("beforeSend — browser-injected stack overflow is reclassified", () =>
     expect(b!.fingerprint).toEqual(a!.fingerprint);
   });
 
-  it("catches the frame-less copy (ECENCY-NEXT-MC8's single unparsed frame)", () => {
-    // The long-running bucket carries one frame whose filename is the literal
-    // string "undefined". Nothing to act on, so it belongs in the same bucket.
+  it("does NOT collapse an unparsed stack (ECENCY-NEXT-MC8's 'undefined' frame)", () => {
+    // No frames means no evidence. Burying an unattributed overflow in a bucket
+    // labelled "injected" is how a real regression goes unnoticed, and MC8 already
+    // sits in one stable bucket of its own, so nothing fans out by leaving it.
     const ev = makeEvent(OVERFLOW, [{ filename: "undefined" }], { type: "RangeError" });
     const out = beforeSend(ev);
-    expect(out!.fingerprint).toEqual(["browser-injected-stack-overflow"]);
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT collapse an event with no frames at all", () => {
+    const out = beforeSend(makeEvent(OVERFLOW, [], { type: "RangeError" }));
+    expect(out!.fingerprint).toBeUndefined();
   });
 
   it("does NOT touch a real overflow recursing inside our own bundle", () => {
@@ -857,6 +885,46 @@ describe("beforeSend — browser-injected stack overflow is reclassified", () =>
     for (const filename of ["https://cdn.example.com/sdk.mjs", "https://cdn.example.com/sdk.cjs"]) {
       expect(beforeSend(makeEvent(OVERFLOW, [{ filename }]))!.fingerprint).toBeUndefined();
     }
+  });
+
+  it("does NOT touch an overflow from a blob: or data: script", () => {
+    // Neither names a .js file, so an absence test would have swallowed both.
+    for (const filename of ["blob:https://ecency.com/9f2c-4a1b", "data:text/javascript,void 0"]) {
+      const out = beforeSend(makeEvent(OVERFLOW, [{ filename }]));
+      expect(out!.level).toBeUndefined();
+      expect(out!.fingerprint).toBeUndefined();
+    }
+  });
+
+  it("does NOT touch an overflow inside WebAssembly", () => {
+    const ev = makeEvent(OVERFLOW, [{ filename: "app:///_next/static/media/codec.wasm" }]);
+    expect(beforeSend(ev)!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch React's inline streaming runtime, which is page-attributed too", () => {
+    // $RS/$RC/$RB ship as inline script in the document, so their frames carry the
+    // page URL exactly like an injected script's. A recursion there is ours.
+    const ev = makeEvent(OVERFLOW, [
+      { filename: "app:///@wotjsozm/following", function: "$RS" },
+      { filename: "app:///@wotjsozm/following", function: "$RC" }
+    ]);
+    const out = beforeSend(ev);
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch a frame on a foreign origin that names no file", () => {
+    // Only our own origin is rewritten to app:///, so anything absolute is
+    // someone else's code with a real URL: not the shape we are bucketing.
+    const ev = makeEvent(OVERFLOW, [{ filename: "https://cdn.example.com/bundle" }]);
+    expect(beforeSend(ev)!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch a frame whose abs_path names a file even if filename does not", () => {
+    const ev = makeEvent(OVERFLOW, [
+      { filename: "app:///@wotjsozm/following", abs_path: "app:///scripts/config-stub.js" }
+    ]);
+    expect(beforeSend(ev)!.fingerprint).toBeUndefined();
   });
 
   it("does NOT touch a mixed stack where our code appears even once", () => {

--- a/apps/web/src/specs/utils/sentry-before-send.spec.ts
+++ b/apps/web/src/specs/utils/sentry-before-send.spec.ts
@@ -830,10 +830,40 @@ describe("beforeSend — browser-injected stack overflow is reclassified", () =>
     expect(out!.fingerprint).toBeUndefined();
   });
 
+  it("does NOT touch an overflow in our first-party /scripts helpers", () => {
+    // chunk-reload.js, translate-dom-guard.js and config-stub.js are served from
+    // outside the chunk path, so a `_next/static` test would have swallowed them.
+    // translate-dom-guard patches Node.prototype.removeChild/insertBefore, which is
+    // exactly where a runaway recursion of ours would show up.
+    const ev = makeEvent(OVERFLOW, [
+      { filename: "app:///scripts/translate-dom-guard.js", function: "removeChild" }
+    ]);
+    const out = beforeSend(ev);
+    expect(out!.level).toBeUndefined();
+    expect(out!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch an overflow in the analytics script", () => {
+    const ev = makeEvent(OVERFLOW, [{ filename: "app:///pl/js/script.js" }]);
+    expect(beforeSend(ev)!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch an overflow in a third-party SDK", () => {
+    const ev = makeEvent(OVERFLOW, [{ filename: "https://s3.tradingview.com/tv.js?v=2" }]);
+    expect(beforeSend(ev)!.fingerprint).toBeUndefined();
+  });
+
+  it("does NOT touch a .mjs or .cjs frame either", () => {
+    for (const filename of ["https://cdn.example.com/sdk.mjs", "https://cdn.example.com/sdk.cjs"]) {
+      expect(beforeSend(makeEvent(OVERFLOW, [{ filename }]))!.fingerprint).toBeUndefined();
+    }
+  });
+
   it("does NOT touch a mixed stack where our code appears even once", () => {
     const ev = makeEvent(OVERFLOW, [...injectedFrames("@wotjsozm/following"), WEBPACK_FRAME], {
       type: "RangeError"
     });
+    // One real script frame anywhere in the stack is enough to disqualify it.
     const out = beforeSend(ev);
     expect(out!.fingerprint).toBeUndefined();
   });

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -6,13 +6,25 @@ import { isDeploySkewError } from "./deploy-skew";
 // in lockstep with the SDK without a runtime import of @sentry/nextjs here.
 type SentryErrorEvent = Parameters<NonNullable<Sentry.BrowserOptions["beforeSend"]>>[0];
 
-// A stack-frame source that names an actual JavaScript file: our own chunks, the
-// first-party helpers under /scripts, analytics, any vendor SDK. Query and hash
-// are allowed after the extension (`page-abc.js?dpl=67bf6584`). A frame the
-// engine attributed to the document itself (`app:///@user/post`) or failed to
-// parse ("undefined") has no extension and is NOT one of these.
-function isScriptFileUrl(source?: string): boolean {
-  return !!source && /\.[cm]?js(?:[?#]|$)/i.test(source);
+// A frame the engine attributed to the DOCUMENT rather than to a file it could
+// name: `app:///@user/post`, our own origin with a page path and no extension.
+// The SDK's rewriteFrames runs as an event processor, i.e. BEFORE beforeSend, so
+// same-origin sources already carry the `app:///` prefix here.
+//
+// Everything else fails this test on purpose, because it is code someone can open
+// and fix: a chunk, a first-party helper under /scripts, analytics, a vendor SDK
+// on its own origin, a blob:/data: script, WebAssembly, an extension URL, and a
+// source the stack parser could not read at all ("undefined", empty).
+function isPageAttributedFrame(source?: string): boolean {
+  return !!source && source.startsWith("app:///") && !/\.(?:[cm]?js|wasm)(?:[?#]|$)/i.test(source);
+}
+
+// React's streaming runtime ships as INLINE script in the document, so its frames
+// are page-attributed exactly like an injected script's. Its helpers are named
+// `$RS`, `$RC`, `$RB`, `$RV`, `$RT` (the hydration rule above keys on the same
+// marker), so a recursion of theirs is ours to investigate, not noise to bucket.
+function isFrameworkInlineFrame(frame: { function?: string }): boolean {
+  return !!frame.function && /\$R[A-Z]/.test(frame.function);
 }
 
 /**
@@ -401,27 +413,38 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
   // Grouping is the actual damage: Sentry keys these on the culprit, which here is the page
   // URL, so ONE visitor spawned 12 fresh issues in a single session. One fingerprint, one
   // bucket, spikes still visible.
-  // The gate is that NO frame names a real script file, NOT the message alone: a genuine
-  // runaway recursion in code we can actually edit always leaves a `.js` frame behind, so it
-  // keeps reporting at error level under its own grouping. Testing for a script file rather
-  // than for `_next/static` is deliberate (Qodo + Codex on #1700): we also serve first-party
-  // JS from outside the chunk path (`/scripts/chunk-reload.js`,
-  // `/scripts/translate-dom-guard.js`, `/scripts/config-stub.js`, analytics at
-  // `/pl/js/script.js`) plus third-party SDKs, and an overflow in any of those is a real bug
-  // that must not be buried here. translate-dom-guard in particular patches
-  // Node.prototype.removeChild/insertBefore, where runaway recursion is a live possibility.
-  // The injected script has no URL of its own, so WebKit attributes it to the page URL
-  // (`app:///@user/post`, no extension) or leaves it unparsed, which is what makes the
-  // absence of any `.js` frame a positive signature rather than a guess. A frameless copy is
-  // caught by this rule on purpose: with no frames there is nothing to act on either way, and
-  // a single labelled bucket beats a per-URL fan-out of unactionable issues.
+  // The gate is POSITIVE: every frame must be attributed to the document itself, which is
+  // the shape the injected script leaves because it has no URL of its own. An absence test
+  // ("no `_next/static` frame", or even "no `.js` frame") proves too little, since it also
+  // swallows an overflow in a blob:/data: script, in WebAssembly, or in a stack the parser
+  // could not read (Qodo + Codex on #1700, then a P2 follow-up). Those keep their own
+  // error-level grouping, because nothing about them says the code is unreachable to us.
+  // What the positive test buys: every line of first-party logic we author is served as a
+  // FILE, either a `_next/static` chunk or `/scripts/chunk-reload.js`,
+  // `/scripts/translate-dom-guard.js`, `/scripts/config-stub.js`, with analytics at
+  // `/pl/js/script.js` and vendor SDKs on their own origins. All of those name a file, so a
+  // genuine runaway recursion in code we can edit can never land in this bucket.
+  // translate-dom-guard matters most here: it patches Node.prototype.removeChild and
+  // insertBefore, where runaway recursion is a live possibility, and it is not under
+  // `_next/static`.
+  // The one first-party exception is React's streaming runtime, which IS inline and so is
+  // page-attributed too. Its `$R*` helpers are excluded by name.
+  // A frameless or unparsed event is NOT collapsed: with no frames there is no evidence of
+  // anything, and burying an unattributed overflow in a bucket labelled "injected" is how a
+  // real regression goes unnoticed. ECENCY-NEXT-MC8 is that shape and already sits in one
+  // stable bucket of its own, so nothing fans out by leaving it alone.
   // Matched on the message alone rather than on `RangeError`: the phrase is thrown by the
   // engine and appears nowhere in our own throw sites, so the type adds no safety, while
   // requiring it would miss a copy that reaches the SDK wrapped as a plain Error.
-  const namesAScriptFile = frames.some(
-    (f) => isScriptFileUrl(f.filename) || isScriptFileUrl(f.abs_path)
-  );
-  if (/Maximum call stack size exceeded/i.test(message) && !namesAScriptFile) {
+  const isPageAttributedOverflow =
+    frames.length > 0 &&
+    frames.every((f) => {
+      const sources = [f.filename, f.abs_path].filter(Boolean);
+      return (
+        sources.length > 0 && sources.every(isPageAttributedFrame) && !isFrameworkInlineFrame(f)
+      );
+    });
+  if (/Maximum call stack size exceeded/i.test(message) && isPageAttributedOverflow) {
     event.level = "warning";
     event.tags = { ...event.tags, injected_script_overflow: "true" };
     event.fingerprint = ["browser-injected-stack-overflow"];

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -16,7 +16,16 @@ type SentryErrorEvent = Parameters<NonNullable<Sentry.BrowserOptions["beforeSend
 // on its own origin, a blob:/data: script, WebAssembly, an extension URL, and a
 // source the stack parser could not read at all ("undefined", empty).
 function isPageAttributedFrame(source?: string): boolean {
-  return !!source && source.startsWith("app:///") && !/\.(?:[cm]?js|wasm)(?:[?#]|$)/i.test(source);
+  if (!source || !source.startsWith("app:///")) {
+    return false;
+  }
+  // The extension test reads the PATH only. A page URL can carry a query or hash
+  // that ends in ".js" (`?ref=widget.js`), and matching that would read the page
+  // frame as a script frame, leaving the injected event uncollapsed (CodeRabbit
+  // on #1700). A chunk keeps its extension before the query, so `page-abc.js?dpl=`
+  // is still recognised.
+  const path = source.split(/[?#]/)[0];
+  return !/\.(?:[cm]?js|wasm)$/i.test(path);
 }
 
 // React's streaming runtime ships as INLINE script in the document, so its frames

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -372,5 +372,40 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
     return event;
   }
 
+  // ECENCY-NEXT-1GP9 + 16 sibling buckets (issue #1699): `RangeError: Maximum call stack
+  // size exceeded` thrown by a script GOOGLE'S iOS BROWSERS inject into the page, never by
+  // our bundle. Across the latest+oldest event of all 17 buckets (895 events, 35 users,
+  // first seen 2025-06-26) the shape is invariant:
+  //   - every stack is the same two-function mutual recursion at the same columns, whose
+  //     minified names track the BROWSER build rather than our release (release 2e1e3039
+  //     gave Fk/Hk under Chrome iOS and Gk/Ik under the Google Search app on the same
+  //     page; other builds give Ik/Kk, Qk/Sk),
+  //   - `abs_path` is the PAGE URL itself (`app:///@user/post`), which is how WebKit
+  //     attributes an inline script that has no URL of its own, and the reported lines sit
+  //     past the end of our served document, i.e. the code was appended after our HTML,
+  //   - the browser is Chrome Mobile iOS or the Google Search app in 100% of events, over
+  //     14 months and iOS 15.8 through 26.6.1.
+  // Probably the in-page translate / page-analysis walker recursing over the DOM; the same
+  // browser family already forced public/scripts/translate-dom-guard.js. The app itself
+  // keeps working (visitors keep navigating and keep emitting these), so warning is the
+  // honest level.
+  // Grouping is the actual damage: Sentry keys these on the culprit, which here is the page
+  // URL, so ONE visitor spawned 12 fresh issues in a single session. One fingerprint, one
+  // bucket, spikes still visible.
+  // The gate is the absence of any `_next/static` frame, NOT the message alone: a genuine
+  // runaway recursion in our own code (or in a dep we bundle) always carries chunk frames,
+  // so it keeps reporting at error level under its own grouping. A frameless copy is caught
+  // by this rule on purpose: with no frames there is nothing to act on either way, and a
+  // single labelled bucket beats a per-URL fan-out of unactionable issues.
+  // Matched on the message alone rather than on `RangeError`: the phrase is thrown by the
+  // engine and appears nowhere in our own throw sites, so the type adds no safety, while
+  // requiring it would miss a copy that reaches the SDK wrapped as a plain Error.
+  if (/Maximum call stack size exceeded/i.test(message) && !/_next\/static/.test(stackStr)) {
+    event.level = "warning";
+    event.tags = { ...event.tags, injected_script_overflow: "true" };
+    event.fingerprint = ["browser-injected-stack-overflow"];
+    return event;
+  }
+
   return event;
 }

--- a/apps/web/src/utils/sentry-before-send.ts
+++ b/apps/web/src/utils/sentry-before-send.ts
@@ -6,6 +6,15 @@ import { isDeploySkewError } from "./deploy-skew";
 // in lockstep with the SDK without a runtime import of @sentry/nextjs here.
 type SentryErrorEvent = Parameters<NonNullable<Sentry.BrowserOptions["beforeSend"]>>[0];
 
+// A stack-frame source that names an actual JavaScript file: our own chunks, the
+// first-party helpers under /scripts, analytics, any vendor SDK. Query and hash
+// are allowed after the extension (`page-abc.js?dpl=67bf6584`). A frame the
+// engine attributed to the document itself (`app:///@user/post`) or failed to
+// parse ("undefined") has no extension and is NOT one of these.
+function isScriptFileUrl(source?: string): boolean {
+  return !!source && /\.[cm]?js(?:[?#]|$)/i.test(source);
+}
+
 /**
  * The single Sentry `beforeSend` hook for the web client — the only place EVERY
  * event passes through (render-boundary captures, global handlers, and the
@@ -392,15 +401,27 @@ export function beforeSend(event: SentryErrorEvent): SentryErrorEvent | null {
   // Grouping is the actual damage: Sentry keys these on the culprit, which here is the page
   // URL, so ONE visitor spawned 12 fresh issues in a single session. One fingerprint, one
   // bucket, spikes still visible.
-  // The gate is the absence of any `_next/static` frame, NOT the message alone: a genuine
-  // runaway recursion in our own code (or in a dep we bundle) always carries chunk frames,
-  // so it keeps reporting at error level under its own grouping. A frameless copy is caught
-  // by this rule on purpose: with no frames there is nothing to act on either way, and a
-  // single labelled bucket beats a per-URL fan-out of unactionable issues.
+  // The gate is that NO frame names a real script file, NOT the message alone: a genuine
+  // runaway recursion in code we can actually edit always leaves a `.js` frame behind, so it
+  // keeps reporting at error level under its own grouping. Testing for a script file rather
+  // than for `_next/static` is deliberate (Qodo + Codex on #1700): we also serve first-party
+  // JS from outside the chunk path (`/scripts/chunk-reload.js`,
+  // `/scripts/translate-dom-guard.js`, `/scripts/config-stub.js`, analytics at
+  // `/pl/js/script.js`) plus third-party SDKs, and an overflow in any of those is a real bug
+  // that must not be buried here. translate-dom-guard in particular patches
+  // Node.prototype.removeChild/insertBefore, where runaway recursion is a live possibility.
+  // The injected script has no URL of its own, so WebKit attributes it to the page URL
+  // (`app:///@user/post`, no extension) or leaves it unparsed, which is what makes the
+  // absence of any `.js` frame a positive signature rather than a guess. A frameless copy is
+  // caught by this rule on purpose: with no frames there is nothing to act on either way, and
+  // a single labelled bucket beats a per-URL fan-out of unactionable issues.
   // Matched on the message alone rather than on `RangeError`: the phrase is thrown by the
   // engine and appears nowhere in our own throw sites, so the type adds no safety, while
   // requiring it would miss a copy that reaches the SDK wrapped as a plain Error.
-  if (/Maximum call stack size exceeded/i.test(message) && !/_next\/static/.test(stackStr)) {
+  const namesAScriptFile = frames.some(
+    (f) => isScriptFileUrl(f.filename) || isScriptFileUrl(f.abs_path)
+  );
+  if (/Maximum call stack size exceeded/i.test(message) && !namesAScriptFile) {
     event.level = "warning";
     event.tags = { ...event.tags, injected_script_overflow: "true" };
     event.fingerprint = ["browser-injected-stack-overflow"];


### PR DESCRIPTION
Closes #1699.

`RangeError: Maximum call stack size exceeded` (ECENCY-NEXT-1GP9 plus 16 sibling buckets) is thrown by a script Google's iOS browsers inject into the page, not by anything we ship. Sampling the latest and oldest event of all 17 buckets:

- 34/34 events carry **no frame referencing `_next/static`**.
- 100% of events are Chrome Mobile iOS or the Google Search app, across 14 months and iOS 15.8 through 26.6.1.
- Every stack is the same two-function mutual recursion at the same columns. The minified names track the *browser* build rather than our release (release `2e1e3039` gave `Fk`/`Hk` under Chrome iOS and `Gk`/`Ik` under the Google app on the same page).
- `abs_path` is the page URL itself, which is how WebKit attributes an inline script with no URL of its own. The reported lines sit past the end of our served document.

Sentry groups these on the culprit, which here is the page URL, so a single visitor spawned 12 fresh issues in one session. Family total: 895 events, 35 users, oldest bucket open since 2025-06-26.

### Change

One rule in `beforeSend`, in the shape of the existing `ECENCY-NEXT-1GKP` reclassification: match the engine message plus the absence of any bundle frame, then set `level: "warning"`, an `injected_script_overflow` tag and `fingerprint: ["browser-injected-stack-overflow"]`.

Collapsing rather than dropping keeps a spike visible if this ever reaches real traffic. A genuine runaway recursion in our own code (or in a dep we bundle) always carries chunk frames, so it keeps reporting at error level under its own grouping.

### Tests

8 new cases in `sentry-before-send.spec.ts`: the injected shape collapses, different page URLs land in one bucket, the frame-less MC8 shape is covered and a wrapped plain-`Error` copy is covered. Left untouched: a real overflow inside our bundle, a mixed stack, an `abs_path`-only chunk frame, a different `RangeError` and the Firefox recursion phrasing.

Each gate was mutation-checked: deleting the rule fails 4 tests, dropping the frame gate fails 3, dropping the message gate fails 14. `vitest` 564 passed across `src/specs/utils` and `src/specs/core/sentry`, `tsc --noEmit` clean.

The 17 existing Sentry issues still need merging or resolving in the UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting for browser-injected stack overflow errors.
  - Groups these non-application errors consistently and classifies them as warnings.
  - Preserves normal error reporting for genuine application stack overflows and other recursion-related errors.
  - Recognizes JavaScript stack frames across common file extensions and URL formats.

- **Tests**
  - Added coverage for injected errors across pages, stack formats, browser error representations, and supported script file types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->