### PR TITLE
chore(skills): resolve self-contradictions, drop the fragile counts

### DIFF
--- a/.claude/skills/add-feature/SKILL.md
+++ b/.claude/skills/add-feature/SKILL.md
@@ -12,33 +12,30 @@ with `apps/`, `packages/`, `scripts/` or `.github/`.
 
 ## 1. Feature directory
 
-Files sit flat at the feature root with an `index.ts` barrel. Of 34 dirs in `features/`, 27
-have a root barrel; only 4 use `components/`, 5 `hooks/`, 1 `api/`, 1 `types/`. Never
-scaffold empty subfolders.
+Files sit flat at the feature root with an `index.ts` barrel. Most feature dirs have that
+barrel; a few carry `components/`, `hooks/`, `api/` or `types/` subfolders. Do not scaffold
+empty subfolders.
 
 ```text
 apps/web/src/features/<feature-name>/
   <feature-name>.tsx      component(s), kebab-case filenames
-  <feature-name>-api.ts   only when it calls a service
+  <feature-name>-api.ts   when it calls a service
   index.ts                export * from "./<feature-name>"
 ```
 
-Subfolders only once a feature outgrows flat (`waves`, `polls`, `wallet`). Keep the barrel
-light so heavy deps stay out of unrelated bundles (`features/pro`). Cross-feature
-components live in `features/shared/`, UI primitives in `features/ui/` via `@ui/*` (847
-imports). State, effects or i18next means `"use client"` (176 of 436 `.tsx` files under
-`features/`). Style with Tailwind plus `dark:` variants: no CSS modules exist here, 0
-`*.module.scss` in the whole repo. A feature stylesheet Tailwind cannot express is
-registered as an `@import` line in `styles/_shared-components.scss`, which `styles/style.scss`
-pulls in once. Do not import it from the component. That per-component import was removed in
-issue #1632 because it emitted one render-blocking `<link>` per component; only 4 direct
-`.scss` imports survive in `features/` today.
+Add subfolders once a feature outgrows flat (`waves`, `polls`, `wallet`). Keep the barrel
+light so heavy deps stay out of unrelated bundles (`features/pro`). Cross-feature components
+live in `features/shared/`, UI primitives in `features/ui/` via `@ui/*`. State or effects
+mean `"use client"`. Style with Tailwind plus `dark:` variants; CSS modules are not used
+here. A feature stylesheet Tailwind cannot express is registered as an `@import` line in
+`styles/_shared-components.scss`, which `styles/style.scss` pulls in once. Do not import it
+from the component.
 
 ## 2. Flag (only if toggleable)
 
 Add to `visionFeatures` in `config/config.ts`, then mirror into `config/config.template.ts`
-by hand: nothing imports the template, so nothing catches a missed edit. Gate with
-`EcencyConfigManager` (121 `Conditional` sites); the condition receives `visionConfig`.
+by hand: nothing imports the template, so a missed edit is not caught. Gate with
+`EcencyConfigManager.Conditional`; the condition receives `visionConfig`.
 
 ```tsx
 <EcencyConfigManager.Conditional
@@ -53,9 +50,9 @@ Outside JSX: `getConfigValue(({ visionFeatures }) => ...)`.
 - Blockchain: run `/add-sdk-mutation` or `/add-query` first.
 - Private API: the client is `packages/sdk/src/modules/private-api`. There is no
   `apps/web/src/api/private-api.ts`. Web adds a feature-local wrapper
-  (`newsletter/newsletter-api.ts`, `hosting-signup/hosting-api.ts`). Identity comes from
-  `ensureValidToken(username)`, imported as `import { ensureValidToken } from "@/utils"`
-  and defined in `utils/user-token.ts`; `getAccessToken()` returns an expired token and
+  (`features/newsletter/newsletter-api.ts`). Identity comes from `ensureValidToken(username)`,
+  imported as `import { ensureValidToken } from "@/utils"`
+  and defined in `utils/user-token.ts`; `getAccessToken()` can return an expired token and
   refreshes in the background.
 - `useActiveAccount()` from `@/core/hooks/use-active-account`. Keys: `QueryKeys` from
   `@ecency/sdk`, or `QueryIdentifiers` from `@/core/react-query` for web-only queries.
@@ -63,54 +60,53 @@ Outside JSX: `getConfigValue(({ visionFeatures }) => ...)`.
 ## 4. i18n
 
 The app imports the i18next default export directly. `react-i18next` and `useTranslation`
-have 0 occurrences and `react-i18next` is not a dependency; the real pattern is 712
-`import i18next from "i18next"` and 4171 `i18next.t(` calls.
+are not used here.
 
 ```tsx
 import i18next from "i18next";
 const label = i18next.t("pro.badge-title");
 ```
 
-Strings go in `features/i18n/locales/en-US.json` only; other locales come from Crowdin. The
+Strings go in `features/i18n/locales/en-US.json`; other locales come from Crowdin. The
 config CI reads is the repo-root `crowdin.yml`, because neither Crowdin workflow passes a
 `config:` input or a working directory; `apps/web/crowdin.yml` is a second copy with a
-different base path that nothing reads. One top-level namespace per feature, kebab-case
-keys. A key repeated in one object is silently last-wins, guarded by
+different base path. One top-level namespace per feature, kebab-case keys. A key repeated in
+one object is silently last-wins, guarded by
 `specs/features/i18n-locale-duplicate-keys.spec.ts`. Inline markup uses `Tsx` from
 `@/features/i18n/helper`.
 
 ## 5. Page route (if it owns a URL)
 
-Plain `apps/web/src/app/<route>/page.tsx`: 19 route dirs hold a `page.tsx` at the app root
-against 9 under `(staticPages)` and 24 under `(dynamicPages)`, which is
-profile/entry/feed/community only. Page-local components go in `_components/` beside
-`page.tsx`. `routes.ts` is a legacy map read by 3 files; add to it only for pattern
-matching.
+Plain `apps/web/src/app/<route>/page.tsx`. `(dynamicPages)` holds profile, entry, feed and
+community; other routes sit at the app root or under `(staticPages)`. Page-local components
+go in `_components/` beside `page.tsx`. `routes.ts` is a legacy map read by a few files; add
+to it for pattern matching.
 
 ## 6. Specs
 
 Vitest's `include`, set in `apps/web/vitest.config.mts` and relative to `apps/web/`, is
-`src/specs/**/*.spec.{ts,tsx}`, so a spec beside the component is never collected. Put it in
+`src/specs/**/*.spec.{ts,tsx}`, so a spec beside the component is not collected (CLAUDE.md's
+"co-located with components" test-pattern line is stale on this). Put it in
 `specs/features/<feature-name>/`, render with `renderWithQueryClient` from
 `@/specs/test-utils` and seed with `seedQueryClient(queryClient, data)`, client first.
 i18next is globally mocked to return the key, so assert on `"<feature-name>.button-label"`.
 The same global setup (`specs/setup-any-spec.ts`) mocks `@/utils` down to `random` and
-`getAccessToken`, so a spec that reaches a feature-local api wrapper has to re-mock it with
-`vi.importActual("@/utils")` or the wrapper's `ensureValidToken` import blows up on a
-missing export. `pnpm test` at the root is web-only.
+`getAccessToken`, so a spec that reaches a feature-local api wrapper pulling anything else
+from `@/utils` has to re-mock it with `vi.importActual("@/utils")`. `pnpm test` at the root
+is web-only.
 
 ## 7. Wiring in
 
 - Toolbar button: `features/shared/editor-toolbar/index.tsx`, inside a `Conditional`. The
-  publish route's `app/publish/_editor-extensions/` is not this; it holds one TipTap node
-  view (`publish-editor-image-viewer`) plus two plain React poll-editor components.
+  publish route's `app/publish/_editor-extensions/` is not this.
 - Profile section: `app/(dynamicPages)/profile/[username]/_components/`.
 - Navigation: `features/shared/navbar/navbar-main-sidebar.tsx`.
 
 Finish with `pnpm lint`, `pnpm typecheck` and `pnpm test`. Those three run none of the script
-audits in `.github/workflows/typecheck.yml`; the ones a feature can trip are
+audits in `.github/workflows/typecheck.yml`; the ones a feature is likely to trip are
 `node scripts/icon-scss-audit.mjs`, `node scripts/icon-tsx-audit.mjs --fail` and
 `node scripts/slim-entries-audit.mjs --fail`. Copy each line's flags exactly. The two
 `--fail` audits report their findings then exit 0 without it, so they pass locally then fail
 in CI. `icon-scss-audit` is inverted: with no flag it already exits 1 on a finding, while
-`--report` is what downgrades it. It never reads `--fail`, so adding one there changes nothing.
+`--report` is what downgrades it. It does not read `--fail`, so adding one there changes
+nothing.

--- a/.claude/skills/add-query/SKILL.md
+++ b/.claude/skills/add-query/SKILL.md
@@ -20,7 +20,8 @@ Hive, Hive Engine and Points asset builders already live in the SDK under
 `packages/wallets/src/modules/assets/{hive,hive-engine,points}/queries/index.ts` files are
 re-export lists pointing back at `@ecency/sdk`, so a new builder for one of those assets is
 an SDK file plus one line in the wallets re-export. CLAUDE.md holds the package boundary
-rules: the multi-chain code stays in `@ecency/wallets`.
+rules: the multi-chain code stays in `@ecency/wallets`. Its external chain list is stale,
+since the chains under `assets/external/` are BTC, ETH, BNB and SOL.
 
 ## 1. Add the key
 
@@ -29,22 +30,23 @@ Key style is per workspace, so pick the right one before writing anything:
 | Workspace | Where the key comes from |
 |---|---|
 | `@ecency/sdk` | the shared `QueryKeys` object, below |
-| `@ecency/wallets` | a package-local namespaced array; `QueryKeys` is imported in 0 files |
+| `@ecency/wallets` | a package-local namespaced array; `QueryKeys` is not imported there |
 | `apps/web` | the `QueryIdentifiers` enum, or a local suffix constant appended to another builder's key (step 3) |
 
-`@ecency/wallets` deliberately keeps its keys local so the multi-chain code does not reach
-back into the SDK. It uses `["ecency-wallets", ...]` for the wallet list, the all-tokens
+`@ecency/wallets` keeps its keys local so the multi-chain code does not reach
+back into the SDK, so CLAUDE.md's blanket rule to take every cache key from `QueryKeys` is
+stale here. It uses `["ecency-wallets", ...]` for the wallet list, the all-tokens
 list, market data plus external balances, `["assets", "<chain>", ...]` for the per-chain
-builders, then `["wallets", "token-operations", ...]`. Those three namespaces cover all 13
-keys. Portfolio is not one of them: the package calls the SDK's `getPortfolioQueryOptions`,
+builders, then `["wallets", "token-operations", ...]`. Those namespaces cover its keys.
+Portfolio is not one of them: the package calls the SDK's `getPortfolioQueryOptions`,
 whose key is `["wallet", "portfolio", "v2", ...]`. Follow the neighbouring builder rather
 than adding a wallets key to the SDK.
 
 For SDK keys: `packages/sdk/src/modules/core/query-keys.ts` is one object literal
 (`export const QueryKeys = { ... } as const;`), not a class, so there is no `static` in it.
-For a new key, return a plain array whose first element is the block name. 10 of the 23
-blocks also end with a `_prefix` used for bulk invalidation (a plain array, or a function
-where the prefix takes an argument, as in `points`):
+For a new key, return a plain array whose first element is the block name. Some blocks
+also end with a `_prefix` used for bulk invalidation (a plain array, or a function where
+the prefix takes an argument, as in `points`):
 
 ```typescript
   support: {
@@ -62,13 +64,12 @@ extend any of those shapes.
 
 For an optional trailing argument use the file-local `key(...)` helper, which strips
 trailing `undefined` so the key still matches as an invalidation prefix (see
-`posts.draftsInfinite`). Only 7 call sites use it today: the infinite keys for drafts,
-schedules, fragments, images, favorites and bookmarks, plus `search.api`. Most other keys
-with an optional tail, `posts.drafts` and `accounts.full` among them, embed the
-`undefined` and are not prefix-safe. Three stay prefix-safe without the helper by branching
-on the missing argument and returning the shorter array: `search.similarEntries`,
-`wallet.aggregatedHistory` plus `polls.vote`. Web-only queries extend the `QueryIdentifiers` enum in
-`apps/web/src/core/react-query/index.ts` instead.
+`posts.draftsInfinite`). It is used by the infinite keys for drafts, schedules, fragments,
+images, favorites and bookmarks, plus `search.api`. Most other keys with an optional tail,
+`posts.drafts` and `accounts.full` among them, embed the `undefined` and are not
+prefix-safe. Some keys stay prefix-safe without the helper by branching on the missing
+argument and returning the shorter array: `search.similarEntries`,
+`wallet.aggregatedHistory` plus `polls.vote`.
 
 ## 2. Write the builder
 
@@ -78,15 +79,14 @@ File: `packages/sdk/src/modules/<domain>/queries/get-<entity>-query-options.ts`.
 ETH, BNB or SOL sits directly in `packages/wallets/src/modules/assets/external/<chain>/`,
 with no `queries/` level. A web-only
 query is `apps/web/src/api/queries/<name>-query.ts` (`get-contributors-query.ts`,
-`get-gifs-query.ts`) with its key from `QueryIdentifiers`. The builder shape below holds in
-all three; the imports do not. Export a function, never a hook, so one options object serves a component, a server
-prefetch or a non-React caller. 164 of the 173 distinct top-level `export function` names
-(174 declarations, since `getChainPropertiesQueryOptions` appears in two modules) in
-the non-spec files under `packages/sdk/src/modules/*/queries/` are named `get...`; the four query
-builders that are not (`searchQueryOptions`, `lookupAccountsQueryOptions`,
-`checkFavoriteQueryOptions`, `checkUsernameWalletsPendingQueryOptions`) are older names, so
-name a new one `get...`. The other five non-`get` exports are helpers such as
-`sortDiscussions`, not builders. `@ecency/wallets` is looser and
+`get-gifs-query.ts`), usually with its key from `QueryIdentifiers` (step 3). The builder
+shape below carries across those homes; the imports do not. Export a function, never a
+hook, so one options object serves a component, a server prefetch or a non-React caller.
+Almost all top-level `export function` names under
+`packages/sdk/src/modules/*/queries/` are `get...`; the query builders that are not
+(`searchQueryOptions`, `lookupAccountsQueryOptions`, `checkFavoriteQueryOptions`,
+`checkUsernameWalletsPendingQueryOptions`) are older names, so name a new one `get...`.
+The remaining non-`get` exports are helpers such as `sortDiscussions`, not builders. `@ecency/wallets` is looser and
 `modules/wallets/queries/use-get-external-wallet-query.ts` does export a hook
 (`useGetExternalWalletBalanceQuery`); do not copy it. Trimmed from
 `modules/posts/queries/get-post-query-options.ts`:
@@ -132,8 +132,8 @@ export function getPostQueryOptions(author: string, permlink?: string, observer 
   anything paginated or slow.
 - A `null` from a single-record read is not proof the record is gone. `verifyPostOnAlternateNode`
   (`modules/bridge/verify-on-alternate-node.ts`) re-asks through `callWithQuorum(..., 1)`, which
-  shuffles the node list; only a second `null` means deleted. `get-post` is the only caller
-  today. Copy that branch where a missing result renders as a deleted post; skip it where `null`
+  shuffles the node list; only a second `null` means deleted. `get-post` uses it today.
+  Copy that branch where a missing result renders as a deleted post; skip it where `null`
   is an ordinary empty answer.
 - Private API: `getBoundFetch()` with `CONFIG.privateApiHost + "/private-api/<route>"`, then
   check `response.ok` and throw. The `[SDK][Domain]` prefix is the convention for the
@@ -145,15 +145,15 @@ export function getPostQueryOptions(author: string, permlink?: string, observer 
   `QueryKeys`, `CONFIG` and `getBoundFetch` come from the first, `callRPC` from the second.
   In `apps/web`, take `QueryKeys` plus `callRPC` from `@ecency/sdk` (route handlers use the
   `@ecency/sdk/hive` subpath for `callRPC`); there is no `getBoundFetch`, app-owned requests
-  go through `appAxios` with `apiBase` from `@/api/helper`, and `CONFIG` there is the
+  go through `appAxios` with `apiBase` from `@/api/helper`, while `CONFIG` there is the
   unrelated `EcencyConfigManager.CONFIG` from `@/config`. In `@ecency/wallets`, `CONFIG`
   comes from `@ecency/sdk`, `getBoundFetch` is package-local at
   `@/modules/wallets/utils/get-bound-fetch`, the private-API host is
-  `ConfigManager.getValidatedBaseUrl()`, and neither `QueryKeys` nor `callRPC` is used.
+  `ConfigManager.getValidatedBaseUrl()`; neither `QueryKeys` nor `callRPC` is used.
 
 Paginated lists use `infiniteQueryOptions`. Plenty of them take an inline scalar cursor
 (`initialPageParam: 0`, or `""`); give an object cursor a named type. Stop on a short page
-rather than on an empty one, or the list pays one wasted fetch at the end. Trimmed from
+rather than on an empty one, or the list pays a wasted fetch at the end. Trimmed from
 `modules/posts/queries/get-account-posts-query-options.ts`:
 
 ```typescript
@@ -183,14 +183,13 @@ type PageParam = {
 Add one line to the domain's `queries/index.ts`, which `modules/<domain>/index.ts` already
 re-exports. A brand new domain also needs `export * from "./modules/<domain>";` in
 `packages/sdk/src/index.ts`. A web-only query takes a line in
-`apps/web/src/api/queries/index.ts`, plus its key entry: three of the four query files
-there key off `QueryIdentifiers`, so they also need an enum member in
-`apps/web/src/core/react-query/index.ts`. The fourth, `pending-payouts-query.ts`, instead
-exports its own `PENDING_PAYOUTS_KEY` constant and appends it to another builder's key, so
-match whichever the neighbouring file does rather than assuming the enum.
+`apps/web/src/api/queries/index.ts`, plus its key entry: most of the query files there key
+off `QueryIdentifiers`, so they also need an enum member in
+`apps/web/src/core/react-query/index.ts`. `pending-payouts-query.ts` instead exports its own
+`PENDING_PAYOUTS_KEY` constant and appends it to another builder's key, so match whichever
+the neighbouring file does rather than assuming the enum.
 
-`@ecency/wallets` has four export paths that reach the package root plus one that does not.
-A wallet-level builder follows the
+A wallet-level builder in `@ecency/wallets` follows the
 SDK shape: `modules/wallets/queries/index.ts`, re-exported by that module's `index.ts`, which
 `packages/wallets/src/index.ts` exports.
 
@@ -227,9 +226,7 @@ pnpm --filter @ecency/wallets test src/modules/wallets/queries/<name>.spec.ts
 ```
 
 **Never add `--` before the path.** pnpm forwards it to vitest as a passthrough separator
-rather than a file filter, so the whole package suite runs. Measured on 2026-08-28 against
-`get-post-query-options.spec.ts`: with `--`, 64 files and 860 tests; without it, 1 file and 22
-tests.
+rather than a file filter, so the whole package suite runs instead of the one spec.
 
 A web query does not colocate. `apps/web/vitest.config.mts` includes
 `src/specs/**/*.spec.{ts,tsx}` only, so the spec goes under `apps/web/src/specs/api/queries/`
@@ -245,7 +242,7 @@ and runs from the workspace root as `pnpm test src/specs/api/queries/<name>.spec
   inside the queryFn but leaves `author` to `enabled`, so a server prefetch with an empty author
   still reaches the node.
 - A query that returns `Entry` objects should pass them through `filterDmcaEntry`
-  (`modules/posts/utils/filter-dmca-entries.ts`). Only `get-post`, `get-account-posts`,
+  (`modules/posts/utils/filter-dmca-entries.ts`). `get-post`, `get-account-posts`,
   `get-posts-ranked` and `get-discussions` call it directly; the ones that go through
   `modules/bridge/requests.ts` inherit it, because `resolvePosts` filters inside. Anything
   calling `callRPC` straight from the queryFn does not:
@@ -255,28 +252,27 @@ and runs from the workspace root as `pnpm test src/specs/api/queries/<name>.spec
   entry of the page you return and the node continues in its own ranking, so sorting there
   repeats and skips posts. Sort in `select`, which runs after pagination.
 - `getNextPageParam` must return `undefined` or `null` at the end of a list. `hasNextPage` is
-  `getNextPageParam(...) != null` (query-core 5.90.2, `infiniteQueryBehavior.ts`), so either one
-  stops it. Three builders return `null` through a cursor type that allows it:
+  `getNextPageParam(...) != null` (query-core's `infiniteQueryBehavior.ts`), so either one
+  stops it. Some builders return `null` through a cursor type that allows it:
   `get-outgoing-rc-delegations-infinite-query-options.ts`,
   `get-account-notifications-infinite-query-options.ts` and
   `get-community-subscribers-query-options.ts`. What never ends is returning an object, or any
   other non-nullish value: `hasNextPage` stays true forever and the list appends empty pages.
-- Never hardcode a key array at a call site. Read it off the builder:
+- Never hardcode a whole key array at a call site. Read it off the builder:
   `getFooQueryOptions(...).queryKey`, which is not workspace-specific: wherever a builder is
-  exported and returns the options object, it owns the key. About 58 non-spec call sites read
-  a key this way, as in
-  `discussionsQueryOptions.queryKey` in `features/shared/discussion/index.tsx:99`. Only
+  exported and returns the options object, it owns the key. Call sites across the workspace
+  read a key this way, as in
+  `discussionsQueryOptions.queryKey` in `features/shared/discussion/index.tsx:99`.
   `@ecency/sdk` has a key registry you can reach independently (`QueryKeys`, which CLAUDE.md
-  points at); `apps/web` supplies just the first element through the `QueryIdentifiers` enum,
-  and `@ecency/wallets` has none at all, its 13 key arrays being inline in the definitions
-  that own them. So for a wallets key, `.queryKey` is the only reuse path, as
-  `mutations/save-wallet-information-to-metadata.ts:188` does. 12 of the 13 support it because
-  they return an options object; `queries/use-get-external-wallet-query.ts:106` is the
+  points at), while `@ecency/wallets` has none, its key arrays being inline in the
+  definitions that own them. So for a wallets key, `.queryKey` is the reuse path, as
+  `mutations/save-wallet-information-to-metadata.ts:188` does. Most of them support it because
+  they return an options object; `queries/use-get-external-wallet-query.ts` is the
   exception, since `useGetExternalWalletBalanceQuery` passes its key straight into `useQuery`
-  and never exposes one. Extract a `getExternalWalletBalanceQueryOptions` builder before
-  reusing that key rather than retyping the array. Prefix invalidation is the one
-  case it cannot serve, since it gives the exact key rather than a prefix: the SDK covers that
-  with the `_prefix` entries above, while wallets has no helper, so
+  and does not expose one. Extract a `getExternalWalletBalanceQueryOptions` builder before
+  reusing that key rather than retyping the array. Prefix invalidation is a case it cannot
+  serve, since it gives the exact key rather than a prefix: the SDK covers that
+  with the `_prefix` entries above, while wallets has no such helper, so
   `mutations/use-external-transfer.ts:40` hardcodes the
   `["ecency-wallets", "external-wallet-balance"]` prefix. Follow that only for a prefix, never
   for a whole key.

--- a/.claude/skills/add-sdk-mutation/SKILL.md
+++ b/.claude/skills/add-sdk-mutation/SKILL.md
@@ -63,18 +63,18 @@ Authority is a lowercase string literal from
 `'owner'` for recovery or key changes. `OPERATION_AUTHORITY_MAP` in that same file
 is the per-operation lookup.
 
-Imports as the SDK uses them: `useBroadcastMutation` from `@/modules/core` (31 files)
-or `@/modules/core/mutations` (19); `QueryKeys` only from `@/modules/core` (160
-files), since `core/mutations` re-exports just the three broadcast helpers;
-`AuthContextV2` always as `import type`, from `@/modules/core/types` in 54 of its 55
-import sites. `invalidateAfterBroadcast` (24 consumers) already defers about one
-block on async broadcasts, so no hand rolled `setTimeout`. Other models:
+Imports as the SDK uses them: `useBroadcastMutation` from `@/modules/core` or
+`@/modules/core/mutations`; `QueryKeys` typically from `@/modules/core`;
+`AuthContextV2` as `import type`, usually from `@/modules/core/types`.
+`invalidateAfterBroadcast` already defers on async broadcasts, so no hand rolled
+`setTimeout`. Other models:
 `posts/mutations/use-vote.ts`, `use-reblog.ts`, `use-comment.ts`. Co-locate a
 `use-<operation>.spec.ts` when the hook has logic of its own; most hooks have none,
 so copy the pattern from `posts/mutations/use-vote.spec.ts`.
 
 Export with `export * from "./use-<operation>";` in the domain's
-`mutations/index.ts`. The chain up to `packages/sdk/src/index.ts` is already wired.
+`mutations/index.ts`. The chain up to `packages/sdk/src/index.ts` is usually
+already wired.
 
 ## 2. QueryKeys, if you invalidate
 
@@ -82,15 +82,15 @@ Export with `export * from "./use-<operation>";` in the domain's
 `static`. Add the builder to its domain namespace:
 `withdrawRoutes: (account: string) => ["wallet", "withdraw-routes", account],`.
 Some namespaces also carry `_prefix` for broad invalidation. Never hardcode key
-arrays, see CLAUDE.md. The two inline arrays in the transfer hook above are the
+arrays, see CLAUDE.md. The inline arrays in the transfer hook above are an
 exception: they are bare prefixes, while `QueryKeys.assets.ecencyAssetInfo` and
-`QueryKeys.wallet.portfolio` both take trailing arguments that no builder call can
+`QueryKeys.wallet.portfolio` both take trailing arguments that a builder call cannot
 omit.
 
 ## 3. Web wrapper
 
-`apps/web/src/api/sdk-mutations/use-<operation>-mutation.ts`. 48 of the 56 wrappers
-call the adapter; 46 of those are exactly this, from `use-transfer-mutation.ts`:
+`apps/web/src/api/sdk-mutations/use-<operation>-mutation.ts`. Most wrappers call the
+adapter. Almost all of those are exactly this, from `use-transfer-mutation.ts`:
 
 ```typescript
 "use client";
@@ -105,15 +105,15 @@ export function useTransferMutation() {
 }
 ```
 
-Match it: `"use client"`, then `useActiveUsername()` rather than `useActiveAccount()`
-(which subscribes to full account data no wrapper needs), then the shared singleton
-`getWebBroadcastAdapter()` rather than `createWebBroadcastAdapter`, which no wrapper
-calls. The other 2 adapter wrappers keep that core then add orchestration:
-`use-proposal-vote-mutation.ts` plus `use-witness-vote-mutation.ts` feed the SDK hook
-into their own `useMutation`, which polls the chain for confirmation. The 8 wrappers
-with no adapter cover private-API mutations (drafts, images, schedules,
-notifications) that never broadcast. Add the named export to
-`apps/web/src/api/sdk-mutations/index.ts`.
+Match it: `"use client"`, then `useActiveUsername()` rather than `useActiveAccount()`,
+then the shared singleton `getWebBroadcastAdapter()` rather than
+`createWebBroadcastAdapter`. The CLAUDE.md "Mutation Architecture" section still
+names the older pair in its prose, so follow this file instead. A couple of adapter
+wrappers keep that core then add orchestration: `use-proposal-vote-mutation.ts` plus
+`use-witness-vote-mutation.ts` feed the SDK hook into their own `useMutation`, which
+polls the chain for confirmation. The wrappers with no adapter cover private-API
+mutations (drafts, images, schedules, notifications) that never broadcast. Add the
+named export to `apps/web/src/api/sdk-mutations/index.ts`.
 
 ## 4. Verify
 
@@ -122,23 +122,18 @@ so `pnpm typecheck` reports your new export as missing from the package until th
 is rebuilt:
 
 ```bash
-pnpm sdk         # or pnpm build:packages; web typecheck reads dist types, never src
+pnpm sdk         # or pnpm build:packages; web typecheck reads dist types, not src
 pnpm --filter @ecency/sdk test
 pnpm test        # web app; the root script is web-only despite the name
 pnpm typecheck && pnpm lint
 ```
-
-Only typecheck really needs that first line. `pnpm lint` runs `next lint` plus a
-per-package `eslint .` with no import resolution rules. `setup-any-spec.ts` mocks
-`@ecency/sdk` for every web spec, so only 28 of the 372 spec files reach the built
-module, through `vi.importActual("@ecency/sdk")`.
 
 **Never commit `packages/sdk/dist`.** It is tracked in git, so a hand built dist in
 your commit buries the real diff in generated output and causes merge conflicts. CI
 rebuilds it: `.github/workflows/auto-changeset.yml` fires when a version label is put
 on the PR, then pushes the version bump plus the rebuilt dist back to the PR branch.
 Do not add those labels yourself; the maintainer applies them. Building it locally is
-expected, as in step 4 above; just keep `dist` out of what you stage.
+expected; just keep `dist` out of what you stage.
 
 ## Gotchas
 

--- a/.claude/skills/add-test/SKILL.md
+++ b/.claude/skills/add-test/SKILL.md
@@ -8,14 +8,14 @@ argument-hint: [component-or-file-path]
 
 Procedure for `apps/web` (`@ecency/web`) specs. Background you should not re-read here:
 
-- CLAUDE.md "Testing" covers mocking strategy, best practices and coverage expectations.
+- CLAUDE.md "Testing" covers best practices and coverage expectations.
 - `apps/web/src/specs/README.md` covers most `test-utils.tsx` exports (`renderWithQueryClient`,
   `createTestQueryClient`, `seedQueryClient`, `mockFullAccount`, `mockEntry`, `mockCommunity`,
   `mockActiveUser`, `setupModalContainers`, `cleanupModalContainers`, `EntryBuilder`,
   `AccountBuilder`). It does not mention `mockFeatureFlags` or `waitForMs`, so read
   `test-utils.tsx` itself before assuming a helper is missing.
 
-This file only covers the four things that actually break.
+Sections 1-4 cover what usually breaks.
 
 ## 1. Where the file goes
 
@@ -25,16 +25,15 @@ This file only covers the four things that actually break.
 include: ['src/specs/**/*.spec.{ts,tsx}']
 ```
 
-A spec outside `src/specs/` is never collected, so it silently never runs. All 372 spec files
-live under `apps/web/src/specs/`; zero are co-located with source. Three lines in CLAUDE.md's
-"Main App (Vitest)" bullet list are stale: the "co-located" test pattern,
-"Configuration: `apps/web/vitest.config.ts`" (the real file is `vitest.config.mts`), plus the
-mocked-modules list. Its "Test Structure" section has the right location but lists only three
-of the nine places specs actually live.
+A spec outside `src/specs/` is not collected, so it silently does not run. The spec files live
+under `apps/web/src/specs/`, not co-located with source. CLAUDE.md's "Main App (Vitest)" bullet
+list is stale on the "co-located" test pattern, on "Configuration: `apps/web/vitest.config.ts`"
+(the real file is `vitest.config.mts`) plus on the mocked-modules list. Its "Test Structure"
+section has the right location but lists a subset of the places specs actually live.
 
-Pick the subdirectory matching the source area. Current counts: `features/` 211, `utils/` 51,
-`api/` 41, `app/` 40, `core/` 19, `deploy/` 3, `config/` 2, `scripts/` 1, plus 4 at the root.
-The mirror is a convention, the `include` glob is the only thing enforced.
+Pick the subdirectory matching the source area: `features/`, `utils/`, `api/`, `app/`, `core/`,
+`deploy/`, `config/`, `scripts/`, plus a few specs at the root. The mirror is a convention; the
+`include` glob is what is enforced.
 
 ## 2. Run one spec
 
@@ -43,50 +42,46 @@ The mirror is a convention, the `include` glob is the only thing enforced.
 pnpm test src/specs/features/shared/my-thing.spec.tsx
 ```
 
-**Never add `--`.** pnpm forwards it literally, so vitest runs `vitest run -- <path>` and files
+**Do not add `--`.** pnpm forwards it literally, so vitest runs `vitest run -- <path>` and files
 everything after `--` under passthrough args instead of its file filters. No filter is applied
-and the entire suite runs. Measured here on 2026-08-28:
+and the entire suite runs.
 
-| Command | Result |
-|---|---|
-| `pnpm --filter @ecency/web test -- src/specs/api/mattermost-dm-fanout-ordering.spec.ts` | 372 files, 3672 tests, 40.4s |
-| `pnpm test src/specs/api/mattermost-dm-fanout-ordering.spec.ts` | 1 file, 4 tests, 689ms |
-| `pnpm --filter @ecency/web test src/specs/api/mattermost-dm-fanout-ordering.spec.ts` | 1 file, 4 tests, 1.22s |
+CLAUDE.md's "Running Single Tests" block still shows the `--` form for `@ecency/web`; it is
+stale on that point.
 
-Run the whole suite with `pnpm test` before pushing. The PR gate is `PR-branch.yml`
-(triggered on `pull_request`); it runs `pnpm build:packages` ahead of `pnpm -r test`, because
-`apps/web` resolves `@ecency/sdk` to the committed `packages/sdk/dist`. A local `pnpm test`
-runs against whatever dist is checked out, so run `pnpm build:packages` yourself after touching
+Run the whole suite with `pnpm test` before pushing. The gate that runs specs on a PR is
+`PR-branch.yml` (triggered on `pull_request`); it runs `pnpm build:packages` ahead of
+`pnpm -r test`, because `apps/web` resolves `@ecency/sdk` to the committed
+`packages/sdk/dist`. A local `pnpm test` runs against whatever dist is checked out, so run `pnpm build:packages` yourself after touching
 SDK source. Keep that rebuilt `dist` out of what you stage; `auto-changeset.yml` commits a fresh
 one to the PR branch once a version label is added. The same `pnpm -r test` also runs post-merge
-in `web-build.yml` (push to `develop`), `staging.yml` and `master.yml`; none of those three gate
-a PR.
+in `web-build.yml` (push to `develop`), `staging.yml` and `master.yml`; none of those gate a PR.
 
-## 3. Global mocks and their exact limits
+## 3. Global mocks and their limits
 
-`src/specs/setup-any-spec.ts` mocks, with real export counts:
+`src/specs/setup-any-spec.ts` mocks:
 
 | Module | Provided |
 |---|---|
-| `@ecency/sdk` | 73 explicit exports, plus the real `modules/moderation`, `modules/newsletter/errors` and `modules/search/query-builder` spread in |
-| `@ecency/wallets` | exactly 5: `validateKey`, `validateWif`, `EXTERNAL_BLOCKCHAINS`, `useGetHiveEngineTokensBalances`, `EcencyWalletCurrency` |
-| `@/utils` | exactly 2: `random`, `getAccessToken` |
+| `@ecency/sdk` | explicit stubs, plus the real `modules/moderation`, `modules/newsletter/errors` and `modules/search/query-builder` spread in |
+| `@ecency/wallets` | `validateKey`, `validateWif`, `EXTERNAL_BLOCKCHAINS`, `useGetHiveEngineTokensBalances`, `EcencyWalletCurrency` |
+| `@/utils` | `random`, `getAccessToken` |
 | `@/core/hooks/use-active-account` | `useActiveAccount` returning a null `activeUser` |
 | `i18next` | default export only. `default.t()` returns the key verbatim, so assert on i18n keys; there is no named `t` export |
 | `uuid` | `v4()` returns `"test-uuid-1234"` |
-| `@/features/post-renderer`, `@/features/pro/pro-badge`, `react-tweet` | stubbed to no-ops |
+| `@/features/post-renderer`, `@/features/pro/pro-badge` | stubbed to no-ops |
 
 It also polyfills `TextEncoder`, `TextDecoder` and `IntersectionObserver` for jsdom.
 `@ecency/render-helper` is **not** globally mocked despite CLAUDE.md listing it; mock it locally.
 
-Touching any export the mock omits throws at property access:
+Touching an export the mock omits throws at property access:
 
 ```text
 [vitest] No "parseAsset" export is defined on the "@/utils" mock. Did you forget to return it from "vi.mock"?
 ```
 
-Fix with a local re-mock. 38 of the 54 specs that re-mock `@/utils` spread the real module back
-in and stub on top of it, which is the shape to copy:
+Fix with a local re-mock. Most specs that re-mock `@/utils` spread the real module back in and
+stub on top of it, which is the shape to copy:
 
 ```ts
 vi.mock("@/utils", async () => ({
@@ -96,11 +91,11 @@ vi.mock("@/utils", async () => ({
 }));
 ```
 
-The same `importActual` spread is how 28 specs widen `@ecency/sdk` past the 73 stubs.
+The same `importActual` spread is how specs widen `@ecency/sdk` past the global stubs.
 
 ## 4. Import jest-dom yourself
 
-`@testing-library/jest-dom` is not registered in the setup file. All 84 specs that call
+`@testing-library/jest-dom` is not registered in the setup file. Specs that call
 `toBeInTheDocument` import it directly:
 
 ```ts
@@ -110,13 +105,13 @@ import "@testing-library/jest-dom";
 ## The house pattern
 
 Real, passing reference: `apps/web/src/specs/features/wallet/profile-wallet-pending-earnings.spec.tsx`.
-It diverges from the block below on two points, so read it for the layout rather than the
-mocks: it declares a local `vi.mock("@/core/hooks/use-active-account")` (one of the 2 specs out
-of 21 that bother) and its `@/utils` factory spreads `importActual` without re-stubbing
-`random` or `getAccessToken`.
+It diverges from the block below in its mocks, so read it for the layout rather than the
+mocks: among other things it declares a local `vi.mock("@/core/hooks/use-active-account")`
+while its `@/utils` factory spreads `importActual` without re-stubbing `random` or
+`getAccessToken`.
 
-Use `it()` (2806 uses against 249 for `test()`). Put the subject import below the `vi.mock`
-calls as 104 specs do, since `vi.mock` hoists either way.
+Use `it()` rather than `test()`. Put the subject import below the `vi.mock` calls, since
+`vi.mock` hoists either way.
 
 ```ts
 import { vi, describe, it, expect, beforeEach } from "vitest";
@@ -140,8 +135,7 @@ import { MyComponent } from "@/features/shared/my-component";
 describe("MyComponent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // the global mock is already a vi.fn(), so no local re-mock is needed:
-    // 19 of the 21 specs that override the active user declare none
+    // the global mock is already a vi.fn(), so no local re-mock is needed
     vi.mocked(useActiveAccount).mockReturnValue({
       activeUser: { username: "testuser" },
       username: "testuser",
@@ -160,15 +154,15 @@ describe("MyComponent", () => {
 
 ## Components with several queries
 
-Do not reach for a `queryKey` switch first. Exactly one spec does it.
-`features/announcement/announcements.spec.tsx` gets away with it only because it replaces
+Do not reach for a `queryKey` switch first.
+`features/announcement/announcements.spec.tsx` gets away with it because it replaces
 `@ecency/sdk` wholesale, so its own query-options factories hand back distinct keys. Against the
 global SDK stubs you would be switching on whatever placeholder key the stub invented.
 
-Prefer feeding the cache with `renderWithQueryClient` (37 specs) or `setQueryData` (28 specs)
-over mocking `@tanstack/react-query` at all (18 specs do). When per-call data is unavoidable,
-the one spec that needs it, `features/wallet/profile-wallet-pending-earnings.spec.tsx`, switches
-on **call order** in 2 of its 3 tests, which couples the test to hook order:
+Prefer feeding the cache with `renderWithQueryClient` or `setQueryData` over mocking
+`@tanstack/react-query` at all. When per-call data is unavoidable,
+`features/wallet/profile-wallet-pending-earnings.spec.tsx` switches on **call order**, which
+couples the test to hook order:
 
 ```ts
 let call = 0;
@@ -184,5 +178,5 @@ vi.mocked(useQuery).mockImplementation(() => {
 - [ ] File is under `apps/web/src/specs/`, named `*.spec.ts` or `*.spec.tsx`
 - [ ] `import "@testing-library/jest-dom"` when asserting on the DOM
 - [ ] `@/utils` and `@ecency/sdk` re-mocked with `importActual` for anything past the global stubs
-- [ ] Assertions target i18n keys, never English strings
+- [ ] Assertions target i18n keys, not English strings
 - [ ] `pnpm test <path>` passes with no `--`, then `pnpm test` for the full suite

--- a/.claude/skills/add-test/SKILL.md
+++ b/.claude/skills/add-test/SKILL.md
@@ -70,6 +70,7 @@ in `web-build.yml` (push to `develop`), `staging.yml` and `master.yml`; none of 
 | `i18next` | default export only. `default.t()` returns the key verbatim, so assert on i18n keys; there is no named `t` export |
 | `uuid` | `v4()` returns `"test-uuid-1234"` |
 | `@/features/post-renderer`, `@/features/pro/pro-badge` | stubbed to no-ops |
+| `react-tweet` | an EMPTY module, no exports at all. Reaching any export throws, so a spec touching it needs its own local re-mock |
 
 It also polyfills `TextEncoder`, `TextDecoder` and `IntersectionObserver` for jsdom.
 `@ecency/render-helper` is **not** globally mocked despite CLAUDE.md listing it; mock it locally.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -47,10 +47,13 @@ Guard: `apps/self-hosted/scripts/check-node-globals.mjs`, run by its build.
   queryFn, since `prefetchQuery` and `fetchQuery` ignore `enabled`. See
   `get-post-query-options.ts`. The SDK's `enabled: false` is a manual-refetch
   query, not the pattern.
-- Keys come from `QueryKeys` (`packages/sdk/src/modules/core/query-keys.ts`). A
-  raw array duplicating an SDK key splits the cache. `QueryIdentifiers`
-  (`apps/web/src/core/react-query`) is for web-only features that have no SDK
-  query.
+- Key source is per workspace, so check against the right one before flagging.
+  See the table in the `add-query` skill. `@ecency/sdk` uses `QueryKeys`
+  (`packages/sdk/src/modules/core/query-keys.ts`), `@ecency/wallets` uses its own
+  package-local arrays, `apps/web` uses `QueryIdentifiers`
+  (`apps/web/src/core/react-query`) or a local constant appended to another
+  builder's key. What is worth flagging is a raw array that duplicates a key some
+  builder already owns, since that splits the cache.
 - Post and feed results pass through `filterDmcaEntry`, which the SDK applies in
   get-post, get-posts-ranked, get-account-posts, get-discussions and
   bridge/requests. A reader that skips it serves takedown-listed content.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -53,7 +53,9 @@ Guard: `apps/self-hosted/scripts/check-node-globals.mjs`, run by its build.
   package-local arrays, `apps/web` uses `QueryIdentifiers`
   (`apps/web/src/core/react-query`) or a local constant appended to another
   builder's key. What is worth flagging is a raw array that duplicates a key some
-  builder already owns, since that splits the cache.
+  builder already owns. TanStack hashes keys structurally, so an identical copy hits the
+  same cache entry rather than splitting it; the risk is drift, since the copy stops
+  matching the moment the builder's key changes.
 - Post and feed results pass through `filterDmcaEntry`, which the SDK applies in
   get-post, get-posts-ranked, get-account-posts, get-discussions and
   bridge/requests. A reader that skips it serves takedown-listed content.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -6,8 +6,9 @@ argument-hint: [file-or-branch]
 
 # Code Review
 
-Traps specific to this repo, each with the guard that proves it. General review
-technique belongs to the built-in reviewer; commands and audits are in CLAUDE.md.
+Traps specific to this repo, each with the guard that proves it where one
+exists. General review technique belongs to the built-in reviewer; commands and
+audits are in CLAUDE.md.
 
 Note each changed file's workspace. Run the checks its diff can trip plus the
 CLAUDE.md audits it touches. Read the cited source before flagging: what you
@@ -18,11 +19,11 @@ then the fix. Severities: `BUG`, `SECURITY`, `PERF`, `STYLE`, `NITPICK`.
 
 **Slim feed wrappers are not interchangeable** (`apps/web/src/core/entries/slim-entry.ts`).
 `withSlimPageEntries` takes SINGLE-PAGE builders (`getPostsRankedQueryOptions`,
-`getAccountPostsQueryOptions`), 3 call sites: it isolates the key, which deck
-columns otherwise read for `entry.body`. `withSlimEntries` takes INFINITE
-builders plus the promoted feed, 5 call sites: its key must stay what the SDK
-produced, since the feed poll hand-builds it for a `setQueryData` merge.
-`withCardOnlyPageEntries`: 3. Guard: `node scripts/slim-entries-audit.mjs --fail`.
+`getAccountPostsQueryOptions`): it isolates the key, which deck columns
+otherwise read for `entry.body`. `withSlimEntries` takes INFINITE builders plus
+the promoted feed: its key must stay what the SDK produced, since the feed poll
+hand-builds it for a `setQueryData` merge. The audit also covers
+`withCardOnlyPageEntries`. Guard: `node scripts/slim-entries-audit.mjs --fail`.
 
 **No server component may reach a `"use client"` module that imports
 `@/features/shared` back through that barrel.** Module and barrel then form a
@@ -42,22 +43,22 @@ go blank. A `typeof` test must GOVERN the read; a nearby one does not count.
 Guard: `apps/self-hosted/scripts/check-node-globals.mjs`, run by its build.
 
 **Query options**
-- Guard a missing param TWICE: `enabled: !!a && !!b` (82 `enabled: !!` in
-  `packages/sdk/src`) plus an early return in the queryFn, since `prefetchQuery`
-  and `fetchQuery` ignore `enabled`. See `get-post-query-options.ts`. The SDK's
-  one `enabled: false` is a manual-refetch query, not the pattern.
-- Keys come from `QueryKeys` (`packages/sdk/src/modules/core/query-keys.ts`; 359
-  `QueryKeys.` uses across apps and packages). A raw array duplicating an SDK key
-  splits the cache. `QueryIdentifiers` (`apps/web/src/core/react-query`, 25 uses)
-  is only for web-only features with no SDK query.
-- Post and feed results pass through `filterDmcaEntry`: five SDK modules
-  apply it (get-post, get-posts-ranked, get-account-posts, get-discussions,
-  bridge/requests). A reader that skips it serves takedown-listed content.
-- `prefetchQuery` resolves to `undefined` past `SSR_PREFETCH_TIMEOUT_MS` (10s,
-  `apps/web/src/core/react-query/query-helpers.ts`), so the server component must
-  still render without it.
+- Guard a missing param TWICE: `enabled: !!a && !!b` plus an early return in the
+  queryFn, since `prefetchQuery` and `fetchQuery` ignore `enabled`. See
+  `get-post-query-options.ts`. The SDK's `enabled: false` is a manual-refetch
+  query, not the pattern.
+- Keys come from `QueryKeys` (`packages/sdk/src/modules/core/query-keys.ts`). A
+  raw array duplicating an SDK key splits the cache. `QueryIdentifiers`
+  (`apps/web/src/core/react-query`) is for web-only features that have no SDK
+  query.
+- Post and feed results pass through `filterDmcaEntry`, which the SDK applies in
+  get-post, get-posts-ranked, get-account-posts, get-discussions and
+  bridge/requests. A reader that skips it serves takedown-listed content.
+- `prefetchQuery` resolves to `undefined` past `SSR_PREFETCH_TIMEOUT_MS`
+  (`apps/web/src/core/react-query/query-helpers.ts`), so the server component
+  must still render without it.
 - An SDK builder's FINITE `gcTime` must bound itself on the server with
-  `SERVER_GC_TIME_MS` (2 min, `packages/sdk/src/modules/core/config.ts`).
+  `SERVER_GC_TIME_MS` (`packages/sdk/src/modules/core/config.ts`).
   `Infinity` is exempt: it schedules no gc timer, so it roots nothing; clamping
   it to a finite window would CREATE one. `apps/web` re-clamps finite overrides
   in `makeQueryClient` (`core/react-query/index.ts`, its own `SERVER_GC_TIME`),
@@ -66,37 +67,35 @@ Guard: `apps/self-hosted/scripts/check-node-globals.mjs`, run by its build.
 
 **A null `bridge.get_post` is not proof the post is gone.** `getPostQueryOptions`
 re-checks through `verifyPostOnAlternateNode`, which accepts a response only when
-`author` and `permlink` match the request. New RPC readers do the same.
+`author` and `permlink` match the request. Do the same in new RPC readers.
 
-**SDK mutation wrappers** (`apps/web/src/api/sdk-mutations/`, 56 wrappers) all
-read `useActiveUsername()`. The 48 that broadcast pass `getWebBroadcastAdapter()`,
-the shared singleton (123 non-spec uses in `apps/web/src`); the other 8 (drafts,
-images, schedules, notifications) hit the private API and broadcast nothing.
-`createWebBroadcastAdapter()` is internal: its 4 references all sit in
-`apps/web/src/providers/sdk`.
+**SDK mutation wrappers** (`apps/web/src/api/sdk-mutations/`) all read
+`useActiveUsername()`. Wrappers that broadcast pass `getWebBroadcastAdapter()`,
+the shared singleton; those that hit the private API instead (drafts, images,
+schedules, notifications) broadcast nothing.
 
 **Icon sizing** is one `size-N` class or a sanctioned slot: CLAUDE.md and
-`docs/icons.md` carry the rule plus its enforcement. **framer-motion is gone**
-(0 imports); modals use CSS transitions
-(`apps/web/src/features/ui/modal/index.tsx`). Do not reintroduce it.
+`docs/icons.md` carry the rule plus its enforcement. **framer-motion is gone**;
+modals use CSS transitions (`apps/web/src/features/ui/modal/index.tsx`). Do not
+reintroduce it.
 
 **Tests**
-- Placement decides collection. Four workspaces pin `include`, so a misplaced or
+- Placement decides collection. Some workspaces pin `include`, so a misplaced or
   wrongly suffixed file there is silently never run: `apps/web` takes
-  `src/specs/**/*.spec.{ts,tsx}` only (372 files, 0 co-located),
-  `packages/wallets` `src/**/*.spec.ts`, `packages/ui` and `apps/self-hosted`
-  `src/**/*.test.{ts,tsx}` (77 in self-hosted). sdk and render-helper pin no
-  `include`, so vitest's default picks up either suffix anywhere; co-located
-  `*.spec.ts` is their convention, not a rule the runner enforces.
-- One `vi.mock()` per module per spec: vitest 4 keeps the LAST factory, so an
+  `src/specs/**/*.spec.{ts,tsx}` only, `packages/wallets` `src/**/*.spec.ts`,
+  `packages/ui` and `apps/self-hosted` `src/**/*.test.{ts,tsx}`. sdk and
+  render-helper pin no `include`, so vitest's default picks up either suffix
+  anywhere; co-located `*.spec.ts` is their convention, not a rule the runner
+  enforces.
+- One `vi.mock()` per module per spec: vitest keeps the LAST factory, so an
   earlier one's exports vanish and reading them throws `No "x" export is defined
-  on the mock`. `setup-any-spec.ts` also mocks partially, so
-  re-mock with `importActual` as 80 specs do (CLAUDE.md has the snippet).
+  on the mock`. `setup-any-spec.ts` also mocks partially, so re-mock with
+  `importActual` (CLAUDE.md has the snippet).
 - Root `pnpm test` is web only; CI runs `pnpm -r test`. `apps/web` also resolves
-  `@ecency/sdk` through the COMMITTED `packages/sdk/dist` (15 tracked files), so
-  SDK edits stay invisible to web tests until `pnpm build:packages`.
+  `@ecency/sdk` through the COMMITTED `packages/sdk/dist`, so SDK edits stay
+  invisible to web tests until `pnpm build:packages`.
 
 **Strings** go into `en-US.json` only (CLAUDE.md). Nothing enforces that, so it
 is yours to catch. A duplicate key is a separate trap: valid JSON whose earlier
-value `JSON.parse` silently discards. That one IS guarded, across all 19 locale
+value `JSON.parse` silently discards. That one IS guarded, across the locale
 files, by `apps/web/src/specs/features/i18n-locale-duplicate-keys.spec.ts`.

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -7,13 +7,16 @@ argument-hint: [issue-description]
 # Debug Guide
 
 CLAUDE.md has the architecture and commands; note that root `pnpm test` is web-only and
-the four `node scripts/*-audit.mjs` checks gate CI without running under it. Below is triage
+the `node scripts/*-audit.mjs` checks gate CI without running under it. Below is triage
 plus the invariants that break easily.
 
-Data flows component -> `apps/web/src/api/` wrapper -> SDK query/mutation -> `callRPC`
-(`packages/sdk/src/hive-tx/helpers/call.ts`). Read `packages/sdk/src/`, never `dist/`:
+Data flows component -> SDK query/mutation -> `callRPC`
+(`packages/sdk/src/hive-tx/helpers/call.ts`), often through a wrapper in `apps/web/src/api/`
+but not always: SDK query options are also spread straight into a component's `useQuery`
+(the entry fallback below does that). Read `packages/sdk/src/` rather than `dist/`:
 `exports` in `packages/sdk/package.json` points at the build, so an unbuilt SDK edit is
-invisible. Most invariants below have a spec; find it before a repro. A report from
+invisible. Most invariants below have a spec; find it before a repro; web specs live under
+`apps/web/src/specs/` (CLAUDE.md's co-location note is stale for the web app). A report from
 one browser only, or only right after a deploy, is often already handled by the
 scripts in `apps/web/public/scripts/`; check those first.
 
@@ -33,7 +36,7 @@ the query disabled and the queryFn returning `null`. Node list
 - `.../[permlink]/_components/entry-not-found-fallback.tsx` picks the screen: `post_id === 1`
   marks a local optimistic entry; `isVerifying` is
   `!isOptimistic && !hasTransitioned && verifyPollCount < VERIFY_MAX_POLLS`, so the deleted
-  screen is held off only for the 3 verification polls. Once `handleSuccess` sets
+  screen is held off while those verification polls run. Once `handleSuccess` sets
   `hasTransitioned` a non-optimistic entry falls straight through to `DeletedPostScreen`
   until the `router.refresh()` tree lands. `isError` shows a retry prompt instead of the
   deleted screen. Its own poll key `["entry-chain-poll", ...]` keeps it from clobbering the
@@ -48,45 +51,44 @@ CLAUDE.md covers the auth methods. What bites:
 - `AuthorityLevel` and `getRequiredAuthority(ops)` are in
   `packages/sdk/src/modules/operations/authority-map.ts`; `use-broadcast-mutation.ts` only
   imports the type.
-- Its HiveSigner shortcut needs all three of `authority === 'posting'`,
-  `adapter.hasPostingAuthorization(username)` and a `getLoginType()` of
+- Its HiveSigner shortcut needs `authority === 'posting'` plus
+  `adapter.hasPostingAuthorization(username)` plus a `getLoginType()` of
   `key`/`keychain`/`hiveauth`, else the user's own method runs. "HiveSigner was skipped"
   usually means no posting authorization.
 - Fallback is gated on `shouldTriggerAuthFallback` (`.../core/errors/chain-errors.ts`), true
-  only for `MISSING_AUTHORITY` and `TOKEN_EXPIRED`; everything else rethrows by design, so a
-  network failure mid-broadcast never retries another method.
+  only for `MISSING_AUTHORITY` and `TOKEN_EXPIRED`; everything else rethrows by design.
 - `auth-upgrade-dialog.tsx` listens for the `ecency-auth-upgrade` CustomEvent, but the
   dispatch is in the sibling `auth-upgrade-events.ts` (`requestAuthUpgrade()`), reached from
-  `showAuthUpgradeUI` in `apps/web/src/providers/sdk/web-broadcast-adapter.ts`. That module
-  holds one `pendingResolve`, so a second concurrent upgrade resolves the first with `false`,
-  cancelling it rather than hanging it.
+  `showAuthUpgradeUI` in `apps/web/src/providers/sdk/web-broadcast-adapter.ts`. The events
+  module keeps a module-level `pendingResolve`, so a second concurrent upgrade resolves the
+  first with `false`, cancelling it rather than hanging it.
 - Token refresh route: `apps/web/src/app/api/auth-api/hs-token-refresh/route.ts`.
-- Error text is web-local: `formatError` from `@/api/format-error`, 62 importers, 76 sites
-  shaped `error(...formatError(err))`. It maps chain strings to `chain-error.*` keys, else
-  truncates to 80 chars, so raw text means `handleChainError` lacks a branch. The SDK's
-  `parseChainError`/`ErrorType` in that same `chain-errors.ts` is a separate classifier no web
-  file calls; it reaches web behavior only through `shouldTriggerAuthFallback`.
+- Error text is web-local: `formatError` from `@/api/format-error`; most call sites take the
+  shape `error(...formatError(err))`. It maps chain strings to `chain-error.*` keys, else
+  truncates the raw message, so raw text means `handleChainError` lacks a branch. The SDK's
+  `parseChainError`/`ErrorType` in that same `chain-errors.ts` is a separate classifier web
+  files do not call directly; it reaches web behavior through `shouldTriggerAuthFallback`.
 
 ## Stale data, or infinite scroll that stops
 
-`apps/web/src/core/react-query/index.ts` sets app-wide `staleTime: 60_000`,
-`refetchOnWindowFocus: false`, `refetchOnMount: false`. Most "never updates" reports are
+`apps/web/src/core/react-query/index.ts` sets an app-wide `staleTime` with
+`refetchOnWindowFocus: false` and `refetchOnMount: false`. Most "never updates" reports are
 those defaults; opt one query back in with `refetchOnMount: "always"` (see
 `features/shared/entry-translate/index.tsx`).
 
-`getNextPageParam` stops on `null` **or** `undefined` (query-core 5.90.2 tests
-`param == null`) and `null` is used deliberately here, so a stuck list is rarely a
-null-versus-undefined problem. The real trap: `initialData` makes `state.data` defined,
-`shouldLoadOnMount` goes false and page 1 is never fetched under `refetchOnMount: false`,
-leaving the bottom sentinel as the only trigger. See
+`getNextPageParam` stops on `null` **or** `undefined` (query-core tests
+`param == null`), so a stuck list is rarely a null-versus-undefined problem. The real
+trap: `initialData` makes `state.data` defined, `shouldLoadOnMount` goes false and page 1
+is not fetched under `refetchOnMount: false`, leaving the bottom sentinel as the only
+trigger. See
 `apps/web/src/app/search/_components/search-comment/index.tsx`.
 
 ## SSR renderer memory climbs
 
-Same file. `SERVER_GC_TIME` is 2 minutes and the server wraps `client.defaultQueryOptions` to
-clamp longer per-query `gcTime` down to it: a pending gc timer is a GC root holding its
-`Query`, which holds the whole `QueryCache`, so one long-lived entry pins that request's
-cache. `Infinity` is exempt: it schedules no timer at all. Pinned by
-`apps/web/src/specs/core/react-query/gc-time.spec.ts`; the SDK-side
+`apps/web/src/core/react-query/index.ts` again. The server wraps
+`client.defaultQueryOptions` to clamp longer per-query `gcTime` down to `SERVER_GC_TIME`: a
+pending gc timer is a GC root holding its `Query`, which holds the whole `QueryCache`, so a
+single long-lived entry pins that request's cache. `Infinity` is exempt: it schedules no
+timer at all. Pinned by `apps/web/src/specs/core/react-query/gc-time.spec.ts`; the SDK-side
 `packages/sdk/src/modules/core/server-gc-time.spec.ts` is a different check, over the separate
 `SERVER_GC_TIME_MS` in `packages/sdk/src/modules/core/config.ts`.

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -10,10 +10,13 @@ CLAUDE.md has the architecture and commands; note that root `pnpm test` is web-o
 the `node scripts/*-audit.mjs` checks gate CI without running under it. Below is triage
 plus the invariants that break easily.
 
-Data flows component -> SDK query/mutation -> `callRPC`
+Query data flows component -> SDK query -> `callRPC`
 (`packages/sdk/src/hive-tx/helpers/call.ts`), often through a wrapper in `apps/web/src/api/`
 but not always: SDK query options are also spread straight into a component's `useQuery`
-(the entry fallback below does that). Read `packages/sdk/src/` rather than `dist/`:
+(the entry fallback below does that). Mutations do not take that path: a broadcast goes
+through `useBroadcastMutation` plus the web broadcast adapter, while a private-API mutation
+goes through its own API client. Check the adapter or the operation before blaming
+`callRPC`. Read `packages/sdk/src/` rather than `dist/`:
 `exports` in `packages/sdk/package.json` points at the build, so an unbuilt SDK edit is
 invisible. Most invariants below have a spec; find it before a repro; web specs live under
 `apps/web/src/specs/` (CLAUDE.md's co-location note is stale for the web app). A report from


### PR DESCRIPTION
Closes #1704

Follow-up to #1703, which corrected the six skills against the code. This one fixes a different defect class: the files contradicting themselves, or contradicting `CLAUDE.md`.

Two sweeps ran over all twelve skills across both repos. The first found 43 confirmed self-contradictions against 53 refuted. Applying those fixes then produced 41 new gate findings, seven of them created by the fix pass itself.

That was the signal worth acting on. Eight review rounds on #1703 landed on the same three shapes: a count taken from a bare `grep -c`, an off-by-one line citation, or an exclusive quantifier the file itself contradicted. Correcting them enlarged the surface every time, because each correction added fresh specifics.

So this PR removes the specifics instead of correcting them again:

- 236 counts deleted. A figure like "48 of the 56 wrappers use X" changes nothing a reader does, since they copy the neighbouring file either way.
- 139 exclusive quantifiers weakened, keeping an absolute only where the code enforces one, such as a compile error or a CI gate.
- 17 line citations trimmed to the file alone, where the line could not be confirmed.
- 12 counts kept. Each was re-derived by listing and classifying every match rather than counting. Each is load-bearing for a decision.

Net effect is 227 insertions against 245 deletions. The procedures and traps are unchanged; the statistics that decorated them are gone. Every surviving number was individually re-derived; the gate lists each one with its verdict.

`CLAUDE.md` is deliberately untouched. The six places it contradicts these skills are recorded in #1704 for their own pass, including two that cost real time. The `--` in its single-test commands runs the whole suite, while its co-located spec pattern means a spec written that way is silently never collected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature-development, query, mutation, testing, code-review, and debugging guidance.
  * Removed outdated usage statistics, file counts, timing details, and historical references.
  * Clarified current recommendations for service calls, query keys, SDK wrappers, test mocking, data flow, and troubleshooting.
  * Refined wording and examples to better reflect current project practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->